### PR TITLE
Fix ModelFactory to wire inherited flattened properties

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -290,7 +290,7 @@ namespace Azure.Generator.Management.Visitors
                         // This is a nested flattened property case - the constructor parameter is a complex type
                         // We need to find the correct internal property by matching the constructor parameter name,
                         // then recursively collect all nested flattened properties for that specific internal property
-                        if (_flattenedModelTypes.TryGetValue(propertyType, out var propertyNameMap))
+                        if (TryGetFlattenedModelType(propertyType, out var propertyNameMap))
                         {
                             // Try to match the constructor parameter name with an internal property name
                             if (propertyNameMap.TryGetValue(constructorParameter.Name, out var list) && list.Count > 0)
@@ -751,6 +751,33 @@ namespace Azure.Generator.Management.Visitors
 
         private bool IsOverriddenValueType(PropertyProvider flattenedProperty)
             => flattenedProperty.Type.IsValueType && !flattenedProperty.Type.IsNullable;
+
+        /// <summary>
+        /// Looks up the flattened model type map for the given type, also checking base types
+        /// when the type itself has no entry (handles inherited flattened properties).
+        /// </summary>
+        private bool TryGetFlattenedModelType(CSharpType type, [NotNullWhen(true)] out Dictionary<string, List<FlattenPropertyInfo>>? propertyNameMap)
+        {
+            if (_flattenedModelTypes.TryGetValue(type, out propertyNameMap))
+            {
+                return true;
+            }
+            // Check base types for inherited flattened properties
+            if (ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(type, out var typeProvider)
+                && typeProvider is ModelProvider model)
+            {
+                var baseModel = model.BaseModelProvider;
+                while (baseModel is not null)
+                {
+                    if (_flattenedModelTypes.TryGetValue(baseModel.Type, out propertyNameMap))
+                    {
+                        return true;
+                    }
+                    baseModel = baseModel.BaseModelProvider;
+                }
+            }
+            return false;
+        }
 
         /// <summary>
         /// Recursively collects all nested flattened properties for a given internal property.

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
@@ -540,7 +540,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         {
             tags ??= new ChangeTrackingDictionary<string, string>();
 
-            return new IssueTestResourcePatch(tags, displayName is null && status is null && innerValue is null && innerFlag is null && updateOnlyValue is null ? default : new IssueTestUpdateProperties(displayName, default, status, null, updateOnlyValue), additionalBinaryDataProperties: null);
+            return new IssueTestResourcePatch(tags, displayName is null && status is null && innerValue is null && innerFlag is null && updateOnlyValue is null ? default : new IssueTestUpdateProperties(displayName, new IssueTestNestedConfig(innerValue, innerFlag, null), status, null, updateOnlyValue), additionalBinaryDataProperties: null);
         }
 
         /// <param name="displayName"> Simple property. </param>
@@ -1172,8 +1172,8 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 highAvailability is null && minimumTlsVersion is null && hostName is null && provisioningState is null && redundancyMode is null && resourceState is null && redisVersion is null && privateEndpointConnections is null && customerManagedKeyEncryption is null && maintenanceWindows is null && publicNetworkAccess is null ? default : new ClusterCreateProperties(
                     highAvailability,
                     minimumTlsVersion,
-                    default,
-                    default,
+                    new ClusterPropertiesEncryption(customerManagedKeyEncryption, null),
+                    new MaintenanceConfiguration((maintenanceWindows ?? new ChangeTrackingList<MaintenanceWindow>()).ToList(), null),
                     hostName,
                     provisioningState,
                     redundancyMode,


### PR DESCRIPTION
## Problem
The ModelFactory method for `ClusterData` accepted `customerManagedKeyEncryption` and `maintenanceWindows` parameters but passed `default` for the `encryption` and `maintenanceConfiguration` constructor arguments of `ClusterCreateProperties`, silently discarding those inputs.

This is a follow-up to PR #55622 (which fixed flatten generation with nested inheritance). While #55622 fixed the property generation on the resource data class, the ModelFactory code path had the same inheritance-blind lookup issue.

**Before (wrong):**
```csharp
new ClusterCreateProperties(
    highAvailability,
    minimumTlsVersion,
    default,              // encryption - customerManagedKeyEncryption is lost!
    default,              // maintenanceConfiguration - maintenanceWindows is lost!
    ...);
```

**After (correct):**
```csharp
new ClusterCreateProperties(
    highAvailability,
    minimumTlsVersion,
    new ClusterPropertiesEncryption(customerManagedKeyEncryption, null),
    new MaintenanceConfiguration(maintenanceWindows.ToList(), null),
    ...);
```

## Root Cause
`BuildConstructorParameters` looked up the property type directly in `_flattenedModelTypes` to find nested flattened property mappings. When the property type (`ClusterCreateProperties`) inherits flattened properties from a base type (`ClusterProperties`), the mapping was registered under the base type, not the derived type. The lookup failed and fell through to `default`.

## Fix
Added `TryGetFlattenedModelType` helper that walks the inheritance chain when looking up flattened model type mappings, similar to the existing `TryGetFlattenPropertyInfo` method. Only 2 files changed.

All 110 unit tests pass.