### PR TITLE
Transparency client - allow the use of offline keys for the transparent statement verification

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- A new option to pass transparent statement verification key sets mapped to domain names for offline verification using `CodeTransparencyVerificationOptions.OfflineKeys`
+- A new option to restrict the use of a network resolution of the ledger keys when using `OfflineKeys` with `CodeTransparencyVerificationOptions.OfflineKeysBehavior`
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
@@ -74,6 +74,13 @@ namespace Azure.Security.CodeTransparency
             V2025_01_31_Preview = 1,
         }
     }
+    public sealed partial class CodeTransparencyOfflineKeys
+    {
+        public CodeTransparencyOfflineKeys() { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Azure.Security.CodeTransparency.JwksDocument> ByDomain { get { throw null; } }
+        public void Add(string ledgerDomain, Azure.Security.CodeTransparency.JwksDocument jwksDocument) { }
+        public static Azure.Security.CodeTransparency.CodeTransparencyOfflineKeys FromBinaryData(System.BinaryData json) { throw null; }
+    }
     public enum CodeTransparencyOperationStatus
     {
         Running = 0,
@@ -85,6 +92,8 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyVerificationOptions() { }
         public System.Collections.Generic.IList<string> AuthorizedDomains { get { throw null; } set { } }
         public Azure.Security.CodeTransparency.AuthorizedReceiptBehavior AuthorizedReceiptBehavior { get { throw null; } set { } }
+        public Azure.Security.CodeTransparency.CodeTransparencyOfflineKeys OfflineKeys { get { throw null; } set { } }
+        public Azure.Security.CodeTransparency.OfflineKeysBehavior OfflineKeysBehavior { get { throw null; } set { } }
         public Azure.Security.CodeTransparency.UnauthorizedReceiptBehavior UnauthorizedReceiptBehavior { get { throw null; } set { } }
     }
     public partial class JsonWebKey : System.ClientModel.Primitives.IJsonModel<Azure.Security.CodeTransparency.JsonWebKey>, System.ClientModel.Primitives.IPersistableModel<Azure.Security.CodeTransparency.JsonWebKey>
@@ -124,6 +133,11 @@ namespace Azure.Security.CodeTransparency
         Azure.Security.CodeTransparency.JwksDocument System.ClientModel.Primitives.IPersistableModel<Azure.Security.CodeTransparency.JwksDocument>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         string System.ClientModel.Primitives.IPersistableModel<Azure.Security.CodeTransparency.JwksDocument>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Security.CodeTransparency.JwksDocument>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public enum OfflineKeysBehavior
+    {
+        FallbackToNetwork = 0,
+        NoFallbackToNetwork = 1,
     }
     public static partial class SecurityCodeTransparencyModelFactory
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
@@ -80,6 +80,7 @@ namespace Azure.Security.CodeTransparency
         public System.Collections.Generic.IReadOnlyDictionary<string, Azure.Security.CodeTransparency.JwksDocument> ByIssuer { get { throw null; } }
         public void Add(string ledgerDomain, Azure.Security.CodeTransparency.JwksDocument jwksDocument) { }
         public static Azure.Security.CodeTransparency.CodeTransparencyOfflineKeys FromBinaryData(System.BinaryData json) { throw null; }
+        public System.BinaryData ToBinaryData() { throw null; }
     }
     public enum CodeTransparencyOperationStatus
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.net8.0.cs
@@ -77,7 +77,7 @@ namespace Azure.Security.CodeTransparency
     public sealed partial class CodeTransparencyOfflineKeys
     {
         public CodeTransparencyOfflineKeys() { }
-        public System.Collections.Generic.IReadOnlyDictionary<string, Azure.Security.CodeTransparency.JwksDocument> ByDomain { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Azure.Security.CodeTransparency.JwksDocument> ByIssuer { get { throw null; } }
         public void Add(string ledgerDomain, Azure.Security.CodeTransparency.JwksDocument jwksDocument) { }
         public static Azure.Security.CodeTransparency.CodeTransparencyOfflineKeys FromBinaryData(System.BinaryData json) { throw null; }
     }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
@@ -74,6 +74,13 @@ namespace Azure.Security.CodeTransparency
             V2025_01_31_Preview = 1,
         }
     }
+    public sealed partial class CodeTransparencyOfflineKeys
+    {
+        public CodeTransparencyOfflineKeys() { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Azure.Security.CodeTransparency.JwksDocument> ByDomain { get { throw null; } }
+        public void Add(string ledgerDomain, Azure.Security.CodeTransparency.JwksDocument jwksDocument) { }
+        public static Azure.Security.CodeTransparency.CodeTransparencyOfflineKeys FromBinaryData(System.BinaryData json) { throw null; }
+    }
     public enum CodeTransparencyOperationStatus
     {
         Running = 0,
@@ -85,6 +92,8 @@ namespace Azure.Security.CodeTransparency
         public CodeTransparencyVerificationOptions() { }
         public System.Collections.Generic.IList<string> AuthorizedDomains { get { throw null; } set { } }
         public Azure.Security.CodeTransparency.AuthorizedReceiptBehavior AuthorizedReceiptBehavior { get { throw null; } set { } }
+        public Azure.Security.CodeTransparency.CodeTransparencyOfflineKeys OfflineKeys { get { throw null; } set { } }
+        public Azure.Security.CodeTransparency.OfflineKeysBehavior OfflineKeysBehavior { get { throw null; } set { } }
         public Azure.Security.CodeTransparency.UnauthorizedReceiptBehavior UnauthorizedReceiptBehavior { get { throw null; } set { } }
     }
     public partial class JsonWebKey : System.ClientModel.Primitives.IJsonModel<Azure.Security.CodeTransparency.JsonWebKey>, System.ClientModel.Primitives.IPersistableModel<Azure.Security.CodeTransparency.JsonWebKey>
@@ -124,6 +133,11 @@ namespace Azure.Security.CodeTransparency
         Azure.Security.CodeTransparency.JwksDocument System.ClientModel.Primitives.IPersistableModel<Azure.Security.CodeTransparency.JwksDocument>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         string System.ClientModel.Primitives.IPersistableModel<Azure.Security.CodeTransparency.JwksDocument>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Security.CodeTransparency.JwksDocument>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public enum OfflineKeysBehavior
+    {
+        FallbackToNetwork = 0,
+        NoFallbackToNetwork = 1,
     }
     public static partial class SecurityCodeTransparencyModelFactory
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
@@ -80,6 +80,7 @@ namespace Azure.Security.CodeTransparency
         public System.Collections.Generic.IReadOnlyDictionary<string, Azure.Security.CodeTransparency.JwksDocument> ByIssuer { get { throw null; } }
         public void Add(string ledgerDomain, Azure.Security.CodeTransparency.JwksDocument jwksDocument) { }
         public static Azure.Security.CodeTransparency.CodeTransparencyOfflineKeys FromBinaryData(System.BinaryData json) { throw null; }
+        public System.BinaryData ToBinaryData() { throw null; }
     }
     public enum CodeTransparencyOperationStatus
     {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/api/Azure.Security.CodeTransparency.netstandard2.0.cs
@@ -77,7 +77,7 @@ namespace Azure.Security.CodeTransparency
     public sealed partial class CodeTransparencyOfflineKeys
     {
         public CodeTransparencyOfflineKeys() { }
-        public System.Collections.Generic.IReadOnlyDictionary<string, Azure.Security.CodeTransparency.JwksDocument> ByDomain { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, Azure.Security.CodeTransparency.JwksDocument> ByIssuer { get { throw null; } }
         public void Add(string ledgerDomain, Azure.Security.CodeTransparency.JwksDocument jwksDocument) { }
         public static Azure.Security.CodeTransparency.CodeTransparencyOfflineKeys FromBinaryData(System.BinaryData json) { throw null; }
     }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Formats.Cbor;
 using System.IO;
 using System.Security.Cryptography.Cose;
@@ -37,9 +38,9 @@ namespace Azure.Security.CodeTransparency
         public static readonly string UnknownIssuerPrefix = "__unknown-issuer::";
 
         /// <summary>
-        /// Public key storage used to verify receipts. It can be prepopulated to do offline verification.
+        /// Public key storage used to verify receipts. The value can be set through the verification options.
         /// </summary>
-        private IDictionary<string, JwksDocument> _offlineKeys = new ConcurrentDictionary<string, JwksDocument>(StringComparer.OrdinalIgnoreCase);
+        private IReadOnlyDictionary<string, JwksDocument> _offlineKeys = null;
 
         /// <summary>
         /// Initializes a new instance of CodeTransparencyClient. The client will download its own
@@ -522,7 +523,7 @@ namespace Azure.Security.CodeTransparency
             }
 
             // Check if we have offline keys for this domain
-            if (! _offlineKeys.TryGetValue(issuer, out JwksDocument jwksDocument))
+            if (_offlineKeys == null || ! _offlineKeys.TryGetValue(issuer, out JwksDocument jwksDocument))
             {
                 // Get all the public keys from the JWKS endpoint
                 jwksDocument = GetPublicKeys().Value;

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -3,15 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Collections.ObjectModel;
 using System.Formats.Cbor;
-using System.IO;
 using System.Security.Cryptography.Cose;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -432,7 +432,7 @@ namespace Azure.Security.CodeTransparency
                         clientInstance = new CodeTransparencyClient(new Uri($"https://{issuer}"), clientOptions);
                         if (verificationOptions?.OfflineKeys != null)
                         {
-                            clientInstance._offlineKeys = verificationOptions.OfflineKeys.ByDomain;
+                            clientInstance._offlineKeys = verificationOptions.OfflineKeys.ByIssuer;
                             clientInstance._offlineKeysAllowNetworkFallback = verificationOptions.OfflineKeysBehavior == OfflineKeysBehavior.FallbackToNetwork;
                         }
                         clientInstances[issuer] = clientInstance;

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClientOptions.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClientOptions.cs
@@ -20,6 +20,7 @@ namespace Azure.Security.CodeTransparency
         /// The default identity service endpoint.
         /// </summary>
         public string IdentityClientEndpoint { get; set; } = "https://identity.confidential-ledger.core.azure.com/";
+
         /// <summary>
         /// Used in the regular client constructor.
         /// Creates the <see cref="CodeTransparencyCertificateClient"/> used to get the identity service certificate.

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
@@ -15,20 +15,20 @@ namespace Azure.Security.CodeTransparency
     /// </summary>
     public sealed class CodeTransparencyOfflineKeys
     {
-        private IDictionary<string, JwksDocument> _keysByDomain;
+        private IDictionary<string, JwksDocument> _keysByIssuer;
 
         /// <summary>
         /// Initializes a new instance of CodeTransparencyOfflineKeys.
         /// </summary>
         public CodeTransparencyOfflineKeys()
         {
-            _keysByDomain = new Dictionary<string, JwksDocument>(StringComparer.OrdinalIgnoreCase);
+            _keysByIssuer = new Dictionary<string, JwksDocument>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
         /// Gets the dictionary of ledger domains to their JWKS documents.
         /// </summary>
-        public IReadOnlyDictionary<string, JwksDocument> ByDomain => new ReadOnlyDictionary<string, JwksDocument>(_keysByDomain);
+        public IReadOnlyDictionary<string, JwksDocument> ByIssuer => new ReadOnlyDictionary<string, JwksDocument>(_keysByIssuer);
 
         /// <summary>
         /// Adds or updates a JWKS document for the specified ledger domain.
@@ -37,7 +37,7 @@ namespace Azure.Security.CodeTransparency
         {
             Argument.AssertNotNullOrEmpty(ledgerDomain, nameof(ledgerDomain));
             Argument.AssertNotNull(jwksDocument, nameof(jwksDocument));
-            _keysByDomain[ledgerDomain] = jwksDocument;
+            _keysByIssuer[ledgerDomain] = jwksDocument;
         }
 
         /// <summary>

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.Json;
@@ -30,7 +31,7 @@ namespace Azure.Security.CodeTransparency
         /// <summary>
         /// Gets the dictionary of ledger domains to their JWKS documents.
         /// </summary>
-        public IDictionary<string, JwksDocument> ByDomain => _keysByDomain;
+        public IReadOnlyDictionary<string, JwksDocument> ByDomain => new ReadOnlyDictionary<string, JwksDocument>(_keysByDomain);
 
         /// <summary>
         /// Adds or updates a JWKS document for the specified ledger domain.
@@ -38,6 +39,14 @@ namespace Azure.Security.CodeTransparency
         public void Add(string ledgerDomain, JwksDocument jwksDocument)
         {
             _keysByDomain[ledgerDomain] = jwksDocument;
+        }
+
+        /// <summary>
+        /// Creates a CodeTransparencyOfflineKeys instance from a BinaryData containing JSON.
+        /// </summary>
+        public static CodeTransparencyOfflineKeys FromBinaryData(BinaryData json)
+        {
+            return FromJsonDocument(JsonDocument.Parse(json.ToString()));
         }
 
         internal static CodeTransparencyOfflineKeys FromJsonDocument(JsonDocument jsonDocument)

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
@@ -51,6 +51,26 @@ namespace Azure.Security.CodeTransparency
             }
         }
 
+        /// <summary>
+        /// Serializes the CodeTransparencyOfflineKeys to JSON bytes.
+        /// </summary>
+        public BinaryData ToBinaryData()
+        {
+            using (var stream = new System.IO.MemoryStream())
+            using (var writer = new Utf8JsonWriter(stream))
+            {
+                writer.WriteStartObject();
+                foreach (var kvp in _keysByIssuer)
+                {
+                    writer.WritePropertyName(kvp.Key);
+                    writer.WriteObjectValue(kvp.Value);
+                }
+                writer.WriteEndObject();
+                writer.Flush();
+                return new BinaryData(stream.ToArray());
+            }
+        }
+
         internal static CodeTransparencyOfflineKeys FromJsonDocument(JsonDocument jsonDocument)
         {
             return DeserializeKeys(jsonDocument.RootElement);

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
@@ -46,7 +46,10 @@ namespace Azure.Security.CodeTransparency
         /// </summary>
         public static CodeTransparencyOfflineKeys FromBinaryData(BinaryData json)
         {
-            return FromJsonDocument(JsonDocument.Parse(json.ToString()));
+            using (JsonDocument doc = JsonDocument.Parse(json.ToString()))
+            {
+                return FromJsonDocument(doc);
+            }
         }
 
         internal static CodeTransparencyOfflineKeys FromJsonDocument(JsonDocument jsonDocument)

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyOfflineKeys.cs
@@ -5,10 +5,7 @@ using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.Core;
 
 namespace Azure.Security.CodeTransparency
@@ -38,6 +35,8 @@ namespace Azure.Security.CodeTransparency
         /// </summary>
         public void Add(string ledgerDomain, JwksDocument jwksDocument)
         {
+            Argument.AssertNotNullOrEmpty(ledgerDomain, nameof(ledgerDomain));
+            Argument.AssertNotNull(jwksDocument, nameof(jwksDocument));
             _keysByDomain[ledgerDomain] = jwksDocument;
         }
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationKeys.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationKeys.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Core;
+
+namespace Azure.Security.CodeTransparency
+{
+    /// <summary>
+    /// A case-insensitive dictionary mapping ledger domains to their JWKS documents for offline verification.
+    /// </summary>
+    public sealed class CodeTransparencyVerificationKeys
+    {
+        private IDictionary<string, JwksDocument> _serializedKeys;
+
+        /// <summary>
+        /// Initializes a new instance of CodeTransparencyVerificationKeys.
+        /// </summary>
+        public CodeTransparencyVerificationKeys()
+        {
+            _serializedKeys = new Dictionary<string, JwksDocument>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Gets the dictionary of ledger domains to their JWKS documents.
+        /// </summary>
+        public IDictionary<string, JwksDocument> SerializedKeys => _serializedKeys;
+
+        /// <summary>
+        /// Adds or updates a JWKS document for the specified ledger domain.
+        /// </summary>
+        public void Add(string ledgerDomain, JwksDocument jwksDocument)
+        {
+            _serializedKeys[ledgerDomain] = jwksDocument;
+        }
+
+        internal static CodeTransparencyVerificationKeys FromJsonDocument(JsonDocument jsonDocument)
+        {
+            return DeserializeKeys(jsonDocument.RootElement);
+        }
+
+        internal static CodeTransparencyVerificationKeys DeserializeKeys(JsonElement element, ModelReaderWriterOptions options = null)
+        {
+            var keys = new CodeTransparencyVerificationKeys();
+
+            foreach (var property in element.EnumerateObject())
+            {
+                var ledgerDomain = property.Name;
+                var jwksDocument = JwksDocument.DeserializeJwksDocument(property.Value, options);
+                keys.Add(ledgerDomain, jwksDocument);
+            }
+
+            return keys;
+        }
+    }
+}

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationKeys.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationKeys.cs
@@ -15,39 +15,39 @@ namespace Azure.Security.CodeTransparency
     /// <summary>
     /// A case-insensitive dictionary mapping ledger domains to their JWKS documents for offline verification.
     /// </summary>
-    public sealed class CodeTransparencyVerificationKeys
+    public sealed class CodeTransparencyOfflineKeys
     {
-        private IDictionary<string, JwksDocument> _serializedKeys;
+        private IDictionary<string, JwksDocument> _keysByDomain;
 
         /// <summary>
-        /// Initializes a new instance of CodeTransparencyVerificationKeys.
+        /// Initializes a new instance of CodeTransparencyOfflineKeys.
         /// </summary>
-        public CodeTransparencyVerificationKeys()
+        public CodeTransparencyOfflineKeys()
         {
-            _serializedKeys = new Dictionary<string, JwksDocument>(StringComparer.OrdinalIgnoreCase);
+            _keysByDomain = new Dictionary<string, JwksDocument>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>
         /// Gets the dictionary of ledger domains to their JWKS documents.
         /// </summary>
-        public IDictionary<string, JwksDocument> SerializedKeys => _serializedKeys;
+        public IDictionary<string, JwksDocument> ByDomain => _keysByDomain;
 
         /// <summary>
         /// Adds or updates a JWKS document for the specified ledger domain.
         /// </summary>
         public void Add(string ledgerDomain, JwksDocument jwksDocument)
         {
-            _serializedKeys[ledgerDomain] = jwksDocument;
+            _keysByDomain[ledgerDomain] = jwksDocument;
         }
 
-        internal static CodeTransparencyVerificationKeys FromJsonDocument(JsonDocument jsonDocument)
+        internal static CodeTransparencyOfflineKeys FromJsonDocument(JsonDocument jsonDocument)
         {
             return DeserializeKeys(jsonDocument.RootElement);
         }
 
-        internal static CodeTransparencyVerificationKeys DeserializeKeys(JsonElement element, ModelReaderWriterOptions options = null)
+        internal static CodeTransparencyOfflineKeys DeserializeKeys(JsonElement element, ModelReaderWriterOptions options = null)
         {
-            var keys = new CodeTransparencyVerificationKeys();
+            var keys = new CodeTransparencyOfflineKeys();
 
             foreach (var property in element.EnumerateObject())
             {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
@@ -72,5 +72,11 @@ namespace Azure.Security.CodeTransparency
         /// Defaults to <see cref="AuthorizedReceiptBehavior.VerifyAllMatching"/>.
         /// </summary>
         public AuthorizedReceiptBehavior AuthorizedReceiptBehavior { get; set; } = AuthorizedReceiptBehavior.VerifyAllMatching;
+
+        /// <summary>
+        /// Gets or sets a store mapping ledger domains to JWKS documents for offline verification.
+        /// When provided, will skip network calls and use the matching JWKS document from this store instead.
+        /// </summary>
+        public CodeTransparencyVerificationKeys CodeTransparencyVerificationKeys { get; set; } = null;
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
@@ -24,6 +24,7 @@ namespace Azure.Security.CodeTransparency
         /// </summary>
         RequireAll = 2
     }
+
     /// <summary>
     /// Specifies behaviors for receipts whose issuer domains are not contained in <see cref="CodeTransparencyVerificationOptions.AuthorizedDomains"/>.
     /// </summary>

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
@@ -45,6 +45,21 @@ namespace Azure.Security.CodeTransparency
     }
 
     /// <summary>
+    /// Specifies behaviors for the use of offline keys contained in <see cref="CodeTransparencyVerificationOptions.OfflineKeys"/>.
+    /// </summary>
+    public enum OfflineKeysBehavior
+    {
+        /// <summary>
+        /// Use offline keys when available, but fall back to network retrieval if no offline key is found for a given ledger domain.
+        /// </summary>
+        FallbackToNetwork = 0,
+        /// <summary>
+        /// Use only offline keys. If no offline key is found for a given ledger domain, verification fails.
+        /// </summary>
+        NoFallbackToNetwork = 1
+    }
+
+    /// <summary>
     /// Options controlling <see cref="CodeTransparencyClient.VerifyTransparentStatement(byte[], CodeTransparencyVerificationOptions, CodeTransparencyClientOptions)"/>.
     /// </summary>
     public sealed class CodeTransparencyVerificationOptions
@@ -78,6 +93,12 @@ namespace Azure.Security.CodeTransparency
         /// Gets or sets a store mapping ledger domains to JWKS documents for offline verification.
         /// When provided, will skip network calls and use the matching JWKS document from this store instead.
         /// </summary>
-        public CodeTransparencyOfflineKeys CodeTransparencyOfflineKeys { get; set; } = null;
+        public CodeTransparencyOfflineKeys OfflineKeys { get; set; } = null;
+
+        /// <summary>
+        /// Gets or sets the behavior for using offline keys in <see cref="CodeTransparencyOfflineKeys"/>.
+        /// Defaults to <see cref="OfflineKeysBehavior.FallbackToNetwork"/>.
+        /// </summary>
+        public OfflineKeysBehavior OfflineKeysBehavior { get; set; } = OfflineKeysBehavior.FallbackToNetwork;
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
@@ -79,7 +79,7 @@ namespace Azure.Security.CodeTransparency
 
         /// <summary>
         /// Gets or sets the behavior for receipts whose issuer domain is not in <see cref="AuthorizedDomains"/>.
-        /// Defaults to <see cref="UnauthorizedReceiptBehavior.VerifyAll"/> to preserve current behavior.
+        /// Defaults to <see cref="UnauthorizedReceiptBehavior.FailIfPresent"/>.
         /// </summary>
         public UnauthorizedReceiptBehavior UnauthorizedReceiptBehavior { get; set; } = UnauthorizedReceiptBehavior.FailIfPresent;
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyVerificationOptions.cs
@@ -77,6 +77,6 @@ namespace Azure.Security.CodeTransparency
         /// Gets or sets a store mapping ledger domains to JWKS documents for offline verification.
         /// When provided, will skip network calls and use the matching JWKS document from this store instead.
         /// </summary>
-        public CodeTransparencyVerificationKeys CodeTransparencyVerificationKeys { get; set; } = null;
+        public CodeTransparencyOfflineKeys CodeTransparencyOfflineKeys { get; set; } = null;
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -490,7 +490,7 @@ namespace Azure.Security.CodeTransparency.Tests
                 "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
                 "}]}}";
             var jsonDoc = JsonDocument.Parse(doc);
-            var offlineStore = CodeTransparencyVerificationKeys.FromJsonDocument(jsonDoc);
+            var offlineStore = CodeTransparencyOfflineKeys.FromJsonDocument(jsonDoc);
 
             var options = new CodeTransparencyClientOptions
             {
@@ -500,7 +500,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var verificationOptions = new CodeTransparencyVerificationOptions
             {
                 AuthorizedDomains = new string[] { "foo.bar.com" },
-                CodeTransparencyVerificationKeys = offlineStore
+                CodeTransparencyOfflineKeys = offlineStore
             };
 
             byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -28,6 +28,42 @@ namespace Azure.Security.CodeTransparency.Tests
         }
         """;
 
+        private readonly string ValidSignedStatementJWKS =
+            "{\"keys\":" +
+                "[{\"crv\": \"P-384\"," +
+                "\"kid\":\"fb29ce6d6b37e7a0b03a5fc94205490e1c37de1f41f68b92e3620021e9981d01\"," +
+                "\"kty\":\"EC\"," +
+                "\"x\": \"Tv_tP9eJIb5oJY9YB6iAzMfds4v3N84f8pgcPYLaxd_Nj3Nb_dBm6Fc8ViDZQhGR\"," +
+                "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
+                "}]}";
+
+        private readonly string InvalidSignedStatementJWKSWithWrongKid =
+            "{\"keys\":" +
+                "[{\"crv\": \"P-384\"," +
+                "\"kid\":\"99954f9b6272971320c95850f74a9459c283b375531173c3d5d9bfd5822163cb\"," +
+                "\"kty\":\"EC\"," +
+                "\"x\": \"Tv_tP9eJIb5oJY9YB6iAzMfds4v3N84f8pgcPYLaxd_Nj3Nb_dBm6Fc8ViDZQhGR\"," +
+                "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
+                "}]}";
+
+        private readonly string InvalidSignedStatementJWKSWithWrongCurve =
+            "{\"keys\":" +
+                "[{\"crv\": \"P-512\"," +
+                "\"kid\":\"fb29ce6d6b37e7a0b03a5fc94205490e1c37de1f41f68b92e3620021e9981d01\"," +
+                "\"kty\":\"EC\"," +
+                "\"x\": \"Tv_tP9eJIb5oJY9YB6iAzMfds4v3N84f8pgcPYLaxd_Nj3Nb_dBm6Fc8ViDZQhGR\"," +
+                "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
+                "}]}";
+
+        private readonly string InvalidSignedStatementJWKSWithWrongParams =
+            "{\"keys\":" +
+                "[{\"crv\": \"P-384\"," +
+                "\"kid\":\"1dd54f9b6272971320c95850f74a9459c283b375531173c3d5d9bfd5822163cb\"," +
+                "\"kty\":\"EC\"," +
+                "\"x\": \"WAHDpC-ECgc7LvCxlaOPsY-xVYF9iStcEPU3XGF8dlhtb6dMHZSYVPMs2gliK-gc\"," +
+                "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
+                "}]}";
+
         private byte[] readFileBytes(string name)
         {
             var assembly = Assembly.GetExecutingAssembly();
@@ -61,52 +97,28 @@ namespace Azure.Security.CodeTransparency.Tests
         private MockResponse createValidSignedStatementPublicKeyResponse()
         {
             var content = new MockResponse(200);
-            content.SetContent("{\"keys\":" +
-                "[{\"crv\": \"P-384\"," +
-                "\"kid\":\"fb29ce6d6b37e7a0b03a5fc94205490e1c37de1f41f68b92e3620021e9981d01\"," +
-                "\"kty\":\"EC\"," +
-                "\"x\": \"Tv_tP9eJIb5oJY9YB6iAzMfds4v3N84f8pgcPYLaxd_Nj3Nb_dBm6Fc8ViDZQhGR\"," +
-                "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
-                "}]}");
+            content.SetContent(ValidSignedStatementJWKS);
             return content;
         }
 
         private MockResponse createInvalidSignedStatementPublicKeyResponseWithWrongKid()
         {
             var content = new MockResponse(200);
-            content.SetContent("{\"keys\":" +
-                "[{\"crv\": \"P-384\"," +
-                "\"kid\":\"99954f9b6272971320c95850f74a9459c283b375531173c3d5d9bfd5822163cb\"," +
-                "\"kty\":\"EC\"," +
-                "\"x\": \"Tv_tP9eJIb5oJY9YB6iAzMfds4v3N84f8pgcPYLaxd_Nj3Nb_dBm6Fc8ViDZQhGR\"," +
-                "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
-                "}]}");
+            content.SetContent(InvalidSignedStatementJWKSWithWrongKid);
             return content;
         }
 
         private MockResponse createInvalidSignedStatementPublicKeyResponseWithWrongCurve()
         {
             var content = new MockResponse(200);
-            content.SetContent("{\"keys\":" +
-                "[{\"crv\": \"P-512\"," +
-                "\"kid\":\"fb29ce6d6b37e7a0b03a5fc94205490e1c37de1f41f68b92e3620021e9981d01\"," +
-                "\"kty\":\"EC\"," +
-                "\"x\": \"Tv_tP9eJIb5oJY9YB6iAzMfds4v3N84f8pgcPYLaxd_Nj3Nb_dBm6Fc8ViDZQhGR\"," +
-                "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
-                "}]}");
+            content.SetContent(InvalidSignedStatementJWKSWithWrongCurve);
             return content;
         }
 
         private MockResponse createInvalidSignedStatementPublicKeyResponseWithWrongParams()
         {
             var content = new MockResponse(200);
-            content.SetContent("{\"keys\":" +
-                "[{\"crv\": \"P-384\"," +
-                "\"kid\":\"1dd54f9b6272971320c95850f74a9459c283b375531173c3d5d9bfd5822163cb\"," +
-                "\"kty\":\"EC\"," +
-                "\"x\": \"WAHDpC-ECgc7LvCxlaOPsY-xVYF9iStcEPU3XGF8dlhtb6dMHZSYVPMs2gliK-gc\"," +
-                "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
-                "}]}");
+            content.SetContent(InvalidSignedStatementJWKSWithWrongParams);
             return content;
         }
 
@@ -117,7 +129,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             return (mockTransport, options);
         }
@@ -133,7 +145,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             var _ = new CodeTransparencyClient(new Uri("https://foo.bar.com"), null, options);
             Assert.AreEqual(0, mockTransport.Requests.Count);
@@ -163,7 +175,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
 
             CodeTransparencyClient client = new(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
@@ -198,7 +210,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
 
             CodeTransparencyClient client = new(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
@@ -232,7 +244,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             var client = new CodeTransparencyClient(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
             BinaryData content = BinaryData.FromString("Hello World!");
@@ -291,7 +303,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             CodeTransparencyClient client = new CodeTransparencyClient(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
 
@@ -348,7 +360,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             CodeTransparencyClient client = new CodeTransparencyClient(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
 
@@ -368,7 +380,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             var client = new CodeTransparencyClient(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
             Response<BinaryData> response = await client.GetEntryAsync("4.44");
@@ -387,7 +399,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             var client = new CodeTransparencyClient(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
             Response<BinaryData> response = await client.GetEntryAsync("4.44");
@@ -405,7 +417,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             var client = new CodeTransparencyClient(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
 
@@ -424,7 +436,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             var client = new CodeTransparencyClient(new Uri("https://foo.bar.com"), new AzureKeyCredential("token"), options);
 
@@ -446,7 +458,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             var verificationOptions = new CodeTransparencyVerificationOptions
             {
@@ -482,19 +494,15 @@ namespace Azure.Security.CodeTransparency.Tests
             Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
 #else
             // Parse the JWKS JSON from the mocked response
-            string doc = "{\"foo.bar.com\":{\"keys\":" +
-                "[{\"crv\": \"P-384\"," +
-                "\"kid\":\"fb29ce6d6b37e7a0b03a5fc94205490e1c37de1f41f68b92e3620021e9981d01\"," +
-                "\"kty\":\"EC\"," +
-                "\"x\": \"Tv_tP9eJIb5oJY9YB6iAzMfds4v3N84f8pgcPYLaxd_Nj3Nb_dBm6Fc8ViDZQhGR\"," +
-                "\"y\": \"xJ7fI2kA8gs11XDc9h2zodU-fZYRrE0UJHpzPfDVJrOpTvPcDoC5EWOBx9Fks0bZ\"" +
-                "}]}}";
+            string doc = "{\"foo.bar.com\":" + ValidSignedStatementJWKS + "}";
             var jsonDoc = JsonDocument.Parse(doc);
             var offlineStore = CodeTransparencyOfflineKeys.FromJsonDocument(jsonDoc);
 
+            var mockTransport = new MockTransport(new MockResponse(503));
             var options = new CodeTransparencyClientOptions
             {
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com",
+                Transport = mockTransport,
             };
 
             var verificationOptions = new CodeTransparencyVerificationOptions
@@ -507,6 +515,8 @@ namespace Azure.Security.CodeTransparency.Tests
 
             // Should not make any network calls since we're using offline keys
             CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
+
+            Assert.AreEqual(0, mockTransport.Requests.Count);
 #endif
         }
 
@@ -521,7 +531,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             var verificationOptions = new CodeTransparencyVerificationOptions
             {
@@ -545,7 +555,7 @@ namespace Azure.Security.CodeTransparency.Tests
             var options = new CodeTransparencyClientOptions
             {
                 Transport = mockTransport,
-                IdentityClientEndpoint = "https://foo.bar.com"
+                IdentityClientEndpoint = "https://some.identity.com"
             };
             var verificationOptions = new CodeTransparencyVerificationOptions
             {

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -495,28 +495,30 @@ namespace Azure.Security.CodeTransparency.Tests
 #else
             // Parse the JWKS JSON from the mocked response
             string doc = "{\"foo.bar.com\":" + ValidSignedStatementJWKS + "}";
-            var jsonDoc = JsonDocument.Parse(doc);
-            var offlineStore = CodeTransparencyOfflineKeys.FromJsonDocument(jsonDoc);
-
-            var mockTransport = new MockTransport(new MockResponse(503));
-            var options = new CodeTransparencyClientOptions
+            using (var jsonDoc = JsonDocument.Parse(doc))
             {
-                IdentityClientEndpoint = "https://some.identity.com",
-                Transport = mockTransport,
-            };
+                var offlineStore = CodeTransparencyOfflineKeys.FromJsonDocument(jsonDoc);
 
-            var verificationOptions = new CodeTransparencyVerificationOptions
-            {
-                AuthorizedDomains = new string[] { "foo.bar.com" },
-                OfflineKeys = offlineStore
-            };
+                var mockTransport = new MockTransport(new MockResponse(503));
+                var options = new CodeTransparencyClientOptions
+                {
+                    IdentityClientEndpoint = "https://some.identity.com",
+                    Transport = mockTransport,
+                };
 
-            byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");
+                var verificationOptions = new CodeTransparencyVerificationOptions
+                {
+                    AuthorizedDomains = new string[] { "foo.bar.com" },
+                    OfflineKeys = offlineStore
+                };
 
-            // Should not make any network calls since we're using offline keys
-            CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
+                byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");
 
-            Assert.AreEqual(0, mockTransport.Requests.Count);
+                // Should not make any network calls since we're using offline keys
+                CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
+
+                Assert.AreEqual(0, mockTransport.Requests.Count);
+            }
 #endif
         }
 
@@ -528,23 +530,25 @@ namespace Azure.Security.CodeTransparency.Tests
 #else
             // Parse the JWKS JSON from the mocked response
             string doc = "{}";
-            var jsonDoc = JsonDocument.Parse(doc);
-            var offlineStore = CodeTransparencyOfflineKeys.FromJsonDocument(jsonDoc);
-
-            var (mockTransport, options) = createClientOptionsWithValidPublicKeyResponse();
-
-            var verificationOptions = new CodeTransparencyVerificationOptions
+            using (var jsonDoc = JsonDocument.Parse(doc))
             {
-                AuthorizedDomains = new string[] { "foo.bar.com" },
-                OfflineKeys = offlineStore
-            };
+                var offlineStore = CodeTransparencyOfflineKeys.FromJsonDocument(jsonDoc);
 
-            byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");
+                var (mockTransport, options) = createClientOptionsWithValidPublicKeyResponse();
 
-            // Offline keys are empty, so network fallback is expected; should make 1 network call
-            CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
+                var verificationOptions = new CodeTransparencyVerificationOptions
+                {
+                    AuthorizedDomains = new string[] { "foo.bar.com" },
+                    OfflineKeys = offlineStore
+                };
 
-            Assert.AreEqual(1, mockTransport.Requests.Count);
+                byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");
+
+                // Offline keys are empty, so network fallback is expected; should make 1 network call
+                CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
+
+                Assert.AreEqual(1, mockTransport.Requests.Count);
+            }
 #endif
         }
 
@@ -556,27 +560,29 @@ namespace Azure.Security.CodeTransparency.Tests
 #else
             // Parse the JWKS JSON from the mocked response
             string doc = "{}";
-            var jsonDoc = JsonDocument.Parse(doc);
-            var offlineStore = CodeTransparencyOfflineKeys.FromJsonDocument(jsonDoc);
-
-            var mockTransport = new MockTransport(new MockResponse(503));
-            var options = new CodeTransparencyClientOptions
+            using (var jsonDoc = JsonDocument.Parse(doc))
             {
-                IdentityClientEndpoint = "https://some.identity.com",
-                Transport = mockTransport,
-            };
+                var offlineStore = CodeTransparencyOfflineKeys.FromJsonDocument(jsonDoc);
 
-            var verificationOptions = new CodeTransparencyVerificationOptions
-            {
-                AuthorizedDomains = new string[] { "foo.bar.com" },
-                OfflineKeys = offlineStore,
-                OfflineKeysBehavior = OfflineKeysBehavior.NoFallbackToNetwork
-            };
+                var mockTransport = new MockTransport(new MockResponse(503));
+                var options = new CodeTransparencyClientOptions
+                {
+                    IdentityClientEndpoint = "https://some.identity.com",
+                    Transport = mockTransport,
+                };
 
-            byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");
-            var exception = Assert.Throws<AggregateException>(() => CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options));
-            StringAssert.Contains("Either offline keys are not configured or network fallback is disabled.", exception.Message);
-            Assert.AreEqual(0, mockTransport.Requests.Count);
+                var verificationOptions = new CodeTransparencyVerificationOptions
+                {
+                    AuthorizedDomains = new string[] { "foo.bar.com" },
+                    OfflineKeys = offlineStore,
+                    OfflineKeysBehavior = OfflineKeysBehavior.NoFallbackToNetwork
+                };
+
+                byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");
+                var exception = Assert.Throws<AggregateException>(() => CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options));
+                StringAssert.Contains("Either offline keys are not configured or network fallback is disabled.", exception.Message);
+                Assert.AreEqual(0, mockTransport.Requests.Count);
+            }
 #endif
         }
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -541,7 +541,7 @@ namespace Azure.Security.CodeTransparency.Tests
 
             byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");
 
-            // Should not make any network calls since we're using offline keys
+            // Offline keys are empty, so network fallback is expected; should make 1 network call
             CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
 
             Assert.AreEqual(1, mockTransport.Requests.Count);

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyOfflineKeysTest.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyOfflineKeysTest.cs
@@ -30,8 +30,8 @@ namespace Azure.Security.CodeTransparency.Tests
         {
             var keys = new CodeTransparencyOfflineKeys();
 
-            Assert.IsNotNull(keys.ByDomain);
-            Assert.AreEqual(0, keys.ByDomain.Count);
+            Assert.IsNotNull(keys.ByIssuer);
+            Assert.AreEqual(0, keys.ByIssuer.Count);
         }
 
         [Test]
@@ -42,8 +42,8 @@ namespace Azure.Security.CodeTransparency.Tests
 
             keys.Add("ledger1", doc);
 
-            Assert.AreEqual(1, keys.ByDomain.Count);
-            Assert.AreSame(doc, keys.ByDomain["ledger1"]);
+            Assert.AreEqual(1, keys.ByIssuer.Count);
+            Assert.AreSame(doc, keys.ByIssuer["ledger1"]);
         }
 
         [Test]
@@ -56,8 +56,8 @@ namespace Azure.Security.CodeTransparency.Tests
             keys.Add("ledger1", doc1);
             keys.Add("ledger1", doc2);
 
-            Assert.AreEqual(1, keys.ByDomain.Count);
-            Assert.AreSame(doc2, keys.ByDomain["ledger1"]);
+            Assert.AreEqual(1, keys.ByIssuer.Count);
+            Assert.AreSame(doc2, keys.ByIssuer["ledger1"]);
         }
 
         [Test]
@@ -70,8 +70,8 @@ namespace Azure.Security.CodeTransparency.Tests
             keys.Add("Ledger.Domain", doc1);
             keys.Add("ledger.domain", doc2);
 
-            Assert.AreEqual(1, keys.ByDomain.Count);
-            Assert.AreSame(doc2, keys.ByDomain["LEDGER.DOMAIN"]);
+            Assert.AreEqual(1, keys.ByIssuer.Count);
+            Assert.AreSame(doc2, keys.ByIssuer["LEDGER.DOMAIN"]);
         }
 
         [Test]
@@ -101,18 +101,18 @@ namespace Azure.Security.CodeTransparency.Tests
         }
 
         [Test]
-        public void ByDomain_ReturnsReadOnlyDictionary()
+        public void ByIssuer_ReturnsReadOnlyDictionary()
         {
             var keys = new CodeTransparencyOfflineKeys();
             var doc = new DummyJwksDocument("doc1");
             keys.Add("ledger1", doc);
 
-            var byDomain = keys.ByDomain;
+            var byIssuer = keys.ByIssuer;
 
             // IReadOnlyDictionary is read-only by design
             Assert.Throws<NotSupportedException>(() =>
             {
-                var cast = (IDictionary<string, JwksDocument>)byDomain;
+                var cast = (IDictionary<string, JwksDocument>)byIssuer;
                 cast["ledger2"] = doc;
             });
         }
@@ -133,9 +133,9 @@ namespace Azure.Security.CodeTransparency.Tests
 
             var keys = CodeTransparencyOfflineKeys.FromBinaryData(binary);
 
-            Assert.AreEqual(2, keys.ByDomain.Count);
-            Assert.IsTrue(keys.ByDomain.ContainsKey("ledger1.contoso.com"));
-            Assert.IsTrue(keys.ByDomain.ContainsKey("ledger2.contoso.com"));
+            Assert.AreEqual(2, keys.ByIssuer.Count);
+            Assert.IsTrue(keys.ByIssuer.ContainsKey("ledger1.contoso.com"));
+            Assert.IsTrue(keys.ByIssuer.ContainsKey("ledger2.contoso.com"));
         }
 
         [Test]
@@ -150,9 +150,9 @@ namespace Azure.Security.CodeTransparency.Tests
             using var doc = JsonDocument.Parse(json);
             var keys = CodeTransparencyOfflineKeys.DeserializeKeys(doc.RootElement);
 
-            Assert.AreEqual(2, keys.ByDomain.Count);
-            Assert.IsTrue(keys.ByDomain.ContainsKey("ledger1.example.com"));
-            Assert.IsTrue(keys.ByDomain.ContainsKey("ledger2.example.com"));
+            Assert.AreEqual(2, keys.ByIssuer.Count);
+            Assert.IsTrue(keys.ByIssuer.ContainsKey("ledger1.example.com"));
+            Assert.IsTrue(keys.ByIssuer.ContainsKey("ledger2.example.com"));
         }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyOfflineKeysTest.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyOfflineKeysTest.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.Json;
+using Azure.Core;
+using Azure.Security.CodeTransparency;
+using NUnit.Framework;
+
+namespace Azure.Security.CodeTransparency.Tests
+{
+    public class CodeTransparencyOfflineKeysTest
+    {
+        private sealed class DummyJwksDocument : JwksDocument
+        {
+            private readonly string _id;
+
+            public DummyJwksDocument(string id)
+            {
+                _id = id;
+            }
+
+            public string Id => _id;
+        }
+
+        [Test]
+        public void Constructor_InitializesEmptyDictionary()
+        {
+            var keys = new CodeTransparencyOfflineKeys();
+
+            Assert.IsNotNull(keys.ByDomain);
+            Assert.AreEqual(0, keys.ByDomain.Count);
+        }
+
+        [Test]
+        public void Add_AddsNewEntry()
+        {
+            var keys = new CodeTransparencyOfflineKeys();
+            var doc = new DummyJwksDocument("doc1");
+
+            keys.Add("ledger1", doc);
+
+            Assert.AreEqual(1, keys.ByDomain.Count);
+            Assert.AreSame(doc, keys.ByDomain["ledger1"]);
+        }
+
+        [Test]
+        public void Add_UpdatesExistingEntry()
+        {
+            var keys = new CodeTransparencyOfflineKeys();
+            var doc1 = new DummyJwksDocument("doc1");
+            var doc2 = new DummyJwksDocument("doc2");
+
+            keys.Add("ledger1", doc1);
+            keys.Add("ledger1", doc2);
+
+            Assert.AreEqual(1, keys.ByDomain.Count);
+            Assert.AreSame(doc2, keys.ByDomain["ledger1"]);
+        }
+
+        [Test]
+        public void Add_IsCaseInsensitiveOnDomain()
+        {
+            var keys = new CodeTransparencyOfflineKeys();
+            var doc1 = new DummyJwksDocument("doc1");
+            var doc2 = new DummyJwksDocument("doc2");
+
+            keys.Add("Ledger.Domain", doc1);
+            keys.Add("ledger.domain", doc2);
+
+            Assert.AreEqual(1, keys.ByDomain.Count);
+            Assert.AreSame(doc2, keys.ByDomain["LEDGER.DOMAIN"]);
+        }
+
+        [Test]
+        public void Add_ThrowsOnNullLedgerDomain()
+        {
+            var keys = new CodeTransparencyOfflineKeys();
+            var doc = new DummyJwksDocument("doc");
+
+            Assert.Throws<ArgumentNullException>(() => keys.Add(null, doc));
+        }
+
+        [Test]
+        public void Add_ThrowsOnEmptyLedgerDomain()
+        {
+            var keys = new CodeTransparencyOfflineKeys();
+            var doc = new DummyJwksDocument("doc");
+
+            Assert.Throws<ArgumentException>(() => keys.Add(string.Empty, doc));
+        }
+
+        [Test]
+        public void Add_ThrowsOnNullJwksDocument()
+        {
+            var keys = new CodeTransparencyOfflineKeys();
+
+            Assert.Throws<ArgumentNullException>(() => keys.Add("ledger1", null));
+        }
+
+        [Test]
+        public void ByDomain_ReturnsReadOnlyDictionary()
+        {
+            var keys = new CodeTransparencyOfflineKeys();
+            var doc = new DummyJwksDocument("doc1");
+            keys.Add("ledger1", doc);
+
+            var byDomain = keys.ByDomain;
+
+            // IReadOnlyDictionary is read-only by design
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                var cast = (IDictionary<string, JwksDocument>)byDomain;
+                cast["ledger2"] = doc;
+            });
+        }
+
+        [Test]
+        public void FromBinaryData_ParsesMultipleEntries()
+        {
+            var json = @"
+            {
+                ""ledger1.contoso.com"": {},
+                ""ledger2.contoso.com"": {}
+            }";
+
+            // We only care that JwksDocument.DeserializeJwksDocument is called for each entry.
+            // Since we cannot easily assert the internal JwksDocument instances without
+            // relying on its implementation, we focus on the key count.
+            var binary = new BinaryData(json);
+
+            var keys = CodeTransparencyOfflineKeys.FromBinaryData(binary);
+
+            Assert.AreEqual(2, keys.ByDomain.Count);
+            Assert.IsTrue(keys.ByDomain.ContainsKey("ledger1.contoso.com"));
+            Assert.IsTrue(keys.ByDomain.ContainsKey("ledger2.contoso.com"));
+        }
+
+        [Test]
+        public void DeserializeKeys_UsesPropertyNamesAsLedgerDomains()
+        {
+            var json = @"
+            {
+                ""ledger1.example.com"": {},
+                ""ledger2.example.com"": {}
+            }";
+
+            using var doc = JsonDocument.Parse(json);
+            var keys = CodeTransparencyOfflineKeys.DeserializeKeys(doc.RootElement);
+
+            Assert.AreEqual(2, keys.ByDomain.Count);
+            Assert.IsTrue(keys.ByDomain.ContainsKey("ledger1.example.com"));
+            Assert.IsTrue(keys.ByDomain.ContainsKey("ledger2.example.com"));
+        }
+    }
+}


### PR DESCRIPTION
# Updates to verification

- Allow clients to pass JSON `{ "domain.name": { "JWKS" } }` to enable offline verification of transparent statements, this is to improve potential issues with latency when verifying statements on a scale in Confidential Signing Service
- Allow clients to determine if network fallback is allowed if the public key domain is not to be found in the provided JSON

### Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
