### PR TITLE
[CODEOWNERS] Fix linter errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1007,10 +1007,7 @@
 # ServiceOwners:                                                   @emmeliaAra
 
 # PRLabel: %HybridConnectivity
-/sdk/hybridconnectivity/Azure.ResourceManager.*/                   @apmehrotra
-
-# ServiceLabel: %HybridConnectivity %Mgmt
-# ServiceOwners:                                                   @apmehrotra
+/sdk/hybridconnectivity/Azure.ResourceManager.*/                   @ArcturusZhang @ArthurMa1978
 
 # PRLabel: %LambdaTest HyperExecute
 /sdk/lambdatesthyperexecute/Azure.ResourceManager.*/               @ArcturusZhang @ArthurMa1978


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner being flagged by the linter as no longer valid.

# References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5605265&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_


