### PR TITLE
Fix AOT compatibility check to skip tools directory

### DIFF
--- a/eng/scripts/compatibility/Check-AOT-Compatibility.ps1
+++ b/eng/scripts/compatibility/Check-AOT-Compatibility.ps1
@@ -24,6 +24,12 @@ if ($PSCmdlet.ParameterSetName -eq 'ByNameAndDirectory') {
 
 Write-Host "Path: $PackagePath"
 
+# Skip AOT compatibility check for tools service directory (analyzers, etc.)
+if ($PackagePath -like "sdk/tools/*" -or $PackagePath -like "sdk\tools\*") {
+    Write-Host "Skipping AOT compatibility check for tools service directory."
+    exit 0
+}
+
 $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot .. .. ..)
 $ProjectPath = Join-Path $RepoRoot $PackagePath
 $PackageNameFromPath = [System.IO.Path]::GetFileNameWithoutExtension($PackagePath)

--- a/eng/scripts/compatibility/Check-AOT-Compatibility.ps1
+++ b/eng/scripts/compatibility/Check-AOT-Compatibility.ps1
@@ -24,8 +24,10 @@ if ($PSCmdlet.ParameterSetName -eq 'ByNameAndDirectory') {
 
 Write-Host "Path: $PackagePath"
 
+$normalizedPackagePath = $PackagePath.Replace('\', '/')
+
 # Skip AOT compatibility check for tools service directory (analyzers, etc.)
-if ($PackagePath -like "sdk/tools/*" -or $PackagePath -like "sdk\tools\*") {
+if ($normalizedPackagePath -like "sdk/tools/*") {
     Write-Host "Skipping AOT compatibility check for tools service directory."
     exit 0
 }

--- a/sdk/tools/Azure.SdkAnalyzers/ci.yml
+++ b/sdk/tools/Azure.SdkAnalyzers/ci.yml
@@ -29,4 +29,3 @@ extends:
     Artifacts:
     - name: Azure.SdkAnalyzers
       safeName: AzureSdkAnalyzers
-    CheckAOTCompat: false


### PR DESCRIPTION
## Description

This PR fixes issue #55419 by updating the AOT compatibility check script to properly skip packages in the tools service directory.

**Problem:**
- PR #55420 attempted to fix this by adding `CheckAOTCompat: false` to ci.yml
- This parameter is not recognized by the pipeline template, causing failures
- Analyzers and other build-time tools in sdk/tools don't need AOT runtime compatibility checks

**Solution:**
- Updated `Check-AOT-Compatibility.ps1` to detect and skip any package path starting with `sdk/tools/` or `sdk\tools\`
- The check now works for both parameter sets (ByPath and ByNameAndDirectory)
- Handles both forward slash and backslash path separators
- Reverted the invalid `CheckAOTCompat: false` parameter from Azure.SdkAnalyzers ci.yml

**Testing:**
- Verified script skips tools directory with ByNameAndDirectory parameter set
- Verified script skips tools directory with ByPath parameter set (forward slashes)
- Verified script skips tools directory with ByPath parameter set (backslashes)

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message.

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

Fixes #55419