### PR TITLE
Always visit scmmethods

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/MatchConditionsHeadersVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/MatchConditionsHeadersVisitor.cs
@@ -53,22 +53,6 @@ namespace Azure.Generator.Visitors
             { RequestConditionHeaders.IfUnmodifiedSince, IfUnmodifiedSince }
         };
 
-        protected override ScmMethodProviderCollection? Visit(
-            InputServiceMethod serviceMethod,
-            ClientProvider enclosingType,
-            ScmMethodProviderCollection? methodProviderCollection)
-        {
-            if (methodProviderCollection != null)
-            {
-                foreach (var method in methodProviderCollection)
-                {
-                    UpdateMethod(method);
-                }
-            }
-
-            return methodProviderCollection;
-        }
-
         protected override ScmMethodProvider? VisitCreateRequestMethod(
             InputServiceMethod serviceMethod,
             RestClientProvider enclosingType,
@@ -80,6 +64,13 @@ namespace Azure.Generator.Visitors
             }
 
             return createRequestMethodProvider;
+        }
+
+        protected override ScmMethodProvider? VisitMethod(ScmMethodProvider method)
+        {
+            UpdateMethod(method);
+
+            return method;
         }
 
         /// <summary>

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/MatchConditionsHeadersVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/MatchConditionsHeadersVisitorTests.cs
@@ -45,10 +45,9 @@ namespace Azure.Generator.Tests.Visitors
 
             var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
 
-            visitor.VisitScmMethodCollection(serviceMethod, clientProvider!, methodCollection);
-
             foreach (var method in methodCollection)
             {
+                visitor.VisitScmMethod(method);
                 // Verify that the RequestConditions parameter is added to all the client methods
                 Assert.AreEqual(2, method.Signature.Parameters.Count);
                 Assert.IsTrue(method.Signature.Parameters[0].Name == "requestConditions");
@@ -123,10 +122,9 @@ namespace Azure.Generator.Tests.Visitors
 
             var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
 
-            visitor.VisitScmMethodCollection(serviceMethod, clientProvider!, methodCollection);
-
             foreach (var method in methodCollection)
             {
+                visitor.VisitScmMethod(method);
                 // Verify that the RequestConditions parameter is added to all the client methods
                 Assert.AreEqual(2, method.Signature.Parameters.Count);
                 Assert.IsTrue(method.Signature.Parameters[0].Name == conditionName.ToVariableName());
@@ -258,10 +256,9 @@ namespace Azure.Generator.Tests.Visitors
             MethodProvider? protocolMethod = null;
             var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
 
-            visitor.VisitScmMethodCollection(serviceMethod, clientProvider!, methodCollection);
-
             foreach (var method in methodCollection)
             {
+                visitor.VisitScmMethod(method);
                 if (method.Kind == ScmMethodKind.Protocol && method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Async))
                 {
                     protocolMethod = method;
@@ -309,10 +306,9 @@ namespace Azure.Generator.Tests.Visitors
             MethodProvider? protocolMethod = null;
             var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
 
-            visitor.VisitScmMethodCollection(serviceMethod, clientProvider!, methodCollection);
-
             foreach (var method in methodCollection)
             {
+                visitor.VisitScmMethod(method);
                 if (method.Kind == ScmMethodKind.Protocol && method.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Async))
                 {
                     protocolMethod = method;
@@ -354,10 +350,9 @@ namespace Azure.Generator.Tests.Visitors
 
             var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
 
-            visitor.VisitScmMethodCollection(serviceMethod, clientProvider!, methodCollection);
-
             foreach (var method in methodCollection)
             {
+                visitor.VisitScmMethod(method);
                 // Verify that the RequestConditions parameter is added to all the client methods
                 Assert.AreEqual(3, method.Signature.Parameters.Count);
                 Assert.IsTrue(method.Signature.Parameters[0].Type.Equals(ETagType));
@@ -397,10 +392,9 @@ namespace Azure.Generator.Tests.Visitors
 
             var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
 
-            visitor.VisitScmMethodCollection(serviceMethod, clientProvider!, methodCollection);
-
             foreach (var method in methodCollection)
             {
+                visitor.VisitScmMethod(method);
                 // Verify that the parameters are unchanged
                 Assert.AreEqual(3, method.Signature.Parameters.Count);
                 Assert.IsTrue(method.Signature.Parameters.Any(p => p.Name == "authorization"));
@@ -443,10 +437,9 @@ namespace Azure.Generator.Tests.Visitors
 
             var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
 
-            visitor.VisitScmMethodCollection(serviceMethod, clientProvider!, methodCollection);
-
             foreach (var method in methodCollection)
             {
+                visitor.VisitScmMethod(method);
                 // Verify that the MatchConditions parameter is added
                 Assert.AreEqual(2, method.Signature.Parameters.Count);
                 Assert.IsTrue(method.Signature.Parameters[0].Name == "matchConditions");
@@ -486,10 +479,9 @@ namespace Azure.Generator.Tests.Visitors
 
             var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
 
-            visitor.VisitScmMethodCollection(serviceMethod, clientProvider!, methodCollection);
-
             foreach (var method in methodCollection)
             {
+                visitor.VisitScmMethod(method);
                 // Verify that the RequestConditions parameter is added
                 Assert.AreEqual(2, method.Signature.Parameters.Count);
                 Assert.IsTrue(method.Signature.Parameters[0].Name == "requestConditions");
@@ -531,10 +523,9 @@ namespace Azure.Generator.Tests.Visitors
 
             var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
 
-            visitor.VisitScmMethodCollection(serviceMethod, clientProvider!, methodCollection);
-
             foreach (var method in methodCollection)
             {
+                visitor.VisitScmMethod(method);
                 // Verify that the RequestConditions parameter is added
                 Assert.AreEqual(3, method.Signature.Parameters.Count);
                 Assert.IsTrue(method.Signature.Parameters[0].Name == "requestConditions");
@@ -683,12 +674,9 @@ namespace Azure.Generator.Tests.Visitors
 
         private class TestMatchConditionsHeaderVisitor : MatchConditionsHeadersVisitor
         {
-            public ScmMethodProviderCollection? VisitScmMethodCollection(
-                InputServiceMethod serviceMethod,
-                ClientProvider enclosingType,
-                ScmMethodProviderCollection? methodProviderCollection)
+            public ScmMethodProvider? VisitScmMethod(ScmMethodProvider method)
             {
-                return base.Visit(serviceMethod, enclosingType, methodProviderCollection);
+                return base.VisitMethod(method);
             }
 
             public ScmMethodProvider? VisitCreateRequest(

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecClient.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/BasicTypeSpecClient.cs
@@ -2096,15 +2096,15 @@ namespace BasicTypeSpec
         /// <returns> The response returned from the service. </returns>
         public virtual Response ConditionalRequestDate(RequestConditions requestConditions, RequestContext context)
         {
+            if (requestConditions?.IfUnmodifiedSince != null)
+            {
+                throw new ArgumentException("Service does not support the If-Unmodified-Since header for this operation.");
+            }
+
             using DiagnosticScope scope = ClientDiagnostics.CreateScope("BasicTypeSpecClient.ConditionalRequestDate");
             scope.Start();
             try
             {
-                if (requestConditions?.IfUnmodifiedSince != null)
-                {
-                    throw new ArgumentException("Service does not support the If-Unmodified-Since header for this operation.");
-                }
-
                 using HttpMessage message = CreateConditionalRequestDateRequest(requestConditions, context);
                 return Pipeline.ProcessMessage(message, context);
             }
@@ -2129,15 +2129,15 @@ namespace BasicTypeSpec
         /// <returns> The response returned from the service. </returns>
         public virtual async Task<Response> ConditionalRequestDateAsync(RequestConditions requestConditions, RequestContext context)
         {
+            if (requestConditions?.IfUnmodifiedSince != null)
+            {
+                throw new ArgumentException("Service does not support the If-Unmodified-Since header for this operation.");
+            }
+
             using DiagnosticScope scope = ClientDiagnostics.CreateScope("BasicTypeSpecClient.ConditionalRequestDate");
             scope.Start();
             try
             {
-                if (requestConditions?.IfUnmodifiedSince != null)
-                {
-                    throw new ArgumentException("Service does not support the If-Unmodified-Since header for this operation.");
-                }
-
                 using HttpMessage message = CreateConditionalRequestDateRequest(requestConditions, context);
                 return await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
             }


### PR DESCRIPTION
We need to make sure to visit all ScmMethodProviders for MatchConditions logic as the previous change updated to only consider the ScmMethodProviderCollection which would only contain methods on a ClientProvider. 
See issue in https://github.com/Azure/azure-sdk-for-net/pull/54919/files#diff-1a6c9c8c0ca1fcb3c2ed39d8469475299d985d586537877b75141484edf69acfR280