### PR TITLE
[CODEOWNERS] Fix linter failures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -818,30 +818,6 @@
 # ServiceLabel: %SignalR
 # ServiceOwners:                                                   @chenkennt @vicancy @JialinXin @Y-Sindo
 
-# PRLabel: %SQL
-/sdk/sqlmanagement/                                                @ericshape @jeremyfrosti
-
-# ServiceLabel: %SQL
-# ServiceOwners:                                                   @ericshape @jeremyfrosti
-
-# ServiceLabel: %SQL - Backup & Restore
-# ServiceOwners:                                                   @ericshape @jeremyfrosti
-
-# ServiceLabel: %SQL - Data Security
-# ServiceOwners:                                                   @ericshape @jeremyfrosti
-
-# ServiceLabel: %SQL - Elastic Jobs
-# ServiceOwners:                                                   @ericshape @jeremyfrosti
-
-# ServiceLabel: %SQL - Managed Instance
-# ServiceOwners:                                                   @ericshape @jeremyfrosti
-
-# ServiceLabel: %SQL - Replication & Failover
-# ServiceOwners:                                                   @ericshape @jeremyfrosti
-
-# ServiceLabel: %SQL - VM
-# ServiceOwners:                                                   @ericshape @jeremyfrosti
-
 # PRLabel: %Storage
 /sdk/storage*/                                                     @seanmcc-msft @amnguye @jaschrep-msft @jalauzon-msft @nickliu-msft
 
@@ -1144,14 +1120,38 @@
 # PRLabel: %Service Fabric
 /sdk/servicefabric/Azure.ResourceManager.*/                        @QingChenmsft @vaishnavk @juhacket
 
-# ServiceLabel: %Service Fabric
+# ServiceLabel: %Service Fabric %Mgmt
 # ServiceOwners:                                                   @QingChenmsft @vaishnavk @juhacket
 
 # PRLabel: %SiteManager
-/sdk/sitemanager/Azure.ResourceManager.*/                          @bsomeshekar
+/sdk/sitemanager/Azure.ResourceManager.*/                          @bsomeshekar @ArcturusZhang @ArthurMa1978
 
 # ServiceLabel: %SiteManager %Mgmt
-# ServiceOwners:                                                   @bsomeshekar
+# ServiceOwners:                                                   @bsomeshekar @ArcturusZhang @ArthurMa1978
+
+# PRLabel: %SQL
+/sdk/sqlmanagement/                                                @ericshape @ArcturusZhang @ArthurMa1978
+
+# ServiceLabel: %SQL %Mgmt
+# ServiceOwners:                                                   @ericshape
+
+# ServiceLabel: %SQL - Backup & Restore %Mgmt
+# ServiceOwners:                                                   @ericshape
+
+# ServiceLabel: %SQL - Data Security %Mgmt
+# ServiceOwners:                                                   @ericshape
+
+# ServiceLabel: %SQL - Elastic Jobs %Mgmt
+# ServiceOwners:                                                   @ericshape
+
+# ServiceLabel: %SQL - Managed Instance %Mgmt
+# ServiceOwners:                                                   @ericshape
+
+# ServiceLabel: %SQL - Replication & Failover %Mgmt
+# ServiceOwners:                                                   @ericshape
+
+# ServiceLabel: %SQL - VM %Mgmt
+# ServiceOwners:                                                   @ericshape
 
 # ServiceLabel: %Virtual Enclaves %Mgmt
 # ServiceOwners:                                                   @jchavaherrera


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner recently flagged by the linter as no longer being invalid.  As part of this change, several entries for management packages were moved to the appropriate location in the file.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/public%20Team/_build/results?buildId=5527455&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4&l=17) _(Microsoft internal)_