### PR TITLE
Agents v2 (branch-to-branch): basic e2e support for structured inputs; restored workflow (now yaml) support

### DIFF
--- a/sdk/ai/Azure.AI.Agents/api/Azure.AI.Agents.net8.0.cs
+++ b/sdk/ai/Azure.AI.Agents/api/Azure.AI.Agents.net8.0.cs
@@ -774,7 +774,7 @@ namespace Azure.AI.Agents
         public static Azure.AI.Agents.ToolArgumentBinding ToolArgumentBinding(string toolName = null, string argumentName = null) { throw null; }
         public static Azure.AI.Agents.ToolProjectConnection ToolProjectConnection(string projectConnectionId = null) { throw null; }
         public static Azure.AI.Agents.UserProfileMemoryItem UserProfileMemoryItem(string memoryId = null, System.DateTimeOffset updatedAt = default(System.DateTimeOffset), string scope = null, string content = null) { throw null; }
-        public static Azure.AI.Agents.WorkflowAgentDefinition WorkflowAgentDefinition(Azure.AI.Agents.RaiConfig raiConfig = null, string workflow = null) { throw null; }
+        public static Azure.AI.Agents.WorkflowAgentDefinition WorkflowAgentDefinition(Azure.AI.Agents.RaiConfig raiConfig = null, string workflowYaml = null) { throw null; }
     }
     public partial class AzureAISearchAgentTool : Azure.AI.Agents.AgentTool, System.ClientModel.Primitives.IJsonModel<Azure.AI.Agents.AzureAISearchAgentTool>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.Agents.AzureAISearchAgentTool>
     {
@@ -1797,12 +1797,14 @@ namespace Azure.AI.Agents
     }
     public static partial class ResponseCreationOptionsExtensions
     {
+        public static void AddStructuredInput(this OpenAI.Responses.ResponseCreationOptions options, string key, string value) { }
         public static void SetAgentReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, Azure.AI.Agents.AgentRecord agentObject, string version = null) { }
         public static void SetAgentReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, Azure.AI.Agents.AgentReference agentReference) { }
         public static void SetAgentReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, Azure.AI.Agents.AgentVersion agentVersion) { }
         public static void SetAgentReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, string agentName, string version = null) { }
         public static void SetConversationReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, Azure.AI.Agents.AgentConversation conversation) { }
         public static void SetConversationReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, string conversationId) { }
+        public static void SetStructuredInputs(this OpenAI.Responses.ResponseCreationOptions options, System.BinaryData structuredInputsBytes) { }
     }
     public static partial class ResponseItemExtensions
     {
@@ -1920,8 +1922,7 @@ namespace Azure.AI.Agents
     public partial class WorkflowAgentDefinition : Azure.AI.Agents.AgentDefinition, System.ClientModel.Primitives.IJsonModel<Azure.AI.Agents.WorkflowAgentDefinition>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.Agents.WorkflowAgentDefinition>
     {
         public WorkflowAgentDefinition() { }
-        public System.BinaryData TriggerBytes { get { throw null; } set { } }
-        public string Workflow { get { throw null; } set { } }
+        public static Azure.AI.Agents.WorkflowAgentDefinition FromYaml(string workflowYamlDocument) { throw null; }
         protected override Azure.AI.Agents.AgentDefinition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         protected override Azure.AI.Agents.AgentDefinition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/ai/Azure.AI.Agents/api/Azure.AI.Agents.netstandard2.0.cs
+++ b/sdk/ai/Azure.AI.Agents/api/Azure.AI.Agents.netstandard2.0.cs
@@ -774,7 +774,7 @@ namespace Azure.AI.Agents
         public static Azure.AI.Agents.ToolArgumentBinding ToolArgumentBinding(string toolName = null, string argumentName = null) { throw null; }
         public static Azure.AI.Agents.ToolProjectConnection ToolProjectConnection(string projectConnectionId = null) { throw null; }
         public static Azure.AI.Agents.UserProfileMemoryItem UserProfileMemoryItem(string memoryId = null, System.DateTimeOffset updatedAt = default(System.DateTimeOffset), string scope = null, string content = null) { throw null; }
-        public static Azure.AI.Agents.WorkflowAgentDefinition WorkflowAgentDefinition(Azure.AI.Agents.RaiConfig raiConfig = null, string workflow = null) { throw null; }
+        public static Azure.AI.Agents.WorkflowAgentDefinition WorkflowAgentDefinition(Azure.AI.Agents.RaiConfig raiConfig = null, string workflowYaml = null) { throw null; }
     }
     public partial class AzureAISearchAgentTool : Azure.AI.Agents.AgentTool, System.ClientModel.Primitives.IJsonModel<Azure.AI.Agents.AzureAISearchAgentTool>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.Agents.AzureAISearchAgentTool>
     {
@@ -1797,12 +1797,14 @@ namespace Azure.AI.Agents
     }
     public static partial class ResponseCreationOptionsExtensions
     {
+        public static void AddStructuredInput(this OpenAI.Responses.ResponseCreationOptions options, string key, string value) { }
         public static void SetAgentReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, Azure.AI.Agents.AgentRecord agentObject, string version = null) { }
         public static void SetAgentReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, Azure.AI.Agents.AgentReference agentReference) { }
         public static void SetAgentReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, Azure.AI.Agents.AgentVersion agentVersion) { }
         public static void SetAgentReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, string agentName, string version = null) { }
         public static void SetConversationReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, Azure.AI.Agents.AgentConversation conversation) { }
         public static void SetConversationReference(this OpenAI.Responses.ResponseCreationOptions responseCreationOptions, string conversationId) { }
+        public static void SetStructuredInputs(this OpenAI.Responses.ResponseCreationOptions options, System.BinaryData structuredInputsBytes) { }
     }
     public static partial class ResponseItemExtensions
     {
@@ -1920,8 +1922,7 @@ namespace Azure.AI.Agents
     public partial class WorkflowAgentDefinition : Azure.AI.Agents.AgentDefinition, System.ClientModel.Primitives.IJsonModel<Azure.AI.Agents.WorkflowAgentDefinition>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.Agents.WorkflowAgentDefinition>
     {
         public WorkflowAgentDefinition() { }
-        public System.BinaryData TriggerBytes { get { throw null; } set { } }
-        public string Workflow { get { throw null; } set { } }
+        public static Azure.AI.Agents.WorkflowAgentDefinition FromYaml(string workflowYamlDocument) { throw null; }
         protected override Azure.AI.Agents.AgentDefinition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
         protected override Azure.AI.Agents.AgentDefinition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }

--- a/sdk/ai/Azure.AI.Agents/assets.json
+++ b/sdk/ai/Azure.AI.Agents/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/ai/Azure.AI.Agents",
-  "Tag": "net/ai/Azure.AI.Agents_40ad414f20"
+  "Tag": "net/ai/Azure.AI.Agents_b72fcc1965"
 }

--- a/sdk/ai/Azure.AI.Agents/src/Custom/OpenAIFileExtensions.cs
+++ b/sdk/ai/Azure.AI.Agents/src/Custom/OpenAIFileExtensions.cs
@@ -13,7 +13,7 @@ public static partial class OpenAIFileExtensions
 {
     public static string GetAzureFileStatus(this OpenAIFile file)
     {
-        if (AdditionalPropertyHelpers.GetAdditionalProperty<OpenAIFile, string>(file, "_sdk_status") is string extraStatusValue
+        if (file.TryGetAdditionalProperty("_sdk_status", out string extraStatusValue)
             && extraStatusValue.Length > 2)
         {
             return extraStatusValue.Substring(1, extraStatusValue.Length - 2);

--- a/sdk/ai/Azure.AI.Agents/src/Custom/ResponseCreationOptionsExtensions.cs
+++ b/sdk/ai/Azure.AI.Agents/src/Custom/ResponseCreationOptionsExtensions.cs
@@ -4,9 +4,8 @@
 #nullable disable
 
 using System;
-using System.ClientModel.Primitives;
 using System.Collections.Generic;
-using System.Reflection;
+using System.Text.Json.Nodes;
 using OpenAI.Responses;
 
 #pragma warning disable OPENAI001
@@ -22,9 +21,9 @@ public static partial class ResponseCreationOptionsExtensions
     /// <param name="agentReference"></param>
     public static void SetAgentReference(this ResponseCreationOptions responseCreationOptions, AgentReference agentReference)
     {
-        AdditionalPropertyHelpers.SetAdditionalProperty(responseCreationOptions, "agent", agentReference);
+        responseCreationOptions.SetAdditionalProperty("agent", agentReference);
         // Agent specification is mutually exclusive with model specification; see internal issue 4770700
-        AdditionalPropertyHelpers.SetAdditionalProperty(responseCreationOptions, "model", BinaryData.FromBytes("\"__EMPTY__\""u8.ToArray()));
+        responseCreationOptions.SetAdditionalProperty("model", BinaryData.FromBytes("\"__EMPTY__\""u8.ToArray()));
     }
 
     /// <summary>
@@ -72,4 +71,19 @@ public static partial class ResponseCreationOptionsExtensions
     /// <param name="conversation"></param>
     public static void SetConversationReference(this ResponseCreationOptions responseCreationOptions, AgentConversation conversation)
         => SetConversationReference(responseCreationOptions, conversation.Id);
+
+    public static void AddStructuredInput(this ResponseCreationOptions options, string key, string value)
+    {
+        IDictionary<string, BinaryData> structuredInputs
+            = options.TryGetAdditionalProperty("structured_inputs", out IDictionary<string, BinaryData> existingDictionary)
+                ? existingDictionary
+                : new ChangeTrackingDictionary<string, BinaryData>();
+        structuredInputs[key] = BinaryData.FromString(JsonValue.Create(value).ToJsonString());
+        options.SetAdditionalProperty("structured_inputs", structuredInputs);
+    }
+
+    public static void SetStructuredInputs(this ResponseCreationOptions options, BinaryData structuredInputsBytes)
+    {
+        options.SetAdditionalProperty("structured_inputs", structuredInputsBytes);
+    }
 }

--- a/sdk/ai/Azure.AI.Agents/src/Custom/WorkflowAgentDefinition.cs
+++ b/sdk/ai/Azure.AI.Agents/src/Custom/WorkflowAgentDefinition.cs
@@ -3,15 +3,19 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Text.Json;
-
 namespace Azure.AI.Agents;
 
 [CodeGenType("WorkflowDefinition")]
 public partial class WorkflowAgentDefinition
 {
-    [CodeGenMember("Trigger")]
-    public BinaryData TriggerBytes { get; set; }
+    public static WorkflowAgentDefinition FromYaml(string workflowYamlDocument)
+    {
+        return new()
+        {
+            WorkflowYaml = workflowYamlDocument,
+        };
+    }
+
+    [CodeGenMember("Workflow")]
+    private string WorkflowYaml { get; set; }
 }

--- a/sdk/ai/Azure.AI.Agents/src/Generated/AzureAIAgentsModelFactory.cs
+++ b/sdk/ai/Azure.AI.Agents/src/Generated/AzureAIAgentsModelFactory.cs
@@ -84,11 +84,11 @@ namespace Azure.AI.Agents
 
         /// <summary> The workflow specification in CSDL format. </summary>
         /// <param name="raiConfig"> Configuration for Responsible AI (RAI) content filtering and safety features. </param>
-        /// <param name="workflow"> The CSDL YAML definition of the workflow. </param>
+        /// <param name="workflowYaml"> The CSDL YAML definition of the workflow. </param>
         /// <returns> A new <see cref="Agents.WorkflowAgentDefinition"/> instance for mocking. </returns>
-        public static WorkflowAgentDefinition WorkflowAgentDefinition(RaiConfig raiConfig = default, string workflow = default)
+        public static WorkflowAgentDefinition WorkflowAgentDefinition(RaiConfig raiConfig = default, string workflowYaml = default)
         {
-            return new WorkflowAgentDefinition(AgentKind.Workflow, raiConfig, additionalBinaryDataProperties: null, workflow);
+            return new WorkflowAgentDefinition(AgentKind.Workflow, raiConfig, additionalBinaryDataProperties: null, workflowYaml);
         }
 
         /// <summary> The hosted agent definition. </summary>

--- a/sdk/ai/Azure.AI.Agents/src/Generated/Models/WorkflowAgentDefinition.Serialization.cs
+++ b/sdk/ai/Azure.AI.Agents/src/Generated/Models/WorkflowAgentDefinition.Serialization.cs
@@ -31,10 +31,10 @@ namespace Azure.AI.Agents
                 throw new FormatException($"The model {nameof(WorkflowAgentDefinition)} does not support writing '{format}' format.");
             }
             base.JsonModelWriteCore(writer, options);
-            if (Optional.IsDefined(Workflow))
+            if (Optional.IsDefined(WorkflowYaml))
             {
                 writer.WritePropertyName("workflow"u8);
-                writer.WriteStringValue(Workflow);
+                writer.WriteStringValue(WorkflowYaml);
             }
         }
 
@@ -66,7 +66,7 @@ namespace Azure.AI.Agents
             AgentKind kind = default;
             RaiConfig raiConfig = default;
             IDictionary<string, BinaryData> additionalBinaryDataProperties = new ChangeTrackingDictionary<string, BinaryData>();
-            string workflow = default;
+            string workflowYaml = default;
             foreach (var prop in element.EnumerateObject())
             {
                 if (prop.NameEquals("kind"u8))
@@ -85,7 +85,7 @@ namespace Azure.AI.Agents
                 }
                 if (prop.NameEquals("workflow"u8))
                 {
-                    workflow = prop.Value.GetString();
+                    workflowYaml = prop.Value.GetString();
                     continue;
                 }
                 if (options.Format != "W")
@@ -93,7 +93,7 @@ namespace Azure.AI.Agents
                     additionalBinaryDataProperties.Add(prop.Name, BinaryData.FromString(prop.Value.GetRawText()));
                 }
             }
-            return new WorkflowAgentDefinition(kind, raiConfig, additionalBinaryDataProperties, workflow);
+            return new WorkflowAgentDefinition(kind, raiConfig, additionalBinaryDataProperties, workflowYaml);
         }
 
         /// <param name="options"> The client options for reading and writing models. </param>

--- a/sdk/ai/Azure.AI.Agents/src/Generated/Models/WorkflowAgentDefinition.cs
+++ b/sdk/ai/Azure.AI.Agents/src/Generated/Models/WorkflowAgentDefinition.cs
@@ -19,13 +19,10 @@ namespace Azure.AI.Agents
         /// <param name="kind"></param>
         /// <param name="raiConfig"> Configuration for Responsible AI (RAI) content filtering and safety features. </param>
         /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="workflow"> The CSDL YAML definition of the workflow. </param>
-        internal WorkflowAgentDefinition(AgentKind kind, RaiConfig raiConfig, IDictionary<string, BinaryData> additionalBinaryDataProperties, string workflow) : base(kind, raiConfig, additionalBinaryDataProperties)
+        /// <param name="workflowYaml"> The CSDL YAML definition of the workflow. </param>
+        internal WorkflowAgentDefinition(AgentKind kind, RaiConfig raiConfig, IDictionary<string, BinaryData> additionalBinaryDataProperties, string workflowYaml) : base(kind, raiConfig, additionalBinaryDataProperties)
         {
-            Workflow = workflow;
+            WorkflowYaml = workflowYaml;
         }
-
-        /// <summary> The CSDL YAML definition of the workflow. </summary>
-        public string Workflow { get; set; }
     }
 }


### PR DESCRIPTION
- Adds two extension methods for `ResponseCreationOptions`:
  - `AddStructuredInput(string, string)` will add or set a single, simple key/value string/string pair for a structured input (this is a common case)
  - `SetStructuredInputs(BinaryData)` will set or replace any existing structured_inputs with the verbatim data provided, allowing direct JSON and arbitrary complexity when needed

- Removes the old `TriggerBytes` from `WorkflowAgentDefinition` and adds a `WorkflowAgentDefinition.FromYaml(string)` factory method

- Restores several disabled tests that now work

- `AdditionalPropertyHelpers` gains significant complexity to support dictionary manipulation; this is *very* temporary (when OpenAI gets AdditionalProperties in, this goes first thing)
  - This support is very certainly *not* robust to all potential reuse cases, either; it's special-cased for what's being done right now