### PR TITLE
[ClientModel.TestFramework] Initialization fixes

### DIFF
--- a/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net10.0.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net10.0.cs
@@ -384,7 +384,9 @@ namespace Microsoft.ClientModel.TestFramework
         public Microsoft.ClientModel.TestFramework.RecordedTestMode? Mode { get { throw null; } set { } }
         public string? PathToTestResourceBootstrappingScript { get { throw null; } set { } }
         public static string? RepositoryRoot { get { throw null; } protected set { } }
-        public void BootStrapTestResources() { }
+        public virtual void BootStrapTestResources() { }
+        protected static string FindDevelopmentCertificatePath(string repositoryRoot) { throw null; }
+        protected static string FindRepositoryRoot() { throw null; }
         protected string? GetOptionalVariable(string name) { throw null; }
         protected string? GetRecordedOptionalVariable(string name) { throw null; }
         protected string? GetRecordedOptionalVariable(string name, System.Action<Microsoft.ClientModel.TestFramework.RecordedVariableOptions>? options) { throw null; }

--- a/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net462.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net462.cs
@@ -384,7 +384,9 @@ namespace Microsoft.ClientModel.TestFramework
         public Microsoft.ClientModel.TestFramework.RecordedTestMode? Mode { get { throw null; } set { } }
         public string? PathToTestResourceBootstrappingScript { get { throw null; } set { } }
         public static string? RepositoryRoot { get { throw null; } protected set { } }
-        public void BootStrapTestResources() { }
+        public virtual void BootStrapTestResources() { }
+        protected static string FindDevelopmentCertificatePath(string repositoryRoot) { throw null; }
+        protected static string FindRepositoryRoot() { throw null; }
         protected string? GetOptionalVariable(string name) { throw null; }
         protected string? GetRecordedOptionalVariable(string name) { throw null; }
         protected string? GetRecordedOptionalVariable(string name, System.Action<Microsoft.ClientModel.TestFramework.RecordedVariableOptions>? options) { throw null; }

--- a/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net8.0.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net8.0.cs
@@ -384,7 +384,9 @@ namespace Microsoft.ClientModel.TestFramework
         public Microsoft.ClientModel.TestFramework.RecordedTestMode? Mode { get { throw null; } set { } }
         public string? PathToTestResourceBootstrappingScript { get { throw null; } set { } }
         public static string? RepositoryRoot { get { throw null; } protected set { } }
-        public void BootStrapTestResources() { }
+        public virtual void BootStrapTestResources() { }
+        protected static string FindDevelopmentCertificatePath(string repositoryRoot) { throw null; }
+        protected static string FindRepositoryRoot() { throw null; }
         protected string? GetOptionalVariable(string name) { throw null; }
         protected string? GetRecordedOptionalVariable(string name) { throw null; }
         protected string? GetRecordedOptionalVariable(string name, System.Action<Microsoft.ClientModel.TestFramework.RecordedVariableOptions>? options) { throw null; }

--- a/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net9.0.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net9.0.cs
@@ -384,7 +384,9 @@ namespace Microsoft.ClientModel.TestFramework
         public Microsoft.ClientModel.TestFramework.RecordedTestMode? Mode { get { throw null; } set { } }
         public string? PathToTestResourceBootstrappingScript { get { throw null; } set { } }
         public static string? RepositoryRoot { get { throw null; } protected set { } }
-        public void BootStrapTestResources() { }
+        public virtual void BootStrapTestResources() { }
+        protected static string FindDevelopmentCertificatePath(string repositoryRoot) { throw null; }
+        protected static string FindRepositoryRoot() { throw null; }
         protected string? GetOptionalVariable(string name) { throw null; }
         protected string? GetRecordedOptionalVariable(string name) { throw null; }
         protected string? GetRecordedOptionalVariable(string name, System.Action<Microsoft.ClientModel.TestFramework.RecordedVariableOptions>? options) { throw null; }

--- a/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestEnvironment.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestEnvironment.cs
@@ -20,25 +20,195 @@ namespace Microsoft.ClientModel.TestFramework;
 /// </summary>
 public abstract class TestEnvironment
 {
+    /// <summary>The default password used for development certificates in test environments.</summary>
+    public const string DevCertPassword = "password";
+
+    private static readonly HashSet<Type> BootstrappingAttemptedTypes = [];
+    private static readonly object SyncLock = new();
+
+    private static RecordedTestMode? s_recordedTestMode;
+    private static bool? s_disableAutoRecording;
+    private static bool? s_enableFiddler;
+    private static bool? s_disableBootstrapping;
+    private static bool? s_enableTestProxyDebugLogs;
+
+    private readonly Dictionary<string, string>? _environmentFile;
+    private readonly Type _type;
+
     private AuthenticationTokenProvider? _credential;
     private TestRecording? _recording;
-    private readonly Dictionary<string, string>? _environmentFile;
-    private static readonly HashSet<Type> s_bootstrappingAttemptedTypes = [];
-    private static readonly object s_syncLock = new();
     private Exception? _bootstrappingException;
-    private readonly Type _type;
+
+    /// <summary>
+    /// Gets a value indicating whether the current platform is Windows.
+    /// Used for platform-specific test behavior and resource bootstrapping.
+    /// </summary>
+    public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
     /// <summary>
     /// Gets the root directory of the repository containing the test project.
     /// This is determined by searching for common repository indicators like .github directories or build files.
     /// </summary>
-    public static string? RepositoryRoot { get; protected set; }
+    public static string? RepositoryRoot
+    {
+        get
+        {
+            return field ??= FindRepositoryRoot();
+        }
+
+        protected set
+        {
+            field = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the path to the development certificate used by the test proxy for HTTPS connections.
     /// Can be overridden by derived classes to specify custom certificate locations.
     /// </summary>
-    public static string? DevCertPath { get; protected set; }
+    public static string? DevCertPath
+    {
+        get
+        {
+            return field ??= FindDevelopmentCertificatePath(RepositoryRoot!);
+        }
+
+        protected set
+        {
+            field = value;
+        }
+    }
+
+    /// <summary>
+    /// Determines if the current global test mode.
+    /// </summary>
+    internal static RecordedTestMode GlobalTestMode
+    {
+        get
+        {
+            // If a value was explicitly set, use it. Otherwise, check for configuration
+            // to determine the test mode.
+            if (s_recordedTestMode is { })
+            {
+                return s_recordedTestMode.Value;
+            }
+
+            string? modeString = TestContext.Parameters["TestMode"] ?? Environment.GetEnvironmentVariable("CLIENTMODEL_TEST_MODE");
+
+            RecordedTestMode mode = RecordedTestMode.Playback;
+            if (!string.IsNullOrEmpty(modeString))
+            {
+                mode = (RecordedTestMode)Enum.Parse(typeof(RecordedTestMode), modeString, true);
+            }
+
+            return mode;
+        }
+
+        set
+        {
+            s_recordedTestMode = value;
+        }
+    }
+
+    /// <summary>
+    /// Determines if tests that use <see cref="RecordedTestAttribute"/> should try to re-record on failure.
+    /// </summary>
+    internal static bool GlobalDisableAutoRecording
+    {
+        get
+        {
+            // If a value was explicitly set, use it. Otherwise, check for a switch to
+            // disable auto-recording before re-recording on playback failures.
+            if (s_disableAutoRecording is { })
+            {
+                return s_disableAutoRecording.Value;
+            }
+
+            string? switchString = TestContext.Parameters["DisableAutoRecording"] ?? Environment.GetEnvironmentVariable("CLIENTMODEL_DISABLE_AUTO_RECORDING");
+            bool.TryParse(switchString, out bool disableAutoRecording);
+
+            return disableAutoRecording;
+        }
+
+        set
+        {
+            s_disableAutoRecording = value;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether to enable the test framework to proxy traffic through fiddler.
+    /// </summary>
+    internal static bool EnableFiddler
+    {
+        get
+        {
+            if (s_enableFiddler is { })
+            {
+                return s_enableFiddler.Value;
+            }
+
+            string? switchString = TestContext.Parameters["EnableFiddler"] ??
+                                  Environment.GetEnvironmentVariable("CLIENTMODEL_ENABLE_FIDDLER");
+            bool.TryParse(switchString, out bool enableFiddler);
+
+            return enableFiddler;
+        }
+
+        set
+        {
+            s_enableFiddler = value;
+        }
+    }
+
+    /// <summary>
+    /// Determines if the bootstrapping prompt and automatic resource group expiration extension should be disabled.
+    /// </summary>
+    internal static bool DisableBootstrapping
+    {
+        get
+        {
+            if (s_disableBootstrapping is { })
+            {
+                return s_disableBootstrapping.Value;
+            }
+
+            string? switchString = TestContext.Parameters["DisableBootstrapping"] ?? Environment.GetEnvironmentVariable("CLIENTMODEL_DISABLE_BOOTSTRAPPING");
+            bool.TryParse(switchString, out bool disableBootstrapping);
+
+            return disableBootstrapping;
+        }
+
+        set
+        {
+            s_disableBootstrapping = value;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether to enable debug level proxy logging. Errors are logged by default.
+    /// </summary>
+    internal static bool EnableTestProxyDebugLogs
+    {
+        get
+        {
+            if (s_enableTestProxyDebugLogs is { })
+            {
+                return s_enableTestProxyDebugLogs.Value;
+            }
+
+            string? switchString = TestContext.Parameters[nameof(EnableTestProxyDebugLogs)] ??
+                                  Environment.GetEnvironmentVariable("CLIENTMODEL_ENABLE_TEST_PROXY_DEBUG_LOGS");
+            bool.TryParse(switchString, out bool enableProxyLogging);
+
+            return enableProxyLogging;
+        }
+
+        set
+        {
+            s_enableTestProxyDebugLogs = value;
+        }
+    }
 
     /// <summary>
     /// Gets or sets the path to the PowerShell script used for bootstrapping test resources.
@@ -47,80 +217,10 @@ public abstract class TestEnvironment
     public string? PathToTestResourceBootstrappingScript { get; set; }
 
     /// <summary>
-    /// The default password used for development certificates in test environments.
-    /// </summary>
-    public const string DevCertPassword = "password";
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TestEnvironment"/> class.
-    /// Validates that repository root and certificate paths are available, then loads environment configuration.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when RepositoryRoot is null.
-    /// </exception>
-    protected TestEnvironment()
-    {
-        // DevCertPath is optional - if null, the test proxy will run without HTTPS support
-        if (DevCertPath != null && !File.Exists(DevCertPath))
-        {
-            Console.WriteLine($"Warning: Dev certificate not found at {DevCertPath}. HTTPS tests may not work.");
-        }
-
-        _type = GetType();
-
-        _environmentFile = ParseEnvironmentFile();
-    }
-
-    /// <summary>
-    /// Initializes static members of the <see cref="TestEnvironment"/> class.
-    /// Discovers the repository root and sets the default development certificate path.
-    /// </summary>
-    static TestEnvironment()
-    {
-        var directoryInfo = new DirectoryInfo(Assembly.GetExecutingAssembly().Location);
-        string? repositoryRoot = null;
-
-        while (directoryInfo != null)
-        {
-            if (Directory.Exists(Path.Combine(directoryInfo.FullName, ".git")) ||
-                Directory.Exists(Path.Combine(directoryInfo.FullName, ".github")) ||
-                File.Exists(Path.Combine(directoryInfo.FullName, "global.json")) ||
-                directoryInfo.Name == "artifacts")
-            {
-                repositoryRoot = directoryInfo.Name == "artifacts" ? directoryInfo.Parent?.FullName : directoryInfo.FullName;
-                break;
-            }
-
-            directoryInfo = directoryInfo.Parent;
-        }
-
-        RepositoryRoot ??= repositoryRoot;
-
-        if (RepositoryRoot == null)
-        {
-            throw new InvalidOperationException("Repository root has not been set and was not found when searching. " +
-                "Be sure that the value is set in a static constructor if setting directly.");
-        }
-
-        DevCertPath ??= Path.Combine(
-            RepositoryRoot,
-            "eng",
-            "common",
-            "testproxy",
-            "dotnet-devcert.pfx");
-    }
-
-    /// <summary>
     /// Gets or sets the recording mode for this test environment instance.
     /// Determines whether tests run against live services, record interactions, or replay recorded data.
     /// </summary>
     public RecordedTestMode? Mode { get; set; }
-
-    /// <summary>
-    /// Gets a value indicating whether the current platform is Windows.
-    /// Used for platform-specific test behavior and resource bootstrapping.
-    /// </summary>
-    public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
     /// <summary>
     /// Gets the credential provider for authenticating with Azure services during tests.
@@ -144,6 +244,16 @@ public abstract class TestEnvironment
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="TestEnvironment"/> class.
+    /// Loads environment configuration from the environment file.
+    /// </summary>
+    protected TestEnvironment()
+    {
+        _type = GetType();
+        _environmentFile = ParseEnvironmentFile();
+    }
+
+    /// <summary>
     /// Parses and returns environment variables from configuration files and system environment.
     /// Must be implemented by derived classes to define how environment configuration is loaded.
     /// </summary>
@@ -155,6 +265,74 @@ public abstract class TestEnvironment
     /// </summary>
     /// <returns>A task.</returns>
     public abstract Task WaitForEnvironmentAsync();
+
+    /// <summary>
+    /// Associates a test recording with this environment for variable recording and playback.
+    /// Resets the credential provider to ensure proper authentication context for the recording mode.
+    /// </summary>
+    /// <param name="recording">The test recording to associate with this environment.</param>
+    public virtual void SetRecording(TestRecording recording)
+    {
+        _credential = null;
+        _recording = recording;
+    }
+
+    /// <summary>
+    /// Attempts to bootstrap test resources by running the configured PowerShell script.
+    /// Only runs on Windows platforms when bootstrapping is enabled and not in Playback mode.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when PathToTestResourceBootstrappingScript is null and bootstrapping is attempted.
+    /// </exception>
+    public virtual void BootStrapTestResources()
+    {
+        lock (SyncLock)
+        {
+            if (DisableBootstrapping)
+            {
+                return;
+            }
+            if (PathToTestResourceBootstrappingScript is null)
+            {
+                throw new InvalidOperationException("Attempting to bootstrap test resources, but PathToTestResourceBootstrappingScript is null");
+            }
+            try
+            {
+                if (!IsWindows ||
+                    BootstrappingAttemptedTypes.Contains(_type) ||
+                    Mode == RecordedTestMode.Playback)
+                {
+                    return;
+                }
+
+                var processInfo = new ProcessStartInfo(
+                @"pwsh.exe",
+                PathToTestResourceBootstrappingScript)
+                {
+                    UseShellExecute = true
+                };
+                Process? process = null;
+                try
+                {
+                    process = Process.Start(processInfo);
+                }
+                catch (Exception ex)
+                {
+                    _bootstrappingException = ex;
+                }
+
+                if (process != null)
+                {
+                    process.WaitForExit();
+                    ParseEnvironmentFile();
+                }
+            }
+            finally
+            {
+                BootstrappingAttemptedTypes.Add(_type);
+            }
+        }
+    }
 
     /// <summary>
     /// Returns and records an environment variable value when running live or recorded value during playback.
@@ -253,10 +431,10 @@ public abstract class TestEnvironment
             _environmentFile?.TryGetValue(name, out value);
         }
 
-        if (value == null)
-        {
-            value = Environment.GetEnvironmentVariable(name);
-        }
+        // Since the System.ClientModel test framework is used by multiple Azure SDK
+        // client libraries, assume an Azure prefix convention if the requested name
+        // was not found in either source.
+        name = $"AZURE_{name}";
 
         if (value == null)
         {
@@ -265,7 +443,7 @@ public abstract class TestEnvironment
 
         if (value == null)
         {
-            _environmentFile?.TryGetValue(name, out value);
+            _environmentFile?.TryGetValue($"AZURE_{name}", out value);
         }
 
         return value;
@@ -306,17 +484,6 @@ public abstract class TestEnvironment
 
             throw new InvalidOperationException(message);
         }
-    }
-
-    /// <summary>
-    /// Associates a test recording with this environment for variable recording and playback.
-    /// Resets the credential provider to ensure proper authentication context for the recording mode.
-    /// </summary>
-    /// <param name="recording">The test recording to associate with this environment.</param>
-    public virtual void SetRecording(TestRecording recording)
-    {
-        _credential = null;
-        _recording = recording;
     }
 
     private string? GetRecordedValue(string name)
@@ -360,140 +527,48 @@ public abstract class TestEnvironment
     }
 
     /// <summary>
-    /// Determines if the current global test mode.
+    /// Finds the root path of the repository that contains the test project.
     /// </summary>
-    internal static RecordedTestMode GlobalTestMode
+    /// <returns>The root path of the repository.</returns>
+    /// <exception cref="System.InvalidOperationException">Unable to find repository root when searching from: {assemblyLocation}</exception>
+    protected static string FindRepositoryRoot()
     {
-        get
-        {
-            string? modeString = TestContext.Parameters["TestMode"] ?? Environment.GetEnvironmentVariable("CLIENTMODEL_TEST_MODE");
+        var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+        var directoryInfo = new DirectoryInfo(assemblyLocation);
+        string? repositoryRoot = null;
 
-            RecordedTestMode mode = RecordedTestMode.Playback;
-            if (!string.IsNullOrEmpty(modeString))
+        while (directoryInfo != null)
+        {
+            if (Directory.Exists(Path.Combine(directoryInfo.FullName, ".git")) ||
+                Directory.Exists(Path.Combine(directoryInfo.FullName, ".github")) ||
+                File.Exists(Path.Combine(directoryInfo.FullName, "global.json")) ||
+                directoryInfo.Name == "artifacts")
             {
-                mode = (RecordedTestMode)Enum.Parse(typeof(RecordedTestMode), modeString, true);
+                repositoryRoot = directoryInfo.Name == "artifacts" ? directoryInfo.Parent?.FullName : directoryInfo.FullName;
+                break;
             }
 
-            return mode;
+            directoryInfo = directoryInfo.Parent;
         }
+
+        return repositoryRoot
+            ?? throw new InvalidOperationException($"Unable to find repository root when searching from: {assemblyLocation}");
     }
 
     /// <summary>
-    /// Determines if tests that use <see cref="RecordedTestAttribute"/> should try to re-record on failure.
+    /// Finds the path to the development certificate used by the test proxy for HTTPS connections.
     /// </summary>
-    internal static bool GlobalDisableAutoRecording
+    /// <param name="repositoryRoot">The root directory of the repository that contains the test project.</param>
+    /// <returns>The path to the development certificate.</returns>
+    protected static string FindDevelopmentCertificatePath(string repositoryRoot)
     {
-        get
-        {
-            string? switchString = TestContext.Parameters["DisableAutoRecording"] ?? Environment.GetEnvironmentVariable("CLIENTMODEL_DISABLE_AUTO_RECORDING");
+        Argument.AssertNotNullOrEmpty(repositoryRoot, nameof(repositoryRoot));
 
-            bool.TryParse(switchString, out bool disableAutoRecording);
-
-            return disableAutoRecording;
-        }
-    }
-
-    /// <summary>
-    /// Determines whether to enable the test framework to proxy traffic through fiddler.
-    /// </summary>
-    internal static bool EnableFiddler
-    {
-        get
-        {
-            string? switchString = TestContext.Parameters["EnableFiddler"] ??
-                                  Environment.GetEnvironmentVariable("CLIENTMODEL_ENABLE_FIDDLER");
-
-            bool.TryParse(switchString, out bool enableFiddler);
-
-            return enableFiddler;
-        }
-    }
-
-    /// <summary>
-    /// Determines if the bootstrapping prompt and automatic resource group expiration extension should be disabled.
-    /// </summary>
-    internal static bool DisableBootstrapping
-    {
-        get
-        {
-            string? switchString = TestContext.Parameters["DisableBootstrapping"] ?? Environment.GetEnvironmentVariable("CLIENTMODEL_DISABLE_BOOTSTRAPPING");
-
-            bool.TryParse(switchString, out bool disableBootstrapping);
-
-            return disableBootstrapping;
-        }
-    }
-
-    /// <summary>
-    /// Determines whether to enable debug level proxy logging. Errors are logged by default.
-    /// </summary>
-    internal static bool EnableTestProxyDebugLogs
-    {
-        get
-        {
-            string? switchString = TestContext.Parameters[nameof(EnableTestProxyDebugLogs)] ??
-                                  Environment.GetEnvironmentVariable("CLIENTMODEL_ENABLE_TEST_PROXY_DEBUG_LOGS");
-
-            bool.TryParse(switchString, out bool enableProxyLogging);
-
-            return enableProxyLogging;
-        }
-    }
-
-    /// <summary>
-    /// Attempts to bootstrap test resources by running the configured PowerShell script.
-    /// Only runs on Windows platforms when bootstrapping is enabled and not in Playback mode.
-    /// </summary>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when PathToTestResourceBootstrappingScript is null and bootstrapping is attempted.
-    /// </exception>
-    public void BootStrapTestResources()
-    {
-        lock (s_syncLock)
-        {
-            if (DisableBootstrapping)
-            {
-                return;
-            }
-            if (PathToTestResourceBootstrappingScript is null)
-            {
-                throw new InvalidOperationException("Attempting to bootstrap test resources, but PathToTestResourceBootstrappingScript is null");
-            }
-            try
-            {
-                if (!IsWindows ||
-                    s_bootstrappingAttemptedTypes.Contains(_type) ||
-                    Mode == RecordedTestMode.Playback)
-                {
-                    return;
-                }
-
-                var processInfo = new ProcessStartInfo(
-                @"pwsh.exe",
-                PathToTestResourceBootstrappingScript)
-                {
-                    UseShellExecute = true
-                };
-                Process? process = null;
-                try
-                {
-                    process = Process.Start(processInfo);
-                }
-                catch (Exception ex)
-                {
-                    _bootstrappingException = ex;
-                }
-
-                if (process != null)
-                {
-                    process.WaitForExit();
-                    ParseEnvironmentFile();
-                }
-            }
-            finally
-            {
-                s_bootstrappingAttemptedTypes.Add(_type);
-            }
-        }
+        return Path.Combine(
+            repositoryRoot,
+            "eng",
+            "common",
+            "testproxy",
+            "dotnet-devcert.pfx");
     }
 }

--- a/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestEnvironment.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestEnvironment.cs
@@ -80,7 +80,7 @@ public abstract class TestEnvironment
     }
 
     /// <summary>
-    /// Determines if the current global test mode.
+    /// Determines if there is a current global test mode.
     /// </summary>
     internal static RecordedTestMode GlobalTestMode
     {

--- a/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestEnvironment.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestEnvironment.cs
@@ -438,12 +438,12 @@ public abstract class TestEnvironment
 
         if (value == null)
         {
-            value = Environment.GetEnvironmentVariable($"AZURE_{name}");
+            value = Environment.GetEnvironmentVariable(name);
         }
 
         if (value == null)
         {
-            _environmentFile?.TryGetValue($"AZURE_{name}", out value);
+            _environmentFile?.TryGetValue(name, out value);
         }
 
         return value;
@@ -524,6 +524,19 @@ public abstract class TestEnvironment
 
         Console.WriteLine($"Using fallback path: {assemblyDir}");
         return assemblyDir;
+    }
+
+    /// <summary>
+    ///   Intended for test use, this operation resets any
+    ///   static environment overrides back to their default state.
+    /// </summary>
+    internal static void ResetEnvironmentOverrides()
+    {
+        s_recordedTestMode = null;
+        s_disableAutoRecording = null;
+        s_enableFiddler = null;
+        s_disableBootstrapping = null;
+        s_enableTestProxyDebugLogs = null;
     }
 
     /// <summary>

--- a/sdk/core/Microsoft.ClientModel.TestFramework/tests/RecordedTests/TestProxy/TestEnvironmentTests.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/tests/RecordedTests/TestProxy/TestEnvironmentTests.cs
@@ -462,8 +462,7 @@ public class TestEnvironmentTests
     [TearDown]
     public void ResetStaticProperties()
     {
-        // Reset all static properties to their default state after each test
-        // by setting them to read from environment variables again
+        // Reset all static properties to their default state after each test.
         TestEnvironment.GlobalTestMode = RecordedTestMode.Playback;
         TestEnvironment.GlobalDisableAutoRecording = false;
         TestEnvironment.EnableFiddler = false;

--- a/sdk/core/Microsoft.ClientModel.TestFramework/tests/RecordedTests/TestProxy/TestEnvironmentTests.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/tests/RecordedTests/TestProxy/TestEnvironmentTests.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.IO;
 using Moq;
-using System.ClientModel;
+using NUnit.Framework;
 
 namespace Microsoft.ClientModel.TestFramework.Tests;
 
@@ -199,33 +197,41 @@ public class TestEnvironmentTests
     }
 
     [Test]
+    [NonParallelizable]
     public void GetVariableWithNonExistingVariableThrowsInvalidOperationException()
     {
+        TestEnvironment.DisableBootstrapping = true;
         var environment = new TestableTestEnvironment();
-        // Set a dummy script path to avoid bootstrapping exception and get to the actual variable missing exception
-        environment.PathToTestResourceBootstrappingScript = @"C:\dummy\script.ps1";
 
         var exception = Assert.Throws<InvalidOperationException>(() => environment.GetVariable("MISSING_VAR"));
+
         Assert.That(exception.Message, Does.Contain("Unable to find environment variable MISSING_VAR"));
     }
 
     [Test]
+    [NonParallelizable]
     public void GetVariableWithNonExistingVariableAndNoBootstrapScriptThrowsBootstrapException()
     {
+        TestEnvironment.DisableBootstrapping = false;
         var environment = new TestableTestEnvironment();
         environment.PathToTestResourceBootstrappingScript = null;
 
-        if (!TestEnvironment.DisableBootstrapping)
-        {
-            var exception = Assert.Throws<InvalidOperationException>(() => environment.GetVariable("MISSING_VAR"));
-            Assert.That(exception.Message, Does.Contain("PathToTestResourceBootstrappingScript is null"));
-        }
-        else
-        {
-            // If bootstrapping is disabled, should get the variable not found exception
-            var exception = Assert.Throws<InvalidOperationException>(() => environment.GetVariable("MISSING_VAR"));
-            Assert.That(exception.Message, Does.Contain("Unable to find environment variable MISSING_VAR"));
-        }
+        var exception = Assert.Throws<InvalidOperationException>(() => environment.GetVariable("MISSING_VAR"));
+
+        Assert.That(exception.Message, Does.Contain("PathToTestResourceBootstrappingScript is null"));
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void GetVariableWithNonExistingVariableWhenBootstrappingDisabledThrowsVariableNotFoundException()
+    {
+        TestEnvironment.DisableBootstrapping = true;
+        var environment = new TestableTestEnvironment();
+        environment.PathToTestResourceBootstrappingScript = null;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => environment.GetVariable("MISSING_VAR"));
+
+        Assert.That(exception.Message, Does.Contain("Unable to find environment variable MISSING_VAR"));
     }
 
     #endregion
@@ -319,15 +325,16 @@ public class TestEnvironmentTests
     }
 
     [Test]
+    [NonParallelizable]
     public void GetRecordedVariableWithMissingVariableThrowsInvalidOperationException()
     {
+        TestEnvironment.DisableBootstrapping = true;
         var environment = new TestableTestEnvironment();
         environment.Mode = RecordedTestMode.Live;
-        // Set a dummy script path to avoid bootstrapping exception and get to the actual variable missing exception
-        environment.PathToTestResourceBootstrappingScript = @"C:\dummy\script.ps1";
 
         var exception = Assert.Throws<InvalidOperationException>(() =>
             environment.GetRecordedVariable("MISSING_VAR"));
+
         Assert.That(exception.Message, Does.Contain("Unable to find environment variable MISSING_VAR"));
     }
 
@@ -379,40 +386,41 @@ public class TestEnvironmentTests
     #region BootStrapTestResources Method
 
     [Test]
+    [NonParallelizable]
     public void BootStrapTestResourcesWithNullScriptPathThrowsInvalidOperationException()
     {
+        TestEnvironment.DisableBootstrapping = false;
         var environment = new TestableTestEnvironment();
         environment.PathToTestResourceBootstrappingScript = null;
 
-        if (!TestEnvironment.DisableBootstrapping)
-        {
-            var exception = Assert.Throws<InvalidOperationException>(() => environment.BootStrapTestResources());
-            Assert.That(exception.Message, Does.Contain("PathToTestResourceBootstrappingScript is null"));
-        }
+        var exception = Assert.Throws<InvalidOperationException>(() => environment.BootStrapTestResources());
+
+        Assert.That(exception.Message, Does.Contain("PathToTestResourceBootstrappingScript is null"));
     }
 
     [Test]
-    public void BootStrapTestResourcesWhenBootstrappingDisabledDoesNotThrow()
+    [NonParallelizable]
+    public void BootStrapTestResourcesWhenBootstrappingDisabledReturnsEarly()
     {
+        TestEnvironment.DisableBootstrapping = true;
         var environment = new TestableTestEnvironment();
         environment.PathToTestResourceBootstrappingScript = null;
 
-        // Set environment variable to disable bootstrapping using TestEnvVar
-        using var envVar = new TestEnvVar("CLIENTMODEL_DISABLE_BOOTSTRAPPING", "true");
-
-        // This should not throw regardless of script path if bootstrapping is disabled
-        Assert.DoesNotThrow(() => environment.BootStrapTestResources());
+        // Should return early without throwing when bootstrapping is disabled
+        environment.BootStrapTestResources();
     }
 
     [Test]
-    public void BootStrapTestResourcesInPlaybackModeDoesNotExecute()
+    [NonParallelizable]
+    public void BootStrapTestResourcesInPlaybackModeReturnsEarly()
     {
+        TestEnvironment.DisableBootstrapping = false;
         var environment = new TestableTestEnvironment();
         environment.Mode = RecordedTestMode.Playback;
         environment.PathToTestResourceBootstrappingScript = @"C:\nonexistent\script.ps1";
 
-        // Should not throw even with invalid script path in Playback mode
-        Assert.DoesNotThrow(() => environment.BootStrapTestResources());
+        // Should return early in Playback mode without attempting to execute the script
+        environment.BootStrapTestResources();
     }
 
     #endregion
@@ -445,6 +453,135 @@ public class TestEnvironmentTests
             Assert.That(result, Contains.Key("KEY2"));
         }
         Assert.That(result["KEY2"], Is.EqualTo("VALUE2"));
+    }
+
+    #endregion
+
+    #region Static Environment Properties
+
+    [TearDown]
+    public void ResetStaticProperties()
+    {
+        // Reset all static properties to their default state after each test
+        // by setting them to read from environment variables again
+        TestEnvironment.GlobalTestMode = RecordedTestMode.Playback;
+        TestEnvironment.GlobalDisableAutoRecording = false;
+        TestEnvironment.EnableFiddler = false;
+        TestEnvironment.DisableBootstrapping = false;
+        TestEnvironment.EnableTestProxyDebugLogs = false;
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void GlobalTestModeCanBeSetAndRetrieved()
+    {
+        TestEnvironment.GlobalTestMode = RecordedTestMode.Live;
+        Assert.That(TestEnvironment.GlobalTestMode, Is.EqualTo(RecordedTestMode.Live));
+
+        TestEnvironment.GlobalTestMode = RecordedTestMode.Record;
+        Assert.That(TestEnvironment.GlobalTestMode, Is.EqualTo(RecordedTestMode.Record));
+
+        TestEnvironment.GlobalTestMode = RecordedTestMode.Playback;
+        Assert.That(TestEnvironment.GlobalTestMode, Is.EqualTo(RecordedTestMode.Playback));
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void GlobalTestModeExplicitValueTakesPrecedenceOverEnvironment()
+    {
+        using var envVar = new TestEnvVar("CLIENTMODEL_TEST_MODE", "Record");
+
+        TestEnvironment.GlobalTestMode = RecordedTestMode.Playback;
+
+        Assert.That(TestEnvironment.GlobalTestMode, Is.EqualTo(RecordedTestMode.Playback));
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void GlobalDisableAutoRecordingCanBeSetAndRetrieved()
+    {
+        TestEnvironment.GlobalDisableAutoRecording = true;
+        Assert.That(TestEnvironment.GlobalDisableAutoRecording, Is.True);
+
+        TestEnvironment.GlobalDisableAutoRecording = false;
+        Assert.That(TestEnvironment.GlobalDisableAutoRecording, Is.False);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void GlobalDisableAutoRecordingExplicitValueTakesPrecedenceOverEnvironment()
+    {
+        using var envVar = new TestEnvVar("CLIENTMODEL_DISABLE_AUTO_RECORDING", "true");
+
+        TestEnvironment.GlobalDisableAutoRecording = false;
+
+        Assert.That(TestEnvironment.GlobalDisableAutoRecording, Is.False);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void EnableFiddlerCanBeSetAndRetrieved()
+    {
+        TestEnvironment.EnableFiddler = true;
+        Assert.That(TestEnvironment.EnableFiddler, Is.True);
+
+        TestEnvironment.EnableFiddler = false;
+        Assert.That(TestEnvironment.EnableFiddler, Is.False);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void EnableFiddlerExplicitValueTakesPrecedenceOverEnvironment()
+    {
+        using var envVar = new TestEnvVar("CLIENTMODEL_ENABLE_FIDDLER", "true");
+
+        TestEnvironment.EnableFiddler = false;
+
+        Assert.That(TestEnvironment.EnableFiddler, Is.False);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void DisableBootstrappingCanBeSetAndRetrieved()
+    {
+        TestEnvironment.DisableBootstrapping = true;
+        Assert.That(TestEnvironment.DisableBootstrapping, Is.True);
+
+        TestEnvironment.DisableBootstrapping = false;
+        Assert.That(TestEnvironment.DisableBootstrapping, Is.False);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void DisableBootstrappingExplicitValueTakesPrecedenceOverEnvironment()
+    {
+        using var envVar = new TestEnvVar("CLIENTMODEL_DISABLE_BOOTSTRAPPING", "true");
+
+        TestEnvironment.DisableBootstrapping = false;
+
+        Assert.That(TestEnvironment.DisableBootstrapping, Is.False);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void EnableTestProxyDebugLogsCanBeSetAndRetrieved()
+    {
+        TestEnvironment.EnableTestProxyDebugLogs = true;
+        Assert.That(TestEnvironment.EnableTestProxyDebugLogs, Is.True);
+
+        TestEnvironment.EnableTestProxyDebugLogs = false;
+        Assert.That(TestEnvironment.EnableTestProxyDebugLogs, Is.False);
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void EnableTestProxyDebugLogsExplicitValueTakesPrecedenceOverEnvironment()
+    {
+        using var envVar = new TestEnvVar("CLIENTMODEL_ENABLE_TEST_PROXY_DEBUG_LOGS", "true");
+
+        TestEnvironment.EnableTestProxyDebugLogs = false;
+
+        Assert.That(TestEnvironment.EnableTestProxyDebugLogs, Is.False);
     }
 
     #endregion

--- a/sdk/core/Microsoft.ClientModel.TestFramework/tests/RecordedTests/TestProxy/TestEnvironmentTests.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/tests/RecordedTests/TestProxy/TestEnvironmentTests.cs
@@ -13,6 +13,14 @@ namespace Microsoft.ClientModel.TestFramework.Tests;
 [TestFixture]
 public class TestEnvironmentTests
 {
+    [TearDown]
+    public void TearDown()
+    {
+        // Clear all static overrides after each test so subsequent tests
+        // can rely on environment variables and default behavior.
+        TestEnvironment.ResetEnvironmentOverrides();
+    }
+
     #region Test Implementation
 
     private class TestableTestEnvironment : TestEnvironment
@@ -458,17 +466,6 @@ public class TestEnvironmentTests
     #endregion
 
     #region Static Environment Properties
-
-    [TearDown]
-    public void ResetStaticProperties()
-    {
-        // Reset all static properties to their default state after each test.
-        TestEnvironment.GlobalTestMode = RecordedTestMode.Playback;
-        TestEnvironment.GlobalDisableAutoRecording = false;
-        TestEnvironment.EnableFiddler = false;
-        TestEnvironment.DisableBootstrapping = false;
-        TestEnvironment.EnableTestProxyDebugLogs = false;
-    }
 
     [Test]
     [NonParallelizable]


### PR DESCRIPTION
# Summary

The focus of these changes is to revise how the `TestEnvironment` initializes its static state, attempting to defer initialization until state is needed to allow derived environments to customize initialization and override state.  The pattern of eager initialization in a static constructor has been replaced with property-focused lazy initialization, also moving from read-only members to allowing overrides by derived environments.

Members of `TestEnvironment` were also sorted by visibility and static/instance for organization and better locality of like members.