### PR TITLE
Minor fixers for Azure.Provisioning.Dns

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.Dns/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.Dns/CHANGELOG.md
@@ -6,7 +6,12 @@
 
 ### Breaking Changes
 
+- `DnsAaaRecordInfo`: `Ipv6Addresses` renamed to `Ipv6Address`
+- `DnsARecordInfo `: `ipv4Addresses` renamed to `Ipv4Address`
+
 ### Bugs Fixed
+
+- `DnsCnameRecord.Cname`: property is now backed by the correct Bicep field ( `.properties.CNAMERecord.cname` )
 
 ### Other Changes
 

--- a/sdk/provisioning/Azure.Provisioning.Dns/README.md
+++ b/sdk/provisioning/Azure.Provisioning.Dns/README.md
@@ -59,8 +59,8 @@ DnsARecord aRecord = new(nameof(aRecord), DnsARecord.ResourceVersions.V2018_05_0
     TtlInSeconds = 3600,
     ARecords =
     {
-        new DnsARecordInfo() { Ipv4Addresses = IPAddress.Parse("203.0.113.1") },
-        new DnsARecordInfo() { Ipv4Addresses = IPAddress.Parse("203.0.113.2") }
+        new DnsARecordInfo() { Ipv4Address = IPAddress.Parse("203.0.113.1") },
+        new DnsARecordInfo() { Ipv4Address = IPAddress.Parse("203.0.113.2") }
     }
 };
 infra.Add(aRecord);

--- a/sdk/provisioning/Azure.Provisioning.Dns/api/Azure.Provisioning.Dns.net8.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/api/Azure.Provisioning.Dns.net8.0.cs
@@ -30,7 +30,7 @@ namespace Azure.Provisioning.Dns
     public partial class DnsAaaaRecordInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
     {
         public DnsAaaaRecordInfo() { }
-        public Azure.Provisioning.BicepValue<System.Net.IPAddress> Ipv6Addresses { get { throw null; } set { } }
+        public Azure.Provisioning.BicepValue<System.Net.IPAddress> Ipv6Address { get { throw null; } set { } }
         protected override void DefineProvisionableProperties() { }
     }
     public partial class DnsARecord : Azure.Provisioning.Primitives.ProvisionableResource
@@ -55,7 +55,7 @@ namespace Azure.Provisioning.Dns
     public partial class DnsARecordInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
     {
         public DnsARecordInfo() { }
-        public Azure.Provisioning.BicepValue<System.Net.IPAddress> Ipv4Addresses { get { throw null; } set { } }
+        public Azure.Provisioning.BicepValue<System.Net.IPAddress> Ipv4Address { get { throw null; } set { } }
         protected override void DefineProvisionableProperties() { }
     }
     public partial class DnsCaaRecord : Azure.Provisioning.Primitives.ProvisionableResource

--- a/sdk/provisioning/Azure.Provisioning.Dns/api/Azure.Provisioning.Dns.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/api/Azure.Provisioning.Dns.netstandard2.0.cs
@@ -30,7 +30,7 @@ namespace Azure.Provisioning.Dns
     public partial class DnsAaaaRecordInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
     {
         public DnsAaaaRecordInfo() { }
-        public Azure.Provisioning.BicepValue<System.Net.IPAddress> Ipv6Addresses { get { throw null; } set { } }
+        public Azure.Provisioning.BicepValue<System.Net.IPAddress> Ipv6Address { get { throw null; } set { } }
         protected override void DefineProvisionableProperties() { }
     }
     public partial class DnsARecord : Azure.Provisioning.Primitives.ProvisionableResource
@@ -55,7 +55,7 @@ namespace Azure.Provisioning.Dns
     public partial class DnsARecordInfo : Azure.Provisioning.Primitives.ProvisionableConstruct
     {
         public DnsARecordInfo() { }
-        public Azure.Provisioning.BicepValue<System.Net.IPAddress> Ipv4Addresses { get { throw null; } set { } }
+        public Azure.Provisioning.BicepValue<System.Net.IPAddress> Ipv4Address { get { throw null; } set { } }
         protected override void DefineProvisionableProperties() { }
     }
     public partial class DnsCaaRecord : Azure.Provisioning.Primitives.ProvisionableResource

--- a/sdk/provisioning/Azure.Provisioning.Dns/src/DnsARecord.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/src/DnsARecord.cs
@@ -93,11 +93,11 @@ public partial class DnsARecord : ProvisionableResource
     protected override void DefineProvisionableProperties()
     {
         base.DefineProvisionableProperties();
-        _name = DefineProperty<string>("Name", ["name"], isRequired: true);
-        _id = DefineProperty<ResourceIdentifier>("Id", ["id"], isOutput: true);
-        _systemData = DefineModelProperty<SystemData>("SystemData", ["systemData"], isOutput: true);
-        _parent = DefineResource<DnsZone>("Parent", ["parent"], isRequired: true);
-        _aRecords = DefineListProperty<DnsARecordInfo>("ARecords", ["properties", "ARecords"]);
+        _name = DefineProperty<string>(nameof(Name), ["name"], isRequired: true);
+        _id = DefineProperty<ResourceIdentifier>(nameof(Id), ["id"], isOutput: true);
+        _systemData = DefineModelProperty<SystemData>(nameof(SystemData), ["systemData"], isOutput: true);
+        _parent = DefineResource<DnsZone>(nameof(Parent), ["parent"], isRequired: true);
+        _aRecords = DefineListProperty<DnsARecordInfo>(nameof(ARecords), ["properties", "ARecords"]);
         _ttlInSeconds = DefineProperty<long>(nameof(TtlInSeconds), ["properties", "TTL"]);
     }
 

--- a/sdk/provisioning/Azure.Provisioning.Dns/src/DnsCnameRecord.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/src/DnsCnameRecord.cs
@@ -95,11 +95,11 @@ public partial class DnsCnameRecord : ProvisionableResource
     protected override void DefineProvisionableProperties()
     {
         base.DefineProvisionableProperties();
-        _name = DefineProperty<string>("Name", ["name"], isRequired: true);
-        _id = DefineProperty<ResourceIdentifier>("Id", ["id"], isOutput: true);
-        _systemData = DefineModelProperty<SystemData>("SystemData", ["systemData"], isOutput: true);
-        _parent = DefineResource<DnsZone>("Parent", ["parent"], isRequired: true);
-        _cname = DefineProperty<string>("Cname", ["CNAMERecord", "cname"]);
+        _name = DefineProperty<string>(nameof(Name), ["name"], isRequired: true);
+        _id = DefineProperty<ResourceIdentifier>(nameof(Id), ["id"], isOutput: true);
+        _systemData = DefineModelProperty<SystemData>(nameof(SystemData), ["systemData"], isOutput: true);
+        _parent = DefineResource<DnsZone>(nameof(Parent), ["parent"], isRequired: true);
+        _cname = DefineProperty<string>(nameof(Cname), ["properties", "cname"]);
         _ttlInSeconds = DefineProperty<long>(nameof(TtlInSeconds), ["properties", "TTL"]);
     }
 

--- a/sdk/provisioning/Azure.Provisioning.Dns/src/DnsCnameRecord.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/src/DnsCnameRecord.cs
@@ -99,7 +99,7 @@ public partial class DnsCnameRecord : ProvisionableResource
         _id = DefineProperty<ResourceIdentifier>(nameof(Id), ["id"], isOutput: true);
         _systemData = DefineModelProperty<SystemData>(nameof(SystemData), ["systemData"], isOutput: true);
         _parent = DefineResource<DnsZone>(nameof(Parent), ["parent"], isRequired: true);
-        _cname = DefineProperty<string>(nameof(Cname), ["properties", "cname"]);
+        _cname = DefineProperty<string>(nameof(Cname), ["properties", "CNAMERecord", "cname"]);
         _ttlInSeconds = DefineProperty<long>(nameof(TtlInSeconds), ["properties", "TTL"]);
     }
 

--- a/sdk/provisioning/Azure.Provisioning.Dns/src/DnsTxtRecord.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/src/DnsTxtRecord.cs
@@ -91,11 +91,11 @@ public partial class DnsTxtRecord : ProvisionableResource
     protected override void DefineProvisionableProperties()
     {
         base.DefineProvisionableProperties();
-        _name = DefineProperty<string>("Name", ["name"], isRequired: true);
-        _id = DefineProperty<ResourceIdentifier>("Id", ["id"], isOutput: true);
-        _systemData = DefineModelProperty<SystemData>("SystemData", ["systemData"], isOutput: true);
-        _txtRecords = DefineListProperty<DnsTxtRecordInfo>("TxtRecords", ["properties", "TXTRecords"]);
-        _parent = DefineResource<DnsZone>("Parent", ["parent"], isRequired: true);
+        _name = DefineProperty<string>(nameof(Name), ["name"], isRequired: true);
+        _id = DefineProperty<ResourceIdentifier>(nameof(Id), ["id"], isOutput: true);
+        _systemData = DefineModelProperty<SystemData>(nameof(SystemData), ["systemData"], isOutput: true);
+        _txtRecords = DefineListProperty<DnsTxtRecordInfo>(nameof(TxtRecords), ["properties", "TXTRecords"]);
+        _parent = DefineResource<DnsZone>(nameof(Parent), ["parent"], isRequired: true);
         _ttlInSeconds = DefineProperty<long>(nameof(TtlInSeconds), ["properties", "TTL"]);
     }
 

--- a/sdk/provisioning/Azure.Provisioning.Dns/src/Models/DnsARecordInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/src/Models/DnsARecordInfo.cs
@@ -13,12 +13,12 @@ namespace Azure.Provisioning.Dns;
 /// </summary>
 public partial class DnsARecordInfo : ProvisionableConstruct
 {
-    public BicepValue<IPAddress> Ipv4Addresses
+    public BicepValue<IPAddress> Ipv4Address
     {
-        get { Initialize(); return _ipv4Addresses!; }
-        set { Initialize(); _ipv4Addresses!.Assign(value); }
+        get { Initialize(); return _ipv4Address!; }
+        set { Initialize(); _ipv4Address!.Assign(value); }
     }
-    private BicepValue<IPAddress>? _ipv4Addresses;
+    private BicepValue<IPAddress>? _ipv4Address;
 
     /// <summary>
     /// Creates a new DnsARecordInfo.
@@ -33,6 +33,6 @@ public partial class DnsARecordInfo : ProvisionableConstruct
     protected override void DefineProvisionableProperties()
     {
         base.DefineProvisionableProperties();
-        _ipv4Addresses = DefineProperty<IPAddress>("IPv4Addresses", ["ipv4Addresses"], isRequired: true);
+        _ipv4Address = DefineProperty<IPAddress>(nameof(Ipv4Address), ["ipv4Address"], isRequired: true);
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.Dns/src/Models/DnsAaaaRecordInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/src/Models/DnsAaaaRecordInfo.cs
@@ -13,12 +13,12 @@ namespace Azure.Provisioning.Dns;
 /// </summary>
 public partial class DnsAaaaRecordInfo : ProvisionableConstruct
 {
-    public BicepValue<IPAddress> Ipv6Addresses
+    public BicepValue<IPAddress> Ipv6Address
     {
-        get { Initialize(); return _ipv6Addresses!; }
-        set { Initialize(); _ipv6Addresses!.Assign(value); }
+        get { Initialize(); return _ipv6Address!; }
+        set { Initialize(); _ipv6Address!.Assign(value); }
     }
-    private BicepValue<IPAddress>? _ipv6Addresses;
+    private BicepValue<IPAddress>? _ipv6Address;
 
     /// <summary>
     /// Creates a new DnsAaaaRecordInfo.
@@ -33,6 +33,6 @@ public partial class DnsAaaaRecordInfo : ProvisionableConstruct
     protected override void DefineProvisionableProperties()
     {
         base.DefineProvisionableProperties();
-        _ipv6Addresses = DefineProperty<IPAddress>("IPv6Addresses", ["ipv6Addresses"]);
+        _ipv6Address = DefineProperty<IPAddress>("IPv6Address", ["ipv6Address"]);
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.Dns/src/Models/DnsAaaaRecordInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/src/Models/DnsAaaaRecordInfo.cs
@@ -33,6 +33,6 @@ public partial class DnsAaaaRecordInfo : ProvisionableConstruct
     protected override void DefineProvisionableProperties()
     {
         base.DefineProvisionableProperties();
-        _ipv6Address = DefineProperty<IPAddress>("IPv6Address", ["ipv6Address"]);
+        _ipv6Address = DefineProperty<IPAddress>(nameof(Ipv6Address), ["ipv6Address"]);
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.Dns/src/Models/DnsTxtRecordInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/src/Models/DnsTxtRecordInfo.cs
@@ -33,6 +33,6 @@ public partial class DnsTxtRecordInfo : ProvisionableConstruct
     protected override void DefineProvisionableProperties()
     {
         base.DefineProvisionableProperties();
-        _values = DefineListProperty<string>("Values", ["value"]);
+        _values = DefineListProperty<string>(nameof(Values), ["value"]);
     }
 }

--- a/sdk/provisioning/Azure.Provisioning.Dns/tests/BasicDnsTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/tests/BasicDnsTests.cs
@@ -97,4 +97,175 @@ public class BasicDnsTests
             }
             """);
     }
+
+    [Test]
+    public async Task TestCnameAndIpv4andIpv6ARecords()
+    {
+        await using Trycep test = new Trycep().Define(
+            ctx =>
+            {
+                Infrastructure infra = new();
+
+                DnsZone zone = DnsZone.FromExisting(nameof(zone), DnsZone.ResourceVersions.V2018_05_01);
+                zone.Name = "contoso.com";
+                infra.Add(zone);
+
+                DnsCnameRecord cnameRecord = new(nameof(cnameRecord), DnsCnameRecord.ResourceVersions.V2018_05_01)
+                {
+                    Parent = zone,
+                    Name = "www",
+                    TtlInSeconds = 3600,
+                    Cname = "contoso.azurewebsites.net"
+                };
+                infra.Add(cnameRecord);
+
+                DnsARecord dnsRecordA = new("dnsRecordA")
+                {
+                    Parent = zone,
+                    Name = "privatev4",
+                    TtlInSeconds = 3600,
+                    ARecords =
+                    [
+                        new DnsARecordInfo()
+                        {
+                            Ipv4Address = IPAddress.Parse("127.0.0.1")
+                        },
+                        new DnsARecordInfo()
+                        {
+                            Ipv4Address = IPAddress.Parse("192.168.0.1")
+                        }
+                    ],
+                };
+                infra.Add(dnsRecordA);
+
+                DnsAaaaRecord aaaaRecord = new(nameof(aaaaRecord), DnsAaaaRecord.ResourceVersions.V2018_05_01)
+                {
+                    Parent = zone,
+                    Name = "privatev6",
+                    TtlInSeconds = 3600,
+                    AaaaRecords =
+                    {
+                        new DnsAaaaRecordInfo() { Ipv6Address = IPAddress.Parse("0000:0000:0000:0000:0000:0000:0000:0001") },
+                        new DnsAaaaRecordInfo() { Ipv6Address = IPAddress.Parse("FD00::45:AA:1") }
+                    }
+                };
+                infra.Add(aaaaRecord);
+
+                DnsTxtRecord spfTxtRecord = new(nameof(spfTxtRecord), DnsTxtRecord.ResourceVersions.V2018_05_01)
+                {
+                    Parent = zone,
+                    Name = "@",
+                    TtlInSeconds = 3600,
+                    TxtRecords = {
+                        new DnsTxtRecordInfo()
+                        {
+                            Values = [ "v=spf1 -all" ]
+                        }
+                    }
+                };
+                infra.Add(spfTxtRecord);
+
+                DnsTxtRecord notesTXTRecord = new(nameof(notesTXTRecord), DnsTxtRecord.ResourceVersions.V2018_05_01)
+                {
+                    Parent = zone,
+                    Name = "notes",
+                    TtlInSeconds = 3600,
+                    TxtRecords = {
+                        new DnsTxtRecordInfo()
+                        {
+                            Values = [
+                                "Usually people set SPF rules in TXT records.",
+                                "But they are actually free form text records."
+                            ]
+                        }
+                    }
+                };
+                infra.Add(notesTXTRecord);
+
+                return infra;
+            }
+        );
+
+        test.Compare(
+            """
+            resource zone 'Microsoft.Network/dnsZones@2018-05-01' existing = {
+              name: 'contoso.com'
+            }
+
+            resource cnameRecord 'Microsoft.Network/dnsZones/CNAME@2018-05-01' = {
+              name: 'www'
+              parent: zone
+              properties: {
+                CNAMERecord: {
+                  cname: 'contoso.azurewebsites.net'
+                }
+                TTL: 3600
+              }
+            }
+
+            resource dnsRecordA 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+              name: 'privatev4'
+              parent: zone
+              properties: {
+                ARecords: [
+                  {
+                    ipv4Address: '127.0.0.1'
+                  }
+                  {
+                    ipv4Address: '192.168.0.1'
+                  }
+                ]
+                TTL: 3600
+              }
+            }
+
+            resource aaaaRecord 'Microsoft.Network/dnsZones/AAAA@2018-05-01' = {
+              name: 'privatev6'
+              parent: zone
+              properties: {
+                AAAARecords: [
+                  {
+                    ipv6Address: '::1'
+                  }
+                  {
+                    ipv6Address: 'fd00::45:aa:1'
+                  }
+                ]
+                TTL: 3600
+              }
+            }
+
+            resource spfTxtRecord 'Microsoft.Network/dnsZones/TXT@2018-05-01' = {
+              name: '@'
+              properties: {
+                TXTRecords: [
+                  {
+                    value: [
+                      'v=spf1 -all'
+                    ]
+                  }
+                ]
+                TTL: 3600
+              }
+              parent: zone
+            }
+
+            resource notesTXTRecord 'Microsoft.Network/dnsZones/TXT@2018-05-01' = {
+              name: 'notes'
+              properties: {
+                TXTRecords: [
+                  {
+                    value: [
+                      'Usually people set SPF rules in TXT records.'
+                      'But they are actually free form text records.'
+                    ]
+                  }
+                ]
+                TTL: 3600
+              }
+              parent: zone
+            }
+            """
+        );
+    }
 }

--- a/sdk/provisioning/Azure.Provisioning.Dns/tests/BasicDnsTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Dns/tests/BasicDnsTests.cs
@@ -48,8 +48,8 @@ public class BasicDnsTests
                     TtlInSeconds = 3600,
                     ARecords =
                     {
-                        new DnsARecordInfo() { Ipv4Addresses = IPAddress.Parse("203.0.113.1") },
-                        new DnsARecordInfo() { Ipv4Addresses = IPAddress.Parse("203.0.113.2") }
+                        new DnsARecordInfo() { Ipv4Address = IPAddress.Parse("203.0.113.1") },
+                        new DnsARecordInfo() { Ipv4Address = IPAddress.Parse("203.0.113.2") }
                     }
                 };
                 infra.Add(aRecord);
@@ -86,10 +86,10 @@ public class BasicDnsTests
               properties: {
                 ARecords: [
                   {
-                    ipv4Addresses: '203.0.113.1'
+                    ipv4Address: '203.0.113.1'
                   }
                   {
-                    ipv4Addresses: '203.0.113.2'
+                    ipv4Address: '203.0.113.2'
                   }
                 ]
                 TTL: 3600


### PR DESCRIPTION
Mostly focusing on A, AAAA, TXT and CName records.

* `DnsARecord`: `Ipv4Addresses` to `Ipv4Address`. Something similar on `DnsAaaaRecord`.
* using `nameof` instead of the properties names as strings.
* `DnsCnameRecord.Cname` was not being backed by the `.properties.CNAMERecord.cname`. Fixed.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
