### PR TITLE
remove `TrackedResourceWithOptionalLocation`

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Primitives/KnownManagementTypes.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Primitives/KnownManagementTypes.cs
@@ -34,7 +34,6 @@ namespace Azure.Generator.Management.Primitives
             ["Azure.ResourceManager.CommonTypes.ExtensionResource"] = typeof(ResourceData),
             ["Azure.ResourceManager.CommonTypes.Resource"] = typeof(ResourceData),
             ["Azure.ResourceManager.CommonTypes.TrackedResource"] = typeof(TrackedResourceData),
-            ["Azure.ResourceManager.Legacy.TrackedResourceWithOptionalLocation"] = typeof(TrackedResourceData),
         };
 
         private static readonly IReadOnlyDictionary<string, CSharpType> _idToSystemTypeMap = new Dictionary<string, CSharpType>()


### PR DESCRIPTION
https://github.com/Azure/typespec-azure/blob/32292dabd9a4741b02a211fe3838a7279961f690/packages/typespec-azure-resource-manager/lib/legacy-types/resource.tsp#L26 is a template not a model, TCGC will not return it as base model, the actual base model is `Resource`.
And also since this template intends to support optional location, the base model in .NET SDK should not be `TrackedResource`, whose location is required. We should just take `Resource` as base model.