### PR TITLE
Fix buffer usage

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PartitionedDownloader.cs
@@ -371,7 +371,7 @@ namespace Azure.Storage.Blobs
                     // CopyToAsync causes ConsumeQueuedTask to wait until the
                     // download is complete
 
-                    using (_arrayPool.RentDisposable(_checksumSize, out byte[] partitionChecksum))
+                    using (_arrayPool.RentAsMemoryDisposable(_checksumSize, out Memory<byte> partitionChecksum))
                     {
                         await CopyToInternal(
                             response,


### PR DESCRIPTION
An array rented from the pool wasn't being properly size bound when used. Under some circumstances, the array pool would give back a larger array than needed, which would fail comparison to an array of the expected size.

Replaced rental with an extension method that trims a `Memory<byte>` to the appropriate size, like all other code paths in the file.