### PR TITLE
Added a new static extension method UpdateQuery

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/RawRequestUriBuilderExtensionsDefinition.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/RawRequestUriBuilderExtensionsDefinition.cs
@@ -10,6 +10,7 @@ using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
+using Microsoft.TypeSpec.Generator.Statements;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Providers
@@ -79,9 +80,9 @@ namespace Azure.Generator.Providers
 
         private MethodProvider BuildUpdateQueryMethod()
         {
-            var uriBuilder = new ParameterProvider("builder", "The request URI builder instance.", typeof(RawRequestUriBuilder));
-            var nameParameter = new ParameterProvider("name", "The name of the query parameter.", typeof(string));
-            var valueParameter = new ParameterProvider("value", "The value of the query parameter.", typeof(string));
+            var uriBuilder = new ParameterProvider("builder", $"The request URI builder instance.", typeof(RawRequestUriBuilder));
+            var nameParameter = new ParameterProvider("name", $"The name of the query parameter.", typeof(string));
+            var valueParameter = new ParameterProvider("value", $"The value of the query parameter.", typeof(string));
 
             var parameters = new[] { uriBuilder, nameParameter, valueParameter };
             var modifiers = MethodSignatureModifiers.Public | MethodSignatureModifiers.Static | MethodSignatureModifiers.Extension;
@@ -91,54 +92,70 @@ namespace Azure.Generator.Providers
                 Modifiers: modifiers,
                 Parameters: parameters,
                 ReturnType: null,
-                Description: "Updates an existing query parameter or adds a new one if it doesn't exist.",
+                Description: $"Updates an existing query parameter or adds a new one if it doesn't exist.",
                 ReturnDescription: null);
 
-            // Get the current query string
-            var currentQuery = uriBuilder.Property("Query");
-            var searchPattern = nameParameter.Invoke("Concat", Literal("="));
-            
-            var methodBody = new MethodBodyStatement[]
+            var body = new[]
             {
-                // string currentQuery = builder.Query;
-                Declare("currentQuery", typeof(string), currentQuery, out var currentQueryVar),
-                
-                // Check if parameter exists in query
-                new IfStatement(currentQueryVar.Invoke("Contains", searchPattern))
+                MethodBodyStatement.Empty,
+                // Get the current query string
+                Declare("currentQuery", typeof(string), uriBuilder.Property("Query"), out var currentQueryVar),
+
+                // Create search pattern "name="
+                Declare("searchPattern", typeof(string), new BinaryOperatorExpression("+", nameParameter, Literal("=")), out var searchPattern),
+
+                // Check if parameter exists in query string (at start or after &)
+                Declare("paramStartIndex", typeof(int), Literal(-1), out var paramStartIndex),
+
+                // Check if parameter is at the beginning of the query
+                new IfStatement(currentQueryVar.Invoke("StartsWith", searchPattern))
                 {
-                    // Parameter exists - update its value
-                    Declare("paramIndex", typeof(int), currentQueryVar.Invoke("IndexOf", searchPattern), out var paramIndexVar),
-                    Declare("valueStartIndex", typeof(int), paramIndexVar.Add(searchPattern.Property("Length")), out var valueStartIndexVar),
-                    Declare("valueEndIndex", typeof(int), currentQueryVar.Invoke("IndexOf", [Literal('&'), valueStartIndexVar]), out var valueEndIndexVar),
-                    
-                    // If valueEndIndex is -1, set it to the length of the query
-                    new IfStatement(valueEndIndexVar.Equal(Int(-1)))
-                    {
-                        valueEndIndexVar.Assign(currentQueryVar.Property("Length")).Terminate()
-                    },
-                    
-                    // Build the new query string
-                    Declare("newQuery", typeof(string), 
-                        currentQueryVar.Invoke("Substring", [Int(0), valueStartIndexVar])
-                            .Invoke("Concat", valueParameter)
-                            .Invoke("Concat", currentQueryVar.Invoke("Substring", valueEndIndexVar)), 
-                        out var newQueryVar),
-                    
-                    // Update the builder's query
-                    uriBuilder.Property("Query").Assign(newQueryVar).Terminate()
+                    paramStartIndex.Assign(Int(0)).Terminate()
                 },
-                new ElseStatement
+
+                // Check if parameter is in the middle/end (preceded by &)
+                new IfStatement(paramStartIndex.Equal(Int(-1)))
                 {
-                    // Parameter doesn't exist - append it
+                    Declare("prefixedPattern", typeof(string), new BinaryOperatorExpression("+", Literal("&"), searchPattern), out var prefixedPattern),
+                    Declare("prefixedIndex", typeof(int), currentQueryVar.Invoke("IndexOf", prefixedPattern), out var prefixedIndex),
+                    new IfStatement(prefixedIndex.GreaterThanOrEqual(Int(0)))
+                    {
+                        paramStartIndex.Assign(new BinaryOperatorExpression("+", prefixedIndex, Int(1))).Terminate()
+                    }
+                },
+
+                new IfElseStatement(
+                    paramStartIndex.GreaterThanOrEqual(Int(0)),
+                    // Parameter exists - replace its value
+                    new MethodBodyStatement[]
+                    {
+                        Declare("valueStartIndex", typeof(int), new BinaryOperatorExpression("+", paramStartIndex, searchPattern.Property("Length")), out var valueStartIndex),
+                        Declare("valueEndIndex", typeof(int), currentQueryVar.Invoke("IndexOf", [Literal('&'), valueStartIndex]), out var valueEndIndex),
+
+                        // If no & found after parameter, it goes to end of query
+                        new IfStatement(valueEndIndex.Equal(Int(-1)))
+                        {
+                            valueEndIndex.Assign(currentQueryVar.Property("Length")).Terminate()
+                        },
+
+                        // Build new query: before + newValue + after
+                        Declare("beforeParam", typeof(string), currentQueryVar.Invoke("Substring", [Int(0), valueStartIndex]), out var beforeParam),
+                        Declare("afterParam", typeof(string), currentQueryVar.Invoke("Substring", valueEndIndex), out var afterParam),
+                        Declare("newQuery", typeof(string), new BinaryOperatorExpression("+", new BinaryOperatorExpression("+", beforeParam, valueParameter), afterParam), out var newQuery),
+
+                        // Set the new query
+                        uriBuilder.Property("Query").Assign(newQuery).Terminate()
+                    },
+                    // Parameter doesn't exist - append it using existing method
                     new InvokeMethodExpression(
-                        uriBuilder, 
-                        nameof(RawRequestUriBuilder.AppendQuery), 
+                        uriBuilder,
+                        nameof(RawRequestUriBuilder.AppendQuery),
                         [nameParameter, valueParameter, Bool(true)]
                     ).Terminate()
-                }
+                )
             };
 
-            return new MethodProvider(signature, methodBody, this, XmlDocProvider.Empty);
+            return new MethodProvider(signature, body, this, XmlDocProvider.Empty);
         }
     }
 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/TestData/RawRequestUriBuilderExtensionsTests/AddsAppendExtensionMethods.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/TestData/RawRequestUriBuilderExtensionsTests/AddsAppendExtensionMethods.cs
@@ -19,5 +19,42 @@ namespace Samples
             global::System.Collections.Generic.IEnumerable<string> stringValues = value.Select(v => global::Samples.TypeFormatters.ConvertToString(v, format));
             builder.AppendQuery(name, string.Join(delimiter, stringValues), escape);
         }
+
+        public static void UpdateQuery(this global::Azure.Core.RawRequestUriBuilder builder, string name, string value)
+        {
+            string currentQuery = builder.Query;
+            string searchPattern = (name + "=");
+            int paramStartIndex = -1;
+            if (currentQuery.StartsWith(searchPattern))
+            {
+                paramStartIndex = 0;
+            }
+            if ((paramStartIndex == -1))
+            {
+                string prefixedPattern = ("&" + searchPattern);
+                int prefixedIndex = currentQuery.IndexOf(prefixedPattern);
+                if ((prefixedIndex >= 0))
+                {
+                    paramStartIndex = (prefixedIndex + 1);
+                }
+            }
+            if ((paramStartIndex >= 0))
+            {
+                int valueStartIndex = (paramStartIndex + searchPattern.Length);
+                int valueEndIndex = currentQuery.IndexOf('&', valueStartIndex);
+                if ((valueEndIndex == -1))
+                {
+                    valueEndIndex = currentQuery.Length;
+                }
+                string beforeParam = currentQuery.Substring(0, valueStartIndex);
+                string afterParam = currentQuery.Substring(valueEndIndex);
+                string newQuery = ((beforeParam + value) + afterParam);
+                builder.Query = newQuery;
+            }
+            else
+            {
+                builder.AppendQuery(name, value, true);
+            }
+        }
     }
 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace BasicTypeSpec
         public static void UpdateQuery(this RawRequestUriBuilder builder, string name, string value)
         {
             string currentQuery = builder.Query;
-            string searchPattern = name + "=";
+            string searchPattern = string.Concat(name, "=");
             int paramStartIndex = -1;
             if (currentQuery.StartsWith(searchPattern))
             {

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
@@ -19,5 +19,42 @@ namespace BasicTypeSpec
             IEnumerable<string> stringValues = value.Select(v => TypeFormatters.ConvertToString(v, format));
             builder.AppendQuery(name, string.Join(delimiter, stringValues), escape);
         }
+
+        public static void UpdateQuery(this RawRequestUriBuilder builder, string name, string value)
+        {
+            string currentQuery = builder.Query;
+            string searchPattern = name + "=";
+            int paramStartIndex = -1;
+            if (currentQuery.StartsWith(searchPattern))
+            {
+                paramStartIndex = 0;
+            }
+            if (paramStartIndex == -1)
+            {
+                string prefixedPattern = "&" + searchPattern;
+                int prefixedIndex = currentQuery.IndexOf(prefixedPattern);
+                if (prefixedIndex >= 0)
+                {
+                    paramStartIndex = prefixedIndex + 1;
+                }
+            }
+            if (paramStartIndex >= 0)
+            {
+                int valueStartIndex = paramStartIndex + searchPattern.Length;
+                int valueEndIndex = currentQuery.IndexOf('&', valueStartIndex);
+                if (valueEndIndex == -1)
+                {
+                    valueEndIndex = currentQuery.Length;
+                }
+                string beforeParam = currentQuery.Substring(0, valueStartIndex);
+                string afterParam = currentQuery.Substring(valueEndIndex);
+                string newQuery = beforeParam + value + afterParam;
+                builder.Query = newQuery;
+            }
+            else
+            {
+                builder.AppendQuery(name, value, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request enhances the `RawRequestUriBuilderExtensionsDefinition` by adding new functionality for managing query parameters in URI builders. The main improvement is the introduction of an `UpdateQuery` method, which allows updating existing query parameters or adding them if they don't exist.

* Added a new static extension method `UpdateQuery` to `RawRequestUriBuilderExtensionsDefinition`, enabling updating an existing query parameter or adding it if it doesn't exist. The method checks if the parameter is present in the query string, updates its value if found, or appends it otherwise.
* Updated the `BuildMethods` override to include both `BuildAppendQueryDelimitedMethod` and the new `BuildUpdateQueryMethod`, ensuring the new method is available in the generated extensions.# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
