### PR TITLE
Refactor global Web PubSub connection Options setup in preparation fo…

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubJobsBuilderExtensions.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubJobsBuilderExtensions.cs
@@ -4,7 +4,10 @@
 using System;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.WebPubSub;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Hosting
 {
@@ -27,6 +30,11 @@ namespace Microsoft.Extensions.Hosting
 
             builder.AddExtension<WebPubSubConfigProvider>()
                 .ConfigureOptions<WebPubSubFunctionsOptions>(ApplyConfiguration);
+
+            // Register the options setup to read from default configuration section
+            builder.Services.AddSingleton<IConfigureOptions<WebPubSubServiceAccessOptions>, WebPubSubServiceAccessOptionsSetup>();
+
+            builder.Services.AddAzureClientsCore();
             return builder;
         }
 

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccess.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccess.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub;
+
+#nullable enable
+
+/// <summary>
+/// Access information to Web PubSub service.
+/// </summary>
+internal class WebPubSubServiceAccess(Uri serviceEndpoint, WebPubSubServiceCredential credential)
+{
+    public Uri ServiceEndpoint { get; } = serviceEndpoint;
+    public WebPubSubServiceCredential Credential { get; } = credential;
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccessOptions.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccessOptions.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub;
+
+internal class WebPubSubServiceAccessOptions
+{
+    public WebPubSubServiceAccess? WebPubSubAccess { get; set; }
+    public string? Hub { get; set; }
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccessOptionsSetup.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccessOptionsSetup.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
+{
+    /// <summary>
+    /// Configures <see cref="WebPubSubServiceAccessOptions"/> by reading from the default configuration section.
+    /// </summary>
+    internal class WebPubSubServiceAccessOptionsSetup : IConfigureOptions<WebPubSubServiceAccessOptions>
+    {
+        private readonly IConfiguration _configuration;
+        private readonly AzureComponentFactory _azureComponentFactory;
+        private readonly INameResolver _nameResolver;
+        private readonly IOptionsMonitor<WebPubSubFunctionsOptions> _publicOptions;
+
+        public WebPubSubServiceAccessOptionsSetup(
+            IConfiguration configuration,
+            AzureComponentFactory azureComponentFactory,
+            INameResolver nameResolver,
+            IOptionsMonitor<WebPubSubFunctionsOptions> publicOptions)
+        {
+            _configuration = configuration;
+            _azureComponentFactory = azureComponentFactory;
+            _nameResolver = nameResolver;
+            _publicOptions = publicOptions;
+        }
+
+        public void Configure(WebPubSubServiceAccessOptions options)
+        {
+            var publicOptions = _publicOptions.CurrentValue;
+
+            // WebPubSubFunctionsOptions.ConnectionString can be set via code only. Takes the highest priority.
+            if (!string.IsNullOrEmpty(publicOptions.ConnectionString))
+            {
+                options.WebPubSubAccess = WebPubSubServiceAccessUtil.CreateFromConnectionString(publicOptions.ConnectionString);
+            }
+            else
+            {
+                var defaultSection = _configuration.GetSection(Constants.WebPubSubConnectionStringName);
+                if (WebPubSubServiceAccessUtil.CreateFromIConfiguration(defaultSection, _azureComponentFactory, out var access))
+                {
+                    options.WebPubSubAccess = access!;
+                }
+            }
+
+            // Only configure Hub from the default config section if not already set
+            options.Hub = publicOptions.Hub ?? _nameResolver.Resolve(Constants.HubNameStringName);
+        }
+    }
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccessUtil.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccessUtil.cs
@@ -86,8 +86,8 @@ internal static class WebPubSubServiceAccessUtil
             if (!string.IsNullOrEmpty(serviceUri))
             {
                 var endpoint = new Uri(serviceUri);
-                var tokenCrential = azureComponentFactory.CreateTokenCredential(section);
-                result = new WebPubSubServiceAccess(endpoint, new IdentityCredential(tokenCrential));
+                var tokenCredential = azureComponentFactory.CreateTokenCredential(section);
+                result = new WebPubSubServiceAccess(endpoint, new IdentityCredential(tokenCredential));
                 return true;
             }
         }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccessUtil.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceAccessUtil.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub;
+
+internal static class WebPubSubServiceAccessUtil
+{
+    private const string EndpointPropertyName = "Endpoint";
+    private const string AccessKeyPropertyName = "AccessKey";
+    private const string PortPropertyName = "Port";
+    private static readonly char[] KeyValueSeparator = { '=' };
+    private static readonly char[] PropertySeparator = { ';' };
+
+    internal static WebPubSubServiceAccess CreateFromConnectionString(string connectionString)
+    {
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            throw new ArgumentNullException(nameof(connectionString));
+        }
+
+        var properties = connectionString.Split(PropertySeparator, StringSplitOptions.RemoveEmptyEntries);
+
+        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in properties)
+        {
+            var kvp = property.Split(KeyValueSeparator, 2);
+            if (kvp.Length != 2)
+                continue;
+
+            var key = kvp[0].Trim();
+            if (dict.ContainsKey(key))
+            {
+                throw new ArgumentException($"Duplicate properties found in connection string: {key}.");
+            }
+
+            dict.Add(key, kvp[1].Trim());
+        }
+
+        if (!dict.TryGetValue(EndpointPropertyName, out var endpoint))
+        {
+            throw new ArgumentException($"Required property not found in connection string: {EndpointPropertyName}.");
+        }
+        endpoint = endpoint.TrimEnd('/');
+
+        // AccessKey is optional when connection string is disabled.
+        dict.TryGetValue(AccessKeyPropertyName, out var accessKey);
+
+        int? port = null;
+        if (dict.TryGetValue(PortPropertyName, out var rawPort))
+        {
+            if (int.TryParse(rawPort, out var portValue) && portValue > 0 && portValue <= 0xFFFF)
+            {
+                port = portValue;
+            }
+            else
+            {
+                throw new ArgumentException($"Invalid Port value: {rawPort}");
+            }
+        }
+
+        var uriBuilder = new UriBuilder(endpoint);
+        if (port.HasValue)
+        {
+            uriBuilder.Port = port.Value;
+        }
+
+        return new WebPubSubServiceAccess(uriBuilder.Uri, new KeyCredential(accessKey));
+    }
+
+    internal static bool CreateFromIConfiguration(IConfigurationSection section, AzureComponentFactory azureComponentFactory, out WebPubSubServiceAccess? result)
+    {
+        if (!string.IsNullOrEmpty(section.Value))
+        {
+            result = CreateFromConnectionString(section.Value);
+            return true;
+        }
+        else
+        {
+            // Check if this is an identity-based connection (has serviceUri)
+            var serviceUri = section[Constants.ServiceUriKey];
+            if (!string.IsNullOrEmpty(serviceUri))
+            {
+                var endpoint = new Uri(serviceUri);
+                var tokenCrential = azureComponentFactory.CreateTokenCredential(section);
+                result = new WebPubSubServiceAccess(endpoint, new IdentityCredential(tokenCrential));
+                return true;
+            }
+        }
+        result = null;
+        return false;
+    }
+
+    internal static bool CanCreateFromIConfiguration(IConfigurationSection section)
+    {
+        if (!string.IsNullOrEmpty(section.Value))
+        {
+            // Assume connection string exists.
+            return true;
+        }
+        else
+        {
+            // Check if this is an identity-based connection (has serviceUri)
+            var serviceUri = section[Constants.ServiceUriKey];
+            if (!string.IsNullOrEmpty(serviceUri))
+            {
+                // Identity-based connection
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceCredential.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceCredential.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub;
+
+/// <summary>
+/// Can be key-based credential, identity-based connection, or null (A connection string without access key provided to Web PubSub trigger)
+/// </summary>
+internal abstract class WebPubSubServiceCredential
+{
+    public abstract bool CanValidateSignature { get; }
+}
+
+internal class KeyCredential(string accessKey) : WebPubSubServiceCredential
+{
+    public override bool CanValidateSignature => !string.IsNullOrEmpty(AccessKey);
+    public string AccessKey { get; } = accessKey;
+}
+
+internal class IdentityCredential(TokenCredential tokenCredential) : WebPubSubServiceCredential
+{
+    public override bool CanValidateSignature => false;
+
+    public TokenCredential TokenCredential { get; } = tokenCredential;
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Constants.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Constants.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         public const string HubNameStringName = "WebPubSubHub";
         public const string WebPubSubValidationStringName = "WebPubSubValidation";
 
+        // Identity-based connection configuration keys
+        public const string ServiceUriKey = "serviceUri";
+
         public const string MqttWebSocketSubprotocolValue = "mqtt";
 
         public static class ContentTypes

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
@@ -6,7 +6,8 @@
     <PackageTags>Azure, WebPubSub</PackageTags>
     <Description>Azure Functions extension for the WebPubSub service</Description>
     <Version>1.10.0-beta.1</Version>
-    <!--Removed ApiCompatVersion to skip ApiCompatability check to update binding attributes. They'll be added back automatically after release.-->
+    <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
+    <ApiCompatVersion>1.9.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);CS8632;CA1056;CA2227</NoWarn>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
     <AotCompatOptOut>true</AotCompatOptOut>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
@@ -6,8 +6,7 @@
     <PackageTags>Azure, WebPubSub</PackageTags>
     <Description>Azure Functions extension for the WebPubSub service</Description>
     <Version>1.10.0-beta.1</Version>
-    <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>1.9.0</ApiCompatVersion>
+    <!--Removed ApiCompatVersion to skip ApiCompatability check to update binding attributes. They'll be added back automatically after release.-->
     <NoWarn>$(NoWarn);CS8632;CA1056;CA2227</NoWarn>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>
     <AotCompatOptOut>true</AotCompatOptOut>
@@ -25,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" />
     <PackageReference Include="Microsoft.Azure.WebJobs" />
+    <PackageReference Include="Microsoft.Extensions.Azure" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessOptionsSetupTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessOptionsSetupTests.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             setup.Configure(options);
 
             // Assert
-            Assert.IsNotNull(options.DefaultWebPubSubAccess);
-            Assert.AreEqual(new System.Uri(TestServiceUri), options.DefaultWebPubSubAccess.ServiceEndpoint);
+            Assert.IsNotNull(options.WebPubSubAccess);
+            Assert.AreEqual(new System.Uri(TestServiceUri), options.WebPubSubAccess.ServiceEndpoint);
         }
 
         [Test]

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessOptionsSetupTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessOptionsSetupTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
         private const string TestHub = "TestHub";
 
         [Test]
-        public void Configure_WithConnectionStringInPublicOptions_SetsDefaultWebPubSubAccess()
+        public void Configure_WithConnectionStringInPublicOptions_SetsWebPubSubAccess()
         {
             // Arrange
             var configuration = CreateConfiguration();
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
         }
 
         [Test]
-        public void Configure_WithConnectionStringInConfiguration_SetsDefaultWebPubSubAccess()
+        public void Configure_WithConnectionStringInConfiguration_SetsWebPubSubAccess()
         {
             // Arrange
             var configuration = CreateConfiguration(new Dictionary<string, string>
@@ -66,12 +66,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             setup.Configure(options);
 
             // Assert
-            Assert.IsNotNull(options.DefaultWebPubSubAccess);
-            Assert.AreEqual(new System.Uri(TestServiceUri), options.DefaultWebPubSubAccess.ServiceEndpoint);
+            Assert.IsNotNull(options.WebPubSubAccess);
+            Assert.AreEqual(new System.Uri(TestServiceUri), options.WebPubSubAccess.ServiceEndpoint);
         }
 
         [Test]
-        public void Configure_WithServiceUriInConfiguration_SetsDefaultWebPubSubAccess()
+        public void Configure_WithServiceUriInConfiguration_SetsWebPubSubAccess()
         {
             // Arrange
             var mockCredential = Mock.Of<TokenCredential>();
@@ -96,10 +96,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             setup.Configure(options);
 
             // Assert
-            Assert.IsNotNull(options.DefaultWebPubSubAccess);
-            Assert.AreEqual(new System.Uri(TestServiceUri), options.DefaultWebPubSubAccess.ServiceEndpoint);
-            Assert.IsInstanceOf<IdentityCredential>(options.DefaultWebPubSubAccess.Credential);
-            Assert.AreEqual(mockCredential, ((IdentityCredential)options.DefaultWebPubSubAccess.Credential).TokenCredential);
+            Assert.IsNotNull(options.WebPubSubAccess);
+            Assert.AreEqual(new System.Uri(TestServiceUri), options.WebPubSubAccess.ServiceEndpoint);
+            Assert.IsInstanceOf<IdentityCredential>(options.WebPubSubAccess.Credential);
+            Assert.AreEqual(mockCredential, ((IdentityCredential)options.WebPubSubAccess.Credential).TokenCredential);
         }
 
         [Test]
@@ -128,13 +128,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             setup.Configure(options);
 
             // Assert
-            Assert.IsNotNull(options.DefaultWebPubSubAccess);
-            Assert.AreEqual(new System.Uri(TestServiceUri), options.DefaultWebPubSubAccess.ServiceEndpoint);
-            Assert.IsInstanceOf<KeyCredential>(options.DefaultWebPubSubAccess.Credential);
+            Assert.IsNotNull(options.WebPubSubAccess);
+            Assert.AreEqual(new System.Uri(TestServiceUri), options.WebPubSubAccess.ServiceEndpoint);
+            Assert.IsInstanceOf<KeyCredential>(options.WebPubSubAccess.Credential);
         }
 
         [Test]
-        public void Configure_WithNoConnectionInfo_DoesNotSetDefaultWebPubSubAccess()
+        public void Configure_WithNoConnectionInfo_DoesNotSetWebPubSubAccess()
         {
             // Arrange
             var configuration = CreateConfiguration();
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             setup.Configure(options);
 
             // Assert
-            Assert.IsNull(options.DefaultWebPubSubAccess);
+            Assert.IsNull(options.WebPubSubAccess);
         }
 
         [Test]

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessOptionsSetupTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessOptionsSetupTests.cs
@@ -1,0 +1,259 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.Core;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
+{
+    public class WebPubSubServiceAccessOptionsSetupTests
+    {
+        private const string TestConnectionString = "Endpoint=https://test.webpubsub.azure.com;AccessKey=test-key;";
+        private const string TestServiceUri = "https://test.webpubsub.azure.com";
+        private const string TestHub = "TestHub";
+
+        [Test]
+        public void Configure_WithConnectionStringInPublicOptions_SetsDefaultWebPubSubAccess()
+        {
+            // Arrange
+            var configuration = CreateConfiguration();
+            var publicOptions = CreatePublicOptions(connectionString: TestConnectionString);
+            var azureComponentFactory = Mock.Of<AzureComponentFactory>();
+            var nameResolver = new Mock<INameResolver>().Object;
+
+            var setup = new WebPubSubServiceAccessOptionsSetup(
+                configuration,
+                azureComponentFactory,
+                nameResolver,
+                publicOptions);
+
+            var options = new WebPubSubServiceAccessOptions();
+
+            // Act
+            setup.Configure(options);
+
+            // Assert
+            Assert.IsNotNull(options.DefaultWebPubSubAccess);
+            Assert.AreEqual(new System.Uri(TestServiceUri), options.DefaultWebPubSubAccess.ServiceEndpoint);
+        }
+
+        [Test]
+        public void Configure_WithConnectionStringInConfiguration_SetsDefaultWebPubSubAccess()
+        {
+            // Arrange
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { Constants.WebPubSubConnectionStringName, TestConnectionString }
+            });
+            var publicOptions = CreatePublicOptions();
+            var azureComponentFactory = Mock.Of<AzureComponentFactory>();
+            var nameResolver = new Mock<INameResolver>().Object;
+
+            var setup = new WebPubSubServiceAccessOptionsSetup(
+                configuration,
+                azureComponentFactory,
+                nameResolver,
+                publicOptions);
+
+            var options = new WebPubSubServiceAccessOptions();
+
+            // Act
+            setup.Configure(options);
+
+            // Assert
+            Assert.IsNotNull(options.DefaultWebPubSubAccess);
+            Assert.AreEqual(new System.Uri(TestServiceUri), options.DefaultWebPubSubAccess.ServiceEndpoint);
+        }
+
+        [Test]
+        public void Configure_WithServiceUriInConfiguration_SetsDefaultWebPubSubAccess()
+        {
+            // Arrange
+            var mockCredential = Mock.Of<TokenCredential>();
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { $"{Constants.WebPubSubConnectionStringName}:{Constants.ServiceUriKey}", TestServiceUri }
+            });
+            var publicOptions = CreatePublicOptions();
+            var azureComponentFactory = Mock.Of<AzureComponentFactory>(f =>
+                f.CreateTokenCredential(It.IsAny<IConfiguration>()) == mockCredential);
+            var nameResolver = new Mock<INameResolver>().Object;
+
+            var setup = new WebPubSubServiceAccessOptionsSetup(
+                configuration,
+                azureComponentFactory,
+                nameResolver,
+                publicOptions);
+
+            var options = new WebPubSubServiceAccessOptions();
+
+            // Act
+            setup.Configure(options);
+
+            // Assert
+            Assert.IsNotNull(options.DefaultWebPubSubAccess);
+            Assert.AreEqual(new System.Uri(TestServiceUri), options.DefaultWebPubSubAccess.ServiceEndpoint);
+            Assert.IsInstanceOf<IdentityCredential>(options.DefaultWebPubSubAccess.Credential);
+            Assert.AreEqual(mockCredential, ((IdentityCredential)options.DefaultWebPubSubAccess.Credential).TokenCredential);
+        }
+
+        [Test]
+        public void Configure_ConnectionStringTakesPrecedenceOverConfiguration()
+        {
+            // Arrange
+            var mockCredential = Mock.Of<TokenCredential>();
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { $"{Constants.WebPubSubConnectionStringName}:{Constants.ServiceUriKey}", "https://other.webpubsub.azure.com" }
+            });
+            var publicOptions = CreatePublicOptions(connectionString: TestConnectionString);
+            var azureComponentFactory = Mock.Of<AzureComponentFactory>(f =>
+                f.CreateTokenCredential(It.IsAny<IConfiguration>()) == mockCredential);
+            var nameResolver = new Mock<INameResolver>().Object;
+
+            var setup = new WebPubSubServiceAccessOptionsSetup(
+                configuration,
+                azureComponentFactory,
+                nameResolver,
+                publicOptions);
+
+            var options = new WebPubSubServiceAccessOptions();
+
+            // Act
+            setup.Configure(options);
+
+            // Assert
+            Assert.IsNotNull(options.DefaultWebPubSubAccess);
+            Assert.AreEqual(new System.Uri(TestServiceUri), options.DefaultWebPubSubAccess.ServiceEndpoint);
+            Assert.IsInstanceOf<KeyCredential>(options.DefaultWebPubSubAccess.Credential);
+        }
+
+        [Test]
+        public void Configure_WithNoConnectionInfo_DoesNotSetDefaultWebPubSubAccess()
+        {
+            // Arrange
+            var configuration = CreateConfiguration();
+            var publicOptions = CreatePublicOptions();
+            var azureComponentFactory = Mock.Of<AzureComponentFactory>();
+            var nameResolver = new Mock<INameResolver>().Object;
+
+            var setup = new WebPubSubServiceAccessOptionsSetup(
+                configuration,
+                azureComponentFactory,
+                nameResolver,
+                publicOptions);
+
+            var options = new WebPubSubServiceAccessOptions();
+
+            // Act
+            setup.Configure(options);
+
+            // Assert
+            Assert.IsNull(options.DefaultWebPubSubAccess);
+        }
+
+        [Test]
+        public void Configure_WithHubInPublicOptions_SetsHub()
+        {
+            // Arrange
+            var configuration = CreateConfiguration();
+            var publicOptions = CreatePublicOptions(hub: TestHub);
+            var azureComponentFactory = Mock.Of<AzureComponentFactory>();
+            var nameResolver = new Mock<INameResolver>().Object;
+
+            var setup = new WebPubSubServiceAccessOptionsSetup(
+                configuration,
+                azureComponentFactory,
+                nameResolver,
+                publicOptions);
+
+            var options = new WebPubSubServiceAccessOptions();
+
+            // Act
+            setup.Configure(options);
+
+            // Assert
+            Assert.AreEqual(TestHub, options.Hub);
+        }
+
+        [Test]
+        public void Configure_WithHubInNameResolver_SetsHub()
+        {
+            // Arrange
+            var configuration = CreateConfiguration();
+            var publicOptions = CreatePublicOptions();
+            var azureComponentFactory = Mock.Of<AzureComponentFactory>();
+            var mockNameResolver = new Mock<INameResolver>();
+            mockNameResolver.Setup(x => x.Resolve(Constants.HubNameStringName)).Returns(TestHub);
+
+            var setup = new WebPubSubServiceAccessOptionsSetup(
+                configuration,
+                azureComponentFactory,
+                mockNameResolver.Object,
+                publicOptions);
+
+            var options = new WebPubSubServiceAccessOptions();
+
+            // Act
+            setup.Configure(options);
+
+            // Assert
+            Assert.AreEqual(TestHub, options.Hub);
+        }
+
+        [Test]
+        public void Configure_HubInPublicOptionsTakesPrecedenceOverNameResolver()
+        {
+            // Arrange
+            var configuration = CreateConfiguration();
+            var publicOptions = CreatePublicOptions(hub: TestHub);
+            var azureComponentFactory = Mock.Of<AzureComponentFactory>();
+            var mockNameResolver = new Mock<INameResolver>();
+            mockNameResolver.Setup(x => x.Resolve(Constants.HubNameStringName)).Returns("OtherHub");
+
+            var setup = new WebPubSubServiceAccessOptionsSetup(
+                configuration,
+                azureComponentFactory,
+                mockNameResolver.Object,
+                publicOptions);
+
+            var options = new WebPubSubServiceAccessOptions();
+
+            // Act
+            setup.Configure(options);
+
+            // Assert
+            Assert.AreEqual(TestHub, options.Hub);
+        }
+
+        private static IConfiguration CreateConfiguration(Dictionary<string, string> values = null)
+        {
+            var builder = new ConfigurationBuilder();
+            if (values != null)
+            {
+                builder.AddInMemoryCollection(values);
+            }
+            return builder.Build();
+        }
+
+        private static IOptionsMonitor<WebPubSubFunctionsOptions> CreatePublicOptions(
+            string connectionString = null,
+            string hub = null)
+        {
+            var options = new WebPubSubFunctionsOptions
+            {
+                ConnectionString = connectionString,
+                Hub = hub
+            };
+
+            var mockOptionsMonitor = new Mock<IOptionsMonitor<WebPubSubFunctionsOptions>>();
+            mockOptionsMonitor.Setup(x => x.CurrentValue).Returns(options);
+            return mockOptionsMonitor.Object;
+        }
+    }
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessUtilTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessUtilTests.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
+{
+    public class WebPubSubServiceAccessUtilTests
+    {
+        [Test]
+        public void CreateFromConnectionString_ThrowsArgumentNullException_WhenConnectionStringIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                WebPubSubServiceAccessUtil.CreateFromConnectionString(null));
+        }
+
+        [Test]
+        public void CreateFromConnectionString_ThrowsArgumentNullException_WhenConnectionStringIsEmpty()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                WebPubSubServiceAccessUtil.CreateFromConnectionString(string.Empty));
+        }
+
+        [Test]
+        public void CreateFromConnectionString_ThrowsArgumentException_WhenEndpointIsMissing()
+        {
+            var connectionString = "AccessKey=testkey";
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+                WebPubSubServiceAccessUtil.CreateFromConnectionString(connectionString));
+
+            Assert.That(ex.Message, Does.Contain("Required property not found in connection string: Endpoint"));
+        }
+
+        [Test]
+        public void CreateFromConnectionString_SucceedsWithoutAccessKey()
+        {
+            var endpoint = "https://test.webpubsub.azure.com";
+            var connectionString = $"Endpoint={endpoint}";
+
+            var result = WebPubSubServiceAccessUtil.CreateFromConnectionString(connectionString);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(new Uri(endpoint), result.ServiceEndpoint);
+            Assert.IsNull((result.Credential as KeyCredential).AccessKey);
+        }
+
+        [Test]
+        public void CreateFromConnectionString_ParsesValidConnectionString()
+        {
+            var endpoint = "https://test.webpubsub.azure.com";
+            var accessKey = "test-access-key";
+            var connectionString = $"Endpoint={endpoint};AccessKey={accessKey}";
+
+            var result = WebPubSubServiceAccessUtil.CreateFromConnectionString(connectionString);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(new Uri(endpoint), result.ServiceEndpoint);
+            Assert.IsNotNull(result.Credential);
+            Assert.IsInstanceOf<KeyCredential>(result.Credential);
+            var keyCredential = (KeyCredential)result.Credential;
+            Assert.AreEqual(accessKey, keyCredential.AccessKey);
+        }
+
+        [Test]
+        public void CreateFromConnectionString_ParsesWithCustomPort()
+        {
+            var endpoint = "https://test.webpubsub.azure.com";
+            var accessKey = "test-access-key";
+            var port = "8080";
+            var connectionString = $"Endpoint={endpoint};AccessKey={accessKey};Port={port}";
+
+            var result = WebPubSubServiceAccessUtil.CreateFromConnectionString(connectionString);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(8080, result.ServiceEndpoint.Port);
+            Assert.AreEqual("test.webpubsub.azure.com", result.ServiceEndpoint.Host);
+        }
+
+        [Test]
+        [TestCase("0")]
+        [TestCase("-1")]
+        [TestCase("65536")]
+        [TestCase("70000")]
+        [TestCase("abc")]
+        [TestCase("")]
+        public void CreateFromConnectionString_ThrowsArgumentException_WhenPortIsInvalid(string invalidPort)
+        {
+            var endpoint = "https://test.webpubsub.azure.com";
+            var accessKey = "test-access-key";
+            var connectionString = $"Endpoint={endpoint};AccessKey={accessKey};Port={invalidPort}";
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+                WebPubSubServiceAccessUtil.CreateFromConnectionString(connectionString));
+
+            Assert.That(ex.Message, Does.Contain($"Invalid Port value: {invalidPort}"));
+        }
+
+        [Test]
+        [TestCase("1")]
+        [TestCase("80")]
+        [TestCase("443")]
+        [TestCase("8080")]
+        [TestCase("65535")]
+        public void CreateFromConnectionString_AcceptsValidPort(string validPort)
+        {
+            var endpoint = "https://test.webpubsub.azure.com";
+            var accessKey = "test-access-key";
+            var connectionString = $"Endpoint={endpoint};AccessKey={accessKey};Port={validPort}";
+
+            var result = WebPubSubServiceAccessUtil.CreateFromConnectionString(connectionString);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(int.Parse(validPort), result.ServiceEndpoint.Port);
+        }
+
+        [Test]
+        public void CreateFromIConfiguration_ReturnsTrue_WhenConnectionStringValueExists()
+        {
+            var endpoint = "https://test.webpubsub.azure.com";
+            var accessKey = "test-access-key";
+            var connectionString = $"Endpoint={endpoint};AccessKey={accessKey}";
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "TestConnection", connectionString }
+                })
+                .Build();
+
+            var section = configuration.GetSection("TestConnection");
+            var mockFactory = new Mock<AzureComponentFactory>();
+
+            var success = WebPubSubServiceAccessUtil.CreateFromIConfiguration(section, mockFactory.Object, out var result);
+
+            Assert.IsTrue(success);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(new Uri(endpoint), result.ServiceEndpoint);
+            Assert.IsInstanceOf<KeyCredential>(result.Credential);
+            var keyCredential = (KeyCredential)result.Credential;
+            Assert.AreEqual(accessKey, keyCredential.AccessKey);
+        }
+
+        [Test]
+        public void CreateFromIConfiguration_ReturnsTrue_WhenServiceUriExists()
+        {
+            var serviceUri = "https://test.webpubsub.azure.com";
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "TestConnection:serviceUri", serviceUri }
+                })
+                .Build();
+
+            var section = configuration.GetSection("TestConnection");
+            var mockFactory = new Mock<AzureComponentFactory>();
+            mockFactory.Setup(f => f.CreateTokenCredential(It.IsAny<IConfiguration>()))
+                .Returns(Mock.Of<TokenCredential>());
+
+            var success = WebPubSubServiceAccessUtil.CreateFromIConfiguration(section, mockFactory.Object, out var result);
+
+            Assert.IsTrue(success);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(new Uri(serviceUri), result.ServiceEndpoint);
+            Assert.IsInstanceOf<IdentityCredential>(result.Credential);
+            var identityCredential = (IdentityCredential)result.Credential;
+        }
+
+        [Test]
+        public void CreateFromIConfiguration_ReturnsFalse_WhenNoConnectionInfoExists()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "TestConnection:SomeOtherKey", "value" }
+                })
+                .Build();
+
+            var section = configuration.GetSection("TestConnection");
+            var mockFactory = new Mock<AzureComponentFactory>();
+
+            var success = WebPubSubServiceAccessUtil.CreateFromIConfiguration(section, mockFactory.Object, out var result);
+
+            Assert.IsFalse(success);
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void CreateFromIConfiguration_PrefersConnectionStringOverServiceUri()
+        {
+            var endpoint = "https://connstring.webpubsub.azure.com";
+            var accessKey = "test-access-key";
+            var connectionString = $"Endpoint={endpoint};AccessKey={accessKey}";
+            var serviceUri = "https://serviceuri.webpubsub.azure.com";
+            var mockCredential = new Mock<TokenCredential>();
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "TestConnection", connectionString },
+                    { "TestConnection:serviceUri", serviceUri }
+                })
+                .Build();
+
+            var section = configuration.GetSection("TestConnection");
+            var mockFactory = new Mock<AzureComponentFactory>();
+            mockFactory.Setup(f => f.CreateTokenCredential(It.IsAny<IConfiguration>()))
+                .Returns(mockCredential.Object);
+
+            var success = WebPubSubServiceAccessUtil.CreateFromIConfiguration(section, mockFactory.Object, out var result);
+
+            Assert.IsTrue(success);
+            Assert.IsNotNull(result);
+            // Connection string value should be used, not serviceUri
+            Assert.AreEqual(new Uri(endpoint), result.ServiceEndpoint);
+            Assert.IsInstanceOf<KeyCredential>(result.Credential);
+        }
+    }
+}

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessUtilTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubServiceAccessUtilTests.cs
@@ -170,7 +170,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(new Uri(serviceUri), result.ServiceEndpoint);
             Assert.IsInstanceOf<IdentityCredential>(result.Credential);
-            var identityCredential = (IdentityCredential)result.Credential;
         }
 
         [Test]


### PR DESCRIPTION
…r AAD

* Abstract Web PubSub access credential into a new class, unifies identity-based connection and key-based connection
* Add a util class to create Web PubSub access object from conneciton string or identity-based connection
* Unify global service access info into `WebPubSubServiceAccessOptions`.
