### PR TITLE
[Microsoft.ClientModel.TestFramework] Up timeout to align with SCM

### DIFF
--- a/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/ProxyTransport.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/ProxyTransport.cs
@@ -6,6 +6,7 @@ using System.ClientModel.Primitives;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.ClientModel.TestFramework;
@@ -49,7 +50,12 @@ public class ProxyTransport : PipelineTransport
             AllowAutoRedirect = false,
             UseCookies = false
         };
-        _innerTransport = new HttpClientPipelineTransport(new HttpClient(handler));
+        var httpClient = new HttpClient(handler)
+        {
+            // Timeouts are handled by the pipeline
+            Timeout = Timeout.InfiniteTimeSpan
+        };
+        _innerTransport = new HttpClientPipelineTransport(httpClient);
     }
 
     /// <inheritdoc/>

--- a/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/ProxyTransport.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/ProxyTransport.cs
@@ -6,7 +6,6 @@ using System.ClientModel.Primitives;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.ClientModel.TestFramework;
@@ -50,12 +49,7 @@ public class ProxyTransport : PipelineTransport
             AllowAutoRedirect = false,
             UseCookies = false
         };
-        var httpClient = new HttpClient(handler)
-        {
-            // Timeouts are handled by the pipeline
-            Timeout = Timeout.InfiniteTimeSpan
-        };
-        _innerTransport = new HttpClientPipelineTransport(httpClient);
+        _innerTransport = new HttpClientPipelineTransport(new HttpClient(handler));
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
We should have the same behavior in the proxy transport as in https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/System.ClientModel/src/Pipeline/HttpClientPipelineTransport.cs#L81-L82