### PR TITLE
fix cspell in provisioning projects

### DIFF
--- a/sdk/provisioning/cspell.yaml
+++ b/sdk/provisioning/cspell.yaml
@@ -1,7 +1,28 @@
 import:
   - ../../.vscode/cspell.json
 overrides:
-  - filename: '**/sdk/provisioning/**/*.cs'
+  - filename: '**/sdk/provisioning/Azure.Provisioning.Kusto/**/*.cs'
+    words:
+      - apacheavro
+      - openai
+      - scsv
+      - sohsv
+      - tbps
+      - tsve
+  - filename: '**/sdk/provisioning/Azure.Provisioning.PostgreSql/**/*.cs'
     words:
       - awsec
-      - postgre
+  - filename: '**/sdk/provisioning/Azure.Provisioning.Sql/**/*.cs'
+    words:
+      - freemium
+  - filename: '**/sdk/provisioning/Azure.Provisioning.Storage/**/*.cs'
+    words:
+      - mibps
+  - filename: '**/sdk/provisioning/Azure.Provisioning.Network/**/*.cs'
+    words:
+      - dscp
+      - fqdns
+      - ipam
+      - snat
+      - vnets
+      - vxlan


### PR DESCRIPTION
[This PR](https://github.com/Azure/azure-sdk-for-net/pull/53501) changed the structure of cspell, but some words are no longer there, therefore we notice in some other PRs, provisioning libraries now have spell check issues.
This PR is fixing this issue.