### PR TITLE
[Avs] Add 1.6.0 changelog entry

### DIFF
--- a/sdk/avs/Azure.ResourceManager.Avs/CHANGELOG.md
+++ b/sdk/avs/Azure.ResourceManager.Avs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.6.0 (2025-12-10)
+## 1.6.0 (Unreleased)
 
 ### Features Added
 
 - Added support for API version 2025-09-01.
-
-## 1.6.0-beta.1 (Unreleased)
-
-### Features Added
 
 ### Breaking Changes
 

--- a/sdk/avs/Azure.ResourceManager.Avs/CHANGELOG.md
+++ b/sdk/avs/Azure.ResourceManager.Avs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.6.0 (2025-12-10)
+
+### Features Added
+
+- Added support for API version 2025-09-01.
+
 ## 1.6.0-beta.1 (Unreleased)
 
 ### Features Added


### PR DESCRIPTION
Adds a 1.6.0 changelog entry dated 2025-12-10 for Azure.ResourceManager.Avs to satisfy changelog verification in packaging.