### PR TITLE
Add VisualStudioCodeCredential ConfigurableCredential support

### DIFF
--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCodeCredentialTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudioCode
+{
+    /// <summary>
+    /// Tests for VisualStudioCodeCredential accessed through ConfigurableCredential.
+    /// Inherits from Tests.VisualStudioCodeCredentialTests to get all VS Code-specific test cases.
+    /// Overrides factory methods to create credentials via IConfiguration.
+    /// </summary>
+    internal class VisualStudioCodeCredentialTests : Tests.VisualStudioCodeCredentialTests
+    {
+        private readonly ConfigurableCredentialTestHelper<VisualStudioCodeCredential> _helper;
+
+        public VisualStudioCodeCredentialTests()
+        {
+            _helper = new ConfigurableCredentialTestHelper<VisualStudioCodeCredential>(
+                "VisualStudioCode");
+        }
+
+        protected override void CreateBareCredential()
+        {
+            IConfiguration config = _helper.GetConfiguration();
+
+            using (new TestEnvVar("AZURE_TENANT_ID", null))
+            {
+                _helper.GetCredentialFromConfig(config);
+            }
+        }
+
+        protected override void CreateCredentialWithOptions(string tenantId = null, Uri authorityHost = null, bool isUnsafeSupportLoggingEnabled = false)
+        {
+            IConfiguration config = _helper.GetConfiguration();
+
+            if (tenantId != null)
+            {
+                config["MyClient:Credential:TenantId"] = tenantId;
+            }
+            if (authorityHost != null)
+            {
+                config["MyClient:Credential:AuthorityHost"] = authorityHost.ToString();
+            }
+            config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = isUnsafeSupportLoggingEnabled.ToString();
+
+            using (new TestEnvVar("AZURE_TENANT_ID", null))
+            {
+                _helper.GetCredentialFromConfig(config);
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCodeCredentialTests.cs
@@ -171,24 +171,48 @@ namespace Azure.Identity.Tests
             Assert.IsNull(authRecord, "Authentication record should be null when file doesn't exist");
         }
 
+        #region Virtual Factory Methods
+        /// <summary>
+        /// Creates a VisualStudioCodeCredential with null options.
+        /// </summary>
+        protected virtual void CreateBareCredential()
+        {
+            new VisualStudioCodeCredential(null);
+        }
+
+        /// <summary>
+        /// Creates a VisualStudioCodeCredential with the specified options.
+        /// </summary>
+        protected virtual void CreateCredentialWithOptions(string tenantId = null, Uri authorityHost = null, bool isUnsafeSupportLoggingEnabled = false)
+        {
+            var options = new VisualStudioCodeCredentialOptions
+            {
+                TenantId = tenantId,
+                IsUnsafeSupportLoggingEnabled = isUnsafeSupportLoggingEnabled
+            };
+
+            if (authorityHost != null)
+            {
+                options.AuthorityHost = authorityHost;
+            }
+
+            new VisualStudioCodeCredential(options);
+        }
+        #endregion
+
         [Test]
         public void Constructor_WithNullOptions_Succeeds()
         {
-            Assert.DoesNotThrow(() => new VisualStudioCodeCredential(null));
+            Assert.DoesNotThrow(() => CreateBareCredential());
         }
 
         [Test]
         public void Constructor_WithValidOptions_TransfersProperties()
         {
-            var options = new VisualStudioCodeCredentialOptions
-            {
-                TenantId = "test-tenant",
-                AuthorityHost = new Uri("https://login.microsoftonline.us"),
-                IsUnsafeSupportLoggingEnabled = true
-            };
-
-            // Constructor should succeed and not throw
-            Assert.DoesNotThrow(() => new VisualStudioCodeCredential(options));
+            Assert.DoesNotThrow(() => CreateCredentialWithOptions(
+                tenantId: "test-tenant",
+                authorityHost: new Uri("https://login.microsoftonline.us"),
+                isUnsafeSupportLoggingEnabled: true));
         }
     }
 }


### PR DESCRIPTION
Closes #55497

## Changes

- **VisualStudioCodeCredentialTests.cs** (base): Added virtual factory methods and updated constructor tests to use them.
- **ConfigurableCredentialTestHelper.cs**: Made processOutput, defaultFileSystem, and instrumentClient parameters optional. Guarded process service instrumentation while keeping pipeline instrumentation unconditional.
- **ConfigurableCredentials/VisualStudioCodeCredentialTests.cs** (new): Configurable credential test class that creates credentials via IConfiguration with CredentialSource = VisualStudioCode.

All 387 configurable credential tests pass (339 passed, 48 skipped).