### PR TITLE
[AzureFunctions] [EventHubs] Avoid swallowing exceptions when ing votes

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -249,8 +249,8 @@
     <PackageReference Update="Microsoft.Azure.SignalR.Management" Version="1.29.0" />
     <PackageReference Update="Microsoft.Azure.SignalR.Protocols" Version="1.29.0" />
     <PackageReference Update="Microsoft.Azure.SignalR.Serverless.Protocols" Version="1.10.0" />
-    <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.41" />
-    <PackageReference Update="Microsoft.Azure.WebJobs.Sources" Version="3.0.41" PrivateAssets="All"/>
+    <PackageReference Update="Microsoft.Azure.WebJobs" Version="3.0.42" />
+    <PackageReference Update="Microsoft.Azure.WebJobs.Sources" Version="3.0.42" PrivateAssets="All"/>
     <PackageReference Update="Microsoft.Azure.WebJobs.Extensions.Rpc" Version="3.0.41" />
     <PackageReference Update="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
     <PackageReference Update="Microsoft.Spatial" Version="7.5.3" />

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTargetScaler.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTargetScaler.cs
@@ -103,12 +103,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             int[] sortedValidWorkerCounts = GetSortedValidWorkerCountsForPartitionCount(partitionCount);
             int validatedTargetWorkerCount = GetValidWorkerCount(desiredWorkerCount, sortedValidWorkerCounts);
 
+            string details = $"Target worker count for function '{_functionId}' is '{validatedTargetWorkerCount}' (EventHubName='{_client.EventHubName}', EventCount ='{eventCount}', Concurrency='{desiredConcurrency}', PartitionCount='{partitionCount}').";
             if (validatedTargetWorkerCount != desiredWorkerCount)
             {
-                _logger.LogInformation($"Desired target worker count of '{desiredWorkerCount}' is not in list of valid sorted workers: '{string.Join(",", sortedValidWorkerCounts)}'. Using next largest valid worker as target worker count.");
+                details += $" Desired target worker count of '{desiredWorkerCount}' is not in list of valid sorted workers: '{string.Join(",", sortedValidWorkerCounts)}'. Using next largest valid worker as target worker count.";
             }
 
-            _logger.LogInformation($"Target worker count for function '{_functionId}' is '{validatedTargetWorkerCount}' (EventHubName='{_client.EventHubName}', EventCount ='{eventCount}', Concurrency='{desiredConcurrency}', PartitionCount='{partitionCount}').");
+            _logger.LogFunctionScaleVote(_functionId, validatedTargetWorkerCount, (int)eventCount, desiredConcurrency, details);
 
             return new TargetScalerResult
             {


### PR DESCRIPTION
**Proposed Improvement**
We want to emit error logs to the customer’s Application Insights whenever there are connectivity issues to the resource.

**Current Behavior**
Exceptions are swallowed in the extension code and logged only in internal logs.

**Planned Change**
- The change will allow connectivity exceptions to bubble up to the WebJobs SDK, so they can be logged in the standard WebJobs format.
- All extensions will follow the same logging format for consistency.
- In case of an exception, the trigger will be ignored for the current vote integration.

**References**
-https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs#L195
-https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Scale/ScaleManager.cs#L121

**Additional Notes**
- The ScaleManager class in WebJobs SDK is used for both regular scale and runtime-driven scale.
- We are also adding voting logs in the PR to standardize how the current vote is logged. These logs will also be provided to the customer.
