### PR TITLE
Add ClientRequestId requestapi impl & bump to 1.0.0-alpha.20251103.8 

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -473,7 +473,7 @@
 
   <PropertyGroup>
     <TestProxyVersion>1.0.0-dev.20250930.1</TestProxyVersion>
-    <UnbrandedGeneratorVersion>1.0.0-alpha.20251103.3</UnbrandedGeneratorVersion>
+    <UnbrandedGeneratorVersion>1.0.0-alpha.20251103.8</UnbrandedGeneratorVersion>
     <AzureGeneratorVersion>1.0.0-alpha.20251022.3</AzureGeneratorVersion>
   </PropertyGroup>
 </Project>

--- a/eng/http-client-csharp-emitter-package-lock.json
+++ b/eng/http-client-csharp-emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20251103.3",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20251103.8",
         "client-plugin": "file:../../../../eng/packages/plugins/client"
       },
       "devDependencies": {
@@ -607,9 +607,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20251103.3",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20251103.3.tgz",
-      "integrity": "sha512-VTgF/B4KfJKLnXgVfBFjxSAzBKumyd6aIvVi0z2dXQmAIYR9UYp4JQw9DNCvt/ItDwodMwQLso96m+euOMbaMw==",
+      "version": "1.0.0-alpha.20251103.8",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20251103.8.tgz",
+      "integrity": "sha512-axVV4R4LSIRHl8Cczg93XQDmHEzTAlgWk/X40B9oNIT8TfHqDa1qIeyGG5OPcAh0sbrtOc5VNqb1LPmKQn765Q==",
       "license": "MIT",
       "peerDependencies": {
         "@azure-tools/typespec-client-generator-core": ">=0.61.0 < 0.62.0 || ~0.62.0-0",

--- a/eng/http-client-csharp-emitter-package.json
+++ b/eng/http-client-csharp-emitter-package.json
@@ -2,7 +2,7 @@
   "main": "dist/src/index.js",
   "dependencies": {
     "client-plugin": "file:../../../../eng/packages/plugins/client",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20251103.3"
+    "@typespec/http-client-csharp": "1.0.0-alpha.20251103.8"
   },
   "devDependencies": {
     "@azure-tools/typespec-client-generator-core": "0.61.0",

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/Abstraction/HttpRequestProvider.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/Abstraction/HttpRequestProvider.cs
@@ -4,10 +4,10 @@
 using Azure.Core;
 using Microsoft.TypeSpec.Generator.ClientModel.Providers;
 using Microsoft.TypeSpec.Generator.Expressions;
+using Microsoft.TypeSpec.Generator.Snippets;
 using Microsoft.TypeSpec.Generator.Statements;
 using System;
 using System.Collections.Generic;
-using Microsoft.TypeSpec.Generator.Snippets;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Providers
@@ -28,6 +28,9 @@ namespace Azure.Generator.Providers
 
         public override HttpRequestApi FromExpression(ValueExpression original)
             => new HttpRequestProvider(original);
+
+        public override ValueExpression ClientRequestId()
+            => Original.Property(nameof(Request.ClientRequestId));
 
         public override MethodBodyStatement SetHeaders(IReadOnlyList<ValueExpression> arguments)
             => Original.Property(nameof(Request.Headers)).Invoke(nameof(RequestHeaders.SetValue), arguments).Terminate();

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/RequestClientIdHeaderVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/RequestClientIdHeaderVisitor.cs
@@ -46,7 +46,7 @@ namespace Azure.Generator.Visitors
                 var newStatements = new List<MethodBodyStatement>(originalBodyStatements[..^1]);
 
                 // Find the request variable
-                VariableExpression? requestVariable = null;
+                HttpRequestApi? requestVariable = null;
                 foreach (var statement in newStatements)
                 {
                     if (statement is ExpressionStatement
@@ -57,7 +57,7 @@ namespace Azure.Generator.Visitors
                         var variable = declaration.Variable;
                         if (variable.Type.Equals(variable.ToApi<HttpRequestApi>().Type))
                         {
-                            requestVariable = variable;
+                            requestVariable = variable.ToApi<HttpRequestApi>();
                         }
                     }
                 }
@@ -67,7 +67,7 @@ namespace Azure.Generator.Visitors
                     // Set the client-request-id header
                     newStatements.Add(requestVariable.As<Request>().SetHeaderValue(
                         clientRequestIdParameter.SerializedName,
-                        requestVariable.Property(nameof(Request.ClientRequestId))));
+                        requestVariable.ClientRequestId()));
                 }
 
                 // Add the return statement back

--- a/eng/packages/http-client-csharp/package-lock.json
+++ b/eng/packages/http-client-csharp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20251103.3"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20251103.8"
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.30",
@@ -2791,9 +2791,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20251103.3",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20251103.3.tgz",
-      "integrity": "sha512-VTgF/B4KfJKLnXgVfBFjxSAzBKumyd6aIvVi0z2dXQmAIYR9UYp4JQw9DNCvt/ItDwodMwQLso96m+euOMbaMw==",
+      "version": "1.0.0-alpha.20251103.8",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20251103.8.tgz",
+      "integrity": "sha512-axVV4R4LSIRHl8Cczg93XQDmHEzTAlgWk/X40B9oNIT8TfHqDa1qIeyGG5OPcAh0sbrtOc5VNqb1LPmKQn765Q==",
       "license": "MIT",
       "peerDependencies": {
         "@azure-tools/typespec-client-generator-core": ">=0.61.0 < 0.62.0 || ~0.62.0-0",

--- a/eng/packages/http-client-csharp/package.json
+++ b/eng/packages/http-client-csharp/package.json
@@ -38,7 +38,7 @@
     "dist/generator/**"
   ],
   "dependencies": {
-    "@typespec/http-client-csharp": "1.0.0-alpha.20251103.3"
+    "@typespec/http-client-csharp": "1.0.0-alpha.20251103.8"
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.30",


### PR DESCRIPTION
This PR bumps the emitter to 1.0.0-alpha.20251103.8 and adds the implementation for the request abstraction's `ClientRequestId`.

fixes: https://github.com/microsoft/typespec/issues/8911