### PR TITLE
[App Configuration] Removed enabled/conditions from feature flag required properties

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/appconfiguration/Azure.Data.AppConfiguration",
-  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_932ea57074"
+  "Tag": "net/appconfiguration/Azure.Data.AppConfiguration_0ef5fd0bc3"
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/FeatureFlagConfigurationSetting.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/FeatureFlagConfigurationSetting.cs
@@ -44,9 +44,7 @@ namespace Azure.Data.AppConfiguration
 
         private static readonly string[] s_requiredJsonPropertyNames =
         {
-            "id",
-            "enabled",
-            "conditions"
+            "id"
         };
 
         /// <summary>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -1994,6 +1994,42 @@ namespace Azure.Data.AppConfiguration.Tests
         }
 
         [RecordedTest]
+        public async Task CanAddAndGetMinimalFeatureFlag()
+        {
+            ConfigurationClient service = GetClient();
+            string featureId = GenerateKeyId("minimal-feature");
+            string key = FeatureFlagConfigurationSetting.KeyPrefix + featureId;
+
+            var minimalFeatureFlagSetting = new ConfigurationSetting(key, "{\"id\":\"" + featureId + "\"}")
+            {
+                ContentType = FeatureFlagConfigurationSetting.FeatureFlagContentType
+            };
+
+            try
+            {
+                var addResponse = await service.AddConfigurationSettingAsync(minimalFeatureFlagSetting);
+                Assert.AreEqual(key, addResponse.Value.Key);
+                Assert.AreEqual(FeatureFlagConfigurationSetting.FeatureFlagContentType, addResponse.Value.ContentType);
+
+                var getResponse = await service.GetConfigurationSettingAsync(key);
+                var retrievedSetting = getResponse.Value;
+
+                Assert.IsInstanceOf<FeatureFlagConfigurationSetting>(retrievedSetting);
+                Assert.AreEqual(key, retrievedSetting.Key);
+                Assert.AreEqual(FeatureFlagConfigurationSetting.FeatureFlagContentType, retrievedSetting.ContentType);
+
+                var featureFlag = (FeatureFlagConfigurationSetting)retrievedSetting;
+                Assert.AreEqual(featureId, featureFlag.FeatureId);
+                Assert.AreEqual(false, featureFlag.IsEnabled);
+                Assert.AreEqual(0, featureFlag.ClientFilters.Count);
+            }
+            finally
+            {
+                AssertStatus200(await service.DeleteConfigurationSettingAsync(key));
+            }
+        }
+
+        [RecordedTest]
         public async Task CanAddAndUpdateFeatureFlag()
         {
             ConfigurationClient service = GetClient();

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/FeatureFlagConfigurationSettingTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/FeatureFlagConfigurationSettingTests.cs
@@ -400,5 +400,91 @@ namespace Azure.Data.AppConfiguration.Tests
 
             Assert.IsTrue(_jsonComparer.Equals(expected.RootElement, actual.RootElement));
         }
+
+        [Test]
+        public void FeatureFlagWithoutConditionsIsValid()
+        {
+            var featureFlagValue = "{\"id\":\"my feature\",\"enabled\":true}";
+            var featureFlag = new FeatureFlagConfigurationSetting();
+            featureFlag.Value = featureFlagValue;
+
+            Assert.AreEqual("my feature", featureFlag.FeatureId);
+            Assert.AreEqual(true, featureFlag.IsEnabled);
+            Assert.AreEqual(0, featureFlag.ClientFilters.Count);
+        }
+
+        [Test]
+        public void FeatureFlagWithoutConditionsCanBeModified()
+        {
+            var featureFlagValue = "{\"id\":\"my feature\",\"enabled\":false}";
+            var featureFlag = new FeatureFlagConfigurationSetting();
+            featureFlag.Value = featureFlagValue;
+
+            featureFlag.IsEnabled = true;
+            featureFlag.Description = "New description";
+            featureFlag.DisplayName = "New display name";
+
+            Assert.AreEqual("my feature", featureFlag.FeatureId);
+            Assert.AreEqual(true, featureFlag.IsEnabled);
+            Assert.AreEqual("New description", featureFlag.Description);
+            Assert.AreEqual("New display name", featureFlag.DisplayName);
+            Assert.AreEqual(0, featureFlag.ClientFilters.Count);
+
+            using var actual = JsonDocument.Parse(featureFlag.Value);
+            Assert.IsTrue(actual.RootElement.TryGetProperty("id", out _));
+            Assert.IsTrue(actual.RootElement.TryGetProperty("enabled", out _));
+            Assert.IsTrue(actual.RootElement.TryGetProperty("description", out _));
+            Assert.IsTrue(actual.RootElement.TryGetProperty("display_name", out _));
+            Assert.IsTrue(actual.RootElement.TryGetProperty("conditions", out _));
+        }
+
+        [Test]
+        public void FeatureFlagWithOnlyIdIsValid()
+        {
+            var featureFlagValue = "{\"id\":\"my feature\"}";
+            var featureFlag = new FeatureFlagConfigurationSetting();
+            featureFlag.Value = featureFlagValue;
+
+            Assert.AreEqual("my feature", featureFlag.FeatureId);
+            Assert.AreEqual(false, featureFlag.IsEnabled);
+            Assert.AreEqual(0, featureFlag.ClientFilters.Count);
+        }
+
+        [Test]
+        public void FeatureFlagWithoutEnabledIsValid()
+        {
+            var featureFlagValue = "{\"id\":\"my feature\",\"conditions\":{}}";
+            var featureFlag = new FeatureFlagConfigurationSetting();
+            featureFlag.Value = featureFlagValue;
+
+            Assert.AreEqual("my feature", featureFlag.FeatureId);
+            Assert.AreEqual(false, featureFlag.IsEnabled);
+            Assert.AreEqual(0, featureFlag.ClientFilters.Count);
+        }
+
+        [Test]
+        public void FeatureFlagWithoutEnabledCanBeModified()
+        {
+            var featureFlagValue = "{\"id\":\"my feature\",\"conditions\":{}}";
+            var featureFlag = new FeatureFlagConfigurationSetting();
+            featureFlag.Value = featureFlagValue;
+
+            featureFlag.IsEnabled = true;
+            featureFlag.Description = "New description";
+            featureFlag.DisplayName = "New display name";
+
+            Assert.AreEqual("my feature", featureFlag.FeatureId);
+            Assert.AreEqual(true, featureFlag.IsEnabled);
+            Assert.AreEqual("New description", featureFlag.Description);
+            Assert.AreEqual("New display name", featureFlag.DisplayName);
+            Assert.AreEqual(0, featureFlag.ClientFilters.Count);
+
+            using var actual = JsonDocument.Parse(featureFlag.Value);
+            Assert.IsTrue(actual.RootElement.TryGetProperty("id", out _));
+            Assert.IsTrue(actual.RootElement.TryGetProperty("enabled", out _));
+            Assert.IsTrue(actual.RootElement.TryGetProperty("description", out _));
+            Assert.IsTrue(actual.RootElement.TryGetProperty("display_name", out _));
+            Assert.IsTrue(actual.RootElement.TryGetProperty("conditions", out _));
+        }
     }
 }


### PR DESCRIPTION
 Making `enabled` and `conditions` optional according to the [Feature Flag schema](https://github.com/microsoft/FeatureManagement/blob/main/Schema/FeatureFlag.v2.0.0.schema.json), where only `id` is required.

