### PR TITLE
[AzureMonitorExporter] [AzureMonitorDistro] Change default to rate limited sampler without api change

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -6,6 +6,28 @@
 
 ### Breaking Changes
 
+*  **Default Sampler Changed**: The default sampling behavior has been changed from
+  `ApplicationInsightsSampler` with 100% sampling (all traces sampled) to
+  `RateLimitedSampler` with 5.0 traces per second. This change significantly
+  reduces telemetry volume for high-traffic applications and provides better
+  cost optimization out of the box.
+  **Impact**: Applications with more than 5 requests per second will see fewer
+  traces exported by default.
+  **Migration**: To maintain the previous behavior (100% sampling), explicitly
+  configure the sampler:
+  
+  ```csharp
+  // Option 1: Set SamplingRatio and clear TracesPerSecond
+  builder.Services.AddOpenTelemetry()
+      .UseAzureMonitor(options =>
+      {
+          options.SamplingRatio = 1.0f;
+          options.TracesPerSecond = null;
+      });
+  // Option 2: Use environment variables
+  // OTEL_TRACES_SAMPLER=microsoft.fixed_percentage
+  // OTEL_TRACES_SAMPLER_ARG=1.0
+  ```
 ### Bugs Fixed
 
 * Fixed an issue where Azure Container Apps instances were showing VM instance GUIDs

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
@@ -130,16 +130,44 @@ Note that the `Credential` property is optional. If it is not set, Azure Monitor
 
 ### Advanced configuration
 
-#### Customizing Sampling Percentage
+#### Customizing Sampling Behavior
 
-When using the Azure Monitor Distro, the sampling percentage for telemetry data is set to 100% (1.0F) by default. For example, let's say you want to set the sampling percentage to 50%. You can achieve this by modifying the code as follows:
+The Azure Monitor Distro uses **rate-limited sampling** by default, collecting up to **5.0 traces per second**. This provides cost-effective telemetry collection for most applications while maintaining observability.
+
+To customize the sampling behavior:
 
 ``` C#
 builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
 {
-    options.SamplingRatio = 0.5F;
+    options.TracesPerSecond = 10.0; // Collect up to 10 traces per second
 });
 ```
+
+**Option 2: Switch to percentage-based sampling**
+``` C#
+builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
+{
+    options.SamplingRatio = 0.5F; // Sample 50% of traces
+    options.TracesPerSecond = null; // Disable rate-limited sampling
+});
+```
+
+**Option 3: Use environment variables**
+For rate-limited sampling:
+
+```
+OTEL_TRACES_SAMPLER=microsoft.rate_limited
+OTEL_TRACES_SAMPLER_ARG=10
+```
+
+For percentage-based sampling:
+
+```
+OTEL_TRACES_SAMPLER=microsoft.fixed_percentage
+OTEL_TRACES_SAMPLER_ARG=0.5
+```
+
+**Note**: When both `TracesPerSecond` and `SamplingRatio` are configured, `TracesPerSecond` takes precedence.
 
 #### Adding Custom ActivitySource to Traces
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/README.md
@@ -136,6 +136,7 @@ The Azure Monitor Distro uses **rate-limited sampling** by default, collecting u
 
 To customize the sampling behavior:
 
+**Option 1: Set the rate limited sampler to use a configured traces per second**
 ``` C#
 builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
 {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
@@ -61,7 +61,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// <summary>
         /// Gets or sets the ratio of telemetry items to be sampled. The value must be between 0.0F and 1.0F, inclusive.
         /// For example, specifying 0.4 means that 40% of traces are sampled and 60% are dropped.
-        /// The default value is 1.0F, indicating that all telemetry items are sampled.
         /// </summary>
         public float SamplingRatio { get; set; } = 1.0F;
 
@@ -70,7 +69,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// For example, specifying 0.5 means one request every two seconds.
         /// When both TracesPerSecond and SamplingRatio are specified, TracesPerSecond takes precedence.
         /// </summary>
-        public double? TracesPerSecond { get; set; }
+        public double? TracesPerSecond { get; set; } = 5.0;
 
         /// <summary>
         /// Override the default directory for offline storage.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
@@ -28,7 +28,14 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             {
                 if (_configuration != null)
                 {
-                    _configuration.GetSection(AzureMonitorSectionFromConfig).Bind(options);
+                    //_configuration.GetSection(AzureMonitorSectionFromConfig).Bind(options);
+                    var azureMonitorSection = _configuration.GetSection(AzureMonitorSectionFromConfig);
+                    azureMonitorSection.Bind(options);
+                    if (azureMonitorSection["TracesPerSecond"] == null && azureMonitorSection["SamplingRatio"] != null)
+                    {
+                        // This is so user does not have to explicitly set TracesPerSecond to null in config to use fixed-percentage sampling.
+                        options.TracesPerSecond = null;
+                    }
 
                     // IConfiguration can read from EnvironmentVariables or InMemoryCollection if configured to do so.
                     var connectionStringFromIConfig = _configuration[EnvironmentVariableConstants.APPLICATIONINSIGHTS_CONNECTION_STRING];
@@ -97,6 +104,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
                             if (ratio >= 0.0 && ratio <= 1.0)
                             {
                                 options.SamplingRatio = (float)ratio;
+                                options.TracesPerSecond = null; // Explicitly set to null to use fixed-percentage sampling
                             }
                             else
                             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/DefaultAzureMonitorOptions.cs
@@ -28,7 +28,6 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             {
                 if (_configuration != null)
                 {
-                    //_configuration.GetSection(AzureMonitorSectionFromConfig).Bind(options);
                     var azureMonitorSection = _configuration.GetSection(AzureMonitorSectionFromConfig);
                     azureMonitorSection.Bind(options);
                     if (azureMonitorSection["TracesPerSecond"] == null && azureMonitorSection["SamplingRatio"] != null)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsSamplerTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsSamplerTests.cs
@@ -60,8 +60,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             var configurator = new DefaultAzureMonitorOptions(configuration);
             var options = new AzureMonitorOptions();
             configurator.Configure(options);
-            Assert.Equal(1.0f, options.SamplingRatio); // default
-            Assert.Null(options.TracesPerSecond);
+            Assert.Equal(1.0f, options.SamplingRatio);
+            Assert.Equal(5.0, options.TracesPerSecond); // default value retained
 
             // invalid negative rate
             configValues = new List<KeyValuePair<string, string?>>
@@ -73,7 +73,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             configurator = new DefaultAzureMonitorOptions(configuration);
             options = new AzureMonitorOptions();
             configurator.Configure(options);
-            Assert.Null(options.TracesPerSecond);
+            Assert.Equal(5.0, options.TracesPerSecond); // default value retained
             Assert.Equal(1.0f, options.SamplingRatio);
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Xunit;
@@ -28,6 +29,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             Assert.Null(azureMonitorOptions.ConnectionString);
             Assert.False(azureMonitorOptions.DisableOfflineStorage);
             Assert.Equal(1.0F, azureMonitorOptions.SamplingRatio);
+            Assert.Equal(5.0, azureMonitorOptions.TracesPerSecond);
             Assert.Null(azureMonitorOptions.StorageDirectory);
             Assert.True(azureMonitorOptions.EnableTraceBasedLogsSampler);
         }
@@ -57,6 +59,35 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             Assert.Equal("testJsonValue", azureMonitorOptions.ConnectionString);
             Assert.True(azureMonitorOptions.DisableOfflineStorage);
             Assert.Equal(0.5F, azureMonitorOptions.SamplingRatio);
+            Assert.Null(azureMonitorOptions.TracesPerSecond);
+            Assert.Equal("testJsonValue", azureMonitorOptions.StorageDirectory);
+        }
+
+        [Fact]
+        public void VerifyConfigure_TracesPerSecond_ViaJson()
+        {
+            var appSettings = @"{""AzureMonitor"":{
+                ""ConnectionString"" : ""testJsonValue"",
+                ""DisableOfflineStorage"" : ""true"",
+                ""TracesPerSecond"" : 6.0,
+                ""StorageDirectory"" : ""testJsonValue"",
+                ""EnableTraceBasedLogsSampler"" : ""true""
+                }}";
+
+            var configuration = new ConfigurationBuilder()
+                .AddJsonStream(new MemoryStream(Encoding.UTF8.GetBytes(appSettings)))
+                .Build();
+
+            var defaultAzureMonitorOptions = new DefaultAzureMonitorOptions(configuration);
+
+            var azureMonitorOptions = new AzureMonitorOptions();
+
+            defaultAzureMonitorOptions.Configure(azureMonitorOptions);
+
+            Assert.Equal("testJsonValue", azureMonitorOptions.ConnectionString);
+            Assert.True(azureMonitorOptions.DisableOfflineStorage);
+            Assert.Equal(1.0F, azureMonitorOptions.SamplingRatio);
+            Assert.Equal(6.0, azureMonitorOptions.TracesPerSecond);
             Assert.Equal("testJsonValue", azureMonitorOptions.StorageDirectory);
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/DefaultAzureMonitorOptionsTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Xunit;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/AspNetCoreInstrumentationTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/AspNetCoreInstrumentationTests.cs
@@ -71,6 +71,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
                             {
                                 x.EnableLiveMetrics = false;
                                 x.ConnectionString = testConnectionString;
+                                x.SamplingRatio = 1.0f; // Ensure 100% sampling for tests
+                                x.TracesPerSecond = null; // Disable rate limited sampler
                             })
                             .WithTracing(x => x.AddInMemoryExporter(activities))
                             // Custom resources must be added AFTER AzureMonitor to override the included ResourceDetectors.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/HttpClientInstrumentationTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/HttpClientInstrumentationTests.cs
@@ -58,7 +58,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
             var serviceCollection = new ServiceCollection();
 
             serviceCollection.AddOpenTelemetry()
-                .UseAzureMonitor(x => x.ConnectionString = testConnectionString)
+                .UseAzureMonitor(x =>
+                {
+                    x.ConnectionString = testConnectionString;
+                    x.SamplingRatio = 1.0f; // Ensure 100% sampling for tests
+                    x.TracesPerSecond = null; // Disable rate limited sampler
+                })
                 .WithTracing(x => x.AddInMemoryExporter(activities))
                 // Custom resources must be added AFTER AzureMonitor to override the included ResourceDetectors.
                 .ConfigureResource(x => x.AddAttributes(SharedTestVars.TestResourceAttributes));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/SqlClientInstrumentationTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/E2ETests/SqlClientInstrumentationTests.cs
@@ -72,7 +72,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
             var activities = new List<Activity>();
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddOpenTelemetry()
-                .UseAzureMonitor(x => x.ConnectionString = testConnectionString)
+                .UseAzureMonitor(x =>
+                {
+                    x.ConnectionString = testConnectionString;
+                    x.SamplingRatio = 1.0f; // Ensure 100% sampling for tests
+                    x.TracesPerSecond = null; // Disable rate limiting sampler
+                })
                 .WithTracing(x => x.AddInMemoryExporter(activities))
                 // Custom resources must be added AFTER AzureMonitor to override the included ResourceDetectors.
                 .ConfigureResource(x => x.AddAttributes(SharedTestVars.TestResourceAttributes));
@@ -172,7 +177,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests.E2ETests
             var activities = new List<Activity>();
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddOpenTelemetry()
-                .UseAzureMonitor(x => x.ConnectionString = testConnectionString)
+                .UseAzureMonitor(x =>
+                {
+                    x.ConnectionString = testConnectionString;
+                    x.SamplingRatio = 1.0f; // Ensure 100% sampling for tests
+                    x.TracesPerSecond = null; // Disable rate limited sampler
+                })
                 .WithTracing(x => x.AddInMemoryExporter(activities))
                 // Custom resources must be added AFTER AzureMonitor to override the included ResourceDetectors.
                 .ConfigureResource(x => x.AddAttributes(SharedTestVars.TestResourceAttributes));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/InitializationTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/InitializationTests.cs
@@ -300,7 +300,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
                 Assert.Equal(expectedProfilingSessionTraceProcessor, variables.foundProfilingSessionTraceProcessor);
 
                 // Validate Sampler
-                EvaluationHelper.EvaluateTracerProviderSampler(serviceProvider, false);
+                // The default TracesPerSecond is 5.0, so we expect RateLimitedSampler by default
+                EvaluationHelper.EvaluateTracerProviderSampler(serviceProvider, true);
 
                 // Validate Instrumentations
                 var instrumentationsProperty = tracerProvider.GetType().GetProperty("Instrumentations", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -5,6 +5,27 @@
 ### Features Added
 
 ### Breaking Changes
+* **Default Sampler Changed**: The default sampling behavior has been changed from
+  `ApplicationInsightsSampler` with 100% sampling (all traces sampled) to
+  `RateLimitedSampler` with 5.0 traces per second. This change significantly
+  reduces telemetry volume for high-traffic applications and provides better
+  cost optimization out of the box.
+  **Impact**: Applications with more than 5 requests per second will see fewer
+  traces exported by default.
+  **Migration**: To maintain the previous behavior (100% sampling), explicitly
+  configure the sampler:
+  ```csharp
+  // Option 1: Set SamplingRatio and clear TracesPerSecond
+  builder.Services.AddOpenTelemetry()
+      .UseAzureMonitorExporter(options =>
+      {
+          options.SamplingRatio = 1.0f;
+          options.TracesPerSecond = null;
+      });
+  // Option 2: Use environment variables
+  // OTEL_TRACES_SAMPLER=microsoft.fixed_percentage
+  // OTEL_TRACES_SAMPLER_ARG=1.0
+  ```
 
 ### Bugs Fixed
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -150,6 +150,38 @@ Some key concepts for OpenTelemetry include:
 
 - [Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling):
   Sampling is a mechanism to control the noise and overhead introduced by OpenTelemetry by reducing the number of samples of traces collected and sent to the backend.
+  **Default Sampling**: By default, the Azure Monitor Exporter uses `RateLimitedSampler` with a rate of 5.0 traces per second. This provides cost-effective telemetry collection for most applications. To change the sampling behavior:
+
+- **For rate-limited sampling**: Set `TracesPerSecond` in `AzureMonitorExporterOptions`:
+
+  ```csharp
+  .AddAzureMonitorTraceExporter(options => {
+      options.TracesPerSecond = 10.0; // Sample 10 traces per second
+  })
+  ```
+
+- **For percentage-based sampling**: Set `SamplingRatio` and clear `TracesPerSecond`:
+
+  ```csharp
+  .AddAzureMonitorTraceExporter(options => {
+      options.SamplingRatio = 0.5f; // Sample 50% of traces
+      options.TracesPerSecond = null;
+  })
+  ```
+
+- **Via environment variables**:
+
+  ```
+  OTEL_TRACES_SAMPLER=microsoft.rate_limited
+  OTEL_TRACES_SAMPLER_ARG=10
+  ```
+
+  or
+
+  ```
+  OTEL_TRACES_SAMPLER=microsoft.fixed_percentage
+  OTEL_TRACES_SAMPLER_ARG=0.5
+  ```
 
 - [Metric Signal](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#metric-signal):
   OpenTelemetry allows to record raw measurements or metrics with predefined aggregation and a set of attributes (dimensions).

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/README.md
@@ -152,36 +152,36 @@ Some key concepts for OpenTelemetry include:
   Sampling is a mechanism to control the noise and overhead introduced by OpenTelemetry by reducing the number of samples of traces collected and sent to the backend.
   **Default Sampling**: By default, the Azure Monitor Exporter uses `RateLimitedSampler` with a rate of 5.0 traces per second. This provides cost-effective telemetry collection for most applications. To change the sampling behavior:
 
-- **For rate-limited sampling**: Set `TracesPerSecond` in `AzureMonitorExporterOptions`:
+    - **For rate-limited sampling**: Set `TracesPerSecond` in `AzureMonitorExporterOptions`:
 
-  ```csharp
-  .AddAzureMonitorTraceExporter(options => {
-      options.TracesPerSecond = 10.0; // Sample 10 traces per second
-  })
-  ```
+      ```csharp
+      .AddAzureMonitorTraceExporter(options => {
+          options.TracesPerSecond = 10.0; // Sample 10 traces per second
+      })
+      ```
 
-- **For percentage-based sampling**: Set `SamplingRatio` and clear `TracesPerSecond`:
+    - **For percentage-based sampling**: Set `SamplingRatio` and clear `TracesPerSecond`:
 
-  ```csharp
-  .AddAzureMonitorTraceExporter(options => {
-      options.SamplingRatio = 0.5f; // Sample 50% of traces
-      options.TracesPerSecond = null;
-  })
-  ```
+      ```csharp
+      .AddAzureMonitorTraceExporter(options => {
+          options.SamplingRatio = 0.5f; // Sample 50% of traces
+          options.TracesPerSecond = null;
+      })
+      ```
 
-- **Via environment variables**:
+    - **Via environment variables**:
 
-  ```
-  OTEL_TRACES_SAMPLER=microsoft.rate_limited
-  OTEL_TRACES_SAMPLER_ARG=10
-  ```
+      ```
+      OTEL_TRACES_SAMPLER=microsoft.rate_limited
+      OTEL_TRACES_SAMPLER_ARG=10
+      ```
 
-  or
+      or
 
-  ```
-  OTEL_TRACES_SAMPLER=microsoft.fixed_percentage
-  OTEL_TRACES_SAMPLER_ARG=0.5
-  ```
+      ```
+      OTEL_TRACES_SAMPLER=microsoft.fixed_percentage
+      OTEL_TRACES_SAMPLER_ARG=0.5
+      ```
 
 - [Metric Signal](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#metric-signal):
   OpenTelemetry allows to record raw measurements or metrics with predefined aggregation and a set of attributes (dimensions).

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -36,7 +36,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// <summary>
         /// Gets or sets the ratio of telemetry items to be sampled. The value must be between 0.0F and 1.0F, inclusive.
         /// For example, specifying 0.4 means that 40% of traces are sampled and 60% are dropped.
-        /// The default value is 1.0F, indicating that all telemetry items are sampled.
         /// </summary>
         public float SamplingRatio { get; set; } = 1.0F;
 
@@ -45,7 +44,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// For example, specifying 0.5 means one request every two seconds.
         /// When both TracesPerSecond and SamplingRatio are specified, TracesPerSecond takes precedence.
         /// </summary>
-        public double? TracesPerSecond { get; set; }
+        public double? TracesPerSecond { get; set; } = 5.0;
 
         /// <summary>
         /// The <see cref="ServiceVersion"/> of the Azure Monitor ingestion API.

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
@@ -31,7 +31,14 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 if (_configuration != null)
                 {
-                    BindIConfigurationOptions(_configuration, options);
+                    //BindIConfigurationOptions(_configuration, options);
+                    var azureMonitorSection = _configuration.GetSection(AzureMonitorExporterSectionFromConfig);
+                    azureMonitorSection.Bind(options);
+                    if (azureMonitorSection["TracesPerSecond"] == null && azureMonitorSection["SamplingRatio"] != null)
+                    {
+                        // This is so user does not have to explicitly set TracesPerSecond to null in config to use fixed-percentage sampling.
+                        options.TracesPerSecond = null;
+                    }
 
                     // IConfiguration can read from EnvironmentVariables or InMemoryCollection if configured to do so.
                     var connectionStringFromIConfig = _configuration[EnvironmentVariableConstants.APPLICATIONINSIGHTS_CONNECTION_STRING];
@@ -100,6 +107,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
                             if (ratio >= 0.0 && ratio <= 1.0)
                             {
                                 options.SamplingRatio = (float)ratio;
+                                options.TracesPerSecond = null; // Explicitly set to null to use fixed-percentage sampling
                             }
                             else
                             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
@@ -31,7 +31,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 if (_configuration != null)
                 {
-                    //BindIConfigurationOptions(_configuration, options);
                     var azureMonitorSection = _configuration.GetSection(AzureMonitorExporterSectionFromConfig);
                     azureMonitorSection.Bind(options);
                     if (azureMonitorSection["TracesPerSecond"] == null && azureMonitorSection["SamplingRatio"] != null)


### PR DESCRIPTION
This PR changes the default sampler to rate limited. When we choose to do a major version bump, we will consider changing this implementation to have a nullable sample ratio so that the user doesn't have to set tracespersecond to null. 
