### PR TITLE
Fix to allocate all resource operations not just list

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -1484,12 +1484,12 @@ interface NoGetResources {
     ok(parentResource);
     strictEqual(parentResource.metadata.resourceName, "Parent");
 
-    // Parent should have 5 methods: its own 4 methods (get, createOrUpdate, delete, listByResourceGroup)
-    // plus the listByResourceGroup for NoGetResource children
+    // Parent should have 7 methods: its own 4 methods (get, createOrUpdate, delete, listByResourceGroup)
+    // plus all 3 operations from NoGetResource (createOrUpdate, delete, listByResourceGroup)
     strictEqual(
       parentResource.metadata.methods.length,
-      5,
-      "Parent should have 5 methods including the list operation from NoGetResource"
+      7,
+      "Parent should have 7 methods including all operations from NoGetResource"
     );
 
     // Verify the list operation for NoGetResource is in parent's methods
@@ -1502,22 +1502,41 @@ interface NoGetResources {
       "Parent resource should have the list operation for NoGetResource"
     );
 
+    // Verify the create operation for NoGetResource is in parent's methods
+    const noGetCreateInParent = parentResource.metadata.methods.find(
+      (m) =>
+        m.kind === "Create" && m.operationPath.includes("noGetResources")
+    );
+    ok(
+      noGetCreateInParent,
+      "Parent resource should have the create operation for NoGetResource"
+    );
+
+    // Verify the delete operation for NoGetResource is in parent's methods
+    const noGetDeleteInParent = parentResource.metadata.methods.find(
+      (m) =>
+        m.kind === "Delete" && m.operationPath.includes("noGetResources")
+    );
+    ok(
+      noGetDeleteInParent,
+      "Parent resource should have the delete operation for NoGetResource"
+    );
+
     // Verify NoGetResource is NOT in resources
     const noGetResource = armProviderSchema.resources.find(
       (r) => r.metadata.resourceName === "NoGetResource"
     );
     strictEqual(noGetResource, undefined);
 
-    // Verify only non-list NoGetResource operations are in non-resource methods
+    // Verify NO NoGetResource operations are in non-resource methods (all should be on parent)
     ok(armProviderSchema.nonResourceMethods);
     const noGetMethods = armProviderSchema.nonResourceMethods.filter((m) =>
       m.operationPath.includes("noGetResources")
     );
-    // Should have only createOrUpdate and delete operations (list is now on parent)
     strictEqual(
       noGetMethods.length,
-      2,
-      "Should have only createOrUpdate and delete in non-resource methods"
+      0,
+      "Should have no NoGetResource operations in non-resource methods"
     );
   });
 });


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-sdk-for-net/pull/54329/files#r2711667674
For an interface without get, we should allocate all operations to corresponding resources, we only deal with list operation before.
