### PR TITLE
[Storage] [Webjobs] Bumping date in changelog for WebJobs 5.3.7 release

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.3.7 (2025-10-29)
+## 5.3.7 (2025-10-30)
 
 ### Other Changes
 - The following optimizations were added to Blob Trigger processing:

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.3.7 (2025-10-29)
+## 5.3.7 (2025-10-30)
 
 ### Other Changes
 - This release contains bug fixes to improve quality.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 5.3.7 (2025-10-29)
+## 5.3.7 (2025-10-30)
 
 ### Other Changes
 Please refer to [`Microsoft.Azure.WebJobs.Extension.Storage.Blobs`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Blobs/CHANGELOG.md) and [`Microsoft.Azure.WebJobs.Extension.Storage.Queues`](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md) for detailed list of changes.


### PR DESCRIPTION
Bumping date in case that we are not able to release on 10/29.

(Do not merge until we confirm pipelines are running)