### PR TITLE
[agentserver]feat: Implement UseFoundryTools for C# SDK(tool support part2)

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -208,7 +208,7 @@
     <PackageReference Update="Azure.AI.Projects" Version="1.1.0" />
     <PackageReference Update="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0"/>
     <PackageReference Update="ModelContextProtocol" Version="0.4.0-preview.3" />
-    <PackageReference Update="Microsoft.Agents.AI" Version="1.0.0-preview.251104.1" />
+    <PackageReference Update="Microsoft.Agents.AI" Version="1.0.0-preview.251125.1" />
     <PackageReference Update="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0"/>
   </ItemGroup>
 
@@ -366,8 +366,8 @@
     <PackageReference Update="CommandLineParser" Version="2.8.0" />
     <PackageReference Update="FluentAssertions" Version="5.10.3" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />
-    <PackageReference Update="Microsoft.Agents.AI.OpenAI" Version="1.0.0-preview.251104.1" />
-    <PackageReference Update="Microsoft.Agents.AI.Workflows" Version="1.0.0-preview.251104.1" />
+    <PackageReference Update="Microsoft.Agents.AI.OpenAI" Version="1.0.0-preview.251125.1" />
+    <PackageReference Update="Microsoft.Agents.AI.Workflows" Version="1.0.0-preview.251125.1" />
     <PackageReference Update="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Update="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Update="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Extensions/AIAgentBuilderExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Extensions/AIAgentBuilderExtensions.cs
@@ -19,28 +19,18 @@ public static class AIAgentBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="AIAgentBuilder"/> to augment.</param>
     /// <param name="toolDefinitions">The Foundry tool definitions to resolve.</param>
-    /// <param name="projectEndpoint">
-    /// Optional Foundry project endpoint. If not provided, the method uses the
-    /// <c>AZURE_AI_PROJECT_ENDPOINT</c> or <c>AGENT_PROJECT_NAME</c> environment variables.
-    /// </param>
-    /// <param name="credential">
-    /// Optional credential for accessing Foundry tools. If not provided, the method falls back to
-    /// a <see cref="DefaultAzureCredential"/> or a resolved <see cref="TokenCredential"/> from the service provider.
-    /// </param>
     /// <returns>The <see cref="AIAgentBuilder"/> instance with tool discovery added.</returns>
     public static AIAgentBuilder UseFoundryTools(
         this AIAgentBuilder builder,
-        IList<ToolDefinition> toolDefinitions,
-        Uri? projectEndpoint = null,
-        TokenCredential? credential = null)
+        params ToolDefinition[] toolDefinitions)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(toolDefinitions);
 
         return builder.Use((innerAgent, services) =>
         {
-            var endpoint = ResolveProjectEndpoint(projectEndpoint);
-            var toolCredential = credential ?? (services.GetService(typeof(TokenCredential)) as TokenCredential) ?? new DefaultAzureCredential();
+            var endpoint = ResolveProjectEndpoint();
+            var toolCredential = (services.GetService(typeof(TokenCredential)) as TokenCredential) ?? new DefaultAzureCredential();
 
             var options = new AzureAIToolClientOptions
             {
@@ -52,13 +42,8 @@ public static class AIAgentBuilderExtensions
         });
     }
 
-    private static Uri ResolveProjectEndpoint(Uri? projectEndpoint)
+    private static Uri ResolveProjectEndpoint()
     {
-        if (projectEndpoint is not null)
-        {
-            return projectEndpoint;
-        }
-
         var endpointFromEnv = Environment.GetEnvironmentVariable("AZURE_AI_PROJECT_ENDPOINT");
         if (!string.IsNullOrWhiteSpace(endpointFromEnv))
         {

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Extensions/AIAgentBuilderExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Extensions/AIAgentBuilderExtensions.cs
@@ -28,7 +28,7 @@ public static class AIAgentBuilderExtensions
     /// a <see cref="DefaultAzureCredential"/> or a resolved <see cref="TokenCredential"/> from the service provider.
     /// </param>
     /// <returns>The <see cref="AIAgentBuilder"/> instance with tool discovery added.</returns>
-    public static AIAgentBuilder useFoundryTools(
+    public static AIAgentBuilder UseFoundryTools(
         this AIAgentBuilder builder,
         IList<ToolDefinition> toolDefinitions,
         Uri? projectEndpoint = null,

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Extensions/AIAgentBuilderExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Extensions/AIAgentBuilderExtensions.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.AI.AgentServer.Core.Tools;
+using Azure.AI.AgentServer.Core.Tools.Models;
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+
+namespace Azure.AI.AgentServer.AgentFramework.Extensions;
+
+/// <summary>
+/// Provides extension methods for configuring and customizing <see cref="AIAgentBuilder"/> instances.
+/// </summary>
+public static class AIAgentBuilderExtensions
+{
+    /// <summary>
+    /// Adds Foundry tool discovery to the agent pipeline and enables tool calling using the resolved tools.
+    /// </summary>
+    /// <param name="builder">The <see cref="AIAgentBuilder"/> to augment.</param>
+    /// <param name="toolDefinitions">The Foundry tool definitions to resolve.</param>
+    /// <param name="projectEndpoint">
+    /// Optional Foundry project endpoint. If not provided, the method uses the
+    /// <c>AZURE_AI_PROJECT_ENDPOINT</c> or <c>AGENT_PROJECT_NAME</c> environment variables.
+    /// </param>
+    /// <param name="credential">
+    /// Optional credential for accessing Foundry tools. If not provided, the method falls back to
+    /// a <see cref="DefaultAzureCredential"/> or a resolved <see cref="TokenCredential"/> from the service provider.
+    /// </param>
+    /// <returns>The <see cref="AIAgentBuilder"/> instance with tool discovery added.</returns>
+    public static AIAgentBuilder useFoundryTools(
+        this AIAgentBuilder builder,
+        IList<ToolDefinition> toolDefinitions,
+        Uri? projectEndpoint = null,
+        TokenCredential? credential = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(toolDefinitions);
+
+        return builder.Use((innerAgent, services) =>
+        {
+            var endpoint = ResolveProjectEndpoint(projectEndpoint);
+            var toolCredential = credential ?? (services.GetService(typeof(TokenCredential)) as TokenCredential) ?? new DefaultAzureCredential();
+
+            var options = new AzureAIToolClientOptions
+            {
+                Tools = new List<ToolDefinition>(toolDefinitions)
+            };
+
+            var toolClient = new ToolClient(new AzureAIToolClient(endpoint, toolCredential, options));
+            return new FoundryToolAgent(innerAgent, toolClient);
+        });
+    }
+
+    private static Uri ResolveProjectEndpoint(Uri? projectEndpoint)
+    {
+        if (projectEndpoint is not null)
+        {
+            return projectEndpoint;
+        }
+
+        var endpointFromEnv = Environment.GetEnvironmentVariable("AZURE_AI_PROJECT_ENDPOINT");
+        if (!string.IsNullOrWhiteSpace(endpointFromEnv))
+        {
+            return new Uri(endpointFromEnv);
+        }
+
+        throw new InvalidOperationException("AZURE_AI_PROJECT_ENDPOINT must be set to resolve tools.");
+    }
+}

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/FoundryToolAgent.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/FoundryToolAgent.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace Azure.AI.AgentServer.AgentFramework;
+
+internal sealed class FoundryToolAgent : DelegatingAIAgent, IAsyncDisposable
+{
+    private readonly ToolClient _toolClient;
+    private readonly bool _innerAgentAddsDefaultTools;
+
+    public FoundryToolAgent(AIAgent innerAgent, ToolClient toolClient) : base(innerAgent)
+    {
+        _toolClient = toolClient ?? throw new ArgumentNullException(nameof(toolClient));
+        _innerAgentAddsDefaultTools = innerAgent.GetService<ChatClientAgent>() is not null;
+    }
+
+    public override async Task<AgentRunResponse> RunAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentThread? thread = null,
+        AgentRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var runOptions = await CreateRunOptionsAsync(options, cancellationToken).ConfigureAwait(false);
+        return await InnerAgent.RunAsync(messages, thread, runOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override async IAsyncEnumerable<AgentRunResponseUpdate> RunStreamingAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentThread? thread = null,
+        AgentRunOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var runOptions = await CreateRunOptionsAsync(options, cancellationToken).ConfigureAwait(false);
+        await foreach (var update in InnerAgent.RunStreamingAsync(messages, thread, runOptions, cancellationToken).ConfigureAwait(false))
+        {
+            yield return update;
+        }
+    }
+
+    public async ValueTask DisposeAsync() => await _toolClient.DisposeAsync().ConfigureAwait(false);
+
+    private async Task<AgentRunOptions?> CreateRunOptionsAsync(AgentRunOptions? options, CancellationToken cancellationToken)
+    {
+        var foundryTools = await _toolClient.ListToolsAsync(cancellationToken).ConfigureAwait(false);
+        var requestTools = (options as ChatClientAgentRunOptions)?.ChatOptions?.Tools;
+        var agentTools = InnerAgent.GetService<ChatOptions>()?.Tools;
+
+        var mergedTools = MergeTools(requestTools, agentTools, foundryTools, _innerAgentAddsDefaultTools);
+        if (mergedTools.Count == 0)
+        {
+            return options;
+        }
+
+        var runOptions = EnsureChatClientRunOptions(options);
+        runOptions.ChatOptions ??= new ChatOptions();
+        runOptions.ChatOptions.Tools = mergedTools;
+        return runOptions;
+    }
+
+    private static IList<AITool> MergeTools(
+        IList<AITool>? requestTools,
+        IList<AITool>? agentTools,
+        IReadOnlyList<AIFunction> foundryTools,
+        bool innerAgentAddsDefaultTools)
+    {
+        List<AITool> merged = [];
+        HashSet<string> names = new(StringComparer.OrdinalIgnoreCase);
+
+        if (innerAgentAddsDefaultTools && agentTools is { Count: > 0 })
+        {
+            foreach (var tool in agentTools)
+            {
+                if (tool is not null)
+                {
+                    _ = names.Add(tool.Name);
+                }
+            }
+        }
+
+        AddUnique(merged, names, requestTools);
+        AddUnique(merged, names, foundryTools);
+
+        if (!innerAgentAddsDefaultTools)
+        {
+            AddUnique(merged, names, agentTools);
+        }
+
+        return merged;
+    }
+
+    private static void AddUnique(ICollection<AITool> target, ISet<string> names, IEnumerable<AITool>? tools)
+    {
+        if (tools is null)
+        {
+            return;
+        }
+
+        foreach (var tool in tools)
+        {
+            if (tool is null)
+            {
+                continue;
+            }
+
+            if (names.Add(tool.Name))
+            {
+                target.Add(tool);
+            }
+        }
+    }
+
+    private static ChatClientAgentRunOptions EnsureChatClientRunOptions(AgentRunOptions? options)
+    {
+        if (options is ChatClientAgentRunOptions chatOptions)
+        {
+            return chatOptions;
+        }
+
+        var runOptions = new ChatClientAgentRunOptions();
+        if (options is not null)
+        {
+            runOptions.AllowBackgroundResponses = options.AllowBackgroundResponses;
+            runOptions.ContinuationToken = options.ContinuationToken;
+        }
+
+        return runOptions;
+    }
+}

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Models/ToolDefinition.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Models/ToolDefinition.cs
@@ -1,7 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Azure.AI.AgentServer.Core.Tools.Models;
+
+/// <summary>
+/// Supported tool protocols.
+/// </summary>
+public enum ToolProtocol
+{
+    /// <summary>
+    /// Model Context Protocol tools.
+    /// </summary>
+    Mcp,
+
+    /// <summary>
+    /// Agent-to-agent tools.
+    /// </summary>
+    A2a
+}
 
 /// <summary>
 /// Represents a tool configuration definition.
@@ -10,6 +28,44 @@ namespace Azure.AI.AgentServer.Core.Tools.Models;
 public record ToolDefinition
 {
     /// <summary>
+    /// Creates a typed tool definition.
+    /// </summary>
+    /// <param name="protocol">The tool protocol.</param>
+    /// <param name="projectConnectionId">The project connection ID for the tool.</param>
+    /// <param name="additionalProperties">Optional additional properties for the tool configuration.</param>
+    [SetsRequiredMembers]
+    public ToolDefinition(
+        ToolProtocol protocol,
+        string projectConnectionId,
+        IReadOnlyDictionary<string, object?>? additionalProperties = null)
+    {
+        Type = protocol switch
+        {
+            ToolProtocol.Mcp => "mcp",
+            ToolProtocol.A2a => "a2a",
+            _ => throw new ArgumentOutOfRangeException(nameof(protocol))
+        };
+        ProjectConnectionId = projectConnectionId ?? throw new ArgumentNullException(nameof(projectConnectionId));
+        AdditionalProperties = additionalProperties;
+    }
+
+    /// <summary>
+    /// Creates an MCP tool definition.
+    /// </summary>
+    public static ToolDefinition Mcp(
+        string projectConnectionId,
+        IReadOnlyDictionary<string, object?>? additionalProperties = null)
+        => new(ToolProtocol.Mcp, projectConnectionId, additionalProperties);
+
+    /// <summary>
+    /// Creates an A2A tool definition.
+    /// </summary>
+    public static ToolDefinition A2a(
+        string projectConnectionId,
+        IReadOnlyDictionary<string, object?>? additionalProperties = null)
+        => new(ToolProtocol.A2a, projectConnectionId, additionalProperties);
+
+    /// <summary>
     /// Gets or initializes the type of the tool (e.g., "mcp", "a2a").
     /// </summary>
     required public string Type { get; init; }
@@ -17,7 +73,7 @@ public record ToolDefinition
     /// <summary>
     /// Gets or initializes the project connection ID for the tool.
     /// </summary>
-    public string? ProjectConnectionId { get; init; }
+    required public string ProjectConnectionId { get; init; }
 
     /// <summary>
     /// Gets or initializes additional properties for the tool configuration.


### PR DESCRIPTION
**UseFoundryTools implementation**

Tested with
- ToolClientCase sample: [https://github.com/Azure/azure-sdk-for-net/blob/agentserver-first-release-lixiaoli/sdk/agentserver/samples/AgentFramework/ToolClientCase/Program.cs](https://github.com/Azure/azure-sdk-for-net/blob/agentserver-first-release-lixiaoli/sdk/agentserver/samples/AgentFramework/ToolClientCase/Program.cs)
- ToolWorkflow sample: [https://github.com/Azure/azure-sdk-for-net/blob/agentserver-first-release-lixiaoli/sdk/agentserver/samples/AgentFramework/Workflow/ToolWorkflow/Program.cs](https://github.com/Azure/azure-sdk-for-net/blob/agentserver-first-release-lixiaoli/sdk/agentserver/samples/AgentFramework/Workflow/ToolWorkflow/Program.cs)

```c#
// Usage
var agent = new ChatClientAgent(chatClient,
      name: "AgentWithHostedMCP",
      instructions: @"You are a helpful assistant with access to tools for fetching Microsoft documentation.

  IMPORTANT: When the user asks about Microsoft Learn articles or documentation:
  1. You MUST use the microsoft_docs_fetch tool to retrieve the actual content
  2. Do NOT rely on your training data
  3. Always fetch the latest information from the provided URL

  Available tools:
  - microsoft_docs_fetch: Fetches and converts Microsoft Learn documentation
  - microsoft_docs_search: Searches Microsoft/Azure documentation
  - microsoft_code_sample_search: Searches for code examples")
      .AsBuilder()
      .UseFoundryTools(new List<ToolDefinition> { ToolDefinition.Mcp(toolConnectionId) })
      .UseOpenTelemetry(sourceName: "Agents", configure: (cfg) => cfg.EnableSensitiveData = true)
      .Build();
```