### PR TITLE
Make `User-Agent` header the same behavior as in python.

### DIFF
--- a/sdk/ai/Azure.AI.Projects.OpenAI/assets.json
+++ b/sdk/ai/Azure.AI.Projects.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/ai/Azure.AI.Projects.OpenAI",
-  "Tag": "net/ai/Azure.AI.Projects.OpenAI_f6b14f8f7c"
+  "Tag": "net/ai/Azure.AI.Projects.OpenAI_b1bbbf4b96"
 }

--- a/sdk/ai/Azure.AI.Projects.OpenAI/assets.json
+++ b/sdk/ai/Azure.AI.Projects.OpenAI/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/ai/Azure.AI.Projects.OpenAI",
-  "Tag": "net/ai/Azure.AI.Projects.OpenAI_b1bbbf4b96"
+  "Tag": "net/ai/Azure.AI.Projects.OpenAI_da6c4d2cba"
 }

--- a/sdk/ai/Azure.AI.Projects.OpenAI/src/Properties/AssemblyInfo.cs
+++ b/sdk/ai/Azure.AI.Projects.OpenAI/src/Properties/AssemblyInfo.cs
@@ -1,2 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Azure.AI.Projects.OpenAI.Tests, PublicKey=" +
+    "0024000004800000940000000602000000240000525341310004000001000100d15ddcb2968829" +
+    "5338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc" +
+    "012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265" +
+    "e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593d" +
+    "aa7b11b4")]

--- a/sdk/ai/Azure.AI.Projects.OpenAI/tests/ProjectOpenAIClientSmokeTest.cs
+++ b/sdk/ai/Azure.AI.Projects.OpenAI/tests/ProjectOpenAIClientSmokeTest.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Azure.Identity;
+using Microsoft.ClientModel.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.AI.Projects.OpenAI.Tests;
+
+[Category("Smoke")]
+public class ProjectOpenAIClientSmokeTest : ProjectsOpenAITestBase
+{
+    private static readonly string AGENT_NAME = "MyAgentOAI";
+    public ProjectOpenAIClientSmokeTest(bool isAsync) : base(isAsync)
+    {
+    }
+
+    [RecordedTest]
+    [TestCase("", "^AIProjectClient OpenAI/.+ [(][^)]+[)]$")]
+    [TestCase(null, "^AIProjectClient OpenAI/.+ [(][^)]+[)]$")]
+    [TestCase("MyClient", "^MyClient-AIProjectClient OpenAI/.+ [(][^)]+[)]$")]
+    public async Task TestUserAgentHeaders(string customUserAgent, string expectedRegex)
+    {
+        AIProjectClient proojectClient = GetTestProjectClient();
+        PromptAgentDefinition def = new(model: TestEnvironment.MODELDEPLOYMENTNAME)
+        {
+            Instructions = "You are helpful assistant",
+        };
+        AgentVersion agentVersion = await proojectClient.Agents.CreateAgentVersionAsync(
+            agentName: AGENT_NAME,
+            options: new(def)
+        );
+        PipelineMessageClassifier pipelineMessageClassifier200 = PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
+        ProjectOpenAIClientOptions options = CreateTestOpenAIClientOptions<ProjectOpenAIClientOptions>();
+        options.UserAgentApplicationId = customUserAgent;
+        ClientPipeline pipeline = ProjectOpenAIClient.CreatePipeline(new BearerTokenPolicy(new AzureCliCredential(), "https://ai.azure.com/.default"), options);
+        ClientUriBuilder uri = new();
+        uri.Reset(new System.Uri(TestEnvironment.PROJECT_ENDPOINT));
+        uri.AppendPath("/openai/responses", false);
+        PipelineMessage msg = pipeline.CreateMessage(uri.ToUri(), "POST", pipelineMessageClassifier200);
+        PipelineRequest request = msg.Request;
+        request.Headers.Set("Accept", "application/json, text/event-stream");
+        request.Headers.Set("Content-Type", "application/json");
+        BinaryData contentData = BinaryData.FromObjectAsJson(new
+        {
+            input = new[]
+            {
+                new
+                {
+                    type = "message",
+                    role = "user",
+                    content = new[]
+                    {
+                        new
+                        {
+                            type = "input_text",
+                            text = "Please greet me and tell me what would be good to wear outside today."
+                        }
+                    }
+                }
+            },
+            agent = new
+            {
+                type = "agent_reference",
+                name = agentVersion.Name,
+                version = agentVersion.Version
+            }
+        });
+        using BinaryContent content = BinaryContent.Create(contentData);
+        request.Content = content;
+        PipelineResponse response = await pipeline.ProcessMessageAsync(msg, options: new());
+        if (msg.Request.Headers.TryGetValues("User-Agent", out IEnumerable<string> headers))
+        {
+            List<string> userAgent = [..headers];
+            Assert.That(userAgent.Count, Is.EqualTo(1), $"Unexpectedly found {userAgent.Count} User-Agent headers.");
+            Assert.That(Regex.IsMatch(userAgent[0], expectedRegex), Is.True, $"The header {userAgent[0]} does not match the pattern {expectedRegex}");
+        }
+        else
+        {
+            Assert.Fail("No User-Agent headers were found.");
+        }
+    }
+
+    [TearDown]
+    public override void Cleanup()
+    {
+        if (Mode == RecordedTestMode.Playback)
+            return;
+        Uri connectionString = new(TestEnvironment.PROJECT_ENDPOINT);
+        AIProjectClient projectClient = new(connectionString, TestEnvironment.Credential);
+        // Remove Agents.
+        foreach (AgentVersion ag in projectClient.Agents.GetAgentVersions(agentName: AGENT_NAME))
+        {
+            projectClient.Agents.DeleteAgentVersion(agentName: ag.Name, agentVersion: ag.Version);
+        }
+    }
+}

--- a/sdk/ai/Azure.AI.Projects.OpenAI/tests/ProjectOpenAIClientSmokeTest.cs
+++ b/sdk/ai/Azure.AI.Projects.OpenAI/tests/ProjectOpenAIClientSmokeTest.cs
@@ -38,7 +38,7 @@ public class ProjectOpenAIClientSmokeTest : ProjectsOpenAITestBase
         PipelineMessageClassifier pipelineMessageClassifier200 = PipelineMessageClassifier.Create(stackalloc ushort[] { 200 });
         ProjectOpenAIClientOptions options = CreateTestOpenAIClientOptions<ProjectOpenAIClientOptions>();
         options.UserAgentApplicationId = customUserAgent;
-        ClientPipeline pipeline = ProjectOpenAIClient.CreatePipeline(new BearerTokenPolicy(new AzureCliCredential(), "https://ai.azure.com/.default"), options);
+        ClientPipeline pipeline = ProjectOpenAIClient.CreatePipeline(new BearerTokenPolicy(TestEnvironment.Credential, "https://ai.azure.com/.default"), options);
         ClientUriBuilder uri = new();
         uri.Reset(new System.Uri(TestEnvironment.PROJECT_ENDPOINT));
         uri.AppendPath("/openai/responses", false);

--- a/sdk/ai/Azure.AI.Projects.OpenAI/tests/ProjectsOpenAITestBase.cs
+++ b/sdk/ai/Azure.AI.Projects.OpenAI/tests/ProjectsOpenAITestBase.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 
 using Azure.AI.Projects;
 using Azure.AI.Projects.OpenAI;
+using Azure.AI.Projects.OpenAI.Tests.Utils;
 using Azure.Identity;
 using Microsoft.ClientModel.TestFramework;
 using NUnit.Framework;
@@ -41,6 +42,7 @@ public class ProjectsOpenAITestBase : RecordedTestBase<ProjectsOpenAITestEnviron
 
     public ProjectsOpenAITestBase(bool isAsync, RecordedTestMode? testMode = null) : base(isAsync, testMode)
     {
+        ProjectsTestSanitizers.ApplySanitizers(this);
     }
 
     protected AIProjectClientOptions CreateTestProjectClientOptions(bool instrument = true)
@@ -156,7 +158,7 @@ public class ProjectsOpenAITestBase : RecordedTestBase<ProjectsOpenAITestEnviron
         };
     }
 
-    private AuthenticationTokenProvider GetTestAuthenticationProvider()
+    protected AuthenticationTokenProvider GetTestAuthenticationProvider()
     {
         // For local testing if you are using non default account
         // add USE_CLI_CREDENTIAL into the .runsettings and set it to true,

--- a/sdk/ai/Azure.AI.Projects.OpenAI/tests/ProjectsOpenAITestEnvironment.cs
+++ b/sdk/ai/Azure.AI.Projects.OpenAI/tests/ProjectsOpenAITestEnvironment.cs
@@ -12,7 +12,7 @@ namespace Azure.AI.Projects.OpenAI.Tests
 {
     public class ProjectsOpenAITestEnvironment : TestEnvironment
     {
-        public string PROJECT_ENDPOINT => WrappedGetRecordedVariable(nameof(PROJECT_ENDPOINT), isSecret: false);
+        public string PROJECT_ENDPOINT => GetRecordedVariable(nameof(PROJECT_ENDPOINT), options => options.IsSecret("https://sanitized-host.services.ai.azure.com/api/projects/sanitized-project"));
         public string AGENT_NAME => WrappedGetRecordedVariable("AZURE_AI_FOUNDRY_AGENT_NAME", isSecret: false);
         public string MODELDEPLOYMENTNAME => WrappedGetRecordedVariable("MODEL_DEPLOYMENT_NAME", isSecret: false);
         public string EMBEDDINGMODELDEPLOYMENTNAME => WrappedGetRecordedVariable("EMBEDDING_MODEL_DEPLOYMENT_NAME", isSecret: false);

--- a/sdk/ai/Azure.AI.Projects.OpenAI/tests/ResponsesParityTests.cs
+++ b/sdk/ai/Azure.AI.Projects.OpenAI/tests/ResponsesParityTests.cs
@@ -14,6 +14,8 @@ using Azure.AI.Projects.OpenAI;
 using OpenAI.Files;
 using OpenAI.Responses;
 using OpenAI.VectorStores;
+// We need this alias to avoid conflict with internal enum MessageRole.
+using RealOpenAI = OpenAI;
 
 namespace Azure.AI.Projects.OpenAI.Tests;
 
@@ -255,7 +257,7 @@ public class ResponsesParityTests : ProjectsOpenAITestBase
         Assert.That(completedUpdate?.Response?.Id, Is.EqualTo(createdUpdate.Response.Id));
 
         MessageResponseItem messageItem = completedUpdate.Response.OutputItems?.LastOrDefault() as MessageResponseItem;
-        Assert.That(messageItem?.Role, Is.EqualTo(MessageRole.Assistant));
+        Assert.That(messageItem?.Role, Is.EqualTo(RealOpenAI::Responses.MessageRole.Assistant));
 
         StringBuilder deltaBuilder = new();
         foreach (StreamingResponseUpdate streamedUpdate in streamedUpdates)

--- a/sdk/ai/Azure.AI.Projects.OpenAI/tests/Utils/ProjectsTestSanitizers.cs
+++ b/sdk/ai/Azure.AI.Projects.OpenAI/tests/Utils/ProjectsTestSanitizers.cs
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.ClientModel.TestFramework;
+using Microsoft.ClientModel.TestFramework.TestProxy.Admin;
+
+namespace Azure.AI.Projects.OpenAI.Tests.Utils
+{
+    /// <summary>
+    /// Provides sanitization configuration for Azure.AI.Projects test recordings.
+    /// This class centralizes all sanitization patterns and replacement values.
+    /// </summary>
+    public static class ProjectsTestSanitizers
+    {
+        // Replacement values
+        public const string SANITIZED_SUBSCRIPTION = "00000000-0000-0000-0000-000000000000";
+        public const string SANITIZED_HOST = "sanitized-host";
+        public const string SANITIZED_PROJECT = "sanitized-project";
+        public const string SANITIZED_ACCOUNT = "sanitized-account";
+        public const string SANITIZED_STORAGE_ACCOUNT = "sanitized-storage-account";
+        public const string SANITIZED_RESOURCE_GROUP = "sanitized-rg";
+        public const string SANITIZED_CONTAINER = "sanitized-container";
+        public const string SANITIZED_CONNECTION = "sanitizedconnection";
+        public const string SANITIZED_AZURE_OPENAI_ENDPOINT = "sanitized";
+
+        // Common patterns for sanitization
+        public static readonly UriRegexSanitizerBody AZURE_SUBSCRIPTION_PATTERN = BodySanitizer(@"(?<=/subscriptions/)([^/]+)(?=/)", SANITIZED_SUBSCRIPTION);
+        public static readonly UriRegexSanitizerBody AZURE_RESOURCE_GROUP_PATTERN = BodySanitizer(@"(?<=/resourceGroups/)([^/]+)(?=/)", SANITIZED_RESOURCE_GROUP);
+        public static readonly UriRegexSanitizerBody AZURE_ACCOUNT_NAME_PATTERN = BodySanitizer(@"(?<=/accounts/)([^/]+)(?=/|$)", SANITIZED_ACCOUNT);
+        public static readonly UriRegexSanitizerBody AZURE_STORAGE_ACCOUNT_NAME_PATTERN = BodySanitizer(@"(?<=/storageAccounts/)([^/]+)(?=/|$)", SANITIZED_STORAGE_ACCOUNT);
+        public static readonly UriRegexSanitizerBody AZURE_PROJECT_NAME_PATTERN = BodySanitizer(@"(?<=/projects/)([^/]+)(?=[/?]|$)", SANITIZED_PROJECT);
+        public static readonly UriRegexSanitizerBody HOST_SUBDOMAIN_PATTERN = BodySanitizer(@"(?<=https://)([^.]+)(?=\.services\.ai\.azure\.com)", SANITIZED_HOST);
+        public static readonly UriRegexSanitizerBody OPENAI_HOST_PATTERN = BodySanitizer(@"(?<=https://)([^.]+)(?=\.openai\.azure\.com)", SANITIZED_HOST);
+        public static readonly UriRegexSanitizerBody AI_SEARCH_HOST_PATTERN = BodySanitizer(@"(?<=https://)([^.]+)(?=\.search\.windows\.net)", SANITIZED_HOST);
+        public static readonly UriRegexSanitizerBody AZURE_CONTAINER_NAME_PATTERN = BodySanitizer(@"\d+dp[^/\s]*container", SANITIZED_CONTAINER);
+        public static readonly UriRegexSanitizerBody AZURE_CONNECTION_PATTERN = BodySanitizer(@"(?<=/connections/)([^/]+)$", SANITIZED_CONNECTION);
+        public static readonly UriRegexSanitizerBody AZURE_CONNECTION_PATTERN_URI = BodySanitizer(@"(?<=/connections/)([^?]+)(?=[?])", SANITIZED_CONNECTION);
+        public static readonly UriRegexSanitizerBody AZURE_OPENAI_ENDPOINT = BodySanitizer(@"(?<=https://)([^/]+)(?=\.cognitiveservices\.azure.com\/)", SANITIZED_AZURE_OPENAI_ENDPOINT);
+
+        // UUID pattern for various IDs
+        public const string UUID_PATTERN = @"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+        // Base64 image pattern for sanitizing images
+        public const string BASE64_IMAGE_PATTERN = @"(?<=data:image/[^;]+;base64,)(.+)";
+
+        // Small 1x1 PNG image for sanitizing base64 images
+        public const string SMALL_1x1_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFiQAABYkAZsVxhQAAAAMSURBVBhXY2BgYAAAAAQAAVzN/2kAAAAASUVORK5CYII=";
+
+        /// <summary>
+        /// Applies sanitizers to the recording options for Azure.AI.Projects tests.
+        /// This method works with Azure.Core.TestFramework RecordedTestBase.
+        /// </summary>
+        /// <param name="testBase">The RecordedTestBase instance to configure.</param>
+        public static void ApplySanitizers<TEnvironment>(RecordedTestBase<TEnvironment> testBase)
+            where TEnvironment : TestEnvironment, new()
+        {
+            // Remove default sanitizers that are too restrictive
+            testBase.SanitizersToRemove.Add("AZSDK2003"); // Location header (we use a custom one)
+            testBase.SanitizersToRemove.Add("AZSDK4001"); // Replaces entire host name (we want to keep structure)
+            testBase.SanitizersToRemove.Add("AZSDK3430"); // OpenAI liberally uses "id" in responses, keep them
+            testBase.SanitizersToRemove.Add("AZSDK3493"); // OpenAI uses "name" for legitimate purposes
+
+            // URI-based sanitizers for hosts and Azure resource paths
+            testBase.UriRegexSanitizers.Add(new UriRegexSanitizer(HOST_SUBDOMAIN_PATTERN));
+            testBase.UriRegexSanitizers.Add(new UriRegexSanitizer(OPENAI_HOST_PATTERN));
+            testBase.UriRegexSanitizers.Add(new UriRegexSanitizer(AI_SEARCH_HOST_PATTERN));
+            testBase.UriRegexSanitizers.Add(new UriRegexSanitizer(AZURE_SUBSCRIPTION_PATTERN));
+            testBase.UriRegexSanitizers.Add(new UriRegexSanitizer(AZURE_RESOURCE_GROUP_PATTERN));
+            testBase.UriRegexSanitizers.Add(new UriRegexSanitizer(AZURE_ACCOUNT_NAME_PATTERN));
+            testBase.UriRegexSanitizers.Add(new UriRegexSanitizer(AZURE_PROJECT_NAME_PATTERN));
+            testBase.UriRegexSanitizers.Add(new UriRegexSanitizer(AZURE_CONNECTION_PATTERN_URI));
+
+            // Header sanitizers
+            testBase.HeaderRegexSanitizers.Add(new HeaderRegexSanitizer(new("Location")
+            {
+                Regex = AZURE_SUBSCRIPTION_PATTERN.Regex,
+                Value = AZURE_SUBSCRIPTION_PATTERN.Value
+            }));
+            testBase.HeaderRegexSanitizers.Add(new HeaderRegexSanitizer(new("Location")
+            {
+                Regex = AZURE_RESOURCE_GROUP_PATTERN.Regex,
+                Value = AZURE_RESOURCE_GROUP_PATTERN.Value
+            }));
+            testBase.HeaderRegexSanitizers.Add(new HeaderRegexSanitizer(new("Location")
+            {
+                Regex = AZURE_ACCOUNT_NAME_PATTERN.Regex,
+                Value = AZURE_ACCOUNT_NAME_PATTERN.Value
+            }));
+            testBase.HeaderRegexSanitizers.Add(new HeaderRegexSanitizer(new("Location")
+            {
+                Regex = AZURE_PROJECT_NAME_PATTERN.Regex,
+                Value = AZURE_PROJECT_NAME_PATTERN.Value
+            }));
+            testBase.HeaderRegexSanitizers.Add(new HeaderRegexSanitizer(new("Azure-AsyncOperation")
+            {
+                Regex = AZURE_SUBSCRIPTION_PATTERN.Regex,
+                Value = AZURE_SUBSCRIPTION_PATTERN.Value
+            }));
+
+            // JSON body sanitizers for common sensitive fields
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..endpoint")
+            {
+                Regex = HOST_SUBDOMAIN_PATTERN.Regex,
+                Value = HOST_SUBDOMAIN_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..target")
+            {
+                Regex = OPENAI_HOST_PATTERN.Regex,
+                Value = OPENAI_HOST_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..target")
+            {
+                Regex = AI_SEARCH_HOST_PATTERN.Regex,
+                Value = AI_SEARCH_HOST_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..target")
+            {
+                Regex = AZURE_SUBSCRIPTION_PATTERN.Regex,
+                Value = AZURE_SUBSCRIPTION_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..target")
+            {
+                Regex = AZURE_RESOURCE_GROUP_PATTERN.Regex,
+                Value = AZURE_RESOURCE_GROUP_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..target")
+            {
+                Regex = AZURE_ACCOUNT_NAME_PATTERN.Regex,
+                Value = AZURE_ACCOUNT_NAME_PATTERN.Value
+            }));
+
+            // Sanitize subscription IDs in JSON responses
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..id")
+            {
+                Regex = AZURE_SUBSCRIPTION_PATTERN.Regex,
+                Value = AZURE_SUBSCRIPTION_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..id")
+            {
+                Regex = AZURE_RESOURCE_GROUP_PATTERN.Regex,
+                Value = AZURE_RESOURCE_GROUP_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..id")
+            {
+                Regex = AZURE_ACCOUNT_NAME_PATTERN.Regex,
+                Value = AZURE_ACCOUNT_NAME_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..id")
+            {
+                Regex = AZURE_PROJECT_NAME_PATTERN.Regex,
+                Value = AZURE_PROJECT_NAME_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..id")
+            {
+                Regex = AZURE_CONNECTION_PATTERN.Regex,
+                Value = AZURE_CONNECTION_PATTERN.Value
+            }));
+
+            // Sanitize subscription Project Connection Ids in JSON responses
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..project_connection_id")
+            {
+                Regex = AZURE_SUBSCRIPTION_PATTERN.Regex,
+                Value = AZURE_SUBSCRIPTION_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..project_connection_id")
+            {
+                Regex = AZURE_RESOURCE_GROUP_PATTERN.Regex,
+                Value = AZURE_RESOURCE_GROUP_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..project_connection_id")
+            {
+                Regex = AZURE_ACCOUNT_NAME_PATTERN.Regex,
+                Value = AZURE_ACCOUNT_NAME_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..project_connection_id")
+            {
+                Regex = AZURE_PROJECT_NAME_PATTERN.Regex,
+                Value = AZURE_PROJECT_NAME_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..project_connection_id")
+            {
+                Regex = AZURE_CONNECTION_PATTERN.Regex,
+                Value = AZURE_CONNECTION_PATTERN.Value
+            }));
+
+            // Sanitize ResourceId metadata field
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..ResourceId")
+            {
+                Regex = AZURE_SUBSCRIPTION_PATTERN.Regex,
+                Value = AZURE_SUBSCRIPTION_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..ResourceId")
+            {
+                Regex = AZURE_RESOURCE_GROUP_PATTERN.Regex,
+                Value = AZURE_RESOURCE_GROUP_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..ResourceId")
+            {
+                Regex = AZURE_ACCOUNT_NAME_PATTERN.Regex,
+                Value = AZURE_ACCOUNT_NAME_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..ResourceId")
+            {
+                Regex = AZURE_STORAGE_ACCOUNT_NAME_PATTERN.Regex,
+                Value = AZURE_STORAGE_ACCOUNT_NAME_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..AccountName")
+            {
+                Regex = AZURE_ACCOUNT_NAME_PATTERN.Regex,
+                Value = AZURE_ACCOUNT_NAME_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..ContainerName")
+            {
+                Regex = AZURE_CONTAINER_NAME_PATTERN.Regex,
+                Value = AZURE_CONTAINER_NAME_PATTERN.Value
+            }));
+
+            // Sanitize API keys and credentials using JSONPath
+            testBase.JsonPathSanitizers.Add("$..key");
+            testBase.JsonPathSanitizers.Add("$..apiKey");
+            testBase.JsonPathSanitizers.Add("$..api_key");
+            testBase.JsonPathSanitizers.Add("$..connectionString");
+            testBase.JsonPathSanitizers.Add("$..APPLICATIONINSIGHTS_CONNECTION_STRING");
+            testBase.JsonPathSanitizers.Add("$.definition.image");
+
+            // Sanitize base64 encoded images
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..url")
+            {
+                Regex = BASE64_IMAGE_PATTERN,
+                Value = SMALL_1x1_PNG
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..b64_json")
+            {
+                Value = SMALL_1x1_PNG
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..image")
+            {
+                Regex = BASE64_IMAGE_PATTERN,
+                Value = SMALL_1x1_PNG
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..AZURE_OPENAI_ENDPOINT")
+            {
+                Regex = AZURE_OPENAI_ENDPOINT.Regex,
+                Value = AZURE_OPENAI_ENDPOINT.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..AGENT_PROJECT_RESOURCE_ID")
+            {
+                Regex = HOST_SUBDOMAIN_PATTERN.Regex,
+                Value = HOST_SUBDOMAIN_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..AGENT_PROJECT_RESOURCE_ID")
+            {
+                Regex = AZURE_PROJECT_NAME_PATTERN.Regex,
+                Value = AZURE_PROJECT_NAME_PATTERN.Value
+            }));
+
+            // Sanitize Variables section PROJECT_ENDPOINT
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$.Variables.PROJECT_ENDPOINT")
+            {
+                Regex = HOST_SUBDOMAIN_PATTERN.Regex,
+                Value = HOST_SUBDOMAIN_PATTERN.Value
+            }));
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$.Variables.PROJECT_ENDPOINT")
+            {
+                Regex = AZURE_PROJECT_NAME_PATTERN.Regex,
+                Value = AZURE_PROJECT_NAME_PATTERN.Value
+            }));
+
+            // Sanitize the pass_threshold to avoid issues with float representation
+            testBase.BodyKeySanitizers.Add(new BodyKeySanitizer(new("$..initialization_parameters.pass_threshold")
+            {
+                Regex = @"\d+[.]\d+",
+                Value = "[Sanitized]"
+            }));
+
+            // Sanitize UUIDs in request IDs and operation IDs
+            testBase.HeaderRegexSanitizers.Add(new HeaderRegexSanitizer(new("apim-request-id")
+            {
+                Regex = UUID_PATTERN,
+                Value = "00000000-0000-0000-0000-000000000000"
+            }));
+            testBase.HeaderRegexSanitizers.Add(new HeaderRegexSanitizer(new("x-ms-client-request-id")
+            {
+                Regex = UUID_PATTERN,
+                Value = "00000000-0000-0000-0000-000000000000"
+            }));
+            testBase.HeaderRegexSanitizers.Add(new HeaderRegexSanitizer(new("model-api-key")
+            {
+                Regex = @"\w+",
+                Value = "Sanitized"
+            }));
+            testBase.HeaderRegexSanitizers.Add(new HeaderRegexSanitizer(new("model-endpoint")
+            {
+                Regex = @"(?<=https://)([^/]+)(?=[.]openai[.]azure[.]com/|$)",
+                Value = "sanitized"
+            }));
+        }
+
+        private static UriRegexSanitizerBody BodySanitizer(string regex, string value)
+        {
+            UriRegexSanitizerBody rv = new()
+            {
+                Regex = regex,
+                Value = value,
+            };
+            return rv;
+        }
+    }
+}


### PR DESCRIPTION
Make client name as follows

- User provided custom application ID "MyClient" as in code below:
    ```C#
    ProjectOpenAIClientOptions options = new();
    options.UserAgentApplicationId = "MyClient";
    ```
    The `User-Agent` header will be:
    MyClient-AIProjectClient OpenAI/2.8.0 (.NET 9.0.11; Microsoft Windows 10.0.26200)
- User did not provided application ID:
   The `User-Agent` header will be:
   AIProjectClient OpenAI/2.8.0 (.NET 9.0.11; Microsoft Windows 10.0.26200)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
