### PR TITLE
[Event Grid] Fix vulnerable STJ version

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
+++ b/sdk/eventgrid/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents/src/Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents.csproj
@@ -20,5 +20,11 @@
     <PackageReference Include="Azure.Messaging.EventGrid" />
     <PackageReference Include="CloudNative.CloudEvents" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" />
+
+    <!-- 
+      A direct reference is needed to hoist the transitive dependency in CloudNative.CloudEvents.SystemTextJson 
+      The latest release (2.8.0) references a vulnerable System.Text.Json (8.0.4).
+    -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary

The focus of these changes is to take a direct reference to `System.Text.Json` to hoist the transitive dependency from `CloudNative.CloudEvents.SystemTextJson`, as the referenced version (STJ 8.0.4) has a known vulnerability.

## References and resources

- [Component Governance Alert](https://dev.azure.com/azure-sdk/internal/_componentGovernance/98522/alert/12053923?typeId=9149649) _(Microsoft internal)_