### PR TITLE
[Identity] Bump MSAL dependencies to latest version

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -185,9 +185,9 @@
     <!-- Other approved packages -->
     <PackageReference Update="Microsoft.Azure.Amqp" Version="2.7.0" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
-    <PackageReference Update="Microsoft.Identity.Client" Version="4.79.1" />
-    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.79.1" />
-    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.79.1" />
+    <PackageReference Update="Microsoft.Identity.Client" Version="4.79.2" />
+    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.79.2" />
+    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.79.2" />
     <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.14.0" />
     <PackageReference Update="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -185,9 +185,9 @@
     <!-- Other approved packages -->
     <PackageReference Update="Microsoft.Azure.Amqp" Version="2.7.0" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
-    <PackageReference Update="Microsoft.Identity.Client" Version="4.76.0" />
-    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.76.0" />
-    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.76.0" />
+    <PackageReference Update="Microsoft.Identity.Client" Version="4.79.1" />
+    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.79.1" />
+    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.79.1" />
     <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.14.0" />
     <PackageReference Update="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Updated `Microsoft.Identity.Client.Broker` dependency to version 4.79.1.
+- Updated `Microsoft.Identity.Client.Broker` dependency to version 4.79.2.
 
 ## 1.3.0 (2025-09-04)
 

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.1 (2025-11-17)
 
 ### Other Changes
 

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated `Microsoft.Identity.Client.Broker` dependency to version 4.79.1.
+
 ## 1.3.0 (2025-09-04)
 
 ### Breaking Changes

--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides authentication broker APIs for authenticating to Microsoft Entra ID</Description>
     <AssemblyTitle>Microsoft Azure.Identity.Broker Component</AssemblyTitle>
-    <Version>1.4.0-beta.1</Version>
+    <Version>1.3.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity Broker;$(PackageCommonTags)</PackageTags>

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated `Microsoft.Identity.Client` and `Microsoft.Identity.Client.Extensions.Msal` dependencies to version 4.79.1.
+
 ## 1.18.0-beta.1 (2025-11-14)
 
 ### Features Added

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Updated `Microsoft.Identity.Client` and `Microsoft.Identity.Client.Extensions.Msal` dependencies to version 4.79.1.
+- Updated `Microsoft.Identity.Client` and `Microsoft.Identity.Client.Extensions.Msal` dependencies to version 4.79.2.
 
 ## 1.18.0-beta.1 (2025-11-14)
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 1.18.0-beta.2 (2025-11-17)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
 
 - Updated `Microsoft.Identity.Client` and `Microsoft.Identity.Client.Extensions.Msal` dependencies to version 4.79.2.

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.18.0-beta.2 (Unreleased)
+## 1.18.0-beta.2 (2025-11-17)
 
 ### Features Added
 

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -63,29 +63,9 @@ namespace Azure.Identity
         {
             AuthenticationResult result;
 
-            // Convert Azure.Identity.ManagedIdentityId to Microsoft.Identity.Client.AppConfig.ManagedIdentityId
-            Microsoft.Identity.Client.AppConfig.ManagedIdentityId msalManagedIdentityId = ManagedIdentityId._idType switch
-            {
-                ManagedIdentityIdType.SystemAssigned => Microsoft.Identity.Client.AppConfig.ManagedIdentityId.SystemAssigned,
-                ManagedIdentityIdType.ClientId => Microsoft.Identity.Client.AppConfig.ManagedIdentityId.WithUserAssignedClientId(ManagedIdentityId._userAssignedId),
-                ManagedIdentityIdType.ResourceId => Microsoft.Identity.Client.AppConfig.ManagedIdentityId.WithUserAssignedResourceId(ManagedIdentityId._userAssignedId),
-                ManagedIdentityIdType.ObjectId => Microsoft.Identity.Client.AppConfig.ManagedIdentityId.WithUserAssignedObjectId(ManagedIdentityId._userAssignedId),
-                _ => throw new InvalidOperationException("Invalid ManagedIdentityIdType")
-            };
-
-            ManagedIdentityApplication mi = ManagedIdentityApplicationBuilder.Create(msalManagedIdentityId).Build() as ManagedIdentityApplication;
-
-            MSAL.ManagedIdentitySource availableSource;
-            if (async)
-            {
-                availableSource = await mi.GetManagedIdentitySourceAsync().ConfigureAwait(false);
-            }
-            else
-            {
 #pragma warning disable CS0618 // Type or member is obsolete
-                availableSource = ManagedIdentityApplication.GetManagedIdentitySource();
+            MSAL.ManagedIdentitySource availableSource = ManagedIdentityApplication.GetManagedIdentitySource();
 #pragma warning restore CS0618 // Type or member is obsolete
-            }
 
             AzureIdentityEventSource.Singleton.ManagedIdentityCredentialSelected(availableSource.ToString(), _options.ManagedIdentityId.ToString());
 

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -339,7 +339,7 @@ namespace Azure.Identity.Tests
             {
                 (Item1: null, Item2: true) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)), Pipeline = pipeline, IsForceRefreshEnabled = true },
                 (Item1: not null, Item2: false) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true },
-                _ => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.SystemAssigned, Pipeline = pipeline, Options = options, PreserveTransport = true, IsForceRefreshEnabled = true }
+                _ => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.SystemAssigned, Pipeline = pipeline, PreserveTransport = true, IsForceRefreshEnabled = true }
             };
             ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(new ManagedIdentityClient(clientOptions)));
 
@@ -520,7 +520,7 @@ namespace Azure.Identity.Tests
 
             ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
                 new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { ManagedIdentityId = clientId is null ? ManagedIdentityId.SystemAssigned : ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true, Options = options, PreserveTransport = true })
+                    new ManagedIdentityClientOptions() { ManagedIdentityId = clientId is null ? ManagedIdentityId.SystemAssigned : ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true, PreserveTransport = true })
             ));
 
             AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
@@ -774,7 +774,7 @@ namespace Azure.Identity.Tests
             {
                 (Item1: null, Item2: true) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)), Pipeline = pipeline, IsForceRefreshEnabled = true },
                 (Item1: not null, Item2: false) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true },
-                _ => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.SystemAssigned, Pipeline = pipeline, Options = options, PreserveTransport = true, IsForceRefreshEnabled = true }
+                _ => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.SystemAssigned, Pipeline = pipeline, PreserveTransport = true, IsForceRefreshEnabled = true }
             };
             ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(new ManagedIdentityClient(clientOptions)));
 
@@ -1053,7 +1053,7 @@ namespace Azure.Identity.Tests
             var options = new TokenCredentialOptions() { Transport = mockTransport };
             var pipeline = CredentialPipeline.GetInstance(options, IsManagedIdentityCredential: true);
 
-            var credential = InstrumentClient(new ManagedIdentityCredential(new ManagedIdentityClient(new ManagedIdentityClientOptions { IsForceRefreshEnabled = true, Pipeline = pipeline })));
+            var credential = InstrumentClient(new ManagedIdentityCredential(new ManagedIdentityClient(new ManagedIdentityClientOptions { IsForceRefreshEnabled = true, Pipeline = pipeline, Options = options, PreserveTransport = true })));
 
             var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
 

--- a/sdk/identity/Azure.Identity/tests/StaticCachesUtilities.cs
+++ b/sdk/identity/Azure.Identity/tests/StaticCachesUtilities.cs
@@ -13,11 +13,41 @@ namespace Azure.Identity.Tests
     {
         private static readonly Lazy<Action> s_clearStaticMetadataProvider = new Lazy<Action>(() =>
         {
-            Type staticMetadataProviderType = typeof(PublicClientApplication).Assembly.GetType("Microsoft.Identity.Client.Instance.Discovery.NetworkCacheMetadataProvider", true);
-            MethodInfo clearMethod = staticMetadataProviderType.GetMethod("Clear", BindingFlags.Public | BindingFlags.Instance);
-            NewExpression callConstructor = Expression.New(staticMetadataProviderType);
-            MethodCallExpression invokeClear = Expression.Call(callConstructor, clearMethod);
-            return Expression.Lambda<Action>(invokeClear).Compile();
+            Type staticMetadataProviderType = typeof(PublicClientApplication).Assembly.GetType("Microsoft.Identity.Client.Instance.Discovery.NetworkCacheMetadataProvider", false);
+
+            // Return no-op if the type doesn't exist (MSAL implementation changed)
+            if (staticMetadataProviderType == null)
+            {
+                return () => { };
+            }
+
+            // Try new method name first (MSAL 4.79+)
+            MethodInfo clearMethod = staticMetadataProviderType.GetMethod("ResetStaticCacheForTest", BindingFlags.NonPublic | BindingFlags.Static);
+
+            // Fallback to old method name for older MSAL versions
+            if (clearMethod == null)
+            {
+                clearMethod = staticMetadataProviderType.GetMethod("Clear", BindingFlags.Public | BindingFlags.Instance);
+            }
+
+            // Return no-op if neither method exists
+            if (clearMethod == null)
+            {
+                return () => { };
+            }
+
+            // If it's a static method, call it directly; otherwise create an instance
+            if (clearMethod.IsStatic)
+            {
+                MethodCallExpression invokeStatic = Expression.Call(clearMethod);
+                return Expression.Lambda<Action>(invokeStatic).Compile();
+            }
+            else
+            {
+                NewExpression callConstructor = Expression.New(staticMetadataProviderType);
+                MethodCallExpression invokeClear = Expression.Call(callConstructor, clearMethod);
+                return Expression.Lambda<Action>(invokeClear).Compile();
+            }
         });
         public static void ClearStaticMetadataProviderCache() => s_clearStaticMetadataProvider.Value();
     }


### PR DESCRIPTION
Version `4.76.0` has been deprecated, updating the MSAL dependencies to the latest.