### PR TITLE
[AzureFunctions] [ServiceBus] Avoid swallowing exceptions when retrieving votes

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -249,8 +249,8 @@
     <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.29.0" />
     <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.29.0" />
     <PackageReference Update="Microsoft.Azure.SignalR.Serverless.Protocols" Version="1.10.0" />
-    <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.41" />
-    <PackageReference Update="Microsoft.Azure.WebJobs.Sources" Version="3.0.41" PrivateAssets="All"/>
+    <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.42" />
+    <PackageReference Update="Microsoft.Azure.WebJobs.Sources" Version="3.0.42" PrivateAssets="All"/>
     <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.Rpc" Version="3.0.41" />
     <PackageReference Update="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
     <PackageReference Update="Microsoft.Spatial" Version="7.5.3" />

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMetricsProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusMetricsProvider.cs
@@ -100,10 +100,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Listeners
                 }
                 throw;
             }
-            catch (Exception e)
-            {
-                _logger.LogWarning(e, $"Error querying for Service Bus {entityName} scale");
-            }
 
             long totalNewMessageCount = 0;
             if ((!_isListeningOnDeadLetterQueue && activeMessageCount > 0) || (_isListeningOnDeadLetterQueue && deadLetterCount > 0))
@@ -172,10 +168,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Listeners
                     _logger.LogWarning($"Connection string does not have Manage claim for {entityName} '{_entityPath}'. Failed to get {entityName} description to " +
                         $"derive {entityName} length metrics. Falling back to using first message enqueued time.");
                 }
-            }
-            catch (Exception e)
-            {
-                _logger.LogWarning($"Error querying for Service Bus {entityName} scale status: {e.Message}");
             }
 
             // Path for connection strings with no manage claim

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusTargetScaler.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusTargetScaler.cs
@@ -108,7 +108,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Listeners
                 targetWorkerCount = int.MaxValue;
             }
 
-            _logger.LogInformation($"Target worker count for function '{_functionId}' is '{targetWorkerCount}' (EntityPath='{_entityPath}', MessageCount ='{messageCount}', Concurrency='{concurrency}').");
+            string details = $"Target worker count for function '{_functionId}' is '{targetWorkerCount}' (EntityPath='{_entityPath}', MessageCount ='{messageCount}', Concurrency='{concurrency}').");
+            _logger.LogFunctionScaleVote(_functionId, targetWorkerCount, (int)messageCount, concurrency, details);
 
             return new TargetScalerResult
             {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusTargetScaler.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusTargetScaler.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Listeners
                 targetWorkerCount = int.MaxValue;
             }
 
-            string details = $"Target worker count for function '{_functionId}' is '{targetWorkerCount}' (EntityPath='{_entityPath}', MessageCount ='{messageCount}', Concurrency='{concurrency}').");
+            string details = $"Target worker count for function '{_functionId}' is '{targetWorkerCount}' (EntityPath='{_entityPath}', MessageCount ='{messageCount}', Concurrency='{concurrency}').";
             _logger.LogFunctionScaleVote(_functionId, targetWorkerCount, (int)messageCount, concurrency, details);
 
             return new TargetScalerResult

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
@@ -69,6 +69,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             ServiceBusProcessor messageProcessor = _client.CreateProcessor(_entityPath);
 
             _mockAdminClient = new Mock<ServiceBusAdministrationClient>(MockBehavior.Strict);
+            _mockAdminClient.Setup(c => c.GetSubscriptionRuntimePropertiesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new UnauthorizedAccessException("UnauthorizedAccessException exception"));
+            _mockAdminClient.Setup(c => c.GetQueueRuntimePropertiesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new UnauthorizedAccessException("UnauthorizedAccessException exception"));
 
             _mockMessageProcessor = new Mock<MessageProcessor>(MockBehavior.Strict, messageProcessor);
             var configuration = ConfigurationUtilities.CreateConfiguration(new KeyValuePair<string, string>(_connection, _testConnection));
@@ -355,6 +359,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             _mockMessageReceiver.Setup(x => x.PeekMessageAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(message);
 
+            _mockAdminClient.Reset();
             if (_entityType == ServiceBusEntityType.Queue)
             {
                 _mockAdminClient.Setup(x => x.GetQueueRuntimePropertiesAsync(_entityPath, It.IsAny<CancellationToken>()))
@@ -408,6 +413,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             _mockMessageReceiver.Setup(x => x.PeekMessageAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(message);
 
+            _mockAdminClient.Reset();
             if (_entityType == ServiceBusEntityType.Queue)
             {
                 _mockAdminClient.Setup(x => x.GetQueueRuntimePropertiesAsync(_entityPath, It.IsAny<CancellationToken>()))

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
@@ -499,15 +499,9 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
                 .Throws(new Exception("Uh oh"));
             listener = CreateListener();
 
-            metrics = await ((ServiceBusScaleMonitor)listener.GetMonitor()).GetMetricsAsync();
-
-            Assert.AreEqual(0, metrics.PartitionCount);
-            Assert.AreEqual(0, metrics.MessageCount);
-            Assert.AreEqual(TimeSpan.FromSeconds(0), metrics.QueueTime);
-            Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
-
-            warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == LogLevel.Warning);
-            Assert.AreEqual($"Error querying for Service Bus {_entityTypeName} scale status: Uh oh", warning.FormattedMessage);
+            var ex = Assert.ThrowsAsync<Exception>(async () =>
+                await ((ServiceBusScaleMonitor)listener.GetMonitor()).GetMetricsAsync());
+            Assert.AreEqual("Uh oh", ex.Message);
         }
 
         private ServiceBusListener CreateListener(bool useDeadletterQueue = false)


### PR DESCRIPTION
**Proposed Improvement**
We want to emit error logs to the customer’s Application Insights whenever there are connectivity issues to the resource.

**Current Behavior**
Exceptions are swallowed in the extension code and logged only in internal logs.

**Planned Change**
- The change will allow connectivity exceptions to bubble up to the WebJobs SDK, so they can be logged in the standard WebJobs format.
- All extensions will follow the same logging format for consistency.
- In case of an exception, the trigger will be ignored for the current vote integration.

**References**
-https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs#L195
-https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs#L121

**Additional Notes**
- The ScaleManager class in WebJobs SDK is used for both regular scale and runtime-driven scale.
- We are also adding voting logs in the PR to standardize how the current vote is logged. These logs will also be provided to the customer.
