### PR TITLE
Export Azure.SdkAnalyzers types in lib folder for direct referencing

### DIFF
--- a/sdk/tools/Azure.SdkAnalyzers/src/Azure.SdkAnalyzers.csproj
+++ b/sdk/tools/Azure.SdkAnalyzers/src/Azure.SdkAnalyzers.csproj
@@ -11,8 +11,9 @@
     <!-- Prevent Azure.ClientSdk.Analyzers from running on this analyzer project -->
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
     <IsPackable>true</IsPackable>
-    <!-- Analyzer packaging properties -->
-    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- Include build output in lib/ folder so types can be referenced directly -->
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <!-- Mark as development dependency for analyzer usage -->
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

Enable \IncludeBuildOutput\ so the package includes the DLL in both:
- \nalyzers/dotnet/cs/\ (for compile-time analysis)
- \lib/netstandard2.0/\ (for direct type references)

This allows tools like APIView to instantiate analyzers (e.g., \TypeNameAnalyzer\) directly, similar to how it uses analyzers from \Azure.ClientSdk.Analyzers\.

## Related Issues

Fixes #55462

## Use Case

APIView (https://github.com/Azure/azure-sdk-tools/tree/main/src/dotnet/APIView) needs to instantiate analyzers from this package directly to perform analysis on SDK assemblies. With the current package structure (DLL only in \nalyzers/\ folder), the types cannot be referenced directly.

## Changes

- Changed \<IncludeBuildOutput>false</IncludeBuildOutput>\ to \<IncludeBuildOutput>true</IncludeBuildOutput>\ in \Azure.SdkAnalyzers.csproj\

All existing tests pass.