### PR TITLE
Use parameter sets to determine filter expression, exit on failure of dotnet build

### DIFF
--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -54,7 +54,7 @@ if ($LASTEXITCODE) {
 
 # Normalize line endings to LF in generated API listing files
 Write-Host "Normalizing line endings in API listing files"
-$apiListingFiles = Get-ChildItem -Path $apiListingFilesFilter
+$apiListingFiles = Get-ChildItem -Path $apiListingFilesFilter -ErrorAction SilentlyContinue
 foreach ($file in $apiListingFiles) {
     $content = Get-Content -Path $file.FullName -Raw
     if ($content) {

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -16,6 +16,9 @@ if ($SpellCheckPublicApiSurface -and -not (Get-Command 'npx')) {
     Write-Error "Could not locate npx. Install NodeJS (includes npm and npx) https://nodejs.org/en/download/"
     exit 1
 }
+
+. $PSScriptRoot/../common/scripts/Helpers/CommandInvocation-Helpers.ps1
+
 $relativePackagePath = $ServiceDirectory
 $apiListingFilesFilter = "$PSScriptRoot/../../sdk/$ServiceDirectory/*/api/*.cs"
 
@@ -30,21 +33,7 @@ $debugLogging = $env:SYSTEM_DEBUG -eq "true"
 $logsFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 $diagnosticArguments = ($debugLogging -and $logsFolder) ? "/binarylogger:$logsFolder/exportapi.binlog" : ""
 
-."$PSScriptRoot/runwithdevopslogging.ps1" dotnet build `
-    /t:ExportApi `
-    /p:RunApiCompat=false `
-    /p:InheritDocEnabled=false `
-    /p:GeneratePackageOnBuild=false `
-    /p:Configuration=Release `
-    /p:IncludeSamples=false `
-    /p:IncludePerf=false `
-    /p:IncludeStress=false `
-    /p:IncludeTests=false `
-    /p:Scope="$relativePackagePath" `
-    /p:SDKType=$SDKType `
-    /restore `
-    $servicesProj `
-    $diagnosticArguments
+Invoke-LoggedMsbuildCommand "dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$relativePackagePath" /p:SDKType=$SDKType /restore $servicesProj $diagnosticArguments"
 
 # Normalize line endings to LF in generated API listing files
 Write-Host "Normalizing line endings in API listing files"

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -31,7 +31,7 @@ $debugLogging = $env:SYSTEM_DEBUG -eq "true"
 $logsFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 $diagnosticArguments = ($debugLogging -and $logsFolder) ? "/binarylogger:$logsFolder/exportapi.binlog" : ""
 
-dotnet build `
+."$PSScriptRoot/runwithdevopslogging.ps1" dotnet build `
     /t:ExportApi `
     /p:RunApiCompat=false `
     /p:InheritDocEnabled=false `

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -1,7 +1,6 @@
 [CmdletBinding()]
 param (
-    [Parameter(Position=0)]
-    [Parameter(Mandatory=$true, ParameterSetName='ServiceDirectory')]
+    [Parameter(Position=0, Mandatory=$true, ParameterSetName='ServiceDirectory')]
     [string] $ServiceDirectory,
 
     [string] $SDKType = "all",

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -46,11 +46,6 @@ $diagnosticArguments = ($debugLogging -and $logsFolder) ? "/binarylogger:$logsFo
     $servicesProj `
     $diagnosticArguments
 
-if ($LASTEXITCODE) {
-    Write-Host "##vso[task.LogIssue type=error;]API export failed. See the build logs for details."
-    exit $LASTEXITCODE
-}
-
 # Normalize line endings to LF in generated API listing files
 Write-Host "Normalizing line endings in API listing files"
 $apiListingFiles = Get-ChildItem -Path $apiListingFilesFilter -ErrorAction SilentlyContinue

--- a/eng/scripts/Export-API.ps1
+++ b/eng/scripts/Export-API.ps1
@@ -33,7 +33,7 @@ $debugLogging = $env:SYSTEM_DEBUG -eq "true"
 $logsFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 $diagnosticArguments = ($debugLogging -and $logsFolder) ? "/binarylogger:$logsFolder/exportapi.binlog" : ""
 
-Invoke-LoggedMsbuildCommand "dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope="$relativePackagePath" /p:SDKType=$SDKType /restore $servicesProj $diagnosticArguments"
+Invoke-LoggedMsbuildCommand "dotnet build /t:ExportApi /p:RunApiCompat=false /p:InheritDocEnabled=false /p:GeneratePackageOnBuild=false /p:Configuration=Release /p:IncludeSamples=false /p:IncludePerf=false /p:IncludeStress=false /p:IncludeTests=false /p:Scope=`"$relativePackagePath`" /p:SDKType=$SDKType /restore $servicesProj $diagnosticArguments"
 
 # Normalize line endings to LF in generated API listing files
 Write-Host "Normalizing line endings in API listing files"


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/12985

1. Use parameter sets to determine expression used for path filter
2. Fail on failure of `dotnet build` (this is new behavior but possibly correct)

Also: 
3. It was possible to call `Export-API.ps1` without any parameters, in this state the dotnet build command would build the whole repo. This was not allowed in previous iterations https://github.com/Azure/azure-sdk-for-net/blob/1218ff47bd89045f688dea67434411961cbd3554/eng/scripts/Export-API.ps1#L4
