### PR TITLE
[ClientModel] Fix RetryPolicy delay calculations

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs Fixed
 
-- Fixed an issue with `ClientRetryPolicy` where delays were being calculated using the retry count instead of the attempt count, causing the initial retry to occur without delay and subsequent retries to performed more quickly than intended.
+- Fixed an issue with `ClientRetryPolicy` where delays were being calculated using the retry count instead of the attempt count, causing the initial retry to occur without delay and subsequent retries to be performed more quickly than intended.
 
 ### Other Changes
 

--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue with `ClientRetryPolicy` where delays were being calculated using the retry count instead of the attempt count, causing the initial retry to occur without delay and subsequent retries to performed more quickly than intended.
+
 ### Other Changes
 
 ## 1.8.1 (2025-11-10)

--- a/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/ClientRetryPolicy.cs
@@ -117,7 +117,9 @@ public class ClientRetryPolicy : PipelinePolicy
 
             if (shouldRetry)
             {
-                TimeSpan delay = GetNextDelay(message, message.RetryCount);
+                // Increment the retry count here to account for the initial (non-retry)
+                // attempt because the delay calculation expects the total try count.
+                TimeSpan delay = GetNextDelay(message, message.RetryCount + 1);
                 if (delay > TimeSpan.Zero)
                 {
                     if (async)

--- a/sdk/core/System.ClientModel/tests/Pipeline/ClientRetryPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ClientRetryPolicyTests.cs
@@ -396,7 +396,6 @@ public class ClientRetryPolicyTests : SyncAsyncTestBase
             await retryPolicy.WaitSyncOrAsync(delay, cts.Token, IsAsync));
     }
 
-    #region Helpers
     [Test]
     public async Task DelayCalculationsIncreasePerRetry()
     {
@@ -422,6 +421,8 @@ public class ClientRetryPolicyTests : SyncAsyncTestBase
         Assert.Greater(capturingPolicy.Delays[1], capturingPolicy.Delays[0]);
     }
 
+
+    #region Helpers
     public static IEnumerable<object[]> RetryAfterTestValues()
     {
         // Retry-After header is larger - wait Retry-After time

--- a/sdk/core/System.ClientModel/tests/Pipeline/ClientRetryPolicyTests.cs
+++ b/sdk/core/System.ClientModel/tests/Pipeline/ClientRetryPolicyTests.cs
@@ -421,7 +421,6 @@ public class ClientRetryPolicyTests : SyncAsyncTestBase
         Assert.Greater(capturingPolicy.Delays[1], capturingPolicy.Delays[0]);
     }
 
-
     #region Helpers
     public static IEnumerable<object[]> RetryAfterTestValues()
     {


### PR DESCRIPTION
# Summary

The focus of these changes is to correct a mismatch between the "try count" parameter used for delay calculations, which assumes that there has been at least the initial attempt but is being passed the current retry count which is zero-based.  This resulted in the delay for the first retry being negative and the retry taking place immediately.