### PR TITLE
[CODEOWNERS] Fix linter errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -380,7 +380,7 @@
 /sdk/containerregistry/                                            @Azure/azsdk-acr
 
 # ServiceLabel: %Container Registry
-# ServiceOwners:                                                   @toddysm @shizhMSFT
+# ServiceOwners:                                                   @toddysm @Azure/azsdk-acr
 
 # ServiceLabel: %Container Service
 # ServiceOwners:                                                   @qike-ms @jwilder @thomas1206 @seanmck


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner flagged by the linter as no longer valid.

## References and resources

- [Linter failure](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5501903&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_