### PR TITLE
[EngSys] Remove redundant package scope

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -57,7 +57,6 @@
     <MicrosoftExtensionsConfigurationVersion>10.0.1</MicrosoftExtensionsConfigurationVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>10.0.1</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
     <MicrosoftExtensionsHostingVersion>10.0.1</MicrosoftExtensionsHostingVersion>
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.1</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingVersion>10.0.1</MicrosoftExtensionsLoggingVersion>
     <MicrosoftSpatialVersion>7.5.3</MicrosoftSpatialVersion>
     <NewtonsoftJsonVersion>13.0.4</NewtonsoftJsonVersion>
@@ -109,7 +108,7 @@
     <!-- BCL packages -->
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="10.0.1" />
     <PackageReference Update="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
     <PackageReference Update="System.Buffers" Version="4.5.1" />
     <PackageReference Update="System.ClientModel" Version="1.8.1" />
     <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="10.0.1" />
@@ -296,7 +295,6 @@
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="$(MicrosoftExtensionsConfigurationBinderVersion)" />
     <PackageReference Update="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
   </ItemGroup>
 
   <!-- Packages intended for WCF/CoreWCF Extensions libraries only -->


### PR DESCRIPTION
# Summary

The focus of these changes is to remove a duplicate scope for the `Microsoft.Extensions.Logging.Abstractions` package, as it is already approved for use in all current generation libraries.