### PR TITLE
Add experimental documentation for Azure.Core SCME0002 APIs

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Update the APIs for Microsoft.Extensions.Configuration and Microsoft.Extensions.DependencyInjection to enable Azure.Identity use cases.
+- Updated BCL dependencies to 10.x.
 
 ## 1.51.0 (2026-01-29)
 

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added two new APIs two enable Azure.Identity support for Microsoft.Extensions.Configuration and Microsoft.Extensions.DependencyInjection.
+- Update the APIs for Microsoft.Extensions.Configuration and Microsoft.Extensions.DependencyInjection to enable Azure.Identity use cases.
 
 ## 1.51.0 (2026-01-29)
 

--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.52.0-beta.1 (Unreleased)
+## 1.51.1 (2026-02-04)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added two new APIs two enable Azure.Identity support for Microsoft.Extensions.Configuration and Microsoft.Extensions.DependencyInjection.
 
 ## 1.51.0 (2026-01-29)
 

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -435,6 +435,7 @@ namespace Azure.Core
     public partial class DiagnosticsOptions
     {
         protected internal DiagnosticsOptions() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
         protected internal DiagnosticsOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         public string? ApplicationId { get { throw null; } set { } }
         public static string? DefaultApplicationId { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -435,6 +435,7 @@ namespace Azure.Core
     public partial class DiagnosticsOptions
     {
         protected internal DiagnosticsOptions() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
         protected internal DiagnosticsOptions(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
         public string? ApplicationId { get { throw null; } set { } }
         public static string? DefaultApplicationId { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.52.0-beta.1</Version>
+    <Version>1.51.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.51.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>

--- a/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
+++ b/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
@@ -28,6 +28,7 @@ namespace Azure.Core
         /// <summary>
         /// Creates a new instance of <see cref="DiagnosticsOptions"/> with default values.
         /// </summary>
+        [Experimental("SCME0002")]
         protected internal DiagnosticsOptions(IConfigurationSection section)
         {
             if (section is null || !section.Exists())

--- a/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
+++ b/sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md
@@ -1,0 +1,34 @@
+# Experimental Feature Diagnostics
+
+This document lists the experimental feature diagnostic IDs used in Azure.Core to mark APIs that are under development and subject to change.
+
+## SCME0002 - Microsoft.Extensions.Configuration Integration Experimental API
+
+### Description
+
+The Microsoft.Extensions.Configuration integration APIs are experimental features for configuring Azure SDK clients using .NET configuration patterns. These APIs are subject to change or removal in future updates as we gather feedback and refine the implementation.
+
+### Affected APIs
+
+- `Azure.Core.ClientOptions` constructor that accepts `IConfigurationSection`
+- `Azure.Core.DiagnosticsOptions` constructor that accepts `IConfigurationSection`
+
+### Example Usage
+
+See [ConfigurationAndDependencyInjection.md](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/System.ClientModel/src/docs/ConfigurationAndDependencyInjection.md) for detailed examples.
+
+### Suppression
+
+If you want to use these experimental APIs and accept the risk that they may change, you can suppress the warning:
+
+```csharp
+#pragma warning disable SCME0002 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+```
+
+Or in your project file:
+
+```xml
+<PropertyGroup>
+  <NoWarn>$(NoWarn);SCME0002</NoWarn>
+</PropertyGroup>
+```


### PR DESCRIPTION
This PR adds documentation for the experimental SCME0002 APIs in Azure.Core.

## Changes
- Added Experimental SCME0002 attribute to DiagnosticsOptions constructor that accepts IConfigurationSection
- Created sdk/core/Azure.Core/src/docs/ExperimentalFeatures.md documenting the experimental APIs
- Regenerated API files to reflect the new attribute