### PR TITLE
DO NOT MERGE: Add SKU support to Azure.ResourceManager.HealthDataAIServices

### DIFF
--- a/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices/tsp-location.yaml
+++ b/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices/tsp-location.yaml
@@ -1,4 +1,6 @@
 directory: specification/healthdataaiservices/HealthDataAIServices.Management
 commit: 18651ab2460e0874397f3597b91dcc00cb4ca7bc
 repo: Azure/azure-rest-api-specs
-emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"
+additionalDirectories: 
+
+emitterPackageJsonPath: eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json


### PR DESCRIPTION
DEMO PR - DO NOT MERGE

Adds SKU support (Free, Basic, Standard tiers) to the HealthDataAIServices SDK.

### Changes
- Added DeidServiceSku model
- Added HealthDataAIServicesSkuName enum
- Updated DeidService and DeidUpdate to include SKU property