### PR TITLE
[AzureMonitorExporter] Stabilize Customer SDK Stats metric names

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -10,6 +10,16 @@
 
 ### Other Changes
 
+* The customer-facing SDK stats feature 
+  metric names have been updated to match the stable specification.
+  - **Metric names changed**: `preview.item.success.count` → `Item_Success_Count`,
+    `preview.item.dropped.count` → `Item_Dropped_Count`,
+    `preview.item.retry.count` → `Item_Retry_Count`.
+  - **New environment variable**: To enable, set environment variable
+    `APPLICATIONINSIGHTS_SDKSTATS_DISABLED=false`.
+  - The old environment variable `APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW`
+    is no longer recognized.
+
 ## 1.6.0-beta.2 (2026-01-12)
 
 ### Breaking Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsHelper.cs
@@ -38,14 +38,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
         /// <summary>
         /// Checks if customer SDK stats are enabled.
         /// </summary>
-        /// <returns>True if enabled, false otherwise</returns>
+        /// <returns>True if enabled (when APPLICATIONINSIGHTS_SDKSTATS_DISABLED=false), false otherwise</returns>
         public static bool IsEnabled()
         {
             if (s_isEnabled == null)
             {
-                var enabledValue = DefaultPlatform.Instance.GetEnvironmentVariable(EnvironmentVariableConstants.APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW);
-                s_isEnabled = string.Equals(enabledValue, "true", StringComparison.OrdinalIgnoreCase);
+                var disabledValue = DefaultPlatform.Instance.GetEnvironmentVariable(EnvironmentVariableConstants.APPLICATIONINSIGHTS_SDKSTATS_DISABLED);
+                s_isEnabled = string.Equals(disabledValue, "false", StringComparison.OrdinalIgnoreCase);
             }
+
             return s_isEnabled.Value;
         }
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsMeters.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/CustomerSdkStats/CustomerSdkStatsMeters.cs
@@ -24,21 +24,21 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.CustomerSdkStats
         /// Counter for successful telemetry items sent to Application Insights.
         /// </summary>
         public static readonly Counter<long> ItemSuccessCount = Meter.CreateCounter<long>(
-            "preview.item.success.count",
+            "Item_Success_Count",
             description: "Count of successful telemetry items sent to Application Insights");
 
         /// <summary>
         /// Counter for dropped telemetry items.
         /// </summary>
         public static readonly Counter<long> ItemDroppedCount = Meter.CreateCounter<long>(
-            "preview.item.dropped.count",
+            "Item_Dropped_Count",
             description: "Count of dropped telemetry items");
 
         /// <summary>
         /// Counter for retried telemetry items.
         /// </summary>
         public static readonly Counter<long> ItemRetryCount = Meter.CreateCounter<long>(
-            "preview.item.retry.count",
+            "Item_Retry_Count",
             description: "Count of retried telemetry items");
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         {
             APPLICATIONINSIGHTS_CONNECTION_STRING,
             APPLICATIONINSIGHTS_STATSBEAT_DISABLED,
-            APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW,
+            APPLICATIONINSIGHTS_SDKSTATS_DISABLED,
             APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL,
             FUNCTIONS_WORKER_RUNTIME,
             LOCALAPPDATA,
@@ -49,12 +49,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         public const string APPLICATIONINSIGHTS_STATSBEAT_DISABLED = "APPLICATIONINSIGHTS_STATSBEAT_DISABLED";
 
         /// <summary>
-        /// Available for users to enable customer SDK stats preview feature.
+        /// Available for users to enable customer SDK stats.
         /// </summary>
         /// <remarks>
         /// Customer SDK stats provide insights into SDK success/failure/retry counts.
+        /// Set to "false" to enable this feature.
         /// </remarks>
-        public const string APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW = "APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW";
+        public const string APPLICATIONINSIGHTS_SDKSTATS_DISABLED = "APPLICATIONINSIGHTS_SDKSTATS_DISABLED";
 
         /// <summary>
         /// Available for users to configure customer SDK stats export interval in seconds.


### PR DESCRIPTION
## Summary

Updates Customer SDK Stats feature to use stable metric names per the specification.

## Changes

- **Metric names updated to stable format:**
  - `preview.item.success.count` → `Item_Success_Count`
  - `preview.item.dropped.count` → `Item_Dropped_Count`
  - `preview.item.retry.count` → `Item_Retry_Count`

- **Environment variable updated:**
  - Replaced `APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW` with `APPLICATIONINSIGHTS_SDKSTATS_DISABLED`
  - Feature remains opt-in: set `APPLICATIONINSIGHTS_SDKSTATS_DISABLED=false` to enable

## Breaking Changes

- The old environment variable `APPLICATIONINSIGHTS_SDKSTATS_ENABLED_PREVIEW` is no longer recognized
- Metric names have changed (dashboards will aggregate old and new names together)

## Related

- Customer-facing SDK Stats specification