### PR TITLE
Fix NRE in ListPartitionIdsAsync when called before StartProcessingAsync

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -1360,17 +1360,35 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <returns>The set of identifiers for the Event Hub partitions.</returns>
         ///
-        protected virtual async Task<string[]> ListPartitionIdsAsync(EventHubConnection connection,
+        protected virtual Task<string[]> ListPartitionIdsAsync(EventHubConnection connection,
                                                                      CancellationToken cancellationToken)
         {
-            // If EventHubProperties hasn't been initialized (processor not yet started),
-            // fall back to querying the service directly to preserve pre-5.12.0 behavior.
+            // If EventHubProperties has been initialized, return the cached partition IDs
+            // synchronously to avoid async state machine allocation on the common path.
 
             if (EventHubProperties != null)
             {
-                return EventHubProperties.PartitionIds;
+                return Task.FromResult(EventHubProperties.PartitionIds);
             }
 
+            // If EventHubProperties hasn't been initialized (processor not yet started),
+            // fall back to querying the service directly to preserve pre-5.12.0 behavior.
+
+            return ListPartitionIdsFromServiceAsync(connection, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Queries the Event Hub service for the set of partition identifiers.
+        /// </summary>
+        ///
+        /// <param name="connection">The connection to the Event Hubs namespace to be used for service communication.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>The set of identifiers for the Event Hub partitions.</returns>
+        ///
+        private async Task<string[]> ListPartitionIdsFromServiceAsync(EventHubConnection connection,
+                                                                      CancellationToken cancellationToken)
+        {
             var properties = await connection.GetPropertiesAsync(RetryPolicy, cancellationToken).ConfigureAwait(false);
             return properties.PartitionIds;
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -1360,37 +1360,18 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <returns>The set of identifiers for the Event Hub partitions.</returns>
         ///
-        protected virtual Task<string[]> ListPartitionIdsAsync(EventHubConnection connection,
-                                                                     CancellationToken cancellationToken)
+        protected virtual async Task<string[]> ListPartitionIdsAsync(EventHubConnection connection,
+                                                                           CancellationToken cancellationToken)
         {
-            // If EventHubProperties has been initialized, return the cached partition IDs
-            // synchronously to avoid async state machine allocation on the common path.
-
             if (EventHubProperties != null)
             {
-                return Task.FromResult(EventHubProperties.PartitionIds);
+                return EventHubProperties.PartitionIds;
             }
 
             // If EventHubProperties hasn't been initialized (processor not yet started),
             // fall back to querying the service directly to preserve pre-5.12.0 behavior.
 
-            return ListPartitionIdsFromServiceAsync(connection, cancellationToken);
-        }
-
-        /// <summary>
-        ///   Queries the Event Hub service for the set of partition identifiers.
-        /// </summary>
-        ///
-        /// <param name="connection">The connection to the Event Hubs namespace to be used for service communication.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
-        ///
-        /// <returns>The set of identifiers for the Event Hub partitions.</returns>
-        ///
-        private async Task<string[]> ListPartitionIdsFromServiceAsync(EventHubConnection connection,
-                                                                      CancellationToken cancellationToken)
-        {
-            var properties = await connection.GetPropertiesAsync(RetryPolicy, cancellationToken).ConfigureAwait(false);
-            return properties.PartitionIds;
+            return await connection.GetPartitionIdsAsync(RetryPolicy, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Primitives/EventProcessor.cs
@@ -1360,10 +1360,19 @@ namespace Azure.Messaging.EventHubs.Primitives
         ///
         /// <returns>The set of identifiers for the Event Hub partitions.</returns>
         ///
-        protected virtual Task<string[]> ListPartitionIdsAsync(EventHubConnection connection,
+        protected virtual async Task<string[]> ListPartitionIdsAsync(EventHubConnection connection,
                                                                      CancellationToken cancellationToken)
         {
-            return Task.FromResult(EventHubProperties.PartitionIds);
+            // If EventHubProperties hasn't been initialized (processor not yet started),
+            // fall back to querying the service directly to preserve pre-5.12.0 behavior.
+
+            if (EventHubProperties != null)
+            {
+                return EventHubProperties.PartitionIds;
+            }
+
+            var properties = await connection.GetPropertiesAsync(RetryPolicy, cancellationToken).ConfigureAwait(false);
+            return properties.PartitionIds;
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
@@ -304,8 +304,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(25, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
 
             mockConnection
-                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EventHubProperties("eventHub", DateTime.UtcNow, expectedPartitionIds, false));
+                .Setup(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedPartitionIds);
 
             mockProcessor
                 .Setup(processor => processor.CreateConnection())
@@ -319,7 +319,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(partitionIds, Is.EqualTo(expectedPartitionIds), "The partition IDs should match those returned by the service.");
 
             mockConnection
-                .Verify(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()), Times.Once, "The service should have been queried for partition IDs.");
+                .Verify(conn => conn.GetPartitionIdsAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()), Times.Once, "The service should have been queried for partition IDs.");
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.Infrastructure.cs
@@ -280,5 +280,46 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(loadBalancer.LoadBalanceInterval, Is.EqualTo(options.LoadBalancingUpdateInterval), "The load balancing interval was incorrect.");
             Assert.That(loadBalancer.OwnershipExpirationInterval, Is.EqualTo(options.PartitionOwnershipExpirationInterval), "The ownership expiration interval is incorrect.");
         }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventProcessor{TPartition}.ListPartitionIdsAsync" />
+        ///   method when called before the processor has been started.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   This test covers the regression scenario from issue #51777 where calling
+        ///   <see cref="EventProcessor{TPartition}.ListPartitionIdsAsync" /> before
+        ///   <see cref="EventProcessor{TPartition}.StartProcessingAsync" /> would throw
+        ///   a <see cref="NullReferenceException" /> due to <c>EventHubProperties</c> being null.
+        /// </remarks>
+        ///
+        [Test]
+        public async Task ListPartitionIdsAsyncQueriesServiceWhenEventHubPropertiesIsNull()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var expectedPartitionIds = new[] { "0", "1", "2" };
+            var mockConnection = new Mock<EventHubConnection>();
+            var mockProcessor = new Mock<EventProcessor<EventProcessorPartition>>(25, "consumerGroup", "namespace", "eventHub", Mock.Of<TokenCredential>(), default(EventProcessorOptions)) { CallBase = true };
+
+            mockConnection
+                .Setup(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EventHubProperties("eventHub", DateTime.UtcNow, expectedPartitionIds, false));
+
+            mockProcessor
+                .Setup(processor => processor.CreateConnection())
+                .Returns(mockConnection.Object);
+
+            // Call ListPartitionIdsAsync before StartProcessingAsync, which means EventHubProperties is null.
+            // This should not throw and should fall back to querying the service.
+
+            var partitionIds = await InvokeListPartitionIdsAsync(mockProcessor.Object, mockConnection.Object, cancellationSource.Token);
+
+            Assert.That(partitionIds, Is.EqualTo(expectedPartitionIds), "The partition IDs should match those returned by the service.");
+
+            mockConnection
+                .Verify(conn => conn.GetPropertiesAsync(It.IsAny<EventHubsRetryPolicy>(), It.IsAny<CancellationToken>()), Times.Once, "The service should have been queried for partition IDs.");
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Primitives/EventProcessorTests.cs
@@ -159,6 +159,27 @@ namespace Azure.Messaging.EventHubs.Tests
                     .Invoke(processor, new object[] { partitionId, reason, cancellationToken });
 
         /// <summary>
+        ///   Invokes the processor infrastructure method responsible for listing partition ids,
+        ///   using its private accessor.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The partition type to which the processor is bound.</typeparam>
+        ///
+        /// <param name="processor">The processor instance to operate on.</param>
+        /// <param name="connection">The connection to the Event Hubs namespace to be used for service communication.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>The set of identifiers for the Event Hub partitions.</returns>
+        ///
+        private static Task<string[]> InvokeListPartitionIdsAsync<T>(EventProcessor<T> processor,
+                                                                     EventHubConnection connection,
+                                                                     CancellationToken cancellationToken) where T : EventProcessorPartition, new() =>
+            (Task<string[]>)
+                typeof(EventProcessor<T>)
+                    .GetMethod("ListPartitionIdsAsync", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .Invoke(processor, new object[] { connection, cancellationToken });
+
+        /// <summary>
         ///   A basic custom partition type, allowing for testing or processor functionality.
         /// </summary>
         ///


### PR DESCRIPTION
## Description

Fixes #51777

Starting in version 5.12.0, calling `ListPartitionIdsAsync` before `StartProcessingAsync` throws `NullReferenceException` because `EventHubProperties` is only initialized inside `StartProcessingAsync`.

## Changes

This change adds a null check with fallback to query the service directly when `EventHubProperties` is null, preserving the pre-5.12.0 behavior while maintaining efficiency when the processor is running.

### Before (broken)
\\\csharp
protected virtual Task<string[]> ListPartitionIdsAsync(...)
{
    return Task.FromResult(EventHubProperties.PartitionIds); // NRE if not started
}
\\\

### After (fixed)
\\\csharp
protected virtual async Task<string[]> ListPartitionIdsAsync(...)
{
    if (EventHubProperties != null)
    {
        return EventHubProperties.PartitionIds;
    }
    
    var properties = await connection.GetPropertiesAsync(RetryPolicy, cancellationToken).ConfigureAwait(false);
    return properties.PartitionIds;
}
\\\

## Testing

- [ ] Unit tests for calling `ListPartitionIdsAsync` before `StartProcessingAsync`
- [ ] Verify existing tests still pass
