### PR TITLE
Add back code generation targets

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -187,6 +187,7 @@
   <Import Project="ApiListing.targets" />
   <Import Project="CodeCoverage.targets" Condition="'$(CollectCoverage)' == 'true'" />
   <Import Project="Azure.Management.Test.targets" Condition="'$(IsMgmtLibrary)' == 'true' and '$(IsTestProject)' == 'true'" />
+  <Import Project="CodeGeneration.targets" Condition="'$(IncludeAutorestDependency)' != 'true'" />
 
   <!-- CentralPackageVersions properties -->
   <PropertyGroup>


### PR DESCRIPTION
Need to add back   `<Import Project="CodeGeneration.targets" Condition="'$(IncludeAutorestDependency)' != 'true'" />` to Directory.Build.Common.targets otherwise we'll get  "The target "GenerateCode" does not exist in the project" when generating management SDK.

