### PR TITLE
fixed duplicated diagnostic scopes in TableClient

### DIFF
--- a/sdk/tables/Azure.Data.Tables/CHANGELOG.md
+++ b/sdk/tables/Azure.Data.Tables/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed an issue where `TimeSpan` properties in strongly typed table entities were not being deserialized.
 - Fixed an issue when deserializing strongly typed table entities with enum properties. Enum values that aren't defined in the enum type are now skipped during deserialization of the table entity.
 - Fixed an issue when comparing `TableErrorCode` with null strings using equality operators.
+- Fixed duplicated diagnostic scopes in `TableClient.Query` and `TableServiceClient.Query`
 
 ### Other Changes
 - Use precedence rules to reduce the parenthesis nesting in OData filters generated from LINQ expressions.

--- a/sdk/tables/Azure.Data.Tables/src/TableClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableClient.cs
@@ -1069,17 +1069,7 @@ namespace Azure.Data.Tables
             IEnumerable<string> select = null,
             CancellationToken cancellationToken = default) where T : class, ITableEntity
         {
-            using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Query)}");
-            scope.Start();
-            try
-            {
-                return QueryAsync<T>(Bind(filter), maxPerPage, select, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                throw;
-            }
+            return QueryAsync<T>(Bind(filter), maxPerPage, select, cancellationToken);
         }
 
         /// <summary>
@@ -1116,17 +1106,7 @@ namespace Azure.Data.Tables
             IEnumerable<string> select = null,
             CancellationToken cancellationToken = default) where T : class, ITableEntity
         {
-            using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Query)}");
-            scope.Start();
-            try
-            {
-                return Query<T>(Bind(filter), maxPerPage, select, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                throw;
-            }
+            return Query<T>(Bind(filter), maxPerPage, select, cancellationToken);
         }
 
         /// <summary>

--- a/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
@@ -593,7 +593,7 @@ namespace Azure.Data.Tables
         /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual Pageable<TableItem> Query(Expression<Func<TableItem, bool>> filter, int? maxPerPage = null, CancellationToken cancellationToken = default)
         {
-                return Query(TableClient.Bind(filter), maxPerPage, cancellationToken);
+            return Query(TableClient.Bind(filter), maxPerPage, cancellationToken);
         }
 
         /// <summary>

--- a/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableServiceClient.cs
@@ -516,18 +516,7 @@ namespace Azure.Data.Tables
         /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual AsyncPageable<TableItem> QueryAsync(FormattableString filter, int? maxPerPage = null, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Query)}");
-            scope.Start();
-            try
-            {
-                return QueryAsync(TableOdataFilter.Create(filter), maxPerPage, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                ValidateServiceUriDoesNotContainTableName(ex);
-                throw;
-            }
+            return QueryAsync(TableOdataFilter.Create(filter), maxPerPage, cancellationToken);
         }
 
         /// <summary>
@@ -547,15 +536,12 @@ namespace Azure.Data.Tables
         /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual Pageable<TableItem> Query(FormattableString filter, int? maxPerPage = null, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Query)}");
-            scope.Start();
             try
             {
                 return Query(TableOdataFilter.Create(filter), maxPerPage, cancellationToken);
             }
             catch (Exception ex)
             {
-                scope.Failed(ex);
                 ValidateServiceUriDoesNotContainTableName(ex);
                 throw;
             }
@@ -580,15 +566,12 @@ namespace Azure.Data.Tables
             int? maxPerPage = null,
             CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Query)}");
-            scope.Start();
             try
             {
                 return QueryAsync(TableClient.Bind(filter), maxPerPage, cancellationToken);
             }
             catch (Exception ex)
             {
-                scope.Failed(ex);
                 ValidateServiceUriDoesNotContainTableName(ex);
                 throw;
             }
@@ -610,18 +593,7 @@ namespace Azure.Data.Tables
         /// <exception cref="RequestFailedException">The server returned an error. See <see cref="Exception.Message"/> for details returned from the server.</exception>
         public virtual Pageable<TableItem> Query(Expression<Func<TableItem, bool>> filter, int? maxPerPage = null, CancellationToken cancellationToken = default)
         {
-            using DiagnosticScope scope = _diagnostics.CreateScope($"{nameof(TableClient)}.{nameof(Query)}");
-            scope.Start();
-            try
-            {
                 return Query(TableClient.Bind(filter), maxPerPage, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                scope.Failed(ex);
-                ValidateServiceUriDoesNotContainTableName(ex);
-                throw;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
At the moment there are duplicated diagnostic scopes. It will produce duplicated traces, i.e. in Application Insights:

<img width="877" height="206" alt="image" src="https://github.com/user-attachments/assets/718bea0c-ea48-49e9-92af-c1740011b5e5" />


Thank you for reviewing.