### PR TITLE
Fix error in 'net - provisioning - data' pipeline

### DIFF
--- a/sdk/provisioning/ci.data.yml
+++ b/sdk/provisioning/ci.data.yml
@@ -101,6 +101,7 @@ parameters:
   - name: release_Azure_Provisioning_Redis
     displayName: 'Azure.Provisioning.Redis'
     type: boolean
+    default: false
   - name: release_Azure_Provisioning_RedisEnterprise
     displayName: 'Azure.Provisioning.RedisEnterprise'
     type: boolean


### PR DESCRIPTION
This pipeline has been failing in ADO for a while with the error `A value for the 'release\_Azure\_Provisioning\_Redis' parameter must be provided.`

