### PR TITLE
Support Event in DocumentStream

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
@@ -271,6 +271,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                     case TelemetryType.Trace:
                         AddMetric(metricInfo, traceTelemetryMetrics, out localErrors);
                         break;
+                    case TelemetryType.Event:
+                        AddMetric(metricInfo, eventTelemetryMetrics, out localErrors);
+                        break;
                     default:
                         errorList.Add(
                             CollectionConfigurationError.CreateError(
@@ -299,7 +302,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                 requestDocumentIngressMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType))
                 .Concat(dependencyTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
                 .Concat(exceptionTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
-                .Concat(traceTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType))))
+                .Concat(traceTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType)))
+                .Concat(eventTelemetryMetrics.Select(metric => Tuple.Create(metric.Id, metric.AggregationType))))
             {
                 telemetryMetadata.Add(metricIds);
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/CollectionConfiguration.cs
@@ -37,6 +37,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 
         private readonly List<DerivedMetric<Trace>> traceTelemetryMetrics = new List<DerivedMetric<Trace>>();
 
+        private readonly List<DerivedMetric<Event>> eventTelemetryMetrics = new List<DerivedMetric<Event>>();
+
         private readonly List<DocumentStream> documentStreams = new List<DocumentStream>();
         #endregion
 
@@ -106,6 +108,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
         public IEnumerable<DerivedMetric<ExceptionDocument>> ExceptionMetrics => exceptionTelemetryMetrics;
 
         public IEnumerable<DerivedMetric<Trace>> TraceMetrics => traceTelemetryMetrics;
+
+        public IEnumerable<DerivedMetric<Event>> EventMetrics => eventTelemetryMetrics;
 
         /// <summary>
         /// Gets Telemetry types only. Used by QuickPulseTelemetryProcessor.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DocumentStream.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/Filtering/DocumentStream.cs
@@ -31,6 +31,8 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
 
         private readonly List<FilterConjunctionGroup<Trace>> traceFilterGroups = new List<FilterConjunctionGroup<Trace>>();
 
+        private readonly List<FilterConjunctionGroup<Event>> eventFilterGroups = new List<FilterConjunctionGroup<Event>>();
+
         public DocumentStream(
             DocumentStreamInfo info,
             out CollectionConfigurationError[] errors,
@@ -87,6 +89,11 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
         public bool CheckFilters(Trace document, out CollectionConfigurationError[] errors)
         {
             return CheckFilters(traceFilterGroups, document, out errors);
+        }
+
+        public bool CheckFilters(Event document, out CollectionConfigurationError[] errors)
+        {
+            return CheckFilters(eventFilterGroups, document, out errors);
         }
 
         private static bool CheckFilters<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTelemetry>(
@@ -175,6 +182,9 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals.Filtering
                                 break;
                             case TelemetryType.Trace:
                                 traceFilterGroups.Add(new FilterConjunctionGroup<Trace>(documentFilterConjunctionGroupInfo.Filters, out groupErrors));
+                                break;
+                            case TelemetryType.Event:
+                                eventFilterGroups.Add(new FilterConjunctionGroup<Event>(documentFilterConjunctionGroupInfo.Filters, out groupErrors));
                                 break;
                             default:
                                 throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "Unsupported TelemetryType: '{0}'", documentFilterConjunctionGroupInfo.TelemetryType));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/LiveMetricsClientManager.MetricsCollection.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.LiveMetrics/src/Internals/LiveMetricsClientManager.MetricsCollection.cs
@@ -109,6 +109,14 @@ namespace Azure.Monitor.OpenTelemetry.LiveMetrics.Internals
                         documentStream => documentStream.CheckFilters(trace, out groupErrors));
                     ApplyFilters(metricAccumulators, _collectionConfiguration.TraceMetrics, trace, out filteringErrors, ref projectionError);
                 }
+                else if (item is Models.Event eventModel)
+                {
+                    matchesDocumentStreamFilter = UpdateTelemetryDocumentIfInterested(eventModel,
+                        documentStreams,
+                        documentStream => documentStream.EventQuotaTracker,
+                        documentStream => documentStream.CheckFilters(eventModel, out groupErrors));
+                    ApplyFilters(metricAccumulators, _collectionConfiguration.EventMetrics, eventModel, out filteringErrors, ref projectionError);
+                }
                 else
                 {
                     Debug.WriteLine($"Unknown DocumentType: {item.DocumentType}");


### PR DESCRIPTION
Fixes #53678.

`DocumentStream.EventQuotaTracker` already existed (from 85db3ca0a2785e5249e09c52e7458f7682144f03); this PR hooks it up to the `Event` telemetry type.