### PR TITLE
[CODEOWNERS] Remove invalid account

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -947,10 +947,7 @@
 # ServiceOwners:                                                   @armleads-azure
 
 # PRLabel: %Astronomer
-/sdk/astronomer/Azure.ResourceManager.Astro/                       @banggaurav
-
-# ServiceLabel: %Astronomer %Mgmt
-# ServiceOwners:                                                   @banggaurav
+/sdk/astronomer/Azure.ResourceManager.Astro/                       @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %Communication - Resource Manager
 /sdk/communication/Azure.ResourceManager.Communication/            @ArcturusZhang @ArthurMa1978


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner being flagged by the linter as invalid.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5550904&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_