### PR TITLE
fix: ensure hash uniqueness in regen preview

### DIFF
--- a/eng/packages/http-client-csharp/eng/scripts/RegenPreview.ps1
+++ b/eng/packages/http-client-csharp/eng/scripts/RegenPreview.ps1
@@ -121,10 +121,11 @@ Write-Host ""
 # Generate version string with timestamp and hash
 # Used for both npm and NuGet packages to ensure consistency
 function Get-LocalPackageVersion {
-    $timestamp = Get-Date -Format "yyyyMMdd"
-    $hash = (git -C $packageRoot rev-parse --short HEAD 2>$null) ?? "local"
-    return "1.0.0-alpha.$timestamp.$hash"
+    $timestamp = Get-Date -Format "yyyyMMddHHmmss"
+    $hash = (git -C $packageRoot rev-parse --short=7 HEAD 2>$null) ?? "local"
+    return "1.0.0-alpha-$timestamp.$hash"
 }
+
 
 # Run npm pack and return the package file path
 function Invoke-NpmPack {


### PR DESCRIPTION
Fixes a minor issue where the built artifact would be cached do to uncommitted changes despite the possibility of there being changes in the source code.