### PR TITLE
reintroduce `BicepFunction.GetResourceId` and `BicepFunction.GetExtensionResourceId` in new beta versions

### DIFF
--- a/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+- Added `BicepFunction.GetResourceId` corresponding to bicep built-in function `resourceId`.
+- Added `BicepFunction.GetExtensionResourceId` corresponding to bicep built-in function `extensionResourceId`.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net10.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net10.0.cs
@@ -588,7 +588,9 @@ namespace Azure.Provisioning.Expressions
         public static Azure.Provisioning.BicepValue<string> Concat(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.BicepValue<string> CreateGuid(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.ArmDeployment GetDeployment() { throw null; }
+        public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetExtensionResourceId(Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> resourceId, Azure.Provisioning.BicepValue<string> resourceType, params Azure.Provisioning.BicepValue<string>[] resourceNames) { throw null; }
         public static Azure.Provisioning.Resources.ResourceGroup GetResourceGroup() { throw null; }
+        public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetResourceId(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.Subscription GetSubscription() { throw null; }
         public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetSubscriptionResourceId(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.Tenant GetTenant() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
@@ -588,7 +588,9 @@ namespace Azure.Provisioning.Expressions
         public static Azure.Provisioning.BicepValue<string> Concat(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.BicepValue<string> CreateGuid(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.ArmDeployment GetDeployment() { throw null; }
+        public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetExtensionResourceId(Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> resourceId, Azure.Provisioning.BicepValue<string> resourceType, params Azure.Provisioning.BicepValue<string>[] resourceNames) { throw null; }
         public static Azure.Provisioning.Resources.ResourceGroup GetResourceGroup() { throw null; }
+        public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetResourceId(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.Subscription GetSubscription() { throw null; }
         public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetSubscriptionResourceId(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.Tenant GetTenant() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -588,7 +588,9 @@ namespace Azure.Provisioning.Expressions
         public static Azure.Provisioning.BicepValue<string> Concat(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.BicepValue<string> CreateGuid(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.ArmDeployment GetDeployment() { throw null; }
+        public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetExtensionResourceId(Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> resourceId, Azure.Provisioning.BicepValue<string> resourceType, params Azure.Provisioning.BicepValue<string>[] resourceNames) { throw null; }
         public static Azure.Provisioning.Resources.ResourceGroup GetResourceGroup() { throw null; }
+        public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetResourceId(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.Subscription GetSubscription() { throw null; }
         public static Azure.Provisioning.BicepValue<Azure.Core.ResourceIdentifier> GetSubscriptionResourceId(params Azure.Provisioning.BicepValue<string>[] values) { throw null; }
         public static Azure.Provisioning.Resources.Tenant GetTenant() { throw null; }

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepFunction.cs
@@ -158,8 +158,6 @@ public static class BicepFunction
         return BicepSyntax.Call("subscriptionResourceId", values.Select(v => v.Compile()).ToArray());
     }
 
-    /*
-     * temporarily commented out for the new stable version release
     /// <summary>
     /// Returns the unique identifier of a resource. This represents the <c>resourceId</c>
     /// Bicep function.
@@ -236,7 +234,6 @@ public static class BicepFunction
         }
         return BicepSyntax.Call("extensionResourceId", [resourceId.Compile(), resourceType.Compile(), .. resourceNames.Select(v => v.Compile())]);
     }
-    */
 
     /// <summary>
     /// Returns information about the current deployment operation.  This

--- a/sdk/provisioning/Azure.Provisioning/tests/Expressions/BicepFunctionTests/ResourceIdFunctionsTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/Expressions/BicepFunctionTests/ResourceIdFunctionsTests.cs
@@ -9,8 +9,6 @@ namespace Azure.Provisioning.Tests.Expressions.BicepFunctions;
 
 public class ResourceIdFunctionsTests
 {
-    /*
-     * temporarily commented out since the corresponding API was excluded in the current stable version
     [Test]
     public void TestGetResourceId()
     {
@@ -20,7 +18,6 @@ public class ResourceIdFunctionsTests
         var id2 = BicepFunction.GetResourceId("Microsoft.Network/virtualNetworks/subnets", "myVnet", "mySubnet");
         TestHelpers.AssertExpression("resourceId('Microsoft.Network/virtualNetworks/subnets', 'myVnet', 'mySubnet')", id2);
     }
-    */
 
     [Test]
     public void TestGetSubscriptionResourceId()
@@ -32,8 +29,6 @@ public class ResourceIdFunctionsTests
         TestHelpers.AssertExpression("subscriptionResourceId('00000000-0000-0000-0000-000000000000', 'Microsoft.Resources/resourceGroups', 'myResourceGroup')", id2);
     }
 
-    /*
-     * temporarily commented out since the corresponding API was excluded in the current stable version
     [Test]
     public void TestGetExtensionResourceId()
     {
@@ -45,5 +40,4 @@ public class ResourceIdFunctionsTests
         var id2 = BicepFunction.GetExtensionResourceId(storageAccount.Id, "Microsoft.Authorization/policyDefinitions", "myDef");
         TestHelpers.AssertExpression("extensionResourceId(account.id, 'Microsoft.Authorization/policyDefinitions', 'myDef')", id2);
     }
-    */
 }


### PR DESCRIPTION
We excluded these two APIs in the latest released stable versions, now this PR is introducing it back.
