### PR TITLE
Remove Experimental AZPROVISION001 from Azure.Provisioning.RedisEnterprise

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.AppService/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppService/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.ApplicationInsights/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.Communication/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Communication/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerRegistry/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.ContainerService/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.ContainerService/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.EventGrid/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventGrid/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.EventHubs/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.EventHubs/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.KeyVault/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.KeyVault/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Kubernetes/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.KubernetesConfiguration/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.OperationalInsights/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.Redis/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Redis/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.RedisEnterprise/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.RedisEnterprise/src/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.Search/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Search/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.ServiceBus/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.SignalR/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.SignalR/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.Sql/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Sql/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.Storage/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Storage/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.WebPubSub/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/Azure.Provisioning/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Properties/AssemblyInfo.cs
@@ -1,7 +1,0 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-// TODO: Uncomment if we need to GA before all the APIs are finalized
-// [assembly: Experimental("AZPROVISION001")]


### PR DESCRIPTION
I also removed all the commented out Experimental attributes in AssemblyInfo.cs files since these files are not needed.

cc @ArcturusZhang 