### PR TITLE
DO NOT MERGE - Add SKU support for HealthDataAIServices DeidService (API version 2026-02-01-preview)

### DIFF
--- a/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices/CHANGELOG.md
+++ b/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features Added
 
+- Added SKU support for DeidService with `HealthDataAIServicesSku` model
+- Added `SkuTier` union with Free, Basic, and Standard tiers
+- Added `Sku` property to `DeidServiceData` and `DeidServicePatch` for API version 2026-02-01-preview
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices/tsp-location.yaml
+++ b/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices/tsp-location.yaml
@@ -1,4 +1,6 @@
 directory: specification/healthdataaiservices/HealthDataAIServices.Management
 commit: 18651ab2460e0874397f3597b91dcc00cb4ca7bc
 repo: Azure/azure-rest-api-specs
-emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"
+additionalDirectories: 
+
+emitterPackageJsonPath: eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json


### PR DESCRIPTION
## Demo PR - DO NOT MERGE

This PR adds SKU support for the HealthDataAIServices DeidService management plane SDK.

### Changes
- Added `HealthDataAIServicesSku` model with name, tier, and capacity properties
- Added `SkuTier` with Free, Basic, and Standard options
- Added `Sku` property to `DeidServiceData` and `DeidServicePatch` for API version 2026-02-01-preview

### Related
- API Spec PR: https://github.com/Azure/azure-rest-api-specs/pull/39922

---
**This is a demo PR and should NOT be merged.**