### PR TITLE
Upgrade cspell

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -55,7 +55,8 @@
     "sdk/videoanalyzer/*/api/*.cs",
     "sdk/newrelicobservability/*/api/*.cs",
     "sdk/paloaltonetworks.ngfw/*/api/*.cs",
-    "sdk/servicefabricmanagedclusters/*/api/*.cs"
+    "sdk/servicefabricmanagedclusters/*/api/*.cs",
+    "cspell.yaml"
   ],
   // cspell is not case sensitive
   // Sort words alphabetically to make this list easier to use
@@ -436,22 +437,6 @@
       ]
     },
     {
-      "filename": "**/sdk/connectedvmwarevsphere/**/*",
-      "words": [
-        "cpus",
-        "ctlr",
-        "lsilogic",
-        "lsilogicsas",
-        "pcnet",
-        "pmem",
-        "pvscsi",
-        "sesparse",
-        "vcenter",
-        "vmware",
-        "vsphere"
-      ]
-    },
-    {
       "filename": "**/sdk/containerapps/**/*",
       "words": [
         "agentic",
@@ -648,16 +633,6 @@
       ]
     },
     {
-      "filename": "**/sdk/desktopvirtualization/**/*.cs",
-      "words": [
-        "adfs",
-        "fslogix",
-        "msix",
-        "sso",
-        "unhide"
-      ]
-    },
-    {
       "filename": "**/sdk/deviceupdate/**/*.cs",
       "words": [
         "fqdns"
@@ -763,13 +738,6 @@
       "filename": "**/sdk/hybriddatamanager/**/*.cs",
       "words": [
         "oaep"
-      ]
-    },
-    {
-      "filename": "**/sdk/hybridaks/**/*.cs",
-      "words": [
-        "kubevirt",
-        "vmip"
       ]
     },
     {
@@ -1197,15 +1165,6 @@
       ]
     },
     {
-      "filename": "**/sdk/postgresql/**/*.cs",
-      "words": [
-        "awsec",
-        "byok",
-        "vcore",
-        "vcores"
-      ]
-    },
-    {
       "filename": "**/sdk/powerbidedicated/**/*.cs",
       "words": [
         "pbie",
@@ -1228,46 +1187,6 @@
       ]
     },
     {
-      "filename": "**/sdk/provisioning/Azure.Provisioning.Kusto/**/*.cs",
-      "words": [
-        "apacheavro",
-        "openai",
-        "scsv",
-        "sohsv",
-        "tbps",
-        "tsve"
-      ]
-    },
-    {
-      "filename": "**/sdk/provisioning/Azure.Provisioning.PostgreSql/**/*.cs",
-      "words": [
-        "awsec"
-      ]
-    },
-    {
-      "filename": "**/sdk/provisioning/Azure.Provisioning.Sql/**/*.cs",
-      "words": [
-        "freemium"
-      ]
-    },
-    {
-      "filename": "**/sdk/provisioning/Azure.Provisioning.Storage/**/*.cs",
-      "words": [
-        "mibps"
-      ]
-    },
-    {
-      "filename": "**/sdk/provisioning/Azure.Provisioning.Network/**/*.cs",
-      "words": [
-        "dscp",
-        "fqdns",
-        "ipam",
-        "snat",
-        "vnets",
-        "vxlan"
-      ]
-    },
-    {
       "filename": "**/sdk/qumulo/**/*",
       "words": [
         "qumulo"
@@ -1282,67 +1201,9 @@
       ]
     },
     {
-      "filename": "**/sdk/recoveryservices/**/*.cs",
-      "words": [
-        "bcdr"
-      ]
-    },
-    {
-      "filename": "**/sdk/recoveryservices-backup/**/*.cs",
-      "words": [
-        "dedup",
-        "dpm",
-        "hana",
-        "kpis",
-        "mab",
-        "rehydrated",
-        "reregister",
-        "vmilr",
-        "xcool",
-        "xsmb"
-      ]
-    },
-    {
-      "filename": "**/sdk/recoveryservices-datareplication/**/*.cs",
-      "words": [
-        "dras",
-        "fqdns",
-        "nics",
-        "reprotect"
-      ]
-    },
-    {
-      "filename": "**/sdk/recoveryservices-siterecovery/**/*.cs",
-      "words": [
-        "ahub",
-        "bcdr",
-        "distro",
-        "dras",
-        "esxi",
-        "fqdns",
-        "nics",
-        "orignal",
-        "payg",
-        "reassociate",
-        "reprotect",
-        "seleted",
-        "vcenter",
-        "vcpus",
-        "vmware"
-      ]
-    },
-    {
       "filename": "**/sdk/reservations/**/*.cs",
       "words": [
         "unprovisioning"
-      ]
-    },
-    {
-      "filename": "**/sdk/resourceconnector/Azure.ResourceManager.ResourceConnector/api/*.cs",
-      "words": [
-        "capi",
-        "kvaio",
-        "scvmm"
       ]
     },
     {

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -33,6 +33,7 @@
     "*.sln",
     "*.user",
     ".vscode/cspell.json",
+    "cspell.yaml",
     "assets.json",
     "eng/Packages.Data.props",
     "sdk/confidentialledger/Azure.Security.CodeTransparency/tests/TestFiles/*",
@@ -55,8 +56,7 @@
     "sdk/videoanalyzer/*/api/*.cs",
     "sdk/newrelicobservability/*/api/*.cs",
     "sdk/paloaltonetworks.ngfw/*/api/*.cs",
-    "sdk/servicefabricmanagedclusters/*/api/*.cs",
-    "cspell.yaml"
+    "sdk/servicefabricmanagedclusters/*/api/*.cs"
   ],
   // cspell is not case sensitive
   // Sort words alphabetically to make this list easier to use

--- a/eng/common/spelling/Invoke-Cspell.ps1
+++ b/eng/common/spelling/Invoke-Cspell.ps1
@@ -7,10 +7,8 @@ Invokes cspell using dependencies defined in adjacent ./package*.json
 .PARAMETER JobType
 Maps to cspell command (e.g. `lint`, `trace`, etc.). Default is `lint`
 
-.PARAMETER ScanGlobs
-List of glob expressions to be scanned. This list is not constrained by
-npx/cmd's upper limit on command line length as the globs are inserted into the
-cspell config's `files` property.
+.PARAMETER FileList
+List of file paths to be scanned. This is piped into cspell via stdin.
 
 .PARAMETER CSpellConfigPath
 Location of cspell.json file to use when scanning. Defaults to
@@ -30,19 +28,10 @@ calls to Invoke-Cspell.ps1 to prevent creating multiple working directories and
 redundant calls `npm ci`.
 
 .EXAMPLE
-./eng/common/scripts/Invoke-Cspell.ps1 -ScanGlobs 'sdk/*/*/PublicAPI/**/*.md'
-
-This will run spell check with the given globs
+./eng/common/scripts/Invoke-Cspell.ps1 -FileList @('./README.md', 'file2.txt')
 
 .EXAMPLE
-./eng/common/scripts/Invoke-Cspell.ps1 -ScanGlobs @('sdk/storage/**', 'sdk/keyvault/**')
-
-This will run spell check against multiple globs
-
-.EXAMPLE
-./eng/common/scripts/Invoke-Cspell.ps1 -ScanGlobs './README.md'
-
-This will run spell check against a single file
+git diff main --name-only | ./eng/common/spelling/Invoke-Cspell.ps1
 
 #>
 [CmdletBinding()]
@@ -50,8 +39,8 @@ param(
   [Parameter()]
   [string] $JobType = 'lint',
 
-  [Parameter()]
-  [array]$ScanGlobs = '**',
+  [Parameter(ValueFromPipeline)]
+  [array]$FileList,
 
   [Parameter()]
   [string] $CSpellConfigPath = (Resolve-Path "$PSScriptRoot/../../../.vscode/cspell.json"),
@@ -60,7 +49,7 @@ param(
   [string] $SpellCheckRoot = (Resolve-Path "$PSScriptRoot/../../.."),
 
   [Parameter()]
-  [string] $PackageInstallCache = (Join-Path ([System.IO.Path]::GetTempPath()) "cspell-tool-path"),
+  [string] $PackageInstallCache = (Join-Path ([System.IO.Path]::GetTempPath()) "cspell-tool-path-upgraded"),
 
   [Parameter()]
   [switch] $LeavePackageInstallCache
@@ -92,76 +81,20 @@ if (!(Test-Path "$PackageInstallCache/package-lock.json")) {
   Copy-Item "$PSScriptRoot/package-lock.json" $PackageInstallCache
 }
 
-$deleteNotExcludedFile = $false
-$notExcludedFile = ""
-if (Test-Path "$SpellCheckRoot/LICENSE") {
-  $notExcludedFile = "$SpellCheckRoot/LICENSE"
-} elseif (Test-Path "$SpellCheckRoot/LICENSE.txt") {
-  $notExcludedFile = "$SpellCheckRoot/LICENSE.txt"
-} else {
-  # If there is no LICENSE file, fall back to creating a temporary file
-  # The "files" list must always contain a file which exists, is not empty, and is
-  # not excluded in ignorePaths. In this case it will be a file with the contents
-  # "1" (no spelling errors will be detected)
-  $notExcludedFile = Join-Path $SpellCheckRoot ([System.IO.Path]::GetRandomFileName())
-  "1" >> $notExcludedFile
-  $deleteNotExcludedFile = $true
-}
-$ScanGlobs += $notExcludedFile
+npm --prefix $PackageInstallCache ci | Write-Host
 
-$cspellConfigContent = Get-Content $CSpellConfigPath -Raw
-$cspellConfig = ConvertFrom-Json $cspellConfigContent
-
-# If the config has no "files" property this adds it. If the config has a
-# "files" property this sets the value, overwriting the existing value. In this
-# case, spell checking is only intended to check files from $ScanGlobs so
-# preexisting entries in "files" will be overwritten.
-Add-Member `
-  -MemberType NoteProperty `
-  -InputObject $cspellConfig `
-  -Name "files" `
-  -Value $ScanGlobs `
-  -Force
-
-# Set the temporary config file with the mutated configuration. The temporary
-# location is used to configure the command and the original file remains
-# unchanged.
-Write-Host "Setting config in: $CSpellConfigPath"
-Set-Content `
-  -Path $CSpellConfigPath `
-  -Value (ConvertTo-Json $cspellConfig -Depth 100)
-
-# Before changing the run location, resolve paths specified in parameters
-$CSpellConfigPath = Resolve-Path $CSpellConfigPath
-$SpellCheckRoot = Resolve-Path $SpellCheckRoot
-
-$originalLocation = Get-Location
-
-try {
-  Set-Location $PackageInstallCache
-  npm ci | Write-Host
-
-  # Use the mutated configuration file when calling cspell
-  $command = "npm exec --no -- cspell $JobType --config $CSpellConfigPath --no-must-find-files --root $SpellCheckRoot --relative"
-  Write-Host $command
-  $cspellOutput = npm exec  `
-    --no `
-    -- `
-    cspell `
-    $JobType `
-    --config $CSpellConfigPath `
-    --no-must-find-files `
-    --root $SpellCheckRoot `
-    --relative
-} finally {
-  Set-Location $originalLocation
-
-  Write-Host "cspell run complete, restoring original configuration and removing temp file."
-  Set-Content -Path $CSpellConfigPath -Value $cspellConfigContent -NoNewLine
-
-  if ($deleteNotExcludedFile) {
-    Remove-Item -Path $notExcludedFile
-  }
-}
+$command = "npm --prefix $PackageInstallCache exec --no -- cspell $JobType --config $CSpellConfigPath --no-must-find-files --root $SpellCheckRoot --file-list stdin"
+Write-Host $command
+$cspellOutput = $FileList | npm --prefix $PackageInstallCache `
+  exec  `
+  --no `
+  -- `
+  cspell `
+  $JobType `
+  --config $CSpellConfigPath `
+  --no-must-find-files `
+  --root $SpellCheckRoot `
+  --no-show-suggestions `
+  --file-list stdin
 
 return $cspellOutput

--- a/eng/common/spelling/Invoke-Cspell.ps1
+++ b/eng/common/spelling/Invoke-Cspell.ps1
@@ -7,8 +7,10 @@ Invokes cspell using dependencies defined in adjacent ./package*.json
 .PARAMETER JobType
 Maps to cspell command (e.g. `lint`, `trace`, etc.). Default is `lint`
 
-.PARAMETER FileList
-List of file paths to be scanned. This is piped into cspell via stdin.
+.PARAMETER ScanGlobs
+List of glob expressions to be scanned. This list is not constrained by
+npx/cmd's upper limit on command line length as the globs are inserted into the
+cspell config's `files` property.
 
 .PARAMETER CSpellConfigPath
 Location of cspell.json file to use when scanning. Defaults to
@@ -28,10 +30,19 @@ calls to Invoke-Cspell.ps1 to prevent creating multiple working directories and
 redundant calls `npm ci`.
 
 .EXAMPLE
-./eng/common/scripts/Invoke-Cspell.ps1 -FileList @('./README.md', 'file2.txt')
+./eng/common/scripts/Invoke-Cspell.ps1 -ScanGlobs 'sdk/*/*/PublicAPI/**/*.md'
+
+This will run spell check with the given globs
 
 .EXAMPLE
-git diff main --name-only | ./eng/common/spelling/Invoke-Cspell.ps1
+./eng/common/scripts/Invoke-Cspell.ps1 -ScanGlobs @('sdk/storage/**', 'sdk/keyvault/**')
+
+This will run spell check against multiple globs
+
+.EXAMPLE
+./eng/common/scripts/Invoke-Cspell.ps1 -ScanGlobs './README.md'
+
+This will run spell check against a single file
 
 #>
 [CmdletBinding()]
@@ -39,8 +50,8 @@ param(
   [Parameter()]
   [string] $JobType = 'lint',
 
-  [Parameter(ValueFromPipeline)]
-  [array]$FileList,
+  [Parameter()]
+  [array]$ScanGlobs = '**',
 
   [Parameter()]
   [string] $CSpellConfigPath = (Resolve-Path "$PSScriptRoot/../../../.vscode/cspell.json"),
@@ -49,7 +60,7 @@ param(
   [string] $SpellCheckRoot = (Resolve-Path "$PSScriptRoot/../../.."),
 
   [Parameter()]
-  [string] $PackageInstallCache = (Join-Path ([System.IO.Path]::GetTempPath()) "cspell-tool-path-upgraded"),
+  [string] $PackageInstallCache = (Join-Path ([System.IO.Path]::GetTempPath()) "cspell-tool-path"),
 
   [Parameter()]
   [switch] $LeavePackageInstallCache
@@ -81,20 +92,76 @@ if (!(Test-Path "$PackageInstallCache/package-lock.json")) {
   Copy-Item "$PSScriptRoot/package-lock.json" $PackageInstallCache
 }
 
-npm --prefix $PackageInstallCache ci | Write-Host
+$deleteNotExcludedFile = $false
+$notExcludedFile = ""
+if (Test-Path "$SpellCheckRoot/LICENSE") {
+  $notExcludedFile = "$SpellCheckRoot/LICENSE"
+} elseif (Test-Path "$SpellCheckRoot/LICENSE.txt") {
+  $notExcludedFile = "$SpellCheckRoot/LICENSE.txt"
+} else {
+  # If there is no LICENSE file, fall back to creating a temporary file
+  # The "files" list must always contain a file which exists, is not empty, and is
+  # not excluded in ignorePaths. In this case it will be a file with the contents
+  # "1" (no spelling errors will be detected)
+  $notExcludedFile = Join-Path $SpellCheckRoot ([System.IO.Path]::GetRandomFileName())
+  "1" >> $notExcludedFile
+  $deleteNotExcludedFile = $true
+}
+$ScanGlobs += $notExcludedFile
 
-$command = "npm --prefix $PackageInstallCache exec --no -- cspell $JobType --config $CSpellConfigPath --no-must-find-files --root $SpellCheckRoot --file-list stdin"
-Write-Host $command
-$cspellOutput = $FileList | npm --prefix $PackageInstallCache `
-  exec  `
-  --no `
-  -- `
-  cspell `
-  $JobType `
-  --config $CSpellConfigPath `
-  --no-must-find-files `
-  --root $SpellCheckRoot `
-  --no-show-suggestions `
-  --file-list stdin
+$cspellConfigContent = Get-Content $CSpellConfigPath -Raw
+$cspellConfig = ConvertFrom-Json $cspellConfigContent
+
+# If the config has no "files" property this adds it. If the config has a
+# "files" property this sets the value, overwriting the existing value. In this
+# case, spell checking is only intended to check files from $ScanGlobs so
+# preexisting entries in "files" will be overwritten.
+Add-Member `
+  -MemberType NoteProperty `
+  -InputObject $cspellConfig `
+  -Name "files" `
+  -Value $ScanGlobs `
+  -Force
+
+# Set the temporary config file with the mutated configuration. The temporary
+# location is used to configure the command and the original file remains
+# unchanged.
+Write-Host "Setting config in: $CSpellConfigPath"
+Set-Content `
+  -Path $CSpellConfigPath `
+  -Value (ConvertTo-Json $cspellConfig -Depth 100)
+
+# Before changing the run location, resolve paths specified in parameters
+$CSpellConfigPath = Resolve-Path $CSpellConfigPath
+$SpellCheckRoot = Resolve-Path $SpellCheckRoot
+
+$originalLocation = Get-Location
+
+try {
+  Set-Location $PackageInstallCache
+  npm ci | Write-Host
+
+  # Use the mutated configuration file when calling cspell
+  $command = "npm exec --no -- cspell $JobType --config $CSpellConfigPath --no-must-find-files --root $SpellCheckRoot --relative"
+  Write-Host $command
+  $cspellOutput = npm exec  `
+    --no `
+    -- `
+    cspell `
+    $JobType `
+    --config $CSpellConfigPath `
+    --no-must-find-files `
+    --root $SpellCheckRoot `
+    --relative
+} finally {
+  Set-Location $originalLocation
+
+  Write-Host "cspell run complete, restoring original configuration and removing temp file."
+  Set-Content -Path $CSpellConfigPath -Value $cspellConfigContent -NoNewLine
+
+  if ($deleteNotExcludedFile) {
+    Remove-Item -Path $notExcludedFile
+  }
+}
 
 return $cspellOutput

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -37,9 +37,11 @@ stages:
                 -NupkgFilesDestination 'nupkgFiles'
 
           - pwsh: |
+              $files = Get-ChildItem -Path "sdk/*/*/api/*.cs" -File
+              Write-Host "Found $($files.Count) public API surface files to spell check."
               ."eng/common/spelling/Invoke-Cspell.ps1" `
                 -CSpellConfigPath "./.vscode/cspell.json" `
-                -ScanGlobs "sdk/*/*/api/*.cs"
+                -FileList $files.FullName
             displayName: Check spelling of public API surface
             # Spelling errors in public api surface are not blockers yet but will
             # become blockers when this is rolled out to all services. For now, turn

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -36,10 +36,9 @@ foreach ($file in $apiListingFiles) {
 }
 
 if ($SpellCheckPublicApiSurface) {
-    Write-Host "Spell check public API surface"
-    $files =  Get-ChildItem "sdk/$ServiceDirectory/*/api/*.cs" -File
+    Write-Host "Spell check public API surface (found $($apiListingFiles.Count) files)"
     &"$PSScriptRoot/../common/spelling/Invoke-Cspell.ps1" `
-        -FileList $files.FullName
+        -FileList $apiListingFiles.FullName
 
     if ($LASTEXITCODE) {
         Write-Host "##vso[task.LogIssue type=error;]Spelling errors detected. To correct false positives or learn about spell checking see: https://aka.ms/azsdk/engsys/spellcheck"

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -37,9 +37,9 @@ foreach ($file in $apiListingFiles) {
 
 if ($SpellCheckPublicApiSurface) {
     Write-Host "Spell check public API surface"
+    $files =  Get-ChildItem "sdk/$ServiceDirectory/*/api/*.cs" -File
     &"$PSScriptRoot/../common/spelling/Invoke-Cspell.ps1" `
-        -CSpellConfigPath "$PSScriptRoot/../../.vscode/cspell.json" `
-        -ScanGlobs "sdk/$ServiceDirectory/*/api/*.cs"
+        -FileList $files.FullName
 
     if ($LASTEXITCODE) {
         Write-Host "##vso[task.LogIssue type=error;]Spelling errors detected. To correct false positives or learn about spell checking see: https://aka.ms/azsdk/engsys/spellcheck"

--- a/sdk/connectedvmwarevsphere/cspell.yaml
+++ b/sdk/connectedvmwarevsphere/cspell.yaml
@@ -1,0 +1,27 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/connectedvmwarevsphere/Azure.ResourceManager.ConnectedVMwarevSphere/api/Azure.ResourceManager.ConnectedVMwarevSphere.net8.0.cs'
+    words:
+      - Ctlr
+      - Lsilogic
+      - Lsilogicsas
+      - Mware
+      - Nic
+      - Pcnet
+      - Pmem
+      - Pvscsi
+      - Sesparse
+      - Vm
+  - filename: '**/sdk/connectedvmwarevsphere/Azure.ResourceManager.ConnectedVMwarevSphere/api/Azure.ResourceManager.ConnectedVMwarevSphere.netstandard2.0.cs'
+    words:
+      - Ctlr
+      - Lsilogic
+      - Lsilogicsas
+      - Mware
+      - Nic
+      - Pcnet
+      - Pmem
+      - Pvscsi
+      - Sesparse
+      - Vm

--- a/sdk/connectedvmwarevsphere/cspell.yaml
+++ b/sdk/connectedvmwarevsphere/cspell.yaml
@@ -1,27 +1,18 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/connectedvmwarevsphere/Azure.ResourceManager.ConnectedVMwarevSphere/api/Azure.ResourceManager.ConnectedVMwarevSphere.net8.0.cs'
+  - filename: '**/sdk/connectedvmwarevsphere/**/*'
     words:
-      - Ctlr
-      - Lsilogic
-      - Lsilogicsas
-      - Mware
-      - Nic
-      - Pcnet
-      - Pmem
-      - Pvscsi
-      - Sesparse
-      - Vm
-  - filename: '**/sdk/connectedvmwarevsphere/Azure.ResourceManager.ConnectedVMwarevSphere/api/Azure.ResourceManager.ConnectedVMwarevSphere.netstandard2.0.cs'
-    words:
-      - Ctlr
-      - Lsilogic
-      - Lsilogicsas
-      - Mware
-      - Nic
-      - Pcnet
-      - Pmem
-      - Pvscsi
-      - Sesparse
-      - Vm
+      - cpus
+      - ctlr
+      - lsilogic
+      - lsilogicsas
+      - nic
+      - pcnet
+      - pmem
+      - pvscsi
+      - sesparse
+      - vcenter
+      - vm
+      - vmware
+      - vsphere

--- a/sdk/desktopvirtualization/cspell.yaml
+++ b/sdk/desktopvirtualization/cspell.yaml
@@ -1,0 +1,17 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/api/Azure.ResourceManager.DesktopVirtualization.net8.0.cs'
+    words:
+      - Adfs
+      - Logix
+      - Msix
+      - Redirector
+      - msix
+  - filename: '**/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/api/Azure.ResourceManager.DesktopVirtualization.netstandard2.0.cs'
+    words:
+      - Adfs
+      - Logix
+      - Msix
+      - Redirector
+      - msix

--- a/sdk/desktopvirtualization/cspell.yaml
+++ b/sdk/desktopvirtualization/cspell.yaml
@@ -1,17 +1,10 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/api/Azure.ResourceManager.DesktopVirtualization.net8.0.cs'
+  - filename: '**/sdk/desktopvirtualization/**/*.cs'
     words:
-      - Adfs
-      - Logix
-      - Msix
-      - Redirector
+      - adfs
+      - logix
       - msix
-  - filename: '**/sdk/desktopvirtualization/Azure.ResourceManager.DesktopVirtualization/api/Azure.ResourceManager.DesktopVirtualization.netstandard2.0.cs'
-    words:
-      - Adfs
-      - Logix
-      - Msix
-      - Redirector
       - msix
+      - redirector

--- a/sdk/fleet/cspell.yaml
+++ b/sdk/fleet/cspell.yaml
@@ -1,0 +1,11 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/fleet/Azure.ResourceManager.ContainerServiceFleet/api/Azure.ResourceManager.ContainerServiceFleet.net8.0.cs'
+    words:
+      - Kubeconfigs
+      - kubeconfigs
+  - filename: '**/sdk/fleet/Azure.ResourceManager.ContainerServiceFleet/api/Azure.ResourceManager.ContainerServiceFleet.netstandard2.0.cs'
+    words:
+      - Kubeconfigs
+      - kubeconfigs

--- a/sdk/fleet/cspell.yaml
+++ b/sdk/fleet/cspell.yaml
@@ -3,9 +3,7 @@ import:
 overrides:
   - filename: '**/sdk/fleet/Azure.ResourceManager.ContainerServiceFleet/api/Azure.ResourceManager.ContainerServiceFleet.net8.0.cs'
     words:
-      - Kubeconfigs
       - kubeconfigs
   - filename: '**/sdk/fleet/Azure.ResourceManager.ContainerServiceFleet/api/Azure.ResourceManager.ContainerServiceFleet.netstandard2.0.cs'
     words:
-      - Kubeconfigs
       - kubeconfigs

--- a/sdk/hybridaks/cspell.yaml
+++ b/sdk/hybridaks/cspell.yaml
@@ -1,15 +1,8 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/hybridaks/Azure.ResourceManager.HybridContainerService/api/Azure.ResourceManager.HybridContainerService.net8.0.cs'
+  - filename: '**/sdk/hybridaks/**/*.cs'
     words:
-      - Kubeconfig
-      - Kubeconfigs
-      - Vmip
-      - vmip
-  - filename: '**/sdk/hybridaks/Azure.ResourceManager.HybridContainerService/api/Azure.ResourceManager.HybridContainerService.netstandard2.0.cs'
-    words:
-      - Kubeconfig
-      - Kubeconfigs
-      - Vmip
+      - kubeconfig
+      - kubeconfigs
       - vmip

--- a/sdk/hybridaks/cspell.yaml
+++ b/sdk/hybridaks/cspell.yaml
@@ -1,0 +1,15 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/hybridaks/Azure.ResourceManager.HybridContainerService/api/Azure.ResourceManager.HybridContainerService.net8.0.cs'
+    words:
+      - Kubeconfig
+      - Kubeconfigs
+      - Vmip
+      - vmip
+  - filename: '**/sdk/hybridaks/Azure.ResourceManager.HybridContainerService/api/Azure.ResourceManager.HybridContainerService.netstandard2.0.cs'
+    words:
+      - Kubeconfig
+      - Kubeconfigs
+      - Vmip
+      - vmip

--- a/sdk/postgresql/cspell.yaml
+++ b/sdk/postgresql/cspell.yaml
@@ -1,11 +1,7 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/postgresql/Azure.ResourceManager.PostgreSql/api/Azure.ResourceManager.PostgreSql.net8.0.cs'
+  - filename: '**/sdk/postgresql/**/*.cs'
     words:
-      - AWSEC
-      - Postgre
-  - filename: '**/sdk/postgresql/Azure.ResourceManager.PostgreSql/api/Azure.ResourceManager.PostgreSql.netstandard2.0.cs'
-    words:
-      - AWSEC
-      - Postgre
+      - awsec
+      - postgre

--- a/sdk/postgresql/cspell.yaml
+++ b/sdk/postgresql/cspell.yaml
@@ -1,0 +1,11 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/postgresql/Azure.ResourceManager.PostgreSql/api/Azure.ResourceManager.PostgreSql.net8.0.cs'
+    words:
+      - AWSEC
+      - Postgre
+  - filename: '**/sdk/postgresql/Azure.ResourceManager.PostgreSql/api/Azure.ResourceManager.PostgreSql.netstandard2.0.cs'
+    words:
+      - AWSEC
+      - Postgre

--- a/sdk/provisioning/cspell.yaml
+++ b/sdk/provisioning/cspell.yaml
@@ -1,17 +1,7 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.net8.0.cs'
+  - filename: '**/sdk/provisioning/**/*.cs'
     words:
-      - AWSEC
-      - Postgre
-  - filename: '**/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.netstandard2.0.cs'
-    words:
-      - AWSEC
-      - Postgre
-  - filename: '**/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.net8.0.cs'
-    words:
-      - Mibps
-  - filename: '**/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.netstandard2.0.cs'
-    words:
-      - Mibps
+      - awsec
+      - postgre

--- a/sdk/provisioning/cspell.yaml
+++ b/sdk/provisioning/cspell.yaml
@@ -1,0 +1,17 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.net8.0.cs'
+    words:
+      - AWSEC
+      - Postgre
+  - filename: '**/sdk/provisioning/Azure.Provisioning.PostgreSql/api/Azure.Provisioning.PostgreSql.netstandard2.0.cs'
+    words:
+      - AWSEC
+      - Postgre
+  - filename: '**/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.net8.0.cs'
+    words:
+      - Mibps
+  - filename: '**/sdk/provisioning/Azure.Provisioning.Storage/api/Azure.Provisioning.Storage.netstandard2.0.cs'
+    words:
+      - Mibps

--- a/sdk/recoveryservices-backup/cspell.yaml
+++ b/sdk/recoveryservices-backup/cspell.yaml
@@ -1,19 +1,11 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/recoveryservices-backup/Azure.ResourceManager.RecoveryServicesBackup/api/Azure.ResourceManager.RecoveryServicesBackup.net8.0.cs'
+  - filename: '**/sdk/recoveryservices-backup/**/*.cs'
     words:
-      - Dedup
-      - Kpis
-      - Mware
-      - Xcool
-      - Xsmb
+      - dedup
       - kpis
-  - filename: '**/sdk/recoveryservices-backup/Azure.ResourceManager.RecoveryServicesBackup/api/Azure.ResourceManager.RecoveryServicesBackup.netstandard2.0.cs'
-    words:
-      - Dedup
-      - Kpis
-      - Mware
-      - Xcool
-      - Xsmb
+      - mware
+      - xcool
+      - xsmb
       - kpis

--- a/sdk/recoveryservices-backup/cspell.yaml
+++ b/sdk/recoveryservices-backup/cspell.yaml
@@ -1,0 +1,19 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/recoveryservices-backup/Azure.ResourceManager.RecoveryServicesBackup/api/Azure.ResourceManager.RecoveryServicesBackup.net8.0.cs'
+    words:
+      - Dedup
+      - Kpis
+      - Mware
+      - Xcool
+      - Xsmb
+      - kpis
+  - filename: '**/sdk/recoveryservices-backup/Azure.ResourceManager.RecoveryServicesBackup/api/Azure.ResourceManager.RecoveryServicesBackup.netstandard2.0.cs'
+    words:
+      - Dedup
+      - Kpis
+      - Mware
+      - Xcool
+      - Xsmb
+      - kpis

--- a/sdk/recoveryservices-datareplication/cspell.yaml
+++ b/sdk/recoveryservices-datareplication/cspell.yaml
@@ -1,0 +1,15 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/recoveryservices-datareplication/Azure.ResourceManager.RecoveryServicesDataReplication/api/Azure.ResourceManager.RecoveryServicesDataReplication.net8.0.cs'
+    words:
+      - Mware
+      - Nics
+      - Reprotect
+      - nics
+  - filename: '**/sdk/recoveryservices-datareplication/Azure.ResourceManager.RecoveryServicesDataReplication/api/Azure.ResourceManager.RecoveryServicesDataReplication.netstandard2.0.cs'
+    words:
+      - Mware
+      - Nics
+      - Reprotect
+      - nics

--- a/sdk/recoveryservices-datareplication/cspell.yaml
+++ b/sdk/recoveryservices-datareplication/cspell.yaml
@@ -1,15 +1,9 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/recoveryservices-datareplication/Azure.ResourceManager.RecoveryServicesDataReplication/api/Azure.ResourceManager.RecoveryServicesDataReplication.net8.0.cs'
+  - filename: '**/sdk/recoveryservices-datareplication/**/*.cs'
     words:
-      - Mware
-      - Nics
-      - Reprotect
+      - mware
       - nics
-  - filename: '**/sdk/recoveryservices-datareplication/Azure.ResourceManager.RecoveryServicesDataReplication/api/Azure.ResourceManager.RecoveryServicesDataReplication.netstandard2.0.cs'
-    words:
-      - Mware
-      - Nics
-      - Reprotect
+      - reprotect
       - nics

--- a/sdk/recoveryservices-siterecovery/cspell.yaml
+++ b/sdk/recoveryservices-siterecovery/cspell.yaml
@@ -5,10 +5,7 @@ overrides:
     words:
       - ahub
       - bcdr
-      - bcdr
       - dras
-      - dras
-      - esxi
       - esxi
       - mware
       - nics

--- a/sdk/recoveryservices-siterecovery/cspell.yaml
+++ b/sdk/recoveryservices-siterecovery/cspell.yaml
@@ -1,35 +1,19 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/recoveryservices-siterecovery/Azure.ResourceManager.RecoveryServicesSiteRecovery/api/Azure.ResourceManager.RecoveryServicesSiteRecovery.net8.0.cs'
+  - filename: '**/sdk/recoveryservices-siterecovery/**/*.cs'
     words:
-      - Ahub
-      - Bcdr
-      - Dras
-      - Esxi
-      - Mware
-      - Nics
-      - Orignal
-      - Payg
-      - Reassociate
-      - Reprotect
-      - Seleted
+      - ahub
+      - bcdr
       - bcdr
       - dras
-      - esxi
-  - filename: '**/sdk/recoveryservices-siterecovery/Azure.ResourceManager.RecoveryServicesSiteRecovery/api/Azure.ResourceManager.RecoveryServicesSiteRecovery.netstandard2.0.cs'
-    words:
-      - Ahub
-      - Bcdr
-      - Dras
-      - Esxi
-      - Mware
-      - Nics
-      - Orignal
-      - Payg
-      - Reassociate
-      - Reprotect
-      - Seleted
-      - bcdr
       - dras
       - esxi
+      - esxi
+      - mware
+      - nics
+      - orignal
+      - payg
+      - reassociate
+      - reprotect
+      - seleted

--- a/sdk/recoveryservices-siterecovery/cspell.yaml
+++ b/sdk/recoveryservices-siterecovery/cspell.yaml
@@ -1,0 +1,35 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/recoveryservices-siterecovery/Azure.ResourceManager.RecoveryServicesSiteRecovery/api/Azure.ResourceManager.RecoveryServicesSiteRecovery.net8.0.cs'
+    words:
+      - Ahub
+      - Bcdr
+      - Dras
+      - Esxi
+      - Mware
+      - Nics
+      - Orignal
+      - Payg
+      - Reassociate
+      - Reprotect
+      - Seleted
+      - bcdr
+      - dras
+      - esxi
+  - filename: '**/sdk/recoveryservices-siterecovery/Azure.ResourceManager.RecoveryServicesSiteRecovery/api/Azure.ResourceManager.RecoveryServicesSiteRecovery.netstandard2.0.cs'
+    words:
+      - Ahub
+      - Bcdr
+      - Dras
+      - Esxi
+      - Mware
+      - Nics
+      - Orignal
+      - Payg
+      - Reassociate
+      - Reprotect
+      - Seleted
+      - bcdr
+      - dras
+      - esxi

--- a/sdk/resourceconnector/cspell.yaml
+++ b/sdk/resourceconnector/cspell.yaml
@@ -1,19 +1,10 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/resourceconnector/Azure.ResourceManager.ResourceConnector/api/Azure.ResourceManager.ResourceConnector.net8.0.cs'
+  - filename: '**/sdk/resourceconnector/Azure.ResourceManager.ResourceConnector/api/*.cs'
     words:
-      - Capi
-      - Kubeconfig
-      - Kubeconfigs
-      - Kvaio
-      - Scvmm
+      - capi
+      - kubeconfig
       - kubeconfigs
-  - filename: '**/sdk/resourceconnector/Azure.ResourceManager.ResourceConnector/api/Azure.ResourceManager.ResourceConnector.netstandard2.0.cs'
-    words:
-      - Capi
-      - Kubeconfig
-      - Kubeconfigs
-      - Kvaio
-      - Scvmm
-      - kubeconfigs
+      - kvaio
+      - scvmm

--- a/sdk/resourceconnector/cspell.yaml
+++ b/sdk/resourceconnector/cspell.yaml
@@ -1,0 +1,19 @@
+import:
+  - ../../.vscode/cspell.json
+overrides:
+  - filename: '**/sdk/resourceconnector/Azure.ResourceManager.ResourceConnector/api/Azure.ResourceManager.ResourceConnector.net8.0.cs'
+    words:
+      - Capi
+      - Kubeconfig
+      - Kubeconfigs
+      - Kvaio
+      - Scvmm
+      - kubeconfigs
+  - filename: '**/sdk/resourceconnector/Azure.ResourceManager.ResourceConnector/api/Azure.ResourceManager.ResourceConnector.netstandard2.0.cs'
+    words:
+      - Capi
+      - Kubeconfig
+      - Kubeconfigs
+      - Kvaio
+      - Scvmm
+      - kubeconfigs


### PR DESCRIPTION
> [!WARNING]
> Service owners be advised: This is part of an update to cspell. For services that have spelling error detections in the new cspell version, I've moved service-specific overrides out of `.vscode/cspell.json` and into a `<service>/cspell.yaml` and added the new detected words .. Now you have more control over setting spelling overrides for your service.

Partial https://github.com/Azure/azure-sdk-tools/issues/9479

Once https://github.com/Azure/azure-sdk-tools/pull/12569 merges this will pass CI.

Updates scripts and configs for new cspell version baseline.

Example PR blocked by spelling error: https://dev.azure.com/azure-sdk/public/public%20Team/_build/results?buildId=5508171&view=logs&j=c3e74943-23a9-5e82-9b42-8286fce989d4&t=e049197e-d864-58b1-c0e9-38458fd26878&l=1078
Example release blocked by spelling error: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5508175&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=c9190431-7417-53a5-3fc1-7c7e026cd79d

Example release build with no spelling error: https://dev.azure.com/azure-sdk/internal/internal%20Team/_build/results?buildId=5508526&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=c9190431-7417-53a5-3fc1-7c7e026cd79d&l=831 (build failed, but that should be unrelated to spell checking)
Example PR build with no spelling error: https://dev.azure.com/azure-sdk/public/_build/results?buildId=5508525&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=bc67675d-56bf-581f-e0a2-208848ba68ca (failed because of eng/common changes needed to do testing)
