### PR TITLE
[Hosted Agents] Pin AgentServer internal package dependencies to exact versions

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -205,6 +205,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.StartsWith('Azure.AI.AgentServer'))">
+    <!-- AgentServer internal packages use exact version constraints -->
+    <PackageReference Update="Azure.AI.AgentServer.AgentFramework" Version="[1.0.0-beta.6]" />
+    <PackageReference Update="Azure.AI.AgentServer.Core" Version="[1.0.0-beta.6]" />
+    <PackageReference Update="Azure.AI.AgentServer.Contracts" Version="[1.0.0-beta.6]" />
+
     <PackageReference Update="Azure.AI.Projects" Version="1.1.0" />
     <PackageReference Update="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0"/>
     <PackageReference Update="ModelContextProtocol" Version="0.4.0-preview.3" />

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Azure.AI.AgentServer.AgentFramework.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Azure.AI.AgentServer.AgentFramework.csproj
@@ -10,9 +10,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Agents.AI" />
+    <!-- Explicit PackageReference for exact version constraint (controlled by Packages.Data.props) -->
+    <PackageReference Include="Azure.AI.AgentServer.Core" />
   </ItemGroup>
 
   <ItemGroup>
+    <!-- ProjectReference for local build -->
     <ProjectReference Include="..\..\Azure.AI.AgentServer.Core\src\Azure.AI.AgentServer.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
@@ -9,10 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- ProjectReference for local build -->
     <ProjectReference Include="..\..\Azure.AI.AgentServer.Contracts\src\Azure.AI.AgentServer.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Explicit PackageReference for exact version constraint (controlled by Packages.Data.props) -->
+    <PackageReference Include="Azure.AI.AgentServer.Contracts" />
     <PackageReference Include="Azure.AI.Projects" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="ModelContextProtocol" />


### PR DESCRIPTION
 Add exact version constraints [1.0.0-beta.6] for AgentFramework, Core,
  and Contracts to ensure customers install specific versions rather than
  automatically resolving to newer versions.