### PR TITLE
TEST-RESOURCE: Ensure that CU LLM model defaults are set before running tests

### DIFF
--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/tests/Infrastructure/ContentUnderstandingTestSetupFixture.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/tests/Infrastructure/ContentUnderstandingTestSetupFixture.cs
@@ -26,9 +26,6 @@ namespace Azure.AI.ContentUnderstanding.Tests
     [SetUpFixture]
     public class ContentUnderstandingTestSetupFixture : SetUpFixtureBase<ContentUnderstandingClientTestEnvironment>
     {
-        private static bool s_defaultsConfigured = false;
-        private static readonly object s_lockObject = new object();
-
         /// <summary>
         /// Performs one-time setup to configure Content Understanding service defaults.
         /// </summary>
@@ -40,18 +37,8 @@ namespace Azure.AI.ContentUnderstanding.Tests
                 return;
             }
 
-            // Use double-checked locking to ensure defaults are only configured once
-            if (!s_defaultsConfigured)
-            {
-                lock (s_lockObject)
-                {
-                    if (!s_defaultsConfigured)
-                    {
-                        ConfigureDefaultsAsync().GetAwaiter().GetResult();
-                        s_defaultsConfigured = true;
-                    }
-                }
-            }
+            // Configure defaults asynchronously
+            await ConfigureDefaultsAsync();
         }
 
         /// <summary>

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/tests/Infrastructure/ContentUnderstandingTestSetupFixture.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/tests/Infrastructure/ContentUnderstandingTestSetupFixture.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure;
+using Azure.AI.ContentUnderstanding;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.ContentUnderstanding.Tests
+{
+    /// <summary>
+    /// One-time setup fixture that configures Content Understanding service defaults before any tests run.
+    /// This ensures that GPT model deployments are configured for all tests that depend on them.
+    /// </summary>
+    /// <remarks>
+    /// This fixture runs once per test assembly before any tests execute. It configures the required
+    /// model deployments (gpt-4.1, gpt-4.1-mini, text-embedding-3-large) if they are not already configured.
+    /// This setup is only performed in Live mode; in Playback mode, the recorded defaults are used.
+    /// </remarks>
+    [SetUpFixture]
+    public class ContentUnderstandingTestSetupFixture : SetUpFixtureBase<ContentUnderstandingClientTestEnvironment>
+    {
+        private static bool s_defaultsConfigured = false;
+        private static readonly object s_lockObject = new object();
+
+        /// <summary>
+        /// Performs one-time setup to configure Content Understanding service defaults.
+        /// </summary>
+        public override async Task SetUp()
+        {
+            // Only configure defaults in Live mode (not in Playback mode)
+            if (Environment.Mode == RecordedTestMode.Playback)
+            {
+                return;
+            }
+
+            // Use double-checked locking to ensure defaults are only configured once
+            if (!s_defaultsConfigured)
+            {
+                lock (s_lockObject)
+                {
+                    if (!s_defaultsConfigured)
+                    {
+                        ConfigureDefaultsAsync().GetAwaiter().GetResult();
+                        s_defaultsConfigured = true;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Configures the Content Understanding service defaults with required model deployments.
+        /// </summary>
+        private async Task ConfigureDefaultsAsync()
+        {
+            // Check if model deployments are configured in test environment
+            string? gpt41Deployment = Environment.Gpt41Deployment;
+            string? gpt41MiniDeployment = Environment.Gpt41MiniDeployment;
+            string? textEmbeddingDeployment = Environment.TextEmbedding3LargeDeployment;
+
+            if (string.IsNullOrEmpty(gpt41Deployment) || string.IsNullOrEmpty(gpt41MiniDeployment) || string.IsNullOrEmpty(textEmbeddingDeployment))
+            {
+                var missingDeployments = new List<string>();
+                if (string.IsNullOrEmpty(gpt41Deployment))
+                {
+                    missingDeployments.Add("GPT_4_1_DEPLOYMENT");
+                }
+                if (string.IsNullOrEmpty(gpt41MiniDeployment))
+                {
+                    missingDeployments.Add("GPT_4_1_MINI_DEPLOYMENT");
+                }
+                if (string.IsNullOrEmpty(textEmbeddingDeployment))
+                {
+                    missingDeployments.Add("TEXT_EMBEDDING_3_LARGE_DEPLOYMENT");
+                }
+
+                var errorMessage = $"Content Understanding test setup failed: Required model deployment environment variables are not configured. Missing: {string.Join(", ", missingDeployments)}. " +
+                    $"These variables must be set in the test environment for tests to run. " +
+                    $"In cloud pipelines, they are typically set by test-resources.bicep outputs. " +
+                    $"For local development, set them in your test configuration or environment variables.";
+
+                TestContext.WriteLine(errorMessage);
+                throw new InvalidOperationException(errorMessage);
+            }
+
+            try
+            {
+                var endpoint = new Uri(Environment.Endpoint);
+                var credential = Environment.Credential;
+                var client = new ContentUnderstandingClient(endpoint, credential);
+
+                // Check if defaults are already configured
+                Response<ContentUnderstandingDefaults> currentDefaults = await client.GetDefaultsAsync();
+                bool needsConfiguration = false;
+
+                if (currentDefaults.Value.ModelDeployments == null || currentDefaults.Value.ModelDeployments.Count == 0)
+                {
+                    needsConfiguration = true;
+                }
+                else
+                {
+                    // Check if all required models are configured
+                    needsConfiguration = !currentDefaults.Value.ModelDeployments.ContainsKey("gpt-4.1") ||
+                                        !currentDefaults.Value.ModelDeployments.ContainsKey("gpt-4.1-mini") ||
+                                        !currentDefaults.Value.ModelDeployments.ContainsKey("text-embedding-3-large") ||
+                                        currentDefaults.Value.ModelDeployments["gpt-4.1"] != gpt41Deployment ||
+                                        currentDefaults.Value.ModelDeployments["gpt-4.1-mini"] != gpt41MiniDeployment ||
+                                        currentDefaults.Value.ModelDeployments["text-embedding-3-large"] != textEmbeddingDeployment;
+                }
+
+                if (needsConfiguration)
+                {
+                    TestContext.WriteLine("Configuring Content Understanding service defaults...");
+                    var modelDeployments = new Dictionary<string, string>
+                    {
+                        ["gpt-4.1"] = gpt41Deployment!,
+                        ["gpt-4.1-mini"] = gpt41MiniDeployment!,
+                        ["text-embedding-3-large"] = textEmbeddingDeployment!
+                    };
+
+                    Response<ContentUnderstandingDefaults> response = await client.UpdateDefaultsAsync(modelDeployments);
+                    TestContext.WriteLine("Defaults configured successfully:");
+                    foreach (var kvp in response.Value.ModelDeployments)
+                    {
+                        TestContext.WriteLine($"  {kvp.Key}: {kvp.Value}");
+                    }
+                }
+                else
+                {
+                    TestContext.WriteLine("Content Understanding service defaults are already configured correctly.");
+                }
+            }
+            catch (Exception ex)
+            {
+                TestContext.WriteLine($"Failed to configure Content Understanding service defaults: {ex.Message}");
+                TestContext.WriteLine("Test setup cannot continue without configured defaults.");
+                throw;
+            }
+        }
+    }
+}

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/tests/Infrastructure/ContentUnderstandingTestSetupFixture.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/tests/Infrastructure/ContentUnderstandingTestSetupFixture.cs
@@ -117,11 +117,15 @@ namespace Azure.AI.ContentUnderstanding.Tests
                 if (needsConfiguration)
                 {
                     TestContext.WriteLine("Configuring Content Understanding service defaults...");
+                    var nonNullGpt41Deployment = gpt41Deployment ?? throw new InvalidOperationException("gpt41Deployment must be configured for test setup.");
+                    var nonNullGpt41MiniDeployment = gpt41MiniDeployment ?? throw new InvalidOperationException("gpt41MiniDeployment must be configured for test setup.");
+                    var nonNullTextEmbeddingDeployment = textEmbeddingDeployment ?? throw new InvalidOperationException("textEmbeddingDeployment must be configured for test setup.");
+
                     var modelDeployments = new Dictionary<string, string>
                     {
-                        ["gpt-4.1"] = gpt41Deployment!,
-                        ["gpt-4.1-mini"] = gpt41MiniDeployment!,
-                        ["text-embedding-3-large"] = textEmbeddingDeployment!
+                        ["gpt-4.1"] = nonNullGpt41Deployment,
+                        ["gpt-4.1-mini"] = nonNullGpt41MiniDeployment,
+                        ["text-embedding-3-large"] = nonNullTextEmbeddingDeployment
                     };
 
                     Response<ContentUnderstandingDefaults> response = await client.UpdateDefaultsAsync(modelDeployments);

--- a/sdk/contentunderstanding/test-resources-post.ps1
+++ b/sdk/contentunderstanding/test-resources-post.ps1
@@ -351,10 +351,11 @@ if ($allDeploymentsReady) {
 
     # Build model deployments mapping (model name -> deployment name)
     # The deployment name is the same as the model name in our configuration
-    $modelDeployments = @{
-        'gpt-4.1' = 'gpt-4.1'
-        'gpt-4.1-mini' = 'gpt-4.1-mini'
-        'text-embedding-3-large' = 'text-embedding-3-large'
+    $modelDeployments = @{}
+    foreach ($model in $modelConfigs) {
+        if ($null -ne $model.Name -and -not [string]::IsNullOrWhiteSpace([string]$model.Name)) {
+            $modelDeployments[$model.Name] = $model.Name
+        }
     }
 
     # Update defaults for Primary Microsoft Foundry resource

--- a/sdk/contentunderstanding/test-resources-post.ps1
+++ b/sdk/contentunderstanding/test-resources-post.ps1
@@ -4,6 +4,8 @@
 # This script is used to deploy model deployments to the Foundry resources after the main ARM template deployment.
 # It is invoked by the New-TestResources.ps1 script after the ARM template is finished being deployed.
 # The ARM template creates the Foundry resources, and this script deploys the required models.
+# After model deployments are complete, it calls the Content Understanding UpdateDefaults API to configure
+# the default model deployment mappings.
 
 param (
     [hashtable] $DeploymentOutputs,
@@ -28,6 +30,20 @@ if (-not $targetResourceId) {
 # Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.CognitiveServices/accounts/{accountName}
 $sourceAccountName = $sourceResourceId -replace '^.*/accounts/', ''
 $targetAccountName = $targetResourceId -replace '^.*/accounts/', ''
+
+# Get endpoints from deployment outputs
+$sourceEndpoint = $DeploymentOutputs['CONTENTUNDERSTANDING_ENDPOINT']
+$targetEndpoint = $DeploymentOutputs['CONTENTUNDERSTANDING_TARGET_ENDPOINT']
+
+if (-not $sourceEndpoint) {
+    Write-Error "CONTENTUNDERSTANDING_ENDPOINT not found in deployment outputs"
+    exit 1
+}
+
+if (-not $targetEndpoint) {
+    Write-Error "CONTENTUNDERSTANDING_TARGET_ENDPOINT not found in deployment outputs"
+    exit 1
+}
 
 Write-Host "Deploying models to source Foundry resource: $sourceAccountName"
 Write-Host "Deploying models to target Foundry resource: $targetAccountName"
@@ -131,6 +147,125 @@ function Deploy-Model {
     }
 }
 
+# Function to wait for a deployment to be ready (provisioning state = Succeeded)
+# Returns $true if deployment is ready, $false if timeout or failed
+function Wait-ForDeployment {
+    param (
+        [string] $ResourceGroupName,
+        [string] $AccountName,
+        [string] $DeploymentName,
+        [int] $MaxWaitMinutes = 15,
+        [int] $PollIntervalSeconds = 30
+    )
+
+    Write-Host "Waiting for deployment '$DeploymentName' to be ready..."
+    $startTime = Get-Date
+    $maxWaitTime = $startTime.AddMinutes($MaxWaitMinutes)
+
+    while ((Get-Date) -lt $maxWaitTime) {
+        try {
+            $deploymentJson = az cognitiveservices account deployment show `
+                --resource-group $ResourceGroupName `
+                --name $AccountName `
+                --deployment-name $DeploymentName `
+                --output json 2>&1
+
+            if ($LASTEXITCODE -eq 0) {
+                $deployment = $deploymentJson | ConvertFrom-Json
+                $provisioningState = $deployment.properties.provisioningState
+
+                if ($provisioningState -eq 'Succeeded') {
+                    Write-Host "Deployment '$DeploymentName' is ready (Status: $provisioningState)" -ForegroundColor Green
+                    return $true
+                }
+                elseif ($provisioningState -eq 'Failed') {
+                    Write-Error "Deployment '$DeploymentName' failed" -ErrorAction Continue
+                    return $false
+                }
+                else {
+                    Write-Host "Deployment '$DeploymentName' status: $provisioningState (waiting...)"
+                }
+            }
+            else {
+                Write-Host "Could not check deployment status, will retry..."
+            }
+        }
+        catch {
+            Write-Host "Error checking deployment status: $_, will retry..."
+        }
+
+        Start-Sleep -Seconds $PollIntervalSeconds
+    }
+
+    Write-Warning "Timeout waiting for deployment '$DeploymentName' to be ready after $MaxWaitMinutes minutes"
+    return $false
+}
+
+# Function to call Content Understanding UpdateDefaults API using az rest
+# Returns $true if successful, $false if failed
+function Update-ContentUnderstandingDefaults {
+    param (
+        [string] $Endpoint,
+        [string] $AccountName,
+        [hashtable] $ModelDeployments
+    )
+
+    Write-Host "Updating Content Understanding defaults for account '$AccountName'..."
+
+    try {
+        # Build the request body JSON
+        # Format: { "modelDeployments": { "gpt-4.1": "gpt-4.1", "gpt-4.1-mini": "gpt-4.1-mini", "text-embedding-3-large": "text-embedding-3-large" } }
+        $modelDeploymentsJson = @{}
+        foreach ($kvp in $ModelDeployments.GetEnumerator()) {
+            $modelDeploymentsJson[$kvp.Key] = $kvp.Value
+        }
+        $requestBody = @{
+            modelDeployments = $modelDeploymentsJson
+        } | ConvertTo-Json -Depth 10 -Compress
+
+        # Call UpdateDefaults API using az rest
+        # Endpoint: {endpoint}/contentunderstanding/defaults?api-version=2025-11-01
+        # Method: PATCH
+        # Content-Type: application/merge-patch+json
+        # Note: az rest will automatically determine the resource from the URL for known endpoints
+        $apiUrl = "$($Endpoint.TrimEnd('/'))/contentunderstanding/defaults?api-version=2025-11-01"
+
+        Write-Host "Calling UpdateDefaults API: $apiUrl"
+        Write-Host "Request body: $requestBody"
+
+        # Use the Cognitive Services resource URL for authentication
+        # For Azure Cognitive Services, the resource identifier is https://cognitiveservices.azure.com
+        $resourceUrl = "https://cognitiveservices.azure.com"
+
+        $response = az rest --method patch `
+            --url $apiUrl `
+            --resource $resourceUrl `
+            --headers "Content-Type=application/merge-patch+json" `
+            --body $requestBody `
+            --output json 2>&1
+
+        if ($LASTEXITCODE -eq 0) {
+            $result = $response | ConvertFrom-Json
+            Write-Host "Successfully updated Content Understanding defaults for '$AccountName'" -ForegroundColor Green
+            if ($result.modelDeployments) {
+                Write-Host "Configured model deployments:"
+                foreach ($kvp in $result.modelDeployments.PSObject.Properties) {
+                    Write-Host "  $($kvp.Name): $($kvp.Value)"
+                }
+            }
+            return $true
+        }
+        else {
+            Write-Error "FAILED to update Content Understanding defaults for '$AccountName': $response" -ErrorAction Continue
+            return $false
+        }
+    }
+    catch {
+        Write-Error "FAILED to update Content Understanding defaults for '$AccountName': $_" -ErrorAction Continue
+        return $false
+    }
+}
+
 # Deploy models to source resource
 $deploymentCount = 0
 $successCount = 0
@@ -202,4 +337,77 @@ if ($successCount -lt $deploymentCount) {
 Write-Host ""
 Write-Host "Note: Model deployments are asynchronous and may take 5-15 minutes to fully provision."
 Write-Host "The deployments will be in 'Succeeded' state when ready for use."
+
+# Wait for deployments to be ready before calling UpdateDefaults
+Write-Host ""
+Write-Host "Waiting for model deployments to be ready before updating Content Understanding defaults..." -ForegroundColor Cyan
+
+$allDeploymentsReady = $true
+
+# Wait for source resource deployments
+Write-Host "Checking source resource deployments..."
+foreach ($model in $modelConfigs) {
+    $isReady = Wait-ForDeployment `
+        -ResourceGroupName $ResourceGroupName `
+        -AccountName $sourceAccountName `
+        -DeploymentName $model.Name `
+        -MaxWaitMinutes 15 `
+        -PollIntervalSeconds 30
+    if (-not $isReady) {
+        $allDeploymentsReady = $false
+    }
+}
+
+# Wait for target resource deployments
+Write-Host "Checking target resource deployments..."
+foreach ($model in $modelConfigs) {
+    $isReady = Wait-ForDeployment `
+        -ResourceGroupName $ResourceGroupName `
+        -AccountName $targetAccountName `
+        -DeploymentName $model.Name `
+        -MaxWaitMinutes 15 `
+        -PollIntervalSeconds 30
+    if (-not $isReady) {
+        $allDeploymentsReady = $false
+    }
+}
+
+if ($allDeploymentsReady) {
+    Write-Host ""
+    Write-Host "All deployments are ready. Updating Content Understanding defaults..." -ForegroundColor Cyan
+
+    # Build model deployments mapping (model name -> deployment name)
+    # The deployment name is the same as the model name in our configuration
+    $modelDeployments = @{
+        'gpt-4.1' = 'gpt-4.1'
+        'gpt-4.1-mini' = 'gpt-4.1-mini'
+        'text-embedding-3-large' = 'text-embedding-3-large'
+    }
+
+    # Update defaults for source resource
+    $updateSourceResult = Update-ContentUnderstandingDefaults `
+        -Endpoint $sourceEndpoint `
+        -AccountName $sourceAccountName `
+        -ModelDeployments $modelDeployments
+
+    # Update defaults for target resource
+    $updateTargetResult = Update-ContentUnderstandingDefaults `
+        -Endpoint $targetEndpoint `
+        -AccountName $targetAccountName `
+        -ModelDeployments $modelDeployments
+
+    if ($updateSourceResult -and $updateTargetResult) {
+        Write-Host ""
+        Write-Host "Content Understanding defaults updated successfully for both resources!" -ForegroundColor Green
+    }
+    else {
+        Write-Host ""
+        Write-Warning "Some UpdateDefaults calls may have failed. Check the error messages above."
+    }
+}
+else {
+    Write-Host ""
+    Write-Warning "Not all deployments are ready. Skipping UpdateDefaults API call."
+    Write-Warning "You may need to manually call UpdateDefaults after deployments are ready."
+}
 


### PR DESCRIPTION
Added two test-resource setup to ensure model defaults are set for the created test resources. This ensures Live Test to run successfully in the cloud pipeline:
- In post-test-resource-creation script (test-resources-post.ps1), added 'az rest' call to set up model defaults
- Double check model defaults and also call model defaults updated as needed in the test setup fixture (run only once per test run) in a new file ContentUnderstadningTestSetupFixture.cs

TESTS
- Bicep and post script were tested using the eng/common/TestResources/New-TestREsourceds.ps1
- Ensured all tests passed with the newly created resource

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
