### PR TITLE
Add AzureDeveloperCliCredential ConfigurableCredential support

### DIFF
--- a/sdk/identity/Azure.Identity/tests/AzureDeveloperCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzureDeveloperCliCredentialTests.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 
 namespace Azure.Identity.Tests
 {
-    public class AzureDeveloperCliCredentialTests : CredentialTestBase<AzureDeveloperCliCredentialOptions>
+    internal class AzureDeveloperCliCredentialTests : CredentialTestBase<AzureDeveloperCliCredentialOptions>
     {
         public AzureDeveloperCliCredentialTests(bool isAsync) : base(isAsync) { }
 
@@ -41,6 +41,52 @@ namespace Azure.Identity.Tests
             return InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess, true), azdCliOptions));
         }
 
+        #region Virtual Factory Methods
+        protected virtual TokenCredential CreateCredential(IProcessService processService, string tenantId = null, bool addTenantIdHint = false)
+        {
+            var options = new AzureDeveloperCliCredentialOptions { TenantId = tenantId };
+            if (addTenantIdHint)
+            {
+                options.AdditionallyAllowedTenants.Add(TenantIdHint);
+            }
+            return InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), processService, options));
+        }
+
+        protected virtual TokenCredential CreateCredentialWithTimeout(IProcessService processService, TimeSpan timeout, bool isChained = false)
+        {
+            var options = new AzureDeveloperCliCredentialOptions { ProcessTimeout = timeout, IsChainedCredential = isChained };
+            return InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), processService, options));
+        }
+
+        protected virtual TokenCredential CreateCredentialWithChainedOption(IProcessService processService, bool isChained)
+        {
+            var options = new AzureDeveloperCliCredentialOptions { IsChainedCredential = isChained };
+            return InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), processService, options));
+        }
+
+        protected virtual TokenCredential CreateBareCredential()
+        {
+            return InstrumentClient(new AzureDeveloperCliCredential());
+        }
+
+        /// <summary>
+        /// Creates a credential with only a tenant ID for construction validation tests.
+        /// No instrumentation needed since the credential is never used to get a token.
+        /// </summary>
+        protected virtual void CreateCredentialForTenantValidation(string tenantId)
+        {
+            new AzureDeveloperCliCredential(new AzureDeveloperCliCredentialOptions { TenantId = tenantId });
+        }
+
+        /// <summary>
+        /// Returns the expected exception type for error scenarios.
+        /// Base: AuthenticationFailedException when not chained, CredentialUnavailableException when chained.
+        /// ConfigurableCredential always wraps in DefaultAzureCredential (chained), so always CredentialUnavailableException.
+        /// </summary>
+        protected virtual Type GetExpectedExceptionType(bool isChained)
+            => isChained ? typeof(CredentialUnavailableException) : typeof(AuthenticationFailedException);
+        #endregion
+
         [Test]
         public async Task AuthenticateWithDeveloperCliCredential(
             [Values(null, TenantIdHint)] string tenantId,
@@ -48,14 +94,12 @@ namespace Azure.Identity.Tests
             [Values(null, TenantId)] string explicitTenantId)
         {
             var context = new TokenRequestContext(new[] { Scope }, tenantId: tenantId);
-            var options = new AzureDeveloperCliCredentialOptions { TenantId = explicitTenantId, AdditionallyAllowedTenants = { TenantIdHint } };
             string expectedTenantId = TenantIdResolverBase.Default.Resolve(explicitTenantId, context, TenantIdResolverBase.AllTenants);
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureDeveloperCli();
 
             var testProcess = new TestProcess { Output = processOutput };
-            AzureDeveloperCliCredential credential =
-                InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess, true), options));
-            AccessToken actualToken = await credential.GetTokenAsync(context);
+            var credential = CreateCredential(new TestProcessService(testProcess, true), tenantId: explicitTenantId, addTenantIdHint: true);
+            AccessToken actualToken = await credential.GetTokenAsync(context, default);
 
             Assert.AreEqual(expectedToken, actualToken.Token);
             Assert.AreEqual(expectedExpiresOn, actualToken.ExpiresOn);
@@ -78,9 +122,8 @@ namespace Azure.Identity.Tests
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureDeveloperCli();
 
             var testProcess = new TestProcess { Output = processOutput };
-            AzureDeveloperCliCredential credential =
-                InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess, true)));
-            AccessToken actualToken = await credential.GetTokenAsync(context);
+            var credential = CreateCredential(new TestProcessService(testProcess, true));
+            AccessToken actualToken = await credential.GetTokenAsync(context, default);
 
             Assert.AreEqual(expectedToken, actualToken.Token);
             Assert.AreEqual(expectedExpiresOn, actualToken.ExpiresOn);
@@ -93,10 +136,10 @@ namespace Azure.Identity.Tests
             var claims = "test-claims-challenge";
             var (_, _, processOutput) = CredentialTestHelpers.CreateTokenForAzureDeveloperCli();
             var testProcess = new TestProcess { Error = "AADSTS50076: MFA required" }; // Force InvalidOperationException path
-            var credential = InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess, true)));
+            var credential = CreateCredential(new TestProcessService(testProcess, true));
 
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () =>
-                await credential.GetTokenAsync(new TokenRequestContext([Scope], claims: claims)));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(false), async () =>
+                await credential.GetTokenAsync(new TokenRequestContext([Scope], claims: claims), default));
 
             Assert.That(ex.Message, Does.Contain("Azure Developer CLI authentication requires multi-factor authentication or additional claims."));
             Assert.That(ex.Message, Does.Contain("azd auth login"));
@@ -109,10 +152,10 @@ namespace Azure.Identity.Tests
             var claims = "test-claims-challenge";
             var tenant = TenantId;
             var testProcess = new TestProcess { Error = "AADSTS50076: MFA required" };
-            var credential = InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess, true), new AzureDeveloperCliCredentialOptions { TenantId = tenant }));
+            var credential = CreateCredential(new TestProcessService(testProcess, true), tenantId: tenant);
 
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () =>
-                await credential.GetTokenAsync(new TokenRequestContext([Scope], claims: claims)));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(false), async () =>
+                await credential.GetTokenAsync(new TokenRequestContext([Scope], claims: claims), default));
 
             Assert.That(ex.Message, Does.Contain($"azd auth login --tenant-id {tenant}"));
         }
@@ -125,9 +168,9 @@ namespace Azure.Identity.Tests
         {
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureDeveloperCli();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess, true)));
+            var credential = CreateCredential(new TestProcessService(testProcess, true));
 
-            var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { Scope }, claims: claims));
+            var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { Scope }, claims: claims), default);
             Assert.AreEqual(expectedToken, token.Token);
             Assert.AreEqual(expectedExpiresOn, token.ExpiresOn);
             Assert.That(testProcess.StartInfo.Arguments, Does.Not.Contain("--claims"));
@@ -141,10 +184,10 @@ namespace Azure.Identity.Tests
             var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(claimsJson));
             var (expectedToken, expectedExpiresOn, processOutput) = CredentialTestHelpers.CreateTokenForAzureDeveloperCli();
             var testProcess = new TestProcess { Output = processOutput };
-            var credential = InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess, true)));
+            var credential = CreateCredential(new TestProcessService(testProcess, true));
 
             // Act
-            var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { Scope }, claims: claimsJson));
+            var token = await credential.GetTokenAsync(new TokenRequestContext(new[] { Scope }, claims: claimsJson), default);
 
             // Assert
             Assert.AreEqual(expectedToken, token.Token);
@@ -159,8 +202,9 @@ namespace Azure.Identity.Tests
             string jsonContent)
         {
             var testProcess = new TestProcess { Output = jsonContent };
-            AzureDeveloperCliCredential credential = InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
-            Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var credential = CreateCredential(new TestProcessService(testProcess));
+            Assert.ThrowsAsync(GetExpectedExceptionType(false),
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
         }
 
         private const string RefreshTokenExpiredError = "Azure Developer CLI authentication failed due to an unknown error. ERROR: Get Token request returned http error: 400 and server response: {\"error\":\"invalid_grant\",\"error_description\":\"AADSTS70008: The provided authorization code or refresh token has expired due to inactivity. Send a new interactive authorization request for this user and resource.";
@@ -168,55 +212,54 @@ namespace Azure.Identity.Tests
         public static IEnumerable<object[]> AzureDeveloperCliExceptionScenarios()
         {
             // params
-            // azd thrown Exception message, expected message, expected  exception
-            yield return new object[] {null, AzureDeveloperCliCredential.WinAzdCliError, AzureDeveloperCliCredential.AzdCliNotInstalled, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, "azd: command not found", AzureDeveloperCliCredential.AzdCliNotInstalled, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, "azd: not found", AzureDeveloperCliCredential.AzdCliNotInstalled, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, AzureDeveloperCliCredential.AzdNotLogIn, AzureDeveloperCliCredential.AzdNotLogIn, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, RefreshTokenExpiredError, AzureDeveloperCliCredential.InteractiveLoginRequired, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, AzureDeveloperCliCredential.AzdCLIInternalError, AzureDeveloperCliCredential.InteractiveLoginRequired, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, "random unknown exception", AzureDeveloperCliCredential.AzdCliFailedError + " " + AzureDeveloperCliCredential.Troubleshoot + " random unknown exception", typeof(AuthenticationFailedException) };
-            yield return new object[] {GetExceptionAction(new AuthenticationFailedException("foo")), string.Empty, "foo", typeof(AuthenticationFailedException) };
-            yield return new object[] {GetExceptionAction(new OperationCanceledException("foo")), string.Empty, "Azure Developer CLI authentication timed out.", typeof(AuthenticationFailedException) };
-            yield return new object[] {null, "AADSTS12345: Some AAD error. To re-authenticate, please run: azd auth login", AzureDeveloperCliCredential.AzdCliFailedError + " " + AzureDeveloperCliCredential.Troubleshoot + " AADSTS12345: Some AAD error. To re-authenticate, please run: azd auth login", typeof(AuthenticationFailedException) };
+            // azd thrown Exception message, expected message, isChained
+            yield return new object[] {null, AzureDeveloperCliCredential.WinAzdCliError, AzureDeveloperCliCredential.AzdCliNotInstalled, true };
+            yield return new object[] {null, "azd: command not found", AzureDeveloperCliCredential.AzdCliNotInstalled, true };
+            yield return new object[] {null, "azd: not found", AzureDeveloperCliCredential.AzdCliNotInstalled, true };
+            yield return new object[] {null, AzureDeveloperCliCredential.AzdNotLogIn, AzureDeveloperCliCredential.AzdNotLogIn, true };
+            yield return new object[] {null, RefreshTokenExpiredError, AzureDeveloperCliCredential.InteractiveLoginRequired, true };
+            yield return new object[] {null, AzureDeveloperCliCredential.AzdCLIInternalError, AzureDeveloperCliCredential.InteractiveLoginRequired, true };
+            yield return new object[] {null, "random unknown exception", AzureDeveloperCliCredential.AzdCliFailedError + " " + AzureDeveloperCliCredential.Troubleshoot + " random unknown exception", false };
+            yield return new object[] {GetExceptionAction(new AuthenticationFailedException("foo")), string.Empty, "foo", false };
+            yield return new object[] {GetExceptionAction(new OperationCanceledException("foo")), string.Empty, "Azure Developer CLI authentication timed out.", false };
+            yield return new object[] {null, "AADSTS12345: Some AAD error. To re-authenticate, please run: azd auth login", AzureDeveloperCliCredential.AzdCliFailedError + " " + AzureDeveloperCliCredential.Troubleshoot + " AADSTS12345: Some AAD error. To re-authenticate, please run: azd auth login", false };
         }
 
         public static IEnumerable<object[]> AzureDeveloperCliExceptionScenarios_IsChained()
         {
             // params
-            // azd thrown Exception message, expected message, expected  exception
-            yield return new object[] {null, AzureDeveloperCliCredential.WinAzdCliError, AzureDeveloperCliCredential.AzdCliNotInstalled, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, "azd: command not found", AzureDeveloperCliCredential.AzdCliNotInstalled, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, "azd: not found", AzureDeveloperCliCredential.AzdCliNotInstalled, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, AzureDeveloperCliCredential.AzdNotLogIn, AzureDeveloperCliCredential.AzdNotLogIn, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, RefreshTokenExpiredError, AzureDeveloperCliCredential.InteractiveLoginRequired, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, AzureDeveloperCliCredential.AzdCLIInternalError, AzureDeveloperCliCredential.InteractiveLoginRequired, typeof(CredentialUnavailableException) };
-            yield return new object[] {null, "random unknown exception", AzureDeveloperCliCredential.AzdCliFailedError + " " + AzureDeveloperCliCredential.Troubleshoot + " random unknown exception", typeof(CredentialUnavailableException) };
-            yield return new object[] {GetExceptionAction(new AuthenticationFailedException("foo")), string.Empty, "foo", typeof(CredentialUnavailableException) };
-            yield return new object[] {GetExceptionAction(new OperationCanceledException("foo")), string.Empty, "Azure Developer CLI authentication timed out.", typeof(CredentialUnavailableException) };
-            yield return new object[] {null, "AADSTS12345: Some AAD error. To re-authenticate, please run: azd auth login", AzureDeveloperCliCredential.AzdCliFailedError + " " + AzureDeveloperCliCredential.Troubleshoot + " AADSTS12345: Some AAD error. To re-authenticate, please run: azd auth login", typeof(CredentialUnavailableException) };
+            // azd thrown Exception message, expected message, isChained
+            yield return new object[] {null, AzureDeveloperCliCredential.WinAzdCliError, AzureDeveloperCliCredential.AzdCliNotInstalled, true };
+            yield return new object[] {null, "azd: command not found", AzureDeveloperCliCredential.AzdCliNotInstalled, true };
+            yield return new object[] {null, "azd: not found", AzureDeveloperCliCredential.AzdCliNotInstalled, true };
+            yield return new object[] {null, AzureDeveloperCliCredential.AzdNotLogIn, AzureDeveloperCliCredential.AzdNotLogIn, true };
+            yield return new object[] {null, RefreshTokenExpiredError, AzureDeveloperCliCredential.InteractiveLoginRequired, true };
+            yield return new object[] {null, AzureDeveloperCliCredential.AzdCLIInternalError, AzureDeveloperCliCredential.InteractiveLoginRequired, true };
+            yield return new object[] {null, "random unknown exception", AzureDeveloperCliCredential.AzdCliFailedError + " " + AzureDeveloperCliCredential.Troubleshoot + " random unknown exception", true };
+            yield return new object[] {GetExceptionAction(new AuthenticationFailedException("foo")), string.Empty, "foo", true };
+            yield return new object[] {GetExceptionAction(new OperationCanceledException("foo")), string.Empty, "Azure Developer CLI authentication timed out.", true };
+            yield return new object[] {null, "AADSTS12345: Some AAD error. To re-authenticate, please run: azd auth login", AzureDeveloperCliCredential.AzdCliFailedError + " " + AzureDeveloperCliCredential.Troubleshoot + " AADSTS12345: Some AAD error. To re-authenticate, please run: azd auth login", true };
         }
 
         [Test]
         [TestCaseSource(nameof(AzureDeveloperCliExceptionScenarios))]
-        public void AuthenticateWithDeveloperCliCredential_ExceptionScenarios(Action<object> exceptionOnStartHandler, string errorMessage, string expectedMessage, Type exceptionType)
+        public void AuthenticateWithDeveloperCliCredential_ExceptionScenarios(Action<object> exceptionOnStartHandler, string errorMessage, string expectedMessage, bool isChained)
         {
             var testProcess = new TestProcess { Error = errorMessage, ExceptionOnStartHandler = exceptionOnStartHandler };
-            AzureDeveloperCliCredential credential = InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
-            var ex = Assert.ThrowsAsync(exceptionType, async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            Assert.AreEqual(expectedMessage, ex.Message);
+            var credential = CreateCredential(new TestProcessService(testProcess));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(isChained),
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            Assert.That(ex.Message, Does.Contain(expectedMessage));
         }
 
         [Test]
         [TestCaseSource(nameof(AzureDeveloperCliExceptionScenarios_IsChained))]
-        public void AuthenticateWithDeveloperCliCredential_ExceptionScenarios_IsChained(Action<object> exceptionOnStartHandler, string errorMessage, string expectedMessage, Type exceptionType)
+        public void AuthenticateWithDeveloperCliCredential_ExceptionScenarios_IsChained(Action<object> exceptionOnStartHandler, string errorMessage, string expectedMessage, bool isChained)
         {
             var testProcess = new TestProcess { Error = errorMessage, ExceptionOnStartHandler = exceptionOnStartHandler };
-            AzureDeveloperCliCredential credential = InstrumentClient(new AzureDeveloperCliCredential(
-                CredentialPipeline.GetInstance(null),
-                new TestProcessService(testProcess),
-                new AzureDeveloperCliCredentialOptions() { IsChainedCredential = true }));
-            var ex = Assert.ThrowsAsync(exceptionType, async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var credential = CreateCredentialWithChainedOption(new TestProcessService(testProcess), isChained: true);
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(isChained),
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             Assert.That(ex.Message, Does.Contain(expectedMessage));
         }
 
@@ -226,27 +269,18 @@ namespace Azure.Identity.Tests
             var cts = new CancellationTokenSource();
             var testProcess = new TestProcess { Timeout = 10000 };
             testProcess.Started += (o, e) => cts.Cancel();
-            AzureDeveloperCliCredential credential = InstrumentClient(new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null), new TestProcessService(testProcess)));
-            Assert.CatchAsync<OperationCanceledException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), cts.Token));
+            var credential = CreateCredential(new TestProcessService(testProcess));
+            var ex = Assert.CatchAsync<Exception>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), cts.Token));
+            Assert.That(ex.Message, Does.Contain("canceled").IgnoreCase);
         }
 
         [Test]
         public void ConfigureCliProcessTimeout_ProcessTimeout([Values(true, false)] bool isChainedCredential)
         {
             var testProcess = new TestProcess { Timeout = 10000 };
-            AzureDeveloperCliCredential credential = InstrumentClient(
-                new AzureDeveloperCliCredential(CredentialPipeline.GetInstance(null),
-                    new TestProcessService(testProcess),
-                    new AzureDeveloperCliCredentialOptions() { ProcessTimeout = TimeSpan.Zero, IsChainedCredential = isChainedCredential }));
-            Exception ex = null;
-            if (isChainedCredential)
-            {
-                ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            }
-            else
-            {
-                ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            }
+            var credential = CreateCredentialWithTimeout(new TestProcessService(testProcess), TimeSpan.Zero, isChainedCredential);
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(isChainedCredential),
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             Assert.That(ex.Message, Does.Contain(AzureDeveloperCliCredential.AzdCliTimeoutError));
         }
 
@@ -261,14 +295,14 @@ namespace Azure.Identity.Tests
 
                 tenantIdBuilder.Insert(i, testChar);
 
-                Assert.Throws<ArgumentException>(() => new AzureDeveloperCliCredential(new AzureDeveloperCliCredentialOptions { TenantId = tenantIdBuilder.ToString() }), Validations.InvalidTenantIdErrorMessage);
+                Assert.Throws<ArgumentException>(() => CreateCredentialForTenantValidation(tenantIdBuilder.ToString()), Validations.InvalidTenantIdErrorMessage);
             }
         }
 
         [TestCaseSource(nameof(NegativeTestCharacters))]
         public void VerifyGetTokenTenantIdValidation(char testChar)
         {
-            AzureDeveloperCliCredential credential = InstrumentClient(new AzureDeveloperCliCredential());
+            var credential = CreateBareCredential();
 
             string tenantId = Guid.NewGuid().ToString();
 
@@ -280,14 +314,15 @@ namespace Azure.Identity.Tests
 
                 var tokenRequestContext = new TokenRequestContext(MockScopes.Default, tenantId: tenantIdBuilder.ToString());
 
-                Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(tokenRequestContext), Validations.InvalidTenantIdErrorMessage);
+                Assert.ThrowsAsync(GetExpectedExceptionType(false),
+                    async () => await credential.GetTokenAsync(tokenRequestContext, default), Validations.InvalidTenantIdErrorMessage);
             }
         }
 
         [TestCaseSource(nameof(NegativeTestCharacters))]
         public void VerifyGetTokenScopeValidation(char testChar)
         {
-            AzureDeveloperCliCredential credential = InstrumentClient(new AzureDeveloperCliCredential());
+            var credential = CreateBareCredential();
 
             string scope = MockScopes.Default.ToString();
 
@@ -299,7 +334,8 @@ namespace Azure.Identity.Tests
 
                 var tokenRequestContext = new TokenRequestContext(new string[] { scopeBuilder.ToString() });
 
-                Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(tokenRequestContext), ScopeUtilities.InvalidScopeMessage);
+                Assert.ThrowsAsync(GetExpectedExceptionType(false),
+                    async () => await credential.GetTokenAsync(tokenRequestContext, default), ScopeUtilities.InvalidScopeMessage);
             }
         }
     }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialTests.cs
@@ -78,11 +78,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureCli
             => typeof(CredentialUnavailableException);
 
         protected override void CreateCredentialForTenantValidation(string tenantId)
-        {
-            IConfiguration config = _helper.GetConfiguration();
-            config["MyClient:Credential:TenantId"] = tenantId;
-            _helper.GetCredentialFromConfig(config);
-        }
+            => _helper.CreateCredentialForTenantValidation(tenantId);
 
         // Tests that validate AzureCliCredentialOptions directly need configurable equivalents.
 

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialTests.cs
@@ -8,17 +8,17 @@ using Azure.Identity.Tests.Mock;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 
-namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePowerShell
+namespace Azure.Identity.Tests.ConfigurableCredentials.AzureDeveloperCli
 {
-    internal class AzurePowerShellCredentialTests : Tests.AzurePowerShellCredentialsTests
+    internal class AzureDeveloperCliCredentialTests : Tests.AzureDeveloperCliCredentialTests
     {
-        private readonly ConfigurableCredentialTestHelper<AzurePowerShellCredential> _helper;
+        private readonly ConfigurableCredentialTestHelper<AzureDeveloperCliCredential> _helper;
 
-        public AzurePowerShellCredentialTests(bool isAsync) : base(isAsync)
+        public AzureDeveloperCliCredentialTests(bool isAsync) : base(isAsync)
         {
-            _helper = new ConfigurableCredentialTestHelper<AzurePowerShellCredential>(
-                "AzurePowerShell",
-                CredentialTestHelpers.CreateTokenForAzurePowerShell(TimeSpan.FromSeconds(30)).Json,
+            _helper = new ConfigurableCredentialTestHelper<AzureDeveloperCliCredential>(
+                "AzureDeveloperCli",
+                CredentialTestHelpers.CreateTokenForAzureDeveloperCli().Json,
                 null,
                 InstrumentClient);
         }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialTestHelper.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialTestHelper.cs
@@ -119,6 +119,13 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
             return new ConfigurableCredential(new DefaultAzureCredentialOptions(new CredentialSettings(credentialSection), credentialSection));
         }
 
+        public void CreateCredentialForTenantValidation(string tenantId)
+        {
+            IConfiguration config = GetConfiguration();
+            config["MyClient:Credential:TenantId"] = tenantId;
+            GetCredentialFromConfig(config);
+        }
+
         private IConfiguration GetConfigurationFromCommonCredentialTestConfig<TCredOptions>(
             CredentialTestBase<TCredOptions>.CommonCredentialTestConfig config)
             where TCredOptions : TokenCredentialOptions


### PR DESCRIPTION
## Summary

Add AzureDeveloperCliCredential support in ConfigurableCredentialProvider and refactor shared test helper code.

### Changes

- **Base test class** (AzureDeveloperCliCredentialTests.cs): Added virtual factory methods (CreateCredential, CreateCredentialWithTimeout, CreateCredentialWithChainedOption, CreateBareCredential, CreateCredentialForTenantValidation, GetExpectedExceptionType) and refactored tests to use them
- **New configurable test class** (ConfigurableCredentials/AzureDeveloperCliCredentialTests.cs): 210 new tests via inheritance, creating credentials through IConfiguration with \AzureDeveloperCli\ credential source
- **Shared helper refactoring** (ConfigurableCredentialTestHelper.cs): Moved CreateCredentialForTenantValidation into the helper, simplifying AzureCli, AzurePowerShell, and AzureDeveloperCli configurable test classes

### Testing

All 765 configurable credential tests pass (including 210 new for AzureDeveloperCli).

Resolves #55499