### PR TITLE
Add CodeTransparencyRedirectPolicy to follow 307/308 redirects while preserving Authorization header

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Added `CodeTransparencyRedirectPolicy` to automatically follow HTTP 307/308 redirects while preserving the Authorization header. Previously, redirects between Confidential Ledger nodes would fail because the default redirect behavior strips the Authorization header.
+- Added `CodeTransparencyRedirectPolicy` to automatically follow HTTP 307/308 redirects while preserving the Authorization header. Previously, redirects between Confidential Ledger nodes could return HTTP 307/308 responses that were not automatically followed by the default pipeline, causing these requests to fail unless clients implemented redirect handling themselves.
 
 ## 1.0.0-beta.6 (2025-12-17)
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added `CodeTransparencyRedirectPolicy` to automatically follow HTTP 307/308 redirects while preserving the Authorization header. Previously, redirects between Confidential Ledger nodes would fail because the default redirect behavior strips the Authorization header.
 
 ## 1.0.0-beta.6 (2025-12-17)
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/README.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/README.md
@@ -116,7 +116,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [SCITT_RECEIPT_RFC]: https://www.ietf.org/archive/id/draft-ietf-cose-merkle-tree-proofs-08.txt
 [API_reference]: https://learn.microsoft.com/dotnet/api/azure.security.keyvault.keys
 [Service_source_code]: https://github.com/microsoft/scitt-ccf-ledger
-[CTS_claim_generator_script]: https://github.com/microsoft/scitt-ccf-ledger/tree/main/demo/cts_poc
+[CTS_claim_generator_script]: https://github.com/microsoft/scitt-ccf-ledger/tree/main/demo/transparency-service-poc 
 [CTS_configuration_doc]: https://github.com/microsoft/scitt-ccf-ledger/blob/main/docs/configuration.md
 [ccf]: https://github.com/Microsoft/CCF
 [code_of_conduct]: https://opensource.microsoft.com/codeofconduct/

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyClient.cs
@@ -64,7 +64,7 @@ namespace Azure.Security.CodeTransparency
             _keyCredential = credential;
             Pipeline = HttpPipelineBuilder.Build(
                 options,
-                Array.Empty<HttpPipelinePolicy>(),
+                new HttpPipelinePolicy[] { new CodeTransparencyRedirectPolicy() },
                 _keyCredential == null ?
                     Array.Empty<HttpPipelinePolicy>() :
                     new HttpPipelinePolicy[] { new AzureKeyCredentialPolicy(_keyCredential, AuthorizationHeader, AuthorizationApiKeyPrefix) },

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
@@ -15,7 +15,7 @@ namespace Azure.Security.CodeTransparency
     /// <remarks>
     /// Code Transparency Service nodes may return 307 (Temporary Redirect) or 308 (Permanent Redirect)
     /// responses to route write operations to the primary node. The standard redirect behavior in .NET
-    /// strips the Authorization header on cross-domain redirects for security reasons. However, ACL
+    /// strips the Authorization header on cross-domain redirects for security reasons. However, CTS
     /// redirects occur between trusted nodes within the same ledger, so the Authorization header must
     /// be preserved for the redirected request to succeed.
     /// </remarks>

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
@@ -72,7 +72,7 @@ namespace Azure.Security.CodeTransparency
                 }
 
                 // Update the request URI to the redirect target.
-                // The Authorization header is intentionally preserved because ACL redirects
+                // The Authorization header is intentionally preserved because CTS redirects
                 // are between trusted nodes within the same ledger.
                 message.Request.Uri.Reset(redirectUri);
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
@@ -13,7 +13,7 @@ namespace Azure.Security.CodeTransparency
     /// while preserving the Authorization header.
     /// </summary>
     /// <remarks>
-    /// Azure Confidential Ledger nodes may return 307 (Temporary Redirect) or 308 (Permanent Redirect)
+    /// Code Transparency Service nodes may return 307 (Temporary Redirect) or 308 (Permanent Redirect)
     /// responses to route write operations to the primary node. The standard redirect behavior in .NET
     /// strips the Authorization header on cross-domain redirects for security reasons. However, ACL
     /// redirects occur between trusted nodes within the same ledger, so the Authorization header must

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+
+namespace Azure.Security.CodeTransparency
+{
+    /// <summary>
+    /// An <see cref="HttpPipelinePolicy"/> that follows HTTP 307 and 308 redirect responses
+    /// while preserving the Authorization header.
+    /// </summary>
+    /// <remarks>
+    /// Azure Confidential Ledger nodes may return 307 (Temporary Redirect) or 308 (Permanent Redirect)
+    /// responses to route write operations to the primary node. The standard redirect behavior in .NET
+    /// strips the Authorization header on cross-domain redirects for security reasons. However, ACL
+    /// redirects occur between trusted nodes within the same ledger, so the Authorization header must
+    /// be preserved for the redirected request to succeed.
+    /// </remarks>
+    internal sealed class CodeTransparencyRedirectPolicy : HttpPipelinePolicy
+    {
+        private const int MaxRedirects = 5;
+
+        /// <inheritdoc/>
+        public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            ProcessAsync(message, pipeline, false).EnsureCompleted();
+        }
+
+        /// <inheritdoc/>
+        public override ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            return ProcessAsync(message, pipeline, true);
+        }
+
+        private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
+        {
+            if (async)
+            {
+                await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+            }
+            else
+            {
+                ProcessNext(message, pipeline);
+            }
+
+            int redirectCount = 0;
+
+            while (IsRedirectResponse(message.Response.Status))
+            {
+                if (++redirectCount > MaxRedirects)
+                {
+                    // Too many redirects; return the last redirect response as-is.
+                    break;
+                }
+
+                if (!message.Response.Headers.TryGetValue("Location", out string location))
+                {
+                    // No Location header; return the redirect response as-is.
+                    break;
+                }
+
+                Uri redirectUri = BuildRedirectUri(message.Request.Uri.ToUri(), location);
+
+                // Disallow redirect from HTTPS to HTTP.
+                if (string.Equals(message.Request.Uri.Scheme, "https", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(redirectUri.Scheme, "https", StringComparison.OrdinalIgnoreCase))
+                {
+                    break;
+                }
+
+                // Update the request URI to the redirect target.
+                // The Authorization header is intentionally preserved because ACL redirects
+                // are between trusted nodes within the same ledger.
+                message.Request.Uri.Reset(redirectUri);
+
+                // Dispose of the redirect response before re-sending.
+                message.Response.Dispose();
+
+                if (async)
+                {
+                    await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+                }
+                else
+                {
+                    ProcessNext(message, pipeline);
+                }
+            }
+        }
+
+        private static bool IsRedirectResponse(int statusCode)
+        {
+            return statusCode == 307 || statusCode == 308;
+        }
+
+        private static Uri BuildRedirectUri(Uri requestUri, string location)
+        {
+            Uri redirectUri = new Uri(location, UriKind.RelativeOrAbsolute);
+
+            if (!redirectUri.IsAbsoluteUri)
+            {
+                redirectUri = new Uri(requestUri, redirectUri);
+            }
+
+            return redirectUri;
+        }
+    }
+}

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using NUnit.Framework;
+
+namespace Azure.Security.CodeTransparency.Tests
+{
+    public class CodeTransparencyRedirectPolicyTests : SyncAsyncPolicyTestBase
+    {
+        public CodeTransparencyRedirectPolicyTests(bool isAsync) : base(isAsync)
+        {
+        }
+
+        [Test]
+        public async Task Follows307RedirectToNewLocation()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
+        }
+
+        [Test]
+        public async Task Follows308RedirectToNewLocation()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(308).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[1].Uri.ToString());
+        }
+
+        [Test]
+        public async Task PreservesAuthorizationHeaderOnRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+                message.Request.Headers.SetValue("Authorization", "Bearer test-token");
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.IsTrue(mockTransport.Requests[1].Headers.TryGetValue("Authorization", out string authValue));
+            Assert.AreEqual("Bearer test-token", authValue);
+        }
+
+        [Test]
+        public async Task PreservesHttpMethodOnRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual(RequestMethod.Post, mockTransport.Requests[1].Method);
+        }
+
+        [Test]
+        public async Task DoesNotFollowNonRedirectStatusCodes([Values(200, 201, 400, 404, 500, 301, 302, 303)] int statusCode)
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(statusCode).AddHeader("Location", "https://other.host/"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://example.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(statusCode, response.Status);
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task StopsAfterMaxRedirects()
+        {
+            // The policy allows up to 5 redirects; after that it returns the redirect response.
+            var mockTransport = new MockTransport(_ =>
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(307, response.Status);
+            // 1 original + 5 redirects = 6 total requests
+            Assert.AreEqual(6, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task ReturnsRedirectResponseWhenNoLocationHeader()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307), // No Location header
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(307, response.Status);
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task BlocksHttpsToHttpRedirect()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "http://insecure-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            // Should NOT follow the redirect (HTTPS → HTTP downgrade)
+            Assert.AreEqual(307, response.Status);
+            Assert.AreEqual(1, mockTransport.Requests.Count);
+        }
+
+        [Test]
+        public async Task FollowsRelativeLocationHeader()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "/app/transactions"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(2, mockTransport.Requests.Count);
+            Assert.AreEqual("https://secondary-node.confidential-ledger.azure.com/app/transactions", mockTransport.Requests[1].Uri.ToString());
+        }
+
+        [Test]
+        public async Task FollowsMultipleRedirectsWithinLimit()
+        {
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://node-1.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://node-2.confidential-ledger.azure.com/ledger"),
+                new MockResponse(307).AddHeader("Location", "https://primary.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(4, mockTransport.Requests.Count);
+            Assert.AreEqual("https://primary.confidential-ledger.azure.com/ledger", mockTransport.Requests[3].Uri.ToString());
+        }
+
+        [Test]
+        public async Task DisposesIntermediateRedirectResponses()
+        {
+            var redirectResponse = new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger");
+            var mockTransport = new MockTransport(
+                redirectResponse,
+                new MockResponse(200));
+
+            var response = await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, new CodeTransparencyRedirectPolicy());
+
+            Assert.AreEqual(200, response.Status);
+            Assert.IsTrue(redirectResponse.IsDisposed);
+        }
+    }
+}

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.1-beta.4 (2026-02-09)
+## 1.4.1-beta.3 (2026-02-09)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.1-beta.4 (Unreleased)
+## 1.4.1-beta.3 (Unreleased)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.1-beta.3 (Unreleased)
+## 1.4.1-beta.4 (Unreleased)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.4.1-beta.3 (2026-02-09)
+## 1.4.1-beta.3 (Unreleased)
 
 ### Features Added
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/src/Azure.Security.ConfidentialLedger.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Client SDK for the Azure Confidential Ledger service</Description>
     <AssemblyTitle>Azure Confidential Ledger</AssemblyTitle>
-    <Version>1.4.1-beta.4</Version>
+    <Version>1.4.1-beta.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageTags>Azure ConfidentialLedger</PackageTags>


### PR DESCRIPTION
## Description

Added `CodeTransparencyRedirectPolicy` to the `Azure.Security.CodeTransparency` SDK to automatically follow HTTP 307/308 redirects while preserving the Authorization header.

### Changes

- **New file**: `CodeTransparencyRedirectPolicy.cs` - Custom `HttpPipelinePolicy` that follows 307/308 redirects while preserving the Authorization header
- **Modified**: `CodeTransparencyClient.cs` - Wired redirect policy into the HTTP pipeline as a per-call policy
- **New file**: `CodeTransparencyRedirectPolicyTests.cs` - 11 unit tests (36 runs across sync/async)
- **Updated**: `CHANGELOG.md` for both CodeTransparency and ConfidentialLedger SDKs

### Motivation

Azure Confidential Ledger nodes may return 307 (Temporary Redirect) or 308 (Permanent Redirect) responses to route write operations to the primary node. The standard redirect behavior in .NET strips the Authorization header on cross-domain redirects for security reasons. However, ACL redirects occur between trusted nodes within the same ledger, so the Authorization header must be preserved for the redirected request to succeed.

### Testing

- 11 unit tests covering: 307/308 redirects, Authorization header preservation, HTTP method preservation, non-redirect status codes, max redirect limit, missing Location header, HTTPS-to-HTTP downgrade blocking, relative Location headers, multiple redirects, and intermediate response disposal.
- All 36 test runs pass (sync + async) on net8.0 and net10.0.