### PR TITLE
UpdateQuery Extension Method

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -27,7 +27,7 @@
 
     <!-- Internal tooling from the Azure Development Feed -->
     <TestProxyVersion>1.0.0-dev.20251209.1</TestProxyVersion>
-    <UnbrandedGeneratorVersion>1.0.0-alpha.20260120.1</UnbrandedGeneratorVersion>
+    <UnbrandedGeneratorVersion>1.0.0-alpha.20260122.1</UnbrandedGeneratorVersion>
     <AzureGeneratorVersion>1.0.0-alpha.20260121.1</AzureGeneratorVersion>
 
     <!-- Legacy package use only -->

--- a/eng/http-client-csharp-emitter-package-lock.json
+++ b/eng/http-client-csharp-emitter-package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260120.1",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260122.1",
         "client-plugin": "file:../../../../eng/packages/plugins/client"
       },
       "devDependencies": {
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260120.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260120.1.tgz",
-      "integrity": "sha512-taVV25vkJc9C+7kx7YKlFWrHaHr1iE8FmyLX/SFcBaPF+GnZBE9QttC7iveTNdMCeqjhzKunLZV7eGrT4MjlqQ==",
+      "version": "1.0.0-alpha.20260122.1",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260122.1.tgz",
+      "integrity": "sha512-D58z77S3IJpRypQ1mkiHza1Ib69hD1q7tHH/EF98cRjM/k8lqSvSA9lKPqk3trfNlG9WIOz+A7FhbeX62OxgXw==",
       "license": "MIT",
       "peerDependencies": {
         "@azure-tools/typespec-client-generator-core": ">=0.64.1 < 0.65.0 || ~0.65.0-0",
@@ -1264,9 +1264,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.4.tgz",
-      "integrity": "sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
+      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/eng/http-client-csharp-emitter-package.json
+++ b/eng/http-client-csharp-emitter-package.json
@@ -2,7 +2,7 @@
   "main": "dist/src/index.js",
   "dependencies": {
     "client-plugin": "file:../../../../eng/packages/plugins/client",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260120.1"
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260122.1"
   },
   "devDependencies": {
     "@azure-tools/typespec-client-generator-core": "0.64.1",

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/RawRequestUriBuilderExtensionsDefinition.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Providers/RawRequestUriBuilderExtensionsDefinition.cs
@@ -10,6 +10,7 @@ using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Snippets;
+using Microsoft.TypeSpec.Generator.Statements;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Providers
@@ -79,9 +80,9 @@ namespace Azure.Generator.Providers
 
         private MethodProvider BuildUpdateQueryMethod()
         {
-            var uriBuilder = new ParameterProvider("builder", "The request URI builder instance.", typeof(RawRequestUriBuilder));
-            var nameParameter = new ParameterProvider("name", "The name of the query parameter.", typeof(string));
-            var valueParameter = new ParameterProvider("value", "The value of the query parameter.", typeof(string));
+            var uriBuilder = new ParameterProvider("builder", $"The request URI builder instance.", typeof(RawRequestUriBuilder));
+            var nameParameter = new ParameterProvider("name", $"The name of the query parameter.", typeof(string));
+            var valueParameter = new ParameterProvider("value", $"The value of the query parameter.", typeof(string));
 
             var parameters = new[] { uriBuilder, nameParameter, valueParameter };
             var modifiers = MethodSignatureModifiers.Public | MethodSignatureModifiers.Static | MethodSignatureModifiers.Extension;
@@ -91,54 +92,70 @@ namespace Azure.Generator.Providers
                 Modifiers: modifiers,
                 Parameters: parameters,
                 ReturnType: null,
-                Description: "Updates an existing query parameter or adds a new one if it doesn't exist.",
+                Description: $"Updates an existing query parameter or adds a new one if it doesn't exist.",
                 ReturnDescription: null);
 
-            // Get the current query string
-            var currentQuery = uriBuilder.Property("Query");
-            var searchPattern = nameParameter.Invoke("Concat", Literal("="));
-            
-            var methodBody = new MethodBodyStatement[]
+            var body = new[]
             {
-                // string currentQuery = builder.Query;
-                Declare("currentQuery", typeof(string), currentQuery, out var currentQueryVar),
-                
-                // Check if parameter exists in query
-                new IfStatement(currentQueryVar.Invoke("Contains", searchPattern))
+                MethodBodyStatement.Empty,
+                // Get the current query string
+                Declare("currentQuery", typeof(string), uriBuilder.Property("Query"), out var currentQueryVar),
+
+                // Create search pattern "name="
+                Declare("searchPattern", typeof(string), new BinaryOperatorExpression("+", nameParameter, Literal("=")), out var searchPattern),
+
+                // Check if parameter exists in query string (at start or after &)
+                Declare("paramStartIndex", typeof(int), Literal(-1), out var paramStartIndex),
+
+                // Check if parameter is at the beginning of the query
+                new IfStatement(currentQueryVar.Invoke("StartsWith", searchPattern))
                 {
-                    // Parameter exists - update its value
-                    Declare("paramIndex", typeof(int), currentQueryVar.Invoke("IndexOf", searchPattern), out var paramIndexVar),
-                    Declare("valueStartIndex", typeof(int), paramIndexVar.Add(searchPattern.Property("Length")), out var valueStartIndexVar),
-                    Declare("valueEndIndex", typeof(int), currentQueryVar.Invoke("IndexOf", [Literal('&'), valueStartIndexVar]), out var valueEndIndexVar),
-                    
-                    // If valueEndIndex is -1, set it to the length of the query
-                    new IfStatement(valueEndIndexVar.Equal(Int(-1)))
-                    {
-                        valueEndIndexVar.Assign(currentQueryVar.Property("Length")).Terminate()
-                    },
-                    
-                    // Build the new query string
-                    Declare("newQuery", typeof(string), 
-                        currentQueryVar.Invoke("Substring", [Int(0), valueStartIndexVar])
-                            .Invoke("Concat", valueParameter)
-                            .Invoke("Concat", currentQueryVar.Invoke("Substring", valueEndIndexVar)), 
-                        out var newQueryVar),
-                    
-                    // Update the builder's query
-                    uriBuilder.Property("Query").Assign(newQueryVar).Terminate()
+                    paramStartIndex.Assign(Int(0)).Terminate()
                 },
-                new ElseStatement
+
+                // Check if parameter is in the middle/end (preceded by &)
+                new IfStatement(paramStartIndex.Equal(Int(-1)))
                 {
-                    // Parameter doesn't exist - append it
+                    Declare("prefixedPattern", typeof(string), new BinaryOperatorExpression("+", Literal("&"), searchPattern), out var prefixedPattern),
+                    Declare("prefixedIndex", typeof(int), currentQueryVar.Invoke("IndexOf", prefixedPattern), out var prefixedIndex),
+                    new IfStatement(prefixedIndex.GreaterThanOrEqual(Int(0)))
+                    {
+                        paramStartIndex.Assign(new BinaryOperatorExpression("+", prefixedIndex, Int(1))).Terminate()
+                    }
+                },
+
+                new IfElseStatement(
+                    paramStartIndex.GreaterThanOrEqual(Int(0)),
+                    // Parameter exists - replace its value
+                    new MethodBodyStatement[]
+                    {
+                        Declare("valueStartIndex", typeof(int), new BinaryOperatorExpression("+", paramStartIndex, searchPattern.Property("Length")), out var valueStartIndex),
+                        Declare("valueEndIndex", typeof(int), currentQueryVar.Invoke("IndexOf", [Literal('&'), valueStartIndex]), out var valueEndIndex),
+
+                        // If no & found after parameter, it goes to end of query
+                        new IfStatement(valueEndIndex.Equal(Int(-1)))
+                        {
+                            valueEndIndex.Assign(currentQueryVar.Property("Length")).Terminate()
+                        },
+
+                        // Build new query: before + newValue + after
+                        Declare("beforeParam", typeof(string), currentQueryVar.Invoke("Substring", [Int(0), valueStartIndex]), out var beforeParam),
+                        Declare("afterParam", typeof(string), currentQueryVar.Invoke("Substring", valueEndIndex), out var afterParam),
+                        Declare("newQuery", typeof(string), new BinaryOperatorExpression("+", new BinaryOperatorExpression("+", beforeParam, valueParameter), afterParam), out var newQuery),
+
+                        // Set the new query
+                        uriBuilder.Property("Query").Assign(newQuery).Terminate()
+                    },
+                    // Parameter doesn't exist - append it using existing method
                     new InvokeMethodExpression(
-                        uriBuilder, 
-                        nameof(RawRequestUriBuilder.AppendQuery), 
+                        uriBuilder,
+                        nameof(RawRequestUriBuilder.AppendQuery),
                         [nameParameter, valueParameter, Bool(true)]
                     ).Terminate()
-                }
+                )
             };
 
-            return new MethodProvider(signature, methodBody, this, XmlDocProvider.Empty);
+            return new MethodProvider(signature, body, this, XmlDocProvider.Empty);
         }
     }
 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/TestData/RawRequestUriBuilderExtensionsTests/AddsAppendExtensionMethods.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/TestData/RawRequestUriBuilderExtensionsTests/AddsAppendExtensionMethods.cs
@@ -19,5 +19,42 @@ namespace Samples
             global::System.Collections.Generic.IEnumerable<string> stringValues = value.Select(v => global::Samples.TypeFormatters.ConvertToString(v, format));
             builder.AppendQuery(name, string.Join(delimiter, stringValues), escape);
         }
+
+        public static void UpdateQuery(this global::Azure.Core.RawRequestUriBuilder builder, string name, string value)
+        {
+            string currentQuery = builder.Query;
+            string searchPattern = (name + "=");
+            int paramStartIndex = -1;
+            if (currentQuery.StartsWith(searchPattern))
+            {
+                paramStartIndex = 0;
+            }
+            if ((paramStartIndex == -1))
+            {
+                string prefixedPattern = ("&" + searchPattern);
+                int prefixedIndex = currentQuery.IndexOf(prefixedPattern);
+                if ((prefixedIndex >= 0))
+                {
+                    paramStartIndex = (prefixedIndex + 1);
+                }
+            }
+            if ((paramStartIndex >= 0))
+            {
+                int valueStartIndex = (paramStartIndex + searchPattern.Length);
+                int valueEndIndex = currentQuery.IndexOf('&', valueStartIndex);
+                if ((valueEndIndex == -1))
+                {
+                    valueEndIndex = currentQuery.Length;
+                }
+                string beforeParam = currentQuery.Substring(0, valueStartIndex);
+                string afterParam = currentQuery.Substring(valueEndIndex);
+                string newQuery = ((beforeParam + value) + afterParam);
+                builder.Query = newQuery;
+            }
+            else
+            {
+                builder.AppendQuery(name, value, true);
+            }
+        }
     }
 }

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/TestData/RawRequestUriBuilderExtensionsTests/AddsAppendExtensionMethods.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/TestData/RawRequestUriBuilderExtensionsTests/AddsAppendExtensionMethods.cs
@@ -25,9 +25,9 @@ namespace Samples
             string currentQuery = builder.Query;
             string searchPattern = string.Concat(name, "=");
             int paramStartIndex = -1;
-            if (currentQuery.StartsWith(searchPattern))
+            if (currentQuery.StartsWith(string.Concat("?", searchPattern)))
             {
-                paramStartIndex = 0;
+                paramStartIndex = 1;
             }
             if ((paramStartIndex == -1))
             {

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/TestData/RawRequestUriBuilderExtensionsTests/AddsAppendExtensionMethods.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Providers/TestData/RawRequestUriBuilderExtensionsTests/AddsAppendExtensionMethods.cs
@@ -23,7 +23,7 @@ namespace Samples
         public static void UpdateQuery(this global::Azure.Core.RawRequestUriBuilder builder, string name, string value)
         {
             string currentQuery = builder.Query;
-            string searchPattern = (name + "=");
+            string searchPattern = string.Concat(name, "=");
             int paramStartIndex = -1;
             if (currentQuery.StartsWith(searchPattern))
             {
@@ -31,7 +31,7 @@ namespace Samples
             }
             if ((paramStartIndex == -1))
             {
-                string prefixedPattern = ("&" + searchPattern);
+                string prefixedPattern = string.Concat("&", searchPattern);
                 int prefixedIndex = currentQuery.IndexOf(prefixedPattern);
                 if ((prefixedIndex >= 0))
                 {
@@ -48,7 +48,7 @@ namespace Samples
                 }
                 string beforeParam = currentQuery.Substring(0, valueStartIndex);
                 string afterParam = currentQuery.Substring(valueEndIndex);
-                string newQuery = ((beforeParam + value) + afterParam);
+                string newQuery = string.Concat(beforeParam, value, afterParam);
                 builder.Query = newQuery;
             }
             else

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local.Tests/RawRequestUriBuilderExtensionsTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local.Tests/RawRequestUriBuilderExtensionsTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using NUnit.Framework;
+
+namespace TestProjects.Local.Tests
+{
+    [TestFixture]
+    public class RawRequestUriBuilderExtensionsTests
+    {
+        [TestCase("http://localhost", "param1", "value1", "http://localhost/?param1=value1")]
+        [TestCase("http://localhost?existing=old", "param1", "value1", "http://localhost/?existing=old&param1=value1")]
+        [TestCase("http://localhost?param1=old", "param1", "new", "http://localhost/?param1=new")]
+        [TestCase("http://localhost?param1=old&param2=value2", "param1", "new", "http://localhost/?param1=new&param2=value2")]
+        [TestCase("http://localhost?param2=value2&param1=old", "param1", "new", "http://localhost/?param2=value2&param1=new")]
+        [TestCase("http://localhost?param2=value2&param1=old&param3=value3", "param1", "new", "http://localhost/?param2=value2&param1=new&param3=value3")]
+        [TestCase("http://localhost?fooparam1=value2&param1=old", "param1", "new", "http://localhost/?fooparam1=value2&param1=new")]
+        [TestCase("http://localhost?param1prefix=value2&param1=old", "param1", "new", "http://localhost/?param1prefix=value2&param1=new")]
+        public void UpdateQuery(string endpoint, string name, string value, string expected)
+        {
+            var builder = new RawRequestUriBuilder();
+            builder.Reset(new Uri(endpoint));
+
+            BasicTypeSpec.RawRequestUriBuilderExtensions.UpdateQuery(builder, name, value);
+
+            Assert.AreEqual(expected, builder.ToUri().ToString());
+        }
+    }
+}

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
@@ -25,9 +25,9 @@ namespace BasicTypeSpec
             string currentQuery = builder.Query;
             string searchPattern = string.Concat(name, "=");
             int paramStartIndex = -1;
-            if (currentQuery.StartsWith(searchPattern))
+            if (currentQuery.StartsWith(string.Concat("?", searchPattern)))
             {
-                paramStartIndex = 0;
+                paramStartIndex = 1;
             }
             if (paramStartIndex == -1)
             {

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace BasicTypeSpec
         public static void UpdateQuery(this RawRequestUriBuilder builder, string name, string value)
         {
             string currentQuery = builder.Query;
-            string searchPattern = name + "=";
+            string searchPattern = string.Concat(name, "=");
             int paramStartIndex = -1;
             if (currentQuery.StartsWith(searchPattern))
             {

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
@@ -31,7 +31,7 @@ namespace BasicTypeSpec
             }
             if (paramStartIndex == -1)
             {
-                string prefixedPattern = "&" + searchPattern;
+                string prefixedPattern = string.Concat("&", searchPattern);
                 int prefixedIndex = currentQuery.IndexOf(prefixedPattern);
                 if (prefixedIndex >= 0)
                 {
@@ -48,7 +48,7 @@ namespace BasicTypeSpec
                 }
                 string beforeParam = currentQuery.Substring(0, valueStartIndex);
                 string afterParam = currentQuery.Substring(valueEndIndex);
-                string newQuery = beforeParam + value + afterParam;
+                string newQuery = string.Concat(beforeParam, value, afterParam);
                 builder.Query = newQuery;
             }
             else

--- a/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Local/Basic-TypeSpec/src/Generated/Internal/RawRequestUriBuilderExtensions.cs
@@ -19,5 +19,42 @@ namespace BasicTypeSpec
             IEnumerable<string> stringValues = value.Select(v => TypeFormatters.ConvertToString(v, format));
             builder.AppendQuery(name, string.Join(delimiter, stringValues), escape);
         }
+
+        public static void UpdateQuery(this RawRequestUriBuilder builder, string name, string value)
+        {
+            string currentQuery = builder.Query;
+            string searchPattern = name + "=";
+            int paramStartIndex = -1;
+            if (currentQuery.StartsWith(searchPattern))
+            {
+                paramStartIndex = 0;
+            }
+            if (paramStartIndex == -1)
+            {
+                string prefixedPattern = "&" + searchPattern;
+                int prefixedIndex = currentQuery.IndexOf(prefixedPattern);
+                if (prefixedIndex >= 0)
+                {
+                    paramStartIndex = prefixedIndex + 1;
+                }
+            }
+            if (paramStartIndex >= 0)
+            {
+                int valueStartIndex = paramStartIndex + searchPattern.Length;
+                int valueEndIndex = currentQuery.IndexOf('&', valueStartIndex);
+                if (valueEndIndex == -1)
+                {
+                    valueEndIndex = currentQuery.Length;
+                }
+                string beforeParam = currentQuery.Substring(0, valueStartIndex);
+                string afterParam = currentQuery.Substring(valueEndIndex);
+                string newQuery = beforeParam + value + afterParam;
+                builder.Query = newQuery;
+            }
+            else
+            {
+                builder.AppendQuery(name, value, true);
+            }
+        }
     }
 }

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/documentation/src/Generated/Models/BulletPointsEnum.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/documentation/src/Generated/Models/BulletPointsEnum.cs
@@ -11,20 +11,17 @@ namespace Documentation._Lists
     {
         /// <summary>
         /// Simple bullet point. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
-        /// - One: one. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
-        /// - Two: two. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
+        /// <list type="bullet"><item><description>One: one. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.</description></item><item><description>Two: two. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.</description></item></list>
         /// </summary>
         Simple,
         /// <summary>
-        /// Bullet point with **bold text**. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
-        /// - **One**: one. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
-        /// - **Two**: two. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
+        /// Bullet point with <b>bold text</b>. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
+        /// <list type="bullet"><item><description><b>One</b>: one. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.</description></item><item><description><b>Two</b>: two. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.</description></item></list>
         /// </summary>
         Bold,
         /// <summary>
-        /// Bullet point with *italic text*. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
-        /// - *One*: one. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
-        /// - *Two*: two. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
+        /// Bullet point with <i>italic text</i>. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.
+        /// <list type="bullet"><item><description><i>One</i>: one. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.</description></item><item><description><i>Two</i>: two. This line is intentionally long to test text wrapping in bullet points within enum documentation comments. It should properly indent the wrapped lines.</description></item></list>
         /// </summary>
         Italic
     }

--- a/eng/packages/http-client-csharp/package-lock.json
+++ b/eng/packages/http-client-csharp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260120.1"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260122.1"
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.35",
@@ -2837,9 +2837,9 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260120.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260120.1.tgz",
-      "integrity": "sha512-taVV25vkJc9C+7kx7YKlFWrHaHr1iE8FmyLX/SFcBaPF+GnZBE9QttC7iveTNdMCeqjhzKunLZV7eGrT4MjlqQ==",
+      "version": "1.0.0-alpha.20260122.1",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260122.1.tgz",
+      "integrity": "sha512-D58z77S3IJpRypQ1mkiHza1Ib69hD1q7tHH/EF98cRjM/k8lqSvSA9lKPqk3trfNlG9WIOz+A7FhbeX62OxgXw==",
       "license": "MIT",
       "peerDependencies": {
         "@azure-tools/typespec-client-generator-core": ">=0.64.1 < 0.65.0 || ~0.65.0-0",

--- a/eng/packages/http-client-csharp/package.json
+++ b/eng/packages/http-client-csharp/package.json
@@ -38,7 +38,7 @@
     "dist/generator/**"
   ],
   "dependencies": {
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260120.1"
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260122.1"
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "0.1.0-alpha.35",


### PR DESCRIPTION
This pull request introduces a new `UpdateQuery` extension method for the `RawRequestUriBuilder`, allowing users to update an existing query parameter or add it if it doesn't exist. Additionally, it updates several dependencies to their latest alpha versions and bumps the `tar` package for security and compatibility.

**Feature addition:**

* Added a new `UpdateQuery` extension method to `RawRequestUriBuilderExtensionsDefinition.cs` and its corresponding test data. This method updates the value of an existing query parameter or appends it if not present, enhancing query string manipulation capabilities.

**Dependency updates:**

* Updated `@typespec/http-client-csharp` dependency from version `1.0.0-alpha.20260120.1` to `1.0.0-alpha.20260122.1` across multiple configuration and lock files for consistency and to incorporate upstream changes. 
* Updated `UnbrandedGeneratorVersion` in `Packages.Data.props` to `1.0.0-alpha.20260122.1`.
* Bumped the `tar` npm package from `7.5.4` to `7.5.6` in `http-client-csharp-emitter-package-lock.json` for improved security and bug fixes.