### PR TITLE
Tweak API compat baseline logic and add .NET 10 api listings to core

### DIFF
--- a/eng/Directory.Build.Common.props
+++ b/eng/Directory.Build.Common.props
@@ -186,8 +186,8 @@
 
     <!--
       The set of frameworks for API Compat checks when the current LTS is being built.  These ensure that
-      CI doesn't fail when a new target framework is added because a library has not done a refresh of the
-      exported API listing.
+      CI doesn't fail when a new target framework is added because a library has not released a version with
+      the new target framework yet.
 
       Because guidelines say that the API must be the same across all supported target frameworks, we can use
       a fallback safely.

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -26,7 +26,7 @@
         but will always have a baseline.  Since the guidelines require that the API surface be the same accross
         all supported targets, we can use the baseline for API compat checks to avoid breaking builds.
     -->
-    <ApiCompatBaselineTargetFramework Condition="'$(ApiCompatBaselineTargetFramework)' == '' AND '$(TargetFramework)' == '$(LtsTargetFramework)' AND '$(SupportsNetStandard20)' == 'true'">$(ApiCompatStandardTargetFramework)</ApiCompatBaselineTargetFramework>
+    <ApiCompatBaselineTargetFramework Condition="'$(ApiCompatBaselineTargetFramework)' == '' AND $(RequiredRunnableTargetFrameworks.Contains('$(TargetFramework)')) AND '$(SupportsNetStandard20)' == 'true'">$(ApiCompatStandardTargetFramework)</ApiCompatBaselineTargetFramework>
     <ApiCompatBaselineTargetFramework Condition="'$(ApiCompatBaselineTargetFramework)' == '' AND '$(TargetFramework)' == '$(LtsTargetFramework)' AND '$(SupportsNetStandard20)' != 'true'">$(ApiCompatRunnableTargetFramework)</ApiCompatBaselineTargetFramework>
   </PropertyGroup>
 

--- a/sdk/core/Azure.Core.Amqp/api/Azure.Core.Amqp.net10.0.cs
+++ b/sdk/core/Azure.Core.Amqp/api/Azure.Core.Amqp.net10.0.cs
@@ -1,0 +1,103 @@
+namespace Azure.Core.Amqp
+{
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct AmqpAddress : System.IEquatable<Azure.Core.Amqp.AmqpAddress>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public AmqpAddress(string address) { throw null; }
+        public bool Equals(Azure.Core.Amqp.AmqpAddress other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(string other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.Amqp.AmqpAddress left, Azure.Core.Amqp.AmqpAddress right) { throw null; }
+        public static bool operator !=(Azure.Core.Amqp.AmqpAddress left, Azure.Core.Amqp.AmqpAddress right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial class AmqpAnnotatedMessage
+    {
+        public AmqpAnnotatedMessage(Azure.Core.Amqp.AmqpMessageBody body) { }
+        public System.Collections.Generic.IDictionary<string, object?> ApplicationProperties { get { throw null; } }
+        public Azure.Core.Amqp.AmqpMessageBody Body { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, object?> DeliveryAnnotations { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, object?> Footer { get { throw null; } }
+        public Azure.Core.Amqp.AmqpMessageHeader Header { get { throw null; } }
+        public System.Collections.Generic.IDictionary<string, object?> MessageAnnotations { get { throw null; } }
+        public Azure.Core.Amqp.AmqpMessageProperties Properties { get { throw null; } }
+        public static Azure.Core.Amqp.AmqpAnnotatedMessage FromBytes(System.BinaryData messageBytes) { throw null; }
+        public bool HasSection(Azure.Core.Amqp.AmqpMessageSection section) { throw null; }
+        public System.BinaryData ToBytes() { throw null; }
+    }
+    public partial class AmqpMessageBody
+    {
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public AmqpMessageBody(System.Collections.Generic.IEnumerable<System.ReadOnlyMemory<byte>> data) { }
+        public Azure.Core.Amqp.AmqpMessageBodyType BodyType { get { throw null; } }
+        public static Azure.Core.Amqp.AmqpMessageBody FromData(System.Collections.Generic.IEnumerable<System.ReadOnlyMemory<byte>> data) { throw null; }
+        public static Azure.Core.Amqp.AmqpMessageBody FromSequence(System.Collections.Generic.IEnumerable<System.Collections.Generic.IList<object>> sequence) { throw null; }
+        public static Azure.Core.Amqp.AmqpMessageBody FromValue(object value) { throw null; }
+        public bool TryGetData(out System.Collections.Generic.IEnumerable<System.ReadOnlyMemory<byte>>? data) { throw null; }
+        public bool TryGetSequence(out System.Collections.Generic.IEnumerable<System.Collections.Generic.IList<object>>? sequence) { throw null; }
+        public bool TryGetValue(out object? value) { throw null; }
+    }
+    public enum AmqpMessageBodyType
+    {
+        Data = 0,
+        Value = 1,
+        Sequence = 2,
+    }
+    public partial class AmqpMessageHeader
+    {
+        internal AmqpMessageHeader() { }
+        public uint? DeliveryCount { get { throw null; } set { } }
+        public bool? Durable { get { throw null; } set { } }
+        public bool? FirstAcquirer { get { throw null; } set { } }
+        public byte? Priority { get { throw null; } set { } }
+        public System.TimeSpan? TimeToLive { get { throw null; } set { } }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct AmqpMessageId : System.IEquatable<Azure.Core.Amqp.AmqpMessageId>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public AmqpMessageId(string messageId) { throw null; }
+        public bool Equals(Azure.Core.Amqp.AmqpMessageId other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(string other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.Amqp.AmqpMessageId left, Azure.Core.Amqp.AmqpMessageId right) { throw null; }
+        public static bool operator !=(Azure.Core.Amqp.AmqpMessageId left, Azure.Core.Amqp.AmqpMessageId right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial class AmqpMessageProperties
+    {
+        internal AmqpMessageProperties() { }
+        public System.DateTimeOffset? AbsoluteExpiryTime { get { throw null; } set { } }
+        public string? ContentEncoding { get { throw null; } set { } }
+        public string? ContentType { get { throw null; } set { } }
+        public Azure.Core.Amqp.AmqpMessageId? CorrelationId { get { throw null; } set { } }
+        public System.DateTimeOffset? CreationTime { get { throw null; } set { } }
+        public string? GroupId { get { throw null; } set { } }
+        public uint? GroupSequence { get { throw null; } set { } }
+        public Azure.Core.Amqp.AmqpMessageId? MessageId { get { throw null; } set { } }
+        public Azure.Core.Amqp.AmqpAddress? ReplyTo { get { throw null; } set { } }
+        public string? ReplyToGroupId { get { throw null; } set { } }
+        public string? Subject { get { throw null; } set { } }
+        public Azure.Core.Amqp.AmqpAddress? To { get { throw null; } set { } }
+        public System.ReadOnlyMemory<byte>? UserId { get { throw null; } set { } }
+    }
+    public enum AmqpMessageSection
+    {
+        Header = 0,
+        DeliveryAnnotations = 1,
+        MessageAnnotations = 2,
+        Properties = 3,
+        ApplicationProperties = 4,
+        Body = 5,
+        Footer = 6,
+    }
+}

--- a/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net10.0.cs
+++ b/sdk/core/Azure.Core.Experimental/api/Azure.Core.Experimental.net10.0.cs
@@ -1,0 +1,122 @@
+namespace Azure
+{
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct Variant
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public static readonly Azure.Variant Null;
+        public Variant(System.ArraySegment<byte> segment) { throw null; }
+        public Variant(System.ArraySegment<char> segment) { throw null; }
+        public Variant(bool value) { throw null; }
+        public Variant(byte value) { throw null; }
+        public Variant(char value) { throw null; }
+        public Variant(System.DateTime value) { throw null; }
+        public Variant(System.DateTimeOffset value) { throw null; }
+        public Variant(double value) { throw null; }
+        public Variant(short value) { throw null; }
+        public Variant(int value) { throw null; }
+        public Variant(long value) { throw null; }
+        public Variant(bool? value) { throw null; }
+        public Variant(byte? value) { throw null; }
+        public Variant(char? value) { throw null; }
+        public Variant(System.DateTimeOffset? value) { throw null; }
+        public Variant(System.DateTime? value) { throw null; }
+        public Variant(double? value) { throw null; }
+        public Variant(short? value) { throw null; }
+        public Variant(int? value) { throw null; }
+        public Variant(long? value) { throw null; }
+        public Variant(sbyte? value) { throw null; }
+        public Variant(float? value) { throw null; }
+        public Variant(ushort? value) { throw null; }
+        public Variant(uint? value) { throw null; }
+        public Variant(ulong? value) { throw null; }
+        public Variant(object? value) { throw null; }
+        public Variant(sbyte value) { throw null; }
+        public Variant(float value) { throw null; }
+        public Variant(ushort value) { throw null; }
+        public Variant(uint value) { throw null; }
+        public Variant(ulong value) { throw null; }
+        public bool IsNull { get { throw null; } }
+        public System.Type? Type { get { throw null; } }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public T As<T>() { throw null; }
+        public static Azure.Variant Create<T>(T value) { throw null; }
+        public static explicit operator System.ArraySegment<byte> (in Azure.Variant value) { throw null; }
+        public static explicit operator System.ArraySegment<char> (in Azure.Variant value) { throw null; }
+        public static explicit operator bool (in Azure.Variant value) { throw null; }
+        public static explicit operator byte (in Azure.Variant value) { throw null; }
+        public static explicit operator char (in Azure.Variant value) { throw null; }
+        public static explicit operator System.DateTime (in Azure.Variant value) { throw null; }
+        public static explicit operator System.DateTimeOffset (in Azure.Variant value) { throw null; }
+        public static explicit operator decimal (in Azure.Variant value) { throw null; }
+        public static explicit operator double (in Azure.Variant value) { throw null; }
+        public static explicit operator short (in Azure.Variant value) { throw null; }
+        public static explicit operator int (in Azure.Variant value) { throw null; }
+        public static explicit operator long (in Azure.Variant value) { throw null; }
+        public static explicit operator bool? (in Azure.Variant value) { throw null; }
+        public static explicit operator byte? (in Azure.Variant value) { throw null; }
+        public static explicit operator char? (in Azure.Variant value) { throw null; }
+        public static explicit operator System.DateTimeOffset? (in Azure.Variant value) { throw null; }
+        public static explicit operator System.DateTime? (in Azure.Variant value) { throw null; }
+        public static explicit operator decimal? (in Azure.Variant value) { throw null; }
+        public static explicit operator double? (in Azure.Variant value) { throw null; }
+        public static explicit operator short? (in Azure.Variant value) { throw null; }
+        public static explicit operator int? (in Azure.Variant value) { throw null; }
+        public static explicit operator long? (in Azure.Variant value) { throw null; }
+        public static explicit operator sbyte? (in Azure.Variant value) { throw null; }
+        public static explicit operator float? (in Azure.Variant value) { throw null; }
+        public static explicit operator ushort? (in Azure.Variant value) { throw null; }
+        public static explicit operator uint? (in Azure.Variant value) { throw null; }
+        public static explicit operator ulong? (in Azure.Variant value) { throw null; }
+        public static explicit operator sbyte (in Azure.Variant value) { throw null; }
+        public static explicit operator float (in Azure.Variant value) { throw null; }
+        public static explicit operator string (in Azure.Variant value) { throw null; }
+        public static explicit operator ushort (in Azure.Variant value) { throw null; }
+        public static explicit operator uint (in Azure.Variant value) { throw null; }
+        public static explicit operator ulong (in Azure.Variant value) { throw null; }
+        public static implicit operator Azure.Variant (System.ArraySegment<byte> value) { throw null; }
+        public static implicit operator Azure.Variant (System.ArraySegment<char> value) { throw null; }
+        public static implicit operator Azure.Variant (bool value) { throw null; }
+        public static implicit operator Azure.Variant (byte value) { throw null; }
+        public static implicit operator Azure.Variant (char value) { throw null; }
+        public static implicit operator Azure.Variant (System.DateTime value) { throw null; }
+        public static implicit operator Azure.Variant (System.DateTimeOffset value) { throw null; }
+        public static implicit operator Azure.Variant (decimal value) { throw null; }
+        public static implicit operator Azure.Variant (double value) { throw null; }
+        public static implicit operator Azure.Variant (short value) { throw null; }
+        public static implicit operator Azure.Variant (int value) { throw null; }
+        public static implicit operator Azure.Variant (long value) { throw null; }
+        public static implicit operator Azure.Variant (bool? value) { throw null; }
+        public static implicit operator Azure.Variant (byte? value) { throw null; }
+        public static implicit operator Azure.Variant (char? value) { throw null; }
+        public static implicit operator Azure.Variant (System.DateTimeOffset? value) { throw null; }
+        public static implicit operator Azure.Variant (System.DateTime? value) { throw null; }
+        public static implicit operator Azure.Variant (decimal? value) { throw null; }
+        public static implicit operator Azure.Variant (double? value) { throw null; }
+        public static implicit operator Azure.Variant (short? value) { throw null; }
+        public static implicit operator Azure.Variant (int? value) { throw null; }
+        public static implicit operator Azure.Variant (long? value) { throw null; }
+        public static implicit operator Azure.Variant (sbyte? value) { throw null; }
+        public static implicit operator Azure.Variant (float? value) { throw null; }
+        public static implicit operator Azure.Variant (ushort? value) { throw null; }
+        public static implicit operator Azure.Variant (uint? value) { throw null; }
+        public static implicit operator Azure.Variant (ulong? value) { throw null; }
+        public static implicit operator Azure.Variant (sbyte value) { throw null; }
+        public static implicit operator Azure.Variant (float value) { throw null; }
+        public static implicit operator Azure.Variant (string value) { throw null; }
+        public static implicit operator Azure.Variant (ushort value) { throw null; }
+        public static implicit operator Azure.Variant (uint value) { throw null; }
+        public static implicit operator Azure.Variant (ulong value) { throw null; }
+        public override string? ToString() { throw null; }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public bool TryGetValue<T>(out T value) { throw null; }
+    }
+}
+namespace Azure.Core
+{
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class, Inherited=false, AllowMultiple=true)]
+    public partial class ProvisionableTemplateAttribute : System.Attribute
+    {
+        public ProvisionableTemplateAttribute(string resourceName) { }
+        public string ResourceName { get { throw null; } }
+    }
+}

--- a/sdk/core/Azure.Core.Expressions.DataFactory/api/Azure.Core.Expressions.DataFactory.net10.0.cs
+++ b/sdk/core/Azure.Core.Expressions.DataFactory/api/Azure.Core.Expressions.DataFactory.net10.0.cs
@@ -1,0 +1,108 @@
+namespace Azure.Core.Expressions.DataFactory
+{
+    public partial class DataFactoryContext : System.ClientModel.Primitives.ModelReaderWriterContext
+    {
+        internal DataFactoryContext() { }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryContext Default { get { throw null; } }
+        protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder builder) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct DataFactoryElementKind : System.IEquatable<Azure.Core.Expressions.DataFactory.DataFactoryElementKind>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public DataFactoryElementKind(string kind) { throw null; }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryElementKind Expression { get { throw null; } }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryElementKind KeyVaultSecret { get { throw null; } }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryElementKind Literal { get { throw null; } }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryElementKind SecretString { get { throw null; } }
+        public bool Equals(Azure.Core.Expressions.DataFactory.DataFactoryElementKind other) { throw null; }
+        public override bool Equals(object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.Expressions.DataFactory.DataFactoryElementKind left, Azure.Core.Expressions.DataFactory.DataFactoryElementKind right) { throw null; }
+        public static bool operator !=(Azure.Core.Expressions.DataFactory.DataFactoryElementKind left, Azure.Core.Expressions.DataFactory.DataFactoryElementKind right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public sealed partial class DataFactoryElement<T> : System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactoryElement<T>>, System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryElement<T>>
+    {
+        internal DataFactoryElement() { }
+        public Azure.Core.Expressions.DataFactory.DataFactoryElementKind Kind { get { throw null; } }
+        public T? Literal { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryElement<T> FromExpression(string expression) { throw null; }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryElement<System.String?> FromKeyVaultSecret(Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret secret) { throw null; }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryElement<T> FromLiteral(T? literal) { throw null; }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryElement<System.String?> FromSecretString(Azure.Core.Expressions.DataFactory.DataFactorySecretString secretString) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static implicit operator Azure.Core.Expressions.DataFactory.DataFactoryElement<T> (T literal) { throw null; }
+        Azure.Core.Expressions.DataFactory.DataFactoryElement<T> System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactoryElement<T>>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactoryElement<T>>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Azure.Core.Expressions.DataFactory.DataFactoryElement<T> System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryElement<T>>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryElement<T>>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryElement<T>>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        public override string? ToString() { throw null; }
+    }
+    public partial class DataFactoryKeyVaultSecret : Azure.Core.Expressions.DataFactory.DataFactorySecret, System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret>, System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret>
+    {
+        public DataFactoryKeyVaultSecret(Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference store, Azure.Core.Expressions.DataFactory.DataFactoryElement<string> secretName) { }
+        public Azure.Core.Expressions.DataFactory.DataFactoryElement<string> SecretName { get { throw null; } set { } }
+        public Azure.Core.Expressions.DataFactory.DataFactoryElement<string> SecretVersion { get { throw null; } set { } }
+        public Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference Store { get { throw null; } set { } }
+        Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret? System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret? System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class DataFactoryLinkedServiceReference : System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference>, System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference>
+    {
+        public DataFactoryLinkedServiceReference(Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind referenceKind, string referenceName) { }
+        public System.Collections.Generic.IDictionary<string, System.BinaryData?> Parameters { get { throw null; } }
+        public Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind ReferenceKind { get { throw null; } set { } }
+        public string? ReferenceName { get { throw null; } set { } }
+        Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference? System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference? System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReference>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct DataFactoryLinkedServiceReferenceKind : System.IEquatable<Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public DataFactoryLinkedServiceReferenceKind(string value) { throw null; }
+        public static Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind LinkedServiceReference { get { throw null; } }
+        public bool Equals(Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind left, Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind right) { throw null; }
+        public static implicit operator Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind (string value) { throw null; }
+        public static bool operator !=(Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind left, Azure.Core.Expressions.DataFactory.DataFactoryLinkedServiceReferenceKind right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public abstract partial class DataFactorySecret : System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactorySecret>, System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactorySecret>
+    {
+        protected DataFactorySecret() { }
+        Azure.Core.Expressions.DataFactory.DataFactorySecret? System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactorySecret>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactorySecret>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Azure.Core.Expressions.DataFactory.DataFactorySecret? System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactorySecret>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactorySecret>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactorySecret>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class DataFactorySecretString : Azure.Core.Expressions.DataFactory.DataFactorySecret, System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactorySecretString>, System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactorySecretString>
+    {
+        public DataFactorySecretString(string value) { }
+        public string? Value { get { throw null; } set { } }
+        public static implicit operator Azure.Core.Expressions.DataFactory.DataFactorySecretString (string literal) { throw null; }
+        Azure.Core.Expressions.DataFactory.DataFactorySecretString? System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactorySecretString>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Azure.Core.Expressions.DataFactory.DataFactorySecretString>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Azure.Core.Expressions.DataFactory.DataFactorySecretString? System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactorySecretString>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactorySecretString>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Core.Expressions.DataFactory.DataFactorySecretString>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+}

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1,0 +1,1261 @@
+namespace Azure
+{
+    public abstract partial class AsyncPageable<T> : System.Collections.Generic.IAsyncEnumerable<T> where T : notnull
+    {
+        protected AsyncPageable() { }
+        protected AsyncPageable(System.Threading.CancellationToken cancellationToken) { }
+        protected virtual System.Threading.CancellationToken CancellationToken { get { throw null; } }
+        public abstract System.Collections.Generic.IAsyncEnumerable<Azure.Page<T>> AsPages(string? continuationToken = null, int? pageSizeHint = default(int?));
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        public static Azure.AsyncPageable<T> FromPages(System.Collections.Generic.IEnumerable<Azure.Page<T>> pages) { throw null; }
+        public virtual System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string? ToString() { throw null; }
+    }
+    public static partial class AzureCoreExtensions
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This utilizes reflection-based JSON serialization and deserialization which is not compatible with trimming.")]
+        public static dynamic ToDynamicFromJson(this System.BinaryData utf8Json) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This utilizes reflection-based JSON serialization and deserialization which is not compatible with trimming.")]
+        public static dynamic ToDynamicFromJson(this System.BinaryData utf8Json, Azure.Core.Serialization.JsonPropertyNames propertyNameFormat, string dateTimeFormat = "o") { throw null; }
+        public static System.Threading.Tasks.ValueTask<T?> ToObjectAsync<T>(this System.BinaryData data, Azure.Core.Serialization.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This utilizes reflection-based JSON serialization and deserialization which is not compatible with trimming.")]
+        public static object? ToObjectFromJson(this System.BinaryData data) { throw null; }
+        public static T? ToObject<T>(this System.BinaryData data, Azure.Core.Serialization.ObjectSerializer serializer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class AzureKeyCredential : System.ClientModel.ApiKeyCredential
+    {
+        public AzureKeyCredential(string key) : base (default(string)) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public string Key { get { throw null; } }
+    }
+    public partial class AzureNamedKeyCredential
+    {
+        public AzureNamedKeyCredential(string name, string key) { }
+        public string Name { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public void Deconstruct(out string name, out string key) { throw null; }
+        public void Update(string name, string key) { }
+    }
+    public partial class AzureSasCredential
+    {
+        public AzureSasCredential(string signature) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public string Signature { get { throw null; } }
+        public void Update(string signature) { }
+    }
+    [System.FlagsAttribute]
+    public enum ErrorOptions
+    {
+        Default = 0,
+        NoThrow = 1,
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct ETag : System.IEquatable<Azure.ETag>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public static readonly Azure.ETag All;
+        public ETag(string etag) { throw null; }
+        public bool Equals(Azure.ETag other) { throw null; }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(string? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.ETag left, Azure.ETag right) { throw null; }
+        public static bool operator !=(Azure.ETag left, Azure.ETag right) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string ToString() { throw null; }
+        public string ToString(string format) { throw null; }
+    }
+    public partial class HttpAuthorization
+    {
+        public HttpAuthorization(string scheme, string parameter) { }
+        public string Parameter { get { throw null; } }
+        public string Scheme { get { throw null; } }
+        public override string ToString() { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct HttpRange : System.IEquatable<Azure.HttpRange>
+    {
+        private readonly int _dummyPrimitive;
+        public HttpRange(long offset = (long)0, long? length = default(long?)) { throw null; }
+        public long? Length { get { throw null; } }
+        public long Offset { get { throw null; } }
+        public bool Equals(Azure.HttpRange other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.HttpRange left, Azure.HttpRange right) { throw null; }
+        public static bool operator !=(Azure.HttpRange left, Azure.HttpRange right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial class JsonPatchDocument
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JsonObjectSerializer uses reflection-based JSON serialization and deserialization that is not compatible with trimming.")]
+        public JsonPatchDocument() { }
+        public JsonPatchDocument(Azure.Core.Serialization.ObjectSerializer serializer) { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JsonObjectSerializer uses reflection-based JSON serialization and deserialization that is not compatible with trimming.")]
+        public JsonPatchDocument(System.ReadOnlyMemory<byte> rawDocument) { }
+        public JsonPatchDocument(System.ReadOnlyMemory<byte> rawDocument, Azure.Core.Serialization.ObjectSerializer serializer) { }
+        public void AppendAddRaw(string path, string rawJsonValue) { }
+        public void AppendAdd<T>(string path, T value) { }
+        public void AppendCopy(string from, string path) { }
+        public void AppendMove(string from, string path) { }
+        public void AppendRemove(string path) { }
+        public void AppendReplaceRaw(string path, string rawJsonValue) { }
+        public void AppendReplace<T>(string path, T value) { }
+        public void AppendTestRaw(string path, string rawJsonValue) { }
+        public void AppendTest<T>(string path, T value) { }
+        public System.ReadOnlyMemory<byte> ToBytes() { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial class MatchConditions
+    {
+        public MatchConditions() { }
+        public Azure.ETag? IfMatch { get { throw null; } set { } }
+        public Azure.ETag? IfNoneMatch { get { throw null; } set { } }
+    }
+    public abstract partial class NullableResponse<T>
+    {
+        protected NullableResponse() { }
+        public abstract bool HasValue { get; }
+        public abstract T? Value { get; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public abstract Azure.Response GetRawResponse();
+        public override string ToString() { throw null; }
+    }
+    public abstract partial class Operation
+    {
+        protected Operation() { }
+        public abstract bool HasCompleted { get; }
+        public abstract string Id { get; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public abstract Azure.Response GetRawResponse();
+        public virtual Azure.Core.RehydrationToken? GetRehydrationToken() { throw null; }
+        public static Azure.Operation Rehydrate(Azure.Core.Pipeline.HttpPipeline pipeline, Azure.Core.RehydrationToken rehydrationToken, Azure.Core.ClientOptions? options = null) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Operation> RehydrateAsync(Azure.Core.Pipeline.HttpPipeline pipeline, Azure.Core.RehydrationToken rehydrationToken, Azure.Core.ClientOptions? options = null) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This method uses reflection.")]
+        public static System.Threading.Tasks.Task<Azure.Operation<T>> RehydrateAsync<T>(Azure.Core.Pipeline.HttpPipeline pipeline, Azure.Core.RehydrationToken rehydrationToken, Azure.Core.ClientOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This method uses reflection.")]
+        public static Azure.Operation<T> Rehydrate<T>(Azure.Core.Pipeline.HttpPipeline pipeline, Azure.Core.RehydrationToken rehydrationToken, Azure.Core.ClientOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string? ToString() { throw null; }
+        public abstract Azure.Response UpdateStatus(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract System.Threading.Tasks.ValueTask<Azure.Response> UpdateStatusAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public virtual Azure.Response WaitForCompletionResponse(Azure.Core.DelayStrategy delayStrategy, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response WaitForCompletionResponse(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response WaitForCompletionResponse(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(Azure.Core.DelayStrategy delayStrategy, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public abstract partial class Operation<T> : Azure.Operation where T : notnull
+    {
+        protected Operation() { }
+        public abstract bool HasValue { get; }
+        public abstract T Value { get; }
+        public virtual Azure.Response<T> WaitForCompletion(Azure.Core.DelayStrategy delayStrategy, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual Azure.Response<T> WaitForCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual Azure.Response<T> WaitForCompletion(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response<T>> WaitForCompletionAsync(Azure.Core.DelayStrategy delayStrategy, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response<T>> WaitForCompletionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.ValueTask<Azure.Response<T>> WaitForCompletionAsync(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override System.Threading.Tasks.ValueTask<Azure.Response> WaitForCompletionResponseAsync(System.TimeSpan pollingInterval, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public abstract partial class PageableOperation<T> : Azure.Operation<Azure.AsyncPageable<T>> where T : notnull
+    {
+        protected PageableOperation() { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override Azure.AsyncPageable<T> Value { get { throw null; } }
+        public abstract Azure.Pageable<T> GetValues(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract Azure.AsyncPageable<T> GetValuesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
+    public abstract partial class Pageable<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable where T : notnull
+    {
+        protected Pageable() { }
+        protected Pageable(System.Threading.CancellationToken cancellationToken) { }
+        protected virtual System.Threading.CancellationToken CancellationToken { get { throw null; } }
+        public abstract System.Collections.Generic.IEnumerable<Azure.Page<T>> AsPages(string? continuationToken = null, int? pageSizeHint = default(int?));
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        public static Azure.Pageable<T> FromPages(System.Collections.Generic.IEnumerable<Azure.Page<T>> pages) { throw null; }
+        public virtual System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string? ToString() { throw null; }
+    }
+    public abstract partial class Page<T>
+    {
+        protected Page() { }
+        public abstract string? ContinuationToken { get; }
+        public abstract System.Collections.Generic.IReadOnlyList<T> Values { get; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        public static Azure.Page<T> FromValues(System.Collections.Generic.IReadOnlyList<T> values, string? continuationToken, Azure.Response response) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public abstract Azure.Response GetRawResponse();
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string? ToString() { throw null; }
+    }
+    public partial class RequestConditions : Azure.MatchConditions
+    {
+        public RequestConditions() { }
+        public System.DateTimeOffset? IfModifiedSince { get { throw null; } set { } }
+        public System.DateTimeOffset? IfUnmodifiedSince { get { throw null; } set { } }
+    }
+    public partial class RequestContext
+    {
+        public RequestContext() { }
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } set { } }
+        public Azure.ErrorOptions ErrorOptions { get { throw null; } set { } }
+        public void AddClassifier(Azure.Core.ResponseClassificationHandler classifier) { }
+        public void AddClassifier(int statusCode, bool isError) { }
+        public void AddPolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.HttpPipelinePosition position) { }
+        public static implicit operator Azure.RequestContext (Azure.ErrorOptions options) { throw null; }
+    }
+    public partial class RequestFailedException : System.Exception, System.Runtime.Serialization.ISerializable
+    {
+        public RequestFailedException(Azure.Response response) { }
+        public RequestFailedException(Azure.Response response, System.Exception? innerException) { }
+        public RequestFailedException(Azure.Response response, System.Exception? innerException, Azure.Core.RequestFailedDetailsParser? detailsParser) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public RequestFailedException(int status, string message) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public RequestFailedException(int status, string message, System.Exception? innerException) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public RequestFailedException(int status, string message, string? errorCode, System.Exception? innerException) { }
+        [System.ObsoleteAttribute(DiagnosticId="SYSLIB0051")]
+        protected RequestFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public RequestFailedException(string message) { }
+        public RequestFailedException(string message, System.Exception? innerException) { }
+        public string? ErrorCode { get { throw null; } }
+        public int Status { get { throw null; } }
+        [System.ObsoleteAttribute(DiagnosticId="SYSLIB0051")]
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public Azure.Response? GetRawResponse() { throw null; }
+    }
+    public abstract partial class Response : System.IDisposable
+    {
+        protected Response() { }
+        public abstract string ClientRequestId { get; set; }
+        public virtual System.BinaryData Content { get { throw null; } }
+        public abstract System.IO.Stream? ContentStream { get; set; }
+        public virtual Azure.Core.ResponseHeaders Headers { get { throw null; } }
+        public virtual bool IsError { get { throw null; } }
+        public abstract string ReasonPhrase { get; }
+        public abstract int Status { get; }
+        protected internal abstract bool ContainsHeader(string name);
+        public abstract void Dispose();
+        protected internal abstract System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader> EnumerateHeaders();
+        public static Azure.Response<T> FromValue<T>(T value, Azure.Response response) { throw null; }
+        public override string ToString() { throw null; }
+        protected internal abstract bool TryGetHeader(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out string? value);
+        protected internal abstract bool TryGetHeaderValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Collections.Generic.IEnumerable<string>? values);
+    }
+    public sealed partial class ResponseError : System.ClientModel.Primitives.IJsonModel<Azure.ResponseError>, System.ClientModel.Primitives.IPersistableModel<Azure.ResponseError>
+    {
+        public ResponseError() { }
+        public ResponseError(string? code, string? message) { }
+        public string? Code { get { throw null; } }
+        public string? Message { get { throw null; } }
+        Azure.ResponseError System.ClientModel.Primitives.IJsonModel<Azure.ResponseError>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Azure.ResponseError>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Azure.ResponseError System.ClientModel.Primitives.IPersistableModel<Azure.ResponseError>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Azure.ResponseError>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.ResponseError>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public abstract partial class Response<T> : Azure.NullableResponse<T>
+    {
+        protected Response() { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool HasValue { get { throw null; } }
+        public override T Value { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static implicit operator T (Azure.Response<T> response) { throw null; }
+    }
+    public partial class SyncAsyncEventArgs : System.EventArgs
+    {
+        public SyncAsyncEventArgs(bool isRunningSynchronously, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+        public bool IsRunningSynchronously { get { throw null; } }
+    }
+    public enum WaitUntil
+    {
+        Completed = 0,
+        Started = 1,
+    }
+}
+namespace Azure.Core
+{
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct AccessToken
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public AccessToken(string accessToken, System.DateTimeOffset expiresOn) { throw null; }
+        public AccessToken(string accessToken, System.DateTimeOffset expiresOn, System.DateTimeOffset? refreshOn) { throw null; }
+        public AccessToken(string accessToken, System.DateTimeOffset expiresOn, System.DateTimeOffset? refreshOn, string tokenType) { throw null; }
+        public AccessToken(string accessToken, System.DateTimeOffset expiresOn, System.DateTimeOffset? refreshOn, string tokenType, System.Security.Cryptography.X509Certificates.X509Certificate2 bindingCertificate) { throw null; }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2? BindingCertificate { get { throw null; } }
+        public System.DateTimeOffset ExpiresOn { get { throw null; } }
+        public System.DateTimeOffset? RefreshOn { get { throw null; } }
+        public string Token { get { throw null; } }
+        public string TokenType { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+    }
+    public partial class AzureCoreContext : System.ClientModel.Primitives.ModelReaderWriterContext
+    {
+        internal AzureCoreContext() { }
+        public static Azure.Core.AzureCoreContext Default { get { throw null; } }
+        protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder builder) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct AzureLocation : System.IEquatable<Azure.Core.AzureLocation>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public AzureLocation(string location) { throw null; }
+        public AzureLocation(string name, string displayName) { throw null; }
+        public static Azure.Core.AzureLocation AustraliaCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation AustraliaCentral2 { get { throw null; } }
+        public static Azure.Core.AzureLocation AustraliaEast { get { throw null; } }
+        public static Azure.Core.AzureLocation AustraliaSoutheast { get { throw null; } }
+        public static Azure.Core.AzureLocation BrazilSouth { get { throw null; } }
+        public static Azure.Core.AzureLocation BrazilSoutheast { get { throw null; } }
+        public static Azure.Core.AzureLocation CanadaCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation CanadaEast { get { throw null; } }
+        public static Azure.Core.AzureLocation CentralIndia { get { throw null; } }
+        public static Azure.Core.AzureLocation CentralUS { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaEast { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaEast2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaEast3 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaNorth { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaNorth2 { get { throw null; } }
+        public static Azure.Core.AzureLocation ChinaNorth3 { get { throw null; } }
+        public string? DisplayName { get { throw null; } }
+        public static Azure.Core.AzureLocation EastAsia { get { throw null; } }
+        public static Azure.Core.AzureLocation EastUS { get { throw null; } }
+        public static Azure.Core.AzureLocation EastUS2 { get { throw null; } }
+        public static Azure.Core.AzureLocation FranceCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation FranceSouth { get { throw null; } }
+        public static Azure.Core.AzureLocation GermanyCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation GermanyNorth { get { throw null; } }
+        public static Azure.Core.AzureLocation GermanyNorthEast { get { throw null; } }
+        public static Azure.Core.AzureLocation GermanyWestCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation IsraelCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation ItalyNorth { get { throw null; } }
+        public static Azure.Core.AzureLocation JapanEast { get { throw null; } }
+        public static Azure.Core.AzureLocation JapanWest { get { throw null; } }
+        public static Azure.Core.AzureLocation KoreaCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation KoreaSouth { get { throw null; } }
+        public static Azure.Core.AzureLocation MexicoCentral { get { throw null; } }
+        public string Name { get { throw null; } }
+        public static Azure.Core.AzureLocation NorthCentralUS { get { throw null; } }
+        public static Azure.Core.AzureLocation NorthEurope { get { throw null; } }
+        public static Azure.Core.AzureLocation NorwayEast { get { throw null; } }
+        public static Azure.Core.AzureLocation NorwayWest { get { throw null; } }
+        public static Azure.Core.AzureLocation PolandCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation QatarCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation SouthAfricaNorth { get { throw null; } }
+        public static Azure.Core.AzureLocation SouthAfricaWest { get { throw null; } }
+        public static Azure.Core.AzureLocation SouthCentralUS { get { throw null; } }
+        public static Azure.Core.AzureLocation SoutheastAsia { get { throw null; } }
+        public static Azure.Core.AzureLocation SouthIndia { get { throw null; } }
+        public static Azure.Core.AzureLocation SpainCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation SwedenSouth { get { throw null; } }
+        public static Azure.Core.AzureLocation SwitzerlandNorth { get { throw null; } }
+        public static Azure.Core.AzureLocation SwitzerlandWest { get { throw null; } }
+        public static Azure.Core.AzureLocation UAECentral { get { throw null; } }
+        public static Azure.Core.AzureLocation UAENorth { get { throw null; } }
+        public static Azure.Core.AzureLocation UKSouth { get { throw null; } }
+        public static Azure.Core.AzureLocation UKWest { get { throw null; } }
+        public static Azure.Core.AzureLocation USDoDCentral { get { throw null; } }
+        public static Azure.Core.AzureLocation USDoDEast { get { throw null; } }
+        public static Azure.Core.AzureLocation USGovArizona { get { throw null; } }
+        public static Azure.Core.AzureLocation USGovIowa { get { throw null; } }
+        public static Azure.Core.AzureLocation USGovTexas { get { throw null; } }
+        public static Azure.Core.AzureLocation USGovVirginia { get { throw null; } }
+        public static Azure.Core.AzureLocation WestCentralUS { get { throw null; } }
+        public static Azure.Core.AzureLocation WestEurope { get { throw null; } }
+        public static Azure.Core.AzureLocation WestIndia { get { throw null; } }
+        public static Azure.Core.AzureLocation WestUS { get { throw null; } }
+        public static Azure.Core.AzureLocation WestUS2 { get { throw null; } }
+        public static Azure.Core.AzureLocation WestUS3 { get { throw null; } }
+        public bool Equals(Azure.Core.AzureLocation other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.AzureLocation left, Azure.Core.AzureLocation right) { throw null; }
+        public static implicit operator string (Azure.Core.AzureLocation location) { throw null; }
+        public static implicit operator Azure.Core.AzureLocation (string location) { throw null; }
+        public static bool operator !=(Azure.Core.AzureLocation left, Azure.Core.AzureLocation right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public abstract partial class ClientOptions
+    {
+        protected ClientOptions() { }
+        protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
+        public static Azure.Core.ClientOptions Default { get { throw null; } }
+        public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }
+        public Azure.Core.RetryOptions Retry { get { throw null; } }
+        public Azure.Core.Pipeline.HttpPipelinePolicy? RetryPolicy { get { throw null; } set { } }
+        public Azure.Core.Pipeline.HttpPipelineTransport Transport { get { throw null; } set { } }
+        public void AddPolicy(Azure.Core.Pipeline.HttpPipelinePolicy policy, Azure.Core.HttpPipelinePosition position) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override string? ToString() { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct ContentType : System.IEquatable<Azure.Core.ContentType>, System.IEquatable<string>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ContentType(string contentType) { throw null; }
+        public static Azure.Core.ContentType ApplicationJson { get { throw null; } }
+        public static Azure.Core.ContentType ApplicationOctetStream { get { throw null; } }
+        public static Azure.Core.ContentType TextPlain { get { throw null; } }
+        public bool Equals(Azure.Core.ContentType other) { throw null; }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(string? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.ContentType left, Azure.Core.ContentType right) { throw null; }
+        public static implicit operator Azure.Core.ContentType (string contentType) { throw null; }
+        public static bool operator !=(Azure.Core.ContentType left, Azure.Core.ContentType right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public abstract partial class DelayStrategy
+    {
+        protected DelayStrategy(System.TimeSpan? maxDelay = default(System.TimeSpan?), double jitterFactor = 0.2) { }
+        public static Azure.Core.DelayStrategy CreateExponentialDelayStrategy(System.TimeSpan? initialDelay = default(System.TimeSpan?), System.TimeSpan? maxDelay = default(System.TimeSpan?)) { throw null; }
+        public static Azure.Core.DelayStrategy CreateFixedDelayStrategy(System.TimeSpan? delay = default(System.TimeSpan?)) { throw null; }
+        public System.TimeSpan GetNextDelay(Azure.Response? response, int retryNumber) { throw null; }
+        protected abstract System.TimeSpan GetNextDelayCore(Azure.Response? response, int retryNumber);
+        protected static System.TimeSpan Max(System.TimeSpan val1, System.TimeSpan val2) { throw null; }
+        protected static System.TimeSpan Min(System.TimeSpan val1, System.TimeSpan val2) { throw null; }
+    }
+    public static partial class DelegatedTokenCredential
+    {
+        public static Azure.Core.TokenCredential Create(System.Func<Azure.Core.TokenRequestContext, System.Threading.CancellationToken, Azure.Core.AccessToken> getToken) { throw null; }
+        public static Azure.Core.TokenCredential Create(System.Func<Azure.Core.TokenRequestContext, System.Threading.CancellationToken, Azure.Core.AccessToken> getToken, System.Func<Azure.Core.TokenRequestContext, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<Azure.Core.AccessToken>> getTokenAsync) { throw null; }
+    }
+    public partial class DiagnosticsOptions
+    {
+        protected internal DiagnosticsOptions() { }
+        public string? ApplicationId { get { throw null; } set { } }
+        public static string? DefaultApplicationId { get { throw null; } set { } }
+        public bool IsDistributedTracingEnabled { get { throw null; } set { } }
+        public bool IsLoggingContentEnabled { get { throw null; } set { } }
+        public bool IsLoggingEnabled { get { throw null; } set { } }
+        public bool IsTelemetryEnabled { get { throw null; } set { } }
+        public int LoggedContentSizeLimit { get { throw null; } set { } }
+        public System.Collections.Generic.IList<string> LoggedHeaderNames { get { throw null; } }
+        public System.Collections.Generic.IList<string> LoggedQueryParameters { get { throw null; } }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct HttpHeader : System.IEquatable<Azure.Core.HttpHeader>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public HttpHeader(string name, string value) { throw null; }
+        public string Name { get { throw null; } }
+        public string Value { get { throw null; } }
+        public bool Equals(Azure.Core.HttpHeader other) { throw null; }
+        public override bool Equals(object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override string ToString() { throw null; }
+        public static partial class Common
+        {
+            public static readonly Azure.Core.HttpHeader FormUrlEncodedContentType;
+            public static readonly Azure.Core.HttpHeader JsonAccept;
+            public static readonly Azure.Core.HttpHeader JsonContentType;
+            public static readonly Azure.Core.HttpHeader OctetStreamContentType;
+        }
+        public static partial class Names
+        {
+            public static string Accept { get { throw null; } }
+            public static string Authorization { get { throw null; } }
+            public static string ContentDisposition { get { throw null; } }
+            public static string ContentLength { get { throw null; } }
+            public static string ContentType { get { throw null; } }
+            public static string Date { get { throw null; } }
+            public static string ETag { get { throw null; } }
+            public static string Host { get { throw null; } }
+            public static string IfMatch { get { throw null; } }
+            public static string IfModifiedSince { get { throw null; } }
+            public static string IfNoneMatch { get { throw null; } }
+            public static string IfUnmodifiedSince { get { throw null; } }
+            public static string Prefer { get { throw null; } }
+            public static string Range { get { throw null; } }
+            public static string Referer { get { throw null; } }
+            public static string UserAgent { get { throw null; } }
+            public static string WwwAuthenticate { get { throw null; } }
+            public static string XMsDate { get { throw null; } }
+            public static string XMsRange { get { throw null; } }
+            public static string XMsRequestId { get { throw null; } }
+        }
+    }
+    public sealed partial class HttpMessage : System.IDisposable
+    {
+        public HttpMessage(Azure.Core.Request request, Azure.Core.ResponseClassifier responseClassifier) { }
+        public bool BufferResponse { get { throw null; } set { } }
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } }
+        public bool HasResponse { get { throw null; } }
+        public System.TimeSpan? NetworkTimeout { get { throw null; } set { } }
+        public Azure.Core.MessageProcessingContext ProcessingContext { get { throw null; } }
+        public Azure.Core.Request Request { get { throw null; } }
+        public Azure.Response Response { get { throw null; } set { } }
+        public Azure.Core.ResponseClassifier ResponseClassifier { get { throw null; } set { } }
+        public void Dispose() { }
+        public System.IO.Stream? ExtractResponseContent() { throw null; }
+        public void SetProperty(string name, object value) { }
+        public void SetProperty(System.Type type, object value) { }
+        public bool TryGetProperty(string name, out object? value) { throw null; }
+        public bool TryGetProperty(System.Type type, out object? value) { throw null; }
+    }
+    public enum HttpPipelinePosition
+    {
+        PerCall = 0,
+        PerRetry = 1,
+        BeforeTransport = 2,
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct MessageProcessingContext
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public int RetryNumber { get { throw null; } set { } }
+        public System.DateTimeOffset StartTime { get { throw null; } }
+    }
+    public static partial class MultipartResponse
+    {
+        public static Azure.Response[] Parse(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public static System.Threading.Tasks.Task<Azure.Response[]> ParseAsync(Azure.Response response, bool expectCrLf, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct RehydrationToken : System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>, System.ClientModel.Primitives.IJsonModel<object>, System.ClientModel.Primitives.IPersistableModel<Azure.Core.RehydrationToken>, System.ClientModel.Primitives.IPersistableModel<object>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public string Id { get { throw null; } }
+        Azure.Core.RehydrationToken System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Azure.Core.RehydrationToken>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        object System.ClientModel.Primitives.IJsonModel<object>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<object>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Azure.Core.RehydrationToken System.ClientModel.Primitives.IPersistableModel<Azure.Core.RehydrationToken>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Azure.Core.RehydrationToken>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Core.RehydrationToken>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        object System.ClientModel.Primitives.IPersistableModel<object>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<object>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<object>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public abstract partial class Request : System.IDisposable
+    {
+        protected Request() { }
+        public abstract string ClientRequestId { get; set; }
+        public virtual Azure.Core.RequestContent? Content { get { throw null; } set { } }
+        public Azure.Core.RequestHeaders Headers { get { throw null; } }
+        public virtual Azure.Core.RequestMethod Method { get { throw null; } set { } }
+        public virtual Azure.Core.RequestUriBuilder Uri { get { throw null; } set { } }
+        protected internal abstract void AddHeader(string name, string value);
+        protected internal abstract bool ContainsHeader(string name);
+        public abstract void Dispose();
+        protected internal abstract System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader> EnumerateHeaders();
+        protected internal abstract bool RemoveHeader(string name);
+        protected internal virtual void SetHeader(string name, string value) { }
+        protected internal abstract bool TryGetHeader(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out string? value);
+        protected internal abstract bool TryGetHeaderValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Collections.Generic.IEnumerable<string>? values);
+    }
+    public abstract partial class RequestContent : System.IDisposable
+    {
+        protected RequestContent() { }
+        public static Azure.Core.RequestContent Create(Azure.Core.Serialization.DynamicData content) { throw null; }
+        public static Azure.Core.RequestContent Create(System.BinaryData content) { throw null; }
+        public static Azure.Core.RequestContent Create(System.Buffers.ReadOnlySequence<byte> bytes) { throw null; }
+        public static Azure.Core.RequestContent Create(byte[] bytes) { throw null; }
+        public static Azure.Core.RequestContent Create(byte[] bytes, int index, int length) { throw null; }
+        public static Azure.Core.RequestContent Create(System.IO.Stream stream) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This method uses reflection-based serialization which is incompatible with trimming. Try using one of the 'Create' overloads that doesn't wrap a serialized version of an object.")]
+        public static Azure.Core.RequestContent Create(object serializable) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This method uses reflection-based serialization which is incompatible with trimming. Try using one of the 'Create' overloads that doesn't wrap a serialized version of an object.")]
+        public static Azure.Core.RequestContent Create(object serializable, Azure.Core.Serialization.JsonPropertyNames propertyNameFormat, string dateTimeFormat = "o") { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This method uses reflection-based serialization which is incompatible with trimming. Try using one of the 'Create' overloads that doesn't wrap a serialized version of an object.")]
+        public static Azure.Core.RequestContent Create(object serializable, Azure.Core.Serialization.ObjectSerializer? serializer) { throw null; }
+        public static Azure.Core.RequestContent Create(System.ReadOnlyMemory<byte> bytes) { throw null; }
+        public static Azure.Core.RequestContent Create(string content) { throw null; }
+        public static Azure.Core.RequestContent Create<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
+        public abstract void Dispose();
+        public static implicit operator Azure.Core.RequestContent (Azure.Core.Serialization.DynamicData content) { throw null; }
+        public static implicit operator Azure.Core.RequestContent (System.BinaryData content) { throw null; }
+        public static implicit operator Azure.Core.RequestContent (string content) { throw null; }
+        public abstract bool TryComputeLength(out long length);
+        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
+        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellation);
+    }
+    public abstract partial class RequestFailedDetailsParser
+    {
+        protected RequestFailedDetailsParser() { }
+        public abstract bool TryParse(Azure.Response response, out Azure.ResponseError? error, out System.Collections.Generic.IDictionary<string, string>? data);
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct RequestHeaders : System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader>, System.Collections.IEnumerable
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public void Add(Azure.Core.HttpHeader header) { }
+        public void Add(string name, string value) { }
+        public bool Contains(string name) { throw null; }
+        public System.Collections.Generic.IEnumerator<Azure.Core.HttpHeader> GetEnumerator() { throw null; }
+        public bool Remove(string name) { throw null; }
+        public void SetValue(string name, string value) { }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public bool TryGetValue(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out string? value) { throw null; }
+        public bool TryGetValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct RequestMethod : System.IEquatable<Azure.Core.RequestMethod>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public RequestMethod(string method) { throw null; }
+        public static Azure.Core.RequestMethod Delete { get { throw null; } }
+        public static Azure.Core.RequestMethod Get { get { throw null; } }
+        public static Azure.Core.RequestMethod Head { get { throw null; } }
+        public string Method { get { throw null; } }
+        public static Azure.Core.RequestMethod Options { get { throw null; } }
+        public static Azure.Core.RequestMethod Patch { get { throw null; } }
+        public static Azure.Core.RequestMethod Post { get { throw null; } }
+        public static Azure.Core.RequestMethod Put { get { throw null; } }
+        public static Azure.Core.RequestMethod Trace { get { throw null; } }
+        public bool Equals(Azure.Core.RequestMethod other) { throw null; }
+        public override bool Equals(object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.RequestMethod left, Azure.Core.RequestMethod right) { throw null; }
+        public static bool operator !=(Azure.Core.RequestMethod left, Azure.Core.RequestMethod right) { throw null; }
+        public static Azure.Core.RequestMethod Parse(string method) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial class RequestUriBuilder
+    {
+        public RequestUriBuilder() { }
+        protected bool HasPath { get { throw null; } }
+        protected bool HasQuery { get { throw null; } }
+        public string? Host { get { throw null; } set { } }
+        public string Path { get { throw null; } set { } }
+        public string PathAndQuery { get { throw null; } }
+        public int Port { get { throw null; } set { } }
+        public string Query { get { throw null; } set { } }
+        public string? Scheme { get { throw null; } set { } }
+        public void AppendPath(System.ReadOnlySpan<char> value, bool escape) { }
+        public void AppendPath(string value) { }
+        public void AppendPath(string value, bool escape) { }
+        public void AppendQuery(System.ReadOnlySpan<char> name, System.ReadOnlySpan<char> value, bool escapeValue) { }
+        public void AppendQuery(string name, string value) { }
+        public void AppendQuery(string name, string value, bool escapeValue) { }
+        public void Reset(System.Uri value) { }
+        public override string ToString() { throw null; }
+        public System.Uri ToUri() { throw null; }
+    }
+    public sealed partial class ResourceIdentifier : System.IComparable<Azure.Core.ResourceIdentifier>, System.IEquatable<Azure.Core.ResourceIdentifier>
+    {
+        public static readonly Azure.Core.ResourceIdentifier Root;
+        public ResourceIdentifier(string resourceId) { }
+        public Azure.Core.AzureLocation? Location { get { throw null; } }
+        public string Name { get { throw null; } }
+        public Azure.Core.ResourceIdentifier? Parent { get { throw null; } }
+        public string? Provider { get { throw null; } }
+        public string? ResourceGroupName { get { throw null; } }
+        public Azure.Core.ResourceType ResourceType { get { throw null; } }
+        public string? SubscriptionId { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public Azure.Core.ResourceIdentifier AppendChildResource(string childResourceType, string childResourceName) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public Azure.Core.ResourceIdentifier AppendProviderResource(string providerNamespace, string resourceType, string resourceName) { throw null; }
+        public int CompareTo(Azure.Core.ResourceIdentifier? other) { throw null; }
+        public bool Equals(Azure.Core.ResourceIdentifier? other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
+        public static bool operator >(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
+        public static bool operator >=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
+        public static implicit operator string (Azure.Core.ResourceIdentifier id) { throw null; }
+        public static bool operator !=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
+        public static bool operator <(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
+        public static bool operator <=(Azure.Core.ResourceIdentifier left, Azure.Core.ResourceIdentifier right) { throw null; }
+        public static Azure.Core.ResourceIdentifier Parse(string input) { throw null; }
+        public override string ToString() { throw null; }
+        public static bool TryParse(string? input, out Azure.Core.ResourceIdentifier? result) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct ResourceType : System.IComparable<Azure.Core.ResourceType>, System.IEquatable<Azure.Core.ResourceType>
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ResourceType(string resourceType) { throw null; }
+        public string Namespace { get { throw null; } }
+        public string Type { get { throw null; } }
+        public int CompareTo(Azure.Core.ResourceType other) { throw null; }
+        public bool Equals(Azure.Core.ResourceType other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? other) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public string GetLastType() { throw null; }
+        public static bool operator ==(Azure.Core.ResourceType left, Azure.Core.ResourceType right) { throw null; }
+        public static implicit operator string (Azure.Core.ResourceType resourceType) { throw null; }
+        public static implicit operator Azure.Core.ResourceType (string resourceType) { throw null; }
+        public static bool operator !=(Azure.Core.ResourceType left, Azure.Core.ResourceType right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public abstract partial class ResponseClassificationHandler
+    {
+        protected ResponseClassificationHandler() { }
+        public abstract bool TryClassify(Azure.Core.HttpMessage message, out bool isError);
+    }
+    public partial class ResponseClassifier
+    {
+        public ResponseClassifier() { }
+        public virtual bool IsErrorResponse(Azure.Core.HttpMessage message) { throw null; }
+        public virtual bool IsRetriable(Azure.Core.HttpMessage message, System.Exception exception) { throw null; }
+        public virtual bool IsRetriableException(System.Exception exception) { throw null; }
+        public virtual bool IsRetriableResponse(Azure.Core.HttpMessage message) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct ResponseHeaders : System.Collections.Generic.IEnumerable<Azure.Core.HttpHeader>, System.Collections.IEnumerable
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public int? ContentLength { get { throw null; } }
+        public long? ContentLengthLong { get { throw null; } }
+        public string? ContentType { get { throw null; } }
+        public System.DateTimeOffset? Date { get { throw null; } }
+        public Azure.ETag? ETag { get { throw null; } }
+        public string? RequestId { get { throw null; } }
+        public bool Contains(string name) { throw null; }
+        public System.Collections.Generic.IEnumerator<Azure.Core.HttpHeader> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public bool TryGetValue(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out string? value) { throw null; }
+        public bool TryGetValues(string name, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.Collections.Generic.IEnumerable<string>? values) { throw null; }
+    }
+    public enum RetryMode
+    {
+        Fixed = 0,
+        Exponential = 1,
+    }
+    public partial class RetryOptions
+    {
+        internal RetryOptions() { }
+        public System.TimeSpan Delay { get { throw null; } set { } }
+        public System.TimeSpan MaxDelay { get { throw null; } set { } }
+        public int MaxRetries { get { throw null; } set { } }
+        public Azure.Core.RetryMode Mode { get { throw null; } set { } }
+        public System.TimeSpan NetworkTimeout { get { throw null; } set { } }
+    }
+    public partial class StatusCodeClassifier : Azure.Core.ResponseClassifier
+    {
+        public StatusCodeClassifier(System.ReadOnlySpan<ushort> successStatusCodes) { }
+        public override bool IsErrorResponse(Azure.Core.HttpMessage message) { throw null; }
+    }
+    public delegate System.Threading.Tasks.Task SyncAsyncEventHandler<T>(T e) where T : Azure.SyncAsyncEventArgs;
+    public partial class TelemetryDetails
+    {
+        public TelemetryDetails(System.Reflection.Assembly assembly, string? applicationId = null) { }
+        public string? ApplicationId { get { throw null; } }
+        public System.Reflection.Assembly Assembly { get { throw null; } }
+        public void Apply(Azure.Core.HttpMessage message) { }
+        public override string ToString() { throw null; }
+    }
+    public abstract partial class TokenCredential : System.ClientModel.AuthenticationTokenProvider
+    {
+        protected TokenCredential() { }
+        public override System.ClientModel.Primitives.GetTokenOptions? CreateTokenOptions(System.Collections.Generic.IReadOnlyDictionary<string, object> properties) { throw null; }
+        public abstract Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken);
+        public override System.ClientModel.Primitives.AuthenticationToken GetToken(System.ClientModel.Primitives.GetTokenOptions properties, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public abstract System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken);
+        public override System.Threading.Tasks.ValueTask<System.ClientModel.Primitives.AuthenticationToken> GetTokenAsync(System.ClientModel.Primitives.GetTokenOptions properties, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct TokenRequestContext
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public TokenRequestContext(string[] scopes, string? parentRequestId) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public TokenRequestContext(string[] scopes, string? parentRequestId, string? claims) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public TokenRequestContext(string[] scopes, string? parentRequestId, string? claims, string? tenantId) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public TokenRequestContext(string[] scopes, string? parentRequestId, string? claims, string? tenantId, bool isCaeEnabled) { throw null; }
+        public TokenRequestContext(string[] scopes, string? parentRequestId = null, string? claims = null, string? tenantId = null, bool isCaeEnabled = false, bool isProofOfPossessionEnabled = false, string? proofOfPossessionNonce = null, System.Uri? requestUri = null, string? requestMethod = null) { throw null; }
+        public string? Claims { get { throw null; } }
+        public bool IsCaeEnabled { get { throw null; } }
+        public bool IsProofOfPossessionEnabled { get { throw null; } }
+        public string? ParentRequestId { get { throw null; } }
+        public string? ProofOfPossessionNonce { get { throw null; } }
+        public string? ResourceRequestMethod { get { throw null; } }
+        public System.Uri? ResourceRequestUri { get { throw null; } }
+        public string[] Scopes { get { throw null; } }
+        public string? TenantId { get { throw null; } }
+    }
+}
+namespace Azure.Core.Cryptography
+{
+    public partial interface IKeyEncryptionKey
+    {
+        string KeyId { get; }
+        byte[] UnwrapKey(string algorithm, System.ReadOnlyMemory<byte> encryptedKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<byte[]> UnwrapKeyAsync(string algorithm, System.ReadOnlyMemory<byte> encryptedKey, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        byte[] WrapKey(string algorithm, System.ReadOnlyMemory<byte> key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<byte[]> WrapKeyAsync(string algorithm, System.ReadOnlyMemory<byte> key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
+    public partial interface IKeyEncryptionKeyResolver
+    {
+        Azure.Core.Cryptography.IKeyEncryptionKey Resolve(string keyId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Azure.Core.Cryptography.IKeyEncryptionKey> ResolveAsync(string keyId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
+}
+namespace Azure.Core.Diagnostics
+{
+    public partial class AzureEventSourceListener : System.Diagnostics.Tracing.EventListener
+    {
+        public const string TraitName = "AzureEventSource";
+        public const string TraitValue = "true";
+        public AzureEventSourceListener(System.Action<System.Diagnostics.Tracing.EventWrittenEventArgs, string> log, System.Diagnostics.Tracing.EventLevel level) { }
+        public AzureEventSourceListener(System.Action<System.Diagnostics.Tracing.EventWrittenEventArgs> log, System.Diagnostics.Tracing.EventLevel level) { }
+        public static Azure.Core.Diagnostics.AzureEventSourceListener CreateConsoleLogger(System.Diagnostics.Tracing.EventLevel level = System.Diagnostics.Tracing.EventLevel.Informational) { throw null; }
+        public static Azure.Core.Diagnostics.AzureEventSourceListener CreateTraceLogger(System.Diagnostics.Tracing.EventLevel level = System.Diagnostics.Tracing.EventLevel.Informational) { throw null; }
+        protected sealed override void OnEventSourceCreated(System.Diagnostics.Tracing.EventSource eventSource) { }
+        protected sealed override void OnEventWritten(System.Diagnostics.Tracing.EventWrittenEventArgs eventData) { }
+    }
+}
+namespace Azure.Core.Extensions
+{
+    public partial interface IAzureClientBuilder<TClient, TOptions> where TOptions : class
+    {
+    }
+    public partial interface IAzureClientFactoryBuilder
+    {
+        Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> RegisterClientFactory<TClient, TOptions>(System.Func<TOptions, TClient> clientFactory) where TOptions : class;
+    }
+    public partial interface IAzureClientFactoryBuilderWithConfiguration<in TConfiguration> : Azure.Core.Extensions.IAzureClientFactoryBuilder
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("Binding strongly typed objects to configuration values requires generating dynamic code at runtime, for example instantiating generic types. Use the Configuration Binder Source Generator (EnableConfigurationBindingGenerator=true) instead.")]
+        Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> RegisterClientFactory<TClient, TOptions>(TConfiguration configuration) where TOptions : class;
+    }
+    public partial interface IAzureClientFactoryBuilderWithCredential
+    {
+        Azure.Core.Extensions.IAzureClientBuilder<TClient, TOptions> RegisterClientFactory<TClient, TOptions>(System.Func<TOptions, Azure.Core.TokenCredential, TClient> clientFactory, bool requiresCredential = true) where TOptions : class;
+    }
+}
+namespace Azure.Core.GeoJson
+{
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct GeoArray<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.Generic.IReadOnlyCollection<T>, System.Collections.Generic.IReadOnlyList<T>, System.Collections.IEnumerable
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public int Count { get { throw null; } }
+        public T this[int index] { get { throw null; } }
+        public Azure.Core.GeoJson.GeoArray<T>.Enumerator GetEnumerator() { throw null; }
+        System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct Enumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public T Current { get { throw null; } }
+            object System.Collections.IEnumerator.Current { get { throw null; } }
+            public void Dispose() { }
+            public bool MoveNext() { throw null; }
+            public void Reset() { }
+        }
+    }
+    public sealed partial class GeoBoundingBox : System.IEquatable<Azure.Core.GeoJson.GeoBoundingBox>
+    {
+        public GeoBoundingBox(double west, double south, double east, double north) { }
+        public GeoBoundingBox(double west, double south, double east, double north, double? minAltitude, double? maxAltitude) { }
+        public double East { get { throw null; } }
+        public double this[int index] { get { throw null; } }
+        public double? MaxAltitude { get { throw null; } }
+        public double? MinAltitude { get { throw null; } }
+        public double North { get { throw null; } }
+        public double South { get { throw null; } }
+        public double West { get { throw null; } }
+        public bool Equals(Azure.Core.GeoJson.GeoBoundingBox? other) { throw null; }
+        public override bool Equals(object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public sealed partial class GeoCollection : Azure.Core.GeoJson.GeoObject, System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoObject>, System.Collections.Generic.IReadOnlyCollection<Azure.Core.GeoJson.GeoObject>, System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoObject>, System.Collections.IEnumerable
+    {
+        public GeoCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoObject> geometries) { }
+        public GeoCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoObject> geometries, Azure.Core.GeoJson.GeoBoundingBox? boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object?> customProperties) { }
+        public int Count { get { throw null; } }
+        public Azure.Core.GeoJson.GeoObject this[int index] { get { throw null; } }
+        public override Azure.Core.GeoJson.GeoObjectType Type { get { throw null; } }
+        public System.Collections.Generic.IEnumerator<Azure.Core.GeoJson.GeoObject> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class GeoLinearRing
+    {
+        public GeoLinearRing(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPosition> coordinates) { }
+        public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition> Coordinates { get { throw null; } }
+    }
+    public sealed partial class GeoLineString : Azure.Core.GeoJson.GeoObject
+    {
+        public GeoLineString(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPosition> coordinates) { }
+        public GeoLineString(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPosition> coordinates, Azure.Core.GeoJson.GeoBoundingBox? boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object?> customProperties) { }
+        public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition> Coordinates { get { throw null; } }
+        public override Azure.Core.GeoJson.GeoObjectType Type { get { throw null; } }
+    }
+    public sealed partial class GeoLineStringCollection : Azure.Core.GeoJson.GeoObject, System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLineString>, System.Collections.Generic.IReadOnlyCollection<Azure.Core.GeoJson.GeoLineString>, System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoLineString>, System.Collections.IEnumerable
+    {
+        public GeoLineStringCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLineString> lines) { }
+        public GeoLineStringCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLineString> lines, Azure.Core.GeoJson.GeoBoundingBox? boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object?> customProperties) { }
+        public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition>> Coordinates { get { throw null; } }
+        public int Count { get { throw null; } }
+        public Azure.Core.GeoJson.GeoLineString this[int index] { get { throw null; } }
+        public override Azure.Core.GeoJson.GeoObjectType Type { get { throw null; } }
+        public System.Collections.Generic.IEnumerator<Azure.Core.GeoJson.GeoLineString> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public abstract partial class GeoObject
+    {
+        internal GeoObject() { }
+        public Azure.Core.GeoJson.GeoBoundingBox? BoundingBox { get { throw null; } }
+        public abstract Azure.Core.GeoJson.GeoObjectType Type { get; }
+        public static Azure.Core.GeoJson.GeoObject Parse(string json) { throw null; }
+        public override string ToString() { throw null; }
+        public bool TryGetCustomProperty(string name, out object? value) { throw null; }
+    }
+    public enum GeoObjectType
+    {
+        Point = 0,
+        MultiPoint = 1,
+        Polygon = 2,
+        MultiPolygon = 3,
+        LineString = 4,
+        MultiLineString = 5,
+        GeometryCollection = 6,
+    }
+    public sealed partial class GeoPoint : Azure.Core.GeoJson.GeoObject, System.ClientModel.Primitives.IJsonModel<Azure.Core.GeoJson.GeoPoint>, System.ClientModel.Primitives.IPersistableModel<Azure.Core.GeoJson.GeoPoint>
+    {
+        public GeoPoint() { }
+        public GeoPoint(Azure.Core.GeoJson.GeoPosition position) { }
+        public GeoPoint(Azure.Core.GeoJson.GeoPosition position, Azure.Core.GeoJson.GeoBoundingBox? boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object?> customProperties) { }
+        public GeoPoint(double longitude, double latitude) { }
+        public GeoPoint(double longitude, double latitude, double? altitude) { }
+        public Azure.Core.GeoJson.GeoPosition Coordinates { get { throw null; } }
+        public override Azure.Core.GeoJson.GeoObjectType Type { get { throw null; } }
+        Azure.Core.GeoJson.GeoPoint? System.ClientModel.Primitives.IJsonModel<Azure.Core.GeoJson.GeoPoint>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Azure.Core.GeoJson.GeoPoint>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Azure.Core.GeoJson.GeoPoint? System.ClientModel.Primitives.IPersistableModel<Azure.Core.GeoJson.GeoPoint>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Azure.Core.GeoJson.GeoPoint>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.Core.GeoJson.GeoPoint>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public sealed partial class GeoPointCollection : Azure.Core.GeoJson.GeoObject, System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPoint>, System.Collections.Generic.IReadOnlyCollection<Azure.Core.GeoJson.GeoPoint>, System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoPoint>, System.Collections.IEnumerable
+    {
+        public GeoPointCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPoint> points) { }
+        public GeoPointCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPoint> points, Azure.Core.GeoJson.GeoBoundingBox? boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object?> customProperties) { }
+        public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition> Coordinates { get { throw null; } }
+        public int Count { get { throw null; } }
+        public Azure.Core.GeoJson.GeoPoint this[int index] { get { throw null; } }
+        public override Azure.Core.GeoJson.GeoObjectType Type { get { throw null; } }
+        public System.Collections.Generic.IEnumerator<Azure.Core.GeoJson.GeoPoint> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public sealed partial class GeoPolygon : Azure.Core.GeoJson.GeoObject
+    {
+        public GeoPolygon(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLinearRing> rings) { }
+        public GeoPolygon(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoLinearRing> rings, Azure.Core.GeoJson.GeoBoundingBox? boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object?> customProperties) { }
+        public GeoPolygon(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPosition> positions) { }
+        public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition>> Coordinates { get { throw null; } }
+        public Azure.Core.GeoJson.GeoLinearRing OuterRing { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoLinearRing> Rings { get { throw null; } }
+        public override Azure.Core.GeoJson.GeoObjectType Type { get { throw null; } }
+    }
+    public sealed partial class GeoPolygonCollection : Azure.Core.GeoJson.GeoObject, System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPolygon>, System.Collections.Generic.IReadOnlyCollection<Azure.Core.GeoJson.GeoPolygon>, System.Collections.Generic.IReadOnlyList<Azure.Core.GeoJson.GeoPolygon>, System.Collections.IEnumerable
+    {
+        public GeoPolygonCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPolygon> polygons) { }
+        public GeoPolygonCollection(System.Collections.Generic.IEnumerable<Azure.Core.GeoJson.GeoPolygon> polygons, Azure.Core.GeoJson.GeoBoundingBox? boundingBox, System.Collections.Generic.IReadOnlyDictionary<string, object?> customProperties) { }
+        public Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoArray<Azure.Core.GeoJson.GeoPosition>>> Coordinates { get { throw null; } }
+        public int Count { get { throw null; } }
+        public Azure.Core.GeoJson.GeoPolygon this[int index] { get { throw null; } }
+        public override Azure.Core.GeoJson.GeoObjectType Type { get { throw null; } }
+        public System.Collections.Generic.IEnumerator<Azure.Core.GeoJson.GeoPolygon> GetEnumerator() { throw null; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct GeoPosition : System.IEquatable<Azure.Core.GeoJson.GeoPosition>
+    {
+        private readonly int _dummyPrimitive;
+        public GeoPosition(double longitude, double latitude) { throw null; }
+        public GeoPosition(double longitude, double latitude, double? altitude) { throw null; }
+        public double? Altitude { get { throw null; } }
+        public int Count { get { throw null; } }
+        public double this[int index] { get { throw null; } }
+        public double Latitude { get { throw null; } }
+        public double Longitude { get { throw null; } }
+        public bool Equals(Azure.Core.GeoJson.GeoPosition other) { throw null; }
+        public override bool Equals(object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.GeoJson.GeoPosition left, Azure.Core.GeoJson.GeoPosition right) { throw null; }
+        public static bool operator !=(Azure.Core.GeoJson.GeoPosition left, Azure.Core.GeoJson.GeoPosition right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+}
+namespace Azure.Core.Pipeline
+{
+    public partial class BearerTokenAuthenticationPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
+    {
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, System.Collections.Generic.IEnumerable<string> scopes) { }
+        public BearerTokenAuthenticationPolicy(Azure.Core.TokenCredential credential, string scope) { }
+        protected void AuthenticateAndAuthorizeRequest(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { }
+        protected System.Threading.Tasks.ValueTask AuthenticateAndAuthorizeRequestAsync(Azure.Core.HttpMessage message, Azure.Core.TokenRequestContext context) { throw null; }
+        protected virtual void AuthorizeRequest(Azure.Core.HttpMessage message) { }
+        protected virtual System.Threading.Tasks.ValueTask AuthorizeRequestAsync(Azure.Core.HttpMessage message) { throw null; }
+        protected virtual bool AuthorizeRequestOnChallenge(Azure.Core.HttpMessage message) { throw null; }
+        protected virtual System.Threading.Tasks.ValueTask<bool> AuthorizeRequestOnChallengeAsync(Azure.Core.HttpMessage message) { throw null; }
+        public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
+        public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
+    }
+    public sealed partial class DisposableHttpPipeline : Azure.Core.Pipeline.HttpPipeline, System.IDisposable
+    {
+        internal DisposableHttpPipeline() : base (default(Azure.Core.Pipeline.HttpPipelineTransport), default(Azure.Core.Pipeline.HttpPipelinePolicy[]), default(Azure.Core.ResponseClassifier)) { }
+        public void Dispose() { }
+    }
+    public partial class HttpClientTransport : Azure.Core.Pipeline.HttpPipelineTransport, System.IDisposable
+    {
+        public static readonly Azure.Core.Pipeline.HttpClientTransport Shared;
+        public HttpClientTransport() { }
+        public HttpClientTransport(System.Func<Azure.Core.Pipeline.HttpPipelineTransportOptions, System.Net.Http.HttpClient> clientFactory) { }
+        public HttpClientTransport(System.Func<Azure.Core.Pipeline.HttpPipelineTransportOptions, System.Net.Http.HttpMessageHandler> handlerFactory) { }
+        public HttpClientTransport(System.Net.Http.HttpClient client) { }
+        public HttpClientTransport(System.Net.Http.HttpMessageHandler messageHandler) { }
+        public sealed override Azure.Core.Request CreateRequest() { throw null; }
+        public void Dispose() { }
+        public override void Process(Azure.Core.HttpMessage message) { }
+        public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message) { throw null; }
+        public override void Update(Azure.Core.Pipeline.HttpPipelineTransportOptions options) { }
+    }
+    public partial class HttpPipeline
+    {
+        public HttpPipeline(Azure.Core.Pipeline.HttpPipelineTransport transport, Azure.Core.Pipeline.HttpPipelinePolicy[]? policies = null, Azure.Core.ResponseClassifier? responseClassifier = null) { }
+        public Azure.Core.ResponseClassifier ResponseClassifier { get { throw null; } }
+        public static System.IDisposable CreateClientRequestIdScope(string? clientRequestId) { throw null; }
+        public static System.IDisposable CreateHttpMessagePropertiesScope(System.Collections.Generic.IDictionary<string, object?> messageProperties) { throw null; }
+        public Azure.Core.HttpMessage CreateMessage() { throw null; }
+        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext? context) { throw null; }
+        public Azure.Core.HttpMessage CreateMessage(Azure.RequestContext? context, Azure.Core.ResponseClassifier? classifier = null) { throw null; }
+        public Azure.Core.Request CreateRequest() { throw null; }
+        public void Send(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.ValueTask SendAsync(Azure.Core.HttpMessage message, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public Azure.Response SendRequest(Azure.Core.Request request, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public System.Threading.Tasks.ValueTask<Azure.Response> SendRequestAsync(Azure.Core.Request request, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public static partial class HttpPipelineBuilder
+    {
+        public static Azure.Core.Pipeline.HttpPipeline Build(Azure.Core.ClientOptions options, params Azure.Core.Pipeline.HttpPipelinePolicy[] perRetryPolicies) { throw null; }
+        public static Azure.Core.Pipeline.DisposableHttpPipeline Build(Azure.Core.ClientOptions options, Azure.Core.Pipeline.HttpPipelinePolicy[] perCallPolicies, Azure.Core.Pipeline.HttpPipelinePolicy[] perRetryPolicies, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions, Azure.Core.ResponseClassifier? responseClassifier) { throw null; }
+        public static Azure.Core.Pipeline.HttpPipeline Build(Azure.Core.ClientOptions options, Azure.Core.Pipeline.HttpPipelinePolicy[] perCallPolicies, Azure.Core.Pipeline.HttpPipelinePolicy[] perRetryPolicies, Azure.Core.ResponseClassifier? responseClassifier) { throw null; }
+        public static Azure.Core.Pipeline.HttpPipeline Build(Azure.Core.Pipeline.HttpPipelineOptions options) { throw null; }
+        public static Azure.Core.Pipeline.DisposableHttpPipeline Build(Azure.Core.Pipeline.HttpPipelineOptions options, Azure.Core.Pipeline.HttpPipelineTransportOptions transportOptions) { throw null; }
+    }
+    public partial class HttpPipelineOptions
+    {
+        public HttpPipelineOptions(Azure.Core.ClientOptions options) { }
+        public Azure.Core.ClientOptions ClientOptions { get { throw null; } }
+        public System.Collections.Generic.IList<Azure.Core.Pipeline.HttpPipelinePolicy> PerCallPolicies { get { throw null; } }
+        public System.Collections.Generic.IList<Azure.Core.Pipeline.HttpPipelinePolicy> PerRetryPolicies { get { throw null; } }
+        public Azure.Core.RequestFailedDetailsParser RequestFailedDetailsParser { get { throw null; } set { } }
+        public Azure.Core.ResponseClassifier? ResponseClassifier { get { throw null; } set { } }
+    }
+    public abstract partial class HttpPipelinePolicy
+    {
+        protected HttpPipelinePolicy() { }
+        public abstract void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline);
+        public abstract System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline);
+        protected static void ProcessNext(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
+        protected static System.Threading.Tasks.ValueTask ProcessNextAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
+    }
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]
+    public abstract partial class HttpPipelineSynchronousPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
+    {
+        protected HttpPipelineSynchronousPolicy() { }
+        public virtual void OnReceivedResponse(Azure.Core.HttpMessage message) { }
+        public virtual void OnSendingRequest(Azure.Core.HttpMessage message) { }
+        public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
+        public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
+    }
+    public abstract partial class HttpPipelineTransport
+    {
+        protected HttpPipelineTransport() { }
+        public abstract Azure.Core.Request CreateRequest();
+        public abstract void Process(Azure.Core.HttpMessage message);
+        public abstract System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message);
+        public virtual void Update(Azure.Core.Pipeline.HttpPipelineTransportOptions options) { }
+    }
+    public partial class HttpPipelineTransportOptions
+    {
+        public HttpPipelineTransportOptions() { }
+        public System.Collections.Generic.IList<System.Security.Cryptography.X509Certificates.X509Certificate2> ClientCertificates { get { throw null; } }
+        public bool IsClientRedirectEnabled { get { throw null; } set { } }
+        public System.Func<Azure.Core.Pipeline.ServerCertificateCustomValidationArgs, bool>? ServerCertificateCustomValidationCallback { get { throw null; } set { } }
+    }
+    public sealed partial class RedirectPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
+    {
+        internal RedirectPolicy() { }
+        public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
+        public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
+        public static void SetAllowAutoRedirect(Azure.Core.HttpMessage message, bool allowAutoRedirect) { }
+    }
+    public partial class RetryPolicy : Azure.Core.Pipeline.HttpPipelinePolicy
+    {
+        public RetryPolicy(int maxRetries = 3, Azure.Core.DelayStrategy? delayStrategy = null) { }
+        protected internal virtual void OnRequestSent(Azure.Core.HttpMessage message) { }
+        protected internal virtual System.Threading.Tasks.ValueTask OnRequestSentAsync(Azure.Core.HttpMessage message) { throw null; }
+        protected internal virtual void OnSendingRequest(Azure.Core.HttpMessage message) { }
+        protected internal virtual System.Threading.Tasks.ValueTask OnSendingRequestAsync(Azure.Core.HttpMessage message) { throw null; }
+        public override void Process(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { }
+        public override System.Threading.Tasks.ValueTask ProcessAsync(Azure.Core.HttpMessage message, System.ReadOnlyMemory<Azure.Core.Pipeline.HttpPipelinePolicy> pipeline) { throw null; }
+        protected internal virtual bool ShouldRetry(Azure.Core.HttpMessage message, System.Exception? exception) { throw null; }
+        protected internal virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryAsync(Azure.Core.HttpMessage message, System.Exception? exception) { throw null; }
+    }
+    public partial class ServerCertificateCustomValidationArgs
+    {
+        public ServerCertificateCustomValidationArgs(System.Security.Cryptography.X509Certificates.X509Certificate2? certificate, System.Security.Cryptography.X509Certificates.X509Chain? certificateAuthorityChain, System.Net.Security.SslPolicyErrors sslPolicyErrors) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2? Certificate { get { throw null; } }
+        public System.Security.Cryptography.X509Certificates.X509Chain? CertificateAuthorityChain { get { throw null; } }
+        public System.Net.Security.SslPolicyErrors SslPolicyErrors { get { throw null; } }
+    }
+}
+namespace Azure.Core.Serialization
+{
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This class utilizes reflection-based JSON serialization and deserialization which is not compatible with trimming.")]
+    [System.Diagnostics.DebuggerDisplayAttribute("{DebuggerDisplay,nq}")]
+    public sealed partial class DynamicData : System.Dynamic.IDynamicMetaObjectProvider, System.IDisposable
+    {
+        internal DynamicData() { }
+        public void Dispose() { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(Azure.Core.Serialization.DynamicData? left, object? right) { throw null; }
+        public static explicit operator System.DateTime (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static explicit operator System.DateTimeOffset (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static explicit operator System.Guid (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator bool (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator byte (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator decimal (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator double (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator short (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator int (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator long (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator sbyte (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator float (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator string (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator ushort (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator uint (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static implicit operator ulong (Azure.Core.Serialization.DynamicData value) { throw null; }
+        public static bool operator !=(Azure.Core.Serialization.DynamicData? left, object? right) { throw null; }
+        System.Dynamic.DynamicMetaObject System.Dynamic.IDynamicMetaObjectProvider.GetMetaObject(System.Linq.Expressions.Expression parameter) { throw null; }
+        public override string ToString() { throw null; }
+    }
+    public partial interface IMemberNameConverter
+    {
+        string? ConvertMemberName(System.Reflection.MemberInfo member);
+    }
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This class uses reflection-based JSON serialization and deserialization that is not compatible with trimming.")]
+    public partial class JsonObjectSerializer : Azure.Core.Serialization.ObjectSerializer, Azure.Core.Serialization.IMemberNameConverter
+    {
+        public JsonObjectSerializer() { }
+        public JsonObjectSerializer(System.Text.Json.JsonSerializerOptions options) { }
+        public static Azure.Core.Serialization.JsonObjectSerializer Default { get { throw null; } }
+        string? Azure.Core.Serialization.IMemberNameConverter.ConvertMemberName(System.Reflection.MemberInfo member) { throw null; }
+        public override object? Deserialize(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<object?> DeserializeAsync(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override void Serialize(System.IO.Stream stream, object? value, System.Type inputType, System.Threading.CancellationToken cancellationToken) { }
+        public override System.BinaryData Serialize(object? value, System.Type? inputType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.ValueTask SerializeAsync(System.IO.Stream stream, object? value, System.Type inputType, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<System.BinaryData> SerializeAsync(object? value, System.Type? inputType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public enum JsonPropertyNames
+    {
+        UseExact = 0,
+        CamelCase = 1,
+    }
+    public abstract partial class ObjectSerializer
+    {
+        protected ObjectSerializer() { }
+        public abstract object? Deserialize(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.ValueTask<object?> DeserializeAsync(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken);
+        public abstract void Serialize(System.IO.Stream stream, object? value, System.Type inputType, System.Threading.CancellationToken cancellationToken);
+        public virtual System.BinaryData Serialize(object? value, System.Type? inputType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public abstract System.Threading.Tasks.ValueTask SerializeAsync(System.IO.Stream stream, object? value, System.Type inputType, System.Threading.CancellationToken cancellationToken);
+        public virtual System.Threading.Tasks.ValueTask<System.BinaryData> SerializeAsync(object? value, System.Type? inputType = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+}
+namespace Azure.Messaging
+{
+    [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This utilizes reflection-based JSON serialization and deserialization which is not compatible with trimming.")]
+    public partial class CloudEvent
+    {
+        public CloudEvent(string source, string type, System.BinaryData? data, string? dataContentType, Azure.Messaging.CloudEventDataFormat dataFormat = Azure.Messaging.CloudEventDataFormat.Binary) { }
+        public CloudEvent(string source, string type, object? jsonSerializableData, System.Type? dataSerializationType = null) { }
+        public System.BinaryData? Data { get { throw null; } set { } }
+        public string? DataContentType { get { throw null; } set { } }
+        public string? DataSchema { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, object> ExtensionAttributes { get { throw null; } }
+        public string Id { get { throw null; } set { } }
+        public string Source { get { throw null; } set { } }
+        public string? Subject { get { throw null; } set { } }
+        public System.DateTimeOffset? Time { get { throw null; } set { } }
+        public string Type { get { throw null; } set { } }
+        public static Azure.Messaging.CloudEvent? Parse(System.BinaryData json, bool skipValidation = false) { throw null; }
+        public static Azure.Messaging.CloudEvent[] ParseMany(System.BinaryData json, bool skipValidation = false) { throw null; }
+    }
+    public enum CloudEventDataFormat
+    {
+        Binary = 0,
+        Json = 1,
+    }
+    public partial class MessageContent
+    {
+        public MessageContent() { }
+        public virtual Azure.Core.ContentType? ContentType { get { throw null; } set { } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        protected virtual Azure.Core.ContentType? ContentTypeCore { get { throw null; } set { } }
+        public virtual System.BinaryData? Data { get { throw null; } set { } }
+        public virtual bool IsReadOnly { get { throw null; } }
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/api/Microsoft.Azure.Core.NewtonsoftJson.net10.0.cs
+++ b/sdk/core/Microsoft.Azure.Core.NewtonsoftJson/api/Microsoft.Azure.Core.NewtonsoftJson.net10.0.cs
@@ -1,0 +1,21 @@
+namespace Azure.Core.Serialization
+{
+    public partial class NewtonsoftJsonETagConverter : Newtonsoft.Json.JsonConverter
+    {
+        public NewtonsoftJsonETagConverter() { }
+        public override bool CanConvert(System.Type objectType) { throw null; }
+        public override object? ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object? existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object? value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+    public partial class NewtonsoftJsonObjectSerializer : Azure.Core.Serialization.ObjectSerializer, Azure.Core.Serialization.IMemberNameConverter
+    {
+        public NewtonsoftJsonObjectSerializer() { }
+        public NewtonsoftJsonObjectSerializer(Newtonsoft.Json.JsonSerializerSettings settings) { }
+        string? Azure.Core.Serialization.IMemberNameConverter.ConvertMemberName(System.Reflection.MemberInfo member) { throw null; }
+        public static Newtonsoft.Json.JsonSerializerSettings CreateJsonSerializerSettings() { throw null; }
+        public override object Deserialize(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<object?> DeserializeAsync(System.IO.Stream stream, System.Type returnType, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override void Serialize(System.IO.Stream stream, object? value, System.Type inputType, System.Threading.CancellationToken cancellationToken) { }
+        public override System.Threading.Tasks.ValueTask SerializeAsync(System.IO.Stream stream, object? value, System.Type inputType, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.Spatial.NewtonsoftJson/api/Microsoft.Azure.Core.Spatial.NewtonsoftJson.net10.0.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial.NewtonsoftJson/api/Microsoft.Azure.Core.Spatial.NewtonsoftJson.net10.0.cs
@@ -1,0 +1,10 @@
+namespace Azure.Core.Serialization
+{
+    public partial class NewtonsoftJsonMicrosoftSpatialGeoJsonConverter : Newtonsoft.Json.JsonConverter
+    {
+        public NewtonsoftJsonMicrosoftSpatialGeoJsonConverter() { }
+        public override bool CanConvert(System.Type objectType) { throw null; }
+        public override object ReadJson(Newtonsoft.Json.JsonReader reader, System.Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer) { throw null; }
+        public override void WriteJson(Newtonsoft.Json.JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer) { }
+    }
+}

--- a/sdk/core/Microsoft.Azure.Core.Spatial/api/Microsoft.Azure.Core.Spatial.net10.0.cs
+++ b/sdk/core/Microsoft.Azure.Core.Spatial/api/Microsoft.Azure.Core.Spatial.net10.0.cs
@@ -1,0 +1,10 @@
+namespace Azure.Core.Serialization
+{
+    public partial class MicrosoftSpatialGeoJsonConverter : System.Text.Json.Serialization.JsonConverter<object>
+    {
+        public MicrosoftSpatialGeoJsonConverter() { }
+        public override bool CanConvert(System.Type typeToConvert) { throw null; }
+        public override object Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
+        public override void Write(System.Text.Json.Utf8JsonWriter writer, object value, System.Text.Json.JsonSerializerOptions options) { }
+    }
+}

--- a/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net10.0.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net10.0.cs
@@ -1,0 +1,1105 @@
+namespace Microsoft.ClientModel.TestFramework
+{
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
+    public partial class AsyncOnlyAttribute : NUnit.Framework.NUnitAttribute
+    {
+        public AsyncOnlyAttribute() { }
+    }
+    [Microsoft.ClientModel.TestFramework.ClientTestFixtureAttribute(new object[]{ })]
+    public abstract partial class ClientTestBase
+    {
+        protected static readonly Castle.DynamicProxy.ProxyGenerator ProxyGenerator;
+        public ClientTestBase(bool isAsync) { }
+        protected System.Collections.Generic.IReadOnlyCollection<Castle.DynamicProxy.IInterceptor>? AdditionalInterceptors { get { throw null; } set { } }
+        public bool IsAsync { get { throw null; } }
+        protected virtual System.DateTime TestStartTime { get { throw null; } }
+        public int TestTimeoutInSeconds { get { throw null; } set { } }
+        protected TClient CreateProxiedClient<TClient>(params object[] args) where TClient : class { throw null; }
+        protected internal virtual object CreateProxyFromClient(System.Type clientType, object client, System.Collections.Generic.IEnumerable<Castle.DynamicProxy.IInterceptor>? preInterceptors) { throw null; }
+        public TClient CreateProxyFromClient<TClient>(TClient client) where TClient : class { throw null; }
+        protected TClient CreateProxyFromClient<TClient>(TClient client, System.Collections.Generic.IEnumerable<Castle.DynamicProxy.IInterceptor> preInterceptors) where TClient : class { throw null; }
+        protected T GetOriginal<T>(T proxied) { throw null; }
+        [NUnit.Framework.TearDownAttribute]
+        public virtual void GlobalTimeoutTearDown() { }
+    }
+    public partial class ClientTestFixtureAttribute : NUnit.Framework.NUnitAttribute, NUnit.Framework.Interfaces.IFixtureBuilder, NUnit.Framework.Interfaces.IFixtureBuilder2, NUnit.Framework.Interfaces.IPreFilter
+    {
+        public static readonly string RecordingDirectorySuffixKey;
+        public static readonly string SyncOnlyKey;
+        public ClientTestFixtureAttribute(params object[] additionalParameters) { }
+        public System.Collections.Generic.IEnumerable<NUnit.Framework.Internal.TestSuite> BuildFrom(NUnit.Framework.Interfaces.ITypeInfo typeInfo) { throw null; }
+        public System.Collections.Generic.IEnumerable<NUnit.Framework.Internal.TestSuite> BuildFrom(NUnit.Framework.Interfaces.ITypeInfo typeInfo, NUnit.Framework.Interfaces.IPreFilter filter) { throw null; }
+        bool NUnit.Framework.Interfaces.IPreFilter.IsMatch(System.Type type) { throw null; }
+        bool NUnit.Framework.Interfaces.IPreFilter.IsMatch(System.Type type, System.Reflection.MethodInfo method) { throw null; }
+    }
+    public abstract partial class DisposableConfig : System.IDisposable
+    {
+        protected readonly System.Collections.Generic.Dictionary<string, string> OriginalValues;
+        public DisposableConfig(System.Collections.Generic.Dictionary<string, string> values, System.Threading.SemaphoreSlim sem) { }
+        public DisposableConfig(string name, string value, System.Threading.SemaphoreSlim sem) { }
+        internal abstract void Cleanup();
+        public void Dispose() { }
+        internal abstract void InitValues();
+        internal abstract void SetValue(string name, string value);
+        internal abstract void SetValues(System.Collections.Generic.Dictionary<string, string> values);
+    }
+    public enum EntryRecordModel
+    {
+        Record = 0,
+        DoNotRecord = 1,
+        RecordWithoutRequestBody = 2,
+    }
+    public partial interface IProxiedClient
+    {
+        object Original { get; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
+    public partial class LiveOnlyAttribute : NUnit.Framework.NUnitAttribute, NUnit.Framework.Interfaces.IApplyToTest
+    {
+        public LiveOnlyAttribute(bool alwaysRunLocally = false) { }
+        public string? Reason { get { throw null; } set { } }
+        public void ApplyToTest(NUnit.Framework.Internal.Test test) { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
+    public partial class LiveParallelizableAttribute : NUnit.Framework.ParallelizableAttribute
+    {
+        public LiveParallelizableAttribute(NUnit.Framework.ParallelScope scope) { }
+    }
+    [Microsoft.ClientModel.TestFramework.LiveOnlyAttribute(false)]
+    public partial class LiveTestBase<TEnvironment> where TEnvironment : Microsoft.ClientModel.TestFramework.TestEnvironment, new()
+    {
+        protected LiveTestBase() { }
+        protected TEnvironment TestEnvironment { get { throw null; } }
+        [NUnit.Framework.OneTimeSetUpAttribute]
+        public System.Threading.Tasks.ValueTask WaitForEnvironment() { throw null; }
+    }
+    public partial class MicrosoftClientModelTestFrameworkContext : System.ClientModel.Primitives.ModelReaderWriterContext
+    {
+        internal MicrosoftClientModelTestFrameworkContext() { }
+        public static Microsoft.ClientModel.TestFramework.MicrosoftClientModelTestFrameworkContext Default { get { throw null; } }
+        protected override bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder builder) { throw null; }
+    }
+    public static partial class MicrosoftClientModelTestFrameworkModelFactory
+    {
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition ApplyCondition(string uriRegex = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer BodyKeySanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody BodyKeySanitizerBody(string jsonPath = null, string value = null, string regex = null, string groupForReplace = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer BodyRegexSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody BodyRegexSanitizerBody(string value = null, string regex = null, string groupForReplace = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer BodyStringSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody BodyStringSanitizerBody(string target = null, string value = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher CustomDefaultMatcher(bool? compareBodies = default(bool?), string excludedHeaders = null, string ignoredHeaders = null, bool? ignoreQueryOrdering = default(bool?), string ignoredQueryParameters = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer GeneralRegexSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody GeneralRegexSanitizerBody(string value = null, string regex = null, string groupForReplace = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer GeneralStringSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody GeneralStringSanitizerBody(string target = null, string value = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer HeaderRegexSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody HeaderRegexSanitizerBody(string key = null, string value = null, string regex = null, string groupForReplace = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer HeaderStringSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody HeaderStringSanitizerBody(string key = null, string target = null, string value = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer OAuthResponseSanitizer() { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions RecordingOptions(bool? handleRedirects = default(bool?), string contextDirectory = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.StoreType? assetsStore = default(Microsoft.ClientModel.TestFramework.TestProxy.Admin.StoreType?), Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations transport = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer RegexEntrySanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody RegexEntrySanitizerBody(Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntryValues target = Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntryValues.Body, string regex = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers RemovedSanitizers(System.Collections.Generic.IEnumerable<string> removed = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer RemoveHeaderSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody RemoveHeaderSanitizerBody(string headersForRemoval = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition SanitizerAddition(string name = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList SanitizerList(System.Collections.Generic.IEnumerable<string> sanitizers = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate TestProxyCertificate(string pemValue = null, string pemKey = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation TestProxyStartInformation(string xRecordingFile = null, string xRecordingAssetsFile = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations TransportCustomizations(bool? allowAutoRedirect = default(bool?), string tlsValidationCert = null, string tlsValidationCertHost = null, System.Collections.Generic.IEnumerable<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate> certificates = null, int? playbackResponseTime = default(int?)) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer UriRegexSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody UriRegexSanitizerBody(string value = null, string regex = null, string groupForReplace = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer UriStringSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody UriStringSanitizerBody(string target = null, string value = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer UriSubscriptionIdSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody body = null) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody UriSubscriptionIdSanitizerBody(string value = null, Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition condition = null) { throw null; }
+    }
+    public partial class MockCredential : System.ClientModel.AuthenticationTokenProvider
+    {
+        public MockCredential() { }
+        public MockCredential(string token, System.DateTimeOffset expiresOn) { }
+        public override System.ClientModel.Primitives.GetTokenOptions? CreateTokenOptions(System.Collections.Generic.IReadOnlyDictionary<string, object> properties) { throw null; }
+        public override System.ClientModel.Primitives.AuthenticationToken GetToken(System.ClientModel.Primitives.GetTokenOptions options, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<System.ClientModel.Primitives.AuthenticationToken> GetTokenAsync(System.ClientModel.Primitives.GetTokenOptions options, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true, Inherited=true)]
+    public partial class PlaybackOnlyAttribute : NUnit.Framework.NUnitAttribute, NUnit.Framework.Interfaces.IApplyToTest
+    {
+        public PlaybackOnlyAttribute(string reason) { }
+        public void ApplyToTest(NUnit.Framework.Internal.Test test) { }
+    }
+    public partial class ProxyTransport : System.ClientModel.Primitives.PipelineTransport
+    {
+        public ProxyTransport(Microsoft.ClientModel.TestFramework.TestProxyProcess proxyProcess, System.ClientModel.Primitives.PipelineTransport innerTransport, Microsoft.ClientModel.TestFramework.TestRecording recording, System.Func<Microsoft.ClientModel.TestFramework.EntryRecordModel> getRecordingMode) { }
+        protected override System.ClientModel.Primitives.PipelineMessage CreateMessageCore() { throw null; }
+        protected override void ProcessCore(System.ClientModel.Primitives.PipelineMessage message) { }
+        protected override System.Threading.Tasks.ValueTask ProcessCoreAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
+    }
+    public static partial class RandomExtensions
+    {
+        public static System.Guid NewGuid(this System.Random random) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method)]
+    public partial class RecordedTestAttribute : NUnit.Framework.TestAttribute, NUnit.Framework.Interfaces.ICommandWrapper, NUnit.Framework.Interfaces.IWrapSetUpTearDown
+    {
+        public RecordedTestAttribute() { }
+        public NUnit.Framework.Internal.Commands.TestCommand Wrap(NUnit.Framework.Internal.Commands.TestCommand command) { throw null; }
+    }
+    [NUnit.Framework.NonParallelizableAttribute]
+    public abstract partial class RecordedTestBase : Microsoft.ClientModel.TestFramework.ClientTestBase
+    {
+        public const string AssetsJson = "assets.json";
+        public System.Collections.Generic.HashSet<string> IgnoredHeaders;
+        public System.Collections.Generic.HashSet<string> IgnoredQueryParameters;
+        public const string SanitizeValue = "Sanitized";
+        protected RecordedTestBase(bool isAsync, Microsoft.ClientModel.TestFramework.RecordedTestMode? mode = default(Microsoft.ClientModel.TestFramework.RecordedTestMode?)) : base (default(bool)) { }
+        public virtual string? AssetsJsonPath { get { throw null; } }
+        public virtual System.Collections.Generic.List<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer> BodyKeySanitizers { get { throw null; } }
+        public virtual System.Collections.Generic.List<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer> BodyRegexSanitizers { get { throw null; } }
+        public bool CompareBodies { get { throw null; } set { } }
+        public virtual System.Collections.Generic.List<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer> HeaderRegexSanitizers { get { throw null; } }
+        public virtual System.Collections.Generic.List<string> JsonPathSanitizers { get { throw null; } }
+        public Microsoft.ClientModel.TestFramework.RecordedTestMode Mode { get { throw null; } set { } }
+        public virtual Microsoft.ClientModel.TestFramework.TestRecording? Recording { get { throw null; } }
+        public virtual System.Collections.Generic.List<string> SanitizedHeaders { get { throw null; } }
+        public virtual System.Collections.Generic.List<string> SanitizedQueryParameters { get { throw null; } }
+        public virtual System.Collections.Generic.List<(string Header, string QueryParameter)> SanitizedQueryParametersInHeaders { get { throw null; } }
+        public virtual System.Collections.Generic.List<string> SanitizersToRemove { get { throw null; } }
+        public bool SaveDebugRecordingsOnFailure { get { throw null; } set { } }
+        protected Microsoft.ClientModel.TestFramework.TestRetryHelper TestRetryHelper { get { throw null; } }
+        protected override System.DateTime TestStartTime { get { throw null; } }
+        public virtual System.Collections.Generic.List<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer> UriRegexSanitizers { get { throw null; } }
+        protected bool UseLocalDebugProxy { get { throw null; } set { } }
+        protected bool ValidateClientInstrumentation { get { throw null; } set { } }
+        protected internal override object CreateProxyFromClient(System.Type clientType, object client, System.Collections.Generic.IEnumerable<Castle.DynamicProxy.IInterceptor>? preInterceptors) { throw null; }
+        protected System.Threading.Tasks.Task<Microsoft.ClientModel.TestFramework.TestRecording> CreateTestRecordingAsync(Microsoft.ClientModel.TestFramework.RecordedTestMode mode, string sessionFile) { throw null; }
+        public static System.Threading.Tasks.Task Delay(Microsoft.ClientModel.TestFramework.RecordedTestMode mode, int milliseconds = 1000, int? playbackDelayMilliseconds = default(int?)) { throw null; }
+        public System.Threading.Tasks.Task Delay(int milliseconds = 1000, int? playbackDelayMilliseconds = default(int?)) { throw null; }
+        protected internal string GetSessionFilePath() { throw null; }
+        public override void GlobalTimeoutTearDown() { }
+        [NUnit.Framework.OneTimeSetUpAttribute]
+        public void InitializeRecordedTestClass() { }
+        public T InstrumentClientOptions<T>(T clientOptions, Microsoft.ClientModel.TestFramework.TestRecording? recording = null) where T : System.ClientModel.Primitives.ClientPipelineOptions { throw null; }
+        protected System.Threading.Tasks.Task SetProxyOptionsAsync(Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions options) { throw null; }
+        [NUnit.Framework.SetUpAttribute]
+        public virtual System.Threading.Tasks.Task StartTestRecordingAsync() { throw null; }
+        [NUnit.Framework.TearDownAttribute]
+        public virtual System.Threading.Tasks.Task StopTestRecordingAsync() { throw null; }
+        [NUnit.Framework.OneTimeTearDownAttribute]
+        public void TearDownRecordedTestClass() { }
+    }
+    public abstract partial class RecordedTestBase<TEnvironment> : Microsoft.ClientModel.TestFramework.RecordedTestBase where TEnvironment : Microsoft.ClientModel.TestFramework.TestEnvironment, new()
+    {
+        protected RecordedTestBase(bool isAsync, Microsoft.ClientModel.TestFramework.RecordedTestMode? mode = default(Microsoft.ClientModel.TestFramework.RecordedTestMode?)) : base (default(bool), default(Microsoft.ClientModel.TestFramework.RecordedTestMode?)) { }
+        public TEnvironment TestEnvironment { get { throw null; } }
+        public override System.Threading.Tasks.Task StartTestRecordingAsync() { throw null; }
+        [NUnit.Framework.OneTimeSetUpAttribute]
+        public System.Threading.Tasks.ValueTask WaitForEnvironment() { throw null; }
+    }
+    public enum RecordedTestMode
+    {
+        Live = 0,
+        Record = 1,
+        Playback = 2,
+    }
+    public partial class RecordedVariableOptions
+    {
+        public RecordedVariableOptions() { }
+        public string Apply(string value) { throw null; }
+        public Microsoft.ClientModel.TestFramework.RecordedVariableOptions IsSecret(Microsoft.ClientModel.TestFramework.SanitizedValue sanitizedValue = Microsoft.ClientModel.TestFramework.SanitizedValue.Default) { throw null; }
+        public Microsoft.ClientModel.TestFramework.RecordedVariableOptions IsSecret(string sanitizedValue) { throw null; }
+    }
+    public partial class RecordEntryMessage
+    {
+        public RecordEntryMessage() { }
+        public byte[]? Body { get { throw null; } set { } }
+        public System.Collections.Generic.SortedDictionary<string, string[]> Headers { get { throw null; } set { } }
+        public bool IsTextContentType(out System.Text.Encoding? encoding) { throw null; }
+        public bool TryGetBodyAsText(out string? text) { throw null; }
+        public bool TryGetContentType(out string? contentType) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Method, AllowMultiple=false, Inherited=false)]
+    public abstract partial class RetryOnErrorAttribute : NUnit.Framework.NUnitAttribute, NUnit.Framework.Interfaces.ICommandWrapper, NUnit.Framework.Interfaces.IRepeatTest
+    {
+        protected RetryOnErrorAttribute(int tryCount, System.Func<NUnit.Framework.Internal.TestExecutionContext, bool> shouldRetry) { }
+        public NUnit.Framework.Internal.Commands.TestCommand Wrap(NUnit.Framework.Internal.Commands.TestCommand command) { throw null; }
+        public partial class RetryOnErrorCommand : NUnit.Framework.Internal.Commands.DelegatingTestCommand
+        {
+            public RetryOnErrorCommand(NUnit.Framework.Internal.Commands.TestCommand innerCommand, int tryCount, System.Func<NUnit.Framework.Internal.TestExecutionContext, bool> shouldRetry) : base (default(NUnit.Framework.Internal.Commands.TestCommand)) { }
+            public override NUnit.Framework.Internal.TestResult Execute(NUnit.Framework.Internal.TestExecutionContext context) { throw null; }
+        }
+    }
+    public enum SanitizedValue
+    {
+        Default = 0,
+        Base64 = 1,
+    }
+    [NUnit.Framework.TestFixtureAttribute(new object[]{ false})]
+    [NUnit.Framework.TestFixtureAttribute(new object[]{ true})]
+    public partial class SyncAsyncPolicyTestBase : Microsoft.ClientModel.TestFramework.SyncAsyncTestBase
+    {
+        public SyncAsyncPolicyTestBase(bool isAsync) : base (default(bool)) { }
+        protected System.Threading.Tasks.Task<System.ClientModel.Primitives.PipelineResponse> SendGetRequest(System.ClientModel.Primitives.HttpClientPipelineTransport transport, System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelineMessageClassifier? responseClassifier = null, bool bufferResponse = true, System.Uri? uri = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected System.Threading.Tasks.Task<System.ClientModel.Primitives.PipelineMessage> SendMessageGetRequest(System.ClientModel.Primitives.ClientPipeline pipeline, System.ClientModel.Primitives.PipelineMessage message, System.ClientModel.Primitives.PipelineMessageClassifier? responseClassifier = null, bool bufferResponse = true, System.Uri? uri = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected System.Threading.Tasks.Task<System.ClientModel.Primitives.PipelineMessage> SendMessageRequestAsync(System.ClientModel.Primitives.ClientPipeline pipeline, System.Action<System.ClientModel.Primitives.PipelineMessage> messageAction, bool bufferResponse = true, System.ClientModel.Primitives.PipelineMessage? message = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected System.Threading.Tasks.Task<System.ClientModel.Primitives.PipelineResponse> SendRequestAsync(System.ClientModel.Primitives.ClientPipeline pipeline, System.Action<System.ClientModel.Primitives.PipelineMessage> messageAction, bool bufferResponse = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected System.Threading.Tasks.Task<System.ClientModel.Primitives.PipelineResponse> SendRequestAsync(System.ClientModel.Primitives.ClientPipeline pipeline, System.Action<System.ClientModel.Primitives.PipelineRequest> requestAction, bool bufferResponse = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected System.Threading.Tasks.Task<System.ClientModel.Primitives.PipelineResponse> SendRequestAsync(System.ClientModel.Primitives.HttpClientPipelineTransport transport, System.Action<System.ClientModel.Primitives.PipelineMessage> messageAction, System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelineMessageClassifier? responseClassifier = null, bool bufferResponse = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected System.Threading.Tasks.Task<System.ClientModel.Primitives.PipelineResponse> SendRequestAsync(System.ClientModel.Primitives.HttpClientPipelineTransport transport, System.Action<System.ClientModel.Primitives.PipelineRequest> requestAction, System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelineMessageClassifier? responseClassifier = null, bool bufferResponse = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class SyncAsyncTestBase
+    {
+        public SyncAsyncTestBase(bool isAsync) { }
+        public bool IsAsync { get { throw null; } }
+        protected Microsoft.ClientModel.TestFramework.Mocks.MockPipelineTransport CreateMockTransport() { throw null; }
+        protected Microsoft.ClientModel.TestFramework.Mocks.MockPipelineTransport CreateMockTransport(System.Func<Microsoft.ClientModel.TestFramework.Mocks.MockPipelineMessage, Microsoft.ClientModel.TestFramework.Mocks.MockPipelineResponse> responseFactory) { throw null; }
+        protected System.IO.Stream WrapStream(System.IO.Stream stream) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=false, Inherited=true)]
+    public partial class SyncOnlyAttribute : NUnit.Framework.NUnitAttribute
+    {
+        public SyncOnlyAttribute() { }
+    }
+    public static partial class TaskExtensions
+    {
+        public static System.TimeSpan DefaultTimeout { get { throw null; } }
+        public static Microsoft.ClientModel.TestFramework.TaskExtensions.WithCancellationTaskAwaitable AwaitWithCancellation(this System.Threading.Tasks.Task task, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TaskExtensions.WithCancellationTaskAwaitable<T> AwaitWithCancellation<T>(this System.Threading.Tasks.Task<T> task, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TaskExtensions.WithCancellationValueTaskAwaitable<T> AwaitWithCancellation<T>(this System.Threading.Tasks.ValueTask<T> task, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public static System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable EnsureCompleted(this System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable awaitable, bool async) { throw null; }
+        public static void EnsureCompleted(this System.Threading.Tasks.Task task) { }
+        public static void EnsureCompleted(this System.Threading.Tasks.ValueTask task) { }
+        public static System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<T> EnsureCompleted<T>(this System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<T> awaitable, bool async) { throw null; }
+        public static T EnsureCompleted<T>(this System.Threading.Tasks.Task<T> task) { throw null; }
+        public static T EnsureCompleted<T>(this System.Threading.Tasks.ValueTask<T> task) { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TaskExtensions.Enumerable<T> EnsureSyncEnumerable<T>(this System.Collections.Generic.IAsyncEnumerable<T> asyncEnumerable) { throw null; }
+        public static object? GetResultFromTask(object returnValue) { throw null; }
+        public static object? GetValueFromTask(System.Type taskResultType, object instrumentedResult) { throw null; }
+        public static bool? IsTaskFaulted(object taskObj) { throw null; }
+        public static bool IsTaskType(System.Type type) { throw null; }
+        public static System.Threading.Tasks.Task TimeoutAfter(this System.Threading.Tasks.Task task, System.TimeSpan timeout, [System.Runtime.CompilerServices.CallerFilePathAttribute] string? filePath = null, [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNumber = 0) { throw null; }
+        public static System.Threading.Tasks.ValueTask TimeoutAfter(this System.Threading.Tasks.ValueTask task, System.TimeSpan timeout, [System.Runtime.CompilerServices.CallerFilePathAttribute] string? filePath = null, [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNumber = 0) { throw null; }
+        public static System.Threading.Tasks.Task TimeoutAfterDefault(this System.Threading.Tasks.Task task, [System.Runtime.CompilerServices.CallerFilePathAttribute] string? filePath = null, [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNumber = 0) { throw null; }
+        public static System.Threading.Tasks.ValueTask TimeoutAfterDefault(this System.Threading.Tasks.ValueTask task, [System.Runtime.CompilerServices.CallerFilePathAttribute] string? filePath = null, [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNumber = 0) { throw null; }
+        public static System.Threading.Tasks.Task<T> TimeoutAfterDefault<T>(this System.Threading.Tasks.Task<T> task, [System.Runtime.CompilerServices.CallerFilePathAttribute] string? filePath = null, [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNumber = 0) { throw null; }
+        public static System.Threading.Tasks.ValueTask<T> TimeoutAfterDefault<T>(this System.Threading.Tasks.ValueTask<T> task, [System.Runtime.CompilerServices.CallerFilePathAttribute] string? filePath = null, [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNumber = 0) { throw null; }
+        public static System.Threading.Tasks.Task<T> TimeoutAfter<T>(this System.Threading.Tasks.Task<T> task, System.TimeSpan timeout, [System.Runtime.CompilerServices.CallerFilePathAttribute] string? filePath = null, [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNumber = 0) { throw null; }
+        public static System.Threading.Tasks.ValueTask<T> TimeoutAfter<T>(this System.Threading.Tasks.ValueTask<T> task, System.TimeSpan timeout, [System.Runtime.CompilerServices.CallerFilePathAttribute] string? filePath = null, [System.Runtime.CompilerServices.CallerLineNumberAttribute] int lineNumber = 0) { throw null; }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct Enumerable<T> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public Enumerable(System.Collections.Generic.IAsyncEnumerable<T> asyncEnumerable) { throw null; }
+            public Microsoft.ClientModel.TestFramework.TaskExtensions.Enumerator<T> GetEnumerator() { throw null; }
+            System.Collections.Generic.IEnumerator<T> System.Collections.Generic.IEnumerable<T>.GetEnumerator() { throw null; }
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct Enumerator<T> : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public Enumerator(System.Collections.Generic.IAsyncEnumerator<T> asyncEnumerator) { throw null; }
+            public T Current { get { throw null; } }
+            object? System.Collections.IEnumerator.Current { get { throw null; } }
+            public void Dispose() { }
+            public bool MoveNext() { throw null; }
+            public void Reset() { }
+        }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct WithCancellationTaskAwaitable
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public WithCancellationTaskAwaitable(System.Threading.Tasks.Task task, System.Threading.CancellationToken cancellationToken) { throw null; }
+            public Microsoft.ClientModel.TestFramework.TaskExtensions.WithCancellationTaskAwaiter GetAwaiter() { throw null; }
+        }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct WithCancellationTaskAwaitable<T>
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public WithCancellationTaskAwaitable(System.Threading.Tasks.Task<T> task, System.Threading.CancellationToken cancellationToken) { throw null; }
+            public Microsoft.ClientModel.TestFramework.TaskExtensions.WithCancellationTaskAwaiter<T> GetAwaiter() { throw null; }
+        }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct WithCancellationTaskAwaiter : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public WithCancellationTaskAwaiter(System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter awaiter, System.Threading.CancellationToken cancellationToken) { throw null; }
+            public bool IsCompleted { get { throw null; } }
+            public void GetResult() { }
+            public void OnCompleted(System.Action continuation) { }
+            public void UnsafeOnCompleted(System.Action continuation) { }
+        }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct WithCancellationTaskAwaiter<T> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public WithCancellationTaskAwaiter(System.Runtime.CompilerServices.ConfiguredTaskAwaitable<T>.ConfiguredTaskAwaiter awaiter, System.Threading.CancellationToken cancellationToken) { throw null; }
+            public bool IsCompleted { get { throw null; } }
+            public T GetResult() { throw null; }
+            public void OnCompleted(System.Action continuation) { }
+            public void UnsafeOnCompleted(System.Action continuation) { }
+        }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct WithCancellationValueTaskAwaitable<T>
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public WithCancellationValueTaskAwaitable(System.Threading.Tasks.ValueTask<T> task, System.Threading.CancellationToken cancellationToken) { throw null; }
+            public Microsoft.ClientModel.TestFramework.TaskExtensions.WithCancellationValueTaskAwaiter<T> GetAwaiter() { throw null; }
+        }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public readonly partial struct WithCancellationValueTaskAwaiter<T> : System.Runtime.CompilerServices.ICriticalNotifyCompletion, System.Runtime.CompilerServices.INotifyCompletion
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public WithCancellationValueTaskAwaiter(System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<T>.ConfiguredValueTaskAwaiter awaiter, System.Threading.CancellationToken cancellationToken) { throw null; }
+            public bool IsCompleted { get { throw null; } }
+            public T GetResult() { throw null; }
+            public void OnCompleted(System.Action continuation) { }
+            public void UnsafeOnCompleted(System.Action continuation) { }
+        }
+    }
+    public static partial class TestAsyncEnumerableExtensions
+    {
+        public static System.Threading.Tasks.Task<System.Collections.Generic.List<T>> ToEnumerableAsync<T>(this System.Collections.Generic.IAsyncEnumerable<T> asyncEnumerable) { throw null; }
+    }
+    public abstract partial class TestEnvironment
+    {
+        public const string DevCertPassword = "password";
+        protected TestEnvironment() { }
+        public virtual System.ClientModel.AuthenticationTokenProvider Credential { get { throw null; } }
+        public static string? DevCertPath { get { throw null; } protected set { } }
+        public static bool IsWindows { get { throw null; } }
+        public Microsoft.ClientModel.TestFramework.RecordedTestMode? Mode { get { throw null; } set { } }
+        public string? PathToTestResourceBootstrappingScript { get { throw null; } set { } }
+        public static string? RepositoryRoot { get { throw null; } protected set { } }
+        public void BootStrapTestResources() { }
+        protected string? GetOptionalVariable(string name) { throw null; }
+        protected string? GetRecordedOptionalVariable(string name) { throw null; }
+        protected string? GetRecordedOptionalVariable(string name, System.Action<Microsoft.ClientModel.TestFramework.RecordedVariableOptions>? options) { throw null; }
+        protected string GetRecordedVariable(string name) { throw null; }
+        protected string GetRecordedVariable(string name, System.Action<Microsoft.ClientModel.TestFramework.RecordedVariableOptions>? options) { throw null; }
+        public static string GetSourcePath(System.Reflection.Assembly assembly) { throw null; }
+        protected string GetVariable(string name) { throw null; }
+        public abstract System.Collections.Generic.Dictionary<string, string> ParseEnvironmentFile();
+        public virtual void SetRecording(Microsoft.ClientModel.TestFramework.TestRecording recording) { }
+        public abstract System.Threading.Tasks.Task WaitForEnvironmentAsync();
+    }
+    public partial class TestEnvVar : Microsoft.ClientModel.TestFramework.DisposableConfig
+    {
+        public TestEnvVar(System.Collections.Generic.Dictionary<string, string> values) : base (default(string), default(string), default(System.Threading.SemaphoreSlim)) { }
+        public TestEnvVar(string name, string value) : base (default(string), default(string), default(System.Threading.SemaphoreSlim)) { }
+    }
+    public partial class TestProxyProcess
+    {
+        internal TestProxyProcess() { }
+        public const string IpAddress = "127.0.0.1";
+        public int? ProxyPortHttp { get { throw null; } }
+        public int? ProxyPortHttps { get { throw null; } }
+        public virtual System.Threading.Tasks.Task CheckProxyOutputAsync() { throw null; }
+        public static Microsoft.ClientModel.TestFramework.TestProxyProcess Start(bool debugMode = false) { throw null; }
+    }
+    public partial class TestRandom : System.Random
+    {
+        public TestRandom(Microsoft.ClientModel.TestFramework.RecordedTestMode mode) { }
+        public TestRandom(Microsoft.ClientModel.TestFramework.RecordedTestMode mode, int seed) { }
+        public System.Guid NewGuid() { throw null; }
+    }
+    public partial class TestRecording : System.IAsyncDisposable
+    {
+        internal TestRecording() { }
+        public bool HasRequests { get { throw null; } }
+        public Microsoft.ClientModel.TestFramework.RecordedTestMode Mode { get { throw null; } }
+        public System.DateTimeOffset Now { get { throw null; } }
+        public Microsoft.ClientModel.TestFramework.TestRandom Random { get { throw null; } }
+        public string? RecordingId { get { throw null; } }
+        public System.DateTimeOffset UtcNow { get { throw null; } }
+        public System.Collections.Generic.SortedDictionary<string, string> Variables { get { throw null; } }
+        public static System.Threading.Tasks.Task<Microsoft.ClientModel.TestFramework.TestRecording> CreateAsync(Microsoft.ClientModel.TestFramework.RecordedTestMode mode, string sessionFile, Microsoft.ClientModel.TestFramework.TestProxyProcess? proxy, Microsoft.ClientModel.TestFramework.RecordedTestBase recordedTestBase, System.Threading.CancellationToken? cancellationToken = default(System.Threading.CancellationToken?)) { throw null; }
+        public virtual System.ClientModel.Primitives.PipelineTransport? CreateTransport(System.ClientModel.Primitives.PipelineTransport? currentTransport) { throw null; }
+        public virtual Microsoft.ClientModel.TestFramework.TestRecording.DisableRecordingScope DisableRecording() { throw null; }
+        public virtual Microsoft.ClientModel.TestFramework.TestRecording.DisableRecordingScope DisableRequestBodyRecording() { throw null; }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
+        public System.Threading.Tasks.ValueTask DisposeAsync(bool save) { throw null; }
+        public virtual string GenerateAlphaNumericId(string prefix, int? maxLength = default(int?), bool useOnlyLowercase = false) { throw null; }
+        public virtual string GenerateAssetName(string prefix, [System.Runtime.CompilerServices.CallerMemberNameAttribute] string callerMethodName = "testframework_failed") { throw null; }
+        public virtual string GenerateId() { throw null; }
+        public virtual string GenerateId(string prefix, int maxLength) { throw null; }
+        public virtual string? GetVariable(string variableName, string defaultValue, System.Func<string, string>? sanitizer = null) { throw null; }
+        public virtual void SetVariable(string variableName, string? value, System.Func<string, string>? sanitizer = null) { }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct DisableRecordingScope : System.IDisposable
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public DisableRecordingScope(Microsoft.ClientModel.TestFramework.TestRecording testRecording, Microsoft.ClientModel.TestFramework.EntryRecordModel entryRecordModel) { throw null; }
+            public void Dispose() { }
+        }
+    }
+    public partial class TestRecordingMismatchException : System.Exception
+    {
+        public TestRecordingMismatchException() { }
+        public TestRecordingMismatchException(string message) { }
+        public TestRecordingMismatchException(string message, System.Exception innerException) { }
+    }
+    public partial class TestRetryHelper
+    {
+        public TestRetryHelper(bool noWait) { }
+        public System.Threading.Tasks.Task<T> RetryAsync<T>(System.Func<System.Threading.Tasks.Task<T>> operation, int maxIterations = 20, System.TimeSpan delay = default(System.TimeSpan)) { throw null; }
+    }
+    public partial class TestTimeoutException : System.Exception
+    {
+        public TestTimeoutException() { }
+        public TestTimeoutException(string message) { }
+        public TestTimeoutException(string message, System.Exception innerException) { }
+    }
+}
+namespace Microsoft.ClientModel.TestFramework.Mocks
+{
+    public partial class MockPipelineMessage : System.ClientModel.Primitives.PipelineMessage
+    {
+        public MockPipelineMessage() : base (default(System.ClientModel.Primitives.PipelineRequest)) { }
+        public MockPipelineMessage(System.ClientModel.Primitives.PipelineRequest request) : base (default(System.ClientModel.Primitives.PipelineRequest)) { }
+        public void SetResponse(System.ClientModel.Primitives.PipelineResponse response) { }
+    }
+    public partial class MockPipelineRequest : System.ClientModel.Primitives.PipelineRequest
+    {
+        public MockPipelineRequest() { }
+        protected override System.ClientModel.BinaryContent? ContentCore { get { throw null; } set { } }
+        protected override System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get { throw null; } }
+        protected override string MethodCore { get { throw null; } set { } }
+        protected override System.Uri? UriCore { get { throw null; } set { } }
+        public sealed override void Dispose() { }
+    }
+    public partial class MockPipelineResponse : System.ClientModel.Primitives.PipelineResponse
+    {
+        public MockPipelineResponse(int status = 0, string reasonPhrase = "") { }
+        public override System.BinaryData Content { get { throw null; } }
+        public override System.IO.Stream? ContentStream { get { throw null; } set { } }
+        protected override System.ClientModel.Primitives.PipelineResponseHeaders HeadersCore { get { throw null; } }
+        public bool IsDisposed { get { throw null; } }
+        public override string ReasonPhrase { get { throw null; } }
+        public override int Status { get { throw null; } }
+        public override System.BinaryData BufferContent(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public override System.Threading.Tasks.ValueTask<System.BinaryData> BufferContentAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public sealed override void Dispose() { }
+        protected void Dispose(bool disposing) { }
+        public void SetIsError(bool value) { }
+        public Microsoft.ClientModel.TestFramework.Mocks.MockPipelineResponse WithContent(byte[] content) { throw null; }
+        public Microsoft.ClientModel.TestFramework.Mocks.MockPipelineResponse WithContent(System.ClientModel.BinaryContent content) { throw null; }
+        public Microsoft.ClientModel.TestFramework.Mocks.MockPipelineResponse WithContent(string content) { throw null; }
+        public Microsoft.ClientModel.TestFramework.Mocks.MockPipelineResponse WithHeader(string name, string value) { throw null; }
+    }
+    public partial class MockPipelineTransport : System.ClientModel.Primitives.PipelineTransport
+    {
+        public MockPipelineTransport() { }
+        public MockPipelineTransport(System.Func<Microsoft.ClientModel.TestFramework.Mocks.MockPipelineMessage, Microsoft.ClientModel.TestFramework.Mocks.MockPipelineResponse> responseFactory, bool addDelay = false, bool enableLogging = false, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory = null) { }
+        public bool? ExpectSyncPipeline { get { throw null; } set { } }
+        public System.Action<Microsoft.ClientModel.TestFramework.Mocks.MockPipelineMessage>? OnReceivedResponse { get { throw null; } set { } }
+        public System.Action<Microsoft.ClientModel.TestFramework.Mocks.MockPipelineMessage>? OnSendingRequest { get { throw null; } set { } }
+        public System.Collections.Generic.List<Microsoft.ClientModel.TestFramework.Mocks.MockPipelineRequest> Requests { get { throw null; } }
+        protected override System.ClientModel.Primitives.PipelineMessage CreateMessageCore() { throw null; }
+        protected override void ProcessCore(System.ClientModel.Primitives.PipelineMessage message) { }
+        protected override System.Threading.Tasks.ValueTask ProcessCoreAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
+    }
+}
+namespace Microsoft.ClientModel.TestFramework.TestProxy
+{
+    public partial class TestProxyClient
+    {
+        public TestProxyClient() { }
+        public TestProxyClient(System.Uri endpoint, Microsoft.ClientModel.TestFramework.TestProxy.TestProxyClientOptions options) { }
+        public System.ClientModel.Primitives.ClientPipeline Pipeline { get { throw null; } }
+        public virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyAdminClient GetTestProxyAdminClient() { throw null; }
+        public virtual System.ClientModel.ClientResult<System.Collections.Generic.IReadOnlyDictionary<string, string>> StartPlayback(Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation body, string recordingId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.ClientModel.ClientResult StartPlayback(System.ClientModel.BinaryContent content, string recordingId = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult<System.Collections.Generic.IReadOnlyDictionary<string, string>>> StartPlaybackAsync(Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation body, string recordingId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> StartPlaybackAsync(System.ClientModel.BinaryContent content, string recordingId = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.ClientModel.ClientResult StartRecord(Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.ClientModel.ClientResult StartRecord(System.ClientModel.BinaryContent content, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> StartRecordAsync(Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation body, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> StartRecordAsync(System.ClientModel.BinaryContent content, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.ClientModel.ClientResult StopPlayback(string recordingId, System.ClientModel.Primitives.RequestOptions options) { throw null; }
+        public virtual System.ClientModel.ClientResult StopPlayback(string recordingId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> StopPlaybackAsync(string recordingId, System.ClientModel.Primitives.RequestOptions options) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> StopPlaybackAsync(string recordingId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.ClientModel.ClientResult StopRecord(string recordingId, System.ClientModel.BinaryContent content, string recordingSkip = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.ClientModel.ClientResult StopRecord(string recordingId, System.Collections.Generic.IDictionary<string, string> variables, string recordingSkip = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> StopRecordAsync(string recordingId, System.ClientModel.BinaryContent content, string recordingSkip = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> StopRecordAsync(string recordingId, System.Collections.Generic.IDictionary<string, string> variables, string recordingSkip = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    public partial class TestProxyClientOptions : System.ClientModel.Primitives.ClientPipelineOptions
+    {
+        public TestProxyClientOptions() { }
+    }
+    public partial class TestProxyStartInformation : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation>
+    {
+        public TestProxyStartInformation(string xRecordingFile) { }
+        public string XRecordingAssetsFile { get { throw null; } set { } }
+        public string XRecordingFile { get { throw null; } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        public static implicit operator System.ClientModel.BinaryContent (Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation testProxyStartInformation) { throw null; }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.TestProxyStartInformation>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+}
+namespace Microsoft.ClientModel.TestFramework.TestProxy.Admin
+{
+    public partial class ApplyCondition : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition>
+    {
+        public ApplyCondition(string uriRegex) { }
+        public string UriRegex { get { throw null; } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class BodyKeySanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer>
+    {
+        public BodyKeySanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class BodyKeySanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody>
+    {
+        public BodyKeySanitizerBody(string jsonPath) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string GroupForReplace { get { throw null; } set { } }
+        public string JsonPath { get { throw null; } }
+        public string Regex { get { throw null; } set { } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyKeySanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class BodyRegexSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer>
+    {
+        public BodyRegexSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class BodyRegexSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody>
+    {
+        public BodyRegexSanitizerBody() { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string GroupForReplace { get { throw null; } set { } }
+        public string Regex { get { throw null; } set { } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyRegexSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class BodyStringSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer>
+    {
+        public BodyStringSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class BodyStringSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody>
+    {
+        public BodyStringSanitizerBody(string target) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string Target { get { throw null; } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.BodyStringSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class CustomDefaultMatcher : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher>
+    {
+        public CustomDefaultMatcher() { }
+        public bool? CompareBodies { get { throw null; } set { } }
+        public string ExcludedHeaders { get { throw null; } set { } }
+        public string IgnoredHeaders { get { throw null; } set { } }
+        public string IgnoredQueryParameters { get { throw null; } set { } }
+        public bool? IgnoreQueryOrdering { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        public static implicit operator System.ClientModel.BinaryContent (Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher customDefaultMatcher) { throw null; }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class GeneralRegexSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer>
+    {
+        public GeneralRegexSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class GeneralRegexSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody>
+    {
+        public GeneralRegexSanitizerBody() { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string GroupForReplace { get { throw null; } set { } }
+        public string Regex { get { throw null; } set { } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralRegexSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class GeneralStringSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer>
+    {
+        public GeneralStringSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class GeneralStringSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody>
+    {
+        public GeneralStringSanitizerBody(string target) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string Target { get { throw null; } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.GeneralStringSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class HeaderRegexSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer>
+    {
+        public HeaderRegexSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody Body { get { throw null; } }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer CreateWithQueryParameter(string headerKey, string queryParameter, string sanitizedValue) { throw null; }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class HeaderRegexSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody>
+    {
+        public HeaderRegexSanitizerBody(string key) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string GroupForReplace { get { throw null; } set { } }
+        public string Key { get { throw null; } }
+        public string Regex { get { throw null; } set { } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderRegexSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class HeaderStringSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer>
+    {
+        public HeaderStringSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class HeaderStringSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody>
+    {
+        public HeaderStringSanitizerBody(string key, string target) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string Key { get { throw null; } }
+        public string Target { get { throw null; } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.HeaderStringSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public enum MatcherType
+    {
+        BodilessMatcher = 0,
+        CustomDefaultMatcher = 1,
+        HeaderlessMatcher = 2,
+    }
+    public partial class OAuthResponseSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer>
+    {
+        public OAuthResponseSanitizer() { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.OAuthResponseSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class RecordingOptions : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions>
+    {
+        public RecordingOptions() { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.StoreType? AssetsStore { get { throw null; } set { } }
+        public string ContextDirectory { get { throw null; } set { } }
+        public bool? HandleRedirects { get { throw null; } set { } }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations Transport { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        public static implicit operator System.ClientModel.BinaryContent (Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions recordingOptions) { throw null; }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class RegexEntrySanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer>
+    {
+        public RegexEntrySanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class RegexEntrySanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody>
+    {
+        public RegexEntrySanitizerBody(Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntryValues target, string regex) { }
+        public string Regex { get { throw null; } }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntryValues Target { get { throw null; } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RegexEntrySanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public enum RegexEntryValues
+    {
+        Body = 0,
+        Header = 1,
+        Uri = 2,
+    }
+    public partial class RemovedSanitizers : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers>
+    {
+        internal RemovedSanitizers() { }
+        public System.Collections.Generic.IList<string> Removed { get { throw null; } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        public static explicit operator Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers (System.ClientModel.ClientResult result) { throw null; }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class RemoveHeaderSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer>
+    {
+        public RemoveHeaderSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class RemoveHeaderSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody>
+    {
+        public RemoveHeaderSanitizerBody(string headersForRemoval) { }
+        public string HeadersForRemoval { get { throw null; } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemoveHeaderSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public abstract partial class SanitizerAddition : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition>
+    {
+        internal SanitizerAddition() { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class SanitizerList : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList>
+    {
+        public SanitizerList(System.Collections.Generic.IEnumerable<string> sanitizers) { }
+        public System.Collections.Generic.IList<string> Sanitizers { get { throw null; } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        public static implicit operator System.ClientModel.BinaryContent (Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList sanitizerList) { throw null; }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public enum StoreType
+    {
+        GitStore = 0,
+    }
+    public partial class TestProxyAdminClient
+    {
+        protected TestProxyAdminClient() { }
+        public System.ClientModel.Primitives.ClientPipeline Pipeline { get { throw null; } }
+        public virtual System.ClientModel.ClientResult AddSanitizers(System.ClientModel.BinaryContent content, string recordingId = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.ClientModel.ClientResult AddSanitizers(System.Collections.Generic.IEnumerable<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition> sanitizers, string recordingId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> AddSanitizersAsync(System.ClientModel.BinaryContent content, string recordingId = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> AddSanitizersAsync(System.Collections.Generic.IEnumerable<Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition> sanitizers, string recordingId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.ClientModel.ClientResult<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers> RemoveSanitizers(Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList sanitizers, string recordingId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.ClientModel.ClientResult RemoveSanitizers(System.ClientModel.BinaryContent content, string recordingId = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult<Microsoft.ClientModel.TestFramework.TestProxy.Admin.RemovedSanitizers>> RemoveSanitizersAsync(Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerList sanitizers, string recordingId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> RemoveSanitizersAsync(System.ClientModel.BinaryContent content, string recordingId = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.ClientModel.ClientResult SetMatcher(Microsoft.ClientModel.TestFramework.TestProxy.Admin.MatcherType matcherType, Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher matcher = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.ClientModel.ClientResult SetMatcher(string matcherType, System.ClientModel.BinaryContent content = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> SetMatcherAsync(Microsoft.ClientModel.TestFramework.TestProxy.Admin.MatcherType matcherType, Microsoft.ClientModel.TestFramework.TestProxy.Admin.CustomDefaultMatcher matcher = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> SetMatcherAsync(string matcherType, System.ClientModel.BinaryContent content = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.ClientModel.ClientResult SetRecordingOptions(Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions body, string recordingId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.ClientModel.ClientResult SetRecordingOptions(System.ClientModel.BinaryContent content, string recordingId = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> SetRecordingOptionsAsync(Microsoft.ClientModel.TestFramework.TestProxy.Admin.RecordingOptions body, string recordingId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.ClientModel.ClientResult> SetRecordingOptionsAsync(System.ClientModel.BinaryContent content, string recordingId = null, System.ClientModel.Primitives.RequestOptions options = null) { throw null; }
+    }
+    public partial class TestProxyCertificate : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate>
+    {
+        public TestProxyCertificate(string pemValue, string pemKey) { }
+        public string PemKey { get { throw null; } }
+        public string PemValue { get { throw null; } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class TransportCustomizations : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations>
+    {
+        public TransportCustomizations() { }
+        public bool? AllowAutoRedirect { get { throw null; } set { } }
+        public System.Collections.Generic.IList<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TestProxyCertificate> Certificates { get { throw null; } }
+        public int? PlaybackResponseTime { get { throw null; } set { } }
+        public string TLSValidationCert { get { throw null; } set { } }
+        public string TLSValidationCertHost { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.TransportCustomizations>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class UriRegexSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer>
+    {
+        public UriRegexSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody Body { get { throw null; } }
+        public static Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer CreateWithQueryParameter(string queryParameter, string sanitizedValue) { throw null; }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class UriRegexSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody>
+    {
+        public UriRegexSanitizerBody() { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string GroupForReplace { get { throw null; } set { } }
+        public string Regex { get { throw null; } set { } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriRegexSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class UriStringSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer>
+    {
+        public UriStringSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class UriStringSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody>
+    {
+        public UriStringSanitizerBody(string target) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string Target { get { throw null; } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriStringSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class UriSubscriptionIdSanitizer : Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition, System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer>
+    {
+        public UriSubscriptionIdSanitizer(Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody body) { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody Body { get { throw null; } }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected override Microsoft.ClientModel.TestFramework.TestProxy.Admin.SanitizerAddition PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected override System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizer>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public partial class UriSubscriptionIdSanitizerBody : System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody>, System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody>
+    {
+        public UriSubscriptionIdSanitizerBody() { }
+        public Microsoft.ClientModel.TestFramework.TestProxy.Admin.ApplyCondition Condition { get { throw null; } set { } }
+        public string Value { get { throw null; } set { } }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody JsonModelCreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual void JsonModelWriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        protected virtual Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody PersistableModelCreateCore(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected virtual System.BinaryData PersistableModelWriteCore(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        string System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<Microsoft.ClientModel.TestFramework.TestProxy.Admin.UriSubscriptionIdSanitizerBody>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+}

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net10.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net10.0.cs
@@ -1,0 +1,590 @@
+namespace System.ClientModel
+{
+    public partial class ApiKeyCredential
+    {
+        public ApiKeyCredential(string key) { }
+        public void Deconstruct(out string key) { throw null; }
+        public void Update(string key) { }
+    }
+    public abstract partial class AsyncCollectionResult<T> : System.ClientModel.Primitives.AsyncCollectionResult, System.Collections.Generic.IAsyncEnumerable<T>
+    {
+        protected internal AsyncCollectionResult() { }
+        public System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected abstract System.Collections.Generic.IAsyncEnumerable<T> GetValuesFromPageAsync(System.ClientModel.ClientResult page);
+    }
+    public abstract partial class AuthenticationTokenProvider
+    {
+        protected AuthenticationTokenProvider() { }
+        public abstract System.ClientModel.Primitives.GetTokenOptions? CreateTokenOptions(System.Collections.Generic.IReadOnlyDictionary<string, object> properties);
+        public abstract System.ClientModel.Primitives.AuthenticationToken GetToken(System.ClientModel.Primitives.GetTokenOptions options, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.ValueTask<System.ClientModel.Primitives.AuthenticationToken> GetTokenAsync(System.ClientModel.Primitives.GetTokenOptions options, System.Threading.CancellationToken cancellationToken);
+    }
+    public abstract partial class BinaryContent : System.IDisposable
+    {
+        protected BinaryContent() { }
+        public string? MediaType { get { throw null; } protected set { } }
+        public static System.ClientModel.BinaryContent Create(System.BinaryData value) { throw null; }
+        public static System.ClientModel.BinaryContent Create(System.IO.Stream stream) { throw null; }
+        public static System.ClientModel.BinaryContent CreateJson(string jsonString, bool validate = false) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation.")]
+        public static System.ClientModel.BinaryContent CreateJson<T>(T jsonSerializable, System.Text.Json.JsonSerializerOptions? options = null) { throw null; }
+        public static System.ClientModel.BinaryContent CreateJson<T>(T jsonSerializable, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo) { throw null; }
+        public static System.ClientModel.BinaryContent Create<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) where T : System.ClientModel.Primitives.IPersistableModel<T> { throw null; }
+        public abstract void Dispose();
+        public abstract bool TryComputeLength(out long length);
+        public abstract void WriteTo(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
+    public partial class ClientResult
+    {
+        protected ClientResult(System.ClientModel.Primitives.PipelineResponse response) { }
+        public static System.ClientModel.ClientResult<T?> FromOptionalValue<T>(T? value, System.ClientModel.Primitives.PipelineResponse response) { throw null; }
+        public static System.ClientModel.ClientResult FromResponse(System.ClientModel.Primitives.PipelineResponse response) { throw null; }
+        public static System.ClientModel.ClientResult<T> FromValue<T>(T value, System.ClientModel.Primitives.PipelineResponse response) { throw null; }
+        public System.ClientModel.Primitives.PipelineResponse GetRawResponse() { throw null; }
+    }
+    public partial class ClientResultException : System.Exception
+    {
+        public ClientResultException(System.ClientModel.Primitives.PipelineResponse response, System.Exception? innerException = null) { }
+        public ClientResultException(string message, System.ClientModel.Primitives.PipelineResponse? response = null, System.Exception? innerException = null) { }
+        public int Status { get { throw null; } protected set { } }
+        public static System.Threading.Tasks.Task<System.ClientModel.ClientResultException> CreateAsync(System.ClientModel.Primitives.PipelineResponse response, System.Exception? innerException = null) { throw null; }
+        public System.ClientModel.Primitives.PipelineResponse? GetRawResponse() { throw null; }
+    }
+    public partial class ClientResult<T> : System.ClientModel.ClientResult
+    {
+        protected internal ClientResult(T value, System.ClientModel.Primitives.PipelineResponse response) : base (default(System.ClientModel.Primitives.PipelineResponse)) { }
+        public virtual T Value { get { throw null; } }
+        public static implicit operator T (System.ClientModel.ClientResult<T> result) { throw null; }
+    }
+    public abstract partial class CollectionResult<T> : System.ClientModel.Primitives.CollectionResult, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
+    {
+        protected internal CollectionResult() { }
+        public System.Collections.Generic.IEnumerator<T> GetEnumerator() { throw null; }
+        protected abstract System.Collections.Generic.IEnumerable<T> GetValuesFromPage(System.ClientModel.ClientResult page);
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+    }
+    public partial class ContinuationToken
+    {
+        protected ContinuationToken() { }
+        protected ContinuationToken(System.BinaryData bytes) { }
+        public static System.ClientModel.ContinuationToken FromBytes(System.BinaryData bytes) { throw null; }
+        public virtual System.BinaryData ToBytes() { throw null; }
+    }
+}
+namespace System.ClientModel.Primitives
+{
+    public static partial class ActivityExtensions
+    {
+        public static System.Diagnostics.Activity MarkClientActivityFailed(this System.Diagnostics.Activity activity, System.Exception? exception) { throw null; }
+        public static System.Diagnostics.Activity? StartClientActivity(this System.Diagnostics.ActivitySource activitySource, System.ClientModel.Primitives.ClientPipelineOptions options, string name, System.Diagnostics.ActivityKind kind = System.Diagnostics.ActivityKind.Internal, System.Diagnostics.ActivityContext parentContext = default(System.Diagnostics.ActivityContext), System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>? tags = null) { throw null; }
+    }
+    public partial class ApiKeyAuthenticationPolicy : System.ClientModel.Primitives.AuthenticationPolicy
+    {
+        internal ApiKeyAuthenticationPolicy() { }
+        public static System.ClientModel.Primitives.ApiKeyAuthenticationPolicy CreateBasicAuthorizationPolicy(System.ClientModel.ApiKeyCredential credential) { throw null; }
+        public static System.ClientModel.Primitives.ApiKeyAuthenticationPolicy CreateBearerAuthorizationPolicy(System.ClientModel.ApiKeyCredential credential) { throw null; }
+        public static System.ClientModel.Primitives.ApiKeyAuthenticationPolicy CreateHeaderApiKeyPolicy(System.ClientModel.ApiKeyCredential credential, string headerName, string? keyPrefix = null) { throw null; }
+        public sealed override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
+        public sealed override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
+    }
+    public abstract partial class AsyncCollectionResult
+    {
+        protected AsyncCollectionResult() { }
+        public abstract System.ClientModel.ContinuationToken? GetContinuationToken(System.ClientModel.ClientResult page);
+        public abstract System.Collections.Generic.IAsyncEnumerable<System.ClientModel.ClientResult> GetRawPagesAsync();
+    }
+    public abstract partial class AuthenticationPolicy : System.ClientModel.Primitives.PipelinePolicy
+    {
+        protected AuthenticationPolicy() { }
+    }
+    public partial class AuthenticationToken
+    {
+        public AuthenticationToken(string tokenValue, string tokenType, System.DateTimeOffset expiresOn, System.DateTimeOffset? refreshOn = default(System.DateTimeOffset?)) { }
+        public System.DateTimeOffset? ExpiresOn { get { throw null; } }
+        public System.DateTimeOffset? RefreshOn { get { throw null; } }
+        public string TokenType { get { throw null; } }
+        public string TokenValue { get { throw null; } }
+    }
+    public partial class BearerTokenPolicy : System.ClientModel.Primitives.AuthenticationPolicy
+    {
+        public BearerTokenPolicy(System.ClientModel.AuthenticationTokenProvider tokenProvider, System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyDictionary<string, object>> contexts) { }
+        public BearerTokenPolicy(System.ClientModel.AuthenticationTokenProvider tokenProvider, string scope) { }
+        public override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
+        public override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
+    }
+    public partial class ClientCache
+    {
+        public ClientCache(int maxSize) { }
+        public T GetClient<T>(object clientId, System.Func<T> createClient) where T : class { throw null; }
+    }
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public readonly partial struct ClientConnection
+    {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
+        public ClientConnection(string id, string locator) { throw null; }
+        public ClientConnection(string id, string locator, object credential, System.ClientModel.Primitives.CredentialKind credentialKind) { throw null; }
+        public ClientConnection(string id, string locator, object? credential, System.ClientModel.Primitives.CredentialKind credentialKind, System.Collections.Generic.IReadOnlyDictionary<string, string>? metadata) { throw null; }
+        public object? Credential { get { throw null; } }
+        public System.ClientModel.Primitives.CredentialKind CredentialKind { get { throw null; } }
+        public string Id { get { throw null; } }
+        public string Locator { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> Metadata { get { throw null; } }
+        public override string ToString() { throw null; }
+        public bool TryGetLocatorAsUri(out System.Uri? uri) { throw null; }
+    }
+    public partial class ClientConnectionCollection : System.Collections.ObjectModel.KeyedCollection<string, System.ClientModel.Primitives.ClientConnection>
+    {
+        public ClientConnectionCollection() { }
+        public void AddRange(System.Collections.Generic.IEnumerable<System.ClientModel.Primitives.ClientConnection> connections) { }
+        protected override string GetKeyForItem(System.ClientModel.Primitives.ClientConnection item) { throw null; }
+    }
+    public abstract partial class ClientConnectionProvider
+    {
+        protected ClientConnectionProvider(int maxCacheSize) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public System.ClientModel.Primitives.ClientCache Subclients { get { throw null; } }
+        public abstract System.Collections.Generic.IEnumerable<System.ClientModel.Primitives.ClientConnection> GetAllConnections();
+        public abstract System.ClientModel.Primitives.ClientConnection GetConnection(string connectionId);
+    }
+    [System.FlagsAttribute]
+    public enum ClientErrorBehaviors
+    {
+        Default = 0,
+        NoThrow = 1,
+    }
+    public partial class ClientLoggingOptions
+    {
+        public ClientLoggingOptions() { }
+        public System.Collections.Generic.IList<string> AllowedHeaderNames { get { throw null; } }
+        public System.Collections.Generic.IList<string> AllowedQueryParameters { get { throw null; } }
+        public bool? EnableLogging { get { throw null; } set { } }
+        public bool? EnableMessageContentLogging { get { throw null; } set { } }
+        public bool? EnableMessageLogging { get { throw null; } set { } }
+        public Microsoft.Extensions.Logging.ILoggerFactory? LoggerFactory { get { throw null; } set { } }
+        public int? MessageContentSizeLimit { get { throw null; } set { } }
+        protected void AssertNotFrozen() { }
+        public virtual void Freeze() { }
+    }
+    public sealed partial class ClientPipeline
+    {
+        internal ClientPipeline() { }
+        public static System.ClientModel.Primitives.ClientPipeline Create(System.ClientModel.Primitives.ClientPipelineOptions? options = null) { throw null; }
+        public static System.ClientModel.Primitives.ClientPipeline Create(System.ClientModel.Primitives.ClientPipelineOptions options, System.ReadOnlySpan<System.ClientModel.Primitives.PipelinePolicy> perCallPolicies, System.ReadOnlySpan<System.ClientModel.Primitives.PipelinePolicy> perTryPolicies, System.ReadOnlySpan<System.ClientModel.Primitives.PipelinePolicy> beforeTransportPolicies) { throw null; }
+        public System.ClientModel.Primitives.PipelineMessage CreateMessage() { throw null; }
+        public System.ClientModel.Primitives.PipelineMessage CreateMessage(System.Uri uri, string method, System.ClientModel.Primitives.PipelineMessageClassifier? classifier = null) { throw null; }
+        public void Send(System.ClientModel.Primitives.PipelineMessage message) { }
+        public System.Threading.Tasks.ValueTask SendAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
+    }
+    public partial class ClientPipelineOptions
+    {
+        public ClientPipelineOptions() { }
+        public System.ClientModel.Primitives.ClientLoggingOptions? ClientLoggingOptions { get { throw null; } set { } }
+        public bool? EnableDistributedTracing { get { throw null; } set { } }
+        public System.ClientModel.Primitives.PipelinePolicy? MessageLoggingPolicy { get { throw null; } set { } }
+        public System.TimeSpan? NetworkTimeout { get { throw null; } set { } }
+        public System.ClientModel.Primitives.PipelinePolicy? RetryPolicy { get { throw null; } set { } }
+        public System.ClientModel.Primitives.PipelineTransport? Transport { get { throw null; } set { } }
+        public void AddPolicy(System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelinePosition position) { }
+        protected void AssertNotFrozen() { }
+        public virtual void Freeze() { }
+    }
+    public partial class ClientRetryPolicy : System.ClientModel.Primitives.PipelinePolicy
+    {
+        public ClientRetryPolicy(int maxRetries = 3) { }
+        public ClientRetryPolicy(int maxRetries, bool enableLogging, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory) { }
+        public static System.ClientModel.Primitives.ClientRetryPolicy Default { get { throw null; } }
+        protected virtual System.TimeSpan GetNextDelay(System.ClientModel.Primitives.PipelineMessage message, int tryCount) { throw null; }
+        protected virtual void OnRequestSent(System.ClientModel.Primitives.PipelineMessage message) { }
+        protected virtual System.Threading.Tasks.ValueTask OnRequestSentAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
+        protected virtual void OnSendingRequest(System.ClientModel.Primitives.PipelineMessage message) { }
+        protected virtual System.Threading.Tasks.ValueTask OnSendingRequestAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
+        protected virtual void OnTryComplete(System.ClientModel.Primitives.PipelineMessage message) { }
+        public sealed override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
+        public sealed override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
+        protected virtual bool ShouldRetry(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
+        protected virtual System.Threading.Tasks.ValueTask<bool> ShouldRetryAsync(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception) { throw null; }
+        protected virtual void Wait(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { }
+        protected virtual System.Threading.Tasks.Task WaitAsync(System.TimeSpan time, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public abstract partial class CollectionResult
+    {
+        protected CollectionResult() { }
+        public abstract System.ClientModel.ContinuationToken? GetContinuationToken(System.ClientModel.ClientResult page);
+        public abstract System.Collections.Generic.IEnumerable<System.ClientModel.ClientResult> GetRawPages();
+    }
+    public enum CredentialKind
+    {
+        None = 0,
+        ApiKeyString = 1,
+        TokenCredential = 2,
+    }
+    public partial class GetTokenOptions
+    {
+        public const string AuthorizationUrlPropertyName = "authorizationUrl";
+        public const string RefreshUrlPropertyName = "refreshUrl";
+        public const string ScopesPropertyName = "scopes";
+        public const string TokenUrlPropertyName = "tokenUrl";
+        public GetTokenOptions(System.Collections.Generic.IReadOnlyDictionary<string, object> properties) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object> Properties { get { throw null; } }
+    }
+    public partial class HttpClientPipelineTransport : System.ClientModel.Primitives.PipelineTransport, System.IDisposable
+    {
+        public HttpClientPipelineTransport() { }
+        public HttpClientPipelineTransport(System.Net.Http.HttpClient client) { }
+        public HttpClientPipelineTransport(System.Net.Http.HttpClient? client, bool enableLogging, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory) { }
+        public static System.ClientModel.Primitives.HttpClientPipelineTransport Shared { get { throw null; } }
+        protected override System.ClientModel.Primitives.PipelineMessage CreateMessageCore() { throw null; }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        protected virtual void OnReceivedResponse(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpResponseMessage httpResponse) { }
+        protected virtual void OnSendingRequest(System.ClientModel.Primitives.PipelineMessage message, System.Net.Http.HttpRequestMessage httpRequest) { }
+        protected sealed override void ProcessCore(System.ClientModel.Primitives.PipelineMessage message) { }
+        protected sealed override System.Threading.Tasks.ValueTask ProcessCoreAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
+    }
+    public partial interface IJsonModel<out T> : System.ClientModel.Primitives.IPersistableModel<T>
+    {
+        T? Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options);
+        void Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options);
+    }
+    public partial interface IPersistableModel<out T>
+    {
+        T? Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options);
+        string GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options);
+        System.BinaryData Write(System.ClientModel.Primitives.ModelReaderWriterOptions options);
+    }
+    public partial class JsonModelConverter : System.Text.Json.Serialization.JsonConverter<System.ClientModel.Primitives.IJsonModel<object>>
+    {
+        public JsonModelConverter() { }
+        public JsonModelConverter(System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        public JsonModelConverter(System.ClientModel.Primitives.ModelReaderWriterOptions options, System.ClientModel.Primitives.ModelReaderWriterContext context) { }
+        public override bool CanConvert(System.Type typeToConvert) { throw null; }
+        public override System.ClientModel.Primitives.IJsonModel<object>? Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
+        public override void Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.IJsonModel<object> value, System.Text.Json.JsonSerializerOptions options) { }
+    }
+    public abstract partial class JsonModel<T> : System.ClientModel.Primitives.IJsonModel<T>, System.ClientModel.Primitives.IPersistableModel<T>
+    {
+        protected JsonModel() { }
+        public T Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) { throw null; }
+        protected abstract T CreateCore(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options);
+        T System.ClientModel.Primitives.IJsonModel<T>.Create(ref System.Text.Json.Utf8JsonReader reader, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        void System.ClientModel.Primitives.IJsonModel<T>.Write(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options) { }
+        string System.ClientModel.Primitives.IPersistableModel<T>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        System.BinaryData System.ClientModel.Primitives.IPersistableModel<T>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+        protected abstract void WriteCore(System.Text.Json.Utf8JsonWriter writer, System.ClientModel.Primitives.ModelReaderWriterOptions options);
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0001")]
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public partial struct JsonPatch
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public JsonPatch(System.ReadOnlyMemory<byte> utf8Json) { throw null; }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, System.BinaryData utf8Json) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, bool value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, byte value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, byte[] utf8Json) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, System.DateTime value, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, System.DateTimeOffset value, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, decimal value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, double value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, System.Guid value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, short value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, int value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, long value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, System.ReadOnlySpan<byte> utf8Json) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, sbyte value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, float value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, string value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, System.TimeSpan value, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, ushort value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, uint value) { }
+        public void Append(System.ReadOnlySpan<byte> arrayPath, ulong value) { }
+        public void AppendNull(System.ReadOnlySpan<byte> arrayPath) { }
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public bool Contains(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool Contains(System.ReadOnlySpan<byte> prefix, System.ReadOnlySpan<byte> property) { throw null; }
+        public bool GetBoolean(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public byte GetByte(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public System.DateTime GetDateTime(System.ReadOnlySpan<byte> jsonPath, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
+        public System.DateTimeOffset GetDateTimeOffset(System.ReadOnlySpan<byte> jsonPath, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
+        public decimal GetDecimal(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public double GetDouble(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public float GetFloat(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public System.Guid GetGuid(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public short GetInt16(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public int GetInt32(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public long GetInt64(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public sbyte GetInt8(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public System.BinaryData GetJson(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public T? GetNullableValue<T>(System.ReadOnlySpan<byte> jsonPath) where T : struct { throw null; }
+        public string? GetString(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public System.TimeSpan GetTimeSpan(System.ReadOnlySpan<byte> jsonPath, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
+        public ushort GetUInt16(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public uint GetUInt32(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public ulong GetUInt64(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public bool IsRemoved(System.ReadOnlySpan<byte> jsonPath) { throw null; }
+        public void Remove(System.ReadOnlySpan<byte> jsonPath) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, System.BinaryData utf8Json) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, bool value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, byte value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, byte[] utf8Json) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public void Set(System.ReadOnlySpan<byte> jsonPath, System.ClientModel.Primitives.JsonPatch.EncodedValue value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, System.DateTime value, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, System.DateTimeOffset value, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, decimal value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, double value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, System.Guid value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, short value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, int value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, long value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, System.ReadOnlySpan<byte> utf8Json) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, sbyte value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, float value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, string value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, System.TimeSpan value, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, ushort value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, uint value) { }
+        public void Set(System.ReadOnlySpan<byte> jsonPath, ulong value) { }
+        public void SetNull(System.ReadOnlySpan<byte> jsonPath) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public void SetPropagators(System.ClientModel.Primitives.JsonPatch.PropagatorSetter setter, System.ClientModel.Primitives.JsonPatch.PropagatorGetter getter) { }
+        public override string ToString() { throw null; }
+        public string ToString(string format) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public bool TryGetEncodedValue(System.ReadOnlySpan<byte> jsonPath, out System.ClientModel.Primitives.JsonPatch.EncodedValue value) { throw null; }
+        public bool TryGetJson(System.ReadOnlySpan<byte> jsonPath, out System.ReadOnlyMemory<byte> value) { throw null; }
+        public bool TryGetNullableValue<T>(System.ReadOnlySpan<byte> jsonPath, out T? value) where T : struct { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out bool value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out byte value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out System.DateTime value, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out System.DateTimeOffset value, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out decimal value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out double value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out System.Guid value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out short value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out int value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out long value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out sbyte value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out float value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out string? value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out System.TimeSpan value, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out ushort value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out uint value) { throw null; }
+        public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out ulong value) { throw null; }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer) { }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer, System.ReadOnlySpan<byte> jsonPath) { }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct EncodedValue
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+        }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public delegate bool PropagatorGetter(System.ReadOnlySpan<byte> jsonPath, out System.ClientModel.Primitives.JsonPatch.EncodedValue value);
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        public delegate bool PropagatorSetter(System.ReadOnlySpan<byte> jsonPath, System.ClientModel.Primitives.JsonPatch.EncodedValue value);
+    }
+    public partial class MessageLoggingPolicy : System.ClientModel.Primitives.PipelinePolicy
+    {
+        public MessageLoggingPolicy(System.ClientModel.Primitives.ClientLoggingOptions? options = null) { }
+        public static System.ClientModel.Primitives.MessageLoggingPolicy Default { get { throw null; } }
+        public sealed override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
+        public sealed override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
+    }
+    public static partial class ModelReaderWriter
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This method uses reflection.  Use the overload that takes a ModelReaderWriterContext to be AOT compatible.")]
+        public static object? Read(System.BinaryData data, System.Type returnType, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) { throw null; }
+        public static object? Read(System.BinaryData data, System.Type returnType, System.ClientModel.Primitives.ModelReaderWriterOptions options, System.ClientModel.Primitives.ModelReaderWriterContext context) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This method uses reflection.  Use the overload that takes a ModelReaderWriterContext to be AOT compatible.")]
+        public static T? Read<T>(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) { throw null; }
+        public static T? Read<T>(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options, System.ClientModel.Primitives.ModelReaderWriterContext context) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This method uses reflection.  Use the overload that takes a ModelReaderWriterContext to be AOT compatible.")]
+        public static System.BinaryData Write(object model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) { throw null; }
+        public static System.BinaryData Write(object model, System.ClientModel.Primitives.ModelReaderWriterOptions options, System.ClientModel.Primitives.ModelReaderWriterContext context) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("This method uses reflection.  Use the overload that takes a ModelReaderWriterContext to be AOT compatible.")]
+        public static System.BinaryData Write<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions? options = null) { throw null; }
+        public static System.BinaryData Write<T>(T model, System.ClientModel.Primitives.ModelReaderWriterOptions options, System.ClientModel.Primitives.ModelReaderWriterContext context) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class, AllowMultiple=true)]
+    public partial class ModelReaderWriterBuildableAttribute : System.Attribute
+    {
+        public ModelReaderWriterBuildableAttribute(System.Type type) { }
+    }
+    public abstract partial class ModelReaderWriterContext
+    {
+        protected ModelReaderWriterContext() { }
+        public System.ClientModel.Primitives.ModelReaderWriterTypeBuilder GetTypeBuilder(System.Type type) { throw null; }
+        public bool TryGetTypeBuilder(System.Type type, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder? builder) { throw null; }
+        protected virtual bool TryGetTypeBuilderCore(System.Type type, out System.ClientModel.Primitives.ModelReaderWriterTypeBuilder? builder) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly)]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+    public sealed partial class ModelReaderWriterContextTypeAttribute : System.Attribute
+    {
+        public ModelReaderWriterContextTypeAttribute(System.Type contextType) { }
+    }
+    public partial class ModelReaderWriterOptions
+    {
+        public ModelReaderWriterOptions(string format) { }
+        public string Format { get { throw null; } }
+        public static System.ClientModel.Primitives.ModelReaderWriterOptions Json { get { throw null; } }
+        public static System.ClientModel.Primitives.ModelReaderWriterOptions Xml { get { throw null; } }
+    }
+    public abstract partial class ModelReaderWriterTypeBuilder
+    {
+        protected ModelReaderWriterTypeBuilder() { }
+        protected abstract System.Type BuilderType { get; }
+        protected virtual System.Type? ItemType { get { throw null; } }
+        protected virtual void AddItem(object collectionBuilder, object? item) { }
+        protected virtual void AddItemWithKey(object collectionBuilder, string key, object? item) { }
+        protected virtual object ConvertCollectionBuilder(object collectionBuilder) { throw null; }
+        protected abstract object CreateInstance();
+        protected virtual System.Collections.IEnumerable? GetItems(object collection) { throw null; }
+    }
+    public abstract partial class OperationResult
+    {
+        protected OperationResult(System.ClientModel.Primitives.PipelineResponse response) { }
+        public bool HasCompleted { get { throw null; } protected set { } }
+        public abstract System.ClientModel.ContinuationToken? RehydrationToken { get; protected set; }
+        public System.ClientModel.Primitives.PipelineResponse GetRawResponse() { throw null; }
+        protected void SetRawResponse(System.ClientModel.Primitives.PipelineResponse response) { }
+        public abstract System.ClientModel.ClientResult UpdateStatus(System.ClientModel.Primitives.RequestOptions? options = null);
+        public abstract System.Threading.Tasks.ValueTask<System.ClientModel.ClientResult> UpdateStatusAsync(System.ClientModel.Primitives.RequestOptions? options = null);
+        public virtual void WaitForCompletion(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { }
+        public virtual System.Threading.Tasks.ValueTask WaitForCompletionAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class)]
+    public sealed partial class PersistableModelProxyAttribute : System.Attribute
+    {
+        public PersistableModelProxyAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type proxyType) { }
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
+        public System.Type ProxyType { get { throw null; } }
+    }
+    public partial class PipelineMessage : System.IDisposable
+    {
+        protected internal PipelineMessage(System.ClientModel.Primitives.PipelineRequest request) { }
+        public bool BufferResponse { get { throw null; } set { } }
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } protected internal set { } }
+        public System.TimeSpan? NetworkTimeout { get { throw null; } set { } }
+        public System.ClientModel.Primitives.PipelineRequest Request { get { throw null; } }
+        public System.ClientModel.Primitives.PipelineResponse? Response { get { throw null; } protected internal set { } }
+        public System.ClientModel.Primitives.PipelineMessageClassifier ResponseClassifier { get { throw null; } set { } }
+        public void Apply(System.ClientModel.Primitives.RequestOptions? options) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public System.ClientModel.Primitives.PipelineResponse? ExtractResponse() { throw null; }
+        public void SetProperty(System.Type key, object? value) { }
+        public bool TryGetProperty(System.Type key, out object? value) { throw null; }
+    }
+    public abstract partial class PipelineMessageClassifier
+    {
+        protected PipelineMessageClassifier() { }
+        public static System.ClientModel.Primitives.PipelineMessageClassifier Default { get { throw null; } }
+        public static System.ClientModel.Primitives.PipelineMessageClassifier Create(System.ReadOnlySpan<ushort> successStatusCodes) { throw null; }
+        public abstract bool TryClassify(System.ClientModel.Primitives.PipelineMessage message, out bool isError);
+        public abstract bool TryClassify(System.ClientModel.Primitives.PipelineMessage message, System.Exception? exception, out bool isRetriable);
+    }
+    public abstract partial class PipelinePolicy
+    {
+        protected PipelinePolicy() { }
+        public abstract void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex);
+        public abstract System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex);
+        protected static void ProcessNext(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
+        protected static System.Threading.Tasks.ValueTask ProcessNextAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
+    }
+    public enum PipelinePosition
+    {
+        PerCall = 0,
+        PerTry = 1,
+        BeforeTransport = 2,
+    }
+    public abstract partial class PipelineRequest : System.IDisposable
+    {
+        protected PipelineRequest() { }
+        public virtual string ClientRequestId { get { throw null; } }
+        public System.ClientModel.BinaryContent? Content { get { throw null; } set { } }
+        protected abstract System.ClientModel.BinaryContent? ContentCore { get; set; }
+        public System.ClientModel.Primitives.PipelineRequestHeaders Headers { get { throw null; } }
+        protected abstract System.ClientModel.Primitives.PipelineRequestHeaders HeadersCore { get; }
+        public string Method { get { throw null; } set { } }
+        protected abstract string MethodCore { get; set; }
+        public System.Uri? Uri { get { throw null; } set { } }
+        protected abstract System.Uri? UriCore { get; set; }
+        public abstract void Dispose();
+    }
+    public abstract partial class PipelineRequestHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
+    {
+        protected PipelineRequestHeaders() { }
+        public abstract void Add(string name, string value);
+        public abstract System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, string>> GetEnumerator();
+        public abstract bool Remove(string name);
+        public abstract void Set(string name, string value);
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public abstract bool TryGetValue(string name, out string? value);
+        public abstract bool TryGetValues(string name, out System.Collections.Generic.IEnumerable<string>? values);
+    }
+    public abstract partial class PipelineResponse : System.IDisposable
+    {
+        protected PipelineResponse() { }
+        public abstract System.BinaryData Content { get; }
+        public abstract System.IO.Stream? ContentStream { get; set; }
+        public System.ClientModel.Primitives.PipelineResponseHeaders Headers { get { throw null; } }
+        protected abstract System.ClientModel.Primitives.PipelineResponseHeaders HeadersCore { get; }
+        public virtual bool IsError { get { throw null; } }
+        protected internal virtual bool IsErrorCore { get { throw null; } set { } }
+        public abstract string ReasonPhrase { get; }
+        public abstract int Status { get; }
+        public abstract System.BinaryData BufferContent(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract System.Threading.Tasks.ValueTask<System.BinaryData> BufferContentAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        public abstract void Dispose();
+    }
+    public abstract partial class PipelineResponseHeaders : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.IEnumerable
+    {
+        protected PipelineResponseHeaders() { }
+        public abstract System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, string>> GetEnumerator();
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
+        public abstract bool TryGetValue(string name, out string? value);
+        public abstract bool TryGetValues(string name, out System.Collections.Generic.IEnumerable<string>? values);
+    }
+    public abstract partial class PipelineTransport : System.ClientModel.Primitives.PipelinePolicy
+    {
+        protected PipelineTransport() { }
+        protected PipelineTransport(bool enableLogging, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory) { }
+        public System.ClientModel.Primitives.PipelineMessage CreateMessage() { throw null; }
+        protected abstract System.ClientModel.Primitives.PipelineMessage CreateMessageCore();
+        public void Process(System.ClientModel.Primitives.PipelineMessage message) { }
+        public sealed override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
+        public System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message) { throw null; }
+        public sealed override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
+        protected abstract void ProcessCore(System.ClientModel.Primitives.PipelineMessage message);
+        protected abstract System.Threading.Tasks.ValueTask ProcessCoreAsync(System.ClientModel.Primitives.PipelineMessage message);
+    }
+    public partial class RequestOptions
+    {
+        public RequestOptions() { }
+        public bool BufferResponse { get { throw null; } set { } }
+        public System.Threading.CancellationToken CancellationToken { get { throw null; } set { } }
+        public System.ClientModel.Primitives.ClientErrorBehaviors ErrorOptions { get { throw null; } set { } }
+        public void AddHeader(string name, string value) { }
+        public void AddPolicy(System.ClientModel.Primitives.PipelinePolicy policy, System.ClientModel.Primitives.PipelinePosition position) { }
+        protected internal virtual void Apply(System.ClientModel.Primitives.PipelineMessage message) { }
+        protected void AssertNotFrozen() { }
+        public virtual void Freeze() { }
+        public void SetHeader(string name, string value) { }
+    }
+    public partial class UserAgentPolicy : System.ClientModel.Primitives.PipelinePolicy
+    {
+        public UserAgentPolicy(System.Reflection.Assembly callerAssembly, string? applicationId = null) { }
+        public string? ApplicationId { get { throw null; } }
+        public System.Reflection.Assembly Assembly { get { throw null; } }
+        public string UserAgentValue { get { throw null; } }
+        public override void Process(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { }
+        public override System.Threading.Tasks.ValueTask ProcessAsync(System.ClientModel.Primitives.PipelineMessage message, System.Collections.Generic.IReadOnlyList<System.ClientModel.Primitives.PipelinePolicy> pipeline, int currentIndex) { throw null; }
+    }
+}


### PR DESCRIPTION
Updated an API in the test framework in a different PR and I didn't want to include these in that PR.

Saw a failure in the pipeline and also fixed an issue with the API compat baseline for net8.0 targets