### PR TITLE
[AzureMonitorExporter] Fix Container Apps role instance showing VM GUID instead of replica name

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -12,7 +12,7 @@
   instead of replica names in the Role Instance field. The resource detector order
   has been adjusted to ensure Container Apps detector runs before VM detector,
   preventing the VM detector from overwriting the Container Apps replica name.
-  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+  ([#54586](https://github.com/Azure/azure-sdk-for-net/pull/54586))
 
 ### Other Changes
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -9,9 +9,7 @@
 ### Bugs Fixed
 
 * Fixed an issue where Azure Container Apps instances were showing VM instance GUIDs
-  instead of replica names in the Role Instance field. The resource detector order
-  has been adjusted to ensure Container Apps detector runs before VM detector,
-  preventing the VM detector from overwriting the Container Apps replica name.
+  instead of replica names in the Role Instance field.
   ([#54586](https://github.com/Azure/azure-sdk-for-net/pull/54586))
 
 ### Other Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Bugs Fixed
 
+* Fixed an issue where Azure Container Apps instances were showing VM instance GUIDs
+  instead of replica names in the Role Instance field. The resource detector order
+  has been adjusted to ensure Container Apps detector runs before VM detector,
+  preventing the VM detector from overwriting the Container Apps replica name.
+  ([#](https://github.com/Azure/azure-sdk-for-net/pull/))
+
 ### Other Changes
 
 ## 1.4.0 (2025-11-14)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/OpenTelemetryBuilderExtensions.cs
@@ -84,8 +84,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             Action<ResourceBuilder> configureResource = (r) => r
                 .AddAttributes(new[] { new KeyValuePair<string, object>("telemetry.distro.name", "Azure.Monitor.OpenTelemetry.AspNetCore") })
                 .AddDetector(new AppServiceResourceDetector())
-                .AddDetector(new AzureContainerAppsResourceDetector())
-                .AddDetector(new AzureVMResourceDetector());
+                .AddDetector(new AzureVMResourceDetector())
+                .AddDetector(new AzureContainerAppsResourceDetector());
 
             builder.ConfigureResource(configureResource);
 


### PR DESCRIPTION
Fixes #47424

## Description

Fixes an issue where Azure Container Apps instances were showing VM instance GUIDs instead of replica names in the Role Instance field in Application Insights.

### Root Cause
Azure Container Apps infrastructure runs on Azure VMs. When resource detection occurs, both the `AzureVMResourceDetector` and `AzureContainerAppsResourceDetector` detect their respective environments and set the `service.instance.id` attribute. 

The issue occurred because the resource detectors were ordered such that the VM detector could overwrite the Container Apps replica name with a VM instance GUID.

### Solution
Reordered the resource detectors to ensure `AzureContainerAppsResourceDetector` runs **after** `AzureVMResourceDetector`. 

### Testing
Tested in Azure Container Apps environment to verify replica names now appear correctly in Application Insights Role Instance field.