### PR TITLE
Fix for non-resource action operation

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -1183,6 +1183,14 @@ interface ScheduledActionExtension {
     GetAssociatedScheduledActionsRequest,
     GetAssociatedScheduledActionsResponse
   >;
+
+  @doc("Action to retrieve the PostgreSQL versions.")
+  @autoRoute
+  @armResourceAction(ScheduledAction)
+  @post
+  getPostgresVersions(
+    ...ResourceInstanceParameters<GetAssociatedScheduledActionsRequest>
+  ): ArmResponse<GetAssociatedScheduledActionsResponse> | ErrorResponse;
 }
 `,
       runner
@@ -1228,15 +1236,21 @@ interface ScheduledActionExtension {
     );
     strictEqual(methodEntry.operationScope, ResourceScope.ResourceGroup);
 
-    // Validate using resolveArmResources API - use deep equality to ensure schemas match
-    const resolvedSchema = resolveArmResources(program, sdkContext);
-    ok(resolvedSchema);
-
-    // Compare the entire schemas using deep equality
-    deepStrictEqual(
-      normalizeSchemaForComparison(resolvedSchema),
-      normalizeSchemaForComparison(armProviderSchemaResult)
+    // Verify getPostgresVersions is also a non-resource method
+    const getPostgresVersionsEntry = nonResourceMethods.find((m: any) =>
+      m.operationPath.includes("getPostgresVersions")
     );
+    ok(
+      getPostgresVersionsEntry,
+      "getPostgresVersions should be in non-resource methods"
+    );
+    strictEqual(getPostgresVersionsEntry.operationScope, ResourceScope.ResourceGroup);
+
+    // Note: We don't compare with resolveArmResources here because the getPostgresVersions
+    // operation uses ResourceInstanceParameters<GetAssociatedScheduledActionsRequest> which
+    // is a non-resource model, causing the ARM library to not recognize it as a valid operation.
+    // Our buildArmProviderSchema correctly includes it as a non-resource method based on its
+    // operation path not matching any resource instance pattern.
   });
 
   it("multiple resources sharing same model", async () => {


### PR DESCRIPTION
Fix for a corner case that, even an operation has `@armResourceAction` decorator, but it is not a resource operation.

There is a real case in https://github.com/Azure/azure-rest-api-specs/blob/aa47fcdc81cd6b8830e70691ab29babe9c238b78/specification/liftrneon/Neon.Postgres.Management/main.tsp#L83-L94
This operation has been GA and we can't rewrite it by using ArmResourceAction, which will cause path change and regroup this operation to the corresponding resource. So, we have to keep it as a non-resource operation, which it indeed is based on its operation path.