### PR TITLE
[agentserver]chore: Refactor the existing naming de-duplication patterns

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Models/FoundryHostedMcpTool.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Models/FoundryHostedMcpTool.cs
@@ -22,6 +22,14 @@ public sealed record FoundryHostedMcpTool : FoundryTool
     }
 
     /// <summary>
+    /// Creates an MCP tool definition.
+    /// </summary>
+    public static FoundryHostedMcpTool Create(
+        string name,
+        IReadOnlyDictionary<string, object?>? additionalProperties = null)
+        => new(name, additionalProperties);
+
+    /// <summary>
     /// Gets the source of the tool.
     /// </summary>
     public override FoundryToolSource Source => FoundryToolSource.HOSTED_MCP;

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Operations/FoundryConnectedToolsOperations.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Operations/FoundryConnectedToolsOperations.cs
@@ -33,18 +33,16 @@ internal class FoundryConnectedToolsOperations
     /// <summary>
     /// Resolves remote tools synchronously.
     /// </summary>
-    /// <param name="existingNames">Set of existing tool names to avoid conflicts.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of remote tools.</returns>
     public Response<IReadOnlyList<ResolvedFoundryTool>> ResolveTools(
-        HashSet<string> existingNames,
         CancellationToken cancellationToken = default)
     {
         var message = CreateResolveToolsMessage(cancellationToken);
         using (message)
         {
             var response = _invoker.SendRequest(message, cancellationToken);
-            var tools = ProcessResolveToolsResponse(response, existingNames);
+            var tools = ProcessResolveToolsResponse(response);
             return Response.FromValue<IReadOnlyList<ResolvedFoundryTool>>(tools, response);
         }
     }
@@ -52,18 +50,16 @@ internal class FoundryConnectedToolsOperations
     /// <summary>
     /// Resolves remote tools asynchronously.
     /// </summary>
-    /// <param name="existingNames">Set of existing tool names to avoid conflicts.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Task returning list of remote tools.</returns>
     public async Task<Response<IReadOnlyList<ResolvedFoundryTool>>> ResolveToolsAsync(
-        HashSet<string> existingNames,
         CancellationToken cancellationToken = default)
     {
         var message = CreateResolveToolsMessage(cancellationToken);
         using (message)
         {
             var response = await _invoker.SendRequestAsync(message, cancellationToken).ConfigureAwait(false);
-            var tools = await ProcessResolveToolsResponseAsync(response, existingNames, cancellationToken)
+            var tools = await ProcessResolveToolsResponseAsync(response, cancellationToken)
                 .ConfigureAwait(false);
             return Response.FromValue<IReadOnlyList<ResolvedFoundryTool>>(tools, response);
         }
@@ -166,9 +162,7 @@ internal class FoundryConnectedToolsOperations
             cancellationToken);
     }
 
-    private IReadOnlyList<ResolvedFoundryTool> ProcessResolveToolsResponse(
-        Response response,
-        HashSet<string> existingNames)
+    private IReadOnlyList<ResolvedFoundryTool> ProcessResolveToolsResponse(Response response)
     {
         if (response.ContentStream == null)
         {
@@ -188,15 +182,11 @@ internal class FoundryConnectedToolsOperations
 
         var enrichedTools = ParseEnrichedTools(toolsElement, _options.ToolConfig.ConnectedTools);
 
-        return ToolDescriptorBuilder.BuildDescriptors(
-            enrichedTools,
-            FoundryToolSource.CONNECTED,
-            existingNames);
+        return ToolDescriptorBuilder.BuildDescriptors(enrichedTools, FoundryToolSource.CONNECTED);
     }
 
     private async Task<IReadOnlyList<ResolvedFoundryTool>> ProcessResolveToolsResponseAsync(
         Response response,
-        HashSet<string> existingNames,
         CancellationToken cancellationToken)
     {
         if (response.ContentStream == null)
@@ -218,10 +208,7 @@ internal class FoundryConnectedToolsOperations
 
         var enrichedTools = ParseEnrichedTools(toolsElement, _options.ToolConfig.ConnectedTools);
 
-        return ToolDescriptorBuilder.BuildDescriptors(
-            enrichedTools,
-            FoundryToolSource.CONNECTED,
-            existingNames);
+        return ToolDescriptorBuilder.BuildDescriptors(enrichedTools, FoundryToolSource.CONNECTED);
     }
 
     private object? ProcessInvokeToolResponse(Response response)

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Operations/FoundryMcpToolsOperations.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Operations/FoundryMcpToolsOperations.cs
@@ -34,32 +34,28 @@ internal class FoundryMcpToolsOperations
     /// <summary>
     /// Lists MCP tools synchronously.
     /// </summary>
-    /// <param name="existingNames">Set of existing tool names to avoid conflicts.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>List of MCP tools.</returns>
     public Response<IReadOnlyList<ResolvedFoundryTool>> ListTools(
-        HashSet<string> existingNames,
         CancellationToken cancellationToken = default)
     {
         using HttpMessage message = CreateListToolsMessage(cancellationToken);
         var response = _invoker.SendRequest(message, cancellationToken);
-        var tools = ProcessListToolsResponse(response, existingNames);
+        var tools = ProcessListToolsResponse(response);
         return Response.FromValue<IReadOnlyList<ResolvedFoundryTool>>(tools, response);
     }
 
     /// <summary>
     /// Lists MCP tools asynchronously.
     /// </summary>
-    /// <param name="existingNames">Set of existing tool names to avoid conflicts.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Task returning list of MCP tools.</returns>
     public async Task<Response<IReadOnlyList<ResolvedFoundryTool>>> ListToolsAsync(
-        HashSet<string> existingNames,
         CancellationToken cancellationToken = default)
     {
         using HttpMessage message = CreateListToolsMessage(cancellationToken);
         var response = await _invoker.SendRequestAsync(message, cancellationToken).ConfigureAwait(false);
-        var tools = await ProcessListToolsResponseAsync(response, existingNames, cancellationToken)
+        var tools = await ProcessListToolsResponseAsync(response, cancellationToken)
             .ConfigureAwait(false);
         return Response.FromValue<IReadOnlyList<ResolvedFoundryTool>>(tools, response);
     }
@@ -174,9 +170,7 @@ internal class FoundryMcpToolsOperations
         };
     }
 
-    private IReadOnlyList<ResolvedFoundryTool> ProcessListToolsResponse(
-        Response response,
-        HashSet<string> existingNames)
+    private IReadOnlyList<ResolvedFoundryTool> ProcessListToolsResponse(Response response)
     {
         if (response.ContentStream == null)
         {
@@ -196,15 +190,11 @@ internal class FoundryMcpToolsOperations
             toolsElement.GetRawText(),
             JsonExtensions.DefaultJsonSerializerOptions) ?? new List<Dictionary<string, object?>>();
 
-        return ToolDescriptorBuilder.BuildDescriptors(
-            rawTools,
-            FoundryToolSource.HOSTED_MCP,
-            existingNames);
+        return ToolDescriptorBuilder.BuildDescriptors(rawTools, FoundryToolSource.HOSTED_MCP);
     }
 
     private async Task<IReadOnlyList<ResolvedFoundryTool>> ProcessListToolsResponseAsync(
         Response response,
-        HashSet<string> existingNames,
         CancellationToken cancellationToken)
     {
         if (response.ContentStream == null)
@@ -226,10 +216,7 @@ internal class FoundryMcpToolsOperations
             toolsElement.GetRawText(),
             JsonExtensions.DefaultJsonSerializerOptions) ?? new List<Dictionary<string, object?>>();
 
-        return ToolDescriptorBuilder.BuildDescriptors(
-            rawTools,
-            FoundryToolSource.HOSTED_MCP,
-            existingNames);
+        return ToolDescriptorBuilder.BuildDescriptors(rawTools, FoundryToolSource.HOSTED_MCP);
     }
 
     private object? ProcessInvokeToolResponse(Response response)

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Utilities/ToolDescriptorBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Tools/Utilities/ToolDescriptorBuilder.cs
@@ -15,12 +15,10 @@ internal static class ToolDescriptorBuilder
     /// </summary>
     /// <param name="rawTools">Raw tool data from API.</param>
     /// <param name="source">Source of the tools.</param>
-    /// <param name="existingNames">Set of existing tool names to avoid conflicts.</param>
     /// <returns>List of built tool descriptors.</returns>
     public static IReadOnlyList<ResolvedFoundryTool> BuildDescriptors(
         IEnumerable<Dictionary<string, object?>> rawTools,
-        FoundryToolSource source,
-        HashSet<string> existingNames)
+        FoundryToolSource source)
     {
         var descriptors = new List<ResolvedFoundryTool>();
 
@@ -32,7 +30,6 @@ internal static class ToolDescriptorBuilder
                 continue;
             }
 
-            var resolvedName = NameResolver.EnsureUniqueName(name, existingNames);
             var inputSchema = ToolMetadataExtractor.ExtractInputSchema(raw);
             var foundryTool = raw.TryGetValue("foundry_tool", out var td) && td is FoundryTool tDef
                 ? tDef
@@ -40,7 +37,7 @@ internal static class ToolDescriptorBuilder
 
             var descriptor = new ResolvedFoundryTool
             {
-                Name = resolvedName,
+                Name = name,
                 Description = description ?? string.Empty,
                 Metadata = raw,
                 InputSchema = inputSchema,
@@ -48,7 +45,6 @@ internal static class ToolDescriptorBuilder
             };
 
             descriptors.Add(descriptor);
-            existingNames.Add(resolvedName);
         }
 
         return descriptors;


### PR DESCRIPTION
  PR description:

  - Centralized tool name conflict handling in Azure.AI.AgentServer.Core/src/Tools/FoundryToolClient.cs via a single resolver invoked after aggregating sources.
  - Removed existingNames side effects from MCP/Connected tool operations and descriptor builder, leaving them to return raw names.
  - Ensured init-only tool names are handled immutably by cloning records when renaming.
  - Preserved invoker wiring and async parallel fetching behavior.