### PR TITLE
fix: use nullable operator in matchconditions check

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/MatchConditionsHeadersVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/MatchConditionsHeadersVisitor.cs
@@ -300,7 +300,8 @@ namespace Azure.Generator.Visitors
                 {
                     if (!headerFlags.HasFlag(flag))
                     {
-                        var validationStatement = new IfStatement(requestConditionsParameter.Property(propertyName).NotEqual(Null))
+                        var validationStatement = new IfStatement(
+                            Snippet.NullConditional(requestConditionsParameter).Property(propertyName).NotEqual(Null))
                         {
                             Throw(New.Instance(new CSharpType(typeof(ArgumentException)),
                                 Literal($"Service does not support the {_requestConditionsFlagMap[flag]} header for this operation.")))

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/MatchConditionsHeadersVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/MatchConditionsHeadersVisitorTests.cs
@@ -268,10 +268,8 @@ namespace Azure.Generator.Tests.Visitors
             Assert.IsNotNull(protocolMethod, "Protocol method should be found.");
             Assert.IsNotNull(protocolMethod?.BodyStatements);
 
-            var bodyText = protocolMethod!.BodyStatements!.ToDisplayString();
-
-            Assert.IsTrue(bodyText.Contains("throw new global::System.ArgumentException(\"Service does not support the If-Match header for this operation"));
-            Assert.IsTrue(bodyText.Contains("throw new global::System.ArgumentException(\"Service does not support the If-Unmodified-Since header for this operation"));
+            var result = protocolMethod!.BodyStatements!.ToDisplayString();
+            Assert.AreEqual(Helpers.GetExpectedFromFile(), result);
         }
 
         [TestCase(true)]

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/MatchConditionsHeadersVisitorTests/TestProtocolMethodValidation.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/MatchConditionsHeadersVisitorTests/TestProtocolMethodValidation.cs
@@ -1,0 +1,11 @@
+﻿if ((requestConditions?.IfMatch != null))
+{
+    throw new global::System.ArgumentException("Service does not support the If-Match header for this operation.");
+}
+if ((requestConditions?.IfUnmodifiedSince != null))
+{
+    throw new global::System.ArgumentException("Service does not support the If-Unmodified-Since header for this operation.");
+}
+
+using global::Azure.Core.HttpMessage message = this.CreateFooRequest(ifNoneMatch, ifModifiedSince, context);
+return await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecClient.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecClient.cs
@@ -2096,7 +2096,7 @@ namespace BasicTypeSpec
         /// <returns> The response returned from the service. </returns>
         public virtual Response ConditionalRequestDate(RequestConditions requestConditions, RequestContext context)
         {
-            if (requestConditions.IfUnmodifiedSince != null)
+            if (requestConditions?.IfUnmodifiedSince != null)
             {
                 throw new ArgumentException("Service does not support the If-Unmodified-Since header for this operation.");
             }
@@ -2129,7 +2129,7 @@ namespace BasicTypeSpec
         /// <returns> The response returned from the service. </returns>
         public virtual async Task<Response> ConditionalRequestDateAsync(RequestConditions requestConditions, RequestContext context)
         {
-            if (requestConditions.IfUnmodifiedSince != null)
+            if (requestConditions?.IfUnmodifiedSince != null)
             {
                 throw new ArgumentException("Service does not support the If-Unmodified-Since header for this operation.");
             }


### PR DESCRIPTION
Fixes a small bug where the matchConditions/requestConditions parameter within a request method may be null and the method validation would not handle it gracefully.

contributes to : https://github.com/Azure/azure-sdk-for-net/issues/53335