### PR TITLE
[EngSys] Fix NuGet restore loop in Visual Studio

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -367,7 +367,12 @@
     <PackageReference Update="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.19552.1" PrivateAssets="All" />
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Update="SauceControl.InheritDoc" Version="2.0.2" PrivateAssets="All" />
+    <!--
+      Note: SauceControl.InheritDoc 2.0.x causes NuGet restore loops in Visual Studio with multi-targeting projects.
+      See https://github.com/saucecontrol/InheritDoc/releases for v2.0 release notes about incremental build fixes.
+      Do not upgrade until this issue is resolved upstream.
+    -->
+    <PackageReference Update="SauceControl.InheritDoc" Version="1.2.0" PrivateAssets="All" />
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.333" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

This PR fixes the NuGet restore loop issue that occurs in Visual Studio when opening multi-targeting projects in this repository.

<img width="1028" height="125" alt="image" src="https://github.com/user-attachments/assets/66f8d83c-bb06-46c2-a8a0-f2553b57f9b5" />


## Root Cause

\SauceControl.InheritDoc\ version 2.0.2 (upgraded in #54805) causes NuGet restore loops in Visual Studio with multi-targeting projects. Version 2.0.x has issues with incremental builds that cause VS to detect package differences between restore and build evaluations, triggering an endless restore loop.

## Fix

Revert \SauceControl.InheritDoc\ from 2.0.2 back to 1.2.0.

## References

- Original PR that introduced this issue: #54805
- SauceControl.InheritDoc v2.0 release notes: https://github.com/saucecontrol/InheritDoc/releases

## Testing

Verified that opening Azure.Security.KeyVault.sln in Visual Studio 2026 no longer shows the 'NuGet restore loop detected' error banner.