### PR TITLE
[AzureMonitorExporter] Fix statsbeat language dimension to accurately report distro type

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/Azure.Monitor.OpenTelemetry.AspNetCore.csproj
@@ -24,10 +24,10 @@
     <!-- Depending on monthly deliverables, we may switch between PackageReference or ProjectReference. Keeping both here to make the switch easier. -->
 
     <!-- FOR PUBLIC RELEASES, MUST USE PackageReference. THIS REQUIRES A STAGGERED RELEASE IF SHIPPING A NEW EXPORTER. -->
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <!--<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />-->
 
     <!-- FOR LOCAL DEV, ProjectReference IS PREFERRED. -->
-    <!--<ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />-->
+    <ProjectReference Include="..\..\Azure.Monitor.OpenTelemetry.Exporter\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
   </ItemGroup>
 
   <!-- Shared sources from Azure.Core -->

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Statsbeat/AzureMonitorStatsbeat.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.ConnectionString;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
@@ -32,6 +33,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
         private static bool s_hasSdkPrefix => SdkVersionUtils.SdkVersionPrefix != null;
 
         private static string? s_operatingSystem;
+
+        private string? _language;
 
         private readonly string? _customer_Ikey;
 
@@ -73,6 +76,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
                 .AddReader(new PeriodicExportingMetricReader(new AzureMonitorMetricExporter(exporterOptions), StatsbeatConstants.AttachStatsbeatInterval)
                 { TemporalityPreference = MetricReaderTemporalityPreference.Delta })
                 .Build();
+
+            // Flush after 1 minute to ensure we don't collect data from very short-lived apps that could spam the stats
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromMinutes(1)).ConfigureAwait(false);
+                _attachStatsbeatMeterProvider?.ForceFlush();
+            });
         }
 
         internal static string? GetStatsbeatConnectionString(string ingestionEndpoint)
@@ -104,6 +114,20 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
                     SetResourceProviderDetails(_platform);
                 }
 
+                // Lazy initialize language based on VersionType which gets set when customer's Resource is processed.
+                if (_language == null)
+                {
+                    _language = SdkVersionUtils.VersionType switch
+                    {
+                        SdkVersionType.Distro => "dotnet-distro",
+                        SdkVersionType.ShimBase => "dotnet-shim",
+                        SdkVersionType.ShimAspNetCore => "dotnet-core",
+                        SdkVersionType.ShimWorkerService => "dotnet-worker",
+                        SdkVersionType.ShimWeb => "dotnet-web",
+                        _ => "dotnet-exp"
+                    };
+                }
+
                 return
                     new Measurement<int>(1,
                         new("rp", _resourceProvider),
@@ -111,7 +135,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Statsbeat
                         new("attach", s_hasSdkPrefix ? "IntegratedAuto" : "Manual"),
                         new("cikey", _customer_Ikey),
                         new("runtimeVersion", s_runtimeVersion),
-                        new("language", "dotnet"),
+                        new("language", _language),
                         new("version", s_sdkVersion),
                         new("os", s_operatingSystem));
             }


### PR DESCRIPTION
## Problem
The statsbeat language dimension was hardcoded to "dotnet", but it should reflect the actual distro type being used (e.g., "dotnet-distro" for AspNetCore distro, "dotnet-core" for shim AspNetCore, etc.).

## Solution
- Added lazy initialization of the `_language` field in `GetAttachStatsbeat()` method
- The language is computed based on `SdkVersionUtils.VersionType` which gets set when the customer's Resource is processed
- Maps `SdkVersionType` enum values to appropriate language dimension values:
  - `Distro` → "dotnet-distro"
  - `ShimBase` → "dotnet-shim"
  - `ShimAspNetCore` → "dotnet-core"
  - `ShimWorkerService` → "dotnet-worker"
  - `ShimWeb` → "dotnet-web"
  - Default → "dotnet-exp"

## Additional Changes
- Delayed the initial `ForceFlush()` call by 1 minute to prevent collecting data from very short-lived applications that could spam the statsbeat metrics
- The delay is implemented as a background task using `Task.Run`
