### PR TITLE
Do not change resource patch model name when it is used by multiple resources.

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
@@ -102,6 +102,7 @@ namespace Azure.Generator.Management
         private IReadOnlyDictionary<InputModelType, string> BuildResourceUpdateModelToResourceNameMap()
         {
             Dictionary<InputModelType, string> map = new();
+            HashSet<InputModelType> duplicateUpdateModels = new();
 
             foreach (var metadata in ResourceMetadatas)
             {
@@ -112,11 +113,21 @@ namespace Azure.Generator.Management
                     {
                         if (parameter.Location == InputRequestLocation.Body && parameter.Type is InputModelType updateModel && updateModel != metadata.ResourceModel)
                         {
+                            if (map.ContainsKey(updateModel))
+                            {
+                                duplicateUpdateModels.Add(updateModel);
+                            }
                             map[updateModel] = metadata.ResourceModel.Name;
                             break;
                         }
                     }
                 }
+            }
+
+            // Remove update models that are used in more than one resource
+            foreach (var duplicateModel in duplicateUpdateModels)
+            {
+                map.Remove(duplicateModel);
             }
 
             return map;


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

We should not rename resource update model name when it is used by multiple resources, see the autorest.chsarp logic here:
https://github.com/Azure/autorest.csharp/blob/d93297d16162903b0f2647f890a5db99535e2009/src/AutoRest.CSharp/Mgmt/AutoRest/MgmtOutputLibrary.cs#L187
