### PR TITLE
[CODEOWNERS] Fix linter errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -218,13 +218,13 @@
 # ServiceOwners:                                                   @dipidoo @longli0 @ShaoAnLin @leareai @Han-msft
 
 # PRLabel: %Cognitive - Content Understanding
-/sdk/contentunderstanding/                                         @yungshinlintw @bojunehsu @changjian-wang
+/sdk/contentunderstanding/                                         @bojunehsu @changjian-wang
 
 # PRLabel: %Cognitive - Form Recognizer
-/sdk/documentintelligence/                                         @yungshinlintw @bojunehsu
+/sdk/documentintelligence/                                         @changjian-wang @bojunehsu
 
 # PRLabel: %Cognitive - Form Recognizer
-/sdk/formrecognizer/                                               @yungshinlintw @bojunehsu
+/sdk/formrecognizer/                                               @changjian-wang @bojunehsu
 
 # ServiceLabel: %Cognitive - Form Recognizer
 # ServiceOwners:                                                   @vkurpad


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner being flagged by the linter as no longer valid.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5706614&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_