### PR TITLE
Releasing 1.0.0 for socketio serverless package

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/CHANGELOG.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Release History
+
 ## 1.0.0 (2025-11-15)
 
 ### Other Changes

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/CHANGELOG.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/CHANGELOG.md
@@ -1,22 +1,10 @@
-# Release History
-
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-- Updated `System.IdentityModel.Tokens.Jwt` dependency to 8.14.0
-- Updated `Microsoft.IdentityModel.Tokens` dependency to 8.14.0
-
-## 1.0.0 (2025-04-15)
+## 1.0.0 (2025-11-15)
 
 ### Other Changes
 
 - Library GA
+- Updated `System.IdentityModel.Tokens.Jwt` dependency to 8.14.0
+- Updated `Microsoft.IdentityModel.Tokens` dependency to 8.14.0
 
 ## 1.0.0-beta.4 (2024-09-30)
 

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.csproj
@@ -5,7 +5,7 @@
 		<PackageId>Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO</PackageId>
 		<PackageTags>Azure, WebPubSub</PackageTags>
 		<Description>Azure Functions extension for the WebPubSub for Socket.IO</Description>
-		<Version>1.1.0-beta.1</Version>
+		<Version>1.0.0</Version>
 		<NoWarn>$(NoWarn);AZC0001;CS8632;CA1056;CA2227</NoWarn>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<IsExtensionClientLibrary>true</IsExtensionClientLibrary>


### PR DESCRIPTION
# Contributing to the Azure SDK

Revert version to 1.0.0 and prepare for releasing as GA version is never released before. It's got approval recently

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
