### PR TITLE
[Identity] Disable MSAL retries for Confidential Client and Public Client

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Disabled MSAL's internal retry logic for `ConfidentialClientApplication` and `PublicClientApplication` to prevent double retries when combined with Azure SDK's retry policy. Only the configured Azure SDK retry policy is applied, avoiding unexpected additional retry attempts.
+
 ### Other Changes
 
 ## 1.18.0-beta.2 (2025-11-19)

--- a/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalConfidentialClient.cs
@@ -72,7 +72,7 @@ namespace Azure.Identity
                 enableCae ? cp1Capabilities : Array.Empty<string>();
 
             ConfidentialClientApplicationBuilder confClientBuilder = ConfidentialClientApplicationBuilder.Create(ClientId)
-                .WithHttpClientFactory(new HttpPipelineClientFactory(Pipeline.HttpPipeline))
+                .WithHttpClientFactory(new HttpPipelineClientFactory(Pipeline.HttpPipeline), false)
                 .WithLogging(AzureIdentityEventSource.Singleton, enablePiiLogging: IsSupportLoggingEnabled);
 
             // Special case for using appTokenProviderCallback, authority validation and instance metadata discovery should be disabled since we're not calling the STS

--- a/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
+++ b/sdk/identity/Azure.Identity/src/MsalPublicClient.cs
@@ -47,7 +47,7 @@ namespace Azure.Identity
             PublicClientApplicationBuilder pubAppBuilder = PublicClientApplicationBuilder
                 .Create(ClientId)
                 .WithAuthority(AuthorityHost.AbsoluteUri, TenantId ?? Constants.OrganizationsTenantId, false)
-                .WithHttpClientFactory(new HttpPipelineClientFactory(Pipeline.HttpPipeline))
+                .WithHttpClientFactory(new HttpPipelineClientFactory(Pipeline.HttpPipeline), false)
                 .WithLogging(AzureIdentityEventSource.Singleton, enablePiiLogging: IsSupportLoggingEnabled);
 
             if (!string.IsNullOrEmpty(RedirectUrl))

--- a/sdk/identity/Azure.Identity/tests/MsalConfidentialClientTests.cs
+++ b/sdk/identity/Azure.Identity/tests/MsalConfidentialClientTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Identity.Tests.Mock;
 using Microsoft.Identity.Client;
@@ -51,6 +52,39 @@ namespace Azure.Identity.Tests
 
             Assert.True(caeEnabledCache.IsCaeEnabled);
             Assert.False(caeDisabledCache.IsCaeEnabled);
+        }
+
+        [Test]
+        public async Task VerifyMsalRetriesAreDisabled(
+            [Values(true, false)] bool async)
+        {
+            int maxRetries = 3;
+            int expectedCalls = maxRetries + 1; // initial call + retries
+            int requestCount = 0;
+
+            var mockTransport = new MockTransport(req =>
+            {
+                requestCount++;
+                var response = new MockResponse(500);
+                response.SetContent("{\"error\":\"server_error\",\"error_description\":\"Internal server error\"}");
+                return response;
+            });
+
+            var options = new ClientSecretCredentialOptions
+            {
+                Transport = mockTransport,
+                Retry = { MaxRetries = maxRetries, Delay = System.TimeSpan.Zero, MaxDelay = System.TimeSpan.Zero, Mode = Core.RetryMode.Fixed },
+                DisableInstanceDiscovery = true // Disable instance discovery to avoid extra requests
+            };
+
+            var credential = new ClientSecretCredential("tenant", "client", "secret", options);
+
+            var ex = async
+                ? Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })))
+                : Assert.Throws<AuthenticationFailedException>(() => credential.GetToken(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })));
+
+            // If MSAL retry was active, we'd see one or more extra requests.
+            Assert.AreEqual(expectedCalls, requestCount, $"Expected exactly {expectedCalls} requests (1 initial + {maxRetries} Azure SDK retries). MSAL retry is not disabled.");
         }
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions

--- a/sdk/identity/Azure.Identity/tests/MsalPublicClientTests.cs
+++ b/sdk/identity/Azure.Identity/tests/MsalPublicClientTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Core.TestFramework;
 using Azure.Identity.Tests.Mock;
 using Microsoft.Identity.Client;
@@ -51,6 +52,39 @@ namespace Azure.Identity.Tests
 
             Assert.True(caeEnabledCache.IsCaeEnabled);
             Assert.False(caeDisabledCache.IsCaeEnabled);
+        }
+
+        [Test]
+        public async Task VerifyMsalRetriesAreDisabled(
+            [Values(true, false)] bool async)
+        {
+            int maxRetries = 3;
+            int expectedCalls = maxRetries + 1; // initial call + retries
+            int requestCount = 0;
+
+            var mockTransport = new MockTransport(req =>
+            {
+                requestCount++;
+                var response = new MockResponse(500);
+                response.SetContent("{\"error\":\"server_error\",\"error_description\":\"Internal server error\"}");
+                return response;
+            });
+
+            var options = new UsernamePasswordCredentialOptions
+            {
+                Transport = mockTransport,
+                Retry = { MaxRetries = maxRetries, Delay = System.TimeSpan.Zero, MaxDelay = System.TimeSpan.Zero, Mode = Core.RetryMode.Fixed },
+                DisableInstanceDiscovery = true // Disable instance discovery to avoid extra requests
+            };
+
+            var credential = new UsernamePasswordCredential("username", "password", "tenant", "client", options);
+
+            var ex = async
+                ? Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })))
+                : Assert.Throws<AuthenticationFailedException>(() => credential.GetToken(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })));
+
+            // If MSAL retry was active, we'd see one or more extra requests.
+            Assert.AreEqual(expectedCalls, requestCount, $"Expected exactly {expectedCalls} requests (1 initial + {maxRetries} Azure SDK retries). If this is {expectedCalls+1}, MSAL retry is not disabled.");
         }
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions


### PR DESCRIPTION
- Fixes https://github.com/Azure/azure-sdk-for-net/issues/51052

---

This PR disables MSAL retries for CCA and PCA for `Azure.Identity`. It also adds tests and a changelog entry.
