### PR TITLE
Set version v1.2.0 for Azure.Provisioning.CognitiveServices

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
+## 1.2.0 (2025-12-09)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Updated to use latest API version.
+- Added new Cognitive Services resources.
 
 ## 1.1.0 (2025-06-16)
 

--- a/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Azure.Provisioning.CognitiveServices.csproj
+++ b/sdk/provisioning/Azure.Provisioning.CognitiveServices/src/Azure.Provisioning.CognitiveServices.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Azure.Provisioning.CognitiveServices simplifies declarative resource provisioning in .NET.</Description>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.2.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.0</ApiCompatVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>


### PR DESCRIPTION
Bumping version of `Azure.Provisioning.CognitiveServices` to v1.2.0.

