### PR TITLE
[Storage] Replacing scaling logs to WebJobs extension methods

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Azure;
 using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
+using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
@@ -15,16 +16,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
     /// </summary>
     internal class QueueMetricsProvider
     {
+        private readonly string _functionId;
         private readonly QueueClient _queue;
         private readonly ILogger _logger;
 
         /// <summary>
         /// Instantiates a QueueMetricsProvider.
         /// </summary>
+        /// <param name="functionId">The function id to make scale decisions for.</param>
         /// <param name="queue">The QueueClient to use for metrics polling.</param>
         /// <param name="loggerFactory">Used to create an ILogger instance.</param>
-        public QueueMetricsProvider(QueueClient queue, ILoggerFactory loggerFactory)
+        public QueueMetricsProvider(string functionId, QueueClient queue, ILoggerFactory loggerFactory)
         {
+            _functionId = functionId;
             _queue = queue;
             _logger = loggerFactory.CreateLogger<QueueMetricsProvider>();
         }
@@ -49,12 +53,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                     // ignore transient errors, and return default metrics
                     // E.g. if the queue doesn't exist, we'll return a zero queue length
                     // and scale in
-                    _logger.LogWarning($"Error querying for queue scale status: {ex.ToString()}");
+                    _logger.LogFunctionScaleWarning("Error querying for queue scale status", _functionId, ex);
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"Fatal error querying for queue scale status: {ex.ToString()}");
+                _logger.LogFunctionScaleWarning("Fatal error querying for queue scale status", _functionId, ex);
             }
 
             return 0;
@@ -101,12 +105,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                     // ignore transient errors, and return default metrics
                     // E.g. if the queue doesn't exist, we'll return a zero queue length
                     // and scale in
-                    _logger.LogWarning($"Error querying for queue scale status: {ex.ToString()}");
+                    _logger.LogFunctionScaleWarning("Error querying for queue scale status", _functionId, ex);
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogWarning($"Fatal error querying for queue scale status: {ex.ToString()}");
+                _logger.LogFunctionScaleWarning("Fatal error querying for queue scale status", _functionId, ex);
             }
 
             return new QueueTriggerMetrics

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueScaleMonitor.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueScaleMonitor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
             _queue = queue;
             _logger = loggerFactory.CreateLogger<QueueListener>();
             _scaleMonitorDescriptor = new ScaleMonitorDescriptor($"{functionId}-QueueTrigger-{_queue.Name}".ToLower(CultureInfo.InvariantCulture), functionId);
-            _queueMetricsProvider = new QueueMetricsProvider(queue, loggerFactory);
+            _queueMetricsProvider = new QueueMetricsProvider(functionId, queue, loggerFactory);
         }
 
         /// <summary>

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueTargetScaler.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueTargetScaler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
         {
             _functionId = functionId;
             _queueName = queueClient.Name;
-            _queueMetricsProvider = new QueueMetricsProvider(queueClient, loggerFactory);
+            _queueMetricsProvider = new QueueMetricsProvider(_functionId, queueClient, loggerFactory);
             _targetScalerDescriptor = new TargetScalerDescriptor(functionId);
             _options = options;
             _logger = loggerFactory.CreateLogger<QueueTargetScaler>();

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Replaced scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics.
+
 ## 5.3.8 (2026-03-19)
 
 ### Bugs Fixed

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
             _loggerFactory.AddProvider(_loggerProvider);
             _mockQueue = new Mock<QueueClient>(new Uri("https://test.queue.core.windows.net/testqueue"), new QueueClientOptions());
             _mockQueue.Setup(x => x.Name).Returns("testqueue");
-            _metricsProvider = new QueueMetricsProvider(_mockQueue.Object, _loggerFactory);
+            _metricsProvider = new QueueMetricsProvider("testFunctionId", _mockQueue.Object, _loggerFactory);
         }
 
         [OneTimeSetUp]
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
         [Test]
         public async Task GetMetrics_ReturnsExpectedResult()
         {
-            QueueMetricsProvider _provider = new QueueMetricsProvider(Fixture.Queue, _loggerFactory);
+            QueueMetricsProvider _provider = new QueueMetricsProvider("testFunctionId", Fixture.Queue, _loggerFactory);
             var metrics = await _provider.GetMetricsAsync();
 
             Assert.AreEqual(0, metrics.QueueLength);


### PR DESCRIPTION
## Summary

Replace direct `LogWarning` calls in the Storage Queue scaling extensions with standardized `LogFunctionScaleWarning` WebJobs extension method.

This enables the Scale Controller's OpenTelemetry logger to intercept scaling warning/error events (EventIds 8001/8003) and forward them to the customer's Application Insights, providing visibility into connectivity errors during scaling.

## Changes

- **QueueMetricsProvider.cs**: Added `functionId` constructor parameter; replaced `LogWarning` with `LogFunctionScaleWarning` for error logging
- **QueueScaleMonitor.cs**: Updated constructor call to pass `functionId` to `QueueMetricsProvider`
- **QueueTargetScaler.cs**: Updated `QueueMetricsProvider` constructor call to pass `functionId`
- **QueueMetricsProviderTests.cs**: Updated test constructor calls to include `functionId` parameter
- **CHANGELOG.md**: Added entry under Other Changes

## Why no Blob trigger changes?

The Blob trigger's `ZeroToOneTargetScaler` does not need equivalent changes because:

1. **Exceptions are already handled at the WebJobs SDK level** — `ScaleManager.GetTargetScaleResult` wraps every `GetScaleResultAsync` call in a try/catch that logs via `LogFunctionScaleError` (EventId 8001), which the SC's OpenTelemetry logger already intercepts.
2. **Scale votes are already emitted** — `ScaleManager` calls `LogFunctionScaleVote` (EventId 8002) after every successful `GetScaleResultAsync`, so the target worker count is already surfaced.
3. **No connectivity error paths** — unlike Queue/ServiceBus/EventHubs/CosmosDB metrics providers, the Blob target scaler has no internal catch blocks that silently swallow errors.

## Phase 2 (follow-up)

Migrating the `LogInformation` scale vote detail logs to `LogFunctionScaleVote` will follow once [azure-webjobs-sdk #3189](https://github.com/Azure/azure-webjobs-sdk/pull/3189) ships (changes vote log level from Debug to Information).

## Context

Part of the Scale Controller App Insights logging feature ([AAPT-Antares-ScaleController PR #14140160](https://msazure.visualstudio.com/One/_git/AAPT-Antares-ScaleController/pullrequest/14140160)).

Related PRs:
- [#53925](https://github.com/Azure/azure-sdk-for-net/pull/53925) - EventHubs extension
- [#53926](https://github.com/Azure/azure-sdk-for-net/pull/53926) - ServiceBus extension
- [#975](https://github.com/Azure/azure-webjobs-sdk-extensions/pull/975) - CosmosDB extension