### PR TITLE
[Storage] [DataMovement] Fixed bug where if SkipIfExists Failed on Existing Destination Directories.

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Blobs.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs.Files.Shares_926acae5b7"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Blobs.Files.Shares_a524128139"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_c847746677"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_907afff960"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.Storage.DataMovement.Files.Shares",
-  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_907afff960"
+  "Tag": "net/storage/Azure.Storage.DataMovement.Files.Shares_8c9fe55fff"
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferDownloadTests.cs
@@ -31,6 +31,9 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         private const string _fileResourcePrefix = "test-file-";
         private const string _dirResourcePrefix = "test-file-";
         private const string _expectedOverwriteExceptionMessage = "Cannot overwrite file.";
+        private readonly DateTimeOffset _defaultFileCreatedOn = new DateTimeOffset(2024, 4, 1, 9, 5, 55, default);
+        private readonly DateTimeOffset _defaultFileLastWrittenOn = new DateTimeOffset(2024, 4, 1, 12, 16, 6, default);
+        private readonly DateTimeOffset _defaultFileChangedOn = new DateTimeOffset(2024, 4, 1, 13, 30, 3, default);
 
         public ShareDirectoryStartTransferDownloadTests(
             bool async,
@@ -68,11 +71,12 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
 
         private async Task CreateDirectoryAsync(ShareClient container,
             string directoryPath,
+            ShareDirectoryCreateOptions options = default,
             CancellationToken cancellationToken = default)
         {
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
             ShareDirectoryClient directory = container.GetRootDirectoryClient().GetSubdirectoryClient(directoryPath);
-            await directory.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+            await directory.CreateIfNotExistsAsync(options: options, cancellationToken: cancellationToken);
         }
 
         private async Task CreateShareFileNfsAndHardLinkAsync(
@@ -191,6 +195,39 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                     }
                 }
             }
+        }
+
+        private async Task CreateDirectoryTreeSmbAsync(
+            ShareClient client,
+            string sourcePrefix,
+            ShareDirectoryCreateOptions options,
+            int size)
+        {
+            string itemName1 = string.Join("/", sourcePrefix, "item1");
+            string itemName2 = string.Join("/", sourcePrefix, "item2");
+            await CreateObjectClientAsync(client, size, itemName1);
+            await CreateObjectClientAsync(client, size, itemName2);
+
+            string subDirPath = string.Join("/", sourcePrefix, "bar");
+            await CreateDirectoryAsync(client, subDirPath, options);
+            string itemName3 = string.Join("/", subDirPath, "item3");
+            await CreateObjectClientAsync(client, size, itemName3);
+
+            string subDirPath2 = string.Join("/", sourcePrefix, "pik");
+            await CreateDirectoryAsync(client, subDirPath2, options);
+            string itemName4 = string.Join("/", subDirPath2, "item4");
+            await CreateObjectClientAsync(client, size, itemName4);
+        }
+
+        protected async Task VerifyFileContentsAsync(
+            ShareFileClient sourceFileClient,
+            string destinationFilePath,
+            CancellationToken cancellationToken)
+        {
+            // Assert file and file contents
+            using Stream sourceStream = await sourceFileClient.OpenReadAsync(cancellationToken: cancellationToken);
+            using Stream destinationStream = File.OpenRead(destinationFilePath);
+            Assert.That(sourceStream, Is.EqualTo(destinationStream));
         }
 
         [RecordedTest]
@@ -330,6 +367,126 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             Assert.Contains("item1-symlink", sourceFileNames);
             Assert.False(destFileNames.Contains("item1-symlink"));
             Assert.AreEqual("item1", destFileNames[0]);
+        }
+
+        [RecordedTest]
+        public async Task ShareDirectoryToLocalDirectory_SkipIfExists_ExistingDirectories()
+        {
+            // Arrange
+            await using IDisposingContainer<ShareClient> source = await GetDisposingContainerAsync();
+            using DisposingLocalDirectory destination = DisposingLocalDirectory.GetTestDirectory();
+
+            int size = DataMovementTestConstants.KB;
+            string sourcePrefix = "sourceFolder";
+            string destPath = destination.DirectoryPath;
+
+            // Source directory metadata and properties
+            ShareDirectoryCreateOptions sourceDirOptions = new ShareDirectoryCreateOptions()
+            {
+                SmbProperties = new FileSmbProperties()
+                {
+                    FileAttributes = NtfsFileAttributes.Directory,
+                    FileCreatedOn = _defaultFileCreatedOn,
+                    FileChangedOn = _defaultFileChangedOn,
+                    FileLastWrittenOn = _defaultFileLastWrittenOn,
+                },
+            };
+
+            // Setup SOURCE: Create directory structure WITH files
+            await CreateDirectoryAsync(source.Container, sourcePrefix, sourceDirOptions);
+            await CreateDirectoryTreeSmbAsync(source.Container, sourcePrefix, sourceDirOptions, size);
+            // This creates:
+            // sourceFolder/
+            // ├── item1 (file)
+            // ├── item2 (file)
+            // ├── bar/
+            // │   └── item3 (file)
+            // └── pik/
+            //     └── item4 (file)
+
+            // Setup DESTINATION: Create EMPTY local directory structure
+            Directory.CreateDirectory(destPath);
+            string destSubDir1 = Path.Combine(destPath, "bar");
+            Directory.CreateDirectory(destSubDir1);
+            string destSubDir2 = Path.Combine(destPath, "pik");
+            Directory.CreateDirectory(destSubDir2);
+            // Destination has the directories but NO files
+
+            // Store original destination directory creation time to verify it wasn't changed
+            DirectoryInfo destBarDirInfo = new DirectoryInfo(destSubDir1);
+            DateTime originalCreationTime = destBarDirInfo.CreationTime;
+            FileAttributes originalAttributes = destBarDirInfo.Attributes;
+
+            // Create storage resource containers
+            ShareDirectoryClient sourceDirectory = source.Container.GetDirectoryClient(sourcePrefix);
+            StorageResourceContainer sourceResource = new ShareDirectoryStorageResourceContainer(
+                sourceDirectory,
+                new ShareFileStorageResourceOptions() { ShareProtocol = ShareProtocol.Smb });
+
+            StorageResourceContainer destinationResource = new LocalDirectoryStorageResourceContainer(destPath);
+
+            TransferOptions options = new TransferOptions()
+            {
+                CreationMode = StorageResourceCreationMode.SkipIfExists
+            };
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+
+            TransferManager transferManager = new TransferManager();
+
+            // Act
+            TransferOperation transfer = await transferManager.StartTransferAsync(sourceResource, destinationResource, options);
+
+            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await TestTransferWithTimeout.WaitForCompletionAsync(
+                transfer,
+                testEventsRaised,
+                cancellationTokenSource.Token);
+
+            // Assert: Transfer should complete successfully
+            testEventsRaised.AssertUnexpectedFailureCheck();
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+
+            // Verify FILES were transferred
+            // Check root level files
+            string destFile1 = Path.Combine(destPath, "item1");
+            Assert.IsTrue(File.Exists(destFile1), "item1 should exist");
+            await VerifyFileContentsAsync(
+                sourceDirectory.GetFileClient("item1"),
+                destFile1,
+                cancellationTokenSource.Token);
+
+            string destFile2 = Path.Combine(destPath, "item2");
+            Assert.IsTrue(File.Exists(destFile2), "item2 should exist");
+            await VerifyFileContentsAsync(
+                sourceDirectory.GetFileClient("item2"),
+                destFile2,
+                cancellationTokenSource.Token);
+
+            // Check files in subdirectories
+            string destFile3 = Path.Combine(destSubDir1, "item3");
+            Assert.IsTrue(File.Exists(destFile3), "bar/item3 should exist");
+            await VerifyFileContentsAsync(
+                sourceDirectory.GetFileClient("bar/item3"),
+                destFile3,
+                cancellationTokenSource.Token);
+
+            string destFile4 = Path.Combine(destSubDir2, "item4");
+            Assert.IsTrue(File.Exists(destFile4), "pik/item4 should exist");
+            await VerifyFileContentsAsync(
+                sourceDirectory.GetFileClient("pik/item4"),
+                destFile4,
+                cancellationTokenSource.Token);
+
+            // Assert: Verify directory properties were NOT changed (directory was skipped)
+            DirectoryInfo currentDirInfo = new DirectoryInfo(destSubDir1);
+
+            // Directory should retain its ORIGINAL properties (creation time shouldn't change significantly)
+            // Allow small time difference due to file system precision
+            TimeSpan timeDifference = (currentDirInfo.CreationTime - originalCreationTime).Duration();
+            Assert.IsTrue(timeDifference < TimeSpan.FromSeconds(1),
+                $"Directory creation time should not change when skipped. Original: {originalCreationTime}, Current: {currentDirInfo.CreationTime}");
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferUploadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferUploadTests.cs
@@ -262,8 +262,8 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
             ShareFileClient destFile4 = destPikDirClient.GetFileClient("item4");
             Assert.IsTrue(await destFile4.ExistsAsync(), "pik/item4 should exist");
             await VerifyFileContentsAsync(
-                itemName1,
-                destFile1,
+                itemName4,
+                destFile4,
                 CancellationToken.None);
 
             // Assert: Verify directory properties were NOT changed (directory was skipped)

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferUploadTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareDirectoryStartTransferUploadTests.cs
@@ -5,13 +5,19 @@ extern alias DMShare;
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
 using Azure.Storage.DataMovement.Tests;
 using BaseShares::Azure.Storage.Files.Shares;
+using BaseShares::Azure.Storage.Files.Shares.Models;
+using Azure.Storage.Test;
 using Azure.Storage.Test.Shared;
 using DMShare::Azure.Storage.DataMovement.Files.Shares;
+using NUnit.Framework;
 
 namespace Azure.Storage.DataMovement.Files.Shares.Tests
 {
@@ -53,6 +59,7 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         // When the file is created, the last modified time is set to the current time.
         // We need to set the last modified time to a fixed value to make the test recordable/predictable.
         private readonly DateTimeOffset? _defaultFileLastWrittenOn = new DateTimeOffset(2024, 11, 24, 11, 23, 45, TimeSpan.FromHours(10));
+        private readonly Dictionary<string,string> _defaultMetadata = DataProvider.BuildMetadata();
 
         public ShareDirectoryStartTransferUploadTests(bool async, ShareClientOptions.ServiceVersion serviceVersion, bool useNonRootDirectory)
             : base(async, null /* RecordedTestMode.Record /* to re-record */)
@@ -108,6 +115,167 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
                 await file.CreateAsync(size, cancellationToken: cancellationToken);
                 await file.UploadAsync(await CreateLimitedMemoryStream(size), cancellationToken: cancellationToken);
             }
+        }
+
+        private async Task CreateDirectoryAsync(
+            ShareDirectoryClient rootDirectory,
+            string directoryPath,
+            ShareDirectoryCreateOptions options = default,
+            CancellationToken cancellationToken = default)
+        {
+            CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+            ShareDirectoryClient directory = rootDirectory.GetSubdirectoryClient(directoryPath);
+            await directory.CreateIfNotExistsAsync(options: options, cancellationToken: cancellationToken);
+        }
+
+        protected async Task VerifyFileContentsAsync(
+            string sourceFilePath,
+            ShareFileClient destinationFileClient,
+            CancellationToken cancellationToken)
+        {
+            // Assert file and file contents
+            using Stream sourceStream = File.OpenRead(sourceFilePath);
+            using Stream destinationStream = await destinationFileClient.OpenReadAsync(cancellationToken: cancellationToken);
+            Assert.That(sourceStream, Is.EqualTo(destinationStream));
+        }
+
+        [RecordedTest]
+        public async Task LocalDirectoryToShareDirectory_SkipIfExists_ExistingDirectories()
+        {
+            // Arrange
+            using DisposingLocalDirectory source = DisposingLocalDirectory.GetTestDirectory();
+            await using IDisposingContainer<ShareDirectoryClient> destination = await GetDisposingContainerAsync();
+
+            int size = DataMovementTestConstants.KB;
+            string sourcePath = source.DirectoryPath;
+            string destPrefix = "destFolder";
+
+            // Setup SOURCE: Create local directory structure WITH files
+            Directory.CreateDirectory(sourcePath);
+            string itemName1 = Path.Combine(sourcePath, "item1");
+            File.WriteAllBytes(itemName1, new byte[size]);
+            string itemName2 = Path.Combine(sourcePath, "item2");
+            File.WriteAllBytes(itemName2, new byte[size]);
+
+            string sourceSubDir1 = Path.Combine(sourcePath, "bar");
+            Directory.CreateDirectory(sourceSubDir1);
+            string itemName3 = Path.Combine(sourceSubDir1, "item3");
+            File.WriteAllBytes(itemName3, new byte[size]);
+
+            string sourceSubDir2 = Path.Combine(sourcePath, "pik");
+            Directory.CreateDirectory(sourceSubDir2);
+            string itemName4 = Path.Combine(sourceSubDir2, "item4");
+            File.WriteAllBytes(itemName4, new byte[size]);
+            // This creates:
+            // source/
+            // ├── item1 (file)
+            // ├── item2 (file)
+            // ├── bar/
+            // │   └── item3 (file)
+            // └── pik/
+            //     └── item4 (file)
+
+            // Destination directory metadata and properties (DIFFERENT from source)
+            ShareDirectoryCreateOptions destDirOptions = new ShareDirectoryCreateOptions()
+            {
+                Metadata = _defaultMetadata,
+                SmbProperties = new FileSmbProperties()
+                {
+                    FileAttributes = NtfsFileAttributes.Directory | NtfsFileAttributes.System,
+                    FileCreatedOn = new DateTimeOffset(2021, 8, 1, 9, 5, 55, default),
+                    FileChangedOn = new DateTimeOffset(2021, 9, 1, 9, 5, 55, default),
+                    FileLastWrittenOn = new DateTimeOffset(2021, 10, 1, 9, 5, 55, default),
+                },
+            };
+
+            // Setup DESTINATION: Create EMPTY directory structure with DIFFERENT properties
+            await CreateDirectoryAsync(destination.Container, destPrefix, destDirOptions);
+            string destSubDir1 = string.Join("/", destPrefix, "bar");
+            await CreateDirectoryAsync(destination.Container, destSubDir1, destDirOptions);
+            string destSubDir2 = string.Join("/", destPrefix, "pik");
+            await CreateDirectoryAsync(destination.Container, destSubDir2, destDirOptions);
+            // Destination has the directories but NO files
+
+            // Store original destination directory properties to verify they weren't changed
+            ShareDirectoryClient destBarDir = destination.Container.GetSubdirectoryClient(destSubDir1);
+            ShareDirectoryProperties originalBarProps = await destBarDir.GetPropertiesAsync();
+
+            // Create storage resource containers
+            StorageResourceContainer sourceResource = new LocalDirectoryStorageResourceContainer(sourcePath);
+
+            ShareDirectoryClient destinationDirectory = destination.Container.GetSubdirectoryClient(destPrefix);
+            StorageResourceContainer destinationResource = new ShareDirectoryStorageResourceContainer(
+                destinationDirectory,
+                new ShareFileStorageResourceOptions());
+
+            TransferOptions options = new TransferOptions()
+            {
+                CreationMode = StorageResourceCreationMode.SkipIfExists
+            };
+            TestEventsRaised testEventsRaised = new TestEventsRaised(options);
+
+            TransferManager transferManager = new TransferManager();
+
+            // Act
+            TransferOperation transfer = await transferManager.StartTransferAsync(sourceResource, destinationResource, options);
+
+            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await TestTransferWithTimeout.WaitForCompletionAsync(
+                transfer,
+                testEventsRaised,
+                cancellationTokenSource.Token);
+
+            // Assert: Transfer should complete successfully
+            testEventsRaised.AssertUnexpectedFailureCheck();
+            Assert.NotNull(transfer);
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.AreEqual(TransferState.Completed, transfer.Status.State);
+
+            // Verify FILES were transferred
+            ShareDirectoryClient destDirectory = destination.Container.GetSubdirectoryClient(destPrefix);
+
+            // Check root level files
+            ShareFileClient destFile1 = destDirectory.GetFileClient("item1");
+            Assert.IsTrue(await destFile1.ExistsAsync(), "item1 should exist");
+            await VerifyFileContentsAsync(
+                itemName1,
+                destFile1,
+                CancellationToken.None);
+
+            ShareFileClient destFile2 = destDirectory.GetFileClient("item2");
+            Assert.IsTrue(await destFile2.ExistsAsync(), "item2 should exist");
+            await VerifyFileContentsAsync(
+                itemName2,
+                destFile2,
+                CancellationToken.None);
+
+            // Check files in subdirectories
+            ShareDirectoryClient destBarDirClient = destDirectory.GetSubdirectoryClient("bar");
+            ShareFileClient destFile3 = destBarDirClient.GetFileClient("item3");
+            Assert.IsTrue(await destFile3.ExistsAsync(), "bar/item3 should exist");
+            await VerifyFileContentsAsync(
+                itemName3,
+                destFile3,
+                CancellationToken.None);
+
+            ShareDirectoryClient destPikDirClient = destDirectory.GetSubdirectoryClient("pik");
+            ShareFileClient destFile4 = destPikDirClient.GetFileClient("item4");
+            Assert.IsTrue(await destFile4.ExistsAsync(), "pik/item4 should exist");
+            await VerifyFileContentsAsync(
+                itemName1,
+                destFile1,
+                CancellationToken.None);
+
+            // Assert: Verify directory properties were NOT changed (directory was skipped)
+            ShareDirectoryProperties currentBarProps = await destBarDir.GetPropertiesAsync();
+
+            // Directory should retain its ORIGINAL properties (not source properties)
+            Assert.That(originalBarProps.Metadata, Is.EqualTo(currentBarProps.Metadata),
+                "Directory metadata should not change when skipped");
+            Assert.AreEqual(originalBarProps.SmbProperties.FileAttributes, currentBarProps.SmbProperties.FileAttributes,
+                "Directory attributes should not change when skipped");
+            Assert.AreEqual(originalBarProps.SmbProperties.FileCreatedOn, currentBarProps.SmbProperties.FileCreatedOn,
+                "Directory FileCreatedOn should not change when skipped");
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bugs Fixed
+- Fixed bug where `StorageResourceCreationMode.SkipIfExists` failed on existing destination directories during container transfers. Existing directories are now skipped without error.
 
 ### Other Changes
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/DataMovementEventSource.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/DataMovementEventSource.cs
@@ -17,6 +17,7 @@ namespace Azure.Storage.DataMovement
         private const int ResumeTransferEvent = 5;
         private const int ResumeEnumerationCompleteEvent = 6;
         private const int UnexpectedTransferFailedEvent = 7;
+        private const int DirectorySkippedEvent = 8;
 
         private DataMovementEventSource() : base(EventSourceName) { }
 
@@ -98,6 +99,12 @@ namespace Azure.Storage.DataMovement
         public void UnexpectedTransferFailed(string transferId, string errorMessage)
         {
             WriteEvent(UnexpectedTransferFailedEvent, transferId, errorMessage);
+        }
+
+        [Event(DirectorySkippedEvent, Level = EventLevel.Informational, Message = "Transfer [{0}] Directory skipped (already exists): {1}")]
+        public void DirectorySkipped(string transferId, string directoryUriPath)
+        {
+            WriteEvent(DirectorySkippedEvent, transferId, directoryUriPath);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Shared/DataMovementConstants.cs
@@ -137,7 +137,8 @@ namespace Azure.Storage.DataMovement
 
         internal static class ErrorCode
         {
-            internal static readonly string[] CannotOverwrite = { "BlobAlreadyExists", "Cannot overwrite file." };
+            internal static readonly string CannotOverwriteDirectory = "Cannot overwrite directory";
+            internal static readonly string[] CannotOverwrite = { "BlobAlreadyExists", "Cannot overwrite file."};
             internal static readonly string[] AccessDenied = { "AuthenticationFailed", "AuthorizationFailure", "access denied" };
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -330,6 +329,12 @@ namespace Azure.Storage.DataMovement
                             await sourceContainer.GetPropertiesAsync(_cancellationToken).ConfigureAwait(false);
                         bool overwrite = _creationPreference == StorageResourceCreationMode.OverwriteIfExists;
                         await subContainer.CreateAsync(overwrite, sourceProperties, _cancellationToken).ConfigureAwait(false);
+                    }
+                    catch when (_creationPreference == StorageResourceCreationMode.SkipIfExists)
+                    {
+                        DataMovementEventSource.Singleton.DirectorySkipped(
+                            _transferOperation.Id,
+                            subContainer.Uri.AbsolutePath);
                     }
                     catch (Exception ex)
                     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferJobInternal.cs
@@ -333,15 +333,8 @@ namespace Azure.Storage.DataMovement
                     }
                     catch (Exception ex) when (
                         _creationPreference == StorageResourceCreationMode.SkipIfExists &&
-                        (
-                            // Share Directory already exists
-                            (ex is InvalidOperationException operationException &&
-                             operationException.Message.Contains(DataMovementConstants.ErrorCode.CannotOverwriteDirectory)) ||
-                            // Local Directory already exists
-                            (ex is IOException ioException &&
-                             (ioException.Message.Contains("already exists") ||
-                              ioException.Message.Contains("Cannot create")))
-                        ))
+                        (ex is InvalidOperationException operationException &&
+                        operationException.Message.Contains(DataMovementConstants.ErrorCode.CannotOverwriteDirectory)))
                     {
                         DataMovementEventSource.Singleton.DirectorySkipped(
                             _transferOperation.Id,


### PR DESCRIPTION
Currently SkipIfExists does not work for Directory transfers. This change would involve catching any exceptions from create, checking if SkipIfExists and if the exception is related to duplicate directory, log the skip.
(This does not apply to individual files, blobs or resource items).



