### PR TITLE
[CODEOWNERS] Remove invalid owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -801,9 +801,6 @@
 # ServiceLabel: %Search
 # ServiceOwners:                                                   @efrainretana @kuanlu95 @mattgotteiner
 
-# ServiceLabel: %Security
-# ServiceOwners:                                                   @chlahav
-
 # ServiceLabel: %SecurityInsights
 # ServiceOwners:                                                   @amirkeren
 


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an account flagged as invalid by the linter.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/public%20Team/_build/results?buildId=5623687&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4&l=17) _(Microsoft internal)_