### PR TITLE
Updated build command for dotnet sdk used by azsdk mcp tool

### DIFF
--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -23,7 +23,7 @@
   "packageOptions": {
     "packageFolderFromFileSearch": false,
     "buildScript": {
-      "command": "dotnet build {packagePath}"
+      "command": "dotnet build {packagePath}/src"
     },
     "updateMetadataScript": {
       "path": "./eng/scripts/Export-API.ps1"


### PR DESCRIPTION
Fixed https://github.com/Azure/azure-sdk-tools/issues/13329

Updated the build command to build the source code project.

Test screenshot:
<img width="934" height="742" alt="image" src="https://github.com/user-attachments/assets/37200f2c-9ead-4043-82c9-e1ce91596184" />