### PR TITLE
[ClientModel Test Framework] Configurability

### DIFF
--- a/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net10.0.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net10.0.cs
@@ -380,6 +380,11 @@ namespace Microsoft.ClientModel.TestFramework
         protected TestEnvironment() { }
         public virtual System.ClientModel.AuthenticationTokenProvider Credential { get { throw null; } }
         public static string? DevCertPath { get { throw null; } protected set { } }
+        public static bool DisableBootstrapping { get { throw null; } set { } }
+        public static bool EnableFiddler { get { throw null; } set { } }
+        public static bool EnableTestProxyDebugLogs { get { throw null; } set { } }
+        public static bool GlobalDisableAutoRecording { get { throw null; } set { } }
+        public static Microsoft.ClientModel.TestFramework.RecordedTestMode GlobalTestMode { get { throw null; } set { } }
         public static bool IsWindows { get { throw null; } }
         public Microsoft.ClientModel.TestFramework.RecordedTestMode? Mode { get { throw null; } set { } }
         public string? PathToTestResourceBootstrappingScript { get { throw null; } set { } }

--- a/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net462.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net462.cs
@@ -380,6 +380,11 @@ namespace Microsoft.ClientModel.TestFramework
         protected TestEnvironment() { }
         public virtual System.ClientModel.AuthenticationTokenProvider Credential { get { throw null; } }
         public static string? DevCertPath { get { throw null; } protected set { } }
+        public static bool DisableBootstrapping { get { throw null; } set { } }
+        public static bool EnableFiddler { get { throw null; } set { } }
+        public static bool EnableTestProxyDebugLogs { get { throw null; } set { } }
+        public static bool GlobalDisableAutoRecording { get { throw null; } set { } }
+        public static Microsoft.ClientModel.TestFramework.RecordedTestMode GlobalTestMode { get { throw null; } set { } }
         public static bool IsWindows { get { throw null; } }
         public Microsoft.ClientModel.TestFramework.RecordedTestMode? Mode { get { throw null; } set { } }
         public string? PathToTestResourceBootstrappingScript { get { throw null; } set { } }

--- a/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net8.0.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net8.0.cs
@@ -380,6 +380,11 @@ namespace Microsoft.ClientModel.TestFramework
         protected TestEnvironment() { }
         public virtual System.ClientModel.AuthenticationTokenProvider Credential { get { throw null; } }
         public static string? DevCertPath { get { throw null; } protected set { } }
+        public static bool DisableBootstrapping { get { throw null; } set { } }
+        public static bool EnableFiddler { get { throw null; } set { } }
+        public static bool EnableTestProxyDebugLogs { get { throw null; } set { } }
+        public static bool GlobalDisableAutoRecording { get { throw null; } set { } }
+        public static Microsoft.ClientModel.TestFramework.RecordedTestMode GlobalTestMode { get { throw null; } set { } }
         public static bool IsWindows { get { throw null; } }
         public Microsoft.ClientModel.TestFramework.RecordedTestMode? Mode { get { throw null; } set { } }
         public string? PathToTestResourceBootstrappingScript { get { throw null; } set { } }

--- a/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net9.0.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/api/Microsoft.ClientModel.TestFramework.net9.0.cs
@@ -380,6 +380,11 @@ namespace Microsoft.ClientModel.TestFramework
         protected TestEnvironment() { }
         public virtual System.ClientModel.AuthenticationTokenProvider Credential { get { throw null; } }
         public static string? DevCertPath { get { throw null; } protected set { } }
+        public static bool DisableBootstrapping { get { throw null; } set { } }
+        public static bool EnableFiddler { get { throw null; } set { } }
+        public static bool EnableTestProxyDebugLogs { get { throw null; } set { } }
+        public static bool GlobalDisableAutoRecording { get { throw null; } set { } }
+        public static Microsoft.ClientModel.TestFramework.RecordedTestMode GlobalTestMode { get { throw null; } set { } }
         public static bool IsWindows { get { throw null; } }
         public Microsoft.ClientModel.TestFramework.RecordedTestMode? Mode { get { throw null; } set { } }
         public string? PathToTestResourceBootstrappingScript { get { throw null; } set { } }

--- a/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestEnvironment.cs
+++ b/sdk/core/Microsoft.ClientModel.TestFramework/src/RecordedTests/TestProxy/TestEnvironment.cs
@@ -82,7 +82,7 @@ public abstract class TestEnvironment
     /// <summary>
     /// Determines if there is a current global test mode.
     /// </summary>
-    internal static RecordedTestMode GlobalTestMode
+    public static RecordedTestMode GlobalTestMode
     {
         get
         {
@@ -113,7 +113,7 @@ public abstract class TestEnvironment
     /// <summary>
     /// Determines if tests that use <see cref="RecordedTestAttribute"/> should try to re-record on failure.
     /// </summary>
-    internal static bool GlobalDisableAutoRecording
+    public static bool GlobalDisableAutoRecording
     {
         get
         {
@@ -139,7 +139,7 @@ public abstract class TestEnvironment
     /// <summary>
     /// Determines whether to enable the test framework to proxy traffic through fiddler.
     /// </summary>
-    internal static bool EnableFiddler
+    public static bool EnableFiddler
     {
         get
         {
@@ -164,7 +164,7 @@ public abstract class TestEnvironment
     /// <summary>
     /// Determines if the bootstrapping prompt and automatic resource group expiration extension should be disabled.
     /// </summary>
-    internal static bool DisableBootstrapping
+    public static bool DisableBootstrapping
     {
         get
         {
@@ -188,7 +188,7 @@ public abstract class TestEnvironment
     /// <summary>
     /// Determines whether to enable debug level proxy logging. Errors are logged by default.
     /// </summary>
-    internal static bool EnableTestProxyDebugLogs
+    public static bool EnableTestProxyDebugLogs
     {
         get
         {


### PR DESCRIPTION
# Summary

Moving some internal properties related to environment configuration to public, so that they can be set by projects consuming the test framework.