### PR TITLE
[Storage] [DataMovement] [Stress] Remove Core dependency from DataMovement Blob Stress Testing

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/stress/src/Azure.Storage.DataMovement.Blobs.Stress.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/stress/src/Azure.Storage.DataMovement.Blobs.Stress.csproj
@@ -8,8 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Azure.Core.Amqp" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />


### PR DESCRIPTION
We're pointing to the released version of the Core package but the TestFramework pointing at the alpha version of Core.