### PR TITLE
Update APIs for Azure.Identity use cases

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -389,6 +389,8 @@ namespace Azure.Core
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }
         public Azure.Core.RetryOptions Retry { get { throw null; } }
@@ -435,6 +437,7 @@ namespace Azure.Core
     public partial class DiagnosticsOptions
     {
         protected internal DiagnosticsOptions() { }
+        protected internal DiagnosticsOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         public string? ApplicationId { get { throw null; } set { } }
         public static string? DefaultApplicationId { get { throw null; } set { } }
         public bool IsDistributedTracingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -388,8 +388,6 @@ namespace Azure.Core
         protected ClientOptions() { }
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
-        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -378,7 +378,6 @@ namespace Azure.Core
     {
         protected ClientOptions() { }
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
-        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -379,6 +379,7 @@ namespace Azure.Core
         protected ClientOptions() { }
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
+        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }
         public Azure.Core.RetryOptions Retry { get { throw null; } }
@@ -425,6 +426,7 @@ namespace Azure.Core
     public partial class DiagnosticsOptions
     {
         protected internal DiagnosticsOptions() { }
+        protected internal DiagnosticsOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         public string? ApplicationId { get { throw null; } set { } }
         public static string? DefaultApplicationId { get { throw null; } set { } }
         public bool IsDistributedTracingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -378,7 +378,6 @@ namespace Azure.Core
     {
         protected ClientOptions() { }
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
-        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -379,6 +379,7 @@ namespace Azure.Core
         protected ClientOptions() { }
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
+        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }
         public Azure.Core.RetryOptions Retry { get { throw null; } }
@@ -425,6 +426,7 @@ namespace Azure.Core
     public partial class DiagnosticsOptions
     {
         protected internal DiagnosticsOptions() { }
+        protected internal DiagnosticsOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         public string? ApplicationId { get { throw null; } set { } }
         public static string? DefaultApplicationId { get { throw null; } set { } }
         public bool IsDistributedTracingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -389,6 +389,8 @@ namespace Azure.Core
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }
         public Azure.Core.RetryOptions Retry { get { throw null; } }
@@ -435,6 +437,7 @@ namespace Azure.Core
     public partial class DiagnosticsOptions
     {
         protected internal DiagnosticsOptions() { }
+        protected internal DiagnosticsOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         public string? ApplicationId { get { throw null; } set { } }
         public static string? DefaultApplicationId { get { throw null; } set { } }
         public bool IsDistributedTracingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -388,8 +388,6 @@ namespace Azure.Core
         protected ClientOptions() { }
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
-        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -378,7 +378,6 @@ namespace Azure.Core
     {
         protected ClientOptions() { }
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
-        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -379,6 +379,7 @@ namespace Azure.Core
         protected ClientOptions() { }
         protected ClientOptions(Azure.Core.DiagnosticsOptions? diagnostics) { }
         protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
+        protected ClientOptions(Microsoft.Extensions.Configuration.IConfigurationSection section, Azure.Core.DiagnosticsOptions? diagnostics) { }
         public static Azure.Core.ClientOptions Default { get { throw null; } }
         public Azure.Core.DiagnosticsOptions Diagnostics { get { throw null; } }
         public Azure.Core.RetryOptions Retry { get { throw null; } }
@@ -425,6 +426,7 @@ namespace Azure.Core
     public partial class DiagnosticsOptions
     {
         protected internal DiagnosticsOptions() { }
+        protected internal DiagnosticsOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         public string? ApplicationId { get { throw null; } set { } }
         public static string? DefaultApplicationId { get { throw null; } set { } }
         public bool IsDistributedTracingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/src/ApiCompatBaseline.txt
+++ b/sdk/core/Azure.Core/src/ApiCompatBaseline.txt
@@ -1,0 +1,3 @@
+# This constructor was marked as Experimental and was consolidated into the two-parameter overload.
+# It is safe to remove as it was under experimental feature flag SCME0002.
+MembersMustExist : Member 'protected void Azure.Core.ClientOptions..ctor(Microsoft.Extensions.Configuration.IConfigurationSection)' does not exist in the implementation but it does exist in the contract.

--- a/sdk/core/Azure.Core/src/ClientOptions.cs
+++ b/sdk/core/Azure.Core/src/ClientOptions.cs
@@ -74,16 +74,6 @@ namespace Azure.Core
         /// Creates a new instance of <see cref="ClientOptions"/> with the specified <see cref="IConfigurationSection"/>.
         /// </summary>
         /// <param name="section">The <see cref="IConfigurationSection"/> to read from.</param>
-        [Experimental("SCME0002")]
-        protected ClientOptions(IConfigurationSection section)
-            :this(section, null)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new instance of <see cref="ClientOptions"/> with the specified <see cref="IConfigurationSection"/>.
-        /// </summary>
-        /// <param name="section">The <see cref="IConfigurationSection"/> to read from.</param>
         /// <param name="diagnostics"><see cref="DiagnosticsOptions"/> to be used for <see cref="Diagnostics"/>.</param>
         [Experimental("SCME0002")]
         protected ClientOptions(IConfigurationSection section, DiagnosticsOptions? diagnostics)

--- a/sdk/core/Azure.Core/src/ClientOptions.cs
+++ b/sdk/core/Azure.Core/src/ClientOptions.cs
@@ -76,16 +76,27 @@ namespace Azure.Core
         /// <param name="section">The <see cref="IConfigurationSection"/> to read from.</param>
         [Experimental("SCME0002")]
         protected ClientOptions(IConfigurationSection section)
+            :this(section, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ClientOptions"/> with the specified <see cref="IConfigurationSection"/>.
+        /// </summary>
+        /// <param name="section">The <see cref="IConfigurationSection"/> to read from.</param>
+        /// <param name="diagnostics"><see cref="DiagnosticsOptions"/> to be used for <see cref="Diagnostics"/>.</param>
+        [Experimental("SCME0002")]
+        protected ClientOptions(IConfigurationSection section, DiagnosticsOptions? diagnostics)
         {
             _transport = HttpPipelineTransport.Create();
             if (section is null || !section.Exists())
             {
-                Diagnostics = new DiagnosticsOptions((DiagnosticsOptions?)null);
+                Diagnostics = diagnostics ?? new DiagnosticsOptions((DiagnosticsOptions?)null);
                 Retry = new RetryOptions((RetryOptions?)null);
             }
             else
             {
-                Diagnostics = new DiagnosticsOptions(section.GetSection("Diagnostics"));
+                Diagnostics = diagnostics ?? new DiagnosticsOptions(section.GetSection("Diagnostics"));
                 Retry = new RetryOptions(section.GetSection("Retry"));
             }
         }

--- a/sdk/core/Azure.Core/src/DefaultClientOptions.cs
+++ b/sdk/core/Azure.Core/src/DefaultClientOptions.cs
@@ -8,7 +8,8 @@ namespace Azure.Core
 {
     internal class DefaultClientOptions: ClientOptions
     {
-        public DefaultClientOptions(): base(null, null)
+        public DefaultClientOptions()
+            : base((ClientOptions?)null, null)
         {
             Diagnostics.IsTelemetryEnabled = !EnvironmentVariableToBool(Environment.GetEnvironmentVariable("AZURE_TELEMETRY_DISABLED")) ?? true;
             Diagnostics.IsDistributedTracingEnabled = !EnvironmentVariableToBool(Environment.GetEnvironmentVariable("AZURE_TRACING_DISABLED")) ?? true;

--- a/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
+++ b/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
@@ -25,7 +25,10 @@ namespace Azure.Core
         protected internal DiagnosticsOptions() : this(ClientOptions.Default.Diagnostics)
         { }
 
-        internal DiagnosticsOptions(IConfigurationSection section)
+        /// <summary>
+        /// Creates a new instance of <see cref="DiagnosticsOptions"/> with default values.
+        /// </summary>
+        protected internal DiagnosticsOptions(IConfigurationSection section)
         {
             if (section is null || !section.Exists())
             {


### PR DESCRIPTION
Update APIs for Azure.Identity use cases

Follow up to https://github.com/Azure/azure-sdk-for-net/pull/55287.

There are a few missing public APIs needed by Azure.Identity.