### PR TITLE
[EventHubs] Replacing scaling logs to WebJobs extension methods

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Replaced scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics.
+
 ## 6.5.3 (2025-10-20)
 
 ### Bugs Fixed

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubMetricsProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Primitives;
 using Microsoft.Azure.WebJobs.EventHubs.Listeners;
+using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
@@ -102,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             }
             catch (Exception e)
             {
-                _logger.LogWarning($"Encountered an exception while getting partition information for Event Hub '{_client.EventHubName}' used for scaling. Error: {e.Message}");
+                _logger.LogFunctionScaleWarning($"Encountered an exception while getting partition information for Event Hub '{_client.EventHubName}' used for scaling.", _functionId, e);
             }
 
             // Get checkpoints
@@ -149,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
             }
             catch (Exception e)
             {
-                _logger.LogWarning($"Encountered an exception while getting checkpoints for Event Hub '{_client.EventHubName}' used for scaling. Error: {e.Message}");
+                _logger.LogFunctionScaleWarning($"Encountered an exception while getting checkpoints for Event Hub '{_client.EventHubName}' used for scaling.", _functionId, e);
             }
 
             return CreateTriggerMetrics(partitionPropertiesTasks.Select(t => t.Result).ToList(), checkpoints);

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTargetScaler.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/src/Listeners/EventHubsTargetScaler.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EventHubs.Listeners
                 _logger.LogInformation($"Desired target worker count of '{desiredWorkerCount}' is not in list of valid sorted workers: '{string.Join(",", sortedValidWorkerCounts)}'. Using next largest valid worker as target worker count.");
             }
 
-            _logger.LogInformation($"Target worker count for function '{_functionId}' is '{validatedTargetWorkerCount}' (EventHubName='{_client.EventHubName}', EventCount ='{eventCount}', Concurrency='{desiredConcurrency}', PartitionCount='{partitionCount}').");
+            _logger.LogInformation($"Target worker count for function '{_functionId}' is '{validatedTargetWorkerCount}' (EventHubName='{_client.EventHubName}', EventCount='{eventCount}', Concurrency='{desiredConcurrency}', PartitionCount='{partitionCount}').");
 
             return new TargetScalerResult
             {


### PR DESCRIPTION
## Summary

Replace direct `LogWarning` calls in the EventHubs scaling extensions with standardized `LogFunctionScaleWarning` WebJobs extension method.

This enables the Scale Controller's OpenTelemetry logger to intercept scaling warning events (EventId 8003) and forward them to the customer's Application Insights, providing visibility into connectivity errors during scaling.

## Changes

- **EventHubMetricsProvider.cs**: Replaced `LogWarning` with `LogFunctionScaleWarning` for partition info and checkpoint error logging
- **CHANGELOG.md**: Added entry under Other Changes

## Phase 2 (follow-up)

Migrating the `LogInformation` scale vote detail logs to `LogFunctionScaleVote` will follow once [azure-webjobs-sdk #3189](https://github.com/Azure/azure-webjobs-sdk/pull/3189) ships (changes vote log level from Debug to Information).

## Context

Part of the Scale Controller App Insights logging feature ([AAPT-Antares-ScaleController PR #14140160](https://msazure.visualstudio.com/One/_git/AAPT-Antares-ScaleController/pullrequest/14140160)).

Related PRs:
- [#53923](https://github.com/Azure/azure-sdk-for-net/pull/53923) - Storage Queue extension
- [#53926](https://github.com/Azure/azure-sdk-for-net/pull/53926) - ServiceBus extension
- [#975](https://github.com/Azure/azure-webjobs-sdk-extensions/pull/975) - CosmosDB extension