### PR TITLE
Add code interpreter input/output support to PersistentAgentsChatClient (Second Attempt)

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -223,7 +223,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.Contains('Azure.AI.Agents.Persistent'))">
-    <PackageReference Update="Microsoft.Extensions.AI.Abstractions" Version="9.10.1"/>
+    <PackageReference Update="Microsoft.Extensions.AI.Abstractions" Version="10.0.1"/>
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.Contains('Azure.Projects'))">

--- a/sdk/ai/Azure.AI.Agents.Persistent/CHANGELOG.md
+++ b/sdk/ai/Azure.AI.Agents.Persistent/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0-beta.9 (Unreleased)
 
 ### Features Added
+- Added support for `CodeInterpreterToolCallContent` from `Microsoft.Extensions.AI` abstractions when executing `HostedCodeInterpreterTool` tool.
 
 ### Breaking Changes
 

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/PersistentAgentsChatClient.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/PersistentAgentsChatClient.cs
@@ -229,6 +229,59 @@ namespace Azure.AI.Agents.Persistent
                         yield return ruUpdate;
                         break;
 
+                    case RunStepDetailsUpdate details:
+                        if (!string.IsNullOrEmpty(details.CodeInterpreterInput))
+                        {
+                            CodeInterpreterToolCallContent citcc = new()
+                            {
+                                CallId = details.ToolCallId,
+                                Inputs = [new DataContent(Encoding.UTF8.GetBytes(details.CodeInterpreterInput), "text/x-python")],
+                                RawRepresentation = details,
+                            };
+
+                            yield return new ChatResponseUpdate(ChatRole.Assistant, [citcc])
+                            {
+                                AuthorName = _agentId,
+                                ConversationId = threadId,
+                                MessageId = responseId,
+                                RawRepresentation = update,
+                                ResponseId = responseId,
+                            };
+                        }
+
+                        if (details.CodeInterpreterOutputs is { Count: > 0 })
+                        {
+                            CodeInterpreterToolResultContent citrc = new()
+                            {
+                                CallId = details.ToolCallId,
+                                RawRepresentation = details,
+                            };
+
+                            foreach (var output in details.CodeInterpreterOutputs)
+                            {
+                                switch (output)
+                                {
+                                    case RunStepDeltaCodeInterpreterImageOutput imageOutput when imageOutput.Image?.FileId is string imageFileId && !string.IsNullOrWhiteSpace(imageFileId):
+                                        (citrc.Outputs ??= []).Add(new HostedFileContent(imageFileId) { MediaType = "image/*" });
+                                        break;
+
+                                    case RunStepDeltaCodeInterpreterLogOutput logOutput when logOutput.Logs is string logs && !string.IsNullOrEmpty(logs):
+                                        (citrc.Outputs ??= []).Add(new TextContent(logs));
+                                        break;
+                                }
+                            }
+
+                            yield return new ChatResponseUpdate(ChatRole.Assistant, [citrc])
+                            {
+                                AuthorName = _agentId,
+                                ConversationId = threadId,
+                                MessageId = responseId,
+                                RawRepresentation = update,
+                                ResponseId = responseId,
+                            };
+                        }
+                        break;
+
                     case MessageContentUpdate mcu:
                         ChatResponseUpdate textUpdate = new(mcu.Role == MessageRole.User ? ChatRole.User : ChatRole.Assistant, mcu.Text)
                         {


### PR DESCRIPTION
# Contributing to the Azure SDK

Given a [https://aka.ms/azsdk/checkenforcer](https://github.com/Azure/azure-sdk-for-net/actions/runs/19927059205) bug, I'm recreating the PR in an attempt to get past the check error.

- Original PR #53797