### PR TITLE
added missing clientNamespace spector test

### DIFF
--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Client/Namespace/ClientNamespaceTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Client/Namespace/ClientNamespaceTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Client.Clientnamespace;
+using Client.Clientnamespace.Second;
+using NUnit.Framework;
+
+namespace TestProjects.Spector.Tests.Http.Client.Namespace
+{
+    public class ClientNamespaceTests : SpectorTestBase
+    {
+        [SpectorTest]
+        public Task FirstClient() => Test(async (host) =>
+        {
+            var response = await new ClientNamespaceFirstClient(host, null).GetFirstAsync();
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.IsNotNull(response.Value);
+        });
+
+        [SpectorTest]
+        public Task SecondClient() => Test(async (host) =>
+        {
+            var response = await new ClientNamespaceSecondClient(host, null).GetSecondAsync();
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.IsNotNull(response.Value);
+        });
+    }
+}


### PR DESCRIPTION
This pull request introduces a new test class to validate the functionality of client classes within the `Clientnamespace` namespace. The tests ensure that both `ClientNamespaceFirstClient` and `ClientNamespaceSecondClient` return successful responses and non-null values.

New test coverage for client classes:

* Added `ClientNamespaceTests` class to verify the behavior of `ClientNamespaceFirstClient` and `ClientNamespaceSecondClient`, including assertions for HTTP status and response values. (`eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Client/Namespace/ClientNamespaceTests.cs`)

THis PR resolves: https://github.com/Azure/azure-sdk-for-net/issues/53698