### PR TITLE
[AzureMonitorExporter] Add support for Availability telemetry in Azure Monitor OpenTelemetry Exporter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/AvailabilityData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/AvailabilityData.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using OpenTelemetry.Logs;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Models
+{
+    internal partial class AvailabilityData
+    {
+        public AvailabilityData(int version, AvailabilityInfo availabilityInfo, ChangeTrackingDictionary<string, string> properties, LogRecord logRecord)
+            : this(version, availabilityInfo.Id, availabilityInfo.Name, availabilityInfo.Duration, availabilityInfo.Success)
+        {
+            RunLocation = availabilityInfo.RunLocation;
+            Message = availabilityInfo.Message;
+            Properties = properties;
+            Measurements = new ChangeTrackingDictionary<string, double>();
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/TelemetrySchemaTypeCounter.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/TelemetrySchemaTypeCounter.cs
@@ -11,5 +11,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
         internal int _eventCount;
         internal int _metricCount;
         internal int _traceCount;
+        internal int _availabilityCount;
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/HttpPipelineHelper.cs
@@ -340,6 +340,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 case "Message":
                     telemetrySchemaTypeCounter._traceCount++;
                     break;
+                case "Availability":
+                    telemetrySchemaTypeCounter._availabilityCount++;
+                    break;
                     // Unknown types are not tracked
             }
         }
@@ -464,13 +467,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 case "Message":
                     telemetrySchemaTypeCounter._traceCount = Math.Max(0, telemetrySchemaTypeCounter._traceCount - 1);
                     break;
+                case "Availability":
+                    telemetrySchemaTypeCounter._availabilityCount = Math.Max(0, telemetrySchemaTypeCounter._availabilityCount - 1);
+                    break;
             }
         }
 
         private static bool HasAnyCount(TelemetrySchemaTypeCounter telemetrySchemaTypeCounter)
         {
             return telemetrySchemaTypeCounter._requestCount > 0 || telemetrySchemaTypeCounter._dependencyCount > 0 || telemetrySchemaTypeCounter._exceptionCount > 0 ||
-                   telemetrySchemaTypeCounter._eventCount > 0 || telemetrySchemaTypeCounter._metricCount > 0 || telemetrySchemaTypeCounter._traceCount > 0;
+                   telemetrySchemaTypeCounter._eventCount > 0 || telemetrySchemaTypeCounter._metricCount > 0 || telemetrySchemaTypeCounter._traceCount > 0 ||
+                   telemetrySchemaTypeCounter._availabilityCount > 0;
         }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -22,6 +22,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
     {
         private const string CustomEventAttributeName = "microsoft.custom_event.name";
         private const string ClientIpAttributeName = "microsoft.client.ip";
+        private const string AvailabilityIdAttributeName = "microsoft.availability.id";
+        private const string AvailabilityNameAttributeName = "microsoft.availability.name";
+        private const string AvailabilityDurationAttributeName = "microsoft.availability.duration";
+        private const string AvailabilitySuccessAttributeName = "microsoft.availability.success";
+        private const string AvailabilityRunLocationAttributeName = "microsoft.availability.runLocation";
+        private const string AvailabilityMessageAttributeName = "microsoft.availability.message";
         private const int Version = 2;
         private static readonly Action<LogRecordScope, IDictionary<string, string>> s_processScope = (scope, properties) =>
         {
@@ -61,7 +67,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 try
                 {
                     var properties = new ChangeTrackingDictionary<string, string>();
-                    ProcessLogRecordProperties(logRecord, properties, out string? message, out string? eventName, out string? microsoftClientIp);
+                    ProcessLogRecordProperties(logRecord, properties, out string? message, out string? eventName, out string? microsoftClientIp, out AvailabilityInfo? availabilityInfo);
 
                     if (logRecord.Exception is not null)
                     {
@@ -74,6 +80,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             }
                         };
                         telemetrySchemaTypeCounter._exceptionCount++;
+                    }
+                    else if (availabilityInfo is not null)
+                    {
+                        telemetryItem = new TelemetryItem("Availability", logRecord, resource, instrumentationKey, microsoftClientIp)
+                        {
+                            Data = new MonitorBase
+                            {
+                                BaseType = "AvailabilityData",
+                                BaseData = new AvailabilityData(Version, availabilityInfo.Value, properties, logRecord),
+                            }
+                        };
+                        telemetrySchemaTypeCounter._availabilityCount++;
                     }
                     else if (eventName is not null)
                     {
@@ -111,11 +129,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             return (telemetryItems, telemetrySchemaTypeCounter);
         }
 
-        internal static void ProcessLogRecordProperties(LogRecord logRecord, IDictionary<string, string> properties, out string? message, out string? eventName, out string? microsoftClientIp)
+        internal static void ProcessLogRecordProperties(LogRecord logRecord, IDictionary<string, string> properties, out string? message, out string? eventName, out string? microsoftClientIp, out AvailabilityInfo? availabilityInfo)
         {
             eventName = null;
+            availabilityInfo = null;
             message = logRecord.Exception?.Message ?? logRecord.FormattedMessage;
             microsoftClientIp = null;
+            bool hasAvailabilityData = false;
 
             foreach (KeyValuePair<string, object?> item in logRecord.Attributes ?? Enumerable.Empty<KeyValuePair<string, object?>>())
             {
@@ -123,7 +143,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 {
                     eventName = item.Value?.ToString();
                 }
-
+                else if (item.Key == AvailabilityNameAttributeName)
+                {
+                    hasAvailabilityData = true;
+                }
                 else if (item.Key == ClientIpAttributeName)
                 {
                     microsoftClientIp = item.Value?.ToString().Truncate(SchemaConstants.MessageData_Properties_MaxValueLength);
@@ -159,9 +182,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
             }
 
+            // If we detected availability data, do a second pass to extract all availability attributes
+            if (hasAvailabilityData)
+            {
+                availabilityInfo = ExtractAvailabilityInfo(logRecord, message, out microsoftClientIp);
+            }
+
             logRecord.ForEachScope(s_processScope, properties);
 
-            if (eventName is null) // we will omit the following properties if we've detected a custom event.
+            if (eventName is null && availabilityInfo is null) // we will omit the following properties if we've detected a custom event or availability.
             {
                 var categoryName = logRecord.CategoryName;
                 if (!properties.ContainsKey("CategoryName") && !string.IsNullOrEmpty(categoryName))
@@ -179,6 +208,66 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     properties.Add("EventName", logRecord.EventId.Name!.Truncate(SchemaConstants.KVP_MaxValueLength));
                 }
             }
+        }
+
+        private static AvailabilityInfo? ExtractAvailabilityInfo(LogRecord logRecord, string? message, out string? microsoftClientIp)
+        {
+            string? availabilityId = null;
+            string? availabilityName = null;
+            string? availabilityDuration = null;
+            string? availabilitySuccess = null;
+            string? availabilityRunLocation = null;
+            string? availabilityMessage = null;
+            microsoftClientIp = null;
+
+            foreach (KeyValuePair<string, object?> item in logRecord.Attributes ?? Enumerable.Empty<KeyValuePair<string, object?>>())
+            {
+                if (item.Key == AvailabilityIdAttributeName)
+                {
+                    availabilityId = item.Value?.ToString();
+                }
+                else if (item.Key == AvailabilityNameAttributeName)
+                {
+                    availabilityName = item.Value?.ToString();
+                }
+                else if (item.Key == AvailabilityDurationAttributeName)
+                {
+                    availabilityDuration = item.Value?.ToString();
+                }
+                else if (item.Key == AvailabilitySuccessAttributeName)
+                {
+                    availabilitySuccess = item.Value?.ToString();
+                }
+                else if (item.Key == AvailabilityRunLocationAttributeName)
+                {
+                    availabilityRunLocation = item.Value?.ToString();
+                }
+                else if (item.Key == AvailabilityMessageAttributeName)
+                {
+                    availabilityMessage = item.Value?.ToString();
+                }
+                else if (item.Key == ClientIpAttributeName)
+                {
+                    microsoftClientIp = item.Value?.ToString().Truncate(SchemaConstants.MessageData_Properties_MaxValueLength);
+                }
+            }
+
+            // Construct availability info if we have required fields
+            if (!string.IsNullOrEmpty(availabilityId) && !string.IsNullOrEmpty(availabilityName) &&
+                !string.IsNullOrEmpty(availabilityDuration) && !string.IsNullOrEmpty(availabilitySuccess))
+            {
+                return new AvailabilityInfo
+                {
+                    Id = availabilityId!,
+                    Name = availabilityName!,
+                    Duration = availabilityDuration!,
+                    Success = bool.Parse(availabilitySuccess),
+                    RunLocation = availabilityRunLocation,
+                    Message = availabilityMessage ?? message
+                };
+            }
+
+            return null;
         }
 
         internal static string GetProblemId(Exception exception)
@@ -243,5 +332,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     return SeverityLevel.Verbose;
             }
         }
+    }
+
+    /// <summary>
+    /// Struct to hold availability test information extracted from log attributes.
+    /// </summary>
+    internal struct AvailabilityInfo
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Duration { get; set; }
+        public bool Success { get; set; }
+        public string? RunLocation { get; set; }
+        public string? Message { get; set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -81,18 +81,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                         };
                         telemetrySchemaTypeCounter._exceptionCount++;
                     }
-                    else if (availabilityInfo is not null)
-                    {
-                        telemetryItem = new TelemetryItem("Availability", logRecord, resource, instrumentationKey, microsoftClientIp)
-                        {
-                            Data = new MonitorBase
-                            {
-                                BaseType = "AvailabilityData",
-                                BaseData = new AvailabilityData(Version, availabilityInfo.Value, properties, logRecord),
-                            }
-                        };
-                        telemetrySchemaTypeCounter._availabilityCount++;
-                    }
                     else if (eventName is not null)
                     {
                         telemetryItem = new TelemetryItem("Event", logRecord, resource, instrumentationKey, microsoftClientIp)
@@ -104,6 +92,18 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                             }
                         };
                         telemetrySchemaTypeCounter._eventCount++;
+                    }
+                    else if (availabilityInfo is not null)
+                    {
+                        telemetryItem = new TelemetryItem("Availability", logRecord, resource, instrumentationKey, microsoftClientIp)
+                        {
+                            Data = new MonitorBase
+                            {
+                                BaseType = "AvailabilityData",
+                                BaseData = new AvailabilityData(Version, availabilityInfo.Value, properties, logRecord),
+                            }
+                        };
+                        telemetrySchemaTypeCounter._availabilityCount++;
                     }
                     else
                     {
@@ -146,6 +146,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 else if (item.Key == AvailabilityNameAttributeName)
                 {
                     hasAvailabilityData = true;
+                    break;
                 }
                 else if (item.Key == ClientIpAttributeName)
                 {
@@ -261,7 +262,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     Id = availabilityId!,
                     Name = availabilityName!,
                     Duration = availabilityDuration!,
-                    Success = bool.Parse(availabilitySuccess),
+                    Success = bool.TryParse(availabilitySuccess, out var success) ? success : false,
                     RunLocation = availabilityRunLocation,
                     Message = availabilityMessage ?? message
                 };

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -186,7 +186,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             // If we detected availability data, do a second pass to extract all availability attributes
             if (hasAvailabilityData)
             {
-                availabilityInfo = ExtractAvailabilityInfo(logRecord, message, out microsoftClientIp);
+                availabilityInfo = ExtractAvailabilityInfo(logRecord, properties, message, out microsoftClientIp);
             }
 
             logRecord.ForEachScope(s_processScope, properties);
@@ -211,7 +211,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             }
         }
 
-        private static AvailabilityInfo? ExtractAvailabilityInfo(LogRecord logRecord, string? message, out string? microsoftClientIp)
+        private static AvailabilityInfo? ExtractAvailabilityInfo(LogRecord logRecord, IDictionary<string, string> properties, string? message, out string? microsoftClientIp)
         {
             string? availabilityId = null;
             string? availabilityName = null;
@@ -249,7 +249,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
                 else if (item.Key == ClientIpAttributeName)
                 {
-                    microsoftClientIp = item.Value?.ToString().Truncate(SchemaConstants.MessageData_Properties_MaxValueLength);
+                    microsoftClientIp = item.Value?.ToString().Truncate(SchemaConstants.AvailabilityData_Properties_MaxValueLength);
+                }
+                else if (item.Key.Length <= SchemaConstants.AvailabilityData_Properties_MaxValueLength && item.Value != null && !properties.ContainsKey(item.Key))
+                {
+                    properties.Add(item.Key, item.Value.ToString().Truncate(SchemaConstants.AvailabilityData_Properties_MaxValueLength)!);
                 }
             }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/CommonTestFramework/TelemetryItemValidationHelper.cs
@@ -120,6 +120,77 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework
             Assert.Equal(expectedProperties.Count, eventData.Properties.Count);
         }
 
+        public static void AssertAvailabilityTelemetry(
+            TelemetryItem telemetryItem,
+            string expectedId,
+            string expectedName,
+            string expectedDuration,
+            bool expectedSuccess,
+            string? expectedRunLocation = null,
+            string? expectedMessage = null,
+            IDictionary<string, string>? expectedProperties = null,
+            string? expectedSpanId = null,
+            string? expectedTraceId = null,
+            string? expectedClientIp = null,
+            string expectedCloudRole = "[testNamespace]/testName",
+            string expectedCloudInstance = "testInstance",
+            string expectedApplicationVersion = "testVersion")
+        {
+            Assert.Equal("Availability", telemetryItem.Name); // telemetry type
+            Assert.Equal("AvailabilityData", telemetryItem.Data.BaseType); // telemetry data type
+            Assert.Equal(2, telemetryItem.Data.BaseData.Version); // telemetry api version
+            Assert.Equal("00000000-0000-0000-0000-000000000000", telemetryItem.InstrumentationKey);
+
+            var expectedTagsCount = 4;
+
+            if (expectedSpanId != null && expectedTraceId != null)
+            {
+                expectedTagsCount += 2;
+
+                Assert.Equal(expectedSpanId, telemetryItem.Tags["ai.operation.parentId"]);
+                Assert.Equal(expectedTraceId, telemetryItem.Tags["ai.operation.id"]);
+            }
+
+            if (expectedClientIp != null)
+            {
+                expectedTagsCount += 1;
+                Assert.Equal(expectedClientIp, telemetryItem.Tags["ai.location.ip"]);
+            }
+
+            Assert.Equal(expectedTagsCount, telemetryItem.Tags.Count);
+            Assert.Equal(expectedCloudRole, telemetryItem.Tags["ai.cloud.role"]);
+            Assert.Equal(expectedApplicationVersion, telemetryItem.Tags["ai.application.ver"]);
+            Assert.Equal(expectedCloudInstance, telemetryItem.Tags["ai.cloud.roleInstance"]);
+            Assert.Contains("ai.internal.sdkVersion", telemetryItem.Tags.Keys);
+
+            var availabilityData = (AvailabilityData)telemetryItem.Data.BaseData;
+
+            Assert.Equal(expectedId, availabilityData.Id);
+            Assert.Equal(expectedName, availabilityData.Name);
+            Assert.Equal(expectedDuration, availabilityData.Duration);
+            Assert.Equal(expectedSuccess, availabilityData.Success);
+
+            if (expectedRunLocation != null)
+            {
+                Assert.Equal(expectedRunLocation, availabilityData.RunLocation);
+            }
+
+            if (expectedMessage != null)
+            {
+                Assert.Equal(expectedMessage, availabilityData.Message);
+            }
+
+            if (expectedProperties != null && expectedProperties.Count > 0)
+            {
+                foreach (var prop in expectedProperties)
+                {
+                    Assert.Equal(prop.Value, availabilityData.Properties[prop.Key]);
+                }
+
+                Assert.Equal(expectedProperties.Count, availabilityData.Properties.Count);
+            }
+        }
+
         public static void AssertLog_As_ExceptionTelemetry(
             TelemetryItem telemetryItem,
             string expectedSeverityLevel,

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/AvailabilityTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/AvailabilityTests.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
+using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
+{
+    /// <summary>
+    /// The purpose of these tests is to validate the <see cref="TelemetryItem"/> that is created
+    /// based on availability telemetry logging.
+    /// </summary>
+    public class AvailabilityTests
+    {
+        internal readonly TelemetryItemOutputHelper telemetryOutput;
+
+        internal readonly Dictionary<string, object> testResourceAttributes = new()
+        {
+            { "service.instance.id", "testInstance" },
+            { "service.name", "testName" },
+            { "service.namespace", "testNamespace" },
+            { "service.version", "testVersion" },
+        };
+
+        public AvailabilityTests(ITestOutputHelper output)
+        {
+            this.telemetryOutput = new TelemetryItemOutputHelper(output);
+        }
+
+        [Fact]
+        public void VerifyAvailabilityTelemetryViaLogMethod()
+        {
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
+
+            List<TelemetryItem>? telemetryItems = null;
+
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, LogLevel.Information)
+                    .AddOpenTelemetry(options =>
+                    {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
+                        options.AddAzureMonitorLogExporterForTest(out telemetryItems);
+                    });
+            });
+
+            // ACT
+            var logger = loggerFactory.CreateLogger(logCategoryName);
+            logger.LogInformation("{microsoft.availability.id} {microsoft.availability.name} {microsoft.availability.duration} {microsoft.availability.success} {microsoft.availability.runLocation} {microsoft.availability.message}",
+                "test-id-123", "MyAvailabilityTest", "00:00:05", true, "West US", "Test completed successfully");
+
+            // CLEANUP
+            loggerFactory.Dispose();
+
+            // ASSERT
+            Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(telemetryItems);
+            var telemetryItem = telemetryItems?.Where(x => x.Name == "Availability").Single();
+
+            TelemetryItemValidationHelper.AssertAvailabilityTelemetry(
+                telemetryItem: telemetryItem!,
+                expectedId: "test-id-123",
+                expectedName: "MyAvailabilityTest",
+                expectedDuration: "00:00:05",
+                expectedSuccess: true,
+                expectedRunLocation: "West US",
+                expectedMessage: "Test completed successfully",
+                expectedProperties: new Dictionary<string, string>(),
+                expectedSpanId: null,
+                expectedTraceId: null);
+        }
+
+        [Fact]
+        public void VerifyAvailabilityTelemetryWithMinimalFields()
+        {
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
+
+            List<TelemetryItem>? telemetryItems = null;
+
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, LogLevel.Information)
+                    .AddOpenTelemetry(options =>
+                    {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
+                        options.AddAzureMonitorLogExporterForTest(out telemetryItems);
+                    });
+            });
+
+            // ACT
+            var logger = loggerFactory.CreateLogger(logCategoryName);
+            logger.LogInformation("{microsoft.availability.id} {microsoft.availability.name} {microsoft.availability.duration} {microsoft.availability.success}",
+                "test-id-456", "MinimalTest", "00:00:02", false);
+
+            // CLEANUP
+            loggerFactory.Dispose();
+
+            // ASSERT
+            Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(telemetryItems);
+            var telemetryItem = telemetryItems?.Where(x => x.Name == "Availability").Single();
+
+            TelemetryItemValidationHelper.AssertAvailabilityTelemetry(
+                telemetryItem: telemetryItem!,
+                expectedId: "test-id-456",
+                expectedName: "MinimalTest",
+                expectedDuration: "00:00:02",
+                expectedSuccess: false,
+                expectedProperties: new Dictionary<string, string>(),
+                expectedSpanId: null,
+                expectedTraceId: null);
+        }
+
+        [Fact]
+        public void VerifyAvailabilityWithClientIP()
+        {
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
+
+            List<TelemetryItem>? telemetryItems = null;
+
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddOpenTelemetry(options =>
+                    {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
+                        options.AddAzureMonitorLogExporterForTest(out telemetryItems);
+                    });
+            });
+
+            // ACT
+            var logger = loggerFactory.CreateLogger(logCategoryName);
+            logger.LogInformation("{microsoft.availability.id} {microsoft.availability.name} {microsoft.availability.duration} {microsoft.availability.success} {microsoft.client.ip}",
+                "test-id-789", "TestWithIP", "00:00:03", true, "1.2.3.4");
+
+            // CLEANUP
+            loggerFactory.Dispose();
+
+            // ASSERT
+            Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(telemetryItems);
+            var telemetryItem = telemetryItems?.Where(x => x.Name == "Availability").Single();
+
+            TelemetryItemValidationHelper.AssertAvailabilityTelemetry(
+                telemetryItem: telemetryItem!,
+                expectedId: "test-id-789",
+                expectedName: "TestWithIP",
+                expectedDuration: "00:00:03",
+                expectedSuccess: true,
+                expectedProperties: new Dictionary<string, string>(),
+                expectedSpanId: null,
+                expectedTraceId: null,
+                expectedClientIp: "1.2.3.4");
+        }
+
+        [Fact]
+        public void VerifyExceptionTakesPrecedence()
+        {
+            // This test confirms that if a LogRecord contains both an exception and the "availability" attributes then only an exception will be exported.
+
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
+
+            List<TelemetryItem>? telemetryItems = null;
+
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, LogLevel.Information)
+                    .AddOpenTelemetry(options =>
+                    {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
+                        options.AddAzureMonitorLogExporterForTest(out telemetryItems);
+                    });
+            });
+
+            // ACT
+            var logger = loggerFactory.CreateLogger(logCategoryName);
+
+            try
+            {
+                throw new Exception("Test Exception");
+            }
+            catch (Exception ex)
+            {
+                logger.Log(
+                    logLevel: LogLevel.Information,
+                    eventId: 1,
+                    exception: ex,
+                    message: "{microsoft.availability.id} {microsoft.availability.name} {microsoft.availability.duration} {microsoft.availability.success}",
+                    args: new object[] { "test-id", "TestName", "00:00:01", true });
+            }
+
+            // CLEANUP
+            loggerFactory.Dispose();
+
+            // ASSERT
+            Assert.True(telemetryItems!.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(telemetryItems);
+
+            Assert.Single(telemetryItems!.Where(x => x.Name == "Exception"));
+            Assert.DoesNotContain(telemetryItems!, x => x.Name == "Availability");
+        }
+
+        [Fact]
+        public void VerifyAvailabilityWithAdditionalProperties()
+        {
+            // SETUP
+            var uniqueTestId = Guid.NewGuid();
+
+            var logCategoryName = $"logCategoryName{uniqueTestId}";
+
+            List<TelemetryItem>? telemetryItems = null;
+
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .AddFilter<OpenTelemetryLoggerProvider>(logCategoryName, LogLevel.Information)
+                    .AddOpenTelemetry(options =>
+                    {
+                        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddAttributes(testResourceAttributes));
+                        options.AddAzureMonitorLogExporterForTest(out telemetryItems);
+                    });
+            });
+
+            // ACT
+            var logger = loggerFactory.CreateLogger(logCategoryName);
+            logger.LogInformation("{microsoft.availability.id} {microsoft.availability.name} {microsoft.availability.duration} {microsoft.availability.success} {customProp1} {customProp2}",
+                "test-id-999", "TestWithProps", "00:00:04", true, "value1", "value2");
+
+            // CLEANUP
+            loggerFactory.Dispose();
+
+            // ASSERT
+            Assert.True(telemetryItems?.Any(), "Unit test failed to collect telemetry.");
+            this.telemetryOutput.Write(telemetryItems);
+            var telemetryItem = telemetryItems?.Where(x => x.Name == "Availability").Single();
+
+            var availabilityData = (AvailabilityData)telemetryItem!.Data.BaseData;
+            Assert.Equal("test-id-999", availabilityData.Id);
+            Assert.Equal("TestWithProps", availabilityData.Name);
+            Assert.Equal("00:00:04", availabilityData.Duration);
+            Assert.True(availabilityData.Success);
+
+            // Verify custom properties are included
+            Assert.True(availabilityData.Properties.ContainsKey("customProp1"));
+            Assert.Equal("value1", availabilityData.Properties["customProp1"]);
+            Assert.True(availabilityData.Properties.ContainsKey("customProp2"));
+            Assert.Equal("value2", availabilityData.Properties["customProp2"]);
+        }
+    }
+}

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Azure.Core;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
@@ -52,7 +51,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
 
             var properties = new ChangeTrackingDictionary<string, string>();
 
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Test Exception", message);
             Assert.Null(eventName);
@@ -87,7 +86,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(log, "tomato", 2.99);
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Hello from tomato 2.99.", message);
             Assert.Null(eventName);
@@ -118,7 +117,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(log, "tomato", 2.99);
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal(log, message);
             Assert.Null(eventName);
@@ -153,7 +152,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(log, "tomato", 2.99);
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Hello from {name} {price}.", message);
             Assert.Null(eventName);
@@ -185,7 +184,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(id, "Log Information");
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Log Information", message);
             Assert.Null(eventName);
@@ -217,7 +216,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation("Information goes here");
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Information goes here", message);
             Assert.Null(eventName);
@@ -252,7 +251,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             }
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Test Exception", message);
             Assert.Null(eventName);
@@ -283,7 +282,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             logger.LogInformation(id, log, 100, "TestAttributeEventName");
 
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Log Information {EventId} {EventName}.", message);
             Assert.Null(eventName);
@@ -395,7 +394,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Some log information message.", message);
             Assert.Null(eventName);
@@ -447,7 +446,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Some log information message.", message);
             Assert.Null(eventName);
@@ -499,7 +498,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Some log information message.", message);
             Assert.Null(eventName);
@@ -547,7 +546,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Some log information message. {attributeKey} {attributeKey}.", message);
             Assert.Null(eventName);
@@ -594,7 +593,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("Some log information message. {Some scope key}.", message);
             Assert.Null(eventName);
@@ -624,7 +623,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("MyCustomEventName", eventName);
             Assert.Null(clientAddress);
@@ -649,7 +648,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
 
             Assert.Equal("MyCustomEventName", eventName);
             Assert.Null(clientAddress);
@@ -674,10 +673,76 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             // Assert.
             var logRecord = logRecords.Single();
             var properties = new ChangeTrackingDictionary<string, string>();
-            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientIP);
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientIP, out var availabilityInfo);
 
             Assert.Equal("1.2.3.4", clientIP);
             Assert.Null(eventName);
+        }
+
+        [Fact]
+        public void VerifyAvailabilityAttributes()
+        {
+            // Arrange.
+            var logRecords = new List<LogRecord>(1);
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.AddInMemoryExporter(logRecords);
+                });
+            });
+
+            var logger = loggerFactory.CreateLogger("Some category");
+            logger.LogInformation("{microsoft.availability.id} {microsoft.availability.name} {microsoft.availability.duration} {microsoft.availability.success} {microsoft.availability.runLocation} {microsoft.availability.message}",
+                "test-id", "test-name", "00:00:05", true, "test-location", "test-message");
+
+            // Assert.
+            var logRecord = logRecords.Single();
+            var properties = new ChangeTrackingDictionary<string, string>();
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
+
+            Assert.NotNull(availabilityInfo);
+            Assert.Equal("test-id", availabilityInfo.Value.Id);
+            Assert.Equal("test-name", availabilityInfo.Value.Name);
+            Assert.Equal("00:00:05", availabilityInfo.Value.Duration);
+            Assert.True(availabilityInfo.Value.Success);
+            Assert.Equal("test-location", availabilityInfo.Value.RunLocation);
+            Assert.Equal("test-message", availabilityInfo.Value.Message);
+            Assert.Null(eventName);
+            Assert.Null(clientAddress);
+        }
+
+        [Fact]
+        public void VerifyAvailabilityAttributes_MissingOptionalFields()
+        {
+            // Arrange.
+            var logRecords = new List<LogRecord>(1);
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.AddInMemoryExporter(logRecords);
+                });
+            });
+
+            var logger = loggerFactory.CreateLogger("Some category");
+            logger.LogInformation("{microsoft.availability.id} {microsoft.availability.name} {microsoft.availability.duration} {microsoft.availability.success}",
+                "test-id", "test-name", "00:00:05", false);
+
+            // Assert.
+            var logRecord = logRecords.Single();
+            var properties = new ChangeTrackingDictionary<string, string>();
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out var message, out var eventName, out var clientAddress, out var availabilityInfo);
+
+            Assert.NotNull(availabilityInfo);
+            Assert.Equal("test-id", availabilityInfo.Value.Id);
+            Assert.Equal("test-name", availabilityInfo.Value.Name);
+            Assert.Equal("00:00:05", availabilityInfo.Value.Duration);
+            Assert.False(availabilityInfo.Value.Success);
+            Assert.Null(availabilityInfo.Value.RunLocation);
+            Assert.NotNull(availabilityInfo.Value.Message); // Should fallback to formatted message
+            Assert.Null(eventName);
+            Assert.Null(clientAddress);
         }
 
         private class CustomObject

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/LogsHelperTests.cs
@@ -740,7 +740,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.Equal("00:00:05", availabilityInfo.Value.Duration);
             Assert.False(availabilityInfo.Value.Success);
             Assert.Null(availabilityInfo.Value.RunLocation);
-            Assert.NotNull(availabilityInfo.Value.Message); // Should fallback to formatted message
+            Assert.Null(availabilityInfo.Value.Message); // Should fallback to formatted message if options.IncludeFormattedMessage = true;
             Assert.Null(eventName);
             Assert.Null(clientAddress);
         }


### PR DESCRIPTION
## Description
This PR adds support for Availability telemetry type in the Azure Monitor OpenTelemetry Exporter, enabling conversion of OpenTelemetry log records with availability attributes into Azure Monitor AvailabilityData telemetry items.

## Changes Made

### Core Implementation
- **LogsHelper.cs**: Added detection and extraction logic for availability telemetry
  - Added constants for availability attribute names (`microsoft.availability.id`, `microsoft.availability.name`, etc.)
  - Implemented `ProcessLogRecordProperties` to detect availability marker attribute
  - Created `ExtractAvailabilityInfo` helper method to extract all availability fields including optional client IP
  - Added `AvailabilityInfo` struct to hold availability test data
  - Integrated availability detection in telemetry type priority: Exception → Availability → Event → Message

### Telemetry Schema Support
- **AvailabilityData.cs** (Customizations/Models): Added constructor to initialize AvailabilityData from AvailabilityInfo struct
- **HttpPipelineHelper.cs**: Added availability counter tracking in `IncrementCounterByType`, `DecrementCounterByType`, and `HasAnyCount`
- **TelemetrySchemaTypeCounter.cs**: Added `_availabilityCount` field

### Testing
- **LogsHelperTests.cs**: Added comprehensive unit tests
  - `VerifyAvailabilityAttributes`: Tests all availability fields including optional ones
  - `VerifyAvailabilityAttributes_MissingOptionalFields`: Tests minimal required fields
  - Updated 16 existing test method signatures to include `out AvailabilityInfo?` parameter
- **TelemetryItemValidationHelper.cs**: Updated `AssertAvailabilityTelemetry` to only validate property count when expected properties are provided

## Availability Telemetry Format
Availability telemetry is detected via the `microsoft.availability.name` marker attribute. The following attributes are supported:

**Required:**
- `microsoft.availability.id` - Test run identifier
- `microsoft.availability.name` - Test name
- `microsoft.availability.duration` - Test duration (e.g., "00:00:05")
- `microsoft.availability.success` - Test success status (true/false)

**Optional:**
- `microsoft.availability.runLocation` - Test execution location
- `microsoft.availability.message` - Test result message
- `microsoft.client.ip` - Client IP address