### PR TITLE
Set release date for release 1.0.0-beta.1 in Planetary Computer

### DIFF
--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/CHANGELOG.md
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2025-12-23)
 
 ### Features Added
 

--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/CHANGELOG.md
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/CHANGELOG.md
@@ -5,9 +5,3 @@
 ### Features Added
 
 - Initial release of the Azure Planetary Computer client library for .NET.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes


### PR DESCRIPTION
Set release date for release 1.0.0-beta.1 in Planetary Computer. This is to unblock the release pipeline run