### PR TITLE
Added Support for IPv6 102

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_6ff82d4055"
+  "Tag": "net/storage/Azure.Storage.Blobs_8988bab789"
 }

--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_8988bab789"
+  "Tag": "net/storage/Azure.Storage.Blobs_5a7e624251"
 }

--- a/sdk/storage/Azure.Storage.Blobs/assets.json
+++ b/sdk/storage/Azure.Storage.Blobs/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Blobs",
-  "Tag": "net/storage/Azure.Storage.Blobs_736ce86cf0"
+  "Tag": "net/storage/Azure.Storage.Blobs_ba25e77048"
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
@@ -227,7 +227,7 @@ namespace Azure.Storage.Blobs
                 }
                 else
                 {
-                    AccountName = uri.GetAccountNameFromDomain(Constants.Blob.UriSubDomain) ?? string.Empty;
+                    AccountName = uri.GetAccountNameFromHost(Constants.Blob.UriSubDomain) ?? string.Empty;
                 }
 
                 // Find the next slash (if it exists)

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
@@ -83,6 +83,7 @@ namespace Azure.Storage.Blobs.Test
             Assert.AreEqual("", blobUriBuilder.BlobName);
             Assert.AreEqual("", blobUriBuilder.Snapshot);
             Assert.IsNull(blobUriBuilder.Sas);
+            Assert.AreEqual("", blobUriBuilder.Query);
             Assert.AreEqual(443, blobUriBuilder.Port);
             Assert.AreEqual(originalUri, newUri);
         }

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
@@ -61,6 +61,33 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [RecordedTest]
+        [TestCase("https://myaccount.blob.core.windows.net/")]
+        [TestCase("https://myaccount-secondary.blob.core.windows.net/")]
+        [TestCase("https://myaccount-dualstack.blob.core.windows.net/")]
+        [TestCase("https://myaccount-ipv6.blob.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-dualstack.blob.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-ipv6.blob.core.windows.net/")]
+        public void BlobUriBuilder_Secondary_IPV6_Dualstack(string uriString)
+        {
+            // Arrange
+            var originalUri = new UriBuilder(uriString);
+
+            // Act
+            var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
+            Uri newUri = blobUriBuilder.ToUri();
+
+            // Assert
+            Assert.AreEqual("https", blobUriBuilder.Scheme);
+            Assert.AreEqual("myaccount", blobUriBuilder.AccountName);
+            Assert.AreEqual("", blobUriBuilder.BlobContainerName);
+            Assert.AreEqual("", blobUriBuilder.BlobName);
+            Assert.AreEqual("", blobUriBuilder.Snapshot);
+            Assert.IsNull(blobUriBuilder.Sas);
+            Assert.AreEqual(443, blobUriBuilder.Port);
+            Assert.AreEqual(originalUri, newUri);
+        }
+
+        [RecordedTest]
         public void BlobUriBuilder_RegularUrl_ContainerTest()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobUriBuilderTests.cs
@@ -89,6 +89,30 @@ namespace Azure.Storage.Blobs.Test
         }
 
         [RecordedTest]
+        [TestCase("https://md-d3rqxhqbxbwq.blob.core.windows.net/", "md-d3rqxhqbxbwq")]
+        [TestCase("https://md-ssd-bndub02px100c21.blob.core.windows.net/", "md-ssd-bndub02px100c21")]
+        public void BlobUriBuilder_InternalAccounts(string uriString, string actualAccountName)
+        {
+            // Arrange
+            var originalUri = new UriBuilder(uriString);
+
+            // Act
+            var blobUriBuilder = new BlobUriBuilder(originalUri.Uri);
+            Uri newUri = blobUriBuilder.ToUri();
+
+            // Assert
+            Assert.AreEqual("https", blobUriBuilder.Scheme);
+            Assert.AreEqual(actualAccountName, blobUriBuilder.AccountName);
+            Assert.AreEqual("", blobUriBuilder.BlobContainerName);
+            Assert.AreEqual("", blobUriBuilder.BlobName);
+            Assert.AreEqual("", blobUriBuilder.Snapshot);
+            Assert.IsNull(blobUriBuilder.Sas);
+            Assert.AreEqual("", blobUriBuilder.Query);
+            Assert.AreEqual(443, blobUriBuilder.Port);
+            Assert.AreEqual(originalUri, newUri);
+        }
+
+        [RecordedTest]
         public void BlobUriBuilder_RegularUrl_ContainerTest()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
@@ -90,7 +90,16 @@ namespace Azure.Storage
             if (accountEndIndex >= 0)
             {
                 var serviceStartIndex = host.IndexOf(serviceSubDomain, accountEndIndex, StringComparison.InvariantCulture);
-                return serviceStartIndex > -1 ? host.Substring(0, accountEndIndex) : null;
+                if (serviceStartIndex > -1)
+                {
+                    string accountName = host.Substring(0, accountEndIndex);
+                    int dashIndex = accountName.IndexOf('-');
+                    if (dashIndex > 0)
+                    {
+                        accountName = accountName.Substring(0, dashIndex);
+                    }
+                    return accountName;
+                }
             }
             return null;
         }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
@@ -94,7 +94,7 @@ namespace Azure.Storage
                 {
                     string accountName = host.Substring(0, accountEndIndex);
                     int dashIndex = accountName.IndexOf('-');
-                    if (dashIndex > 0)
+                    if (dashIndex > -1)
                     {
                         accountName = accountName.Substring(0, dashIndex);
                     }

--- a/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Shared/UriExtensions.cs
@@ -66,15 +66,15 @@ namespace Azure.Storage
         }
 
         /// <summary>
-        /// Get the account name from the domain portion of a Uri.
+        /// Get the account name from the host portion of a Uri.
         /// </summary>
         /// <param name="uri">The Uri.</param>
         /// <param name="serviceSubDomain">The service subdomain used to validate that the
-        /// domain is in the expected format. This should be "blob" for blobs, "file" for files,
+        /// host is in the expected format. This should be "blob" for blobs, "file" for files,
         /// "queue" for queues, "blob" and "dfs" for datalake.</param>
         /// <returns>Account name or null if not able to be parsed.</returns>
-        public static string GetAccountNameFromDomain(this Uri uri, string serviceSubDomain) =>
-            GetAccountNameFromDomain(uri.Host, serviceSubDomain);
+        public static string GetAccountNameFromHost(this Uri uri, string serviceSubDomain) =>
+            GetAccountNameFromHost(uri.Host, serviceSubDomain);
 
         /// <summary>
         /// Get the account name from the host.
@@ -84,7 +84,7 @@ namespace Azure.Storage
         /// domain is in the expected format. This should be "blob" for blobs, "file" for files,
         /// "queue" for queues, "blob" and "dfs" for datalake.</param>
         /// <returns>Account name or null if not able to be parsed.</returns>
-        public static string GetAccountNameFromDomain(string host, string serviceSubDomain)
+        public static string GetAccountNameFromHost(string host, string serviceSubDomain)
         {
             var accountEndIndex = host.IndexOf(".", StringComparison.InvariantCulture);
             if (accountEndIndex >= 0)
@@ -93,11 +93,27 @@ namespace Azure.Storage
                 if (serviceStartIndex > -1)
                 {
                     string accountName = host.Substring(0, accountEndIndex);
-                    int dashIndex = accountName.IndexOf('-');
-                    if (dashIndex > -1)
+
+                    // Note: The suffixes are specifically checked/trimmed in this order to
+                    // take into account of cases with both "-secondary" and "-ipv6"/"-dualstack"
+                    // ie. "accountname-secondary-ipv6"
+
+                    // Remove "-ipv6" or "-dualstack" from end if present
+                    if (accountName.EndsWith("-ipv6", StringComparison.InvariantCulture))
                     {
-                        accountName = accountName.Substring(0, dashIndex);
+                        accountName = accountName.Substring(0, accountName.Length - "-ipv6".Length);
                     }
+                    else if (accountName.EndsWith("-dualstack", StringComparison.InvariantCulture))
+                    {
+                        accountName = accountName.Substring(0, accountName.Length - "-dualstack".Length);
+                    }
+
+                    // Remove "-secondary" from end if present
+                    if (accountName.EndsWith("-secondary", StringComparison.InvariantCulture))
+                    {
+                        accountName = accountName.Substring(0, accountName.Length - "-secondary".Length);
+                    }
+
                     return accountName;
                 }
             }

--- a/sdk/storage/Azure.Storage.Common/tests/StorageConnectionStringTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageConnectionStringTests.cs
@@ -712,5 +712,19 @@ namespace Azure.Storage.Test
 
             TestHelper.AssertSequenceEqual(expectedKeyBytes, keyBytes);
         }
+
+        [Test]
+        [Description("Ensuring IPv6 connection strings are parsing AccountName correctly")]
+        public void ParseIPv6ConnectionString_AssertAccountName()
+        {
+            string accountName = "storagesample";
+            string blobEndpoint = "https://" + accountName + "-ipv6.blob.core.windows.net/";
+            string connectionString = string.Format(
+                        "DefaultEndpointsProtocol=https;AccountName={0};AccountKey=123=;BlobEndpoint={1};EndpointSuffix=core.windows.net",
+                        accountName,
+                        blobEndpoint);
+            var storageConnectionString = StorageConnectionString.Parse(connectionString);
+            Assert.AreEqual(accountName, storageConnectionString.AccountName);
+        }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/StorageConnectionStringTests.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/StorageConnectionStringTests.cs
@@ -725,6 +725,7 @@ namespace Azure.Storage.Test
                         blobEndpoint);
             var storageConnectionString = StorageConnectionString.Parse(connectionString);
             Assert.AreEqual(accountName, storageConnectionString.AccountName);
+            Assert.AreEqual(new Uri(blobEndpoint), storageConnectionString.BlobEndpoint);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/assets.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.DataLake",
-  "Tag": "net/storage/Azure.Storage.Files.DataLake_e87e5c6594"
+  "Tag": "net/storage/Azure.Storage.Files.DataLake_6105aed450"
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/assets.json
+++ b/sdk/storage/Azure.Storage.Files.DataLake/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.DataLake",
-  "Tag": "net/storage/Azure.Storage.Files.DataLake_6105aed450"
+  "Tag": "net/storage/Azure.Storage.Files.DataLake_4566f624c5"
 }

--- a/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeUriBuilder.cs
@@ -205,8 +205,8 @@ namespace Azure.Storage.Files.DataLake
                 else
                 {
                     // DataLake Uris have two allowed subdomains
-                    AccountName = uri.GetAccountNameFromDomain(Constants.DataLake.BlobUriSuffix) ??
-                        uri.GetAccountNameFromDomain(Constants.DataLake.DfsUriSuffix) ??
+                    AccountName = uri.GetAccountNameFromHost(Constants.DataLake.BlobUriSuffix) ??
+                        uri.GetAccountNameFromHost(Constants.DataLake.DfsUriSuffix) ??
                         string.Empty;
                 }
 
@@ -276,7 +276,7 @@ namespace Azure.Storage.Files.DataLake
         {
             if (!_isIPStyleUri)
             {
-                string account = UriExtensions.GetAccountNameFromDomain(Host, Constants.DataLake.DfsUriSuffix);
+                string account = UriExtensions.GetAccountNameFromHost(Host, Constants.DataLake.DfsUriSuffix);
 
                 if (account != null)
                 {
@@ -305,7 +305,7 @@ namespace Azure.Storage.Files.DataLake
         {
             if (!_isIPStyleUri)
             {
-                string account = UriExtensions.GetAccountNameFromDomain(Host, Constants.DataLake.BlobUriSuffix);
+                string account = UriExtensions.GetAccountNameFromHost(Host, Constants.DataLake.BlobUriSuffix);
 
                 if (account != null)
                 {

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeUriBuilderTests.cs
@@ -77,6 +77,40 @@ namespace Azure.Storage.Files.DataLake.Tests
         }
 
         [RecordedTest]
+        [TestCase("https://myaccount.blob.core.windows.net/")]
+        [TestCase("https://myaccount-secondary.blob.core.windows.net/")]
+        [TestCase("https://myaccount-dualstack.blob.core.windows.net/")]
+        [TestCase("https://myaccount-ipv6.blob.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-dualstack.blob.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-ipv6.blob.core.windows.net/")]
+        [TestCase("https://myaccount.dfs.core.windows.net/")]
+        [TestCase("https://myaccount-secondary.dfs.core.windows.net/")]
+        [TestCase("https://myaccount-dualstack.dfs.core.windows.net/")]
+        [TestCase("https://myaccount-ipv6.dfs.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-dualstack.dfs.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-ipv6.dfs.core.windows.net/")]
+        public void DataLakeUriBuilder_Secondary_IPV6_Dualstack(string uriString)
+        {
+            // Arrange
+            var originalUri = new UriBuilder(uriString);
+
+            // Act
+            var dataLakeUriBuilder = new DataLakeUriBuilder(originalUri.Uri);
+            Uri newUri = dataLakeUriBuilder.ToUri();
+
+            // Assert
+            Assert.AreEqual("https", dataLakeUriBuilder.Scheme);
+            Assert.AreEqual("myaccount", dataLakeUriBuilder.AccountName);
+            Assert.AreEqual("", dataLakeUriBuilder.FileSystemName);
+            Assert.AreEqual("", dataLakeUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual("", dataLakeUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual("", dataLakeUriBuilder.Snapshot);
+            Assert.IsNull(dataLakeUriBuilder.Sas);
+            Assert.AreEqual(443, dataLakeUriBuilder.Port);
+            Assert.AreEqual(originalUri, newUri);
+        }
+
+        [RecordedTest]
         public void DataLakeUriBuilder_ListPaths()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.DataLake/tests/DataLakeUriBuilderTests.cs
@@ -107,6 +107,34 @@ namespace Azure.Storage.Files.DataLake.Tests
             Assert.AreEqual("", dataLakeUriBuilder.Snapshot);
             Assert.IsNull(dataLakeUriBuilder.Sas);
             Assert.AreEqual(443, dataLakeUriBuilder.Port);
+            Assert.AreEqual("", dataLakeUriBuilder.Query);
+            Assert.AreEqual(originalUri, newUri);
+        }
+
+        [RecordedTest]
+        [TestCase("https://md-d3rqxhqbxbwq.blob.core.windows.net/", "md-d3rqxhqbxbwq")]
+        [TestCase("https://md-ssd-bndub02px100c21.blob.core.windows.net/", "md-ssd-bndub02px100c21")]
+        [TestCase("https://md-d3rqxhqbxbwq.dfs.core.windows.net/", "md-d3rqxhqbxbwq")]
+        [TestCase("https://md-ssd-bndub02px100c21.dfs.core.windows.net/", "md-ssd-bndub02px100c21")]
+        public void DataLakeUriBuilder_InternalAccounts(string uriString, string actualAccountName)
+        {
+            // Arrange
+            var originalUri = new UriBuilder(uriString);
+
+            // Act
+            var dataLakeUriBuilder = new DataLakeUriBuilder(originalUri.Uri);
+            Uri newUri = dataLakeUriBuilder.ToUri();
+
+            // Assert
+            Assert.AreEqual("https", dataLakeUriBuilder.Scheme);
+            Assert.AreEqual(actualAccountName, dataLakeUriBuilder.AccountName);
+            Assert.AreEqual("", dataLakeUriBuilder.FileSystemName);
+            Assert.AreEqual("", dataLakeUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual("", dataLakeUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual("", dataLakeUriBuilder.Snapshot);
+            Assert.IsNull(dataLakeUriBuilder.Sas);
+            Assert.AreEqual(443, dataLakeUriBuilder.Port);
+            Assert.AreEqual("", dataLakeUriBuilder.Query);
             Assert.AreEqual(originalUri, newUri);
         }
 

--- a/sdk/storage/Azure.Storage.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.Files.Shares_8cc433b62e"
+  "Tag": "net/storage/Azure.Storage.Files.Shares_597e40a64d"
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.Files.Shares_597e40a64d"
+  "Tag": "net/storage/Azure.Storage.Files.Shares_1d0ba681c6"
 }

--- a/sdk/storage/Azure.Storage.Files.Shares/src/ShareUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/src/ShareUriBuilder.cs
@@ -197,7 +197,7 @@ namespace Azure.Storage.Files.Shares
                 }
                 else
                 {
-                    AccountName = uri.GetAccountNameFromDomain(Constants.File.UriSubDomain) ?? string.Empty;
+                    AccountName = uri.GetAccountNameFromHost(Constants.File.UriSubDomain) ?? string.Empty;
                 }
 
                 // Find the next slash (if it exists)

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
@@ -58,6 +58,34 @@ namespace Azure.Storage.Files.Shares.Tests
         }
 
         [RecordedTest]
+        [TestCase("https://myaccount.file.core.windows.net/")]
+        [TestCase("https://myaccount-secondary.file.core.windows.net/")]
+        [TestCase("https://myaccount-dualstack.file.core.windows.net/")]
+        [TestCase("https://myaccount-ipv6.file.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-dualstack.file.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-ipv6.file.core.windows.net/")]
+        public void FileUriBuilder_Secondary_IPV6_Dualstack(string uriString)
+        {
+            // Arrange
+            var originalUri = new UriBuilder(uriString);
+
+            // Act
+            var fileUriBuilder = new ShareUriBuilder(originalUri.Uri);
+            Uri newUri = fileUriBuilder.ToUri();
+
+            // Assert
+            Assert.AreEqual("https", fileUriBuilder.Scheme);
+            Assert.AreEqual("myaccount", fileUriBuilder.AccountName);
+            Assert.AreEqual("", fileUriBuilder.ShareName);
+            Assert.AreEqual("", fileUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual("", fileUriBuilder.Snapshot);
+            Assert.IsNull(fileUriBuilder.Sas);
+            Assert.AreEqual(443, fileUriBuilder.Port);
+            Assert.AreEqual("", fileUriBuilder.Query);
+            Assert.AreEqual(originalUri, newUri);
+        }
+
+        [RecordedTest]
         public void FileUriBuilder_ShareTest()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Files.Shares/tests/FileUriBuilderTests.cs
@@ -82,6 +82,32 @@ namespace Azure.Storage.Files.Shares.Tests
             Assert.IsNull(fileUriBuilder.Sas);
             Assert.AreEqual(443, fileUriBuilder.Port);
             Assert.AreEqual("", fileUriBuilder.Query);
+            Assert.AreEqual(string.Empty, fileUriBuilder.LastDirectoryOrFileName);
+            Assert.AreEqual(originalUri, newUri);
+        }
+
+        [RecordedTest]
+        [TestCase("https://md-d3rqxhqbxbwq.file.core.windows.net/", "md-d3rqxhqbxbwq")]
+        [TestCase("https://md-ssd-bndub02px100c21.file.core.windows.net/", "md-ssd-bndub02px100c21")]
+        public void FileUriBuilder_InternalAccounts(string uriString, string actualAccountName)
+        {
+            // Arrange
+            var originalUri = new UriBuilder(uriString);
+
+            // Act
+            var fileUriBuilder = new ShareUriBuilder(originalUri.Uri);
+            Uri newUri = fileUriBuilder.ToUri();
+
+            // Assert
+            Assert.AreEqual("https", fileUriBuilder.Scheme);
+            Assert.AreEqual(actualAccountName, fileUriBuilder.AccountName);
+            Assert.AreEqual("", fileUriBuilder.ShareName);
+            Assert.AreEqual("", fileUriBuilder.DirectoryOrFilePath);
+            Assert.AreEqual("", fileUriBuilder.Snapshot);
+            Assert.IsNull(fileUriBuilder.Sas);
+            Assert.AreEqual(443, fileUriBuilder.Port);
+            Assert.AreEqual("", fileUriBuilder.Query);
+            Assert.AreEqual(string.Empty, fileUriBuilder.LastDirectoryOrFileName);
             Assert.AreEqual(originalUri, newUri);
         }
 

--- a/sdk/storage/Azure.Storage.Queues/assets.json
+++ b/sdk/storage/Azure.Storage.Queues/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Queues",
-  "Tag": "net/storage/Azure.Storage.Queues_40d68b46e2"
+  "Tag": "net/storage/Azure.Storage.Queues_954af2dac5"
 }

--- a/sdk/storage/Azure.Storage.Queues/assets.json
+++ b/sdk/storage/Azure.Storage.Queues/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.Queues",
-  "Tag": "net/storage/Azure.Storage.Queues_954af2dac5"
+  "Tag": "net/storage/Azure.Storage.Queues_e74c0f8142"
 }

--- a/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
@@ -178,7 +178,7 @@ namespace Azure.Storage.Queues
                 }
                 else
                 {
-                    AccountName = uri.GetAccountNameFromDomain(Constants.Queue.UriSubDomain) ?? string.Empty;
+                    AccountName = uri.GetAccountNameFromHost(Constants.Queue.UriSubDomain) ?? string.Empty;
                 }
 
                 // Find the next slash (if it exists)

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueUriBuilderTests.cs
@@ -44,6 +44,34 @@ namespace Azure.Storage.Queues.Test
         }
 
         [RecordedTest]
+        [TestCase("https://myaccount.queue.core.windows.net/")]
+        [TestCase("https://myaccount-secondary.queue.core.windows.net/")]
+        [TestCase("https://myaccount-dualstack.queue.core.windows.net/")]
+        [TestCase("https://myaccount-ipv6.queue.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-dualstack.queue.core.windows.net/")]
+        [TestCase("https://myaccount-secondary-ipv6.queue.core.windows.net/")]
+        public void QueueUriBuilder_Secondary_IPV6_Dualstack(string uriString)
+        {
+            // Arrange
+            var originalUri = new UriBuilder(uriString);
+
+            // Act
+            var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
+            Uri newUri = queueUriBuilder.ToUri();
+
+            // Assert
+            Assert.AreEqual("https", queueUriBuilder.Scheme);
+            Assert.AreEqual("myaccount", queueUriBuilder.AccountName);
+            Assert.AreEqual("", queueUriBuilder.QueueName);
+            Assert.IsFalse(queueUriBuilder.Messages);
+            Assert.AreEqual("", queueUriBuilder.MessageId);
+            Assert.IsNull(queueUriBuilder.Sas);
+            Assert.AreEqual(443, queueUriBuilder.Port);
+            Assert.AreEqual("", queueUriBuilder.Query);
+            Assert.AreEqual(originalUri, newUri);
+        }
+
+        [RecordedTest]
         public void QueueUriBuilder_RegularUrl_QueueTest()
         {
             // Arrange

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueUriBuilderTests.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueUriBuilderTests.cs
@@ -72,6 +72,30 @@ namespace Azure.Storage.Queues.Test
         }
 
         [RecordedTest]
+        [TestCase("https://md-d3rqxhqbxbwq.queue.core.windows.net/", "md-d3rqxhqbxbwq")]
+        [TestCase("https://md-ssd-bndub02px100c21.queue.core.windows.net/", "md-ssd-bndub02px100c21")]
+        public void QueueUriBuilder_InternalAccounts(string uriString, string actualAccountName)
+        {
+            // Arrange
+            var originalUri = new UriBuilder(uriString);
+
+            // Act
+            var queueUriBuilder = new QueueUriBuilder(originalUri.Uri);
+            Uri newUri = queueUriBuilder.ToUri();
+
+            // Assert
+            Assert.AreEqual("https", queueUriBuilder.Scheme);
+            Assert.AreEqual(actualAccountName, queueUriBuilder.AccountName);
+            Assert.AreEqual("", queueUriBuilder.QueueName);
+            Assert.IsFalse(queueUriBuilder.Messages);
+            Assert.AreEqual("", queueUriBuilder.MessageId);
+            Assert.IsNull(queueUriBuilder.Sas);
+            Assert.AreEqual(443, queueUriBuilder.Port);
+            Assert.AreEqual("", queueUriBuilder.Query);
+            Assert.AreEqual(originalUri, newUri);
+        }
+
+        [RecordedTest]
         public void QueueUriBuilder_RegularUrl_QueueTest()
         {
             // Arrange


### PR DESCRIPTION
1. Modified host endpoint parsing to trim suffix `-ipv6`, `-dualstack`, and `-secondary`. This change should take into account of internal account names which may contain `-` as well as fix the existing bug for `-secondary`.
2. IPv6 connection string appears to always have the `AccountName` parameter as the _true_ account name without suffixes. As such, the current way of calculating account name should suffice and no change should be needed.
