### PR TITLE
Add back test of multiple-path resources

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -1336,6 +1336,7 @@ interface BestPracticeVersions {
     strictEqual(bestPracticeVersionsMetadata.methods.length, 3, "Should have 3 methods");
     // Note: parentResourceId is not set for legacy operations as there's no explicit @parentResource decorator
     // The parent-child relationship is inferred from the path structure in the generator
+    strictEqual(bestPracticeVersionsMetadata.parentResourceId, bestPracticesMetadata.resourceIdPattern);
 
     // Validate using resolveArmResources API - use deep equality to ensure schemas match
     const resolvedSchema = resolveArmResources(program, sdkContext);

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -1336,5 +1336,15 @@ interface BestPracticeVersions {
     strictEqual(bestPracticeVersionsMetadata.methods.length, 3, "Should have 3 methods");
     // Note: parentResourceId is not set for legacy operations as there's no explicit @parentResource decorator
     // The parent-child relationship is inferred from the path structure in the generator
+
+    // Validate using resolveArmResources API - use deep equality to ensure schemas match
+    const resolvedSchema = resolveArmResources(program, sdkContext);
+    ok(resolvedSchema);
+
+    // Compare the entire schemas using deep equality
+    deepStrictEqual(
+      normalizeSchemaForComparison(resolvedSchema),
+      normalizeSchemaForComparison(armProviderSchemaResult)
+    );
   });
 });

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -1199,4 +1199,142 @@ interface ScheduledActionExtension {
       normalizeSchemaForComparison(armProviderSchemaResult)
     );
   });
+
+  it("multiple resources sharing same model", async () => {
+    // This test validates the scenario where the SAME model is used by two different
+    // resource interfaces operating at different paths using LegacyOperations (similar to the legacy-operations example)
+    const program = await typeSpecCompile(
+      `
+/** A best practice resource - used by both interfaces */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For sample purpose"
+@tenantResource
+model BestPractice is ProxyResource<BestPracticeProperties> {
+  ...ResourceNameParameter<
+    Resource = BestPractice,
+    KeyName = "bestPracticeName",
+    SegmentName = "bestPractices",
+    NamePattern = ""
+  >;
+  ...Azure.ResourceManager.Legacy.ExtendedLocationOptionalProperty;
+}
+/** Best practice properties */
+model BestPracticeProperties {
+  ...DefaultProvisioningStateProperty;
+  description?: string;
+}
+// Define operation aliases with different path patterns using LegacyOperations
+alias BestPracticeOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...Azure.ResourceManager.Legacy.Provider;
+  },
+  {
+    @segment("bestPractices")
+    @key
+    @TypeSpec.Http.path
+    bestPracticeName: string;
+  }
+>;
+alias BestPracticesVersionOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...Azure.ResourceManager.Legacy.Provider;
+    @segment("bestPractices")
+    @key
+    @TypeSpec.Http.path
+    bestPracticeName: string;
+  },
+  {
+    @segment("versions")
+    @key
+    @TypeSpec.Http.path
+    versionName: string;
+  }
+>;
+/** Best practice operations */
+@armResourceOperations
+interface BestPractices {
+  get is BestPracticeOps.Read<BestPractice>;
+  createOrUpdate is BestPracticeOps.CreateOrUpdateSync<BestPractice>;
+  delete is BestPracticeOps.DeleteSync<BestPractice>;
+}
+/** Best practice version operations - uses the SAME BestPractice model */
+@armResourceOperations
+interface BestPracticeVersions {
+  get is BestPracticesVersionOps.Read<BestPractice>;
+  createOrUpdate is BestPracticesVersionOps.CreateOrUpdateSync<BestPractice>;
+  delete is BestPracticesVersionOps.DeleteSync<BestPractice>;
+}
+`,
+      runner
+    );
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const root = createModel(sdkContext);
+
+    // Build ARM provider schema and verify its structure
+    const armProviderSchemaResult = buildArmProviderSchema(sdkContext, root);
+    ok(armProviderSchemaResult);
+
+    // Verify BestPractice model exists
+    const bestPracticeModel = root.models.find((m) => m.name === "BestPractice");
+    ok(bestPracticeModel, "BestPractice model should exist");
+
+    // Verify the ARM provider schema has TWO resource entries for the same model
+    // (one for each interface using the BestPractice model)
+    const bestPracticeModelId = bestPracticeModel.crossLanguageDefinitionId;
+    const resourcesForModel = armProviderSchemaResult.resources.filter(
+      (r) => r.resourceModelId === bestPracticeModelId
+    );
+    strictEqual(
+      resourcesForModel.length,
+      2,
+      "Should have TWO resource entries for the same model"
+    );
+
+    // Find metadata for BestPractices resource (parent-level)
+    const bestPracticesResource = resourcesForModel.find((r) =>
+      r.metadata.resourceIdPattern.includes("/bestPractices/{bestPracticeName}") &&
+      !r.metadata.resourceIdPattern.includes("/versions")
+    );
+    ok(bestPracticesResource, "Should have metadata for parent-level resource");
+    const bestPracticesMetadata = bestPracticesResource.metadata;
+    strictEqual(
+      bestPracticesMetadata.resourceName,
+      "BestPractice",
+      "Parent resource should be named BestPractice"
+    );
+    strictEqual(
+      bestPracticesMetadata.resourceIdPattern,
+      "/providers/Microsoft.ContosoProviderHub/bestPractices/{bestPracticeName}"
+    );
+    strictEqual(
+      bestPracticesMetadata.resourceType,
+      "Microsoft.ContosoProviderHub/bestPractices"
+    );
+    strictEqual(bestPracticesMetadata.methods.length, 3, "Should have 3 methods");
+
+    // Find metadata for BestPracticeVersions resource (child-level)
+    const bestPracticeVersionsResource = resourcesForModel.find((r) =>
+      r.metadata.resourceIdPattern.includes("/versions/{versionName}")
+    );
+    ok(bestPracticeVersionsResource, "Should have metadata for child-level resource");
+    const bestPracticeVersionsMetadata = bestPracticeVersionsResource.metadata;
+    strictEqual(
+      bestPracticeVersionsMetadata.resourceName,
+      "BestPracticeVersion",
+      "Child resource should be named BestPracticeVersion"
+    );
+    strictEqual(
+      bestPracticeVersionsMetadata.resourceIdPattern,
+      "/providers/Microsoft.ContosoProviderHub/bestPractices/{bestPracticeName}/versions/{versionName}"
+    );
+    strictEqual(
+      bestPracticeVersionsMetadata.resourceType,
+      "Microsoft.ContosoProviderHub/bestPractices/versions"
+    );
+    strictEqual(bestPracticeVersionsMetadata.methods.length, 3, "Should have 3 methods");
+    // Note: parentResourceId is not set for legacy operations as there's no explicit @parentResource decorator
+    // The parent-child relationship is inferred from the path structure in the generator
+  });
 });

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/test-util.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/test-util.ts
@@ -123,9 +123,12 @@ export function normalizeSchemaForComparison(schema: ArmProviderSchema) {
   // Work on a deep copy to avoid mutating the original schema used elsewhere in tests.
   const normalizedSchema: ArmProviderSchema = JSON.parse(JSON.stringify(schema));
 
-  // it is a known issue that the resources.metadata.resourceName might be different therefore we need to ignore it
+  // it is a known issue that the following properties might different therefore we need to ignore them:
+  // - resources.metadata.resourceName
+  // - resources.metadata.parentResourceModelId
   for (const resource of normalizedSchema.resources) {
     resource.metadata.resourceName = "<normalized>";
+    resource.metadata.parentResourceModelId = "<normalized>";
   }
 
   // sort resources by resourceIdPattern


### PR DESCRIPTION
The test was removed by mistake in https://github.com/Azure/azure-sdk-for-net/pull/54528/