### PR TITLE
Azure OpenAI: 2.7.0-beta.2 release (small bug fix)

### DIFF
--- a/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
+++ b/sdk/openai/Azure.AI.OpenAI/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 2.7.0-beta.2 (2025-12-01)
+
+### Bugs fixed
+
+- Addressed a Thanksgiving mistake in the `beta.1` release wherein the `SetNewMaxCompletionTokensPropertyEnabled()` extension method was unintentionally removed from the public surface.
+
 ## 2.7.0-beta.1 (2025-11-24)
 
 This update restores compatibility with the latest `2.7.0` release of `OpenAI` and enables access to the latest features. For details, please see [the full OpenAI 2.7.0 release notes](https://github.com/openai/openai-dotnet/blob/main/CHANGELOG.md#270-2025-11-13).

--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.net8.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.net8.0.cs
@@ -434,6 +434,8 @@ namespace Azure.AI.OpenAI.Chat
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AOAI001")]
         public static Azure.AI.OpenAI.UserSecurityContext GetUserSecurityContext(this OpenAI.Chat.ChatCompletionOptions options) { throw null; }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AOAI001")]
+        public static void SetNewMaxCompletionTokensPropertyEnabled(this OpenAI.Chat.ChatCompletionOptions options, bool newPropertyEnabled = true) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AOAI001")]
         public static void SetUserSecurityContext(this OpenAI.Chat.ChatCompletionOptions options, Azure.AI.OpenAI.UserSecurityContext userSecurityContext) { }
     }
     [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AOAI001")]

--- a/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
+++ b/sdk/openai/Azure.AI.OpenAI/api/Azure.AI.OpenAI.netstandard2.0.cs
@@ -386,6 +386,7 @@ namespace Azure.AI.OpenAI.Chat
         public static Azure.AI.OpenAI.ResponseContentFilterResult GetResponseContentFilterResult(this OpenAI.Chat.ChatCompletion chatCompletion) { throw null; }
         public static Azure.AI.OpenAI.ResponseContentFilterResult GetResponseContentFilterResult(this OpenAI.Chat.StreamingChatCompletionUpdate chatUpdate) { throw null; }
         public static Azure.AI.OpenAI.UserSecurityContext GetUserSecurityContext(this OpenAI.Chat.ChatCompletionOptions options) { throw null; }
+        public static void SetNewMaxCompletionTokensPropertyEnabled(this OpenAI.Chat.ChatCompletionOptions options, bool newPropertyEnabled = true) { }
         public static void SetUserSecurityContext(this OpenAI.Chat.ChatCompletionOptions options, Azure.AI.OpenAI.UserSecurityContext userSecurityContext) { }
     }
     public partial class AzureSearchChatDataSource : Azure.AI.OpenAI.Chat.ChatDataSource, System.ClientModel.Primitives.IJsonModel<Azure.AI.OpenAI.Chat.AzureSearchChatDataSource>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.OpenAI.Chat.AzureSearchChatDataSource>

--- a/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/src/Azure.AI.OpenAI.csproj
@@ -44,7 +44,7 @@
     <Otherwise>
       <PropertyGroup>
         <VersionPrefix>2.7.0</VersionPrefix>
-        <VersionSuffix>beta.1</VersionSuffix>
+        <VersionSuffix>beta.2</VersionSuffix>
   </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
+++ b/sdk/openai/Azure.AI.OpenAI/src/Custom/Chat/AzureChatExtensions.cs
@@ -60,7 +60,7 @@ public static partial class AzureChatExtensions
     }
 
     [Experimental("AOAI001")]
-    internal static void SetNewMaxCompletionTokensPropertyEnabled(this ChatCompletionOptions options, bool newPropertyEnabled = true)
+    public static void SetNewMaxCompletionTokensPropertyEnabled(this ChatCompletionOptions options, bool newPropertyEnabled = true)
         => options.SetMaxTokenPatchValues(newPropertyEnabled);
 
     internal static void SetMaxTokenPatchValues(this ChatCompletionOptions options, bool? newPropertyRequested = null)


### PR DESCRIPTION
**Workaround note**: pending the release of this fix, it's also possible to reproduce the functionality of setting the new property using the new `JsonPatch` functionality:

```csharp
#pragma warning disable SCME0001
ChatCompletionOptions options = new();
options.Patch.Set("$.max_completion_tokens"u8, 2048);
#pragma warning restore
```

Although the `options.MaxOutputTokenCount` property will not reflect the patched value, chat completion calls using the above options will appropriately serialize with the new property name.