### PR TITLE
Add ConfidentialLedgerRedirectPolicy to follow 307/308 redirects while preserving Authorization header

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -4,13 +4,7 @@
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
 - Added `ConfidentialLedgerRedirectPolicy` to automatically follow HTTP 307/308 redirects while preserving the Authorization header. Previously, the SDK did not follow redirects by default, and even when redirects were enabled, the Authorization header was stripped on cross-domain redirects between ACL nodes, causing write operations to fail when routed to non-primary nodes.
-
-### Other Changes
 
 ## 1.4.1-beta.2 (2025-04-23)
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.1-beta.3 (Unreleased)
+## 1.4.1-beta.3 (2026-02-09)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Added `ConfidentialLedgerRedirectPolicy` to automatically follow HTTP 307/308 redirects while preserving the Authorization header. Previously, the SDK did not follow redirects by default, and even when redirects were enabled, the Authorization header was stripped on cross-domain redirects between ACL nodes, causing write operations to fail when routed to non-primary nodes.
+
 ### Other Changes
 
 ## 1.4.1-beta.2 (2025-04-23)

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.1-beta.3 (2026-02-09)
+## 1.4.1-beta.4 (2026-02-09)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Client SDK for the Azure Confidential Ledger service</Description>
     <AssemblyTitle>Azure Confidential Ledger</AssemblyTitle>
-    <Version>1.4.1-beta.3</Version>
+    <Version>1.4.1-beta.4</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageTags>Azure ConfidentialLedger</PackageTags>

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerClient.cs
@@ -73,7 +73,7 @@ namespace Azure.Security.ConfidentialLedger
             _tokenCredential = credential;
             _pipeline = HttpPipelineBuilder.Build(
                 actualOptions,
-                Array.Empty<HttpPipelinePolicy>(),
+                new HttpPipelinePolicy[] { new ConfidentialLedgerRedirectPolicy() },
                 _tokenCredential == null ?
                     Array.Empty<HttpPipelinePolicy>() :
                     new HttpPipelinePolicy[] { new BearerTokenAuthenticationPolicy(_tokenCredential, AuthorizationScopes) },

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/ConfidentialLedgerRedirectPolicy.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Security.ConfidentialLedger
+{
+    /// <summary>
+    /// An <see cref="HttpPipelinePolicy"/> that follows HTTP 307 and 308 redirect responses
+    /// while preserving the Authorization header.
+    /// </summary>
+    /// <remarks>
+    /// Azure Confidential Ledger nodes may return 307 (Temporary Redirect) or 308 (Permanent Redirect)
+    /// responses to route write operations to the primary node. The standard redirect behavior in .NET
+    /// strips the Authorization header on cross-domain redirects for security reasons. However, ACL
+    /// redirects occur between trusted nodes within the same ledger, so the Authorization header must
+    /// be preserved for the redirected request to succeed.
+    /// </remarks>
+    internal sealed class ConfidentialLedgerRedirectPolicy : HttpPipelinePolicy
+    {
+        private const int MaxRedirects = 5;
+
+        /// <inheritdoc/>
+        public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            ProcessAsync(message, pipeline, false).EnsureCompleted();
+        }
+
+        /// <inheritdoc/>
+        public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            return ProcessAsync(message, pipeline, true);
+        }
+
+        private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
+        {
+            if (async)
+            {
+                await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+            }
+            else
+            {
+                ProcessNext(message, pipeline);
+            }
+
+            int redirectCount = 0;
+
+            while (IsRedirectResponse(message.Response.Status))
+            {
+                if (++redirectCount > MaxRedirects)
+                {
+                    // Too many redirects; return the last redirect response as-is.
+                    break;
+                }
+
+                if (!message.Response.Headers.TryGetValue("Location", out string location))
+                {
+                    // No Location header; return the redirect response as-is.
+                    break;
+                }
+
+                Uri redirectUri = BuildRedirectUri(message.Request.Uri.ToUri(), location);
+
+                // Disallow redirect from HTTPS to HTTP.
+                if (string.Equals(message.Request.Uri.Scheme, "https", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(redirectUri.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+                {
+                    break;
+                }
+
+                // Update the request URI to the redirect target.
+                // The Authorization header is intentionally preserved because ACL redirects
+                // are between trusted nodes within the same ledger.
+                message.Request.Uri.Reset(redirectUri);
+
+                // Dispose of the redirect response before re-sending.
+                message.Response.Dispose();
+
+                if (async)
+                {
+                    await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+                }
+                else
+                {
+                    ProcessNext(message, pipeline);
+                }
+            }
+        }
+
+        private static bool IsRedirectResponse(int statusCode)
+        {
+            return statusCode == 307 || statusCode == 308;
+        }
+
+        private static Uri BuildRedirectUri(Uri requestUri, string location)
+        {
+            Uri redirectUri = new Uri(location, UriKind.RelativeOrAbsolute);
+
+            if (!redirectUri.IsAbsoluteUri)
+            {
+                redirectUri = new Uri(requestUri, redirectUri);
+            }
+
+            return redirectUri;
+        }
+    }
+}

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerClientLiveTests.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerClientLiveTests.cs
@@ -7,11 +7,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Linq;
-using System.Text;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -96,7 +96,7 @@ namespace Azure.Security.ConfidentialLedger.Tests
         }
 #endif
 
-            [RecordedTest]
+        [RecordedTest]
         [LiveOnly]
         public async Task GetLedgerIdentity()
         {

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerRedirectPolicyTests.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/ConfidentialLedgerRedirectPolicyTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Security.ConfidentialLedger.Tests
+{
+    public class ConfidentialLedgerRedirectPolicyTests : SyncAsyncPolicyTestBase
+    {
+        public ConfidentialLedgerRedirectPolicyTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        [Test]
+        public async Task Follows307RedirectToNewLocation()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
+        }
+
+        [Test]
+        public async Task Follows308RedirectToNewLocation()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(308).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
+        }
+
+        [Test]
+        public async Task PreservesAuthorizationHeaderOnRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+                message.Request.Headers.SetValue("Authorization", "Bearer test-token");
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.IsTrue(mockTransport.Requests[1].Headers.TryGetValue("Authorization", out string authValue));
+            Assert.AreEqual("Bearer test-token", authValue);
+        }
+
+        [Test]
+        public async Task PreservesHttpMethodOnRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual(RequestMethod.Post, mockTransport.Requests[1].Method);
+        }
+
+        [Test]
+        public async Task DoesNotFollowNonRedirectStatusCodes([Values(200, 201, 400, 404, 500, 301, 302, 303)] int statusCode)
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(statusCode).AddHeader("Location", "https://other.host/"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://example.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(statusCode, response.Status);
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task StopsAfterMaxRedirects()
+        {
+            // The policy allows up to 5 redirects; after that it returns the redirect response.
+            var mockTransport = new MockTransport(_ =>
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(307, response.Status);
+            // 1 original + 5 redirects = 6 total requests
+            Assert.AreEqual(6, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ReturnsRedirectResponseWhenNoLocationHeader()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307), // No Location header
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(307, response.Status);
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task BlocksHttpsToHttpRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "http://insecure-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            // Should NOT follow the redirect (HTTPS → HTTP downgrade)
+            Assert.AreEqual(307, response.Status);
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task FollowsRelativeLocationHeader()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "/app/transactions"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual("https://secondary-node.confidential-ledger.azure.com/app/transactions", mockTransport.Requests[1].Uri.ToString());
+        }
+
+        [Test]
+        public async Task FollowsMultipleRedirectsWithinLimit()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://node-2.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(4, mockTransport.Requests.Count);
+            Assert.AreEqual("https://primary.confidential-ledger.azure.com/ledger", mockTransport.Requests[3].Uri.ToString());
+        }
+
+        [Test]
+        public async Task DisposesIntermediateRedirectResponses()
+        {
+            var redirectResponse = new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger");
+            var mockTransport = new MockTransport(
+                redirectResponse,
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new ConfidentialLedgerRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.IsTrue(redirectResponse.IsDisposed);
+        }
+    }
+}

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/Helper/ConfidentialLedgerHelperHttpClient.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/Helper/ConfidentialLedgerHelperHttpClient.cs
@@ -70,6 +70,6 @@ namespace Azure.Data.ConfidentialLedger.Tests.Helper
             {
                 return (HttpStatusCode.InternalServerError, $"Error: {ex.Message}");
             }
-}
+        }
     }
 }


### PR DESCRIPTION
Azure Confidential Ledger nodes return 307/308 redirects to route write operations to the primary node. The built-in Azure.Core RedirectPolicy strips the Authorization header on cross-domain redirects, causing these operations to fail.

This change adds a custom ConfidentialLedgerRedirectPolicy that:
- Follows HTTP 307 and 308 redirect responses
- Preserves the Authorization header across redirects between ACL nodes
- Limits redirects to 5 to prevent infinite loops
- Blocks HTTPS to HTTP downgrades
- Supports relative Location headers

Includes 11 unit tests (36 runs including sync/async).

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
