### PR TITLE
[Identity] Upgrade MSAL dependencies to 4.78.0 and Azure.Identity to 1.17.1

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -126,7 +126,7 @@
     <PackageReference Update="Azure.MixedReality.Authentication" version= "1.2.0" />
     <PackageReference Update="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
     <PackageReference Update="Azure.Monitor.Query.Logs" Version="1.0.0" />
-    <PackageReference Update="Azure.Identity" Version="1.16.0" />
+    <PackageReference Update="Azure.Identity" Version="1.17.1" />
     <PackageReference Update="Azure.Search.Documents" Version="11.6.0" />
     <PackageReference Update="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
     <PackageReference Update="Azure.Security.KeyVault.Keys" Version="4.7.0" />
@@ -333,7 +333,7 @@
     <PackageReference Update="ApprovalTests" Version="3.0.22" />
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
     <PackageReference Update="Azure.Core" Version="1.50.0" />
-    <PackageReference Update="Azure.Identity" Version="1.16.0" />
+    <PackageReference Update="Azure.Identity" Version="1.17.1" />
     <PackageReference Update="Azure.Messaging.EventGrid" Version="4.17.0" />
     <PackageReference Update="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
     <PackageReference Update="Azure.Messaging.ServiceBus" Version="7.20.1" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -185,9 +185,9 @@
     <!-- Other approved packages -->
     <PackageReference Update="Microsoft.Azure.Amqp" Version="2.7.0" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
-    <PackageReference Update="Microsoft.Identity.Client" Version="4.76.0" />
-    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.76.0" />
-    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.76.0" />
+    <PackageReference Update="Microsoft.Identity.Client" Version="4.77.1" />
+    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.77.1" />
+    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.77.1" />
     <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.14.0" />
     <PackageReference Update="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -185,9 +185,9 @@
     <!-- Other approved packages -->
     <PackageReference Update="Microsoft.Azure.Amqp" Version="2.7.0" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
-    <PackageReference Update="Microsoft.Identity.Client" Version="4.77.1" />
-    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.77.1" />
-    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.77.1" />
+    <PackageReference Update="Microsoft.Identity.Client" Version="4.78.0" />
+    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.78.0" />
+    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.78.0" />
     <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.14.0" />
     <PackageReference Update="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.1 (2025-11-19)
 
 ### Other Changes
 

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Other Changes
 
 - Updated `Microsoft.Identity.Client.Broker` dependency to version 4.78.0
+- Updated `Azure.Identity` dependency to version 1.17.1
 
 ## 1.3.0 (2025-09-04)
 

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated `Microsoft.Identity.Client.Broker` dependency to version 4.78.0
+
 ## 1.3.0 (2025-09-04)
 
 ### Breaking Changes

--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides authentication broker APIs for authenticating to Microsoft Entra ID</Description>
     <AssemblyTitle>Microsoft Azure.Identity.Broker Component</AssemblyTitle>
-    <Version>1.4.0-beta.1</Version>
+    <Version>1.3.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity Broker;$(PackageCommonTags)</PackageTags>

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Release History
 
-## 1.18.0-beta.2 (Unreleased)
+## 1.18.0-beta.2 (2025-11-19)
 
-### Features Added
+### Other Changes
 
-### Breaking Changes
+- Updated `Microsoft.Identity.Client` and `Microsoft.Identity.Client.Extensions.Msal` dependencies to version 4.78.0.
 
-### Bugs Fixed
+## 1.17.1 (2025-11-18)
 
 ### Other Changes
 

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated `Microsoft.Identity.Client` and `Microsoft.Identity.Client.Extensions.Msal` dependencies to version 4.78.0.
+
 ## 1.18.0-beta.1 (2025-11-14)
 
 ### Features Added


### PR DESCRIPTION
This PR upgrades the identity-related dependencies used in the Azure SDK for .NET:

- **MSAL (Microsoft Authentication Library) dependencies** have been updated to version **4.78.0**, ensuring usage of the latest non-deprecated release.
- **Azure.Identity** has been upgraded to version **1.17.1**, bringing potential fixes and new features from the latest release.
- The changelogs for both **Azure.Identity** and **Azure.Identity.Broker** packages have been updated to reflect these dependency changes.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/53984