### PR TITLE
Use config namespace

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Extensions/ConfigurationExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Extensions/ConfigurationExtensions.cs
@@ -12,6 +12,9 @@ namespace Azure.Generator.Extensions
         public static bool UseModelNamespace(this Configuration config) =>
             UseModelNamespace(config.AdditionalConfigurationOptions);
 
+        public static string? GetNamespace(this Configuration config) =>
+            config.AdditionalConfigurationOptions.TryGetValue("namespace", out var value) ? value.ToString() : null;
+
         internal static bool UseModelNamespace(IReadOnlyDictionary<string, BinaryData> options)
         {
             return options.TryGetValue("model-namespace", out var value) &&

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/NamespaceVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/NamespaceVisitor.cs
@@ -68,7 +68,7 @@ namespace Azure.Generator.Visitors
                 {
                     type.Update(
                         @namespace: CodeModelGenerator.Instance.TypeFactory.GetCleanNameSpace(
-                            $"{CodeModelGenerator.Instance.TypeFactory.PrimaryNamespace}.Models"));
+                            $"{type.Type.Namespace}.Models"));
                 }
             }
         }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/NamespaceVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/NamespaceVisitor.cs
@@ -68,7 +68,7 @@ namespace Azure.Generator.Visitors
                 {
                     type.Update(
                         @namespace: CodeModelGenerator.Instance.TypeFactory.GetCleanNameSpace(
-                            $"{type.Type.Namespace}.Models"));
+                            $"{CodeModelGenerator.Instance.Configuration.GetNamespace()}.Models"));
                 }
             }
         }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/NamespaceVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/NamespaceVisitorTests.cs
@@ -20,12 +20,12 @@ namespace Azure.Generator.Tests.Visitors
         {
             MockHelpers.LoadMockGenerator(configurationJson: "{ \"package-name\": \"TestLibrary\", \"model-namespace\": true }");
             var visitor = new TestNamespaceVisitor();
-            var inputType = InputFactory.Model("TestModel", "Samples");
+            var inputType = InputFactory.Model("TestModel", "SomeNamespace");
             var model = new ModelProvider(inputType);
             var updatedModel = visitor.InvokePreVisitModel(inputType, model);
 
             Assert.IsNotNull(updatedModel);
-            Assert.AreEqual("Samples.Models", updatedModel!.Type.Namespace);
+            Assert.AreEqual("SomeNamespace.Models", updatedModel!.Type.Namespace);
         }
 
         [Test]


### PR DESCRIPTION
The PrimaryNamespace will be made not public as it should not be used outside of MTG.
Fixes https://github.com/Azure/azure-sdk-for-net/issues/55014