### PR TITLE
Add visitor to fix the maxpagesize parameter casing

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureClientGenerator.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/AzureClientGenerator.cs
@@ -91,6 +91,7 @@ public class AzureClientGenerator : ScmCodeModelGenerator
         AddVisitor(new LroVisitor());
         AddVisitor(new MatchConditionsHeadersVisitor());
         AddVisitor(new ClientRequestIdHeaderVisitor());
+        AddVisitor(new MaxPageSizeCasingVisitor());
         AddVisitor(new SystemTextJsonConverterVisitor());
         AddVisitor(new MultiPartFormDataVisitor());
         AddVisitor(new InvokeDelimitedMethodVisitor());

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/MaxPageSizeCasingVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/MaxPageSizeCasingVisitor.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.TypeSpec.Generator.ClientModel;
+using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Providers;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Azure.Generator.Visitors
+{
+    /// <summary>
+    /// Visitor that fixes the casing of "maxpagesize" parameter to "maxPageSize" in ScmMethodProvider methods.
+    /// </summary>
+    internal class MaxPageSizeCasingVisitor : ScmLibraryVisitor
+    {
+        private const string IncorrectParameterName = "maxpagesize";
+        private const string CorrectParameterName = "maxPageSize";
+
+        protected override ScmMethodProvider? VisitMethod(ScmMethodProvider method)
+        {
+            UpdateMethodParameterCasing(method);
+            return method;
+        }
+
+        protected override ScmMethodProviderCollection? Visit(
+            InputServiceMethod serviceMethod,
+            ClientProvider client,
+            ScmMethodProviderCollection? methods)
+        {
+            if (methods != null)
+            {
+                foreach (var method in methods)
+                {
+                    UpdateMethodParameterCasing(method);
+                }
+            }
+
+            return methods;
+        }
+
+        private static void UpdateMethodParameterCasing(ScmMethodProvider method)
+        {
+            var parameters = method.Signature.Parameters;
+            var needsUpdate = false;
+            var updatedParameters = new List<ParameterProvider>();
+
+            foreach (var parameter in parameters)
+            {
+                if (parameter.Name == IncorrectParameterName)
+                {
+                    var updatedParameter = new ParameterProvider(
+                        CorrectParameterName,
+                        parameter.Description,
+                        parameter.Type,
+                        parameter.DefaultValue,
+                        parameter.IsRef,
+                        parameter.IsOut,
+                        parameter.IsIn,
+                        parameter.IsParams,
+                        parameter.Attributes,
+                        parameter.Property,
+                        parameter.Field,
+                        parameter.InitializationValue,
+                        parameter.Location,
+                        parameter.WireInfo,
+                        parameter.Validation);
+
+                    updatedParameters.Add(updatedParameter);
+                    needsUpdate = true;
+                }
+                else
+                {
+                    updatedParameters.Add(parameter);
+                }
+            }
+
+            if (needsUpdate)
+            {
+                method.Signature.Update(parameters: updatedParameters);
+            }
+        }
+    }
+}

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/MaxPageSizeCasingVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/MaxPageSizeCasingVisitorTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using Azure.Generator.Tests.Common;
+using Azure.Generator.Tests.TestHelpers;
+using Azure.Generator.Visitors;
+using Microsoft.TypeSpec.Generator.ClientModel.Providers;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Primitives;
+using NUnit.Framework;
+
+namespace Azure.Generator.Tests.Visitors
+{
+    public class MaxPageSizeCasingVisitorTests
+    {
+        [Test]
+        public void TestUpdatesMaxPageSizeParameterCasing()
+        {
+            var visitor = new TestMaxPageSizeCasingVisitor();
+            var methodParameters = new[]
+            {
+                InputFactory.MethodParameter("maxpagesize", InputPrimitiveType.Int32, location: InputRequestLocation.Query),
+                InputFactory.MethodParameter("otherParam", InputPrimitiveType.String, location: InputRequestLocation.Query)
+            };
+
+            var parameters = new[]
+            {
+                InputFactory.QueryParameter("maxpagesize", InputPrimitiveType.Int32),
+                InputFactory.QueryParameter("otherParam", InputPrimitiveType.String)
+            };
+
+            var responseModel = InputFactory.Model("TestResponse");
+            var operation = InputFactory.Operation(
+                "testOperation",
+                parameters: parameters,
+                responses: [InputFactory.OperationResponse(bodytype: responseModel)]);
+            var serviceMethod = InputFactory.BasicServiceMethod(
+                "TestMethod",
+                operation,
+                parameters: methodParameters,
+                response: InputFactory.ServiceMethodResponse(responseModel, ["result"]));
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+            MockHelpers.LoadMockGenerator(clients: () => [inputClient]);
+
+            var clientProvider = AzureClientGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(clientProvider);
+
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
+
+            foreach (var method in methodCollection)
+            {
+                visitor.VisitScmMethod(method);
+            }
+
+            foreach (var method in methodCollection)
+            {
+                var maxPageSizeParam = method.Signature.Parameters.FirstOrDefault(p => p.Name == "maxPageSize");
+                var incorrectParam = method.Signature.Parameters.FirstOrDefault(p => p.Name == "maxpagesize");
+
+                Assert.IsNotNull(maxPageSizeParam, "Method should have a parameter named 'maxPageSize'");
+                Assert.IsNull(incorrectParam, "Method should not have a parameter named 'maxpagesize'");
+
+                var otherParam = method.Signature.Parameters.FirstOrDefault(p => p.Name == "otherParam");
+                Assert.IsNotNull(otherParam, "Method should still have the 'otherParam' parameter");
+            }
+        }
+
+        [Test]
+        public void TestDoesNotUpdateParametersWithCorrectCasing()
+        {
+            var visitor = new TestMaxPageSizeCasingVisitor();
+            var methodParameters = new[]
+            {
+                InputFactory.MethodParameter("maxPageSize", InputPrimitiveType.Int32, location: InputRequestLocation.Query),
+                InputFactory.MethodParameter("normalParam", InputPrimitiveType.String, location: InputRequestLocation.Query)
+            };
+
+            var parameters = new[]
+            {
+                InputFactory.QueryParameter("maxPageSize", InputPrimitiveType.Int32),
+                InputFactory.QueryParameter("normalParam", InputPrimitiveType.String)
+            };
+
+            var responseModel = InputFactory.Model("TestResponse");
+            var operation = InputFactory.Operation(
+                "testOperation",
+                parameters: parameters,
+                responses: [InputFactory.OperationResponse(bodytype: responseModel)]);
+            var serviceMethod = InputFactory.BasicServiceMethod(
+                "TestMethod",
+                operation,
+                parameters: methodParameters,
+                response: InputFactory.ServiceMethodResponse(responseModel, ["result"]));
+            var inputClient = InputFactory.Client("TestClient", methods: [serviceMethod]);
+            MockHelpers.LoadMockGenerator(clients: () => [inputClient]);
+
+            var clientProvider = AzureClientGenerator.Instance.TypeFactory.CreateClient(inputClient);
+            Assert.IsNotNull(clientProvider);
+
+            var methodCollection = new ScmMethodProviderCollection(serviceMethod, clientProvider!);
+
+            foreach (var method in methodCollection)
+            {
+                visitor.VisitScmMethod(method);
+            }
+
+            foreach (var method in methodCollection)
+            {
+                var maxPageSizeParam = method.Signature.Parameters.FirstOrDefault(p => p.Name == "maxPageSize");
+                var normalParam = method.Signature.Parameters.FirstOrDefault(p => p.Name == "normalParam");
+
+                Assert.IsNotNull(maxPageSizeParam, "Method should have a parameter named 'maxPageSize'");
+                Assert.IsNotNull(normalParam, "Method should have a parameter named 'normalParam'");
+
+                var incorrectParam = method.Signature.Parameters.FirstOrDefault(p => p.Name == "maxpagesize");
+                Assert.IsNull(incorrectParam, "Method should not have a parameter named 'maxpagesize'");
+            }
+        }
+
+        private class TestMaxPageSizeCasingVisitor : MaxPageSizeCasingVisitor
+        {
+            public ScmMethodProvider? VisitScmMethod(ScmMethodProvider method)
+            {
+                return base.VisitMethod(method);
+            }
+        }
+    }
+}

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/core/basic/src/Generated/BasicClient.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/core/basic/src/Generated/BasicClient.cs
@@ -43,13 +43,13 @@ namespace Specs.Azure.Core.Basic
 
         public virtual Task<Response<User>> GetAsync(int id, CancellationToken cancellationToken = default) => throw null;
 
-        public virtual Pageable<BinaryData> GetAll(int? top, int? skip, int? maxpagesize, IEnumerable<string> @orderby, string filter, IEnumerable<string> @select, IEnumerable<string> expand, RequestContext context) => throw null;
+        public virtual Pageable<BinaryData> GetAll(int? top, int? skip, int? maxPageSize, IEnumerable<string> @orderby, string filter, IEnumerable<string> @select, IEnumerable<string> expand, RequestContext context) => throw null;
 
-        public virtual AsyncPageable<BinaryData> GetAllAsync(int? top, int? skip, int? maxpagesize, IEnumerable<string> @orderby, string filter, IEnumerable<string> @select, IEnumerable<string> expand, RequestContext context) => throw null;
+        public virtual AsyncPageable<BinaryData> GetAllAsync(int? top, int? skip, int? maxPageSize, IEnumerable<string> @orderby, string filter, IEnumerable<string> @select, IEnumerable<string> expand, RequestContext context) => throw null;
 
-        public virtual Pageable<User> GetAll(int? top = default, int? skip = default, int? maxpagesize = default, IEnumerable<string> @orderby = default, string filter = default, IEnumerable<string> @select = default, IEnumerable<string> expand = default, CancellationToken cancellationToken = default) => throw null;
+        public virtual Pageable<User> GetAll(int? top = default, int? skip = default, int? maxPageSize = default, IEnumerable<string> @orderby = default, string filter = default, IEnumerable<string> @select = default, IEnumerable<string> expand = default, CancellationToken cancellationToken = default) => throw null;
 
-        public virtual AsyncPageable<User> GetAllAsync(int? top = default, int? skip = default, int? maxpagesize = default, IEnumerable<string> @orderby = default, string filter = default, IEnumerable<string> @select = default, IEnumerable<string> expand = default, CancellationToken cancellationToken = default) => throw null;
+        public virtual AsyncPageable<User> GetAllAsync(int? top = default, int? skip = default, int? maxPageSize = default, IEnumerable<string> @orderby = default, string filter = default, IEnumerable<string> @select = default, IEnumerable<string> expand = default, CancellationToken cancellationToken = default) => throw null;
 
         public virtual Response Delete(int id, RequestContext context) => throw null;
 

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/payload/pageable/src/Generated/PageableClient.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector/http/azure/payload/pageable/src/Generated/PageableClient.cs
@@ -20,12 +20,12 @@ namespace Specs.Azure.Payload.Pageable
 
         public virtual HttpPipeline Pipeline => throw null;
 
-        public virtual Pageable<BinaryData> GetAll(int? maxpagesize, RequestContext context) => throw null;
+        public virtual Pageable<BinaryData> GetAll(int? maxPageSize, RequestContext context) => throw null;
 
-        public virtual AsyncPageable<BinaryData> GetAllAsync(int? maxpagesize, RequestContext context) => throw null;
+        public virtual AsyncPageable<BinaryData> GetAllAsync(int? maxPageSize, RequestContext context) => throw null;
 
-        public virtual Pageable<User> GetAll(int? maxpagesize = default, CancellationToken cancellationToken = default) => throw null;
+        public virtual Pageable<User> GetAll(int? maxPageSize = default, CancellationToken cancellationToken = default) => throw null;
 
-        public virtual AsyncPageable<User> GetAllAsync(int? maxpagesize = default, CancellationToken cancellationToken = default) => throw null;
+        public virtual AsyncPageable<User> GetAllAsync(int? maxPageSize = default, CancellationToken cancellationToken = default) => throw null;
     }
 }


### PR DESCRIPTION
This pull request introduces a new visitor to the Azure HTTP client C# code generator to standardize the casing of the "maxpagesize" parameter to "maxPageSize" in generated client methods. It also adds comprehensive unit tests to ensure the visitor behaves as expected.

**Enhancements to parameter casing in code generation:**

* Added a new `MaxPageSizeCasingVisitor` class that automatically updates method parameters named "maxpagesize" to use the correct camelCase "maxPageSize" in `ScmMethodProvider` methods. This ensures consistency and adherence to C# naming conventions in generated client code.
* Registered the new visitor in the code generator configuration by adding it to the list of visitors in `AzureClientGenerator.cs`.

**Testing improvements:**

* Introduced `MaxPageSizeCasingVisitorTests.cs` with tests verifying that the visitor correctly updates parameters with the incorrect casing and leaves already-correct parameters unchanged. This protects against regressions and ensures reliable behavior.# Contributing to the Azure SDK
