### PR TITLE
[ServiceBus] Replacing scaling logs to WebJobs extension methods

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- Replaced scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics.
+
 ## 5.17.0 (2025-06-20)
 
 ### Other Changes

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusScaleMonitor.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusScaleMonitor.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
         {
             _functionId = functionId;
             _entityPath = entityPath;
-            _serviceBusMetricsProvider = new ServiceBusMetricsProvider(entityPath, entityType, receiver, administrationClient, loggerFactory);
+            _serviceBusMetricsProvider = new ServiceBusMetricsProvider(_functionId, entityPath, entityType, receiver, administrationClient, loggerFactory);
             _scaleMonitorDescriptor = new ScaleMonitorDescriptor($"{_functionId}-ServiceBusTrigger-{_entityPath}".ToLower(CultureInfo.InvariantCulture), functionId);
             _logger = loggerFactory.CreateLogger<ServiceBusScaleMonitor>();
         }

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusTargetScaler.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusTargetScaler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Listeners
             )
         {
             _functionId = functionId;
-            _serviceBusMetricsProvider = new ServiceBusMetricsProvider(entityPath, entityType, receiver, administrationClient, loggerFactory);
+            _serviceBusMetricsProvider = new ServiceBusMetricsProvider(_functionId, entityPath, entityType, receiver, administrationClient, loggerFactory);
             _entityPath = entityPath;
             _targetScalerDescriptor = new TargetScalerDescriptor(functionId);
             _logger = loggerFactory.CreateLogger<ServiceBusTargetScaler>();
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.ServiceBus.Listeners
                 targetWorkerCount = int.MaxValue;
             }
 
-            _logger.LogInformation($"Target worker count for function '{_functionId}' is '{targetWorkerCount}' (EntityPath='{_entityPath}', MessageCount ='{messageCount}', Concurrency='{concurrency}').");
+            _logger.LogInformation($"Target worker count for function '{_functionId}' is '{targetWorkerCount}' (EntityPath='{_entityPath}', MessageCount='{messageCount}', Concurrency='{concurrency}').");
 
             return new TargetScalerResult
             {

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/tests/Listeners/ServiceBusScaleMonitorTests.cs
@@ -471,7 +471,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
             var warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == LogLevel.Warning);
-            Assert.AreEqual($"ServiceBus {_entityTypeName} '{_entityPath}' was not found.", warning.FormattedMessage);
+            Assert.AreEqual($"Function '{_functionId}' warning: ServiceBus {_entityTypeName} '{_entityPath}' was not found.", warning.FormattedMessage);
             _loggerProvider.ClearAllLogMessages();
 
             // UnauthorizedAccessException
@@ -488,7 +488,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
             warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == LogLevel.Warning);
-            Assert.AreEqual($"Connection string does not have Manage claim for {_entityTypeName} '{_entityPath}'. Failed to get {_entityTypeName} description to derive {_entityTypeName} length metrics. " +
+            Assert.AreEqual($"Function '{_functionId}' warning: Connection string does not have Manage claim for {_entityTypeName} '{_entityPath}'. Failed to get {_entityTypeName} description to derive {_entityTypeName} length metrics. " +
                         $"Falling back to using first message enqueued time.",
                         warning.FormattedMessage);
             _loggerProvider.ClearAllLogMessages();
@@ -507,7 +507,7 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.UnitTests.Listeners
             Assert.AreNotEqual(default(DateTime), metrics.Timestamp);
 
             warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == LogLevel.Warning);
-            Assert.AreEqual($"Error querying for Service Bus {_entityTypeName} scale status: Uh oh", warning.FormattedMessage);
+            Assert.AreEqual($"Function '{_functionId}' warning: Error querying for Service Bus {_entityTypeName} scale status", warning.FormattedMessage);
         }
 
         private ServiceBusListener CreateListener(bool useDeadletterQueue = false)


### PR DESCRIPTION
## Summary

Replace direct `LogWarning` calls in the ServiceBus scaling extensions with standardized `LogFunctionScaleWarning` WebJobs extension method.

This enables the Scale Controller's OpenTelemetry logger to intercept scaling warning events (EventId 8003) and forward them to the customer's Application Insights, providing visibility into connectivity errors during scaling.

## Changes

- **ServiceBusMetricsProvider.cs**: Added `functionId` constructor parameter; replaced `LogWarning` with `LogFunctionScaleWarning` for all error/warning logging paths
- **ServiceBusTargetScaler.cs**: Updated constructor call to pass `functionId` to `ServiceBusMetricsProvider`
- **ServiceBusScaleMonitor.cs**: Updated constructor call to pass `functionId` to `ServiceBusMetricsProvider`
- **ServiceBusScaleMonitorTests.cs**: Updated test assertions to match new warning log format
- **CHANGELOG.md**: Added entry under Other Changes

## Phase 2 (follow-up)

Migrating the `LogInformation` scale vote detail logs to `LogFunctionScaleVote` will follow once [azure-webjobs-sdk #3189](https://github.com/Azure/azure-webjobs-sdk/pull/3189) ships (changes vote log level from Debug to Information).

## Context

Part of the Scale Controller App Insights logging feature ([AAPT-Antares-ScaleController PR #14140160](https://msazure.visualstudio.com/One/_git/AAPT-Antares-ScaleController/pullrequest/14140160)).

Related PRs:
- [#53923](https://github.com/Azure/azure-sdk-for-net/pull/53923) - Storage Queue extension
- [#53925](https://github.com/Azure/azure-sdk-for-net/pull/53925) - EventHubs extension
- [#975](https://github.com/Azure/azure-webjobs-sdk-extensions/pull/975) - CosmosDB extension