### PR TITLE
Remove uneeded copy of bytes in NDJsonWriter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -52,7 +52,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
         internal static (List<TelemetryItem> TelemetryItems, TelemetrySchemaTypeCounter TelemetrySchemaTypeCounter) OtelToAzureMonitorLogs(Batch<LogRecord> batchLogRecord, AzureMonitorResource? resource, string instrumentationKey)
         {
-            List<TelemetryItem> telemetryItems = new List<TelemetryItem>();
+            List<TelemetryItem> telemetryItems = new List<TelemetryItem>(capacity: (int)batchLogRecord.Count);
             var telemetrySchemaTypeCounter = new TelemetrySchemaTypeCounter();
             TelemetryItem telemetryItem;
 


### PR DESCRIPTION
Currently the `NDJsonWriter` class is used for serializing `TelemetryItem` objects when exporting to Azure Monitor via `ApplicationInsightsRestClient`. The `NDJsonWriter` writes to a `MemoryStream`, and copies bytes from the stream via a `ToArray()` call when returning to consumer. This is unneeded. This PR changes `NDJsonWriter` class to use Azure.Core's copy of `ArrayBufferWriter` and just returns `WrittenMemory` to the consumer and avoids the mem copy.

Also, when exporting OpenTelemetry logs in `AzureMonitorLogExporter` we use the size of `Batch<LogRecord>`  when converting them to a `List<TelemetryItem>` in `LogsHelper.OtelToAzureMonitorLogs()`