### PR TITLE
[azsdk-cli] Add script override config for azsdk cli/mcp

### DIFF
--- a/eng/azsdk-cli-command-overrides.json
+++ b/eng/azsdk-cli-command-overrides.json
@@ -1,0 +1,8 @@
+// This config file enables the azsdk cli/mcp tool to call script overrides for various operations
+// See https://github.com/azure/azure-sdk-tools/blob/main/tools/azsdk-cli/docs/specs/7-repo-tooling-contract.md
+[
+  {
+    "tags": [ "CodeChecks" ],
+    "command": "eng/scripts/CodeChecks.ps1"
+  }
+]


### PR DESCRIPTION
Adding the corresponding config to pair with https://github.com/Azure/azure-sdk-tools/pull/12696

Specifically, the dotnet language check service from `azsdk` calls the `CodeChecks.ps1` script, so this config is required to support https://github.com/Azure/azure-sdk-tools/pull/12696

FYI @m-redding 