### PR TITLE
[CODEOWNERS] Update messaging ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -497,14 +497,14 @@
 # ServiceOwners:                                                   @Kishp01 @shankarsama @rajeshka
 
 # PRLabel: %Event Hubs
-/sdk/eventhub/                                                     @axisc @sjkwak @hmlam @jsquire
+/sdk/eventhub/                                                     @axisc @sjkwak @hmlam @j7nw4r @jsquire
 
 # PRLabel: %Event Hubs %Functions
-/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/        @axisc @sjkwak @hmlam @jsquire
+/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/        @axisc @sjkwak @hmlam @j7nw4r @jsquire
 
 # ServiceLabel: %Event Hubs
 # AzureSdkOwners:                                                  @jsquire
-# ServiceOwners:                                                   @axisc @sjkwak @hmlam
+# ServiceOwners:                                                   @axisc @sjkwak @hmlam @j7nw4r
 
 # PRLabel: %Extension - WCF
 /sdk/extension-wcf/                                                @mconnew
@@ -820,14 +820,14 @@
 # ServiceOwners:                                                   @amirkeren
 
 # PRLabel: %Service Bus
-/sdk/servicebus/                                                   @skarri-microsoft @EldertGrootenboer @jsquire
+/sdk/servicebus/                                                   @skarri-microsoft @EldertGrootenboer @j7nw4r @jsquire
 
 # PRLabel: %Service Bus %Functions
-/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/     @skarri-microsoft @EldertGrootenboer @jsquire
+/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/     @skarri-microsoft @EldertGrootenboer @j7nw4r @jsquire
 
 # ServiceLabel: %Service Bus
 # AzureSdkOwners:                                                  @jsquire
-# ServiceOwners:                                                   @skarri-microsoft @EldertGrootenboer
+# ServiceOwners:                                                   @skarri-microsoft @EldertGrootenboer @j7nw4r
 
 # PRLabel: %SignalR
 /sdk/signalr/                                                      @chenkennt @vicancy @JialinXin @Y-Sindo


### PR DESCRIPTION
# Summary

The focus of these changes is to add Jonathan (@j7nw4r) as an owner of Event Hubs and Service Bus.

## References and resources

- [Add @j7nw4r as code owner for Event Hubs and Service Bus SDKs (#54896)](https://github.com/Azure/azure-sdk-for-net/pull/54896)  _(supersedes)_