### PR TITLE
Azure.AI.OpenAI: 2.7.0-beta.1 for OpenAI 2.7.0 compat

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -213,7 +213,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.AI.OpenAI'))">
-    <PackageReference Update="OpenAI" Version="2.5.0" />
+    <PackageReference Update="OpenAI" Version="2.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.Developer.Playwright'))">

--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.7.0-beta.1 (2025-11-24)
 
-This updates restores compatibility with the latest `2.7.0` release of `OpenAI` and enables access to the latest features. For details, please see [the full OpenAI 2.7.0 release notes](https://github.com/openai/openai-dotnet/blob/main/CHANGELOG.md#270-2025-11-13).
+This update restores compatibility with the latest `2.7.0` release of `OpenAI` and enables access to the latest features. For details, please see [the full OpenAI 2.7.0 release notes](https://github.com/openai/openai-dotnet/blob/main/CHANGELOG.md#270-2025-11-13).
 
 ### Features Added
 

--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release History
 
+## 2.7.0-beta.1 (2025-11-24)
+
+This updates restores compatibility with the latest `2.7.0` release of `OpenAI` and enables access to the latest features. For details, please see [the full OpenAI 2.7.0 release notes](https://github.com/openai/openai-dotnet/blob/main/CHANGELOG.md#270-2025-11-13).
+
+### Features Added
+
+- A substantial number of new features are carried forward from the `OpenAI` library. Please see [the full OpenAI 2.5.0 release notes](https://github.com/openai/openai-dotnet/blob/main/CHANGELOG.md#270-2025-11-13) for details.
+
+### Breaking Changes
+
+**`[Experimental]` Chat Extensions**
+
+- Explicitly assigning `null` to the `MaxOutputTokens` property of a `ChatCompletionOptions` instance will now reset opt-in to
+  contemporary serialization of `max_output_tokens` via `.SetNewMaxOutputTokensPropertyEnabled()`. Please ensure the extension
+  method is invoked after non-null assignment of `MaxOutputTokens`.
+
 ## 2.5.0-beta.1 (2025-10-03)
 
 This update restores compatibility with the latest `2.5.0` release of `OpenAI` and enables access to the latest features. For details, please see [the full OpenAI 2.5.0 release notes](https://github.com/openai/openai-dotnet/blob/main/CHANGELOG.md#250-2025-09-23).

--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.net8.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.net8.0.cs
@@ -106,11 +106,17 @@ namespace Azure.AI.OpenAI
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("OPENAI001")]
         public override OpenAI.Batch.BatchClient GetBatchClient() { throw null; }
         public override OpenAI.Chat.ChatClient GetChatClient(string deploymentName) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override OpenAI.Containers.ContainerClient GetContainerClient() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override OpenAI.Conversations.ConversationClient GetConversationClient() { throw null; }
         public override OpenAI.Embeddings.EmbeddingClient GetEmbeddingClient(string deploymentName) { throw null; }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("OPENAI001")]
         public override OpenAI.Evals.EvaluationClient GetEvaluationClient() { throw null; }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("OPENAI001")]
         public override OpenAI.FineTuning.FineTuningClient GetFineTuningClient() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override OpenAI.Graders.GraderClient GetGraderClient() { throw null; }
         public override OpenAI.Images.ImageClient GetImageClient(string deploymentName) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override OpenAI.Moderations.ModerationClient GetModerationClient(string _) { throw null; }
@@ -123,6 +129,8 @@ namespace Azure.AI.OpenAI
         public override OpenAI.Realtime.RealtimeClient GetRealtimeClient() { throw null; }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("OPENAI001")]
         public override OpenAI.VectorStores.VectorStoreClient GetVectorStoreClient() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override OpenAI.Videos.VideoClient GetVideoClient() { throw null; }
     }
     public partial class AzureOpenAIClientOptions : System.ClientModel.Primitives.ClientPipelineOptions
     {
@@ -425,8 +433,6 @@ namespace Azure.AI.OpenAI.Chat
         public static Azure.AI.OpenAI.ResponseContentFilterResult GetResponseContentFilterResult(this OpenAI.Chat.StreamingChatCompletionUpdate chatUpdate) { throw null; }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AOAI001")]
         public static Azure.AI.OpenAI.UserSecurityContext GetUserSecurityContext(this OpenAI.Chat.ChatCompletionOptions options) { throw null; }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AOAI001")]
-        public static void SetNewMaxCompletionTokensPropertyEnabled(this OpenAI.Chat.ChatCompletionOptions options, bool newPropertyEnabled = true) { }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AOAI001")]
         public static void SetUserSecurityContext(this OpenAI.Chat.ChatCompletionOptions options, Azure.AI.OpenAI.UserSecurityContext userSecurityContext) { }
     }

--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -92,9 +92,15 @@ namespace Azure.AI.OpenAI
         public override OpenAI.Audio.AudioClient GetAudioClient(string deploymentName) { throw null; }
         public override OpenAI.Batch.BatchClient GetBatchClient() { throw null; }
         public override OpenAI.Chat.ChatClient GetChatClient(string deploymentName) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override OpenAI.Containers.ContainerClient GetContainerClient() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override OpenAI.Conversations.ConversationClient GetConversationClient() { throw null; }
         public override OpenAI.Embeddings.EmbeddingClient GetEmbeddingClient(string deploymentName) { throw null; }
         public override OpenAI.Evals.EvaluationClient GetEvaluationClient() { throw null; }
         public override OpenAI.FineTuning.FineTuningClient GetFineTuningClient() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override OpenAI.Graders.GraderClient GetGraderClient() { throw null; }
         public override OpenAI.Images.ImageClient GetImageClient(string deploymentName) { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override OpenAI.Moderations.ModerationClient GetModerationClient(string _) { throw null; }
@@ -104,6 +110,8 @@ namespace Azure.AI.OpenAI
         public override OpenAI.Responses.OpenAIResponseClient GetOpenAIResponseClient(string deploymentName) { throw null; }
         public override OpenAI.Realtime.RealtimeClient GetRealtimeClient() { throw null; }
         public override OpenAI.VectorStores.VectorStoreClient GetVectorStoreClient() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override OpenAI.Videos.VideoClient GetVideoClient() { throw null; }
     }
     public partial class AzureOpenAIClientOptions : System.ClientModel.Primitives.ClientPipelineOptions
     {
@@ -378,7 +386,6 @@ namespace Azure.AI.OpenAI.Chat
         public static Azure.AI.OpenAI.ResponseContentFilterResult GetResponseContentFilterResult(this OpenAI.Chat.ChatCompletion chatCompletion) { throw null; }
         public static Azure.AI.OpenAI.ResponseContentFilterResult GetResponseContentFilterResult(this OpenAI.Chat.StreamingChatCompletionUpdate chatUpdate) { throw null; }
         public static Azure.AI.OpenAI.UserSecurityContext GetUserSecurityContext(this OpenAI.Chat.ChatCompletionOptions options) { throw null; }
-        public static void SetNewMaxCompletionTokensPropertyEnabled(this OpenAI.Chat.ChatCompletionOptions options, bool newPropertyEnabled = true) { }
         public static void SetUserSecurityContext(this OpenAI.Chat.ChatCompletionOptions options, Azure.AI.OpenAI.UserSecurityContext userSecurityContext) { }
     }
     public partial class AzureSearchChatDataSource : Azure.AI.OpenAI.Chat.ChatDataSource, System.ClientModel.Primitives.IJsonModel<Azure.AI.OpenAI.Chat.AzureSearchChatDataSource>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.OpenAI.Chat.AzureSearchChatDataSource>

--- a/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -10,6 +10,8 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateAPIListing>true</GenerateAPIListing>
     <NoWarn>$(NoWarn);CS1591;AZC0012;AZC0102;CS8002;CS0436;AZC0112;OPENAI001;OPENAI002;AOAI001</NoWarn>
+    <!-- For System.ClientModel JsonPatch support -->
+    <NoWarn>$(NoWarn);SCME0001</NoWarn>
     <!-- Needs System.ClientModel 1.5.0 in order to add the context and use the new overloads -->
     <!-- After this https://github.com/Azure/azure-sdk-for-net/issues/49916 we can remove this no warn -->
     <NoWarn>$(NoWarn);AZC0150</NoWarn>
@@ -41,7 +43,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <VersionPrefix>2.5.0</VersionPrefix>
+        <VersionPrefix>2.7.0</VersionPrefix>
         <VersionSuffix>beta.1</VersionSuffix>
   </PropertyGroup>
     </Otherwise>

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIClient.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/AzureOpenAIClient.cs
@@ -38,6 +38,11 @@ using Azure.AI.OpenAI.VectorStores;
 using Azure.AI.OpenAI.Responses;
 using OpenAI.Evals;
 using Azure.AI.OpenAI.Evals;
+using OpenAI.Conversations;
+using System.Text;
+using OpenAI.Containers;
+using OpenAI.Graders;
+using OpenAI.Videos;
 #endif
 
 #pragma warning disable AZC0007
@@ -295,6 +300,34 @@ public partial class AzureOpenAIClient : OpenAIClient
         return new AzureOpenAIResponseClient(Pipeline, deploymentName, _endpoint, _options);
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override ConversationClient GetConversationClient()
+    {
+        ThrowUnsupportedAreaException(nameof(ConversationClient));
+        return null;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override ContainerClient GetContainerClient()
+    {
+        ThrowUnsupportedAreaException(nameof(ContainerClient));
+        return null;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override GraderClient GetGraderClient()
+    {
+        ThrowUnsupportedAreaException(nameof(GraderClient));
+        return null;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public override VideoClient GetVideoClient()
+    {
+        ThrowUnsupportedAreaException(nameof(VideoClient));
+        return null;
+    }
+
     private static ClientPipeline CreatePipeline(PipelinePolicy authenticationPolicy, AzureOpenAIClientOptions options)
         => ClientPipeline.Create(
             options ?? new(),
@@ -381,6 +414,16 @@ public partial class AzureOpenAIClient : OpenAIClient
                 request.Uri = uriBuilder.ToUri();
             }
         });
+    }
+
+    private static void ThrowUnsupportedAreaException(string clientName)
+    {
+        StringBuilder builder = new();
+        builder.AppendLine(clientName + " use is not supported via this library.");
+        builder.AppendLine();
+        builder.Append("Please use " + nameof(OpenAIClient) + " with appropriate direct endpoint "
+            + "configuration for access to the latest features.");
+        throw new InvalidOperationException(builder.ToString());
     }
 
     private static readonly string s_userAgentHeaderKey = "User-Agent";

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatClient.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatClient.cs
@@ -42,14 +42,14 @@ internal partial class AzureChatClient : ChatClient
     /// <inheritdoc/>
     public override Task<ClientResult<ChatCompletion>> CompleteChatAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
-        PostfixSwapMaxTokens(ref options);
+        RefreshMaxTokenSerialization(ref options);
         return base.CompleteChatAsync(messages, options, cancellationToken);
     }
 
     /// <inheritdoc/>
     public override ClientResult<ChatCompletion> CompleteChat(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
-        PostfixSwapMaxTokens(ref options);
+        RefreshMaxTokenSerialization(ref options);
         return base.CompleteChat(messages, options, cancellationToken);
     }
 
@@ -65,7 +65,7 @@ internal partial class AzureChatClient : ChatClient
     public override AsyncCollectionResult<StreamingChatCompletionUpdate> CompleteChatStreamingAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
         PostfixClearStreamOptions(messages, ref options);
-        PostfixSwapMaxTokens(ref options);
+        RefreshMaxTokenSerialization(ref options);
         return base.CompleteChatStreamingAsync(messages, options, cancellationToken);
     }
 
@@ -73,7 +73,7 @@ internal partial class AzureChatClient : ChatClient
     public override CollectionResult<StreamingChatCompletionUpdate> CompleteChatStreaming(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default)
     {
         PostfixClearStreamOptions(messages, ref options);
-        PostfixSwapMaxTokens(ref options);
+        RefreshMaxTokenSerialization(ref options);
         return base.CompleteChatStreaming(messages, options, cancellationToken);
     }
 
@@ -86,16 +86,14 @@ internal partial class AzureChatClient : ChatClient
      */
     private static void PostfixClearStreamOptions(IEnumerable<ChatMessage> messages, ref ChatCompletionOptions options)
     {
-        if (AdditionalPropertyHelpers
-                .GetAdditionalPropertyAsListOfChatDataSource(options?.SerializedAdditionalRawData, "data_sources")?.Count > 0
+        if (options?.Patch.GetBytesOrDefaultEx("$.data_sources"u8) is not null
             || messages?.Any(
                 message => message?.Content?.Any(
                     contentPart => contentPart?.Kind == ChatMessageContentPartKind.Image) == true)
                 == true)
         {
             options ??= new();
-            options.SerializedAdditionalRawData ??= new Dictionary<string, BinaryData>();
-            AdditionalPropertyHelpers.SetEmptySentinelValue(options.SerializedAdditionalRawData, "stream_options");
+            options.Patch.Remove("$.stream_options"u8);
         }
     }
 
@@ -110,56 +108,9 @@ internal partial class AzureChatClient : ChatClient
      *   - Otherwise, serialization of max_completion_tokens is blocked and an override serialization of the
      *     corresponding max_tokens value is established
      */
-    private static void PostfixSwapMaxTokens(ref ChatCompletionOptions options)
+    private static void RefreshMaxTokenSerialization(ref ChatCompletionOptions options)
     {
         options ??= new();
-        bool valueIsSet = options.MaxOutputTokenCount is not null;
-        bool oldPropertyBlocked = AdditionalPropertyHelpers.GetIsEmptySentinelValue(options.SerializedAdditionalRawData, "max_tokens");
-
-        if (valueIsSet)
-        {
-            if (!oldPropertyBlocked)
-            {
-                options.SerializedAdditionalRawData ??= new ChangeTrackingDictionary<string, BinaryData>();
-                AdditionalPropertyHelpers.SetEmptySentinelValue(options.SerializedAdditionalRawData, "max_completion_tokens");
-
-                using MemoryStream stream = new();
-                using Utf8JsonWriter writer = new(stream);
-
-                if (options.MaxOutputTokenCount != null)
-                {
-                    writer.WriteNumberValue(options.MaxOutputTokenCount.Value);
-                }
-                else
-                {
-                    writer.WriteNullValue();
-                }
-
-                writer.Flush();
-
-                options.SerializedAdditionalRawData["max_tokens"] = BinaryData.FromBytes(stream.ToArray());
-            }
-            else
-            {
-                // Allow standard serialization to the new property to occur; remove overrides
-                if (options.SerializedAdditionalRawData.ContainsKey("max_completion_tokens"))
-                {
-                    options.SerializedAdditionalRawData.Remove("max_completion_tokens");
-                }
-            }
-        }
-        else
-        {
-            if (!AdditionalPropertyHelpers.GetIsEmptySentinelValue(options.SerializedAdditionalRawData, "max_tokens")
-                && options.SerializedAdditionalRawData?.ContainsKey("max_tokens") == true)
-            {
-                options.SerializedAdditionalRawData.Remove("max_tokens");
-            }
-            if (!AdditionalPropertyHelpers.GetIsEmptySentinelValue(options.SerializedAdditionalRawData, "max_completion_tokens")
-                && options.SerializedAdditionalRawData?.ContainsKey("max_completion_tokens") == true)
-            {
-                options.SerializedAdditionalRawData.Remove("max_completion_tokens");
-            }
-        }
+        options.SetMaxTokenPatchValues();
     }
 }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using Azure.AI.OpenAI.Internal;
+using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 
 #pragma warning disable AZC0112
 
@@ -14,127 +16,159 @@ public static partial class AzureChatExtensions
     [Experimental("AOAI001")]
     public static void AddDataSource(this ChatCompletionOptions options, ChatDataSource dataSource)
     {
-        options.SerializedAdditionalRawData ??= new Dictionary<string, BinaryData>();
+        ChangeTrackingList<ChatDataSource> dataSources = options.GetInternalDataSources();
+        dataSources.Add(dataSource);
 
-        IList<ChatDataSource> existingSources =
-            AdditionalPropertyHelpers.GetAdditionalPropertyAsListOfChatDataSource(
-                options.SerializedAdditionalRawData,
-                "data_sources")
-            ?? new ChangeTrackingList<ChatDataSource>();
-        existingSources.Add(dataSource);
-        AdditionalPropertyHelpers.SetAdditionalProperty(
-            options.SerializedAdditionalRawData,
-            "data_sources",
-            existingSources);
+        using MemoryStream stream = new();
+        Utf8JsonWriter writer = new(stream);
+
+        writer.WriteStartArray();
+        foreach (ChatDataSource listedDataSource in dataSources)
+        {
+            ((IJsonModel<ChatDataSource>)listedDataSource).Write(writer, ModelSerializationExtensions.WireOptions);
+        }
+        writer.WriteEndArray();
+
+        writer.Flush();
+        stream.Position = 0;
+
+        options.Patch.Set("$.data_sources"u8, BinaryData.FromStream(stream));
     }
 
     [Experimental("AOAI001")]
     public static IReadOnlyList<ChatDataSource> GetDataSources(this ChatCompletionOptions options)
     {
-        return AdditionalPropertyHelpers.GetAdditionalPropertyAsListOfChatDataSource(
-            options.SerializedAdditionalRawData,
-            "data_sources") as IReadOnlyList<ChatDataSource>;
+        return options.GetInternalDataSources();
+    }
+
+    private static ChangeTrackingList<ChatDataSource> GetInternalDataSources(this ChatCompletionOptions options)
+    {
+        ChangeTrackingList<ChatDataSource> dataSources = new();
+        if (options.Patch.GetBytesOrDefaultEx("$.data_sources"u8) is BinaryData dataSourceListBytes)
+        {
+            using JsonDocument listDocument = JsonDocument.Parse(dataSourceListBytes);
+            if (listDocument.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement dataSourceElement in listDocument.RootElement.EnumerateArray())
+                {
+                    ChatDataSource dataSource = ChatDataSource.DeserializeChatDataSource(dataSourceElement, ModelSerializationExtensions.WireOptions);
+                    dataSources.Add(dataSource);
+                }
+            }
+        }
+        return dataSources;
     }
 
     [Experimental("AOAI001")]
-    public static void SetNewMaxCompletionTokensPropertyEnabled(this ChatCompletionOptions options, bool newPropertyEnabled = true)
+    internal static void SetNewMaxCompletionTokensPropertyEnabled(this ChatCompletionOptions options, bool newPropertyEnabled = true)
+        => options.SetMaxTokenPatchValues(newPropertyEnabled);
+
+    internal static void SetMaxTokenPatchValues(this ChatCompletionOptions options, bool? newPropertyRequested = null)
     {
-        if (newPropertyEnabled)
+        bool newPropertyInUse = options.Patch.Contains(NewMaxTokenJsonPath.Span) && !options.Patch.IsRemoved(NewMaxTokenJsonPath.Span);
+        bool useNewProperty = newPropertyRequested ?? newPropertyInUse;
+
+        ReadOnlySpan<byte> selectedPath = useNewProperty ? NewMaxTokenJsonPath.Span : OldMaxTokenJsonPath.Span;
+        ReadOnlySpan<byte> deselectedPath = useNewProperty ? OldMaxTokenJsonPath.Span : NewMaxTokenJsonPath.Span;
+
+        BinaryData valueBytes = options.MaxOutputTokenCount is null
+            ? null
+            : BinaryData.FromString(options.MaxOutputTokenCount.ToString());
+
+        if (valueBytes is null)
         {
-            // Blocking serialization of max_tokens via dictionary acts as a signal to skip pre-serialization fixup
-            options.SerializedAdditionalRawData ??= new Dictionary<string, BinaryData>();
-            AdditionalPropertyHelpers.SetEmptySentinelValue(options.SerializedAdditionalRawData, "max_tokens");
+            options.Patch.Remove(selectedPath);
         }
         else
         {
-            // In the absence of a dictionary serialization block to max_tokens, the newer property name will
-            // automatically be blocked and the older property name will be used via dictionary override
-            if (options?.SerializedAdditionalRawData?.ContainsKey("max_tokens") == true)
-            {
-                options?.SerializedAdditionalRawData?.Remove("max_tokens");
-            }
+            options.Patch.Set(selectedPath, valueBytes);
         }
+        options.Patch.Remove(deselectedPath);
     }
 
     [Experimental("AOAI001")]
     public static RequestContentFilterResult GetRequestContentFilterResult(this ChatCompletion chatCompletion)
     {
-        return AdditionalPropertyHelpers.GetAdditionalPropertyAsListOfRequestContentFilterResult(
-            chatCompletion.SerializedAdditionalRawData,
-            "prompt_filter_results")?[0];
+        return chatCompletion.Patch.GetDeserializedInstanceList(
+            "$.prompt_filter_results"u8,
+            RequestContentFilterResult.DeserializeRequestContentFilterResult)?
+                .FirstOrDefault();
     }
 
     [Experimental("AOAI001")]
     public static ResponseContentFilterResult GetResponseContentFilterResult(this ChatCompletion chatCompletion)
     {
-        return AdditionalPropertyHelpers.GetAdditionalPropertyAsResponseContentFilterResult(
-            chatCompletion.Choices?[0]?.SerializedAdditionalRawData,
-            "content_filter_results");
+        return chatCompletion?.Choices?.FirstOrDefault()?.Patch.GetDeserializedInstance(
+            "$.content_filter_results"u8,
+            ResponseContentFilterResult.DeserializeResponseContentFilterResult);
     }
 
     [Experimental("AOAI001")]
     public static ChatMessageContext GetMessageContext(this ChatCompletion chatCompletion)
     {
-        return AdditionalPropertyHelpers.GetAdditionalPropertyAsChatMessageContext(
-            chatCompletion.Choices?[0]?.Message?.SerializedAdditionalRawData,
-            "context");
+        return chatCompletion?.Choices?.FirstOrDefault()?.Message?.Patch.GetDeserializedInstance(
+            "$.context"u8,
+            ChatMessageContext.DeserializeChatMessageContext);
     }
 
     [Experimental("AOAI001")]
     public static ChatMessageContext GetMessageContext(this StreamingChatCompletionUpdate chatUpdate)
     {
-        if (chatUpdate.Choices?.Count > 0)
-        {
-            return AdditionalPropertyHelpers.GetAdditionalPropertyAsChatMessageContext(
-                chatUpdate.Choices[0].Delta?.SerializedAdditionalRawData,
-                "context");
-        }
-        return null;
+        return chatUpdate?.Choices?.FirstOrDefault()?.Delta?.Patch.GetDeserializedInstance(
+            "$.context"u8,
+            ChatMessageContext.DeserializeChatMessageContext);
     }
 
     [Experimental("AOAI001")]
     public static RequestContentFilterResult GetRequestContentFilterResult(this StreamingChatCompletionUpdate chatUpdate)
     {
-        return AdditionalPropertyHelpers.GetAdditionalPropertyAsListOfRequestContentFilterResult(
-            chatUpdate.SerializedAdditionalRawData,
-            "prompt_filter_results")?[0];
+        return chatUpdate?.Patch.GetDeserializedInstanceList(
+            "$.prompt_filter_results"u8,
+            RequestContentFilterResult.DeserializeContentFilterResultForPrompt)?
+                .FirstOrDefault();
     }
 
     [Experimental("AOAI001")]
     public static ResponseContentFilterResult GetResponseContentFilterResult(this StreamingChatCompletionUpdate chatUpdate)
     {
-        return AdditionalPropertyHelpers.GetAdditionalPropertyAsResponseContentFilterResult(
-            chatUpdate?.Choices?.ElementAtOrDefault(0)?.SerializedAdditionalRawData,
-            "content_filter_results");
+        return chatUpdate?.Choices?.FirstOrDefault()?.Patch.GetDeserializedInstance(
+            "$.content_filter_results"u8,
+            ResponseContentFilterResult.DeserializeResponseContentFilterResult);
     }
 
     [Experimental("AOAI001")]
     public static void SetUserSecurityContext(this ChatCompletionOptions options, UserSecurityContext userSecurityContext)
     {
-        options.SerializedAdditionalRawData ??= new Dictionary<string, BinaryData>();
-
-        AdditionalPropertyHelpers.SetAdditionalProperty(
-            options.SerializedAdditionalRawData,
-            "user_security_context",
-            userSecurityContext);
+        BinaryData contextBytes = ((IJsonModel<UserSecurityContext>)userSecurityContext).Write(ModelSerializationExtensions.WireOptions);
+        options.Patch.Set("$.user_security_context"u8, contextBytes);
     }
 
     [Experimental("AOAI001")]
     public static UserSecurityContext GetUserSecurityContext(this ChatCompletionOptions options)
     {
-        return AdditionalPropertyHelpers.GetAdditionalPropertyAsUserSecurityContext(
-            options.SerializedAdditionalRawData,
-            "user_security_context");
+        return options.Patch.GetDeserializedInstance(
+            "$.user_security_context"u8,
+            UserSecurityContext.DeserializeUserSecurityContext);
     }
 
     [Experimental("AOAI001")]
     public static string GetMessageReasoningContent(this ChatCompletion chatCompletion)
     {
-        if (chatCompletion?.Choices?.FirstOrDefault()?.Message?.SerializedAdditionalRawData?.TryGetValue("reasoning_content", out BinaryData reasoningContentData) == true
-            && reasoningContentData?.ToString() is string retrievedReasoningContent)
+        if (chatCompletion?.Choices?.FirstOrDefault()?.Message?.Patch.GetBytesOrDefaultEx("$.reasoning_content"u8)
+            is BinaryData reasoningContentBytes)
         {
-            return retrievedReasoningContent;
+            string serialReasoningContent = reasoningContentBytes.ToString();
+            if (serialReasoningContent.Length > 2
+                && serialReasoningContent[0] == '"'
+                && serialReasoningContent[serialReasoningContent.Length - 1] == '"')
+            {
+                return serialReasoningContent.Substring(1, serialReasoningContent.Length - 2);
+            }
+            return serialReasoningContent;
         }
         return null;
     }
+
+    internal static ReadOnlyMemory<byte> NewMaxTokenJsonPath { get; } = "$.max_completion_tokens"u8.ToArray();
+    internal static ReadOnlyMemory<byte> OldMaxTokenJsonPath { get; } = "$.max_tokens"u8.ToArray();
 }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
@@ -157,14 +157,9 @@ public static partial class AzureChatExtensions
         if (chatCompletion?.Choices?.FirstOrDefault()?.Message?.Patch.GetBytesOrDefaultEx("$.reasoning_content"u8)
             is BinaryData reasoningContentBytes)
         {
-            string serialReasoningContent = reasoningContentBytes.ToString();
-            if (serialReasoningContent.Length > 2
-                && serialReasoningContent[0] == '"'
-                && serialReasoningContent[serialReasoningContent.Length - 1] == '"')
-            {
-                return serialReasoningContent.Substring(1, serialReasoningContent.Length - 2);
-            }
-            return serialReasoningContent;
+            Utf8JsonReader reader = new(reasoningContentBytes);
+            reader.Read();
+            return reader.GetString();
         }
         return null;
     }

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
@@ -20,7 +20,7 @@ public static partial class AzureChatExtensions
         dataSources.Add(dataSource);
 
         using MemoryStream stream = new();
-        Utf8JsonWriter writer = new(stream);
+        using Utf8JsonWriter writer = new(stream);
 
         writer.WriteStartArray();
         foreach (ChatDataSource listedDataSource in dataSources)

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Common/AdditionalPropertyHelpers.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Common/AdditionalPropertyHelpers.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.AI.OpenAI.Chat;
 using System.ClientModel.Primitives;
 using System.Text.Json;
 
@@ -10,8 +9,6 @@ namespace Azure.AI.OpenAI.Internal;
 #pragma warning disable AOAI001
 internal static class AdditionalPropertyHelpers
 {
-    private static string SARD_EMPTY_SENTINEL = "__EMPTY__";
-
     private static T GetAdditionalProperty<T>(IDictionary<string, BinaryData> additionalProperties, string additionalPropertyKey, Func<JsonElement, ModelReaderWriterOptions, T> deserializeFunction) where T : class, IJsonModel<T>
     {
         if (additionalProperties?.TryGetValue(additionalPropertyKey, out BinaryData additionalPropertyValue) != true)
@@ -23,34 +20,6 @@ internal static class AdditionalPropertyHelpers
         return deserializeFunction(document.RootElement, ModelSerializationExtensions.WireOptions);
     }
 
-    private static IList<T> GetAdditionalPropertyAsList<T>(IDictionary<string, BinaryData> additionalProperties, string additionalPropertyKey, Func<JsonElement, ModelReaderWriterOptions, T> deserializeFunction) where T : class, IJsonModel<T>
-    {
-        if (additionalProperties?.TryGetValue(additionalPropertyKey, out BinaryData additionalPropertyValue) != true)
-        {
-            return null;
-        }
-
-        List<T> items = [];
-        using JsonDocument document = JsonDocument.Parse(additionalPropertyValue);
-
-        foreach (JsonElement element in document.RootElement.EnumerateArray())
-        {
-            items.Add(deserializeFunction(element, ModelSerializationExtensions.WireOptions));
-        }
-
-        return items;
-    }
-
-    internal static ResponseContentFilterResult GetAdditionalPropertyAsResponseContentFilterResult(IDictionary<string, BinaryData> additionalProperties, string additionalPropertyKey)
-    {
-        return GetAdditionalProperty(additionalProperties, additionalPropertyKey, ResponseContentFilterResult.DeserializeResponseContentFilterResult);
-    }
-
-    internal static ChatMessageContext GetAdditionalPropertyAsChatMessageContext(IDictionary<string, BinaryData> additionalProperties, string additionalPropertyKey)
-    {
-        return GetAdditionalProperty(additionalProperties, additionalPropertyKey, ChatMessageContext.DeserializeChatMessageContext);
-    }
-
     internal static RequestImageContentFilterResult GetAdditionalPropertyAsRequestImageContentFilterResult(IDictionary<string, BinaryData> additionalProperties, string additionalPropertyKey)
     {
         return GetAdditionalProperty(additionalProperties, additionalPropertyKey, RequestImageContentFilterResult.DeserializeRequestImageContentFilterResult);
@@ -59,53 +28,6 @@ internal static class AdditionalPropertyHelpers
     internal static ResponseImageContentFilterResult GetAdditionalPropertyAsResponseImageContentFilterResult(IDictionary<string, BinaryData> additionalProperties, string additionalPropertyKey)
     {
         return GetAdditionalProperty(additionalProperties, additionalPropertyKey, ResponseImageContentFilterResult.DeserializeResponseImageContentFilterResult);
-    }
-
-    internal static IList<ChatDataSource> GetAdditionalPropertyAsListOfChatDataSource(IDictionary<string, BinaryData> additionalProperties, string additionalPropertyKey)
-    {
-        return GetAdditionalPropertyAsList(additionalProperties, additionalPropertyKey, ChatDataSource.DeserializeChatDataSource);
-    }
-
-    internal static IList<RequestContentFilterResult> GetAdditionalPropertyAsListOfRequestContentFilterResult(IDictionary<string, BinaryData> additionalProperties, string additionalPropertyKey)
-    {
-        return GetAdditionalPropertyAsList(additionalProperties, additionalPropertyKey, RequestContentFilterResult.DeserializeRequestContentFilterResult);
-    }
-
-    internal static UserSecurityContext GetAdditionalPropertyAsUserSecurityContext(IDictionary<string, BinaryData> additionalProperties, string additionalPropertyKey)
-    {
-        return GetAdditionalProperty(additionalProperties, additionalPropertyKey, UserSecurityContext.DeserializeUserSecurityContext);
-    }
-
-    internal static void SetAdditionalProperty<T>(IDictionary<string, BinaryData> additionalProperties, string key, T value)
-    {
-        using MemoryStream stream = new();
-        using (Utf8JsonWriter writer = new(stream))
-        {
-            writer.WriteObjectValue(value);
-        }
-        stream.Position = 0;
-        BinaryData binaryValue = BinaryData.FromStream(stream);
-        additionalProperties[key] = binaryValue;
-    }
-
-    internal static void SetEmptySentinelValue(IDictionary<string, BinaryData> additionalProperties, string key)
-    {
-        Argument.AssertNotNull(additionalProperties, nameof(additionalProperties));
-
-        using MemoryStream stream = new();
-        using Utf8JsonWriter writer = new(stream);
-
-        writer.WriteStringValue(SARD_EMPTY_SENTINEL);
-        writer.Flush();
-
-        additionalProperties[key] = BinaryData.FromBytes(stream.ToArray());
-    }
-
-    internal static bool GetIsEmptySentinelValue(IDictionary<string, BinaryData> additionalProperties, string key)
-    {
-        return additionalProperties is not null
-            && additionalProperties.TryGetValue(key, out BinaryData existingValue)
-            && StringComparer.OrdinalIgnoreCase.Equals(existingValue.ToString(), $@"""{SARD_EMPTY_SENTINEL}""");
     }
 }
 #pragma warning restore AOAI001

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Responses/AzureResponsesClient.Protocol.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Responses/AzureResponsesClient.Protocol.cs
@@ -41,9 +41,13 @@ internal partial class AzureOpenAIResponseClient
             .WithOptions(options)
             .Build();
 
-    internal override PipelineMessage CreateGetInputItemsRequest(string responseId, int? limit, string order, string after, string before, RequestOptions options)
+    internal override PipelineMessage CreateGetResponseInputItemsRequest(string responseId, int? limit, string order, string after, string before, RequestOptions options)
         => new AzureOpenAIPipelineMessageBuilder(Pipeline, _aoaiEndpoint, _apiVersion, string.Empty)
             .WithPath("responses", responseId, "input_items")
+            .WithOptionalQueryParameter("limit", limit)
+            .WithOptionalQueryParameter("order", order)
+            .WithOptionalQueryParameter("after", after)
+            .WithOptionalQueryParameter("before", before)
             .WithMethod("GET")
             .WithOptions(options)
             .Build();

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreCollectionPageToken.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreCollectionPageToken.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !AZURE_OPENAI_GA
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+#nullable enable
+
+namespace Azure.AI.OpenAI;
+
+internal class VectorStoreCollectionPageToken : ContinuationToken
+{
+    protected VectorStoreCollectionPageToken(int? limit, string? order, string? after, string? before)
+    {
+        Limit = limit;
+        Order = order;
+        After = after;
+        Before = before;
+    }
+
+    public int? Limit { get; }
+
+    public string? Order { get; }
+
+    public string? After { get; }
+
+    public string? Before { get; }
+
+    public override BinaryData ToBytes()
+    {
+        using MemoryStream stream = new();
+        using Utf8JsonWriter writer = new(stream);
+
+        writer.WriteStartObject();
+
+        if (Limit.HasValue)
+        {
+            writer.WriteNumber("limit", Limit.Value);
+        }
+
+        if (Order is not null)
+        {
+            writer.WriteString("order", Order);
+        }
+
+        if (After is not null)
+        {
+            writer.WriteString("after", After);
+        }
+
+        if (Before is not null)
+        {
+            writer.WriteString("before", Before);
+        }
+
+        writer.WriteEndObject();
+
+        writer.Flush();
+        stream.Position = 0;
+
+        return BinaryData.FromStream(stream);
+    }
+
+    public static VectorStoreCollectionPageToken FromToken(ContinuationToken pageToken)
+    {
+        if (pageToken is VectorStoreCollectionPageToken token)
+        {
+            return token;
+        }
+
+        BinaryData data = pageToken.ToBytes();
+
+        if (data.ToMemory().Length == 0)
+        {
+            throw new ArgumentException("Failed to create VectorStoresPageToken from provided pageToken.", nameof(pageToken));
+        }
+
+        Utf8JsonReader reader = new(data);
+
+        int? limit = null;
+        string? order = null;
+        string? after = null;
+        string? before = null;
+
+        reader.Read();
+
+        Debug.Assert(reader.TokenType == JsonTokenType.StartObject);
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
+
+            string propertyName = reader.GetString()!;
+
+            switch (propertyName)
+            {
+                case "limit":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.Number);
+                    limit = reader.GetInt32();
+                    break;
+                case "order":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    order = reader.GetString();
+                    break;
+                case "after":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    after = reader.GetString();
+                    break;
+                case "before":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    before = reader.GetString();
+                    break;
+                default:
+                    throw new JsonException($"Unrecognized property '{propertyName}'.");
+            }
+        }
+
+        return new(limit, order, after, before);
+    }
+
+    public static VectorStoreCollectionPageToken FromOptions(int? limit, string? order, string? after, string? before)
+        => new(limit, order, after, before);
+
+    public static VectorStoreCollectionPageToken? FromResponse(ClientResult result, int? limit, string? order, string? before)
+    {
+        PipelineResponse response = result.GetRawResponse();
+        using JsonDocument doc = JsonDocument.Parse(response.Content);
+        string lastId = doc.RootElement.GetProperty("last_id"u8).GetString()!;
+        bool hasMore = doc.RootElement.GetProperty("has_more"u8).GetBoolean();
+
+        if (!hasMore || lastId is null)
+        {
+            return null;
+        }
+
+        return new(limit, order, lastId, before);
+    }
+}
+
+#endif

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreCollectionPageToken.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreCollectionPageToken.cs
@@ -78,7 +78,7 @@ internal class VectorStoreCollectionPageToken : ContinuationToken
 
         if (data.ToMemory().Length == 0)
         {
-            throw new ArgumentException("Failed to create VectorStoresPageToken from provided pageToken.", nameof(pageToken));
+            throw new ArgumentException("Failed to create VectorStoreCollectionPageToken from provided pageToken.", nameof(pageToken));
         }
 
         Utf8JsonReader reader = new(data);

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreFileBatchCollectionPageToken.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreFileBatchCollectionPageToken.cs
@@ -95,7 +95,7 @@ internal class VectorStoreFileBatchCollectionPageToken : ContinuationToken
 
         if (data.ToMemory().Length == 0)
         {
-            throw new ArgumentException("Failed to create VectorStoreFileBatchesPageToken from provided pageToken.", nameof(pageToken));
+            throw new ArgumentException("Failed to create VectorStoreFileBatchCollectionPageToken from provided pageToken.", nameof(pageToken));
         }
 
         Utf8JsonReader reader = new(data);
@@ -168,7 +168,7 @@ internal class VectorStoreFileBatchCollectionPageToken : ContinuationToken
         if (vectorStoreId is null ||
             batchId is null)
         {
-            throw new ArgumentException("Failed to create VectorStoreFileBatchesPageToken from provided pageToken.", nameof(pageToken));
+            throw new ArgumentException("Failed to create VectorStoreFileBatchCollectionPageToken from provided pageToken.", nameof(pageToken));
         }
 
         return new(vectorStoreId, batchId, limit, order, after, before, filter);

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreFileBatchCollectionPageToken.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreFileBatchCollectionPageToken.cs
@@ -1,0 +1,196 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !AZURE_OPENAI_GA
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+#nullable enable
+
+namespace Azure.AI.OpenAI;
+
+internal class VectorStoreFileBatchCollectionPageToken : ContinuationToken
+{
+    protected VectorStoreFileBatchCollectionPageToken(string vectorStoreId, string batchId, int? limit, string? order, string? after, string? before, string? filter)
+    {
+        VectorStoreId = vectorStoreId;
+        BatchId = batchId;
+
+        Limit = limit;
+        Order = order;
+        After = after;
+        Before = before;
+        Filter = filter;
+    }
+
+    public string VectorStoreId { get; }
+
+    public string BatchId { get; }
+
+    public int? Limit { get; }
+
+    public string? Order { get; }
+
+    public string? After { get; }
+
+    public string? Before { get; }
+
+    public string? Filter { get; }
+
+    public override BinaryData ToBytes()
+    {
+        using MemoryStream stream = new();
+        using Utf8JsonWriter writer = new(stream);
+
+        writer.WriteStartObject();
+        writer.WriteString("vectorStoreId", VectorStoreId);
+        writer.WriteString("batchId", BatchId);
+
+        if (Limit.HasValue)
+        {
+            writer.WriteNumber("limit", Limit.Value);
+        }
+
+        if (Order is not null)
+        {
+            writer.WriteString("order", Order);
+        }
+
+        if (After is not null)
+        {
+            writer.WriteString("after", After);
+        }
+
+        if (Before is not null)
+        {
+            writer.WriteString("before", Before);
+        }
+
+        if (Filter is not null)
+        {
+            writer.WriteString("filter", Filter);
+        }
+
+        writer.WriteEndObject();
+
+        writer.Flush();
+        stream.Position = 0;
+
+        return BinaryData.FromStream(stream);
+    }
+
+    public static VectorStoreFileBatchCollectionPageToken FromToken(ContinuationToken pageToken)
+    {
+        if (pageToken is VectorStoreFileBatchCollectionPageToken token)
+        {
+            return token;
+        }
+
+        BinaryData data = pageToken.ToBytes();
+
+        if (data.ToMemory().Length == 0)
+        {
+            throw new ArgumentException("Failed to create VectorStoreFileBatchesPageToken from provided pageToken.", nameof(pageToken));
+        }
+
+        Utf8JsonReader reader = new(data);
+
+        string vectorStoreId = null!;
+        string batchId = null!;
+        int? limit = null;
+        string? order = null;
+        string? after = null;
+        string? before = null;
+        string? filter = null;
+
+        reader.Read();
+
+        Debug.Assert(reader.TokenType == JsonTokenType.StartObject);
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
+
+            string propertyName = reader.GetString()!;
+
+            switch (propertyName)
+            {
+                case "vectorStoreId":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    vectorStoreId = reader.GetString()!;
+                    break;
+                case "batchId":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    batchId = reader.GetString()!;
+                    break;
+                case "limit":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.Number);
+                    limit = reader.GetInt32();
+                    break;
+                case "order":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    order = reader.GetString();
+                    break;
+                case "after":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    after = reader.GetString();
+                    break;
+                case "before":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    before = reader.GetString();
+                    break;
+                case "filter":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    filter = reader.GetString();
+                    break;
+                default:
+                    throw new JsonException($"Unrecognized property '{propertyName}'.");
+            }
+        }
+
+        if (vectorStoreId is null ||
+            batchId is null)
+        {
+            throw new ArgumentException("Failed to create VectorStoreFileBatchesPageToken from provided pageToken.", nameof(pageToken));
+        }
+
+        return new(vectorStoreId, batchId, limit, order, after, before, filter);
+    }
+
+    public static VectorStoreFileBatchCollectionPageToken FromOptions(string vectorStoreId, string batchId, int? limit, string? order, string? after, string? before, string? filter)
+        => new(vectorStoreId, batchId, limit, order, after, before, filter);
+
+    public static VectorStoreFileBatchCollectionPageToken? FromResponse(ClientResult result, string vectorStoreId, string batchId, int? limit, string? order, string? before, string? filter)
+    {
+        PipelineResponse response = result.GetRawResponse();
+        using JsonDocument doc = JsonDocument.Parse(response.Content);
+        string lastId = doc.RootElement.GetProperty("last_id"u8).GetString()!;
+        bool hasMore = doc.RootElement.GetProperty("has_more"u8).GetBoolean();
+
+        if (!hasMore || lastId is null)
+        {
+            return null;
+        }
+
+        return new(vectorStoreId, batchId, limit, order, lastId, before, filter);
+    }
+}
+
+#endif

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreFileCollectionPageToken.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreFileCollectionPageToken.cs
@@ -1,0 +1,185 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if !AZURE_OPENAI_GA
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+#nullable enable
+
+namespace Azure.AI.OpenAI;
+
+internal class VectorStoreFileCollectionPageToken : ContinuationToken
+{
+    protected VectorStoreFileCollectionPageToken(string vectorStoreId, int? limit, string? order, string? after, string? before, string? filter)
+    {
+        VectorStoreId = vectorStoreId;
+
+        Limit = limit;
+        Order = order;
+        After = after;
+        Before = before;
+        Filter = filter;
+    }
+
+    public string VectorStoreId { get; }
+
+    public int? Limit { get; }
+
+    public string? Order { get; }
+
+    public string? After { get; }
+
+    public string? Before { get; }
+
+    public string? Filter { get; }
+
+    public override BinaryData ToBytes()
+    {
+        using MemoryStream stream = new();
+        using Utf8JsonWriter writer = new(stream);
+
+        writer.WriteStartObject();
+        writer.WriteString("vectorStoreId", VectorStoreId);
+
+        if (Limit.HasValue)
+        {
+            writer.WriteNumber("limit", Limit.Value);
+        }
+
+        if (Order is not null)
+        {
+            writer.WriteString("order", Order);
+        }
+
+        if (After is not null)
+        {
+            writer.WriteString("after", After);
+        }
+
+        if (Before is not null)
+        {
+            writer.WriteString("before", Before);
+        }
+
+        if (Filter is not null)
+        {
+            writer.WriteString("filter", Filter);
+        }
+
+        writer.WriteEndObject();
+
+        writer.Flush();
+        stream.Position = 0;
+
+        return BinaryData.FromStream(stream);
+    }
+
+    public static VectorStoreFileCollectionPageToken FromToken(ContinuationToken pageToken)
+    {
+        if (pageToken is VectorStoreFileCollectionPageToken token)
+        {
+            return token;
+        }
+
+        BinaryData data = pageToken.ToBytes();
+
+        if (data.ToMemory().Length == 0)
+        {
+            throw new ArgumentException("Failed to create VectorStoreFilesPageToken from provided pageToken.", nameof(pageToken));
+        }
+
+        Utf8JsonReader reader = new(data);
+
+        string vectorStoreId = null!;
+        int? limit = null;
+        string? order = null;
+        string? after = null;
+        string? before = null;
+        string? filter = null;
+
+        reader.Read();
+
+        Debug.Assert(reader.TokenType == JsonTokenType.StartObject);
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
+
+            string propertyName = reader.GetString()!;
+
+            switch (propertyName)
+            {
+                case "vectorStoreId":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    vectorStoreId = reader.GetString()!;
+                    break;
+                case "limit":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.Number);
+                    limit = reader.GetInt32();
+                    break;
+                case "order":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    order = reader.GetString();
+                    break;
+                case "after":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    after = reader.GetString();
+                    break;
+                case "before":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    before = reader.GetString();
+                    break;
+                case "filter":
+                    reader.Read();
+                    Debug.Assert(reader.TokenType == JsonTokenType.String);
+                    filter = reader.GetString();
+                    break;
+                default:
+                    throw new JsonException($"Unrecognized property '{propertyName}'.");
+            }
+        }
+
+        if (vectorStoreId is null)
+        {
+            throw new ArgumentException("Failed to create VectorStoreFilesPageToken from provided pageToken.", nameof(pageToken));
+        }
+
+        return new(vectorStoreId, limit, order, after, before, filter);
+    }
+
+    public static VectorStoreFileCollectionPageToken FromOptions(string vectorStoreId, int? limit, string? order, string? after, string? before, string? filter)
+        => new(vectorStoreId, limit, order, after, before, filter);
+
+    public static VectorStoreFileCollectionPageToken? FromResponse(ClientResult result, string vectorStoreId, int? limit, string? order, string? before, string? filter)
+    {
+        PipelineResponse response = result.GetRawResponse();
+        using JsonDocument doc = JsonDocument.Parse(response.Content);
+        string lastId = doc.RootElement.GetProperty("last_id"u8).GetString()!;
+        bool hasMore = doc.RootElement.GetProperty("has_more"u8).GetBoolean();
+
+        if (!hasMore || lastId is null)
+        {
+            return null;
+        }
+
+        return new(vectorStoreId, limit, order, lastId, before, filter);
+    }
+}
+
+#endif

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreFileCollectionPageToken.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/VectorStores/VectorStoreFileCollectionPageToken.cs
@@ -91,7 +91,7 @@ internal class VectorStoreFileCollectionPageToken : ContinuationToken
 
         if (data.ToMemory().Length == 0)
         {
-            throw new ArgumentException("Failed to create VectorStoreFilesPageToken from provided pageToken.", nameof(pageToken));
+            throw new ArgumentException("Failed to create VectorStoreFileCollectionPageToken from provided pageToken.", nameof(pageToken));
         }
 
         Utf8JsonReader reader = new(data);
@@ -157,7 +157,7 @@ internal class VectorStoreFileCollectionPageToken : ContinuationToken
 
         if (vectorStoreId is null)
         {
-            throw new ArgumentException("Failed to create VectorStoreFilesPageToken from provided pageToken.", nameof(pageToken));
+            throw new ArgumentException("Failed to create VectorStoreFileCollectionPageToken from provided pageToken.", nameof(pageToken));
         }
 
         return new(vectorStoreId, limit, order, after, before, filter);

--- a/sdk/openai/Azure.AI.OpenAI/src/Utility/JsonPatchHelpers.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Utility/JsonPatchHelpers.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System.ClientModel.Primitives;
+using System.Text.Json;
+
+namespace Azure.AI.OpenAI;
+
+internal static partial class JsonPatchHelpers
+{
+    public static BinaryData? GetBytesOrDefaultEx(this JsonPatch patch, ReadOnlySpan<byte> path)
+    {
+        if (patch.Contains(path)
+            && !patch.IsRemoved(path)
+            && patch.TryGetJson(path, out ReadOnlyMemory<byte> bytes)
+            && !bytes.IsEmpty)
+        {
+            return BinaryData.FromBytes(bytes);
+        }
+        return null;
+    }
+
+    public static T? GetDeserializedInstance<T>(this JsonPatch patch, ReadOnlySpan<byte> path, Func<JsonElement, ModelReaderWriterOptions, T> deserializationFunc)
+        where T : IJsonModel<T>
+    {
+        if (patch.GetBytesOrDefaultEx(path) is BinaryData valueBytes)
+        {
+            using JsonDocument document = JsonDocument.Parse(valueBytes);
+            return deserializationFunc.Invoke(document.RootElement, ModelSerializationExtensions.WireOptions);
+        }
+        return default;
+    }
+
+    public static IReadOnlyList<T> GetDeserializedInstanceList<T>(this JsonPatch patch, ReadOnlySpan<byte> path, Func<JsonElement, ModelReaderWriterOptions, T> deserializationFunc)
+        where T : IJsonModel<T>
+    {
+        List<T> instances = [];
+        if (patch.GetBytesOrDefaultEx(path) is BinaryData valueBytes)
+        {
+            using JsonDocument document = JsonDocument.Parse(valueBytes);
+            if (document.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement element in document.RootElement.EnumerateArray())
+                {
+                    instances.Add(
+                        deserializationFunc.Invoke(
+                            element,
+                            ModelSerializationExtensions.WireOptions));
+                }
+            }
+        }
+        return instances;
+    }
+}

--- a/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Azure.AI.OpenAI.Chat;
 using Azure.AI.OpenAI.Tests.Utils.Config;
@@ -84,18 +85,19 @@ public partial class ChatTests : AoaiTestBase<ChatClient>
                 new Uri("https://my-embedding.com"),
                 DataSourceAuthentication.FromApiKey("embedding-api-key")),
         };
-        dynamic serialized = ModelReaderWriter.Write(source).ToDynamicFromJson();
-        Assert.That(serialized?.type?.ToString(), Is.EqualTo("azure_search"));
-        Assert.That(serialized?.parameters?.authentication?.type?.ToString(), Is.EqualTo("api_key"));
-        Assert.That(serialized?.parameters?.authentication?.key?.ToString(), Does.Contain("test"));
-        Assert.That(serialized?.parameters?.index_name?.ToString(), Is.EqualTo("index-name-here"));
-        Assert.That(serialized?.parameters?.fields_mapping?.content_fields?[0]?.ToString(), Is.EqualTo("hello"));
-        Assert.That(serialized?.parameters?.fields_mapping?.title_field?.ToString(), Is.EqualTo("hi"));
-        Assert.That(bool.TryParse(serialized?.parameters?.allow_partial_result?.ToString(), out bool parsed) && parsed == true);
-        Assert.That(serialized?.parameters?.query_type?.ToString(), Is.EqualTo("simple"));
-        Assert.That(serialized?.parameters?.include_contexts?[0]?.ToString(), Is.EqualTo("citations"));
-        Assert.That(serialized?.parameters?.include_contexts?[1]?.ToString(), Is.EqualTo("all_retrieved_documents"));
-        Assert.That(serialized?.parameters?.embedding_dependency?.type?.ToString(), Is.EqualTo("endpoint"));
+        BinaryData serialized = ModelReaderWriter.Write(source);
+        JsonNode serializedNode = JsonNode.Parse(serialized)!;
+        Assert.That(serializedNode["type"]!.ToString(), Is.EqualTo("azure_search"));
+        Assert.That(serializedNode["parameters"]?["authentication"]?["type"]?.ToString(), Is.EqualTo("api_key"));
+        Assert.That(serializedNode["parameters"]?["authentication"]?["key"]?.ToString(), Does.Contain("test"));
+        Assert.That(serializedNode["parameters"]?["index_name"]?.ToString(), Is.EqualTo("index-name-here"));
+        Assert.That(serializedNode["parameters"]?["fields_mapping"]?["content_fields"]?[0]?.ToString(), Is.EqualTo("hello"));
+        Assert.That(serializedNode["parameters"]?["fields_mapping"]?["title_field"]?.ToString(), Is.EqualTo("hi"));
+        Assert.That(bool.TryParse(serializedNode["parameters"]?["allow_partial_result"]?.ToString(), out bool parsed) && parsed == true);
+        Assert.That(serializedNode["parameters"]?["query_type"]?.ToString(), Is.EqualTo("simple"));
+        Assert.That(serializedNode["parameters"]?["include_contexts"]?[0]?.ToString(), Is.EqualTo("citations"));
+        Assert.That(serializedNode["parameters"]?["include_contexts"]?[1]?.ToString(), Is.EqualTo("all_retrieved_documents"));
+        Assert.That(serializedNode["parameters"]?["embedding_dependency"]?["type"]?.ToString(), Is.EqualTo("endpoint"));
 
         ChatCompletionOptions options = new();
 #if !AZURE_OPENAI_GA
@@ -166,10 +168,12 @@ public partial class ChatTests : AoaiTestBase<ChatClient>
         bool GetSerializedOptionsContains(string value)
         {
             BinaryData serialized = ModelReaderWriter.Write(options);
+            Console.WriteLine(serialized);
             return serialized.ToString().Contains(value);
         }
         async Task AssertExpectedSerializationAsync(bool hasOldMaxTokens, bool hasNewMaxCompletionTokens)
         {
+            Console.WriteLine($"Old: {hasOldMaxTokens}, New: {hasNewMaxCompletionTokens}");
             _ = await client.CompleteChatAsync(["Just mocking, no call here"], options);
             Assert.That(GetSerializedOptionsContains("max_tokens"), Is.EqualTo(hasOldMaxTokens));
             Assert.That(GetSerializedOptionsContains("max_completion_tokens"), Is.EqualTo(hasNewMaxCompletionTokens));
@@ -189,10 +193,12 @@ public partial class ChatTests : AoaiTestBase<ChatClient>
         options.SetNewMaxCompletionTokensPropertyEnabled();
         await AssertExpectedSerializationAsync(false, true);
         await AssertExpectedSerializationAsync(false, true);
+        // Invoking a chat completion call with a null value will
+        // clear the new property usage flag if it was present
         options.MaxOutputTokenCount = null;
         await AssertExpectedSerializationAsync(false, false);
         options.MaxOutputTokenCount = 42;
-        await AssertExpectedSerializationAsync(false, true);
+        await AssertExpectedSerializationAsync(true, false);
 
         options.SetNewMaxCompletionTokensPropertyEnabled(false);
         await AssertExpectedSerializationAsync(true, false);

--- a/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ChatTests.cs
@@ -168,12 +168,10 @@ public partial class ChatTests : AoaiTestBase<ChatClient>
         bool GetSerializedOptionsContains(string value)
         {
             BinaryData serialized = ModelReaderWriter.Write(options);
-            Console.WriteLine(serialized);
             return serialized.ToString().Contains(value);
         }
         async Task AssertExpectedSerializationAsync(bool hasOldMaxTokens, bool hasNewMaxCompletionTokens)
         {
-            Console.WriteLine($"Old: {hasOldMaxTokens}, New: {hasNewMaxCompletionTokens}");
             _ = await client.CompleteChatAsync(["Just mocking, no call here"], options);
             Assert.That(GetSerializedOptionsContains("max_tokens"), Is.EqualTo(hasOldMaxTokens));
             Assert.That(GetSerializedOptionsContains("max_completion_tokens"), Is.EqualTo(hasNewMaxCompletionTokens));

--- a/sdk/openai/Azure.AI.OpenAI/tests/ResponsesTests.cs
+++ b/sdk/openai/Azure.AI.OpenAI/tests/ResponsesTests.cs
@@ -165,7 +165,7 @@ public class ResponsesTests : AoaiTestBase<OpenAIResponseClient>
                 {
                     Tools =
                     {
-                        ResponseTool.CreateWebSearchTool()
+                        ResponseTool.CreateWebSearchPreviewTool()
                     }
                 }));
         Assert.That(expectedException, Is.Not.Null);
@@ -783,7 +783,7 @@ public class ResponsesTests : AoaiTestBase<OpenAIResponseClient>
         }
 
         AssertSerializationRoundTrip<MessageResponseItem>(
-            @"{""type"":""message"",""potato_details"":{""cultivar"":""russet""},""role"":""potato""}",
+            @"{""type"":""message"",""role"":""potato"",""potato_details"":{""cultivar"":""russet""}}",
             potatoMessage =>
             {
                 Assert.That(potatoMessage.Role, Is.EqualTo(MessageRole.Unknown));


### PR DESCRIPTION
`OpenAI` 2.6.0 removed several internal `SerializedAdditionalRawData` dictionaries in favor of awaited `JsonPatch` support in `System.ClientModel`. This produced a forward compat break when advancing the referenced `OpenAI` version past the `2.5.0` release previously referenced.

This change fixes that incompatibility by migrating impacted scenarios to use `JsonPatch`, instead. This will unfortunately repeat in the future as we remove more `SerializedAdditionalRawData`, but this change encompasses the overwhelming majority of cases in both count and complexity.

fixes #54103 