### PR TITLE
[PostgreSql] Remove show-serialized-names debug config and release 1.4.1

### DIFF
--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/CHANGELOG.md
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.5.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.4.1 (2026-02-12)
 
 ### Other Changes
+
+- Removed `show-serialized-names` debug configuration to clean up unnecessary serialized name annotations from XML docs.
 
 ## 1.4.0 (2026-01-30)
 

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Azure.ResourceManager.PostgreSql.csproj
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Azure.ResourceManager.PostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0-beta.1</Version>
+    <Version>1.4.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.4.0</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.PostgreSql</PackageId>

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/ArmPostgreSqlFlexibleServersModelFactory.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/ArmPostgreSqlFlexibleServersModelFactory.cs
@@ -18,14 +18,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
     public static partial class ArmPostgreSqlFlexibleServersModelFactory
     {
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerNameAvailabilityContent"/>. </summary>
-        /// <param name="name">
-        /// The name of the resource for which availability needs to be checked.
-        /// Serialized Name: CheckNameAvailabilityRequest.name
-        /// </param>
-        /// <param name="resourceType">
-        /// The resource type.
-        /// Serialized Name: CheckNameAvailabilityRequest.type
-        /// </param>
+        /// <param name="name"> The name of the resource for which availability needs to be checked. </param>
+        /// <param name="resourceType"> The resource type. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerNameAvailabilityContent"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerNameAvailabilityContent PostgreSqlFlexibleServerNameAvailabilityContent(string name = null, ResourceType? resourceType = null)
         {
@@ -33,26 +27,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerNameAvailabilityResult"/>. </summary>
-        /// <param name="isNameAvailable">
-        /// Indicates if the resource name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.nameAvailable
-        /// </param>
-        /// <param name="reason">
-        /// The reason why the given name is not available.
-        /// Serialized Name: CheckNameAvailabilityResponse.reason
-        /// </param>
-        /// <param name="message">
-        /// Detailed reason why the given name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.message
-        /// </param>
-        /// <param name="name">
-        /// Name for which validity and availability was checked.
-        /// Serialized Name: NameAvailabilityModel.name
-        /// </param>
-        /// <param name="resourceType">
-        /// Type of resource. It can be 'Microsoft.DBforPostgreSQL/flexibleServers' or 'Microsoft.DBforPostgreSQL/flexibleServers/virtualendpoints'.
-        /// Serialized Name: NameAvailabilityModel.type
-        /// </param>
+        /// <param name="isNameAvailable"> Indicates if the resource name is available. </param>
+        /// <param name="reason"> The reason why the given name is not available. </param>
+        /// <param name="message"> Detailed reason why the given name is available. </param>
+        /// <param name="name"> Name for which validity and availability was checked. </param>
+        /// <param name="resourceType"> Type of resource. It can be 'Microsoft.DBforPostgreSQL/flexibleServers' or 'Microsoft.DBforPostgreSQL/flexibleServers/virtualendpoints'. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerNameAvailabilityResult"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerNameAvailabilityResult PostgreSqlFlexibleServerNameAvailabilityResult(bool? isNameAvailable = null, PostgreSqlFlexibleServerNameUnavailableReason? reason = null, string message = null, string name = null, ResourceType? resourceType = null)
         {
@@ -66,18 +45,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerNameAvailabilityResponse"/>. </summary>
-        /// <param name="isNameAvailable">
-        /// Indicates if the resource name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.nameAvailable
-        /// </param>
-        /// <param name="reason">
-        /// The reason why the given name is not available.
-        /// Serialized Name: CheckNameAvailabilityResponse.reason
-        /// </param>
-        /// <param name="message">
-        /// Detailed reason why the given name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.message
-        /// </param>
+        /// <param name="isNameAvailable"> Indicates if the resource name is available. </param>
+        /// <param name="reason"> The reason why the given name is not available. </param>
+        /// <param name="message"> Detailed reason why the given name is available. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerNameAvailabilityResponse"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerNameAvailabilityResponse PostgreSqlFlexibleServerNameAvailabilityResponse(bool? isNameAvailable = null, PostgreSqlFlexibleServerNameUnavailableReason? reason = null, string message = null)
         {
@@ -91,102 +61,30 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="sku">
-        /// Compute tier and size of a server.
-        /// Serialized Name: Server.sku
-        /// </param>
-        /// <param name="identity">
-        /// User assigned managed identities assigned to the server.
-        /// Serialized Name: Server.identity
-        /// </param>
-        /// <param name="administratorLogin">
-        /// Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted.
-        /// Serialized Name: Server.properties.administratorLogin
-        /// </param>
-        /// <param name="administratorLoginPassword">
-        /// Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time.
-        /// Serialized Name: Server.properties.administratorLoginPassword
-        /// </param>
-        /// <param name="version">
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: Server.properties.version
-        /// </param>
-        /// <param name="minorVersion">
-        /// Minor version of PostgreSQL database engine.
-        /// Serialized Name: Server.properties.minorVersion
-        /// </param>
-        /// <param name="state">
-        /// Possible states of a server.
-        /// Serialized Name: Server.properties.state
-        /// </param>
-        /// <param name="fullyQualifiedDomainName">
-        /// Fully qualified domain name of a server.
-        /// Serialized Name: Server.properties.fullyQualifiedDomainName
-        /// </param>
-        /// <param name="storage">
-        /// Storage properties of a server.
-        /// Serialized Name: Server.properties.storage
-        /// </param>
-        /// <param name="authConfig">
-        /// Authentication configuration properties of a server.
-        /// Serialized Name: Server.properties.authConfig
-        /// </param>
-        /// <param name="dataEncryption">
-        /// Data encryption properties of a server.
-        /// Serialized Name: Server.properties.dataEncryption
-        /// </param>
-        /// <param name="backup">
-        /// Backup properties of a server.
-        /// Serialized Name: Server.properties.backup
-        /// </param>
-        /// <param name="network">
-        /// Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer.
-        /// Serialized Name: Server.properties.network
-        /// </param>
-        /// <param name="highAvailability">
-        /// High availability properties of a server.
-        /// Serialized Name: Server.properties.highAvailability
-        /// </param>
-        /// <param name="maintenanceWindow">
-        /// Maintenance window properties of a server.
-        /// Serialized Name: Server.properties.maintenanceWindow
-        /// </param>
-        /// <param name="sourceServerResourceId">
-        /// Identifier of the server to be used as the source of the new server. Required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', 'Replica', or 'ReviveDropped'. This property is returned only when the target server is a read replica.
-        /// Serialized Name: Server.properties.sourceServerResourceId
-        /// </param>
-        /// <param name="pointInTimeUtc">
-        /// Creation time (in ISO8601 format) of the backup which you want to restore in the new server. It's required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', or 'ReviveDropped'.
-        /// Serialized Name: Server.properties.pointInTimeUTC
-        /// </param>
-        /// <param name="availabilityZone">
-        /// Availability zone of a server.
-        /// Serialized Name: Server.properties.availabilityZone
-        /// </param>
-        /// <param name="replicationRole">
-        /// Role of the server in a replication set.
-        /// Serialized Name: Server.properties.replicationRole
-        /// </param>
-        /// <param name="replicaCapacity">
-        /// Maximum number of read replicas allowed for a server.
-        /// Serialized Name: Server.properties.replicaCapacity
-        /// </param>
-        /// <param name="replica">
-        /// Read replica properties of a server. Required only in case that you want to promote a server.
-        /// Serialized Name: Server.properties.replica
-        /// </param>
-        /// <param name="createMode">
-        /// Creation mode of a new server.
-        /// Serialized Name: Server.properties.createMode
-        /// </param>
-        /// <param name="privateEndpointConnections">
-        /// List of private endpoint connections associated with the specified server.
-        /// Serialized Name: Server.properties.privateEndpointConnections
-        /// </param>
-        /// <param name="cluster">
-        /// Cluster properties of a server.
-        /// Serialized Name: Server.properties.cluster
-        /// </param>
+        /// <param name="sku"> Compute tier and size of a server. </param>
+        /// <param name="identity"> User assigned managed identities assigned to the server. </param>
+        /// <param name="administratorLogin"> Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted. </param>
+        /// <param name="administratorLoginPassword"> Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time. </param>
+        /// <param name="version"> Major version of PostgreSQL database engine. </param>
+        /// <param name="minorVersion"> Minor version of PostgreSQL database engine. </param>
+        /// <param name="state"> Possible states of a server. </param>
+        /// <param name="fullyQualifiedDomainName"> Fully qualified domain name of a server. </param>
+        /// <param name="storage"> Storage properties of a server. </param>
+        /// <param name="authConfig"> Authentication configuration properties of a server. </param>
+        /// <param name="dataEncryption"> Data encryption properties of a server. </param>
+        /// <param name="backup"> Backup properties of a server. </param>
+        /// <param name="network"> Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer. </param>
+        /// <param name="highAvailability"> High availability properties of a server. </param>
+        /// <param name="maintenanceWindow"> Maintenance window properties of a server. </param>
+        /// <param name="sourceServerResourceId"> Identifier of the server to be used as the source of the new server. Required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', 'Replica', or 'ReviveDropped'. This property is returned only when the target server is a read replica. </param>
+        /// <param name="pointInTimeUtc"> Creation time (in ISO8601 format) of the backup which you want to restore in the new server. It's required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', or 'ReviveDropped'. </param>
+        /// <param name="availabilityZone"> Availability zone of a server. </param>
+        /// <param name="replicationRole"> Role of the server in a replication set. </param>
+        /// <param name="replicaCapacity"> Maximum number of read replicas allowed for a server. </param>
+        /// <param name="replica"> Read replica properties of a server. Required only in case that you want to promote a server. </param>
+        /// <param name="createMode"> Creation mode of a new server. </param>
+        /// <param name="privateEndpointConnections"> List of private endpoint connections associated with the specified server. </param>
+        /// <param name="cluster"> Cluster properties of a server. </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlFlexibleServerData"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerData PostgreSqlFlexibleServerData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IDictionary<string, string> tags = null, AzureLocation location = default, PostgreSqlFlexibleServerSku sku = null, PostgreSqlFlexibleServerUserAssignedIdentity identity = null, string administratorLogin = null, string administratorLoginPassword = null, PostgreSqlFlexibleServerVersion? version = null, string minorVersion = null, PostgreSqlFlexibleServerState? state = null, string fullyQualifiedDomainName = null, PostgreSqlFlexibleServerStorage storage = null, PostgreSqlFlexibleServerAuthConfig authConfig = null, PostgreSqlFlexibleServerDataEncryption dataEncryption = null, PostgreSqlFlexibleServerBackupProperties backup = null, PostgreSqlFlexibleServerNetwork network = null, PostgreSqlFlexibleServerHighAvailability highAvailability = null, PostgreSqlFlexibleServerMaintenanceWindow maintenanceWindow = null, ResourceIdentifier sourceServerResourceId = null, DateTimeOffset? pointInTimeUtc = null, string availabilityZone = null, PostgreSqlFlexibleServerReplicationRole? replicationRole = null, int? replicaCapacity = null, PostgreSqlFlexibleServersReplica replica = null, PostgreSqlFlexibleServerCreateMode? createMode = null, IEnumerable<PostgreSqlFlexibleServersPrivateEndpointConnectionData> privateEndpointConnections = null, PostgreSqlFlexibleServerClusterProperties cluster = null)
         {
@@ -228,18 +126,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerBackupProperties"/>. </summary>
-        /// <param name="backupRetentionDays">
-        /// Backup retention days for the server.
-        /// Serialized Name: Backup.backupRetentionDays
-        /// </param>
-        /// <param name="geoRedundantBackup">
-        /// Indicates if the server is configured to create geographically redundant backups.
-        /// Serialized Name: Backup.geoRedundantBackup
-        /// </param>
-        /// <param name="earliestRestoreOn">
-        /// Earliest restore point time (ISO8601 format) for a server.
-        /// Serialized Name: Backup.earliestRestoreDate
-        /// </param>
+        /// <param name="backupRetentionDays"> Backup retention days for the server. </param>
+        /// <param name="geoRedundantBackup"> Indicates if the server is configured to create geographically redundant backups. </param>
+        /// <param name="earliestRestoreOn"> Earliest restore point time (ISO8601 format) for a server. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerBackupProperties"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerBackupProperties PostgreSqlFlexibleServerBackupProperties(int? backupRetentionDays = null, PostgreSqlFlexibleServerGeoRedundantBackupEnum? geoRedundantBackup = null, DateTimeOffset? earliestRestoreOn = null)
         {
@@ -247,18 +136,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerHighAvailability"/>. </summary>
-        /// <param name="mode">
-        /// High availability mode for a server.
-        /// Serialized Name: HighAvailability.mode
-        /// </param>
-        /// <param name="state">
-        /// Possible states of the standby server created when high availability is set to SameZone or ZoneRedundant.
-        /// Serialized Name: HighAvailability.state
-        /// </param>
-        /// <param name="standbyAvailabilityZone">
-        /// Availability zone associated to the standby server created when high availability is set to SameZone or ZoneRedundant.
-        /// Serialized Name: HighAvailability.standbyAvailabilityZone
-        /// </param>
+        /// <param name="mode"> High availability mode for a server. </param>
+        /// <param name="state"> Possible states of the standby server created when high availability is set to SameZone or ZoneRedundant. </param>
+        /// <param name="standbyAvailabilityZone"> Availability zone associated to the standby server created when high availability is set to SameZone or ZoneRedundant. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerHighAvailability"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerHighAvailability PostgreSqlFlexibleServerHighAvailability(PostgreSqlFlexibleServerHighAvailabilityMode? mode = null, PostgreSqlFlexibleServerHAState? state = null, string standbyAvailabilityZone = null)
         {
@@ -266,26 +146,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServersReplica"/>. </summary>
-        /// <param name="role">
-        /// Role of the server in a replication set.
-        /// Serialized Name: Replica.role
-        /// </param>
-        /// <param name="capacity">
-        /// Maximum number of read replicas allowed for a server.
-        /// Serialized Name: Replica.capacity
-        /// </param>
-        /// <param name="replicationState">
-        /// Indicates the replication state of a read replica. This property is returned only when the target server is a read replica. Possible  values are Active, Broken, Catchup, Provisioning, Reconfiguring, and Updating
-        /// Serialized Name: Replica.replicationState
-        /// </param>
-        /// <param name="promoteMode">
-        /// Type of operation to apply on the read replica. This property is write only. Standalone means that the read replica will be promoted to a standalone server, and will become a completely independent entity from the replication set. Switchover means that the read replica will roles with the primary server.
-        /// Serialized Name: Replica.promoteMode
-        /// </param>
-        /// <param name="promoteOption">
-        /// Data synchronization option to use when processing the operation specified in the promoteMode property. This property is write only.
-        /// Serialized Name: Replica.promoteOption
-        /// </param>
+        /// <param name="role"> Role of the server in a replication set. </param>
+        /// <param name="capacity"> Maximum number of read replicas allowed for a server. </param>
+        /// <param name="replicationState"> Indicates the replication state of a read replica. This property is returned only when the target server is a read replica. Possible  values are Active, Broken, Catchup, Provisioning, Reconfiguring, and Updating. </param>
+        /// <param name="promoteMode"> Type of operation to apply on the read replica. This property is write only. Standalone means that the read replica will be promoted to a standalone server, and will become a completely independent entity from the replication set. Switchover means that the read replica will roles with the primary server. </param>
+        /// <param name="promoteOption"> Data synchronization option to use when processing the operation specified in the promoteMode property. This property is write only. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServersReplica"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServersReplica PostgreSqlFlexibleServersReplica(PostgreSqlFlexibleServerReplicationRole? role = null, int? capacity = null, PostgreSqlFlexibleServersReplicationState? replicationState = null, ReadReplicaPromoteMode? promoteMode = null, ReplicationPromoteOption? promoteOption = null)
         {
@@ -303,22 +168,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="groupIds">
-        /// The group ids for the private endpoint resource.
-        /// Serialized Name: PrivateEndpointConnection.properties.groupIds
-        /// </param>
-        /// <param name="privateEndpointId">
-        /// The private endpoint resource.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateEndpoint
-        /// </param>
-        /// <param name="connectionState">
-        /// A collection of information about the state of the connection between service consumer and provider.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateLinkServiceConnectionState
-        /// </param>
-        /// <param name="provisioningState">
-        /// The provisioning state of the private endpoint connection resource.
-        /// Serialized Name: PrivateEndpointConnection.properties.provisioningState
-        /// </param>
+        /// <param name="groupIds"> The group ids for the private endpoint resource. </param>
+        /// <param name="privateEndpointId"> The private endpoint resource. </param>
+        /// <param name="connectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
+        /// <param name="provisioningState"> The provisioning state of the private endpoint connection resource. </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlFlexibleServersPrivateEndpointConnectionData"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServersPrivateEndpointConnectionData PostgreSqlFlexibleServersPrivateEndpointConnectionData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IEnumerable<string> groupIds = null, ResourceIdentifier privateEndpointId = null, PostgreSqlFlexibleServersPrivateLinkServiceConnectionState connectionState = null, PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState? provisioningState = null)
         {
@@ -337,22 +190,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerUserAssignedIdentity"/>. </summary>
-        /// <param name="userAssignedIdentities">
-        /// Map of user assigned managed identities.
-        /// Serialized Name: UserAssignedIdentity.userAssignedIdentities
-        /// </param>
-        /// <param name="principalId">
-        /// Identifier of the object of the service principal associated to the user assigned managed identity.
-        /// Serialized Name: UserAssignedIdentity.principalId
-        /// </param>
-        /// <param name="identityType">
-        /// Types of identities associated with a server.
-        /// Serialized Name: UserAssignedIdentity.type
-        /// </param>
-        /// <param name="tenantId">
-        /// Identifier of the tenant of a server.
-        /// Serialized Name: UserAssignedIdentity.tenantId
-        /// </param>
+        /// <param name="userAssignedIdentities"> Map of user assigned managed identities. </param>
+        /// <param name="principalId"> Identifier of the object of the service principal associated to the user assigned managed identity. </param>
+        /// <param name="identityType"> Types of identities associated with a server. </param>
+        /// <param name="tenantId"> Identifier of the tenant of a server. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerUserAssignedIdentity"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerUserAssignedIdentity PostgreSqlFlexibleServerUserAssignedIdentity(IDictionary<string, UserAssignedIdentity> userAssignedIdentities = null, Guid? principalId = null, PostgreSqlFlexibleServerIdentityType identityType = default, Guid? tenantId = null)
         {
@@ -362,62 +203,20 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerCapabilityProperties"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
-        /// <param name="name">
-        /// Name of flexible servers capabilities.
-        /// Serialized Name: Capability.name
-        /// </param>
-        /// <param name="supportedServerEditions">
-        /// List of supported compute tiers.
-        /// Serialized Name: Capability.supportedServerEditions
-        /// </param>
-        /// <param name="supportedServerVersions">
-        /// List of supported major versions of PostgreSQL database engine.
-        /// Serialized Name: Capability.supportedServerVersions
-        /// </param>
-        /// <param name="supportedFeatures">
-        /// Features supported.
-        /// Serialized Name: Capability.supportedFeatures
-        /// </param>
-        /// <param name="supportFastProvisioning">
-        /// Indicates if fast provisioning is supported. 'Enabled' means fast provisioning is supported. 'Disabled' stands for fast provisioning is not supported. Will be deprecated in the future. Look to Supported Features for 'FastProvisioning'.
-        /// Serialized Name: Capability.fastProvisioningSupported
-        /// </param>
-        /// <param name="supportedFastProvisioningEditions">
-        /// List of compute tiers supporting fast provisioning.
-        /// Serialized Name: Capability.supportedFastProvisioningEditions
-        /// </param>
-        /// <param name="geoBackupSupported">
-        /// Indicates if geographically redundant backups are supported in this location. 'Enabled' means geographically redundant backups are supported. 'Disabled' stands for geographically redundant backup is not supported. Will be deprecated in the future. Look to Supported Features for 'GeoBackup'.
-        /// Serialized Name: Capability.geoBackupSupported
-        /// </param>
-        /// <param name="zoneRedundantHaSupported">
-        /// Indicates if high availability with zone redundancy is supported in this location. 'Enabled' means high availability with zone redundancy is supported. 'Disabled' stands for high availability with zone redundancy is not supported. Will be deprecated in the future. Look to Supported Features for  'ZoneRedundantHa'.
-        /// Serialized Name: Capability.zoneRedundantHaSupported
-        /// </param>
-        /// <param name="zoneRedundantHaAndGeoBackupSupported">
-        /// Indicates if high availability with zone redundancy is supported in conjunction with geographically redundant backups in this location. 'Enabled' means high availability with zone redundancy is supported in conjunction with geographically redundant backups is supported. 'Disabled' stands for high availability with zone redundancy is supported in conjunction with geographically redundant backups is not supported. Will be deprecated in the future. Look to Supported Features for 'ZoneRedundantHaAndGeoBackup'.
-        /// Serialized Name: Capability.zoneRedundantHaAndGeoBackupSupported
-        /// </param>
-        /// <param name="storageAutoGrowthSupported">
-        /// Indicates if storage autogrow is supported in this location. 'Enabled' means storage autogrow is supported. 'Disabled' stands for storage autogrow is not supported. Will be deprecated in the future. Look to Supported Features for 'StorageAutoGrowth'.
-        /// Serialized Name: Capability.storageAutoGrowthSupported
-        /// </param>
-        /// <param name="onlineResizeSupported">
-        /// Indicates if resizing the storage, without interrupting the operation of the database engine, is supported in this location for the given subscription. 'Enabled' means resizing the storage without interrupting the operation of the database engine is supported. 'Disabled' means resizing the storage without interrupting the operation of the database engine is not supported. Will be deprecated in the future. Look to Supported Features for 'OnlineResize'.
-        /// Serialized Name: Capability.onlineResizeSupported
-        /// </param>
-        /// <param name="restricted">
-        /// Indicates if this location is restricted. 'Enabled' means location is restricted. 'Disabled' stands for location is not restricted. Will be deprecated in the future. Look to Supported Features for 'Restricted'.
-        /// Serialized Name: Capability.restricted
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
+        /// <param name="name"> Name of flexible servers capabilities. </param>
+        /// <param name="supportedServerEditions"> List of supported compute tiers. </param>
+        /// <param name="supportedServerVersions"> List of supported major versions of PostgreSQL database engine. </param>
+        /// <param name="supportedFeatures"> Features supported. </param>
+        /// <param name="supportFastProvisioning"> Indicates if fast provisioning is supported. 'Enabled' means fast provisioning is supported. 'Disabled' stands for fast provisioning is not supported. Will be deprecated in the future. Look to Supported Features for 'FastProvisioning'. </param>
+        /// <param name="supportedFastProvisioningEditions"> List of compute tiers supporting fast provisioning. </param>
+        /// <param name="geoBackupSupported"> Indicates if geographically redundant backups are supported in this location. 'Enabled' means geographically redundant backups are supported. 'Disabled' stands for geographically redundant backup is not supported. Will be deprecated in the future. Look to Supported Features for 'GeoBackup'. </param>
+        /// <param name="zoneRedundantHaSupported"> Indicates if high availability with zone redundancy is supported in this location. 'Enabled' means high availability with zone redundancy is supported. 'Disabled' stands for high availability with zone redundancy is not supported. Will be deprecated in the future. Look to Supported Features for  'ZoneRedundantHa'. </param>
+        /// <param name="zoneRedundantHaAndGeoBackupSupported"> Indicates if high availability with zone redundancy is supported in conjunction with geographically redundant backups in this location. 'Enabled' means high availability with zone redundancy is supported in conjunction with geographically redundant backups is supported. 'Disabled' stands for high availability with zone redundancy is supported in conjunction with geographically redundant backups is not supported. Will be deprecated in the future. Look to Supported Features for 'ZoneRedundantHaAndGeoBackup'. </param>
+        /// <param name="storageAutoGrowthSupported"> Indicates if storage autogrow is supported in this location. 'Enabled' means storage autogrow is supported. 'Disabled' stands for storage autogrow is not supported. Will be deprecated in the future. Look to Supported Features for 'StorageAutoGrowth'. </param>
+        /// <param name="onlineResizeSupported"> Indicates if resizing the storage, without interrupting the operation of the database engine, is supported in this location for the given subscription. 'Enabled' means resizing the storage without interrupting the operation of the database engine is supported. 'Disabled' means resizing the storage without interrupting the operation of the database engine is not supported. Will be deprecated in the future. Look to Supported Features for 'OnlineResize'. </param>
+        /// <param name="restricted"> Indicates if this location is restricted. 'Enabled' means location is restricted. 'Disabled' stands for location is not restricted. Will be deprecated in the future. Look to Supported Features for 'Restricted'. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerCapabilityProperties"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerCapabilityProperties PostgreSqlFlexibleServerCapabilityProperties(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus = null, string reason = null, string name = null, IEnumerable<PostgreSqlFlexibleServerEditionCapability> supportedServerEditions = null, IEnumerable<PostgreSqlFlexibleServerServerVersionCapability> supportedServerVersions = null, IEnumerable<PostgreSqlFlexibleServerSupportedFeature> supportedFeatures = null, PostgreSqlFlexibleServerFastProvisioningSupported? supportFastProvisioning = null, IEnumerable<PostgreSqlFlexibleServerFastProvisioningEditionCapability> supportedFastProvisioningEditions = null, PostgreSqlFlexibleServerGeoBackupSupported? geoBackupSupported = null, PostgreSqlFlexibleServerZoneRedundantHaSupported? zoneRedundantHaSupported = null, PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported? zoneRedundantHaAndGeoBackupSupported = null, PostgreSqlFlexibleServerStorageAutoGrowthSupported? storageAutoGrowthSupported = null, PostgreSqlFlexibleServerOnlineResizeSupported? onlineResizeSupported = null, PostgreSqlFlexibleServerZoneRedundantRestricted? restricted = null)
         {
@@ -445,30 +244,12 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerEditionCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
-        /// <param name="name">
-        /// Name of compute tier.
-        /// Serialized Name: ServerEditionCapability.name
-        /// </param>
-        /// <param name="defaultSkuName">
-        /// Default compute name (SKU) for this computer tier.
-        /// Serialized Name: ServerEditionCapability.defaultSkuName
-        /// </param>
-        /// <param name="supportedStorageEditions">
-        /// List of storage editions supported by this compute tier and compute name.
-        /// Serialized Name: ServerEditionCapability.supportedStorageEditions
-        /// </param>
-        /// <param name="supportedServerSkus">
-        /// List of supported compute names (SKUs).
-        /// Serialized Name: ServerEditionCapability.supportedServerSkus
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
+        /// <param name="name"> Name of compute tier. </param>
+        /// <param name="defaultSkuName"> Default compute name (SKU) for this computer tier. </param>
+        /// <param name="supportedStorageEditions"> List of storage editions supported by this compute tier and compute name. </param>
+        /// <param name="supportedServerSkus"> List of supported compute names (SKUs). </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerEditionCapability"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerEditionCapability PostgreSqlFlexibleServerEditionCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus = null, string reason = null, string name = null, string defaultSkuName = null, IEnumerable<PostgreSqlFlexibleServerStorageEditionCapability> supportedStorageEditions = null, IEnumerable<PostgreSqlFlexibleServerSkuCapability> supportedServerSkus = null)
         {
@@ -486,26 +267,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerStorageEditionCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
-        /// <param name="name">
-        /// Name of storage tier.
-        /// Serialized Name: StorageEditionCapability.name
-        /// </param>
-        /// <param name="defaultStorageSizeMb">
-        /// Default storage size (in MB) for this storage tier.
-        /// Serialized Name: StorageEditionCapability.defaultStorageSizeMb
-        /// </param>
-        /// <param name="supportedStorageCapabilities">
-        /// Configurations of storage supported for this storage tier.
-        /// Serialized Name: StorageEditionCapability.supportedStorageMb
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
+        /// <param name="name"> Name of storage tier. </param>
+        /// <param name="defaultStorageSizeMb"> Default storage size (in MB) for this storage tier. </param>
+        /// <param name="supportedStorageCapabilities"> Configurations of storage supported for this storage tier. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerStorageEditionCapability"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerStorageEditionCapability PostgreSqlFlexibleServerStorageEditionCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus = null, string reason = null, string name = null, long? defaultStorageSizeMb = null, IEnumerable<PostgreSqlFlexibleServerStorageCapability> supportedStorageCapabilities = null)
         {
@@ -521,46 +287,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerStorageCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
-        /// <param name="supportedIops">
-        /// Minimum IOPS supported by the storage size.
-        /// Serialized Name: StorageMbCapability.supportedIops
-        /// </param>
-        /// <param name="supportedMaximumIops">
-        /// Maximum IOPS supported by the storage size.
-        /// Serialized Name: StorageMbCapability.supportedMaximumIops
-        /// </param>
-        /// <param name="storageSizeInMB">
-        /// Minimum supported size (in MB) of storage.
-        /// Serialized Name: StorageMbCapability.storageSizeMb
-        /// </param>
-        /// <param name="maximumStorageSizeMb">
-        /// Maximum supported size (in MB) of storage.
-        /// Serialized Name: StorageMbCapability.maximumStorageSizeMb
-        /// </param>
-        /// <param name="supportedThroughput">
-        /// Minimum supported throughput (in MB/s) of storage.
-        /// Serialized Name: StorageMbCapability.supportedThroughput
-        /// </param>
-        /// <param name="supportedMaximumThroughput">
-        /// Maximum supported throughput (in MB/s) of storage.
-        /// Serialized Name: StorageMbCapability.supportedMaximumThroughput
-        /// </param>
-        /// <param name="defaultIopsTier">
-        /// Default IOPS for this tier and storage size.
-        /// Serialized Name: StorageMbCapability.defaultIopsTier
-        /// </param>
-        /// <param name="supportedIopsTiers">
-        /// List of all supported storage tiers for this tier and storage size.
-        /// Serialized Name: StorageMbCapability.supportedIopsTiers
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
+        /// <param name="supportedIops"> Minimum IOPS supported by the storage size. </param>
+        /// <param name="supportedMaximumIops"> Maximum IOPS supported by the storage size. </param>
+        /// <param name="storageSizeInMB"> Minimum supported size (in MB) of storage. </param>
+        /// <param name="maximumStorageSizeMb"> Maximum supported size (in MB) of storage. </param>
+        /// <param name="supportedThroughput"> Minimum supported throughput (in MB/s) of storage. </param>
+        /// <param name="supportedMaximumThroughput"> Maximum supported throughput (in MB/s) of storage. </param>
+        /// <param name="defaultIopsTier"> Default IOPS for this tier and storage size. </param>
+        /// <param name="supportedIopsTiers"> List of all supported storage tiers for this tier and storage size. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerStorageCapability"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerStorageCapability PostgreSqlFlexibleServerStorageCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus = null, string reason = null, long? supportedIops = null, int? supportedMaximumIops = null, long? storageSizeInMB = null, long? maximumStorageSizeMb = null, int? supportedThroughput = null, int? supportedMaximumThroughput = null, string defaultIopsTier = null, IEnumerable<PostgreSqlFlexibleServerStorageTierCapability> supportedIopsTiers = null)
         {
@@ -581,22 +317,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerStorageTierCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
-        /// <param name="name">
-        /// Name of the storage tier.
-        /// Serialized Name: StorageTierCapability.name
-        /// </param>
-        /// <param name="iops">
-        /// Supported IOPS for the storage tier.
-        /// Serialized Name: StorageTierCapability.iops
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
+        /// <param name="name"> Name of the storage tier. </param>
+        /// <param name="iops"> Supported IOPS for the storage tier. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerStorageTierCapability"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerStorageTierCapability PostgreSqlFlexibleServerStorageTierCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus = null, string reason = null, string name = null, long? iops = null)
         {
@@ -604,14 +328,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlBaseCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <returns> A new <see cref="Models.PostgreSqlBaseCapability"/> instance for mocking. </returns>
         public static PostgreSqlBaseCapability PostgreSqlBaseCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus = null, string reason = null)
         {
@@ -619,46 +337,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerSkuCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
-        /// <param name="name">
-        /// Name of the compute (SKU).
-        /// Serialized Name: ServerSkuCapability.name
-        /// </param>
-        /// <param name="vCores">
-        /// vCores available for this compute.
-        /// Serialized Name: ServerSkuCapability.vCores
-        /// </param>
-        /// <param name="supportedIops">
-        /// Maximum IOPS supported by this compute.
-        /// Serialized Name: ServerSkuCapability.supportedIops
-        /// </param>
-        /// <param name="supportedMemoryPerVcoreMb">
-        /// Supported memory (in MB) per virtual core assigned to this compute.
-        /// Serialized Name: ServerSkuCapability.supportedMemoryPerVcoreMb
-        /// </param>
-        /// <param name="supportedZones">
-        /// List of supported availability zones. E.g. '1', '2', '3'
-        /// Serialized Name: ServerSkuCapability.supportedZones
-        /// </param>
-        /// <param name="supportedHaMode">
-        /// Modes of high availability supported for this compute.
-        /// Serialized Name: ServerSkuCapability.supportedHaMode
-        /// </param>
-        /// <param name="supportedFeatures">
-        /// Features supported.
-        /// Serialized Name: ServerSkuCapability.supportedFeatures
-        /// </param>
-        /// <param name="securityProfile">
-        /// Security profile of the compute. Indicates if it's a Confidential Compute virtual machine.
-        /// Serialized Name: ServerSkuCapability.securityProfile
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
+        /// <param name="name"> Name of the compute (SKU). </param>
+        /// <param name="vCores"> vCores available for this compute. </param>
+        /// <param name="supportedIops"> Maximum IOPS supported by this compute. </param>
+        /// <param name="supportedMemoryPerVcoreMb"> Supported memory (in MB) per virtual core assigned to this compute. </param>
+        /// <param name="supportedZones"> List of supported availability zones. E.g. '1', '2', '3'. </param>
+        /// <param name="supportedHaMode"> Modes of high availability supported for this compute. </param>
+        /// <param name="supportedFeatures"> Features supported. </param>
+        /// <param name="securityProfile"> Security profile of the compute. Indicates if it's a Confidential Compute virtual machine. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerSkuCapability"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerSkuCapability PostgreSqlFlexibleServerSkuCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus = null, string reason = null, string name = null, int? vCores = null, int? supportedIops = null, long? supportedMemoryPerVcoreMb = null, IEnumerable<string> supportedZones = null, IEnumerable<PostgreSqlFlexibleServerHAMode> supportedHaMode = null, IEnumerable<PostgreSqlFlexibleServerSupportedFeature> supportedFeatures = null, string securityProfile = null)
         {
@@ -681,14 +369,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerSupportedFeature"/>. </summary>
-        /// <param name="name">
-        /// Name of the feature.
-        /// Serialized Name: SupportedFeature.name
-        /// </param>
-        /// <param name="status">
-        /// Status of the feature. Indicates if the feature is enabled or not.
-        /// Serialized Name: SupportedFeature.status
-        /// </param>
+        /// <param name="name"> Name of the feature. </param>
+        /// <param name="status"> Status of the feature. Indicates if the feature is enabled or not. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerSupportedFeature"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerSupportedFeature PostgreSqlFlexibleServerSupportedFeature(string name = null, PostgreSqlFlexibleServerFeatureStatus? status = null)
         {
@@ -696,26 +378,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerServerVersionCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
-        /// <param name="name">
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: ServerVersionCapability.name
-        /// </param>
-        /// <param name="supportedVersionsToUpgrade">
-        /// Major versions of PostgreSQL database engine to which this version can be automatically upgraded.
-        /// Serialized Name: ServerVersionCapability.supportedVersionsToUpgrade
-        /// </param>
-        /// <param name="supportedFeatures">
-        /// Features supported.
-        /// Serialized Name: ServerVersionCapability.supportedFeatures
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
+        /// <param name="name"> Major version of PostgreSQL database engine. </param>
+        /// <param name="supportedVersionsToUpgrade"> Major versions of PostgreSQL database engine to which this version can be automatically upgraded. </param>
+        /// <param name="supportedFeatures"> Features supported. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerServerVersionCapability"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerServerVersionCapability PostgreSqlFlexibleServerServerVersionCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus = null, string reason = null, string name = null, IEnumerable<string> supportedVersionsToUpgrade = null, IEnumerable<PostgreSqlFlexibleServerSupportedFeature> supportedFeatures = null)
         {
@@ -732,34 +399,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerFastProvisioningEditionCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
-        /// <param name="supportedTier">
-        /// Compute tier supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedTier
-        /// </param>
-        /// <param name="supportedSku">
-        /// Compute name (SKU) supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedSku
-        /// </param>
-        /// <param name="supportedStorageGb">
-        /// Storage size (in GB) supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedStorageGb
-        /// </param>
-        /// <param name="supportedServerVersions">
-        /// Major version of PostgreSQL database engine supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedServerVersions
-        /// </param>
-        /// <param name="serverCount">
-        /// Count of servers in cache matching this specification.
-        /// Serialized Name: FastProvisioningEditionCapability.serverCount
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
+        /// <param name="supportedTier"> Compute tier supporting fast provisioning. </param>
+        /// <param name="supportedSku"> Compute name (SKU) supporting fast provisioning. </param>
+        /// <param name="supportedStorageGb"> Storage size (in GB) supporting fast provisioning. </param>
+        /// <param name="supportedServerVersions"> Major version of PostgreSQL database engine supporting fast provisioning. </param>
+        /// <param name="serverCount"> Count of servers in cache matching this specification. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerFastProvisioningEditionCapability"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerFastProvisioningEditionCapability PostgreSqlFlexibleServerFastProvisioningEditionCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus = null, string reason = null, string supportedTier = null, string supportedSku = null, long? supportedStorageGb = null, string supportedServerVersions = null, int? serverCount = null)
         {
@@ -775,15 +421,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerVirtualNetworkSubnetUsageResult"/>. </summary>
-        /// <param name="delegatedSubnetsUsage"> Serialized Name: VirtualNetworkSubnetUsageModel.delegatedSubnetsUsage. </param>
-        /// <param name="location">
-        /// location of the delegated subnet usage
-        /// Serialized Name: VirtualNetworkSubnetUsageModel.location
-        /// </param>
-        /// <param name="subscriptionId">
-        /// subscriptionId of the delegated subnet usage
-        /// Serialized Name: VirtualNetworkSubnetUsageModel.subscriptionId
-        /// </param>
+        /// <param name="delegatedSubnetsUsage"></param>
+        /// <param name="location"> location of the delegated subnet usage. </param>
+        /// <param name="subscriptionId"> subscriptionId of the delegated subnet usage. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerVirtualNetworkSubnetUsageResult"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerVirtualNetworkSubnetUsageResult PostgreSqlFlexibleServerVirtualNetworkSubnetUsageResult(IEnumerable<PostgreSqlFlexibleServerDelegatedSubnetUsage> delegatedSubnetsUsage = null, AzureLocation? location = null, string subscriptionId = null)
         {
@@ -793,14 +433,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerDelegatedSubnetUsage"/>. </summary>
-        /// <param name="subnetName">
-        /// Name of the delegated subnet for which IP addresses are in use
-        /// Serialized Name: DelegatedSubnetUsage.subnetName
-        /// </param>
-        /// <param name="usage">
-        /// Number of IP addresses used by the delegated subnet
-        /// Serialized Name: DelegatedSubnetUsage.usage
-        /// </param>
+        /// <param name="subnetName"> Name of the delegated subnet for which IP addresses are in use. </param>
+        /// <param name="usage"> Number of IP addresses used by the delegated subnet. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerDelegatedSubnetUsage"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerDelegatedSubnetUsage PostgreSqlFlexibleServerDelegatedSubnetUsage(string subnetName = null, long? usage = null)
         {
@@ -808,26 +442,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerQuotaUsage"/>. </summary>
-        /// <param name="name">
-        /// Name of quota usage for servers
-        /// Serialized Name: QuotaUsage.name
-        /// </param>
-        /// <param name="limit">
-        /// Quota limit
-        /// Serialized Name: QuotaUsage.limit
-        /// </param>
-        /// <param name="unit">
-        /// Quota unit
-        /// Serialized Name: QuotaUsage.unit
-        /// </param>
-        /// <param name="currentValue">
-        /// Current Quota usage value
-        /// Serialized Name: QuotaUsage.currentValue
-        /// </param>
-        /// <param name="id">
-        /// Fully qualified ARM resource Id
-        /// Serialized Name: QuotaUsage.id
-        /// </param>
+        /// <param name="name"> Name of quota usage for servers. </param>
+        /// <param name="limit"> Quota limit. </param>
+        /// <param name="unit"> Quota unit. </param>
+        /// <param name="currentValue"> Current Quota usage value. </param>
+        /// <param name="id"> Fully qualified ARM resource Id. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerQuotaUsage"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerQuotaUsage PostgreSqlFlexibleServerQuotaUsage(QuotaUsageNameProperty name = null, long? limit = null, string unit = null, long? currentValue = null, string id = null)
         {
@@ -841,14 +460,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.QuotaUsageNameProperty"/>. </summary>
-        /// <param name="value">
-        /// Name value
-        /// Serialized Name: NameProperty.value
-        /// </param>
-        /// <param name="localizedValue">
-        /// Localized name
-        /// Serialized Name: NameProperty.localizedValue
-        /// </param>
+        /// <param name="value"> Name value. </param>
+        /// <param name="localizedValue"> Localized name. </param>
         /// <returns> A new <see cref="Models.QuotaUsageNameProperty"/> instance for mocking. </returns>
         public static QuotaUsageNameProperty QuotaUsageNameProperty(string value = null, string localizedValue = null)
         {
@@ -860,22 +473,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="principalType">
-        /// Type of Microsoft Entra principal to which the server administrator is associated.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.principalType
-        /// </param>
-        /// <param name="principalName">
-        /// Name of the Microsoft Entra principal.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.principalName
-        /// </param>
-        /// <param name="objectId">
-        /// Object identifier of the Microsoft Entra principal.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.objectId
-        /// </param>
-        /// <param name="tenantId">
-        /// Identifier of the tenant in which the Microsoft Entra principal exists.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.tenantId
-        /// </param>
+        /// <param name="principalType"> Type of Microsoft Entra principal to which the server administrator is associated. </param>
+        /// <param name="principalName"> Name of the Microsoft Entra principal. </param>
+        /// <param name="objectId"> Object identifier of the Microsoft Entra principal. </param>
+        /// <param name="tenantId"> Identifier of the tenant in which the Microsoft Entra principal exists. </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlFlexibleServerMicrosoftEntraAdministratorData"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerMicrosoftEntraAdministratorData PostgreSqlFlexibleServerMicrosoftEntraAdministratorData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, PostgreSqlFlexibleServerPrincipalType? principalType = null, string principalName = null, Guid? objectId = null, Guid? tenantId = null)
         {
@@ -896,14 +497,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="state">
-        /// Specifies the state of the advanced threat protection, whether it is enabled, disabled, or a state has not been applied yet on the server.
-        /// Serialized Name: AdvancedThreatProtectionSettingsModel.properties.state
-        /// </param>
-        /// <param name="createdOn">
-        /// Specifies the creation time (UTC) of the policy.
-        /// Serialized Name: AdvancedThreatProtectionSettingsModel.properties.creationTime
-        /// </param>
+        /// <param name="state"> Specifies the state of the advanced threat protection, whether it is enabled, disabled, or a state has not been applied yet on the server. </param>
+        /// <param name="createdOn"> Specifies the creation time (UTC) of the policy. </param>
         /// <returns> A new <see cref="FlexibleServers.ServerThreatProtectionSettingsModelData"/> instance for mocking. </returns>
         public static ServerThreatProtectionSettingsModelData ServerThreatProtectionSettingsModelData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, ThreatProtectionState? state = null, DateTimeOffset? createdOn = null)
         {
@@ -922,18 +517,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="backupType">
-        /// Type of backup.
-        /// Serialized Name: BackupAutomaticAndOnDemand.properties.backupType
-        /// </param>
-        /// <param name="completedOn">
-        /// Time(ISO8601 format) at which the backup was completed.
-        /// Serialized Name: BackupAutomaticAndOnDemand.properties.completedTime
-        /// </param>
-        /// <param name="source">
-        /// Source of the backup.
-        /// Serialized Name: BackupAutomaticAndOnDemand.properties.source
-        /// </param>
+        /// <param name="backupType"> Type of backup. </param>
+        /// <param name="completedOn"> Time(ISO8601 format) at which the backup was completed. </param>
+        /// <param name="source"> Source of the backup. </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlFlexibleServerBackupData"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerBackupData PostgreSqlFlexibleServerBackupData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, PostgreSqlFlexibleServerBackupOrigin? backupType = null, DateTimeOffset? completedOn = null, string source = null)
         {
@@ -949,26 +535,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlCheckMigrationNameAvailabilityContent"/>. </summary>
-        /// <param name="name">
-        /// Name of the migration to check for validity and availability.
-        /// Serialized Name: MigrationNameAvailability.name
-        /// </param>
-        /// <param name="resourceType">
-        /// Type of resource.
-        /// Serialized Name: MigrationNameAvailability.type
-        /// </param>
-        /// <param name="isNameAvailable">
-        /// Indicates if the migration name is available.
-        /// Serialized Name: MigrationNameAvailability.nameAvailable
-        /// </param>
-        /// <param name="reason">
-        /// Migration name availability reason.
-        /// Serialized Name: MigrationNameAvailability.reason
-        /// </param>
-        /// <param name="message">
-        /// Migration name availability message.
-        /// Serialized Name: MigrationNameAvailability.message
-        /// </param>
+        /// <param name="name"> Name of the migration to check for validity and availability. </param>
+        /// <param name="resourceType"> Type of resource. </param>
+        /// <param name="isNameAvailable"> Indicates if the migration name is available. </param>
+        /// <param name="reason"> Migration name availability reason. </param>
+        /// <param name="message"> Migration name availability message. </param>
         /// <returns> A new <see cref="Models.PostgreSqlCheckMigrationNameAvailabilityContent"/> instance for mocking. </returns>
         public static PostgreSqlCheckMigrationNameAvailabilityContent PostgreSqlCheckMigrationNameAvailabilityContent(string name = null, ResourceType resourceType = default, bool? isNameAvailable = null, PostgreSqlMigrationNameUnavailableReason? reason = null, string message = null)
         {
@@ -986,50 +557,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="value">
-        /// Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: Configuration.properties.value
-        /// </param>
-        /// <param name="description">
-        /// Description of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.description
-        /// </param>
-        /// <param name="defaultValue">
-        /// Value assigned by default to the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.defaultValue
-        /// </param>
-        /// <param name="dataType">
-        /// Data type of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.dataType
-        /// </param>
-        /// <param name="allowedValues">
-        /// Allowed values of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.allowedValues
-        /// </param>
-        /// <param name="source">
-        /// Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: Configuration.properties.source
-        /// </param>
-        /// <param name="isDynamicConfig">
-        /// Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect.
-        /// Serialized Name: Configuration.properties.isDynamicConfig
-        /// </param>
-        /// <param name="isReadOnly">
-        /// Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.isReadOnly
-        /// </param>
-        /// <param name="isConfigPendingRestart">
-        /// Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect.
-        /// Serialized Name: Configuration.properties.isConfigPendingRestart
-        /// </param>
-        /// <param name="unit">
-        /// Units in which the configuration (also known as server parameter) value is expressed.
-        /// Serialized Name: Configuration.properties.unit
-        /// </param>
-        /// <param name="documentationLink">
-        /// Link pointing to the documentation of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.documentationLink
-        /// </param>
+        /// <param name="value"> Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </param>
+        /// <param name="description"> Description of the configuration (also known as server parameter). </param>
+        /// <param name="defaultValue"> Value assigned by default to the configuration (also known as server parameter). </param>
+        /// <param name="dataType"> Data type of the configuration (also known as server parameter). </param>
+        /// <param name="allowedValues"> Allowed values of the configuration (also known as server parameter). </param>
+        /// <param name="source"> Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </param>
+        /// <param name="isDynamicConfig"> Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect. </param>
+        /// <param name="isReadOnly"> Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter). </param>
+        /// <param name="isConfigPendingRestart"> Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect. </param>
+        /// <param name="unit"> Units in which the configuration (also known as server parameter) value is expressed. </param>
+        /// <param name="documentationLink"> Link pointing to the documentation of the configuration (also known as server parameter). </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlFlexibleServerConfigurationData"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerConfigurationData PostgreSqlFlexibleServerConfigurationData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string value = null, string description = null, string defaultValue = null, PostgreSqlFlexibleServerConfigurationDataType? dataType = null, string allowedValues = null, string source = null, bool? isDynamicConfig = null, bool? isReadOnly = null, bool? isConfigPendingRestart = null, string unit = null, string documentationLink = null)
         {
@@ -1053,50 +591,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerConfigurationCreateOrUpdateContent"/>. </summary>
-        /// <param name="value">
-        /// Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: ConfigurationForUpdate.properties.value
-        /// </param>
-        /// <param name="description">
-        /// Description of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.description
-        /// </param>
-        /// <param name="defaultValue">
-        /// Value assigned by default to the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.defaultValue
-        /// </param>
-        /// <param name="dataType">
-        /// Data type of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.dataType
-        /// </param>
-        /// <param name="allowedValues">
-        /// Allowed values of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.allowedValues
-        /// </param>
-        /// <param name="source">
-        /// Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: ConfigurationForUpdate.properties.source
-        /// </param>
-        /// <param name="isDynamicConfig">
-        /// Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect.
-        /// Serialized Name: ConfigurationForUpdate.properties.isDynamicConfig
-        /// </param>
-        /// <param name="isReadOnly">
-        /// Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.isReadOnly
-        /// </param>
-        /// <param name="isConfigPendingRestart">
-        /// Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect.
-        /// Serialized Name: ConfigurationForUpdate.properties.isConfigPendingRestart
-        /// </param>
-        /// <param name="unit">
-        /// Units in which the configuration (also known as server parameter) value is expressed.
-        /// Serialized Name: ConfigurationForUpdate.properties.unit
-        /// </param>
-        /// <param name="documentationLink">
-        /// Link pointing to the documentation of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.documentationLink
-        /// </param>
+        /// <param name="value"> Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </param>
+        /// <param name="description"> Description of the configuration (also known as server parameter). </param>
+        /// <param name="defaultValue"> Value assigned by default to the configuration (also known as server parameter). </param>
+        /// <param name="dataType"> Data type of the configuration (also known as server parameter). </param>
+        /// <param name="allowedValues"> Allowed values of the configuration (also known as server parameter). </param>
+        /// <param name="source"> Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </param>
+        /// <param name="isDynamicConfig"> Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect. </param>
+        /// <param name="isReadOnly"> Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter). </param>
+        /// <param name="isConfigPendingRestart"> Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect. </param>
+        /// <param name="unit"> Units in which the configuration (also known as server parameter) value is expressed. </param>
+        /// <param name="documentationLink"> Link pointing to the documentation of the configuration (also known as server parameter). </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerConfigurationCreateOrUpdateContent"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerConfigurationCreateOrUpdateContent PostgreSqlFlexibleServerConfigurationCreateOrUpdateContent(string value = null, string description = null, string defaultValue = null, PostgreSqlFlexibleServerConfigurationDataType? dataType = null, string allowedValues = null, string source = null, bool? isDynamicConfig = null, bool? isReadOnly = null, bool? isConfigPendingRestart = null, string unit = null, string documentationLink = null)
         {
@@ -1120,14 +625,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="charset">
-        /// Character set of the database.
-        /// Serialized Name: Database.properties.charset
-        /// </param>
-        /// <param name="collation">
-        /// Collation of the database.
-        /// Serialized Name: Database.properties.collation
-        /// </param>
+        /// <param name="charset"> Character set of the database. </param>
+        /// <param name="collation"> Collation of the database. </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlFlexibleServerDatabaseData"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerDatabaseData PostgreSqlFlexibleServerDatabaseData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string charset = null, string collation = null)
         {
@@ -1146,14 +645,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="startIPAddress">
-        /// IP address defining the start of the range of addresses of a firewall rule. Must be expressed in IPv4 format.
-        /// Serialized Name: FirewallRule.properties.startIpAddress
-        /// </param>
-        /// <param name="endIPAddress">
-        /// IP address defining the end of the range of addresses of a firewall rule. Must be expressed in IPv4 format.
-        /// Serialized Name: FirewallRule.properties.endIpAddress
-        /// </param>
+        /// <param name="startIPAddress"> IP address defining the start of the range of addresses of a firewall rule. Must be expressed in IPv4 format. </param>
+        /// <param name="endIPAddress"> IP address defining the end of the range of addresses of a firewall rule. Must be expressed in IPv4 format. </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlFlexibleServerFirewallRuleData"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerFirewallRuleData PostgreSqlFlexibleServerFirewallRuleData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IPAddress startIPAddress = null, IPAddress endIPAddress = null)
         {
@@ -1172,26 +665,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="createdOn">
-        /// Creation timestamp of the log file.
-        /// Serialized Name: CapturedLog.properties.createdTime
-        /// </param>
-        /// <param name="lastModifiedOn">
-        /// Last modified timestamp of the log file.
-        /// Serialized Name: CapturedLog.properties.lastModifiedTime
-        /// </param>
-        /// <param name="sizeInKb">
-        /// Size (in KB) of the log file.
-        /// Serialized Name: CapturedLog.properties.sizeInKb
-        /// </param>
-        /// <param name="typePropertiesType">
-        /// Type of log file. Can be 'ServerLogs' or 'UpgradeLogs'.
-        /// Serialized Name: CapturedLog.properties.type
-        /// </param>
-        /// <param name="uri">
-        /// URL to download the log file from.
-        /// Serialized Name: CapturedLog.properties.url
-        /// </param>
+        /// <param name="createdOn"> Creation timestamp of the log file. </param>
+        /// <param name="lastModifiedOn"> Last modified timestamp of the log file. </param>
+        /// <param name="sizeInKb"> Size (in KB) of the log file. </param>
+        /// <param name="typePropertiesType"> Type of log file. Can be 'ServerLogs' or 'UpgradeLogs'. </param>
+        /// <param name="uri"> URL to download the log file from. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerLogFile"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerLogFile PostgreSqlFlexibleServerLogFile(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, DateTimeOffset? createdOn = null, DateTimeOffset? lastModifiedOn = null, long? sizeInKb = null, string typePropertiesType = null, Uri uri = null)
         {
@@ -1213,46 +691,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="datasourceSizeInBytes">
-        /// Size of datasource in bytes
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.datasourceSizeInBytes
-        /// </param>
-        /// <param name="dataTransferredInBytes">
-        /// Data transferred in bytes
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.dataTransferredInBytes
-        /// </param>
-        /// <param name="backupName">
-        /// Name of Backup operation
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.backupName
-        /// </param>
-        /// <param name="backupMetadata">
-        /// Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.backupMetadata
-        /// </param>
-        /// <param name="status">
-        /// Service-set extensible enum indicating the status of operation
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.status
-        /// </param>
-        /// <param name="startOn">
-        /// Start time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.startTime
-        /// </param>
-        /// <param name="endOn">
-        /// End time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.endTime
-        /// </param>
-        /// <param name="percentComplete">
-        /// PercentageCompleted
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.percentComplete
-        /// </param>
-        /// <param name="errorCode">
-        /// The error code.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.errorCode
-        /// </param>
-        /// <param name="errorMessage">
-        /// The error message.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.errorMessage
-        /// </param>
+        /// <param name="datasourceSizeInBytes"> Size of datasource in bytes. </param>
+        /// <param name="dataTransferredInBytes"> Data transferred in bytes. </param>
+        /// <param name="backupName"> Name of Backup operation. </param>
+        /// <param name="backupMetadata"> Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc. </param>
+        /// <param name="status"> Service-set extensible enum indicating the status of operation. </param>
+        /// <param name="startOn"> Start time of the operation. </param>
+        /// <param name="endOn"> End time of the operation. </param>
+        /// <param name="percentComplete"> PercentageCompleted. </param>
+        /// <param name="errorCode"> The error code. </param>
+        /// <param name="errorMessage"> The error message. </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlLtrServerBackupOperationData"/> instance for mocking. </returns>
         public static PostgreSqlLtrServerBackupOperationData PostgreSqlLtrServerBackupOperationData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, long? datasourceSizeInBytes = null, long? dataTransferredInBytes = null, string backupName = null, string backupMetadata = null, PostgreSqlExecutionStatus? status = null, DateTimeOffset? startOn = null, DateTimeOffset? endOn = null, double? percentComplete = null, string errorCode = null, string errorMessage = null)
         {
@@ -1275,10 +723,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerLtrPreBackupResult"/>. </summary>
-        /// <param name="numberOfContainers">
-        /// Number of storage containers the plugin will use during backup. More than one containers may be used for size limitations, parallelism, or redundancy etc.
-        /// Serialized Name: LtrPreBackupResponse.properties.numberOfContainers
-        /// </param>
+        /// <param name="numberOfContainers"> Number of storage containers the plugin will use during backup. More than one containers may be used for size limitations, parallelism, or redundancy etc. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerLtrPreBackupResult"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerLtrPreBackupResult PostgreSqlFlexibleServerLtrPreBackupResult(int numberOfContainers = default)
         {
@@ -1292,106 +737,31 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="migrationId">
-        /// Identifier of a migration.
-        /// Serialized Name: Migration.properties.migrationId
-        /// </param>
-        /// <param name="currentStatus">
-        /// Current status of a migration.
-        /// Serialized Name: Migration.properties.currentStatus
-        /// </param>
-        /// <param name="migrationInstanceResourceId">
-        /// Identifier of the private endpoint migration instance.
-        /// Serialized Name: Migration.properties.migrationInstanceResourceId
-        /// </param>
-        /// <param name="migrationMode">
-        /// Mode used to perform the migration: Online or Offline.
-        /// Serialized Name: Migration.properties.migrationMode
-        /// </param>
-        /// <param name="migrationOption">
-        /// Supported option for a migration.
-        /// Serialized Name: Migration.properties.migrationOption
-        /// </param>
-        /// <param name="sourceType">
-        /// Source server type used for the migration: ApsaraDB_RDS, AWS, AWS_AURORA, AWS_EC2, AWS_RDS, AzureVM, Crunchy_PostgreSQL, Digital_Ocean_Droplets, Digital_Ocean_PostgreSQL, EDB, EDB_Oracle_Server, EDB_PostgreSQL, GCP, GCP_AlloyDB, GCP_CloudSQL, GCP_Compute, Heroku_PostgreSQL, Huawei_Compute, Huawei_RDS, OnPremises, PostgreSQLCosmosDB, PostgreSQLFlexibleServer, PostgreSQLSingleServer, or Supabase_PostgreSQL
-        /// Serialized Name: Migration.properties.sourceType
-        /// </param>
-        /// <param name="sslMode">
-        /// SSL mode used by a migration. Default SSL mode for 'PostgreSQLSingleServer' is 'VerifyFull'. Default SSL mode for other source types is 'Prefer'.
-        /// Serialized Name: Migration.properties.sslMode
-        /// </param>
-        /// <param name="sourceDbServerMetadata">
-        /// Metadata of source database server.
-        /// Serialized Name: Migration.properties.sourceDbServerMetadata
-        /// </param>
-        /// <param name="targetDbServerMetadata">
-        /// Metadata of target database server.
-        /// Serialized Name: Migration.properties.targetDbServerMetadata
-        /// </param>
-        /// <param name="sourceDbServerResourceId">
-        /// Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username.
-        /// Serialized Name: Migration.properties.sourceDbServerResourceId
-        /// </param>
-        /// <param name="sourceDbServerFullyQualifiedDomainName">
-        /// Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server.
-        /// Serialized Name: Migration.properties.sourceDbServerFullyQualifiedDomainName
-        /// </param>
-        /// <param name="targetDbServerResourceId">
-        /// Identifier of the target database server resource.
-        /// Serialized Name: Migration.properties.targetDbServerResourceId
-        /// </param>
-        /// <param name="targetDbServerFullyQualifiedDomainName">
-        /// Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server.
-        /// Serialized Name: Migration.properties.targetDbServerFullyQualifiedDomainName
-        /// </param>
-        /// <param name="secretParameters">
-        /// Migration secret parameters.
-        /// Serialized Name: Migration.properties.secretParameters
-        /// </param>
-        /// <param name="dbsToMigrate">
-        /// Names of databases to migrate.
-        /// Serialized Name: Migration.properties.dbsToMigrate
-        /// </param>
-        /// <param name="setupLogicalReplicationOnSourceDbIfNeeded">
-        /// Indicates whether to setup logical replication on source server, if needed.
-        /// Serialized Name: Migration.properties.setupLogicalReplicationOnSourceDbIfNeeded
-        /// </param>
-        /// <param name="overwriteDbsInTarget">
-        /// Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation.
-        /// Serialized Name: Migration.properties.overwriteDbsInTarget
-        /// </param>
-        /// <param name="migrationWindowStartTimeInUtc">
-        /// Start time (UTC) for migration window.
-        /// Serialized Name: Migration.properties.migrationWindowStartTimeInUtc
-        /// </param>
-        /// <param name="migrationWindowEndTimeInUtc">
-        /// End time (UTC) for migration window.
-        /// Serialized Name: Migration.properties.migrationWindowEndTimeInUtc
-        /// </param>
-        /// <param name="migrateRoles">
-        /// Indicates if roles and permissions must be migrated.
-        /// Serialized Name: Migration.properties.migrateRoles
-        /// </param>
-        /// <param name="startDataMigration">
-        /// Indicates if data migration must start right away.
-        /// Serialized Name: Migration.properties.startDataMigration
-        /// </param>
-        /// <param name="triggerCutover">
-        /// Indicates if cutover must be triggered for the entire migration.
-        /// Serialized Name: Migration.properties.triggerCutover
-        /// </param>
-        /// <param name="dbsToTriggerCutoverOn">
-        /// When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: Migration.properties.dbsToTriggerCutoverOn
-        /// </param>
-        /// <param name="cancel">
-        /// Indicates if cancel must be triggered for the entire migration.
-        /// Serialized Name: Migration.properties.cancel
-        /// </param>
-        /// <param name="dbsToCancelMigrationOn">
-        /// When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: Migration.properties.dbsToCancelMigrationOn
-        /// </param>
+        /// <param name="migrationId"> Identifier of a migration. </param>
+        /// <param name="currentStatus"> Current status of a migration. </param>
+        /// <param name="migrationInstanceResourceId"> Identifier of the private endpoint migration instance. </param>
+        /// <param name="migrationMode"> Mode used to perform the migration: Online or Offline. </param>
+        /// <param name="migrationOption"> Supported option for a migration. </param>
+        /// <param name="sourceType"> Source server type used for the migration: ApsaraDB_RDS, AWS, AWS_AURORA, AWS_EC2, AWS_RDS, AzureVM, Crunchy_PostgreSQL, Digital_Ocean_Droplets, Digital_Ocean_PostgreSQL, EDB, EDB_Oracle_Server, EDB_PostgreSQL, GCP, GCP_AlloyDB, GCP_CloudSQL, GCP_Compute, Heroku_PostgreSQL, Huawei_Compute, Huawei_RDS, OnPremises, PostgreSQLCosmosDB, PostgreSQLFlexibleServer, PostgreSQLSingleServer, or Supabase_PostgreSQL. </param>
+        /// <param name="sslMode"> SSL mode used by a migration. Default SSL mode for 'PostgreSQLSingleServer' is 'VerifyFull'. Default SSL mode for other source types is 'Prefer'. </param>
+        /// <param name="sourceDbServerMetadata"> Metadata of source database server. </param>
+        /// <param name="targetDbServerMetadata"> Metadata of target database server. </param>
+        /// <param name="sourceDbServerResourceId"> Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username. </param>
+        /// <param name="sourceDbServerFullyQualifiedDomainName"> Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server. </param>
+        /// <param name="targetDbServerResourceId"> Identifier of the target database server resource. </param>
+        /// <param name="targetDbServerFullyQualifiedDomainName"> Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server. </param>
+        /// <param name="secretParameters"> Migration secret parameters. </param>
+        /// <param name="dbsToMigrate"> Names of databases to migrate. </param>
+        /// <param name="setupLogicalReplicationOnSourceDbIfNeeded"> Indicates whether to setup logical replication on source server, if needed. </param>
+        /// <param name="overwriteDbsInTarget"> Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation. </param>
+        /// <param name="migrationWindowStartTimeInUtc"> Start time (UTC) for migration window. </param>
+        /// <param name="migrationWindowEndTimeInUtc"> End time (UTC) for migration window. </param>
+        /// <param name="migrateRoles"> Indicates if roles and permissions must be migrated. </param>
+        /// <param name="startDataMigration"> Indicates if data migration must start right away. </param>
+        /// <param name="triggerCutover"> Indicates if cutover must be triggered for the entire migration. </param>
+        /// <param name="dbsToTriggerCutoverOn"> When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </param>
+        /// <param name="cancel"> Indicates if cancel must be triggered for the entire migration. </param>
+        /// <param name="dbsToCancelMigrationOn"> When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlMigrationData"/> instance for mocking. </returns>
         public static PostgreSqlMigrationData PostgreSqlMigrationData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IDictionary<string, string> tags = null, AzureLocation location = default, string migrationId = null, PostgreSqlMigrationStatus currentStatus = null, ResourceIdentifier migrationInstanceResourceId = null, PostgreSqlMigrationMode? migrationMode = null, MigrationOption? migrationOption = null, PostgreSqlFlexibleServersSourceType? sourceType = null, PostgreSqlFlexibleServersSslMode? sslMode = null, PostgreSqlServerMetadata sourceDbServerMetadata = null, PostgreSqlServerMetadata targetDbServerMetadata = null, ResourceIdentifier sourceDbServerResourceId = null, string sourceDbServerFullyQualifiedDomainName = null, ResourceIdentifier targetDbServerResourceId = null, string targetDbServerFullyQualifiedDomainName = null, PostgreSqlMigrationSecretParameters secretParameters = null, IEnumerable<string> dbsToMigrate = null, PostgreSqlMigrationLogicalReplicationOnSourceDb? setupLogicalReplicationOnSourceDbIfNeeded = null, PostgreSqlMigrationOverwriteDbsInTarget? overwriteDbsInTarget = null, DateTimeOffset? migrationWindowStartTimeInUtc = null, DateTimeOffset? migrationWindowEndTimeInUtc = null, MigrateRolesEnum? migrateRoles = null, PostgreSqlMigrationStartDataMigration? startDataMigration = null, PostgreSqlMigrationTriggerCutover? triggerCutover = null, IEnumerable<string> dbsToTriggerCutoverOn = null, PostgreSqlMigrationCancel? cancel = null, IEnumerable<string> dbsToCancelMigrationOn = null)
         {
@@ -1436,18 +806,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlMigrationStatus"/>. </summary>
-        /// <param name="state">
-        /// State of migration.
-        /// Serialized Name: MigrationStatus.state
-        /// </param>
-        /// <param name="error">
-        /// Error message, if any, for the migration state.
-        /// Serialized Name: MigrationStatus.error
-        /// </param>
-        /// <param name="currentSubStateDetails">
-        /// Current migration sub state details.
-        /// Serialized Name: MigrationStatus.currentSubStateDetails
-        /// </param>
+        /// <param name="state"> State of migration. </param>
+        /// <param name="error"> Error message, if any, for the migration state. </param>
+        /// <param name="currentSubStateDetails"> Current migration sub state details. </param>
         /// <returns> A new <see cref="Models.PostgreSqlMigrationStatus"/> instance for mocking. </returns>
         public static PostgreSqlMigrationStatus PostgreSqlMigrationStatus(PostgreSqlMigrationState? state = null, string error = null, PostgreSqlMigrationSubStateDetails currentSubStateDetails = null)
         {
@@ -1455,18 +816,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlMigrationSubStateDetails"/>. </summary>
-        /// <param name="currentSubState">
-        /// Substate of migration.
-        /// Serialized Name: MigrationSubstateDetails.currentSubState
-        /// </param>
-        /// <param name="dbDetails">
-        /// Dictionary of &lt;DatabaseMigrationState&gt;
-        /// Serialized Name: MigrationSubstateDetails.dbDetails
-        /// </param>
-        /// <param name="validationDetails">
-        /// Details for the validation for migration.
-        /// Serialized Name: MigrationSubstateDetails.validationDetails
-        /// </param>
+        /// <param name="currentSubState"> Substate of migration. </param>
+        /// <param name="dbDetails"> Dictionary of &lt;DatabaseMigrationState&gt;. </param>
+        /// <param name="validationDetails"> Details for the validation for migration. </param>
         /// <returns> A new <see cref="Models.PostgreSqlMigrationSubStateDetails"/> instance for mocking. </returns>
         public static PostgreSqlMigrationSubStateDetails PostgreSqlMigrationSubStateDetails(PostgreSqlMigrationSubState? currentSubState = null, IReadOnlyDictionary<string, DbMigrationStatus> dbDetails = null, PostgreSqlFlexibleServersValidationDetails validationDetails = null)
         {
@@ -1476,70 +828,22 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.DbMigrationStatus"/>. </summary>
-        /// <param name="databaseName">
-        /// Name of database.
-        /// Serialized Name: DatabaseMigrationState.databaseName
-        /// </param>
-        /// <param name="migrationState">
-        /// Migration state of a database.
-        /// Serialized Name: DatabaseMigrationState.migrationState
-        /// </param>
-        /// <param name="migrationOperation">
-        /// Migration operation of a database.
-        /// Serialized Name: DatabaseMigrationState.migrationOperation
-        /// </param>
-        /// <param name="startedOn">
-        /// Start time of a migration state.
-        /// Serialized Name: DatabaseMigrationState.startedOn
-        /// </param>
-        /// <param name="endedOn">
-        /// End time of a migration state.
-        /// Serialized Name: DatabaseMigrationState.endedOn
-        /// </param>
-        /// <param name="fullLoadQueuedTables">
-        /// Number of tables queued for the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadQueuedTables
-        /// </param>
-        /// <param name="fullLoadErroredTables">
-        /// Number of tables encountering errors during the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadErroredTables
-        /// </param>
-        /// <param name="fullLoadLoadingTables">
-        /// Number of tables loading during the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadLoadingTables
-        /// </param>
-        /// <param name="fullLoadCompletedTables">
-        /// Number of tables loaded during the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadCompletedTables
-        /// </param>
-        /// <param name="cdcUpdateCounter">
-        /// Change Data Capture update counter.
-        /// Serialized Name: DatabaseMigrationState.cdcUpdateCounter
-        /// </param>
-        /// <param name="cdcDeleteCounter">
-        /// Change Data Capture delete counter.
-        /// Serialized Name: DatabaseMigrationState.cdcDeleteCounter
-        /// </param>
-        /// <param name="cdcInsertCounter">
-        /// Change Data Capture insert counter.
-        /// Serialized Name: DatabaseMigrationState.cdcInsertCounter
-        /// </param>
-        /// <param name="appliedChanges">
-        /// Change Data Capture applied changes counter.
-        /// Serialized Name: DatabaseMigrationState.appliedChanges
-        /// </param>
-        /// <param name="incomingChanges">
-        /// Change Data Capture incoming changes counter.
-        /// Serialized Name: DatabaseMigrationState.incomingChanges
-        /// </param>
-        /// <param name="latency">
-        /// Lag in seconds between source and target during online phase.
-        /// Serialized Name: DatabaseMigrationState.latency
-        /// </param>
-        /// <param name="message">
-        /// Error message, if any, for the migration state.
-        /// Serialized Name: DatabaseMigrationState.message
-        /// </param>
+        /// <param name="databaseName"> Name of database. </param>
+        /// <param name="migrationState"> Migration state of a database. </param>
+        /// <param name="migrationOperation"> Migration operation of a database. </param>
+        /// <param name="startedOn"> Start time of a migration state. </param>
+        /// <param name="endedOn"> End time of a migration state. </param>
+        /// <param name="fullLoadQueuedTables"> Number of tables queued for the migration of a database. </param>
+        /// <param name="fullLoadErroredTables"> Number of tables encountering errors during the migration of a database. </param>
+        /// <param name="fullLoadLoadingTables"> Number of tables loading during the migration of a database. </param>
+        /// <param name="fullLoadCompletedTables"> Number of tables loaded during the migration of a database. </param>
+        /// <param name="cdcUpdateCounter"> Change Data Capture update counter. </param>
+        /// <param name="cdcDeleteCounter"> Change Data Capture delete counter. </param>
+        /// <param name="cdcInsertCounter"> Change Data Capture insert counter. </param>
+        /// <param name="appliedChanges"> Change Data Capture applied changes counter. </param>
+        /// <param name="incomingChanges"> Change Data Capture incoming changes counter. </param>
+        /// <param name="latency"> Lag in seconds between source and target during online phase. </param>
+        /// <param name="message"> Error message, if any, for the migration state. </param>
         /// <returns> A new <see cref="Models.DbMigrationStatus"/> instance for mocking. </returns>
         public static DbMigrationStatus DbMigrationStatus(string databaseName = null, MigrationDbState? migrationState = null, string migrationOperation = null, DateTimeOffset? startedOn = null, DateTimeOffset? endedOn = null, int? fullLoadQueuedTables = null, int? fullLoadErroredTables = null, int? fullLoadLoadingTables = null, int? fullLoadCompletedTables = null, int? cdcUpdateCounter = null, int? cdcDeleteCounter = null, int? cdcInsertCounter = null, int? appliedChanges = null, int? incomingChanges = null, int? latency = null, string message = null)
         {
@@ -1564,26 +868,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServersValidationDetails"/>. </summary>
-        /// <param name="status">
-        /// Validation status for migration.
-        /// Serialized Name: ValidationDetails.status
-        /// </param>
-        /// <param name="validationStartTimeInUtc">
-        /// Start time (UTC) for validation.
-        /// Serialized Name: ValidationDetails.validationStartTimeInUtc
-        /// </param>
-        /// <param name="validationEndTimeInUtc">
-        /// End time (UTC) for validation.
-        /// Serialized Name: ValidationDetails.validationEndTimeInUtc
-        /// </param>
-        /// <param name="serverLevelValidationDetails">
-        /// Details of server level validations.
-        /// Serialized Name: ValidationDetails.serverLevelValidationDetails
-        /// </param>
-        /// <param name="dbLevelValidationDetails">
-        /// Details of server level validations.
-        /// Serialized Name: ValidationDetails.dbLevelValidationDetails
-        /// </param>
+        /// <param name="status"> Validation status for migration. </param>
+        /// <param name="validationStartTimeInUtc"> Start time (UTC) for validation. </param>
+        /// <param name="validationEndTimeInUtc"> End time (UTC) for validation. </param>
+        /// <param name="serverLevelValidationDetails"> Details of server level validations. </param>
+        /// <param name="dbLevelValidationDetails"> Details of server level validations. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServersValidationDetails"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServersValidationDetails PostgreSqlFlexibleServersValidationDetails(PostgreSqlFlexibleServersValidationState? status = null, DateTimeOffset? validationStartTimeInUtc = null, DateTimeOffset? validationEndTimeInUtc = null, IEnumerable<ValidationSummaryItem> serverLevelValidationDetails = null, IEnumerable<DbLevelValidationStatus> dbLevelValidationDetails = null)
         {
@@ -1600,18 +889,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ValidationSummaryItem"/>. </summary>
-        /// <param name="validationSummaryItemType">
-        /// Validation type.
-        /// Serialized Name: ValidationSummaryItem.type
-        /// </param>
-        /// <param name="state">
-        /// Validation status for migration.
-        /// Serialized Name: ValidationSummaryItem.state
-        /// </param>
-        /// <param name="messages">
-        /// Validation messages.
-        /// Serialized Name: ValidationSummaryItem.messages
-        /// </param>
+        /// <param name="validationSummaryItemType"> Validation type. </param>
+        /// <param name="state"> Validation status for migration. </param>
+        /// <param name="messages"> Validation messages. </param>
         /// <returns> A new <see cref="Models.ValidationSummaryItem"/> instance for mocking. </returns>
         public static ValidationSummaryItem ValidationSummaryItem(string validationSummaryItemType = null, PostgreSqlFlexibleServersValidationState? state = null, IEnumerable<PostgreSqlFlexibleServersValidationMessage> messages = null)
         {
@@ -1621,14 +901,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServersValidationMessage"/>. </summary>
-        /// <param name="state">
-        /// Severity of validation message.
-        /// Serialized Name: ValidationMessage.state
-        /// </param>
-        /// <param name="message">
-        /// Validation message string.
-        /// Serialized Name: ValidationMessage.message
-        /// </param>
+        /// <param name="state"> Severity of validation message. </param>
+        /// <param name="message"> Validation message string. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServersValidationMessage"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServersValidationMessage PostgreSqlFlexibleServersValidationMessage(PostgreSqlFlexibleServersValidationState? state = null, string message = null)
         {
@@ -1636,22 +910,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.DbLevelValidationStatus"/>. </summary>
-        /// <param name="databaseName">
-        /// Name of database.
-        /// Serialized Name: DbLevelValidationStatus.databaseName
-        /// </param>
-        /// <param name="startedOn">
-        /// Start time of a database level validation.
-        /// Serialized Name: DbLevelValidationStatus.startedOn
-        /// </param>
-        /// <param name="endedOn">
-        /// End time of a database level validation.
-        /// Serialized Name: DbLevelValidationStatus.endedOn
-        /// </param>
-        /// <param name="summary">
-        /// Summary of database level validations.
-        /// Serialized Name: DbLevelValidationStatus.summary
-        /// </param>
+        /// <param name="databaseName"> Name of database. </param>
+        /// <param name="startedOn"> Start time of a database level validation. </param>
+        /// <param name="endedOn"> End time of a database level validation. </param>
+        /// <param name="summary"> Summary of database level validations. </param>
         /// <returns> A new <see cref="Models.DbLevelValidationStatus"/> instance for mocking. </returns>
         public static DbLevelValidationStatus DbLevelValidationStatus(string databaseName = null, DateTimeOffset? startedOn = null, DateTimeOffset? endedOn = null, IEnumerable<ValidationSummaryItem> summary = null)
         {
@@ -1661,22 +923,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlServerMetadata"/>. </summary>
-        /// <param name="location">
-        /// Location of database server.
-        /// Serialized Name: DbServerMetadata.location
-        /// </param>
-        /// <param name="version">
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: DbServerMetadata.version
-        /// </param>
-        /// <param name="storageMb">
-        /// Storage size (in MB) for database server.
-        /// Serialized Name: DbServerMetadata.storageMb
-        /// </param>
-        /// <param name="sku">
-        /// Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server.
-        /// Serialized Name: DbServerMetadata.sku
-        /// </param>
+        /// <param name="location"> Location of database server. </param>
+        /// <param name="version"> Major version of PostgreSQL database engine. </param>
+        /// <param name="storageMb"> Storage size (in MB) for database server. </param>
+        /// <param name="sku"> Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server. </param>
         /// <returns> A new <see cref="Models.PostgreSqlServerMetadata"/> instance for mocking. </returns>
         public static PostgreSqlServerMetadata PostgreSqlServerMetadata(AzureLocation? location = null, string version = null, int? storageMb = null, PostgreSqlFlexibleServersServerSku sku = null)
         {
@@ -1684,14 +934,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServersServerSku"/>. </summary>
-        /// <param name="name">
-        /// Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server.
-        /// Serialized Name: ServerSku.name
-        /// </param>
-        /// <param name="tier">
-        /// Tier of the compute assigned to a server.
-        /// Serialized Name: ServerSku.tier
-        /// </param>
+        /// <param name="name"> Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server. </param>
+        /// <param name="tier"> Tier of the compute assigned to a server. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServersServerSku"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServersServerSku PostgreSqlFlexibleServersServerSku(string name = null, PostgreSqlFlexibleServerSkuTier? tier = null)
         {
@@ -1703,18 +947,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="groupId">
-        /// The private link resource group id.
-        /// Serialized Name: PrivateLinkResource.properties.groupId
-        /// </param>
-        /// <param name="requiredMembers">
-        /// The private link resource required member names.
-        /// Serialized Name: PrivateLinkResource.properties.requiredMembers
-        /// </param>
-        /// <param name="requiredZoneNames">
-        /// The private link resource private link DNS zone name.
-        /// Serialized Name: PrivateLinkResource.properties.requiredZoneNames
-        /// </param>
+        /// <param name="groupId"> The private link resource group id. </param>
+        /// <param name="requiredMembers"> The private link resource required member names. </param>
+        /// <param name="requiredZoneNames"> The private link resource private link DNS zone name. </param>
         /// <returns> A new <see cref="FlexibleServers.PostgreSqlFlexibleServersPrivateLinkResourceData"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServersPrivateLinkResourceData PostgreSqlFlexibleServersPrivateLinkResourceData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string groupId = null, IEnumerable<string> requiredMembers = null, IEnumerable<string> requiredZoneNames = null)
         {
@@ -1733,46 +968,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.PostgreSqlFlexibleServerLtrBackupResult"/>. </summary>
-        /// <param name="datasourceSizeInBytes">
-        /// Size of datasource in bytes
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.datasourceSizeInBytes
-        /// </param>
-        /// <param name="dataTransferredInBytes">
-        /// Data transferred in bytes
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.dataTransferredInBytes
-        /// </param>
-        /// <param name="backupName">
-        /// Name of Backup operation
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.backupName
-        /// </param>
-        /// <param name="backupMetadata">
-        /// Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.backupMetadata
-        /// </param>
-        /// <param name="status">
-        /// Service-set extensible enum indicating the status of operation
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.status
-        /// </param>
-        /// <param name="startOn">
-        /// Start time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.startTime
-        /// </param>
-        /// <param name="endOn">
-        /// End time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.endTime
-        /// </param>
-        /// <param name="percentComplete">
-        /// PercentageCompleted
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.percentComplete
-        /// </param>
-        /// <param name="errorCode">
-        /// The error code.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.errorCode
-        /// </param>
-        /// <param name="errorMessage">
-        /// The error message.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.errorMessage
-        /// </param>
+        /// <param name="datasourceSizeInBytes"> Size of datasource in bytes. </param>
+        /// <param name="dataTransferredInBytes"> Data transferred in bytes. </param>
+        /// <param name="backupName"> Name of Backup operation. </param>
+        /// <param name="backupMetadata"> Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc. </param>
+        /// <param name="status"> Service-set extensible enum indicating the status of operation. </param>
+        /// <param name="startOn"> Start time of the operation. </param>
+        /// <param name="endOn"> End time of the operation. </param>
+        /// <param name="percentComplete"> PercentageCompleted. </param>
+        /// <param name="errorCode"> The error code. </param>
+        /// <param name="errorMessage"> The error message. </param>
         /// <returns> A new <see cref="Models.PostgreSqlFlexibleServerLtrBackupResult"/> instance for mocking. </returns>
         public static PostgreSqlFlexibleServerLtrBackupResult PostgreSqlFlexibleServerLtrBackupResult(long? datasourceSizeInBytes = null, long? dataTransferredInBytes = null, string backupName = null, string backupMetadata = null, PostgreSqlExecutionStatus? status = null, DateTimeOffset? startOn = null, DateTimeOffset? endOn = null, double? percentComplete = null, string errorCode = null, string errorMessage = null)
         {
@@ -1806,54 +1011,18 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="kind">
-        /// Always empty.
-        /// Serialized Name: ObjectRecommendation.kind
-        /// </param>
-        /// <param name="initialRecommendedOn">
-        /// Creation time (UTC) of this recommendation.
-        /// Serialized Name: ObjectRecommendation.properties.initialRecommendedTime
-        /// </param>
-        /// <param name="lastRecommendedOn">
-        /// Last time (UTC) that this recommendation was produced.
-        /// Serialized Name: ObjectRecommendation.properties.lastRecommendedTime
-        /// </param>
-        /// <param name="timesRecommended">
-        /// Number of times this recommendation has been produced.
-        /// Serialized Name: ObjectRecommendation.properties.timesRecommended
-        /// </param>
-        /// <param name="improvedQueryIds">
-        /// List of identifiers for all queries identified as targets for improvement if the recommendation is applied. The list is only populated for CREATE INDEX recommendations.
-        /// Serialized Name: ObjectRecommendation.properties.improvedQueryIds
-        /// </param>
-        /// <param name="recommendationReason">
-        /// Reason for this recommendation.
-        /// Serialized Name: ObjectRecommendation.properties.recommendationReason
-        /// </param>
-        /// <param name="currentState">
-        /// Current state.
-        /// Serialized Name: ObjectRecommendation.properties.currentState
-        /// </param>
-        /// <param name="recommendationType">
-        /// Type for this recommendation.
-        /// Serialized Name: ObjectRecommendation.properties.recommendationType
-        /// </param>
-        /// <param name="implementationDetails">
-        /// Implementation details for the recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.implementationDetails
-        /// </param>
-        /// <param name="analyzedWorkload">
-        /// Workload information for the recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.analyzedWorkload
-        /// </param>
-        /// <param name="estimatedImpact">
-        /// Estimated impact of this recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.estimatedImpact
-        /// </param>
-        /// <param name="details">
-        /// Recommendation details for the recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.details
-        /// </param>
+        /// <param name="kind"> Always empty. </param>
+        /// <param name="initialRecommendedOn"> Creation time (UTC) of this recommendation. </param>
+        /// <param name="lastRecommendedOn"> Last time (UTC) that this recommendation was produced. </param>
+        /// <param name="timesRecommended"> Number of times this recommendation has been produced. </param>
+        /// <param name="improvedQueryIds"> List of identifiers for all queries identified as targets for improvement if the recommendation is applied. The list is only populated for CREATE INDEX recommendations. </param>
+        /// <param name="recommendationReason"> Reason for this recommendation. </param>
+        /// <param name="currentState"> Current state. </param>
+        /// <param name="recommendationType"> Type for this recommendation. </param>
+        /// <param name="implementationDetails"> Implementation details for the recommended action. </param>
+        /// <param name="analyzedWorkload"> Workload information for the recommended action. </param>
+        /// <param name="estimatedImpact"> Estimated impact of this recommended action. </param>
+        /// <param name="details"> Recommendation details for the recommended action. </param>
         /// <returns> A new <see cref="Models.ObjectRecommendation"/> instance for mocking. </returns>
         public static ObjectRecommendation ObjectRecommendation(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string kind = null, DateTimeOffset? initialRecommendedOn = null, DateTimeOffset? lastRecommendedOn = null, int? timesRecommended = null, IEnumerable<long> improvedQueryIds = null, string recommendationReason = null, string currentState = null, PostgreSqlFlexibleServerRecommendationType? recommendationType = null, ObjectRecommendationImplementationDetails implementationDetails = null, ObjectRecommendationAnalyzedWorkload analyzedWorkload = null, IEnumerable<RecommendationImpactRecord> estimatedImpact = null, ObjectRecommendationDetails details = null)
         {
@@ -1881,22 +1050,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.RecommendationImpactRecord"/>. </summary>
-        /// <param name="dimensionName">
-        /// Dimension name.
-        /// Serialized Name: ImpactRecord.dimensionName
-        /// </param>
-        /// <param name="unit">
-        /// Dimension unit.
-        /// Serialized Name: ImpactRecord.unit
-        /// </param>
-        /// <param name="queryId">
-        /// Optional property that can be used to store the identifier of the query, if the metric is for a specific query.
-        /// Serialized Name: ImpactRecord.queryId
-        /// </param>
-        /// <param name="absoluteValue">
-        /// Absolute value.
-        /// Serialized Name: ImpactRecord.absoluteValue
-        /// </param>
+        /// <param name="dimensionName"> Dimension name. </param>
+        /// <param name="unit"> Dimension unit. </param>
+        /// <param name="queryId"> Optional property that can be used to store the identifier of the query, if the metric is for a specific query. </param>
+        /// <param name="absoluteValue"> Absolute value. </param>
         /// <returns> A new <see cref="Models.RecommendationImpactRecord"/> instance for mocking. </returns>
         public static RecommendationImpactRecord RecommendationImpactRecord(string dimensionName = null, string unit = null, long? queryId = null, double? absoluteValue = null)
         {
@@ -1904,34 +1061,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ObjectRecommendationDetails"/>. </summary>
-        /// <param name="databaseName">
-        /// Database name.
-        /// Serialized Name: ObjectRecommendationDetails.databaseName
-        /// </param>
-        /// <param name="schema">
-        /// Schema name.
-        /// Serialized Name: ObjectRecommendationDetails.schema
-        /// </param>
-        /// <param name="table">
-        /// Table name.
-        /// Serialized Name: ObjectRecommendationDetails.table
-        /// </param>
-        /// <param name="indexType">
-        /// Index type.
-        /// Serialized Name: ObjectRecommendationDetails.indexType
-        /// </param>
-        /// <param name="indexName">
-        /// Index name.
-        /// Serialized Name: ObjectRecommendationDetails.indexName
-        /// </param>
-        /// <param name="indexColumns">
-        /// Index columns.
-        /// Serialized Name: ObjectRecommendationDetails.indexColumns
-        /// </param>
-        /// <param name="includedColumns">
-        /// Index included columns.
-        /// Serialized Name: ObjectRecommendationDetails.includedColumns
-        /// </param>
+        /// <param name="databaseName"> Database name. </param>
+        /// <param name="schema"> Schema name. </param>
+        /// <param name="table"> Table name. </param>
+        /// <param name="indexType"> Index type. </param>
+        /// <param name="indexName"> Index name. </param>
+        /// <param name="indexColumns"> Index columns. </param>
+        /// <param name="includedColumns"> Index included columns. </param>
         /// <returns> A new <see cref="Models.ObjectRecommendationDetails"/> instance for mocking. </returns>
         public static ObjectRecommendationDetails ObjectRecommendationDetails(string databaseName = null, string schema = null, string table = null, string indexType = null, string indexName = null, IEnumerable<string> indexColumns = null, IEnumerable<string> includedColumns = null)
         {
@@ -1954,18 +1090,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="endpointType">
-        /// Type of endpoint for the virtual endpoints.
-        /// Serialized Name: VirtualEndpoint.properties.endpointType
-        /// </param>
-        /// <param name="members">
-        /// List of servers that one of the virtual endpoints can refer to.
-        /// Serialized Name: VirtualEndpoint.properties.members
-        /// </param>
-        /// <param name="virtualEndpoints">
-        /// List of virtual endpoints for a server.
-        /// Serialized Name: VirtualEndpoint.properties.virtualEndpoints
-        /// </param>
+        /// <param name="endpointType"> Type of endpoint for the virtual endpoints. </param>
+        /// <param name="members"> List of servers that one of the virtual endpoints can refer to. </param>
+        /// <param name="virtualEndpoints"> List of virtual endpoints for a server. </param>
         /// <returns> A new <see cref="FlexibleServers.VirtualEndpointResourceData"/> instance for mocking. </returns>
         public static VirtualEndpointResourceData VirtualEndpointResourceData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, VirtualEndpointType? endpointType = null, IEnumerable<string> members = null, IEnumerable<string> virtualEndpoints = null)
         {
@@ -1984,18 +1111,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.VirtualEndpointResourcePatch"/>. </summary>
-        /// <param name="endpointType">
-        /// Type of endpoint for the virtual endpoints.
-        /// Serialized Name: VirtualEndpointResourceForPatch.properties.endpointType
-        /// </param>
-        /// <param name="members">
-        /// List of servers that one of the virtual endpoints can refer to.
-        /// Serialized Name: VirtualEndpointResourceForPatch.properties.members
-        /// </param>
-        /// <param name="virtualEndpoints">
-        /// List of virtual endpoints for a server.
-        /// Serialized Name: VirtualEndpointResourceForPatch.properties.virtualEndpoints
-        /// </param>
+        /// <param name="endpointType"> Type of endpoint for the virtual endpoints. </param>
+        /// <param name="members"> List of servers that one of the virtual endpoints can refer to. </param>
+        /// <param name="virtualEndpoints"> List of virtual endpoints for a server. </param>
         /// <returns> A new <see cref="Models.VirtualEndpointResourcePatch"/> instance for mocking. </returns>
         public static VirtualEndpointResourcePatch VirtualEndpointResourcePatch(VirtualEndpointType? endpointType = null, IEnumerable<string> members = null, IEnumerable<string> virtualEndpoints = null)
         {

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/AdministratorMicrosoftEntraList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/AdministratorMicrosoftEntraList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of server administrators associated to Microsoft Entra principals.
-    /// Serialized Name: AdministratorMicrosoftEntraList
-    /// </summary>
+    /// <summary> List of server administrators associated to Microsoft Entra principals. </summary>
     internal partial class AdministratorMicrosoftEntraList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="AdministratorMicrosoftEntraList"/>. </summary>
-        /// <param name="value">
-        /// The AdministratorMicrosoftEntra items on this page
-        /// Serialized Name: AdministratorMicrosoftEntraList.value
-        /// </param>
+        /// <param name="value"> The AdministratorMicrosoftEntra items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal AdministratorMicrosoftEntraList(IEnumerable<PostgreSqlFlexibleServerMicrosoftEntraAdministratorData> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AdministratorMicrosoftEntraList"/>. </summary>
-        /// <param name="value">
-        /// The AdministratorMicrosoftEntra items on this page
-        /// Serialized Name: AdministratorMicrosoftEntraList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: AdministratorMicrosoftEntraList.nextLink
-        /// </param>
+        /// <param name="value"> The AdministratorMicrosoftEntra items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AdministratorMicrosoftEntraList(IReadOnlyList<PostgreSqlFlexibleServerMicrosoftEntraAdministratorData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The AdministratorMicrosoftEntra items on this page
-        /// Serialized Name: AdministratorMicrosoftEntraList.value
-        /// </summary>
+        /// <summary> The AdministratorMicrosoftEntra items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerMicrosoftEntraAdministratorData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: AdministratorMicrosoftEntraList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/AdvancedThreatProtectionSettingsList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/AdvancedThreatProtectionSettingsList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of advanced threat protection settings for a server.
-    /// Serialized Name: AdvancedThreatProtectionSettingsList
-    /// </summary>
+    /// <summary> List of advanced threat protection settings for a server. </summary>
     internal partial class AdvancedThreatProtectionSettingsList
     {
         /// <summary>
@@ -50,24 +47,15 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="AdvancedThreatProtectionSettingsList"/>. </summary>
-        /// <param name="value">
-        /// The AdvancedThreatProtectionSettingsModel items on this page
-        /// Serialized Name: AdvancedThreatProtectionSettingsList.value
-        /// </param>
+        /// <param name="value"> The AdvancedThreatProtectionSettingsModel items on this page. </param>
         internal AdvancedThreatProtectionSettingsList(IEnumerable<ServerThreatProtectionSettingsModelData> value)
         {
             Value = value.ToList();
         }
 
         /// <summary> Initializes a new instance of <see cref="AdvancedThreatProtectionSettingsList"/>. </summary>
-        /// <param name="value">
-        /// The AdvancedThreatProtectionSettingsModel items on this page
-        /// Serialized Name: AdvancedThreatProtectionSettingsList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: AdvancedThreatProtectionSettingsList.nextLink
-        /// </param>
+        /// <param name="value"> The AdvancedThreatProtectionSettingsModel items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AdvancedThreatProtectionSettingsList(IReadOnlyList<ServerThreatProtectionSettingsModelData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,15 +69,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The AdvancedThreatProtectionSettingsModel items on this page
-        /// Serialized Name: AdvancedThreatProtectionSettingsList.value
-        /// </summary>
+        /// <summary> The AdvancedThreatProtectionSettingsModel items on this page. </summary>
         public IReadOnlyList<ServerThreatProtectionSettingsModelData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: AdvancedThreatProtectionSettingsList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/BackupAutomaticAndOnDemandList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/BackupAutomaticAndOnDemandList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of backups.
-    /// Serialized Name: BackupAutomaticAndOnDemandList
-    /// </summary>
+    /// <summary> List of backups. </summary>
     internal partial class BackupAutomaticAndOnDemandList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="BackupAutomaticAndOnDemandList"/>. </summary>
-        /// <param name="value">
-        /// The BackupAutomaticAndOnDemand items on this page
-        /// Serialized Name: BackupAutomaticAndOnDemandList.value
-        /// </param>
+        /// <param name="value"> The BackupAutomaticAndOnDemand items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal BackupAutomaticAndOnDemandList(IEnumerable<PostgreSqlFlexibleServerBackupData> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="BackupAutomaticAndOnDemandList"/>. </summary>
-        /// <param name="value">
-        /// The BackupAutomaticAndOnDemand items on this page
-        /// Serialized Name: BackupAutomaticAndOnDemandList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: BackupAutomaticAndOnDemandList.nextLink
-        /// </param>
+        /// <param name="value"> The BackupAutomaticAndOnDemand items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal BackupAutomaticAndOnDemandList(IReadOnlyList<PostgreSqlFlexibleServerBackupData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The BackupAutomaticAndOnDemand items on this page
-        /// Serialized Name: BackupAutomaticAndOnDemandList.value
-        /// </summary>
+        /// <summary> The BackupAutomaticAndOnDemand items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerBackupData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: BackupAutomaticAndOnDemandList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/CapabilityList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/CapabilityList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of capabilities for the Azure Database for PostgreSQL flexible server.
-    /// Serialized Name: CapabilityList
-    /// </summary>
+    /// <summary> List of capabilities for the Azure Database for PostgreSQL flexible server. </summary>
     internal partial class CapabilityList
     {
         /// <summary>
@@ -50,24 +47,15 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="CapabilityList"/>. </summary>
-        /// <param name="value">
-        /// The Capability items on this page
-        /// Serialized Name: CapabilityList.value
-        /// </param>
+        /// <param name="value"> The Capability items on this page. </param>
         internal CapabilityList(IEnumerable<PostgreSqlFlexibleServerCapabilityProperties> value)
         {
             Value = value.ToList();
         }
 
         /// <summary> Initializes a new instance of <see cref="CapabilityList"/>. </summary>
-        /// <param name="value">
-        /// The Capability items on this page
-        /// Serialized Name: CapabilityList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: CapabilityList.nextLink
-        /// </param>
+        /// <param name="value"> The Capability items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal CapabilityList(IReadOnlyList<PostgreSqlFlexibleServerCapabilityProperties> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,15 +69,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The Capability items on this page
-        /// Serialized Name: CapabilityList.value
-        /// </summary>
+        /// <summary> The Capability items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerCapabilityProperties> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: CapabilityList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/CapturedLogList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/CapturedLogList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of log files.
-    /// Serialized Name: CapturedLogList
-    /// </summary>
+    /// <summary> List of log files. </summary>
     internal partial class CapturedLogList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="CapturedLogList"/>. </summary>
-        /// <param name="value">
-        /// The CapturedLog items on this page
-        /// Serialized Name: CapturedLogList.value
-        /// </param>
+        /// <param name="value"> The CapturedLog items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal CapturedLogList(IEnumerable<PostgreSqlFlexibleServerLogFile> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="CapturedLogList"/>. </summary>
-        /// <param name="value">
-        /// The CapturedLog items on this page
-        /// Serialized Name: CapturedLogList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: CapturedLogList.nextLink
-        /// </param>
+        /// <param name="value"> The CapturedLog items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal CapturedLogList(IReadOnlyList<PostgreSqlFlexibleServerLogFile> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The CapturedLog items on this page
-        /// Serialized Name: CapturedLogList.value
-        /// </summary>
+        /// <summary> The CapturedLog items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerLogFile> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: CapturedLogList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ConfigurationList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ConfigurationList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of configurations (also known as server parameters).
-    /// Serialized Name: ConfigurationList
-    /// </summary>
+    /// <summary> List of configurations (also known as server parameters). </summary>
     internal partial class ConfigurationList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ConfigurationList"/>. </summary>
-        /// <param name="value">
-        /// The Configuration items on this page
-        /// Serialized Name: ConfigurationList.value
-        /// </param>
+        /// <param name="value"> The Configuration items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal ConfigurationList(IEnumerable<PostgreSqlFlexibleServerConfigurationData> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ConfigurationList"/>. </summary>
-        /// <param name="value">
-        /// The Configuration items on this page
-        /// Serialized Name: ConfigurationList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: ConfigurationList.nextLink
-        /// </param>
+        /// <param name="value"> The Configuration items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ConfigurationList(IReadOnlyList<PostgreSqlFlexibleServerConfigurationData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The Configuration items on this page
-        /// Serialized Name: ConfigurationList.value
-        /// </summary>
+        /// <summary> The Configuration items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerConfigurationData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: ConfigurationList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/DatabaseList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/DatabaseList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of all databases in a server.
-    /// Serialized Name: DatabaseList
-    /// </summary>
+    /// <summary> List of all databases in a server. </summary>
     internal partial class DatabaseList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="DatabaseList"/>. </summary>
-        /// <param name="value">
-        /// The Database items on this page
-        /// Serialized Name: DatabaseList.value
-        /// </param>
+        /// <param name="value"> The Database items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal DatabaseList(IEnumerable<PostgreSqlFlexibleServerDatabaseData> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="DatabaseList"/>. </summary>
-        /// <param name="value">
-        /// The Database items on this page
-        /// Serialized Name: DatabaseList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: DatabaseList.nextLink
-        /// </param>
+        /// <param name="value"> The Database items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal DatabaseList(IReadOnlyList<PostgreSqlFlexibleServerDatabaseData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The Database items on this page
-        /// Serialized Name: DatabaseList.value
-        /// </summary>
+        /// <summary> The Database items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerDatabaseData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: DatabaseList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/DbLevelValidationStatus.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/DbLevelValidationStatus.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Validation status summary for a database.
-    /// Serialized Name: DbLevelValidationStatus
-    /// </summary>
+    /// <summary> Validation status summary for a database. </summary>
     public partial class DbLevelValidationStatus
     {
         /// <summary>
@@ -55,22 +52,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="DbLevelValidationStatus"/>. </summary>
-        /// <param name="databaseName">
-        /// Name of database.
-        /// Serialized Name: DbLevelValidationStatus.databaseName
-        /// </param>
-        /// <param name="startedOn">
-        /// Start time of a database level validation.
-        /// Serialized Name: DbLevelValidationStatus.startedOn
-        /// </param>
-        /// <param name="endedOn">
-        /// End time of a database level validation.
-        /// Serialized Name: DbLevelValidationStatus.endedOn
-        /// </param>
-        /// <param name="summary">
-        /// Summary of database level validations.
-        /// Serialized Name: DbLevelValidationStatus.summary
-        /// </param>
+        /// <param name="databaseName"> Name of database. </param>
+        /// <param name="startedOn"> Start time of a database level validation. </param>
+        /// <param name="endedOn"> End time of a database level validation. </param>
+        /// <param name="summary"> Summary of database level validations. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal DbLevelValidationStatus(string databaseName, DateTimeOffset? startedOn, DateTimeOffset? endedOn, IReadOnlyList<ValidationSummaryItem> summary, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,28 +66,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Name of database.
-        /// Serialized Name: DbLevelValidationStatus.databaseName
-        /// </summary>
+        /// <summary> Name of database. </summary>
         [WirePath("databaseName")]
         public string DatabaseName { get; }
-        /// <summary>
-        /// Start time of a database level validation.
-        /// Serialized Name: DbLevelValidationStatus.startedOn
-        /// </summary>
+        /// <summary> Start time of a database level validation. </summary>
         [WirePath("startedOn")]
         public DateTimeOffset? StartedOn { get; }
-        /// <summary>
-        /// End time of a database level validation.
-        /// Serialized Name: DbLevelValidationStatus.endedOn
-        /// </summary>
+        /// <summary> End time of a database level validation. </summary>
         [WirePath("endedOn")]
         public DateTimeOffset? EndedOn { get; }
-        /// <summary>
-        /// Summary of database level validations.
-        /// Serialized Name: DbLevelValidationStatus.summary
-        /// </summary>
+        /// <summary> Summary of database level validations. </summary>
         [WirePath("summary")]
         public IReadOnlyList<ValidationSummaryItem> Summary { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/DbMigrationStatus.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/DbMigrationStatus.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Migration state of a database.
-    /// Serialized Name: DatabaseMigrationState
-    /// </summary>
+    /// <summary> Migration state of a database. </summary>
     public partial class DbMigrationStatus
     {
         /// <summary>
@@ -54,70 +51,22 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="DbMigrationStatus"/>. </summary>
-        /// <param name="databaseName">
-        /// Name of database.
-        /// Serialized Name: DatabaseMigrationState.databaseName
-        /// </param>
-        /// <param name="migrationState">
-        /// Migration state of a database.
-        /// Serialized Name: DatabaseMigrationState.migrationState
-        /// </param>
-        /// <param name="migrationOperation">
-        /// Migration operation of a database.
-        /// Serialized Name: DatabaseMigrationState.migrationOperation
-        /// </param>
-        /// <param name="startedOn">
-        /// Start time of a migration state.
-        /// Serialized Name: DatabaseMigrationState.startedOn
-        /// </param>
-        /// <param name="endedOn">
-        /// End time of a migration state.
-        /// Serialized Name: DatabaseMigrationState.endedOn
-        /// </param>
-        /// <param name="fullLoadQueuedTables">
-        /// Number of tables queued for the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadQueuedTables
-        /// </param>
-        /// <param name="fullLoadErroredTables">
-        /// Number of tables encountering errors during the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadErroredTables
-        /// </param>
-        /// <param name="fullLoadLoadingTables">
-        /// Number of tables loading during the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadLoadingTables
-        /// </param>
-        /// <param name="fullLoadCompletedTables">
-        /// Number of tables loaded during the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadCompletedTables
-        /// </param>
-        /// <param name="cdcUpdateCounter">
-        /// Change Data Capture update counter.
-        /// Serialized Name: DatabaseMigrationState.cdcUpdateCounter
-        /// </param>
-        /// <param name="cdcDeleteCounter">
-        /// Change Data Capture delete counter.
-        /// Serialized Name: DatabaseMigrationState.cdcDeleteCounter
-        /// </param>
-        /// <param name="cdcInsertCounter">
-        /// Change Data Capture insert counter.
-        /// Serialized Name: DatabaseMigrationState.cdcInsertCounter
-        /// </param>
-        /// <param name="appliedChanges">
-        /// Change Data Capture applied changes counter.
-        /// Serialized Name: DatabaseMigrationState.appliedChanges
-        /// </param>
-        /// <param name="incomingChanges">
-        /// Change Data Capture incoming changes counter.
-        /// Serialized Name: DatabaseMigrationState.incomingChanges
-        /// </param>
-        /// <param name="latency">
-        /// Lag in seconds between source and target during online phase.
-        /// Serialized Name: DatabaseMigrationState.latency
-        /// </param>
-        /// <param name="message">
-        /// Error message, if any, for the migration state.
-        /// Serialized Name: DatabaseMigrationState.message
-        /// </param>
+        /// <param name="databaseName"> Name of database. </param>
+        /// <param name="migrationState"> Migration state of a database. </param>
+        /// <param name="migrationOperation"> Migration operation of a database. </param>
+        /// <param name="startedOn"> Start time of a migration state. </param>
+        /// <param name="endedOn"> End time of a migration state. </param>
+        /// <param name="fullLoadQueuedTables"> Number of tables queued for the migration of a database. </param>
+        /// <param name="fullLoadErroredTables"> Number of tables encountering errors during the migration of a database. </param>
+        /// <param name="fullLoadLoadingTables"> Number of tables loading during the migration of a database. </param>
+        /// <param name="fullLoadCompletedTables"> Number of tables loaded during the migration of a database. </param>
+        /// <param name="cdcUpdateCounter"> Change Data Capture update counter. </param>
+        /// <param name="cdcDeleteCounter"> Change Data Capture delete counter. </param>
+        /// <param name="cdcInsertCounter"> Change Data Capture insert counter. </param>
+        /// <param name="appliedChanges"> Change Data Capture applied changes counter. </param>
+        /// <param name="incomingChanges"> Change Data Capture incoming changes counter. </param>
+        /// <param name="latency"> Lag in seconds between source and target during online phase. </param>
+        /// <param name="message"> Error message, if any, for the migration state. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal DbMigrationStatus(string databaseName, MigrationDbState? migrationState, string migrationOperation, DateTimeOffset? startedOn, DateTimeOffset? endedOn, int? fullLoadQueuedTables, int? fullLoadErroredTables, int? fullLoadLoadingTables, int? fullLoadCompletedTables, int? cdcUpdateCounter, int? cdcDeleteCounter, int? cdcInsertCounter, int? appliedChanges, int? incomingChanges, int? latency, string message, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -140,100 +89,52 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Name of database.
-        /// Serialized Name: DatabaseMigrationState.databaseName
-        /// </summary>
+        /// <summary> Name of database. </summary>
         [WirePath("databaseName")]
         public string DatabaseName { get; }
-        /// <summary>
-        /// Migration state of a database.
-        /// Serialized Name: DatabaseMigrationState.migrationState
-        /// </summary>
+        /// <summary> Migration state of a database. </summary>
         [WirePath("migrationState")]
         public MigrationDbState? MigrationState { get; }
-        /// <summary>
-        /// Migration operation of a database.
-        /// Serialized Name: DatabaseMigrationState.migrationOperation
-        /// </summary>
+        /// <summary> Migration operation of a database. </summary>
         [WirePath("migrationOperation")]
         public string MigrationOperation { get; }
-        /// <summary>
-        /// Start time of a migration state.
-        /// Serialized Name: DatabaseMigrationState.startedOn
-        /// </summary>
+        /// <summary> Start time of a migration state. </summary>
         [WirePath("startedOn")]
         public DateTimeOffset? StartedOn { get; }
-        /// <summary>
-        /// End time of a migration state.
-        /// Serialized Name: DatabaseMigrationState.endedOn
-        /// </summary>
+        /// <summary> End time of a migration state. </summary>
         [WirePath("endedOn")]
         public DateTimeOffset? EndedOn { get; }
-        /// <summary>
-        /// Number of tables queued for the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadQueuedTables
-        /// </summary>
+        /// <summary> Number of tables queued for the migration of a database. </summary>
         [WirePath("fullLoadQueuedTables")]
         public int? FullLoadQueuedTables { get; }
-        /// <summary>
-        /// Number of tables encountering errors during the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadErroredTables
-        /// </summary>
+        /// <summary> Number of tables encountering errors during the migration of a database. </summary>
         [WirePath("fullLoadErroredTables")]
         public int? FullLoadErroredTables { get; }
-        /// <summary>
-        /// Number of tables loading during the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadLoadingTables
-        /// </summary>
+        /// <summary> Number of tables loading during the migration of a database. </summary>
         [WirePath("fullLoadLoadingTables")]
         public int? FullLoadLoadingTables { get; }
-        /// <summary>
-        /// Number of tables loaded during the migration of a database.
-        /// Serialized Name: DatabaseMigrationState.fullLoadCompletedTables
-        /// </summary>
+        /// <summary> Number of tables loaded during the migration of a database. </summary>
         [WirePath("fullLoadCompletedTables")]
         public int? FullLoadCompletedTables { get; }
-        /// <summary>
-        /// Change Data Capture update counter.
-        /// Serialized Name: DatabaseMigrationState.cdcUpdateCounter
-        /// </summary>
+        /// <summary> Change Data Capture update counter. </summary>
         [WirePath("cdcUpdateCounter")]
         public int? CdcUpdateCounter { get; }
-        /// <summary>
-        /// Change Data Capture delete counter.
-        /// Serialized Name: DatabaseMigrationState.cdcDeleteCounter
-        /// </summary>
+        /// <summary> Change Data Capture delete counter. </summary>
         [WirePath("cdcDeleteCounter")]
         public int? CdcDeleteCounter { get; }
-        /// <summary>
-        /// Change Data Capture insert counter.
-        /// Serialized Name: DatabaseMigrationState.cdcInsertCounter
-        /// </summary>
+        /// <summary> Change Data Capture insert counter. </summary>
         [WirePath("cdcInsertCounter")]
         public int? CdcInsertCounter { get; }
-        /// <summary>
-        /// Change Data Capture applied changes counter.
-        /// Serialized Name: DatabaseMigrationState.appliedChanges
-        /// </summary>
+        /// <summary> Change Data Capture applied changes counter. </summary>
         [WirePath("appliedChanges")]
         public int? AppliedChanges { get; }
-        /// <summary>
-        /// Change Data Capture incoming changes counter.
-        /// Serialized Name: DatabaseMigrationState.incomingChanges
-        /// </summary>
+        /// <summary> Change Data Capture incoming changes counter. </summary>
         [WirePath("incomingChanges")]
         public int? IncomingChanges { get; }
-        /// <summary>
-        /// Lag in seconds between source and target during online phase.
-        /// Serialized Name: DatabaseMigrationState.latency
-        /// </summary>
+        /// <summary> Lag in seconds between source and target during online phase. </summary>
         [WirePath("latency")]
         public int? Latency { get; }
-        /// <summary>
-        /// Error message, if any, for the migration state.
-        /// Serialized Name: DatabaseMigrationState.message
-        /// </summary>
+        /// <summary> Error message, if any, for the migration state. </summary>
         [WirePath("message")]
         public string Message { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/FirewallRuleList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/FirewallRuleList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of firewall rules.
-    /// Serialized Name: FirewallRuleList
-    /// </summary>
+    /// <summary> List of firewall rules. </summary>
     internal partial class FirewallRuleList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="FirewallRuleList"/>. </summary>
-        /// <param name="value">
-        /// The FirewallRule items on this page
-        /// Serialized Name: FirewallRuleList.value
-        /// </param>
+        /// <param name="value"> The FirewallRule items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal FirewallRuleList(IEnumerable<PostgreSqlFlexibleServerFirewallRuleData> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="FirewallRuleList"/>. </summary>
-        /// <param name="value">
-        /// The FirewallRule items on this page
-        /// Serialized Name: FirewallRuleList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: FirewallRuleList.nextLink
-        /// </param>
+        /// <param name="value"> The FirewallRule items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal FirewallRuleList(IReadOnlyList<PostgreSqlFlexibleServerFirewallRuleData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The FirewallRule items on this page
-        /// Serialized Name: FirewallRuleList.value
-        /// </summary>
+        /// <summary> The FirewallRule items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerFirewallRuleData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: FirewallRuleList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/MigrateRolesEnum.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/MigrateRolesEnum.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if roles and permissions must be migrated.
-    /// Serialized Name: MigrateRolesAndPermissions
-    /// </summary>
+    /// <summary> Indicates if roles and permissions must be migrated. </summary>
     public readonly partial struct MigrateRolesEnum : IEquatable<MigrateRolesEnum>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string TrueValue = "True";
         private const string FalseValue = "False";
 
-        /// <summary>
-        /// True
-        /// Serialized Name: MigrateRolesAndPermissions.True
-        /// </summary>
+        /// <summary> True. </summary>
         public static MigrateRolesEnum True { get; } = new MigrateRolesEnum(TrueValue);
-        /// <summary>
-        /// False
-        /// Serialized Name: MigrateRolesAndPermissions.False
-        /// </summary>
+        /// <summary> False. </summary>
         public static MigrateRolesEnum False { get; } = new MigrateRolesEnum(FalseValue);
         /// <summary> Determines if two <see cref="MigrateRolesEnum"/> values are the same. </summary>
         public static bool operator ==(MigrateRolesEnum left, MigrateRolesEnum right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/MigrationDbState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/MigrationDbState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Migration state of a database.
-    /// Serialized Name: MigrationDatabaseState
-    /// </summary>
+    /// <summary> Migration state of a database. </summary>
     public readonly partial struct MigrationDbState : IEquatable<MigrationDbState>
     {
         private readonly string _value;
@@ -32,35 +29,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string SucceededValue = "Succeeded";
         private const string CancelingValue = "Canceling";
 
-        /// <summary>
-        /// InProgress
-        /// Serialized Name: MigrationDatabaseState.InProgress
-        /// </summary>
+        /// <summary> InProgress. </summary>
         public static MigrationDbState InProgress { get; } = new MigrationDbState(InProgressValue);
-        /// <summary>
-        /// WaitingForCutoverTrigger
-        /// Serialized Name: MigrationDatabaseState.WaitingForCutoverTrigger
-        /// </summary>
+        /// <summary> WaitingForCutoverTrigger. </summary>
         public static MigrationDbState WaitingForCutoverTrigger { get; } = new MigrationDbState(WaitingForCutoverTriggerValue);
-        /// <summary>
-        /// Failed
-        /// Serialized Name: MigrationDatabaseState.Failed
-        /// </summary>
+        /// <summary> Failed. </summary>
         public static MigrationDbState Failed { get; } = new MigrationDbState(FailedValue);
-        /// <summary>
-        /// Canceled
-        /// Serialized Name: MigrationDatabaseState.Canceled
-        /// </summary>
+        /// <summary> Canceled. </summary>
         public static MigrationDbState Canceled { get; } = new MigrationDbState(CanceledValue);
-        /// <summary>
-        /// Succeeded
-        /// Serialized Name: MigrationDatabaseState.Succeeded
-        /// </summary>
+        /// <summary> Succeeded. </summary>
         public static MigrationDbState Succeeded { get; } = new MigrationDbState(SucceededValue);
-        /// <summary>
-        /// Canceling
-        /// Serialized Name: MigrationDatabaseState.Canceling
-        /// </summary>
+        /// <summary> Canceling. </summary>
         public static MigrationDbState Canceling { get; } = new MigrationDbState(CancelingValue);
         /// <summary> Determines if two <see cref="MigrationDbState"/> values are the same. </summary>
         public static bool operator ==(MigrationDbState left, MigrationDbState right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/MigrationList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/MigrationList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of migrations.
-    /// Serialized Name: MigrationList
-    /// </summary>
+    /// <summary> List of migrations. </summary>
     internal partial class MigrationList
     {
         /// <summary>
@@ -50,24 +47,15 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="MigrationList"/>. </summary>
-        /// <param name="value">
-        /// The Migration items on this page
-        /// Serialized Name: MigrationList.value
-        /// </param>
+        /// <param name="value"> The Migration items on this page. </param>
         internal MigrationList(IEnumerable<PostgreSqlMigrationData> value)
         {
             Value = value.ToList();
         }
 
         /// <summary> Initializes a new instance of <see cref="MigrationList"/>. </summary>
-        /// <param name="value">
-        /// The Migration items on this page
-        /// Serialized Name: MigrationList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: MigrationList.nextLink
-        /// </param>
+        /// <param name="value"> The Migration items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MigrationList(IReadOnlyList<PostgreSqlMigrationData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,15 +69,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The Migration items on this page
-        /// Serialized Name: MigrationList.value
-        /// </summary>
+        /// <summary> The Migration items on this page. </summary>
         public IReadOnlyList<PostgreSqlMigrationData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: MigrationList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/MigrationOption.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/MigrationOption.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Supported option for a migration
-    /// Serialized Name: MigrationOption
-    /// </summary>
+    /// <summary> Supported option for a migration. </summary>
     public readonly partial struct MigrationOption : IEquatable<MigrationOption>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string MigrateValue = "Migrate";
         private const string ValidateAndMigrateValue = "ValidateAndMigrate";
 
-        /// <summary>
-        /// Validate
-        /// Serialized Name: MigrationOption.Validate
-        /// </summary>
+        /// <summary> Validate. </summary>
         public static MigrationOption Validate { get; } = new MigrationOption(ValidateValue);
-        /// <summary>
-        /// Migrate
-        /// Serialized Name: MigrationOption.Migrate
-        /// </summary>
+        /// <summary> Migrate. </summary>
         public static MigrationOption Migrate { get; } = new MigrationOption(MigrateValue);
-        /// <summary>
-        /// ValidateAndMigrate
-        /// Serialized Name: MigrationOption.ValidateAndMigrate
-        /// </summary>
+        /// <summary> ValidateAndMigrate. </summary>
         public static MigrationOption ValidateAndMigrate { get; } = new MigrationOption(ValidateAndMigrateValue);
         /// <summary> Determines if two <see cref="MigrationOption"/> values are the same. </summary>
         public static bool operator ==(MigrationOption left, MigrationOption right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendation.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendation.cs
@@ -12,10 +12,7 @@ using Azure.ResourceManager.Models;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Object recommendation properties.
-    /// Serialized Name: ObjectRecommendation
-    /// </summary>
+    /// <summary> Object recommendation properties. </summary>
     public partial class ObjectRecommendation : ResourceData
     {
         /// <summary>
@@ -62,54 +59,18 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="kind">
-        /// Always empty.
-        /// Serialized Name: ObjectRecommendation.kind
-        /// </param>
-        /// <param name="initialRecommendedOn">
-        /// Creation time (UTC) of this recommendation.
-        /// Serialized Name: ObjectRecommendation.properties.initialRecommendedTime
-        /// </param>
-        /// <param name="lastRecommendedOn">
-        /// Last time (UTC) that this recommendation was produced.
-        /// Serialized Name: ObjectRecommendation.properties.lastRecommendedTime
-        /// </param>
-        /// <param name="timesRecommended">
-        /// Number of times this recommendation has been produced.
-        /// Serialized Name: ObjectRecommendation.properties.timesRecommended
-        /// </param>
-        /// <param name="improvedQueryIds">
-        /// List of identifiers for all queries identified as targets for improvement if the recommendation is applied. The list is only populated for CREATE INDEX recommendations.
-        /// Serialized Name: ObjectRecommendation.properties.improvedQueryIds
-        /// </param>
-        /// <param name="recommendationReason">
-        /// Reason for this recommendation.
-        /// Serialized Name: ObjectRecommendation.properties.recommendationReason
-        /// </param>
-        /// <param name="currentState">
-        /// Current state.
-        /// Serialized Name: ObjectRecommendation.properties.currentState
-        /// </param>
-        /// <param name="recommendationType">
-        /// Type for this recommendation.
-        /// Serialized Name: ObjectRecommendation.properties.recommendationType
-        /// </param>
-        /// <param name="implementationDetails">
-        /// Implementation details for the recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.implementationDetails
-        /// </param>
-        /// <param name="analyzedWorkload">
-        /// Workload information for the recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.analyzedWorkload
-        /// </param>
-        /// <param name="estimatedImpact">
-        /// Estimated impact of this recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.estimatedImpact
-        /// </param>
-        /// <param name="details">
-        /// Recommendation details for the recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.details
-        /// </param>
+        /// <param name="kind"> Always empty. </param>
+        /// <param name="initialRecommendedOn"> Creation time (UTC) of this recommendation. </param>
+        /// <param name="lastRecommendedOn"> Last time (UTC) that this recommendation was produced. </param>
+        /// <param name="timesRecommended"> Number of times this recommendation has been produced. </param>
+        /// <param name="improvedQueryIds"> List of identifiers for all queries identified as targets for improvement if the recommendation is applied. The list is only populated for CREATE INDEX recommendations. </param>
+        /// <param name="recommendationReason"> Reason for this recommendation. </param>
+        /// <param name="currentState"> Current state. </param>
+        /// <param name="recommendationType"> Type for this recommendation. </param>
+        /// <param name="implementationDetails"> Implementation details for the recommended action. </param>
+        /// <param name="analyzedWorkload"> Workload information for the recommended action. </param>
+        /// <param name="estimatedImpact"> Estimated impact of this recommended action. </param>
+        /// <param name="details"> Recommendation details for the recommended action. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ObjectRecommendation(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string kind, DateTimeOffset? initialRecommendedOn, DateTimeOffset? lastRecommendedOn, int? timesRecommended, IList<long> improvedQueryIds, string recommendationReason, string currentState, PostgreSqlFlexibleServerRecommendationType? recommendationType, ObjectRecommendationImplementationDetails implementationDetails, ObjectRecommendationAnalyzedWorkload analyzedWorkload, IReadOnlyList<RecommendationImpactRecord> estimatedImpact, ObjectRecommendationDetails details, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -128,76 +89,40 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Always empty.
-        /// Serialized Name: ObjectRecommendation.kind
-        /// </summary>
+        /// <summary> Always empty. </summary>
         [WirePath("kind")]
         public string Kind { get; set; }
-        /// <summary>
-        /// Creation time (UTC) of this recommendation.
-        /// Serialized Name: ObjectRecommendation.properties.initialRecommendedTime
-        /// </summary>
+        /// <summary> Creation time (UTC) of this recommendation. </summary>
         [WirePath("properties.initialRecommendedTime")]
         public DateTimeOffset? InitialRecommendedOn { get; set; }
-        /// <summary>
-        /// Last time (UTC) that this recommendation was produced.
-        /// Serialized Name: ObjectRecommendation.properties.lastRecommendedTime
-        /// </summary>
+        /// <summary> Last time (UTC) that this recommendation was produced. </summary>
         [WirePath("properties.lastRecommendedTime")]
         public DateTimeOffset? LastRecommendedOn { get; set; }
-        /// <summary>
-        /// Number of times this recommendation has been produced.
-        /// Serialized Name: ObjectRecommendation.properties.timesRecommended
-        /// </summary>
+        /// <summary> Number of times this recommendation has been produced. </summary>
         [WirePath("properties.timesRecommended")]
         public int? TimesRecommended { get; set; }
-        /// <summary>
-        /// List of identifiers for all queries identified as targets for improvement if the recommendation is applied. The list is only populated for CREATE INDEX recommendations.
-        /// Serialized Name: ObjectRecommendation.properties.improvedQueryIds
-        /// </summary>
+        /// <summary> List of identifiers for all queries identified as targets for improvement if the recommendation is applied. The list is only populated for CREATE INDEX recommendations. </summary>
         [WirePath("properties.improvedQueryIds")]
         public IList<long> ImprovedQueryIds { get; }
-        /// <summary>
-        /// Reason for this recommendation.
-        /// Serialized Name: ObjectRecommendation.properties.recommendationReason
-        /// </summary>
+        /// <summary> Reason for this recommendation. </summary>
         [WirePath("properties.recommendationReason")]
         public string RecommendationReason { get; set; }
-        /// <summary>
-        /// Current state.
-        /// Serialized Name: ObjectRecommendation.properties.currentState
-        /// </summary>
+        /// <summary> Current state. </summary>
         [WirePath("properties.currentState")]
         public string CurrentState { get; set; }
-        /// <summary>
-        /// Type for this recommendation.
-        /// Serialized Name: ObjectRecommendation.properties.recommendationType
-        /// </summary>
+        /// <summary> Type for this recommendation. </summary>
         [WirePath("properties.recommendationType")]
         public PostgreSqlFlexibleServerRecommendationType? RecommendationType { get; set; }
-        /// <summary>
-        /// Implementation details for the recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.implementationDetails
-        /// </summary>
+        /// <summary> Implementation details for the recommended action. </summary>
         [WirePath("properties.implementationDetails")]
         public ObjectRecommendationImplementationDetails ImplementationDetails { get; set; }
-        /// <summary>
-        /// Workload information for the recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.analyzedWorkload
-        /// </summary>
+        /// <summary> Workload information for the recommended action. </summary>
         [WirePath("properties.analyzedWorkload")]
         public ObjectRecommendationAnalyzedWorkload AnalyzedWorkload { get; set; }
-        /// <summary>
-        /// Estimated impact of this recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.estimatedImpact
-        /// </summary>
+        /// <summary> Estimated impact of this recommended action. </summary>
         [WirePath("properties.estimatedImpact")]
         public IReadOnlyList<RecommendationImpactRecord> EstimatedImpact { get; }
-        /// <summary>
-        /// Recommendation details for the recommended action.
-        /// Serialized Name: ObjectRecommendation.properties.details
-        /// </summary>
+        /// <summary> Recommendation details for the recommended action. </summary>
         [WirePath("properties.details")]
         public ObjectRecommendationDetails Details { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendationAnalyzedWorkload.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendationAnalyzedWorkload.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Workload information for the recommended action.
-    /// Serialized Name: ObjectRecommendationPropertiesAnalyzedWorkload
-    /// </summary>
+    /// <summary> Workload information for the recommended action. </summary>
     public partial class ObjectRecommendationAnalyzedWorkload
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ObjectRecommendationAnalyzedWorkload"/>. </summary>
-        /// <param name="startOn">
-        /// Start time (UTC) of the workload analyzed.
-        /// Serialized Name: ObjectRecommendationPropertiesAnalyzedWorkload.startTime
-        /// </param>
-        /// <param name="endOn">
-        /// End time (UTC) of the workload analyzed.
-        /// Serialized Name: ObjectRecommendationPropertiesAnalyzedWorkload.endTime
-        /// </param>
-        /// <param name="queryCount">
-        /// Number of queries from the workload that were examined to produce this recommendation. For DROP INDEX recommendations it's 0 (zero).
-        /// Serialized Name: ObjectRecommendationPropertiesAnalyzedWorkload.queryCount
-        /// </param>
+        /// <param name="startOn"> Start time (UTC) of the workload analyzed. </param>
+        /// <param name="endOn"> End time (UTC) of the workload analyzed. </param>
+        /// <param name="queryCount"> Number of queries from the workload that were examined to produce this recommendation. For DROP INDEX recommendations it's 0 (zero). </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ObjectRecommendationAnalyzedWorkload(DateTimeOffset? startOn, DateTimeOffset? endOn, int? queryCount, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Start time (UTC) of the workload analyzed.
-        /// Serialized Name: ObjectRecommendationPropertiesAnalyzedWorkload.startTime
-        /// </summary>
+        /// <summary> Start time (UTC) of the workload analyzed. </summary>
         [WirePath("startTime")]
         public DateTimeOffset? StartOn { get; set; }
-        /// <summary>
-        /// End time (UTC) of the workload analyzed.
-        /// Serialized Name: ObjectRecommendationPropertiesAnalyzedWorkload.endTime
-        /// </summary>
+        /// <summary> End time (UTC) of the workload analyzed. </summary>
         [WirePath("endTime")]
         public DateTimeOffset? EndOn { get; set; }
-        /// <summary>
-        /// Number of queries from the workload that were examined to produce this recommendation. For DROP INDEX recommendations it's 0 (zero).
-        /// Serialized Name: ObjectRecommendationPropertiesAnalyzedWorkload.queryCount
-        /// </summary>
+        /// <summary> Number of queries from the workload that were examined to produce this recommendation. For DROP INDEX recommendations it's 0 (zero). </summary>
         [WirePath("queryCount")]
         public int? QueryCount { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendationDetails.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendationDetails.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Recommendation details for the recommended action.
-    /// Serialized Name: ObjectRecommendationDetails
-    /// </summary>
+    /// <summary> Recommendation details for the recommended action. </summary>
     public partial class ObjectRecommendationDetails
     {
         /// <summary>
@@ -56,34 +53,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ObjectRecommendationDetails"/>. </summary>
-        /// <param name="databaseName">
-        /// Database name.
-        /// Serialized Name: ObjectRecommendationDetails.databaseName
-        /// </param>
-        /// <param name="schema">
-        /// Schema name.
-        /// Serialized Name: ObjectRecommendationDetails.schema
-        /// </param>
-        /// <param name="table">
-        /// Table name.
-        /// Serialized Name: ObjectRecommendationDetails.table
-        /// </param>
-        /// <param name="indexType">
-        /// Index type.
-        /// Serialized Name: ObjectRecommendationDetails.indexType
-        /// </param>
-        /// <param name="indexName">
-        /// Index name.
-        /// Serialized Name: ObjectRecommendationDetails.indexName
-        /// </param>
-        /// <param name="indexColumns">
-        /// Index columns.
-        /// Serialized Name: ObjectRecommendationDetails.indexColumns
-        /// </param>
-        /// <param name="includedColumns">
-        /// Index included columns.
-        /// Serialized Name: ObjectRecommendationDetails.includedColumns
-        /// </param>
+        /// <param name="databaseName"> Database name. </param>
+        /// <param name="schema"> Schema name. </param>
+        /// <param name="table"> Table name. </param>
+        /// <param name="indexType"> Index type. </param>
+        /// <param name="indexName"> Index name. </param>
+        /// <param name="indexColumns"> Index columns. </param>
+        /// <param name="includedColumns"> Index included columns. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ObjectRecommendationDetails(string databaseName, string schema, string table, string indexType, string indexName, IReadOnlyList<string> indexColumns, IReadOnlyList<string> includedColumns, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -97,46 +73,25 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Database name.
-        /// Serialized Name: ObjectRecommendationDetails.databaseName
-        /// </summary>
+        /// <summary> Database name. </summary>
         [WirePath("databaseName")]
         public string DatabaseName { get; }
-        /// <summary>
-        /// Schema name.
-        /// Serialized Name: ObjectRecommendationDetails.schema
-        /// </summary>
+        /// <summary> Schema name. </summary>
         [WirePath("schema")]
         public string Schema { get; }
-        /// <summary>
-        /// Table name.
-        /// Serialized Name: ObjectRecommendationDetails.table
-        /// </summary>
+        /// <summary> Table name. </summary>
         [WirePath("table")]
         public string Table { get; }
-        /// <summary>
-        /// Index type.
-        /// Serialized Name: ObjectRecommendationDetails.indexType
-        /// </summary>
+        /// <summary> Index type. </summary>
         [WirePath("indexType")]
         public string IndexType { get; }
-        /// <summary>
-        /// Index name.
-        /// Serialized Name: ObjectRecommendationDetails.indexName
-        /// </summary>
+        /// <summary> Index name. </summary>
         [WirePath("indexName")]
         public string IndexName { get; }
-        /// <summary>
-        /// Index columns.
-        /// Serialized Name: ObjectRecommendationDetails.indexColumns
-        /// </summary>
+        /// <summary> Index columns. </summary>
         [WirePath("indexColumns")]
         public IReadOnlyList<string> IndexColumns { get; }
-        /// <summary>
-        /// Index included columns.
-        /// Serialized Name: ObjectRecommendationDetails.includedColumns
-        /// </summary>
+        /// <summary> Index included columns. </summary>
         [WirePath("includedColumns")]
         public IReadOnlyList<string> IncludedColumns { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendationImplementationDetails.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendationImplementationDetails.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Implementation details for the recommended action.
-    /// Serialized Name: ObjectRecommendationPropertiesImplementationDetails
-    /// </summary>
+    /// <summary> Implementation details for the recommended action. </summary>
     public partial class ObjectRecommendationImplementationDetails
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ObjectRecommendationImplementationDetails"/>. </summary>
-        /// <param name="method">
-        /// Method of implementation for recommended action.
-        /// Serialized Name: ObjectRecommendationPropertiesImplementationDetails.method
-        /// </param>
-        /// <param name="script">
-        /// Implementation script for the recommended action.
-        /// Serialized Name: ObjectRecommendationPropertiesImplementationDetails.script
-        /// </param>
+        /// <param name="method"> Method of implementation for recommended action. </param>
+        /// <param name="script"> Implementation script for the recommended action. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ObjectRecommendationImplementationDetails(string method, string script, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Method of implementation for recommended action.
-        /// Serialized Name: ObjectRecommendationPropertiesImplementationDetails.method
-        /// </summary>
+        /// <summary> Method of implementation for recommended action. </summary>
         [WirePath("method")]
         public string Method { get; set; }
-        /// <summary>
-        /// Implementation script for the recommended action.
-        /// Serialized Name: ObjectRecommendationPropertiesImplementationDetails.script
-        /// </summary>
+        /// <summary> Implementation script for the recommended action. </summary>
         [WirePath("script")]
         public string Script { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendationList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ObjectRecommendationList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of available object recommendations.
-    /// Serialized Name: ObjectRecommendationList
-    /// </summary>
+    /// <summary> List of available object recommendations. </summary>
     internal partial class ObjectRecommendationList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ObjectRecommendationList"/>. </summary>
-        /// <param name="value">
-        /// The ObjectRecommendation items on this page
-        /// Serialized Name: ObjectRecommendationList.value
-        /// </param>
+        /// <param name="value"> The ObjectRecommendation items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal ObjectRecommendationList(IEnumerable<ObjectRecommendation> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ObjectRecommendationList"/>. </summary>
-        /// <param name="value">
-        /// The ObjectRecommendation items on this page
-        /// Serialized Name: ObjectRecommendationList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: ObjectRecommendationList.nextLink
-        /// </param>
+        /// <param name="value"> The ObjectRecommendation items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ObjectRecommendationList(IReadOnlyList<ObjectRecommendation> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The ObjectRecommendation items on this page
-        /// Serialized Name: ObjectRecommendationList.value
-        /// </summary>
+        /// <summary> The ObjectRecommendation items on this page. </summary>
         public IReadOnlyList<ObjectRecommendation> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: ObjectRecommendationList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlBackupContent.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlBackupContent.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// BackupRequestBase is the base for all backup request.
-    /// Serialized Name: BackupRequestBase
-    /// </summary>
+    /// <summary> BackupRequestBase is the base for all backup request. </summary>
     public partial class PostgreSqlBackupContent
     {
         /// <summary>
@@ -49,10 +46,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private protected IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlBackupContent"/>. </summary>
-        /// <param name="backupSettings">
-        /// Backup Settings
-        /// Serialized Name: BackupRequestBase.backupSettings
-        /// </param>
+        /// <param name="backupSettings"> Backup Settings. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="backupSettings"/> is null. </exception>
         public PostgreSqlBackupContent(PostgreSqlFlexibleServerBackupSettings backupSettings)
         {
@@ -62,10 +56,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlBackupContent"/>. </summary>
-        /// <param name="backupSettings">
-        /// Backup Settings
-        /// Serialized Name: BackupRequestBase.backupSettings
-        /// </param>
+        /// <param name="backupSettings"> Backup Settings. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlBackupContent(PostgreSqlFlexibleServerBackupSettings backupSettings, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -78,15 +69,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// Backup Settings
-        /// Serialized Name: BackupRequestBase.backupSettings
-        /// </summary>
+        /// <summary> Backup Settings. </summary>
         internal PostgreSqlFlexibleServerBackupSettings BackupSettings { get; }
-        /// <summary>
-        /// Backup Name for the current backup
-        /// Serialized Name: BackupSettings.backupName
-        /// </summary>
+        /// <summary> Backup Name for the current backup. </summary>
         [WirePath("backupSettings.backupName")]
         public string BackupName
         {

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlBaseCapability.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlBaseCapability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Base object for representing capability
-    /// Serialized Name: CapabilityBase
-    /// </summary>
+    /// <summary> Base object for representing capability. </summary>
     public partial class PostgreSqlBaseCapability
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlBaseCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlBaseCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </summary>
+        /// <summary> The status of the capability. </summary>
         [WirePath("status")]
         public PostgreSqlFlexbileServerCapabilityStatus? CapabilityStatus { get; }
-        /// <summary>
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </summary>
+        /// <summary> The reason for the capability not being available. </summary>
         [WirePath("reason")]
         public string Reason { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlCheckMigrationNameAvailabilityContent.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlCheckMigrationNameAvailabilityContent.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Availability of a migration name.
-    /// Serialized Name: MigrationNameAvailability
-    /// </summary>
+    /// <summary> Availability of a migration name. </summary>
     public partial class PostgreSqlCheckMigrationNameAvailabilityContent
     {
         /// <summary>
@@ -50,14 +47,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlCheckMigrationNameAvailabilityContent"/>. </summary>
-        /// <param name="name">
-        /// Name of the migration to check for validity and availability.
-        /// Serialized Name: MigrationNameAvailability.name
-        /// </param>
-        /// <param name="resourceType">
-        /// Type of resource.
-        /// Serialized Name: MigrationNameAvailability.type
-        /// </param>
+        /// <param name="name"> Name of the migration to check for validity and availability. </param>
+        /// <param name="resourceType"> Type of resource. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
         public PostgreSqlCheckMigrationNameAvailabilityContent(string name, ResourceType resourceType)
         {
@@ -68,26 +59,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlCheckMigrationNameAvailabilityContent"/>. </summary>
-        /// <param name="name">
-        /// Name of the migration to check for validity and availability.
-        /// Serialized Name: MigrationNameAvailability.name
-        /// </param>
-        /// <param name="resourceType">
-        /// Type of resource.
-        /// Serialized Name: MigrationNameAvailability.type
-        /// </param>
-        /// <param name="isNameAvailable">
-        /// Indicates if the migration name is available.
-        /// Serialized Name: MigrationNameAvailability.nameAvailable
-        /// </param>
-        /// <param name="reason">
-        /// Migration name availability reason.
-        /// Serialized Name: MigrationNameAvailability.reason
-        /// </param>
-        /// <param name="message">
-        /// Migration name availability message.
-        /// Serialized Name: MigrationNameAvailability.message
-        /// </param>
+        /// <param name="name"> Name of the migration to check for validity and availability. </param>
+        /// <param name="resourceType"> Type of resource. </param>
+        /// <param name="isNameAvailable"> Indicates if the migration name is available. </param>
+        /// <param name="reason"> Migration name availability reason. </param>
+        /// <param name="message"> Migration name availability message. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlCheckMigrationNameAvailabilityContent(string name, ResourceType resourceType, bool? isNameAvailable, PostgreSqlMigrationNameUnavailableReason? reason, string message, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -104,34 +80,19 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// Name of the migration to check for validity and availability.
-        /// Serialized Name: MigrationNameAvailability.name
-        /// </summary>
+        /// <summary> Name of the migration to check for validity and availability. </summary>
         [WirePath("name")]
         public string Name { get; set; }
-        /// <summary>
-        /// Type of resource.
-        /// Serialized Name: MigrationNameAvailability.type
-        /// </summary>
+        /// <summary> Type of resource. </summary>
         [WirePath("type")]
         public ResourceType ResourceType { get; set; }
-        /// <summary>
-        /// Indicates if the migration name is available.
-        /// Serialized Name: MigrationNameAvailability.nameAvailable
-        /// </summary>
+        /// <summary> Indicates if the migration name is available. </summary>
         [WirePath("nameAvailable")]
         public bool? IsNameAvailable { get; }
-        /// <summary>
-        /// Migration name availability reason.
-        /// Serialized Name: MigrationNameAvailability.reason
-        /// </summary>
+        /// <summary> Migration name availability reason. </summary>
         [WirePath("reason")]
         public PostgreSqlMigrationNameUnavailableReason? Reason { get; }
-        /// <summary>
-        /// Migration name availability message.
-        /// Serialized Name: MigrationNameAvailability.message
-        /// </summary>
+        /// <summary> Migration name availability message. </summary>
         [WirePath("message")]
         public string Message { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlExecutionStatus.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlExecutionStatus.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Service-set extensible enum indicating the status of operation
-    /// Serialized Name: ExecutionStatus
-    /// </summary>
+    /// <summary> Service-set extensible enum indicating the status of operation. </summary>
     public readonly partial struct PostgreSqlExecutionStatus : IEquatable<PostgreSqlExecutionStatus>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string FailedValue = "Failed";
         private const string SucceededValue = "Succeeded";
 
-        /// <summary>
-        /// Running
-        /// Serialized Name: ExecutionStatus.Running
-        /// </summary>
+        /// <summary> Running. </summary>
         public static PostgreSqlExecutionStatus Running { get; } = new PostgreSqlExecutionStatus(RunningValue);
-        /// <summary>
-        /// Cancelled
-        /// Serialized Name: ExecutionStatus.Cancelled
-        /// </summary>
+        /// <summary> Cancelled. </summary>
         public static PostgreSqlExecutionStatus Cancelled { get; } = new PostgreSqlExecutionStatus(CancelledValue);
-        /// <summary>
-        /// Failed
-        /// Serialized Name: ExecutionStatus.Failed
-        /// </summary>
+        /// <summary> Failed. </summary>
         public static PostgreSqlExecutionStatus Failed { get; } = new PostgreSqlExecutionStatus(FailedValue);
-        /// <summary>
-        /// Succeeded
-        /// Serialized Name: ExecutionStatus.Succeeded
-        /// </summary>
+        /// <summary> Succeeded. </summary>
         public static PostgreSqlExecutionStatus Succeeded { get; } = new PostgreSqlExecutionStatus(SucceededValue);
         /// <summary> Determines if two <see cref="PostgreSqlExecutionStatus"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlExecutionStatus left, PostgreSqlExecutionStatus right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexbileServerCapabilityStatus.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexbileServerCapabilityStatus.cs
@@ -7,31 +7,16 @@
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The status of the capability.
-    /// Serialized Name: CapabilityStatus
-    /// </summary>
+    /// <summary> The status of the capability. </summary>
     public enum PostgreSqlFlexbileServerCapabilityStatus
     {
-        /// <summary>
-        /// Visible
-        /// Serialized Name: CapabilityStatus.Visible
-        /// </summary>
+        /// <summary> Visible. </summary>
         Visible,
-        /// <summary>
-        /// Available
-        /// Serialized Name: CapabilityStatus.Available
-        /// </summary>
+        /// <summary> Available. </summary>
         Available,
-        /// <summary>
-        /// Default
-        /// Serialized Name: CapabilityStatus.Default
-        /// </summary>
+        /// <summary> Default. </summary>
         Default,
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: CapabilityStatus.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         Disabled
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerActiveDirectoryAuthEnum.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerActiveDirectoryAuthEnum.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if the server supports Microsoft Entra authentication.
-    /// Serialized Name: MicrosoftEntraAuth
-    /// </summary>
+    /// <summary> Indicates if the server supports Microsoft Entra authentication. </summary>
     public readonly partial struct PostgreSqlFlexibleServerActiveDirectoryAuthEnum : IEquatable<PostgreSqlFlexibleServerActiveDirectoryAuthEnum>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: MicrosoftEntraAuth.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerActiveDirectoryAuthEnum Enabled { get; } = new PostgreSqlFlexibleServerActiveDirectoryAuthEnum(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: MicrosoftEntraAuth.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerActiveDirectoryAuthEnum Disabled { get; } = new PostgreSqlFlexibleServerActiveDirectoryAuthEnum(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerActiveDirectoryAuthEnum"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerActiveDirectoryAuthEnum left, PostgreSqlFlexibleServerActiveDirectoryAuthEnum right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerAuthConfig.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerAuthConfig.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Authentication configuration properties of a server.
-    /// Serialized Name: AuthConfig
-    /// </summary>
+    /// <summary> Authentication configuration properties of a server. </summary>
     public partial class PostgreSqlFlexibleServerAuthConfig
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerAuthConfig"/>. </summary>
-        /// <param name="activeDirectoryAuth">
-        /// Indicates if the server supports Microsoft Entra authentication.
-        /// Serialized Name: AuthConfig.activeDirectoryAuth
-        /// </param>
-        /// <param name="passwordAuth">
-        /// Indicates if the server supports password based authentication.
-        /// Serialized Name: AuthConfig.passwordAuth
-        /// </param>
-        /// <param name="tenantId">
-        /// Identifier of the tenant of the delegated resource.
-        /// Serialized Name: AuthConfig.tenantId
-        /// </param>
+        /// <param name="activeDirectoryAuth"> Indicates if the server supports Microsoft Entra authentication. </param>
+        /// <param name="passwordAuth"> Indicates if the server supports password based authentication. </param>
+        /// <param name="tenantId"> Identifier of the tenant of the delegated resource. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerAuthConfig(PostgreSqlFlexibleServerActiveDirectoryAuthEnum? activeDirectoryAuth, PostgreSqlFlexibleServerPasswordAuthEnum? passwordAuth, Guid? tenantId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Indicates if the server supports Microsoft Entra authentication.
-        /// Serialized Name: AuthConfig.activeDirectoryAuth
-        /// </summary>
+        /// <summary> Indicates if the server supports Microsoft Entra authentication. </summary>
         [WirePath("activeDirectoryAuth")]
         public PostgreSqlFlexibleServerActiveDirectoryAuthEnum? ActiveDirectoryAuth { get; set; }
-        /// <summary>
-        /// Indicates if the server supports password based authentication.
-        /// Serialized Name: AuthConfig.passwordAuth
-        /// </summary>
+        /// <summary> Indicates if the server supports password based authentication. </summary>
         [WirePath("passwordAuth")]
         public PostgreSqlFlexibleServerPasswordAuthEnum? PasswordAuth { get; set; }
-        /// <summary>
-        /// Identifier of the tenant of the delegated resource.
-        /// Serialized Name: AuthConfig.tenantId
-        /// </summary>
+        /// <summary> Identifier of the tenant of the delegated resource. </summary>
         [WirePath("tenantId")]
         public Guid? TenantId { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerBackupOrigin.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerBackupOrigin.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Type of backup.
-    /// Serialized Name: BackupType
-    /// </summary>
+    /// <summary> Type of backup. </summary>
     public readonly partial struct PostgreSqlFlexibleServerBackupOrigin : IEquatable<PostgreSqlFlexibleServerBackupOrigin>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string FullValue = "Full";
         private const string CustomerOnDemandValue = "Customer On-Demand";
 
-        /// <summary>
-        /// Full
-        /// Serialized Name: BackupType.Full
-        /// </summary>
+        /// <summary> Full. </summary>
         public static PostgreSqlFlexibleServerBackupOrigin Full { get; } = new PostgreSqlFlexibleServerBackupOrigin(FullValue);
-        /// <summary>
-        /// Customer On-Demand
-        /// Serialized Name: BackupType.Customer On-Demand
-        /// </summary>
+        /// <summary> Customer On-Demand. </summary>
         public static PostgreSqlFlexibleServerBackupOrigin CustomerOnDemand { get; } = new PostgreSqlFlexibleServerBackupOrigin(CustomerOnDemandValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerBackupOrigin"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerBackupOrigin left, PostgreSqlFlexibleServerBackupOrigin right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerBackupProperties.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerBackupProperties.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Backup properties of a server.
-    /// Serialized Name: Backup
-    /// </summary>
+    /// <summary> Backup properties of a server. </summary>
     public partial class PostgreSqlFlexibleServerBackupProperties
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerBackupProperties"/>. </summary>
-        /// <param name="backupRetentionDays">
-        /// Backup retention days for the server.
-        /// Serialized Name: Backup.backupRetentionDays
-        /// </param>
-        /// <param name="geoRedundantBackup">
-        /// Indicates if the server is configured to create geographically redundant backups.
-        /// Serialized Name: Backup.geoRedundantBackup
-        /// </param>
-        /// <param name="earliestRestoreOn">
-        /// Earliest restore point time (ISO8601 format) for a server.
-        /// Serialized Name: Backup.earliestRestoreDate
-        /// </param>
+        /// <param name="backupRetentionDays"> Backup retention days for the server. </param>
+        /// <param name="geoRedundantBackup"> Indicates if the server is configured to create geographically redundant backups. </param>
+        /// <param name="earliestRestoreOn"> Earliest restore point time (ISO8601 format) for a server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerBackupProperties(int? backupRetentionDays, PostgreSqlFlexibleServerGeoRedundantBackupEnum? geoRedundantBackup, DateTimeOffset? earliestRestoreOn, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Backup retention days for the server.
-        /// Serialized Name: Backup.backupRetentionDays
-        /// </summary>
+        /// <summary> Backup retention days for the server. </summary>
         [WirePath("backupRetentionDays")]
         public int? BackupRetentionDays { get; set; }
-        /// <summary>
-        /// Indicates if the server is configured to create geographically redundant backups.
-        /// Serialized Name: Backup.geoRedundantBackup
-        /// </summary>
+        /// <summary> Indicates if the server is configured to create geographically redundant backups. </summary>
         [WirePath("geoRedundantBackup")]
         public PostgreSqlFlexibleServerGeoRedundantBackupEnum? GeoRedundantBackup { get; set; }
-        /// <summary>
-        /// Earliest restore point time (ISO8601 format) for a server.
-        /// Serialized Name: Backup.earliestRestoreDate
-        /// </summary>
+        /// <summary> Earliest restore point time (ISO8601 format) for a server. </summary>
         [WirePath("earliestRestoreDate")]
         public DateTimeOffset? EarliestRestoreOn { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerBackupSettings.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerBackupSettings.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The settings for the long term backup.
-    /// Serialized Name: BackupSettings
-    /// </summary>
+    /// <summary> The settings for the long term backup. </summary>
     public partial class PostgreSqlFlexibleServerBackupSettings
     {
         /// <summary>
@@ -49,10 +46,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerBackupSettings"/>. </summary>
-        /// <param name="backupName">
-        /// Backup Name for the current backup
-        /// Serialized Name: BackupSettings.backupName
-        /// </param>
+        /// <param name="backupName"> Backup Name for the current backup. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="backupName"/> is null. </exception>
         public PostgreSqlFlexibleServerBackupSettings(string backupName)
         {
@@ -62,10 +56,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerBackupSettings"/>. </summary>
-        /// <param name="backupName">
-        /// Backup Name for the current backup
-        /// Serialized Name: BackupSettings.backupName
-        /// </param>
+        /// <param name="backupName"> Backup Name for the current backup. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerBackupSettings(string backupName, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -78,10 +69,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// Backup Name for the current backup
-        /// Serialized Name: BackupSettings.backupName
-        /// </summary>
+        /// <summary> Backup Name for the current backup. </summary>
         [WirePath("backupName")]
         public string BackupName { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerBackupStoreDetails.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerBackupStoreDetails.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Details about the target where the backup content will be stored.
-    /// Serialized Name: BackupStoreDetails
-    /// </summary>
+    /// <summary> Details about the target where the backup content will be stored. </summary>
     public partial class PostgreSqlFlexibleServerBackupStoreDetails
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerBackupStoreDetails"/>. </summary>
-        /// <param name="sasUriList">
-        /// List of SAS uri of storage containers where backup data is to be streamed/copied.
-        /// Serialized Name: BackupStoreDetails.sasUriList
-        /// </param>
+        /// <param name="sasUriList"> List of SAS uri of storage containers where backup data is to be streamed/copied. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="sasUriList"/> is null. </exception>
         public PostgreSqlFlexibleServerBackupStoreDetails(IEnumerable<string> sasUriList)
         {
@@ -63,10 +57,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerBackupStoreDetails"/>. </summary>
-        /// <param name="sasUriList">
-        /// List of SAS uri of storage containers where backup data is to be streamed/copied.
-        /// Serialized Name: BackupStoreDetails.sasUriList
-        /// </param>
+        /// <param name="sasUriList"> List of SAS uri of storage containers where backup data is to be streamed/copied. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerBackupStoreDetails(IList<string> sasUriList, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -79,10 +70,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// List of SAS uri of storage containers where backup data is to be streamed/copied.
-        /// Serialized Name: BackupStoreDetails.sasUriList
-        /// </summary>
+        /// <summary> List of SAS uri of storage containers where backup data is to be streamed/copied. </summary>
         [WirePath("sasUriList")]
         public IList<string> SasUriList { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerCapabilityProperties.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerCapabilityProperties.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Capability for the Azure Database for PostgreSQL flexible server.
-    /// Serialized Name: Capability
-    /// </summary>
+    /// <summary> Capability for the Azure Database for PostgreSQL flexible server. </summary>
     public partial class PostgreSqlFlexibleServerCapabilityProperties : PostgreSqlBaseCapability
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerCapabilityProperties"/>. </summary>
@@ -26,63 +23,21 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerCapabilityProperties"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="name">
-        /// Name of flexible servers capabilities.
-        /// Serialized Name: Capability.name
-        /// </param>
-        /// <param name="supportedServerEditions">
-        /// List of supported compute tiers.
-        /// Serialized Name: Capability.supportedServerEditions
-        /// </param>
-        /// <param name="supportedServerVersions">
-        /// List of supported major versions of PostgreSQL database engine.
-        /// Serialized Name: Capability.supportedServerVersions
-        /// </param>
-        /// <param name="supportedFeatures">
-        /// Features supported.
-        /// Serialized Name: Capability.supportedFeatures
-        /// </param>
-        /// <param name="supportFastProvisioning">
-        /// Indicates if fast provisioning is supported. 'Enabled' means fast provisioning is supported. 'Disabled' stands for fast provisioning is not supported. Will be deprecated in the future. Look to Supported Features for 'FastProvisioning'.
-        /// Serialized Name: Capability.fastProvisioningSupported
-        /// </param>
-        /// <param name="supportedFastProvisioningEditions">
-        /// List of compute tiers supporting fast provisioning.
-        /// Serialized Name: Capability.supportedFastProvisioningEditions
-        /// </param>
-        /// <param name="geoBackupSupported">
-        /// Indicates if geographically redundant backups are supported in this location. 'Enabled' means geographically redundant backups are supported. 'Disabled' stands for geographically redundant backup is not supported. Will be deprecated in the future. Look to Supported Features for 'GeoBackup'.
-        /// Serialized Name: Capability.geoBackupSupported
-        /// </param>
-        /// <param name="zoneRedundantHaSupported">
-        /// Indicates if high availability with zone redundancy is supported in this location. 'Enabled' means high availability with zone redundancy is supported. 'Disabled' stands for high availability with zone redundancy is not supported. Will be deprecated in the future. Look to Supported Features for  'ZoneRedundantHa'.
-        /// Serialized Name: Capability.zoneRedundantHaSupported
-        /// </param>
-        /// <param name="zoneRedundantHaAndGeoBackupSupported">
-        /// Indicates if high availability with zone redundancy is supported in conjunction with geographically redundant backups in this location. 'Enabled' means high availability with zone redundancy is supported in conjunction with geographically redundant backups is supported. 'Disabled' stands for high availability with zone redundancy is supported in conjunction with geographically redundant backups is not supported. Will be deprecated in the future. Look to Supported Features for 'ZoneRedundantHaAndGeoBackup'.
-        /// Serialized Name: Capability.zoneRedundantHaAndGeoBackupSupported
-        /// </param>
-        /// <param name="storageAutoGrowthSupported">
-        /// Indicates if storage autogrow is supported in this location. 'Enabled' means storage autogrow is supported. 'Disabled' stands for storage autogrow is not supported. Will be deprecated in the future. Look to Supported Features for 'StorageAutoGrowth'.
-        /// Serialized Name: Capability.storageAutoGrowthSupported
-        /// </param>
-        /// <param name="onlineResizeSupported">
-        /// Indicates if resizing the storage, without interrupting the operation of the database engine, is supported in this location for the given subscription. 'Enabled' means resizing the storage without interrupting the operation of the database engine is supported. 'Disabled' means resizing the storage without interrupting the operation of the database engine is not supported. Will be deprecated in the future. Look to Supported Features for 'OnlineResize'.
-        /// Serialized Name: Capability.onlineResizeSupported
-        /// </param>
-        /// <param name="restricted">
-        /// Indicates if this location is restricted. 'Enabled' means location is restricted. 'Disabled' stands for location is not restricted. Will be deprecated in the future. Look to Supported Features for 'Restricted'.
-        /// Serialized Name: Capability.restricted
-        /// </param>
+        /// <param name="name"> Name of flexible servers capabilities. </param>
+        /// <param name="supportedServerEditions"> List of supported compute tiers. </param>
+        /// <param name="supportedServerVersions"> List of supported major versions of PostgreSQL database engine. </param>
+        /// <param name="supportedFeatures"> Features supported. </param>
+        /// <param name="supportFastProvisioning"> Indicates if fast provisioning is supported. 'Enabled' means fast provisioning is supported. 'Disabled' stands for fast provisioning is not supported. Will be deprecated in the future. Look to Supported Features for 'FastProvisioning'. </param>
+        /// <param name="supportedFastProvisioningEditions"> List of compute tiers supporting fast provisioning. </param>
+        /// <param name="geoBackupSupported"> Indicates if geographically redundant backups are supported in this location. 'Enabled' means geographically redundant backups are supported. 'Disabled' stands for geographically redundant backup is not supported. Will be deprecated in the future. Look to Supported Features for 'GeoBackup'. </param>
+        /// <param name="zoneRedundantHaSupported"> Indicates if high availability with zone redundancy is supported in this location. 'Enabled' means high availability with zone redundancy is supported. 'Disabled' stands for high availability with zone redundancy is not supported. Will be deprecated in the future. Look to Supported Features for  'ZoneRedundantHa'. </param>
+        /// <param name="zoneRedundantHaAndGeoBackupSupported"> Indicates if high availability with zone redundancy is supported in conjunction with geographically redundant backups in this location. 'Enabled' means high availability with zone redundancy is supported in conjunction with geographically redundant backups is supported. 'Disabled' stands for high availability with zone redundancy is supported in conjunction with geographically redundant backups is not supported. Will be deprecated in the future. Look to Supported Features for 'ZoneRedundantHaAndGeoBackup'. </param>
+        /// <param name="storageAutoGrowthSupported"> Indicates if storage autogrow is supported in this location. 'Enabled' means storage autogrow is supported. 'Disabled' stands for storage autogrow is not supported. Will be deprecated in the future. Look to Supported Features for 'StorageAutoGrowth'. </param>
+        /// <param name="onlineResizeSupported"> Indicates if resizing the storage, without interrupting the operation of the database engine, is supported in this location for the given subscription. 'Enabled' means resizing the storage without interrupting the operation of the database engine is supported. 'Disabled' means resizing the storage without interrupting the operation of the database engine is not supported. Will be deprecated in the future. Look to Supported Features for 'OnlineResize'. </param>
+        /// <param name="restricted"> Indicates if this location is restricted. 'Enabled' means location is restricted. 'Disabled' stands for location is not restricted. Will be deprecated in the future. Look to Supported Features for 'Restricted'. </param>
         internal PostgreSqlFlexibleServerCapabilityProperties(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData, string name, IReadOnlyList<PostgreSqlFlexibleServerEditionCapability> supportedServerEditions, IReadOnlyList<PostgreSqlFlexibleServerServerVersionCapability> supportedServerVersions, IReadOnlyList<PostgreSqlFlexibleServerSupportedFeature> supportedFeatures, PostgreSqlFlexibleServerFastProvisioningSupported? supportFastProvisioning, IReadOnlyList<PostgreSqlFlexibleServerFastProvisioningEditionCapability> supportedFastProvisioningEditions, PostgreSqlFlexibleServerGeoBackupSupported? geoBackupSupported, PostgreSqlFlexibleServerZoneRedundantHaSupported? zoneRedundantHaSupported, PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported? zoneRedundantHaAndGeoBackupSupported, PostgreSqlFlexibleServerStorageAutoGrowthSupported? storageAutoGrowthSupported, PostgreSqlFlexibleServerOnlineResizeSupported? onlineResizeSupported, PostgreSqlFlexibleServerZoneRedundantRestricted? restricted) : base(capabilityStatus, reason, serializedAdditionalRawData)
         {
             Name = name;
@@ -99,76 +54,40 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             Restricted = restricted;
         }
 
-        /// <summary>
-        /// Name of flexible servers capabilities.
-        /// Serialized Name: Capability.name
-        /// </summary>
+        /// <summary> Name of flexible servers capabilities. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// List of supported compute tiers.
-        /// Serialized Name: Capability.supportedServerEditions
-        /// </summary>
+        /// <summary> List of supported compute tiers. </summary>
         [WirePath("supportedServerEditions")]
         public IReadOnlyList<PostgreSqlFlexibleServerEditionCapability> SupportedServerEditions { get; }
-        /// <summary>
-        /// List of supported major versions of PostgreSQL database engine.
-        /// Serialized Name: Capability.supportedServerVersions
-        /// </summary>
+        /// <summary> List of supported major versions of PostgreSQL database engine. </summary>
         [WirePath("supportedServerVersions")]
         public IReadOnlyList<PostgreSqlFlexibleServerServerVersionCapability> SupportedServerVersions { get; }
-        /// <summary>
-        /// Features supported.
-        /// Serialized Name: Capability.supportedFeatures
-        /// </summary>
+        /// <summary> Features supported. </summary>
         [WirePath("supportedFeatures")]
         public IReadOnlyList<PostgreSqlFlexibleServerSupportedFeature> SupportedFeatures { get; }
-        /// <summary>
-        /// Indicates if fast provisioning is supported. 'Enabled' means fast provisioning is supported. 'Disabled' stands for fast provisioning is not supported. Will be deprecated in the future. Look to Supported Features for 'FastProvisioning'.
-        /// Serialized Name: Capability.fastProvisioningSupported
-        /// </summary>
+        /// <summary> Indicates if fast provisioning is supported. 'Enabled' means fast provisioning is supported. 'Disabled' stands for fast provisioning is not supported. Will be deprecated in the future. Look to Supported Features for 'FastProvisioning'. </summary>
         [WirePath("fastProvisioningSupported")]
         public PostgreSqlFlexibleServerFastProvisioningSupported? SupportFastProvisioning { get; }
-        /// <summary>
-        /// List of compute tiers supporting fast provisioning.
-        /// Serialized Name: Capability.supportedFastProvisioningEditions
-        /// </summary>
+        /// <summary> List of compute tiers supporting fast provisioning. </summary>
         [WirePath("supportedFastProvisioningEditions")]
         public IReadOnlyList<PostgreSqlFlexibleServerFastProvisioningEditionCapability> SupportedFastProvisioningEditions { get; }
-        /// <summary>
-        /// Indicates if geographically redundant backups are supported in this location. 'Enabled' means geographically redundant backups are supported. 'Disabled' stands for geographically redundant backup is not supported. Will be deprecated in the future. Look to Supported Features for 'GeoBackup'.
-        /// Serialized Name: Capability.geoBackupSupported
-        /// </summary>
+        /// <summary> Indicates if geographically redundant backups are supported in this location. 'Enabled' means geographically redundant backups are supported. 'Disabled' stands for geographically redundant backup is not supported. Will be deprecated in the future. Look to Supported Features for 'GeoBackup'. </summary>
         [WirePath("geoBackupSupported")]
         public PostgreSqlFlexibleServerGeoBackupSupported? GeoBackupSupported { get; }
-        /// <summary>
-        /// Indicates if high availability with zone redundancy is supported in this location. 'Enabled' means high availability with zone redundancy is supported. 'Disabled' stands for high availability with zone redundancy is not supported. Will be deprecated in the future. Look to Supported Features for  'ZoneRedundantHa'.
-        /// Serialized Name: Capability.zoneRedundantHaSupported
-        /// </summary>
+        /// <summary> Indicates if high availability with zone redundancy is supported in this location. 'Enabled' means high availability with zone redundancy is supported. 'Disabled' stands for high availability with zone redundancy is not supported. Will be deprecated in the future. Look to Supported Features for  'ZoneRedundantHa'. </summary>
         [WirePath("zoneRedundantHaSupported")]
         public PostgreSqlFlexibleServerZoneRedundantHaSupported? ZoneRedundantHaSupported { get; }
-        /// <summary>
-        /// Indicates if high availability with zone redundancy is supported in conjunction with geographically redundant backups in this location. 'Enabled' means high availability with zone redundancy is supported in conjunction with geographically redundant backups is supported. 'Disabled' stands for high availability with zone redundancy is supported in conjunction with geographically redundant backups is not supported. Will be deprecated in the future. Look to Supported Features for 'ZoneRedundantHaAndGeoBackup'.
-        /// Serialized Name: Capability.zoneRedundantHaAndGeoBackupSupported
-        /// </summary>
+        /// <summary> Indicates if high availability with zone redundancy is supported in conjunction with geographically redundant backups in this location. 'Enabled' means high availability with zone redundancy is supported in conjunction with geographically redundant backups is supported. 'Disabled' stands for high availability with zone redundancy is supported in conjunction with geographically redundant backups is not supported. Will be deprecated in the future. Look to Supported Features for 'ZoneRedundantHaAndGeoBackup'. </summary>
         [WirePath("zoneRedundantHaAndGeoBackupSupported")]
         public PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported? ZoneRedundantHaAndGeoBackupSupported { get; }
-        /// <summary>
-        /// Indicates if storage autogrow is supported in this location. 'Enabled' means storage autogrow is supported. 'Disabled' stands for storage autogrow is not supported. Will be deprecated in the future. Look to Supported Features for 'StorageAutoGrowth'.
-        /// Serialized Name: Capability.storageAutoGrowthSupported
-        /// </summary>
+        /// <summary> Indicates if storage autogrow is supported in this location. 'Enabled' means storage autogrow is supported. 'Disabled' stands for storage autogrow is not supported. Will be deprecated in the future. Look to Supported Features for 'StorageAutoGrowth'. </summary>
         [WirePath("storageAutoGrowthSupported")]
         public PostgreSqlFlexibleServerStorageAutoGrowthSupported? StorageAutoGrowthSupported { get; }
-        /// <summary>
-        /// Indicates if resizing the storage, without interrupting the operation of the database engine, is supported in this location for the given subscription. 'Enabled' means resizing the storage without interrupting the operation of the database engine is supported. 'Disabled' means resizing the storage without interrupting the operation of the database engine is not supported. Will be deprecated in the future. Look to Supported Features for 'OnlineResize'.
-        /// Serialized Name: Capability.onlineResizeSupported
-        /// </summary>
+        /// <summary> Indicates if resizing the storage, without interrupting the operation of the database engine, is supported in this location for the given subscription. 'Enabled' means resizing the storage without interrupting the operation of the database engine is supported. 'Disabled' means resizing the storage without interrupting the operation of the database engine is not supported. Will be deprecated in the future. Look to Supported Features for 'OnlineResize'. </summary>
         [WirePath("onlineResizeSupported")]
         public PostgreSqlFlexibleServerOnlineResizeSupported? OnlineResizeSupported { get; }
-        /// <summary>
-        /// Indicates if this location is restricted. 'Enabled' means location is restricted. 'Disabled' stands for location is not restricted. Will be deprecated in the future. Look to Supported Features for 'Restricted'.
-        /// Serialized Name: Capability.restricted
-        /// </summary>
+        /// <summary> Indicates if this location is restricted. 'Enabled' means location is restricted. 'Disabled' stands for location is not restricted. Will be deprecated in the future. Look to Supported Features for 'Restricted'. </summary>
         [WirePath("restricted")]
         public PostgreSqlFlexibleServerZoneRedundantRestricted? Restricted { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerClusterProperties.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerClusterProperties.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Cluster properties of a server.
-    /// Serialized Name: Cluster
-    /// </summary>
+    /// <summary> Cluster properties of a server. </summary>
     public partial class PostgreSqlFlexibleServerClusterProperties
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerClusterProperties"/>. </summary>
-        /// <param name="clusterSize">
-        /// Number of nodes assigned to the elastic cluster.
-        /// Serialized Name: Cluster.clusterSize
-        /// </param>
-        /// <param name="defaultDatabaseName">
-        /// Default database name for the elastic cluster.
-        /// Serialized Name: Cluster.defaultDatabaseName
-        /// </param>
+        /// <param name="clusterSize"> Number of nodes assigned to the elastic cluster. </param>
+        /// <param name="defaultDatabaseName"> Default database name for the elastic cluster. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerClusterProperties(int? clusterSize, string defaultDatabaseName, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Number of nodes assigned to the elastic cluster.
-        /// Serialized Name: Cluster.clusterSize
-        /// </summary>
+        /// <summary> Number of nodes assigned to the elastic cluster. </summary>
         [WirePath("clusterSize")]
         public int? ClusterSize { get; set; }
-        /// <summary>
-        /// Default database name for the elastic cluster.
-        /// Serialized Name: Cluster.defaultDatabaseName
-        /// </summary>
+        /// <summary> Default database name for the elastic cluster. </summary>
         [WirePath("defaultDatabaseName")]
         public string DefaultDatabaseName { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerConfigurationCreateOrUpdateContent.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerConfigurationCreateOrUpdateContent.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Configuration (also known as server parameter).
-    /// Serialized Name: ConfigurationForUpdate
-    /// </summary>
+    /// <summary> Configuration (also known as server parameter). </summary>
     public partial class PostgreSqlFlexibleServerConfigurationCreateOrUpdateContent
     {
         /// <summary>
@@ -54,50 +51,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerConfigurationCreateOrUpdateContent"/>. </summary>
-        /// <param name="value">
-        /// Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: ConfigurationForUpdate.properties.value
-        /// </param>
-        /// <param name="description">
-        /// Description of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.description
-        /// </param>
-        /// <param name="defaultValue">
-        /// Value assigned by default to the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.defaultValue
-        /// </param>
-        /// <param name="dataType">
-        /// Data type of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.dataType
-        /// </param>
-        /// <param name="allowedValues">
-        /// Allowed values of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.allowedValues
-        /// </param>
-        /// <param name="source">
-        /// Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: ConfigurationForUpdate.properties.source
-        /// </param>
-        /// <param name="isDynamicConfig">
-        /// Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect.
-        /// Serialized Name: ConfigurationForUpdate.properties.isDynamicConfig
-        /// </param>
-        /// <param name="isReadOnly">
-        /// Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.isReadOnly
-        /// </param>
-        /// <param name="isConfigPendingRestart">
-        /// Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect.
-        /// Serialized Name: ConfigurationForUpdate.properties.isConfigPendingRestart
-        /// </param>
-        /// <param name="unit">
-        /// Units in which the configuration (also known as server parameter) value is expressed.
-        /// Serialized Name: ConfigurationForUpdate.properties.unit
-        /// </param>
-        /// <param name="documentationLink">
-        /// Link pointing to the documentation of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.documentationLink
-        /// </param>
+        /// <param name="value"> Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </param>
+        /// <param name="description"> Description of the configuration (also known as server parameter). </param>
+        /// <param name="defaultValue"> Value assigned by default to the configuration (also known as server parameter). </param>
+        /// <param name="dataType"> Data type of the configuration (also known as server parameter). </param>
+        /// <param name="allowedValues"> Allowed values of the configuration (also known as server parameter). </param>
+        /// <param name="source"> Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </param>
+        /// <param name="isDynamicConfig"> Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect. </param>
+        /// <param name="isReadOnly"> Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter). </param>
+        /// <param name="isConfigPendingRestart"> Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect. </param>
+        /// <param name="unit"> Units in which the configuration (also known as server parameter) value is expressed. </param>
+        /// <param name="documentationLink"> Link pointing to the documentation of the configuration (also known as server parameter). </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerConfigurationCreateOrUpdateContent(string value, string description, string defaultValue, PostgreSqlFlexibleServerConfigurationDataType? dataType, string allowedValues, string source, bool? isDynamicConfig, bool? isReadOnly, bool? isConfigPendingRestart, string unit, string documentationLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -115,70 +79,37 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: ConfigurationForUpdate.properties.value
-        /// </summary>
+        /// <summary> Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </summary>
         [WirePath("properties.value")]
         public string Value { get; set; }
-        /// <summary>
-        /// Description of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.description
-        /// </summary>
+        /// <summary> Description of the configuration (also known as server parameter). </summary>
         [WirePath("properties.description")]
         public string Description { get; }
-        /// <summary>
-        /// Value assigned by default to the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.defaultValue
-        /// </summary>
+        /// <summary> Value assigned by default to the configuration (also known as server parameter). </summary>
         [WirePath("properties.defaultValue")]
         public string DefaultValue { get; }
-        /// <summary>
-        /// Data type of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.dataType
-        /// </summary>
+        /// <summary> Data type of the configuration (also known as server parameter). </summary>
         [WirePath("properties.dataType")]
         public PostgreSqlFlexibleServerConfigurationDataType? DataType { get; }
-        /// <summary>
-        /// Allowed values of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.allowedValues
-        /// </summary>
+        /// <summary> Allowed values of the configuration (also known as server parameter). </summary>
         [WirePath("properties.allowedValues")]
         public string AllowedValues { get; }
-        /// <summary>
-        /// Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: ConfigurationForUpdate.properties.source
-        /// </summary>
+        /// <summary> Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </summary>
         [WirePath("properties.source")]
         public string Source { get; set; }
-        /// <summary>
-        /// Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect.
-        /// Serialized Name: ConfigurationForUpdate.properties.isDynamicConfig
-        /// </summary>
+        /// <summary> Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect. </summary>
         [WirePath("properties.isDynamicConfig")]
         public bool? IsDynamicConfig { get; }
-        /// <summary>
-        /// Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.isReadOnly
-        /// </summary>
+        /// <summary> Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter). </summary>
         [WirePath("properties.isReadOnly")]
         public bool? IsReadOnly { get; }
-        /// <summary>
-        /// Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect.
-        /// Serialized Name: ConfigurationForUpdate.properties.isConfigPendingRestart
-        /// </summary>
+        /// <summary> Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect. </summary>
         [WirePath("properties.isConfigPendingRestart")]
         public bool? IsConfigPendingRestart { get; }
-        /// <summary>
-        /// Units in which the configuration (also known as server parameter) value is expressed.
-        /// Serialized Name: ConfigurationForUpdate.properties.unit
-        /// </summary>
+        /// <summary> Units in which the configuration (also known as server parameter) value is expressed. </summary>
         [WirePath("properties.unit")]
         public string Unit { get; }
-        /// <summary>
-        /// Link pointing to the documentation of the configuration (also known as server parameter).
-        /// Serialized Name: ConfigurationForUpdate.properties.documentationLink
-        /// </summary>
+        /// <summary> Link pointing to the documentation of the configuration (also known as server parameter). </summary>
         [WirePath("properties.documentationLink")]
         public string DocumentationLink { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerConfigurationDataType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerConfigurationDataType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Data type of the configuration (also known as server parameter).
-    /// Serialized Name: ConfigurationDataType
-    /// </summary>
+    /// <summary> Data type of the configuration (also known as server parameter). </summary>
     public readonly partial struct PostgreSqlFlexibleServerConfigurationDataType : IEquatable<PostgreSqlFlexibleServerConfigurationDataType>
     {
         private readonly string _value;
@@ -32,35 +29,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string StringValue = "String";
         private const string SetValue = "Set";
 
-        /// <summary>
-        /// Boolean
-        /// Serialized Name: ConfigurationDataType.Boolean
-        /// </summary>
+        /// <summary> Boolean. </summary>
         public static PostgreSqlFlexibleServerConfigurationDataType Boolean { get; } = new PostgreSqlFlexibleServerConfigurationDataType(BooleanValue);
-        /// <summary>
-        /// Numeric
-        /// Serialized Name: ConfigurationDataType.Numeric
-        /// </summary>
+        /// <summary> Numeric. </summary>
         public static PostgreSqlFlexibleServerConfigurationDataType Numeric { get; } = new PostgreSqlFlexibleServerConfigurationDataType(NumericValue);
-        /// <summary>
-        /// Integer
-        /// Serialized Name: ConfigurationDataType.Integer
-        /// </summary>
+        /// <summary> Integer. </summary>
         public static PostgreSqlFlexibleServerConfigurationDataType Integer { get; } = new PostgreSqlFlexibleServerConfigurationDataType(IntegerValue);
-        /// <summary>
-        /// Enumeration
-        /// Serialized Name: ConfigurationDataType.Enumeration
-        /// </summary>
+        /// <summary> Enumeration. </summary>
         public static PostgreSqlFlexibleServerConfigurationDataType Enumeration { get; } = new PostgreSqlFlexibleServerConfigurationDataType(EnumerationValue);
-        /// <summary>
-        /// String
-        /// Serialized Name: ConfigurationDataType.String
-        /// </summary>
+        /// <summary> String. </summary>
         public static PostgreSqlFlexibleServerConfigurationDataType String { get; } = new PostgreSqlFlexibleServerConfigurationDataType(StringValue);
-        /// <summary>
-        /// Set
-        /// Serialized Name: ConfigurationDataType.Set
-        /// </summary>
+        /// <summary> Set. </summary>
         public static PostgreSqlFlexibleServerConfigurationDataType Set { get; } = new PostgreSqlFlexibleServerConfigurationDataType(SetValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerConfigurationDataType"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerConfigurationDataType left, PostgreSqlFlexibleServerConfigurationDataType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerCreateMode.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerCreateMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Creation mode of a new server.
-    /// Serialized Name: CreateMode
-    /// </summary>
+    /// <summary> Creation mode of a new server. </summary>
     public readonly partial struct PostgreSqlFlexibleServerCreateMode : IEquatable<PostgreSqlFlexibleServerCreateMode>
     {
         private readonly string _value;
@@ -33,40 +30,19 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string ReplicaValue = "Replica";
         private const string ReviveDroppedValue = "ReviveDropped";
 
-        /// <summary>
-        /// Default
-        /// Serialized Name: CreateMode.Default
-        /// </summary>
+        /// <summary> Default. </summary>
         public static PostgreSqlFlexibleServerCreateMode Default { get; } = new PostgreSqlFlexibleServerCreateMode(DefaultValue);
-        /// <summary>
-        /// Create
-        /// Serialized Name: CreateMode.Create
-        /// </summary>
+        /// <summary> Create. </summary>
         public static PostgreSqlFlexibleServerCreateMode Create { get; } = new PostgreSqlFlexibleServerCreateMode(CreateValue);
-        /// <summary>
-        /// Update
-        /// Serialized Name: CreateMode.Update
-        /// </summary>
+        /// <summary> Update. </summary>
         public static PostgreSqlFlexibleServerCreateMode Update { get; } = new PostgreSqlFlexibleServerCreateMode(UpdateValue);
-        /// <summary>
-        /// PointInTimeRestore
-        /// Serialized Name: CreateMode.PointInTimeRestore
-        /// </summary>
+        /// <summary> PointInTimeRestore. </summary>
         public static PostgreSqlFlexibleServerCreateMode PointInTimeRestore { get; } = new PostgreSqlFlexibleServerCreateMode(PointInTimeRestoreValue);
-        /// <summary>
-        /// GeoRestore
-        /// Serialized Name: CreateMode.GeoRestore
-        /// </summary>
+        /// <summary> GeoRestore. </summary>
         public static PostgreSqlFlexibleServerCreateMode GeoRestore { get; } = new PostgreSqlFlexibleServerCreateMode(GeoRestoreValue);
-        /// <summary>
-        /// Replica
-        /// Serialized Name: CreateMode.Replica
-        /// </summary>
+        /// <summary> Replica. </summary>
         public static PostgreSqlFlexibleServerCreateMode Replica { get; } = new PostgreSqlFlexibleServerCreateMode(ReplicaValue);
-        /// <summary>
-        /// ReviveDropped
-        /// Serialized Name: CreateMode.ReviveDropped
-        /// </summary>
+        /// <summary> ReviveDropped. </summary>
         public static PostgreSqlFlexibleServerCreateMode ReviveDropped { get; } = new PostgreSqlFlexibleServerCreateMode(ReviveDroppedValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerCreateMode"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerCreateMode left, PostgreSqlFlexibleServerCreateMode right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerCreateModeForUpdate.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerCreateModeForUpdate.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Update mode of an existing server.
-    /// Serialized Name: CreateModeForPatch
-    /// </summary>
+    /// <summary> Update mode of an existing server. </summary>
     public readonly partial struct PostgreSqlFlexibleServerCreateModeForUpdate : IEquatable<PostgreSqlFlexibleServerCreateModeForUpdate>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string DefaultValue = "Default";
         private const string UpdateValue = "Update";
 
-        /// <summary>
-        /// Default
-        /// Serialized Name: CreateModeForPatch.Default
-        /// </summary>
+        /// <summary> Default. </summary>
         public static PostgreSqlFlexibleServerCreateModeForUpdate Default { get; } = new PostgreSqlFlexibleServerCreateModeForUpdate(DefaultValue);
-        /// <summary>
-        /// Update
-        /// Serialized Name: CreateModeForPatch.Update
-        /// </summary>
+        /// <summary> Update. </summary>
         public static PostgreSqlFlexibleServerCreateModeForUpdate Update { get; } = new PostgreSqlFlexibleServerCreateModeForUpdate(UpdateValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerCreateModeForUpdate"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerCreateModeForUpdate left, PostgreSqlFlexibleServerCreateModeForUpdate right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerDataEncryption.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerDataEncryption.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Data encryption properties of a server.
-    /// Serialized Name: DataEncryption
-    /// </summary>
+    /// <summary> Data encryption properties of a server. </summary>
     public partial class PostgreSqlFlexibleServerDataEncryption
     {
         /// <summary>
@@ -55,34 +52,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerDataEncryption"/>. </summary>
-        /// <param name="primaryKeyUri">
-        /// URI of the key in Azure Key Vault used for data encryption of the primary storage associated to a server.
-        /// Serialized Name: DataEncryption.primaryKeyURI
-        /// </param>
-        /// <param name="primaryUserAssignedIdentityId">
-        /// Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the primary storage associated to a server.
-        /// Serialized Name: DataEncryption.primaryUserAssignedIdentityId
-        /// </param>
-        /// <param name="geoBackupKeyUri">
-        /// Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the geographically redundant storage associated to a server that is configured to support geographically redundant backups.
-        /// Serialized Name: DataEncryption.geoBackupKeyURI
-        /// </param>
-        /// <param name="geoBackupUserAssignedIdentityId">
-        /// Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the geographically redundant storage associated to a server that is configured to support geographically redundant backups.
-        /// Serialized Name: DataEncryption.geoBackupUserAssignedIdentityId
-        /// </param>
-        /// <param name="keyType">
-        /// Data encryption type used by a server.
-        /// Serialized Name: DataEncryption.type
-        /// </param>
-        /// <param name="primaryEncryptionKeyStatus">
-        /// Status of key used by a server configured with data encryption based on customer managed key, to encrypt the primary storage associated to the server.
-        /// Serialized Name: DataEncryption.primaryEncryptionKeyStatus
-        /// </param>
-        /// <param name="geoBackupEncryptionKeyStatus">
-        /// Status of key used by a server configured with data encryption based on customer managed key, to encrypt the geographically redundant storage associated to the server when it is configured to support geographically redundant backups.
-        /// Serialized Name: DataEncryption.geoBackupEncryptionKeyStatus
-        /// </param>
+        /// <param name="primaryKeyUri"> URI of the key in Azure Key Vault used for data encryption of the primary storage associated to a server. </param>
+        /// <param name="primaryUserAssignedIdentityId"> Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the primary storage associated to a server. </param>
+        /// <param name="geoBackupKeyUri"> Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the geographically redundant storage associated to a server that is configured to support geographically redundant backups. </param>
+        /// <param name="geoBackupUserAssignedIdentityId"> Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the geographically redundant storage associated to a server that is configured to support geographically redundant backups. </param>
+        /// <param name="keyType"> Data encryption type used by a server. </param>
+        /// <param name="primaryEncryptionKeyStatus"> Status of key used by a server configured with data encryption based on customer managed key, to encrypt the primary storage associated to the server. </param>
+        /// <param name="geoBackupEncryptionKeyStatus"> Status of key used by a server configured with data encryption based on customer managed key, to encrypt the geographically redundant storage associated to the server when it is configured to support geographically redundant backups. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerDataEncryption(Uri primaryKeyUri, ResourceIdentifier primaryUserAssignedIdentityId, Uri geoBackupKeyUri, string geoBackupUserAssignedIdentityId, PostgreSqlFlexibleServerKeyType? keyType, PostgreSqlKeyStatus? primaryEncryptionKeyStatus, PostgreSqlKeyStatus? geoBackupEncryptionKeyStatus, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -96,46 +72,25 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// URI of the key in Azure Key Vault used for data encryption of the primary storage associated to a server.
-        /// Serialized Name: DataEncryption.primaryKeyURI
-        /// </summary>
+        /// <summary> URI of the key in Azure Key Vault used for data encryption of the primary storage associated to a server. </summary>
         [WirePath("primaryKeyURI")]
         public Uri PrimaryKeyUri { get; set; }
-        /// <summary>
-        /// Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the primary storage associated to a server.
-        /// Serialized Name: DataEncryption.primaryUserAssignedIdentityId
-        /// </summary>
+        /// <summary> Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the primary storage associated to a server. </summary>
         [WirePath("primaryUserAssignedIdentityId")]
         public ResourceIdentifier PrimaryUserAssignedIdentityId { get; set; }
-        /// <summary>
-        /// Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the geographically redundant storage associated to a server that is configured to support geographically redundant backups.
-        /// Serialized Name: DataEncryption.geoBackupKeyURI
-        /// </summary>
+        /// <summary> Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the geographically redundant storage associated to a server that is configured to support geographically redundant backups. </summary>
         [WirePath("geoBackupKeyURI")]
         public Uri GeoBackupKeyUri { get; set; }
-        /// <summary>
-        /// Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the geographically redundant storage associated to a server that is configured to support geographically redundant backups.
-        /// Serialized Name: DataEncryption.geoBackupUserAssignedIdentityId
-        /// </summary>
+        /// <summary> Identifier of the user assigned managed identity used to access the key in Azure Key Vault for data encryption of the geographically redundant storage associated to a server that is configured to support geographically redundant backups. </summary>
         [WirePath("geoBackupUserAssignedIdentityId")]
         public string GeoBackupUserAssignedIdentityId { get; set; }
-        /// <summary>
-        /// Data encryption type used by a server.
-        /// Serialized Name: DataEncryption.type
-        /// </summary>
+        /// <summary> Data encryption type used by a server. </summary>
         [WirePath("type")]
         public PostgreSqlFlexibleServerKeyType? KeyType { get; set; }
-        /// <summary>
-        /// Status of key used by a server configured with data encryption based on customer managed key, to encrypt the primary storage associated to the server.
-        /// Serialized Name: DataEncryption.primaryEncryptionKeyStatus
-        /// </summary>
+        /// <summary> Status of key used by a server configured with data encryption based on customer managed key, to encrypt the primary storage associated to the server. </summary>
         [WirePath("primaryEncryptionKeyStatus")]
         public PostgreSqlKeyStatus? PrimaryEncryptionKeyStatus { get; set; }
-        /// <summary>
-        /// Status of key used by a server configured with data encryption based on customer managed key, to encrypt the geographically redundant storage associated to the server when it is configured to support geographically redundant backups.
-        /// Serialized Name: DataEncryption.geoBackupEncryptionKeyStatus
-        /// </summary>
+        /// <summary> Status of key used by a server configured with data encryption based on customer managed key, to encrypt the geographically redundant storage associated to the server when it is configured to support geographically redundant backups. </summary>
         [WirePath("geoBackupEncryptionKeyStatus")]
         public PostgreSqlKeyStatus? GeoBackupEncryptionKeyStatus { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerDelegatedSubnetUsage.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerDelegatedSubnetUsage.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Delegated subnet usage data.
-    /// Serialized Name: DelegatedSubnetUsage
-    /// </summary>
+    /// <summary> Delegated subnet usage data. </summary>
     public partial class PostgreSqlFlexibleServerDelegatedSubnetUsage
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerDelegatedSubnetUsage"/>. </summary>
-        /// <param name="subnetName">
-        /// Name of the delegated subnet for which IP addresses are in use
-        /// Serialized Name: DelegatedSubnetUsage.subnetName
-        /// </param>
-        /// <param name="usage">
-        /// Number of IP addresses used by the delegated subnet
-        /// Serialized Name: DelegatedSubnetUsage.usage
-        /// </param>
+        /// <param name="subnetName"> Name of the delegated subnet for which IP addresses are in use. </param>
+        /// <param name="usage"> Number of IP addresses used by the delegated subnet. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerDelegatedSubnetUsage(string subnetName, long? usage, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Name of the delegated subnet for which IP addresses are in use
-        /// Serialized Name: DelegatedSubnetUsage.subnetName
-        /// </summary>
+        /// <summary> Name of the delegated subnet for which IP addresses are in use. </summary>
         [WirePath("subnetName")]
         public string SubnetName { get; }
-        /// <summary>
-        /// Number of IP addresses used by the delegated subnet
-        /// Serialized Name: DelegatedSubnetUsage.usage
-        /// </summary>
+        /// <summary> Number of IP addresses used by the delegated subnet. </summary>
         [WirePath("usage")]
         public long? Usage { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerEditionCapability.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerEditionCapability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Capabilities in terms of compute tier.
-    /// Serialized Name: ServerEditionCapability
-    /// </summary>
+    /// <summary> Capabilities in terms of compute tier. </summary>
     public partial class PostgreSqlFlexibleServerEditionCapability : PostgreSqlBaseCapability
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerEditionCapability"/>. </summary>
@@ -24,31 +21,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerEditionCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="name">
-        /// Name of compute tier.
-        /// Serialized Name: ServerEditionCapability.name
-        /// </param>
-        /// <param name="defaultSkuName">
-        /// Default compute name (SKU) for this computer tier.
-        /// Serialized Name: ServerEditionCapability.defaultSkuName
-        /// </param>
-        /// <param name="supportedStorageEditions">
-        /// List of storage editions supported by this compute tier and compute name.
-        /// Serialized Name: ServerEditionCapability.supportedStorageEditions
-        /// </param>
-        /// <param name="supportedServerSkus">
-        /// List of supported compute names (SKUs).
-        /// Serialized Name: ServerEditionCapability.supportedServerSkus
-        /// </param>
+        /// <param name="name"> Name of compute tier. </param>
+        /// <param name="defaultSkuName"> Default compute name (SKU) for this computer tier. </param>
+        /// <param name="supportedStorageEditions"> List of storage editions supported by this compute tier and compute name. </param>
+        /// <param name="supportedServerSkus"> List of supported compute names (SKUs). </param>
         internal PostgreSqlFlexibleServerEditionCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData, string name, string defaultSkuName, IReadOnlyList<PostgreSqlFlexibleServerStorageEditionCapability> supportedStorageEditions, IReadOnlyList<PostgreSqlFlexibleServerSkuCapability> supportedServerSkus) : base(capabilityStatus, reason, serializedAdditionalRawData)
         {
             Name = name;
@@ -57,28 +36,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             SupportedServerSkus = supportedServerSkus;
         }
 
-        /// <summary>
-        /// Name of compute tier.
-        /// Serialized Name: ServerEditionCapability.name
-        /// </summary>
+        /// <summary> Name of compute tier. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// Default compute name (SKU) for this computer tier.
-        /// Serialized Name: ServerEditionCapability.defaultSkuName
-        /// </summary>
+        /// <summary> Default compute name (SKU) for this computer tier. </summary>
         [WirePath("defaultSkuName")]
         public string DefaultSkuName { get; }
-        /// <summary>
-        /// List of storage editions supported by this compute tier and compute name.
-        /// Serialized Name: ServerEditionCapability.supportedStorageEditions
-        /// </summary>
+        /// <summary> List of storage editions supported by this compute tier and compute name. </summary>
         [WirePath("supportedStorageEditions")]
         public IReadOnlyList<PostgreSqlFlexibleServerStorageEditionCapability> SupportedStorageEditions { get; }
-        /// <summary>
-        /// List of supported compute names (SKUs).
-        /// Serialized Name: ServerEditionCapability.supportedServerSkus
-        /// </summary>
+        /// <summary> List of supported compute names (SKUs). </summary>
         [WirePath("supportedServerSkus")]
         public IReadOnlyList<PostgreSqlFlexibleServerSkuCapability> SupportedServerSkus { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerFailoverMode.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerFailoverMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Failover mode.
-    /// Serialized Name: FailoverMode
-    /// </summary>
+    /// <summary> Failover mode. </summary>
     public readonly partial struct PostgreSqlFlexibleServerFailoverMode : IEquatable<PostgreSqlFlexibleServerFailoverMode>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string PlannedSwitchoverValue = "PlannedSwitchover";
         private const string ForcedSwitchoverValue = "ForcedSwitchover";
 
-        /// <summary>
-        /// PlannedFailover
-        /// Serialized Name: FailoverMode.PlannedFailover
-        /// </summary>
+        /// <summary> PlannedFailover. </summary>
         public static PostgreSqlFlexibleServerFailoverMode PlannedFailover { get; } = new PostgreSqlFlexibleServerFailoverMode(PlannedFailoverValue);
-        /// <summary>
-        /// ForcedFailover
-        /// Serialized Name: FailoverMode.ForcedFailover
-        /// </summary>
+        /// <summary> ForcedFailover. </summary>
         public static PostgreSqlFlexibleServerFailoverMode ForcedFailover { get; } = new PostgreSqlFlexibleServerFailoverMode(ForcedFailoverValue);
-        /// <summary>
-        /// PlannedSwitchover
-        /// Serialized Name: FailoverMode.PlannedSwitchover
-        /// </summary>
+        /// <summary> PlannedSwitchover. </summary>
         public static PostgreSqlFlexibleServerFailoverMode PlannedSwitchover { get; } = new PostgreSqlFlexibleServerFailoverMode(PlannedSwitchoverValue);
-        /// <summary>
-        /// ForcedSwitchover
-        /// Serialized Name: FailoverMode.ForcedSwitchover
-        /// </summary>
+        /// <summary> ForcedSwitchover. </summary>
         public static PostgreSqlFlexibleServerFailoverMode ForcedSwitchover { get; } = new PostgreSqlFlexibleServerFailoverMode(ForcedSwitchoverValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerFailoverMode"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerFailoverMode left, PostgreSqlFlexibleServerFailoverMode right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerFastProvisioningEditionCapability.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerFastProvisioningEditionCapability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Capability of a fast provisioning compute tier.
-    /// Serialized Name: FastProvisioningEditionCapability
-    /// </summary>
+    /// <summary> Capability of a fast provisioning compute tier. </summary>
     public partial class PostgreSqlFlexibleServerFastProvisioningEditionCapability : PostgreSqlBaseCapability
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerFastProvisioningEditionCapability"/>. </summary>
@@ -22,35 +19,14 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerFastProvisioningEditionCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="supportedTier">
-        /// Compute tier supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedTier
-        /// </param>
-        /// <param name="supportedSku">
-        /// Compute name (SKU) supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedSku
-        /// </param>
-        /// <param name="supportedStorageGb">
-        /// Storage size (in GB) supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedStorageGb
-        /// </param>
-        /// <param name="supportedServerVersions">
-        /// Major version of PostgreSQL database engine supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedServerVersions
-        /// </param>
-        /// <param name="serverCount">
-        /// Count of servers in cache matching this specification.
-        /// Serialized Name: FastProvisioningEditionCapability.serverCount
-        /// </param>
+        /// <param name="supportedTier"> Compute tier supporting fast provisioning. </param>
+        /// <param name="supportedSku"> Compute name (SKU) supporting fast provisioning. </param>
+        /// <param name="supportedStorageGb"> Storage size (in GB) supporting fast provisioning. </param>
+        /// <param name="supportedServerVersions"> Major version of PostgreSQL database engine supporting fast provisioning. </param>
+        /// <param name="serverCount"> Count of servers in cache matching this specification. </param>
         internal PostgreSqlFlexibleServerFastProvisioningEditionCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData, string supportedTier, string supportedSku, long? supportedStorageGb, string supportedServerVersions, int? serverCount) : base(capabilityStatus, reason, serializedAdditionalRawData)
         {
             SupportedTier = supportedTier;
@@ -60,28 +36,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             ServerCount = serverCount;
         }
 
-        /// <summary>
-        /// Compute tier supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedTier
-        /// </summary>
+        /// <summary> Compute tier supporting fast provisioning. </summary>
         [WirePath("supportedTier")]
         public string SupportedTier { get; }
-        /// <summary>
-        /// Compute name (SKU) supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedSku
-        /// </summary>
+        /// <summary> Compute name (SKU) supporting fast provisioning. </summary>
         [WirePath("supportedSku")]
         public string SupportedSku { get; }
-        /// <summary>
-        /// Major version of PostgreSQL database engine supporting fast provisioning.
-        /// Serialized Name: FastProvisioningEditionCapability.supportedServerVersions
-        /// </summary>
+        /// <summary> Major version of PostgreSQL database engine supporting fast provisioning. </summary>
         [WirePath("supportedServerVersions")]
         public string SupportedServerVersions { get; }
-        /// <summary>
-        /// Count of servers in cache matching this specification.
-        /// Serialized Name: FastProvisioningEditionCapability.serverCount
-        /// </summary>
+        /// <summary> Count of servers in cache matching this specification. </summary>
         [WirePath("serverCount")]
         public int? ServerCount { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerFastProvisioningSupported.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerFastProvisioningSupported.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if fast provisioning is supported. 'Enabled' means fast provisioning is supported. 'Disabled' stands for fast provisioning is not supported. Will be deprecated in the future. Look to Supported Features for 'FastProvisioning'.
-    /// Serialized Name: FastProvisioningSupport
-    /// </summary>
+    /// <summary> Indicates if fast provisioning is supported. 'Enabled' means fast provisioning is supported. 'Disabled' stands for fast provisioning is not supported. Will be deprecated in the future. Look to Supported Features for 'FastProvisioning'. </summary>
     public readonly partial struct PostgreSqlFlexibleServerFastProvisioningSupported : IEquatable<PostgreSqlFlexibleServerFastProvisioningSupported>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: FastProvisioningSupport.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerFastProvisioningSupported Enabled { get; } = new PostgreSqlFlexibleServerFastProvisioningSupported(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: FastProvisioningSupport.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerFastProvisioningSupported Disabled { get; } = new PostgreSqlFlexibleServerFastProvisioningSupported(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerFastProvisioningSupported"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerFastProvisioningSupported left, PostgreSqlFlexibleServerFastProvisioningSupported right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerFeatureStatus.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerFeatureStatus.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Status of the feature. Indicates if the feature is enabled or not.
-    /// Serialized Name: FeatureStatus
-    /// </summary>
+    /// <summary> Status of the feature. Indicates if the feature is enabled or not. </summary>
     public readonly partial struct PostgreSqlFlexibleServerFeatureStatus : IEquatable<PostgreSqlFlexibleServerFeatureStatus>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: FeatureStatus.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerFeatureStatus Enabled { get; } = new PostgreSqlFlexibleServerFeatureStatus(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: FeatureStatus.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerFeatureStatus Disabled { get; } = new PostgreSqlFlexibleServerFeatureStatus(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerFeatureStatus"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerFeatureStatus left, PostgreSqlFlexibleServerFeatureStatus right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerGeoBackupSupported.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerGeoBackupSupported.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if geographically redundant backups are supported in this location. 'Enabled' means geographically redundant backups are supported. 'Disabled' stands for geographically redundant backup is not supported. Will be deprecated in the future. Look to Supported Features for 'GeoBackup'.
-    /// Serialized Name: GeographicallyRedundantBackupSupport
-    /// </summary>
+    /// <summary> Indicates if geographically redundant backups are supported in this location. 'Enabled' means geographically redundant backups are supported. 'Disabled' stands for geographically redundant backup is not supported. Will be deprecated in the future. Look to Supported Features for 'GeoBackup'. </summary>
     public readonly partial struct PostgreSqlFlexibleServerGeoBackupSupported : IEquatable<PostgreSqlFlexibleServerGeoBackupSupported>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: GeographicallyRedundantBackupSupport.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerGeoBackupSupported Enabled { get; } = new PostgreSqlFlexibleServerGeoBackupSupported(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: GeographicallyRedundantBackupSupport.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerGeoBackupSupported Disabled { get; } = new PostgreSqlFlexibleServerGeoBackupSupported(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerGeoBackupSupported"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerGeoBackupSupported left, PostgreSqlFlexibleServerGeoBackupSupported right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerGeoRedundantBackupEnum.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerGeoRedundantBackupEnum.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if the server is configured to create geographically redundant backups.
-    /// Serialized Name: GeographicallyRedundantBackup
-    /// </summary>
+    /// <summary> Indicates if the server is configured to create geographically redundant backups. </summary>
     public readonly partial struct PostgreSqlFlexibleServerGeoRedundantBackupEnum : IEquatable<PostgreSqlFlexibleServerGeoRedundantBackupEnum>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: GeographicallyRedundantBackup.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerGeoRedundantBackupEnum Enabled { get; } = new PostgreSqlFlexibleServerGeoRedundantBackupEnum(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: GeographicallyRedundantBackup.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerGeoRedundantBackupEnum Disabled { get; } = new PostgreSqlFlexibleServerGeoRedundantBackupEnum(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerGeoRedundantBackupEnum"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerGeoRedundantBackupEnum left, PostgreSqlFlexibleServerGeoRedundantBackupEnum right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerHAMode.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerHAMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Modes of high availability supported for this compute.
-    /// Serialized Name: HighAvailabilityMode
-    /// </summary>
+    /// <summary> Modes of high availability supported for this compute. </summary>
     public readonly partial struct PostgreSqlFlexibleServerHAMode : IEquatable<PostgreSqlFlexibleServerHAMode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string ZoneRedundantValue = "ZoneRedundant";
         private const string SameZoneValue = "SameZone";
 
-        /// <summary>
-        /// ZoneRedundant
-        /// Serialized Name: HighAvailabilityMode.ZoneRedundant
-        /// </summary>
+        /// <summary> ZoneRedundant. </summary>
         public static PostgreSqlFlexibleServerHAMode ZoneRedundant { get; } = new PostgreSqlFlexibleServerHAMode(ZoneRedundantValue);
-        /// <summary>
-        /// SameZone
-        /// Serialized Name: HighAvailabilityMode.SameZone
-        /// </summary>
+        /// <summary> SameZone. </summary>
         public static PostgreSqlFlexibleServerHAMode SameZone { get; } = new PostgreSqlFlexibleServerHAMode(SameZoneValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerHAMode"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerHAMode left, PostgreSqlFlexibleServerHAMode right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerHAState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerHAState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Possible states of the standby server created when high availability is set to SameZone or ZoneRedundant.
-    /// Serialized Name: HighAvailabilityState
-    /// </summary>
+    /// <summary> Possible states of the standby server created when high availability is set to SameZone or ZoneRedundant. </summary>
     public readonly partial struct PostgreSqlFlexibleServerHAState : IEquatable<PostgreSqlFlexibleServerHAState>
     {
         private readonly string _value;
@@ -32,35 +29,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string HealthyValue = "Healthy";
         private const string RemovingStandbyValue = "RemovingStandby";
 
-        /// <summary>
-        /// NotEnabled
-        /// Serialized Name: HighAvailabilityState.NotEnabled
-        /// </summary>
+        /// <summary> NotEnabled. </summary>
         public static PostgreSqlFlexibleServerHAState NotEnabled { get; } = new PostgreSqlFlexibleServerHAState(NotEnabledValue);
-        /// <summary>
-        /// CreatingStandby
-        /// Serialized Name: HighAvailabilityState.CreatingStandby
-        /// </summary>
+        /// <summary> CreatingStandby. </summary>
         public static PostgreSqlFlexibleServerHAState CreatingStandby { get; } = new PostgreSqlFlexibleServerHAState(CreatingStandbyValue);
-        /// <summary>
-        /// ReplicatingData
-        /// Serialized Name: HighAvailabilityState.ReplicatingData
-        /// </summary>
+        /// <summary> ReplicatingData. </summary>
         public static PostgreSqlFlexibleServerHAState ReplicatingData { get; } = new PostgreSqlFlexibleServerHAState(ReplicatingDataValue);
-        /// <summary>
-        /// FailingOver
-        /// Serialized Name: HighAvailabilityState.FailingOver
-        /// </summary>
+        /// <summary> FailingOver. </summary>
         public static PostgreSqlFlexibleServerHAState FailingOver { get; } = new PostgreSqlFlexibleServerHAState(FailingOverValue);
-        /// <summary>
-        /// Healthy
-        /// Serialized Name: HighAvailabilityState.Healthy
-        /// </summary>
+        /// <summary> Healthy. </summary>
         public static PostgreSqlFlexibleServerHAState Healthy { get; } = new PostgreSqlFlexibleServerHAState(HealthyValue);
-        /// <summary>
-        /// RemovingStandby
-        /// Serialized Name: HighAvailabilityState.RemovingStandby
-        /// </summary>
+        /// <summary> RemovingStandby. </summary>
         public static PostgreSqlFlexibleServerHAState RemovingStandby { get; } = new PostgreSqlFlexibleServerHAState(RemovingStandbyValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerHAState"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerHAState left, PostgreSqlFlexibleServerHAState right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerHighAvailability.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerHighAvailability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// High availability properties of a server.
-    /// Serialized Name: HighAvailability
-    /// </summary>
+    /// <summary> High availability properties of a server. </summary>
     public partial class PostgreSqlFlexibleServerHighAvailability
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerHighAvailability"/>. </summary>
-        /// <param name="mode">
-        /// High availability mode for a server.
-        /// Serialized Name: HighAvailability.mode
-        /// </param>
-        /// <param name="state">
-        /// Possible states of the standby server created when high availability is set to SameZone or ZoneRedundant.
-        /// Serialized Name: HighAvailability.state
-        /// </param>
-        /// <param name="standbyAvailabilityZone">
-        /// Availability zone associated to the standby server created when high availability is set to SameZone or ZoneRedundant.
-        /// Serialized Name: HighAvailability.standbyAvailabilityZone
-        /// </param>
+        /// <param name="mode"> High availability mode for a server. </param>
+        /// <param name="state"> Possible states of the standby server created when high availability is set to SameZone or ZoneRedundant. </param>
+        /// <param name="standbyAvailabilityZone"> Availability zone associated to the standby server created when high availability is set to SameZone or ZoneRedundant. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerHighAvailability(PostgreSqlFlexibleServerHighAvailabilityMode? mode, PostgreSqlFlexibleServerHAState? state, string standbyAvailabilityZone, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// High availability mode for a server.
-        /// Serialized Name: HighAvailability.mode
-        /// </summary>
+        /// <summary> High availability mode for a server. </summary>
         [WirePath("mode")]
         public PostgreSqlFlexibleServerHighAvailabilityMode? Mode { get; set; }
-        /// <summary>
-        /// Possible states of the standby server created when high availability is set to SameZone or ZoneRedundant.
-        /// Serialized Name: HighAvailability.state
-        /// </summary>
+        /// <summary> Possible states of the standby server created when high availability is set to SameZone or ZoneRedundant. </summary>
         [WirePath("state")]
         public PostgreSqlFlexibleServerHAState? State { get; }
-        /// <summary>
-        /// Availability zone associated to the standby server created when high availability is set to SameZone or ZoneRedundant.
-        /// Serialized Name: HighAvailability.standbyAvailabilityZone
-        /// </summary>
+        /// <summary> Availability zone associated to the standby server created when high availability is set to SameZone or ZoneRedundant. </summary>
         [WirePath("standbyAvailabilityZone")]
         public string StandbyAvailabilityZone { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerHighAvailabilityMode.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerHighAvailabilityMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// High availability mode for a server.
-    /// Serialized Name: PostgreSqlFlexibleServerHighAvailabilityMode
-    /// </summary>
+    /// <summary> High availability mode for a server. </summary>
     public readonly partial struct PostgreSqlFlexibleServerHighAvailabilityMode : IEquatable<PostgreSqlFlexibleServerHighAvailabilityMode>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string ZoneRedundantValue = "ZoneRedundant";
         private const string SameZoneValue = "SameZone";
 
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: PostgreSqlFlexibleServerHighAvailabilityMode.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerHighAvailabilityMode Disabled { get; } = new PostgreSqlFlexibleServerHighAvailabilityMode(DisabledValue);
-        /// <summary>
-        /// ZoneRedundant
-        /// Serialized Name: PostgreSqlFlexibleServerHighAvailabilityMode.ZoneRedundant
-        /// </summary>
+        /// <summary> ZoneRedundant. </summary>
         public static PostgreSqlFlexibleServerHighAvailabilityMode ZoneRedundant { get; } = new PostgreSqlFlexibleServerHighAvailabilityMode(ZoneRedundantValue);
-        /// <summary>
-        /// SameZone
-        /// Serialized Name: PostgreSqlFlexibleServerHighAvailabilityMode.SameZone
-        /// </summary>
+        /// <summary> SameZone. </summary>
         public static PostgreSqlFlexibleServerHighAvailabilityMode SameZone { get; } = new PostgreSqlFlexibleServerHighAvailabilityMode(SameZoneValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerHighAvailabilityMode"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerHighAvailabilityMode left, PostgreSqlFlexibleServerHighAvailabilityMode right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerIdentityType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerIdentityType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Types of identities associated with a server.
-    /// Serialized Name: IdentityType
-    /// </summary>
+    /// <summary> Types of identities associated with a server. </summary>
     public readonly partial struct PostgreSqlFlexibleServerIdentityType : IEquatable<PostgreSqlFlexibleServerIdentityType>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string UserAssignedValue = "UserAssigned";
         private const string SystemAssignedUserAssignedValue = "SystemAssigned,UserAssigned";
 
-        /// <summary>
-        /// None
-        /// Serialized Name: IdentityType.None
-        /// </summary>
+        /// <summary> None. </summary>
         public static PostgreSqlFlexibleServerIdentityType None { get; } = new PostgreSqlFlexibleServerIdentityType(NoneValue);
-        /// <summary>
-        /// UserAssigned
-        /// Serialized Name: IdentityType.UserAssigned
-        /// </summary>
+        /// <summary> UserAssigned. </summary>
         public static PostgreSqlFlexibleServerIdentityType UserAssigned { get; } = new PostgreSqlFlexibleServerIdentityType(UserAssignedValue);
-        /// <summary>
-        /// SystemAssigned,UserAssigned
-        /// Serialized Name: IdentityType.SystemAssigned,UserAssigned
-        /// </summary>
+        /// <summary> SystemAssigned,UserAssigned. </summary>
         public static PostgreSqlFlexibleServerIdentityType SystemAssignedUserAssigned { get; } = new PostgreSqlFlexibleServerIdentityType(SystemAssignedUserAssignedValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerIdentityType"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerIdentityType left, PostgreSqlFlexibleServerIdentityType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerKeyType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerKeyType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Data encryption type used by a server.
-    /// Serialized Name: DataEncryptionType
-    /// </summary>
+    /// <summary> Data encryption type used by a server. </summary>
     public readonly partial struct PostgreSqlFlexibleServerKeyType : IEquatable<PostgreSqlFlexibleServerKeyType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string SystemManagedValue = "SystemManaged";
         private const string AzureKeyVaultValue = "AzureKeyVault";
 
-        /// <summary>
-        /// SystemManaged
-        /// Serialized Name: DataEncryptionType.SystemManaged
-        /// </summary>
+        /// <summary> SystemManaged. </summary>
         public static PostgreSqlFlexibleServerKeyType SystemManaged { get; } = new PostgreSqlFlexibleServerKeyType(SystemManagedValue);
-        /// <summary>
-        /// AzureKeyVault
-        /// Serialized Name: DataEncryptionType.AzureKeyVault
-        /// </summary>
+        /// <summary> AzureKeyVault. </summary>
         public static PostgreSqlFlexibleServerKeyType AzureKeyVault { get; } = new PostgreSqlFlexibleServerKeyType(AzureKeyVaultValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerKeyType"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerKeyType left, PostgreSqlFlexibleServerKeyType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLogFile.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLogFile.cs
@@ -12,10 +12,7 @@ using Azure.ResourceManager.Models;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Log file.
-    /// Serialized Name: CapturedLog
-    /// </summary>
+    /// <summary> Log file. </summary>
     public partial class PostgreSqlFlexibleServerLogFile : ResourceData
     {
         /// <summary>
@@ -60,26 +57,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="createdOn">
-        /// Creation timestamp of the log file.
-        /// Serialized Name: CapturedLog.properties.createdTime
-        /// </param>
-        /// <param name="lastModifiedOn">
-        /// Last modified timestamp of the log file.
-        /// Serialized Name: CapturedLog.properties.lastModifiedTime
-        /// </param>
-        /// <param name="sizeInKb">
-        /// Size (in KB) of the log file.
-        /// Serialized Name: CapturedLog.properties.sizeInKb
-        /// </param>
-        /// <param name="typePropertiesType">
-        /// Type of log file. Can be 'ServerLogs' or 'UpgradeLogs'.
-        /// Serialized Name: CapturedLog.properties.type
-        /// </param>
-        /// <param name="uri">
-        /// URL to download the log file from.
-        /// Serialized Name: CapturedLog.properties.url
-        /// </param>
+        /// <param name="createdOn"> Creation timestamp of the log file. </param>
+        /// <param name="lastModifiedOn"> Last modified timestamp of the log file. </param>
+        /// <param name="sizeInKb"> Size (in KB) of the log file. </param>
+        /// <param name="typePropertiesType"> Type of log file. Can be 'ServerLogs' or 'UpgradeLogs'. </param>
+        /// <param name="uri"> URL to download the log file from. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerLogFile(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, DateTimeOffset? createdOn, DateTimeOffset? lastModifiedOn, long? sizeInKb, string typePropertiesType, Uri uri, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -91,34 +73,19 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Creation timestamp of the log file.
-        /// Serialized Name: CapturedLog.properties.createdTime
-        /// </summary>
+        /// <summary> Creation timestamp of the log file. </summary>
         [WirePath("properties.createdTime")]
         public DateTimeOffset? CreatedOn { get; set; }
-        /// <summary>
-        /// Last modified timestamp of the log file.
-        /// Serialized Name: CapturedLog.properties.lastModifiedTime
-        /// </summary>
+        /// <summary> Last modified timestamp of the log file. </summary>
         [WirePath("properties.lastModifiedTime")]
         public DateTimeOffset? LastModifiedOn { get; set; }
-        /// <summary>
-        /// Size (in KB) of the log file.
-        /// Serialized Name: CapturedLog.properties.sizeInKb
-        /// </summary>
+        /// <summary> Size (in KB) of the log file. </summary>
         [WirePath("properties.sizeInKb")]
         public long? SizeInKb { get; set; }
-        /// <summary>
-        /// Type of log file. Can be 'ServerLogs' or 'UpgradeLogs'.
-        /// Serialized Name: CapturedLog.properties.type
-        /// </summary>
+        /// <summary> Type of log file. Can be 'ServerLogs' or 'UpgradeLogs'. </summary>
         [WirePath("properties.type")]
         public string TypePropertiesType { get; set; }
-        /// <summary>
-        /// URL to download the log file from.
-        /// Serialized Name: CapturedLog.properties.url
-        /// </summary>
+        /// <summary> URL to download the log file from. </summary>
         [WirePath("properties.url")]
         public Uri Uri { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLtrBackupContent.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLtrBackupContent.cs
@@ -10,21 +10,12 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The request that is made for a long term retention backup.
-    /// Serialized Name: BackupsLongTermRetentionRequest
-    /// </summary>
+    /// <summary> The request that is made for a long term retention backup. </summary>
     public partial class PostgreSqlFlexibleServerLtrBackupContent : PostgreSqlBackupContent
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerLtrBackupContent"/>. </summary>
-        /// <param name="backupSettings">
-        /// Backup Settings
-        /// Serialized Name: BackupRequestBase.backupSettings
-        /// </param>
-        /// <param name="targetDetails">
-        /// Backup store detail for target server
-        /// Serialized Name: BackupsLongTermRetentionRequest.targetDetails
-        /// </param>
+        /// <param name="backupSettings"> Backup Settings. </param>
+        /// <param name="targetDetails"> Backup store detail for target server. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="backupSettings"/> or <paramref name="targetDetails"/> is null. </exception>
         public PostgreSqlFlexibleServerLtrBackupContent(PostgreSqlFlexibleServerBackupSettings backupSettings, PostgreSqlFlexibleServerBackupStoreDetails targetDetails) : base(backupSettings)
         {
@@ -35,15 +26,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerLtrBackupContent"/>. </summary>
-        /// <param name="backupSettings">
-        /// Backup Settings
-        /// Serialized Name: BackupRequestBase.backupSettings
-        /// </param>
+        /// <param name="backupSettings"> Backup Settings. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="targetDetails">
-        /// Backup store detail for target server
-        /// Serialized Name: BackupsLongTermRetentionRequest.targetDetails
-        /// </param>
+        /// <param name="targetDetails"> Backup store detail for target server. </param>
         internal PostgreSqlFlexibleServerLtrBackupContent(PostgreSqlFlexibleServerBackupSettings backupSettings, IDictionary<string, BinaryData> serializedAdditionalRawData, PostgreSqlFlexibleServerBackupStoreDetails targetDetails) : base(backupSettings, serializedAdditionalRawData)
         {
             TargetDetails = targetDetails;
@@ -54,15 +39,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// Backup store detail for target server
-        /// Serialized Name: BackupsLongTermRetentionRequest.targetDetails
-        /// </summary>
+        /// <summary> Backup store detail for target server. </summary>
         internal PostgreSqlFlexibleServerBackupStoreDetails TargetDetails { get; }
-        /// <summary>
-        /// List of SAS uri of storage containers where backup data is to be streamed/copied.
-        /// Serialized Name: BackupStoreDetails.sasUriList
-        /// </summary>
+        /// <summary> List of SAS uri of storage containers where backup data is to be streamed/copied. </summary>
         [WirePath("targetDetails.sasUriList")]
         public IList<string> TargetDetailsSasUriList
         {

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLtrBackupResult.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLtrBackupResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Response for the LTR backup API call
-    /// Serialized Name: BackupsLongTermRetentionResponse
-    /// </summary>
+    /// <summary> Response for the LTR backup API call. </summary>
     public partial class PostgreSqlFlexibleServerLtrBackupResult
     {
         /// <summary>
@@ -54,46 +51,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerLtrBackupResult"/>. </summary>
-        /// <param name="datasourceSizeInBytes">
-        /// Size of datasource in bytes
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.datasourceSizeInBytes
-        /// </param>
-        /// <param name="dataTransferredInBytes">
-        /// Data transferred in bytes
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.dataTransferredInBytes
-        /// </param>
-        /// <param name="backupName">
-        /// Name of Backup operation
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.backupName
-        /// </param>
-        /// <param name="backupMetadata">
-        /// Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.backupMetadata
-        /// </param>
-        /// <param name="status">
-        /// Service-set extensible enum indicating the status of operation
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.status
-        /// </param>
-        /// <param name="startOn">
-        /// Start time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.startTime
-        /// </param>
-        /// <param name="endOn">
-        /// End time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.endTime
-        /// </param>
-        /// <param name="percentComplete">
-        /// PercentageCompleted
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.percentComplete
-        /// </param>
-        /// <param name="errorCode">
-        /// The error code.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.errorCode
-        /// </param>
-        /// <param name="errorMessage">
-        /// The error message.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.errorMessage
-        /// </param>
+        /// <param name="datasourceSizeInBytes"> Size of datasource in bytes. </param>
+        /// <param name="dataTransferredInBytes"> Data transferred in bytes. </param>
+        /// <param name="backupName"> Name of Backup operation. </param>
+        /// <param name="backupMetadata"> Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc. </param>
+        /// <param name="status"> Service-set extensible enum indicating the status of operation. </param>
+        /// <param name="startOn"> Start time of the operation. </param>
+        /// <param name="endOn"> End time of the operation. </param>
+        /// <param name="percentComplete"> PercentageCompleted. </param>
+        /// <param name="errorCode"> The error code. </param>
+        /// <param name="errorMessage"> The error message. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerLtrBackupResult(long? datasourceSizeInBytes, long? dataTransferredInBytes, string backupName, string backupMetadata, PostgreSqlExecutionStatus? status, DateTimeOffset? startOn, DateTimeOffset? endOn, double? percentComplete, string errorCode, string errorMessage, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -110,64 +77,34 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Size of datasource in bytes
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.datasourceSizeInBytes
-        /// </summary>
+        /// <summary> Size of datasource in bytes. </summary>
         [WirePath("properties.datasourceSizeInBytes")]
         public long? DatasourceSizeInBytes { get; }
-        /// <summary>
-        /// Data transferred in bytes
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.dataTransferredInBytes
-        /// </summary>
+        /// <summary> Data transferred in bytes. </summary>
         [WirePath("properties.dataTransferredInBytes")]
         public long? DataTransferredInBytes { get; }
-        /// <summary>
-        /// Name of Backup operation
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.backupName
-        /// </summary>
+        /// <summary> Name of Backup operation. </summary>
         [WirePath("properties.backupName")]
         public string BackupName { get; }
-        /// <summary>
-        /// Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.backupMetadata
-        /// </summary>
+        /// <summary> Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc. </summary>
         [WirePath("properties.backupMetadata")]
         public string BackupMetadata { get; }
-        /// <summary>
-        /// Service-set extensible enum indicating the status of operation
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.status
-        /// </summary>
+        /// <summary> Service-set extensible enum indicating the status of operation. </summary>
         [WirePath("properties.status")]
         public PostgreSqlExecutionStatus? Status { get; }
-        /// <summary>
-        /// Start time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.startTime
-        /// </summary>
+        /// <summary> Start time of the operation. </summary>
         [WirePath("properties.startTime")]
         public DateTimeOffset? StartOn { get; }
-        /// <summary>
-        /// End time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.endTime
-        /// </summary>
+        /// <summary> End time of the operation. </summary>
         [WirePath("properties.endTime")]
         public DateTimeOffset? EndOn { get; }
-        /// <summary>
-        /// PercentageCompleted
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.percentComplete
-        /// </summary>
+        /// <summary> PercentageCompleted. </summary>
         [WirePath("properties.percentComplete")]
         public double? PercentComplete { get; }
-        /// <summary>
-        /// The error code.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.errorCode
-        /// </summary>
+        /// <summary> The error code. </summary>
         [WirePath("properties.errorCode")]
         public string ErrorCode { get; }
-        /// <summary>
-        /// The error message.
-        /// Serialized Name: BackupsLongTermRetentionResponse.properties.errorMessage
-        /// </summary>
+        /// <summary> The error message. </summary>
         [WirePath("properties.errorMessage")]
         public string ErrorMessage { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLtrPreBackupContent.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLtrPreBackupContent.cs
@@ -10,17 +10,11 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// A request that is made for pre-backup.
-    /// Serialized Name: LtrPreBackupRequest
-    /// </summary>
+    /// <summary> A request that is made for pre-backup. </summary>
     public partial class PostgreSqlFlexibleServerLtrPreBackupContent : PostgreSqlBackupContent
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerLtrPreBackupContent"/>. </summary>
-        /// <param name="backupSettings">
-        /// Backup Settings
-        /// Serialized Name: BackupRequestBase.backupSettings
-        /// </param>
+        /// <param name="backupSettings"> Backup Settings. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="backupSettings"/> is null. </exception>
         public PostgreSqlFlexibleServerLtrPreBackupContent(PostgreSqlFlexibleServerBackupSettings backupSettings) : base(backupSettings)
         {
@@ -28,10 +22,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerLtrPreBackupContent"/>. </summary>
-        /// <param name="backupSettings">
-        /// Backup Settings
-        /// Serialized Name: BackupRequestBase.backupSettings
-        /// </param>
+        /// <param name="backupSettings"> Backup Settings. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerLtrPreBackupContent(PostgreSqlFlexibleServerBackupSettings backupSettings, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(backupSettings, serializedAdditionalRawData)
         {

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLtrPreBackupResult.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerLtrPreBackupResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Response for the LTR pre-backup API call
-    /// Serialized Name: LtrPreBackupResponse
-    /// </summary>
+    /// <summary> Response for the LTR pre-backup API call. </summary>
     public partial class PostgreSqlFlexibleServerLtrPreBackupResult
     {
         /// <summary>
@@ -49,20 +46,14 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerLtrPreBackupResult"/>. </summary>
-        /// <param name="numberOfContainers">
-        /// Number of storage containers the plugin will use during backup. More than one containers may be used for size limitations, parallelism, or redundancy etc.
-        /// Serialized Name: LtrPreBackupResponse.properties.numberOfContainers
-        /// </param>
+        /// <param name="numberOfContainers"> Number of storage containers the plugin will use during backup. More than one containers may be used for size limitations, parallelism, or redundancy etc. </param>
         internal PostgreSqlFlexibleServerLtrPreBackupResult(int numberOfContainers)
         {
             NumberOfContainers = numberOfContainers;
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerLtrPreBackupResult"/>. </summary>
-        /// <param name="numberOfContainers">
-        /// Number of storage containers the plugin will use during backup. More than one containers may be used for size limitations, parallelism, or redundancy etc.
-        /// Serialized Name: LtrPreBackupResponse.properties.numberOfContainers
-        /// </param>
+        /// <param name="numberOfContainers"> Number of storage containers the plugin will use during backup. More than one containers may be used for size limitations, parallelism, or redundancy etc. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerLtrPreBackupResult(int numberOfContainers, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,10 +66,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// Number of storage containers the plugin will use during backup. More than one containers may be used for size limitations, parallelism, or redundancy etc.
-        /// Serialized Name: LtrPreBackupResponse.properties.numberOfContainers
-        /// </summary>
+        /// <summary> Number of storage containers the plugin will use during backup. More than one containers may be used for size limitations, parallelism, or redundancy etc. </summary>
         [WirePath("properties.numberOfContainers")]
         public int NumberOfContainers { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerMaintenanceWindow.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerMaintenanceWindow.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Maintenance window properties of a server.
-    /// Serialized Name: MaintenanceWindow
-    /// </summary>
+    /// <summary> Maintenance window properties of a server. </summary>
     public partial class PostgreSqlFlexibleServerMaintenanceWindow
     {
         /// <summary>
@@ -54,22 +51,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerMaintenanceWindow"/>. </summary>
-        /// <param name="customWindow">
-        /// Indicates whether custom window is enabled or disabled.
-        /// Serialized Name: MaintenanceWindow.customWindow
-        /// </param>
-        /// <param name="startHour">
-        /// Start hour to be used for maintenance window.
-        /// Serialized Name: MaintenanceWindow.startHour
-        /// </param>
-        /// <param name="startMinute">
-        /// Start minute to be used for maintenance window.
-        /// Serialized Name: MaintenanceWindow.startMinute
-        /// </param>
-        /// <param name="dayOfWeek">
-        /// Day of the week to be used for maintenance window.
-        /// Serialized Name: MaintenanceWindow.dayOfWeek
-        /// </param>
+        /// <param name="customWindow"> Indicates whether custom window is enabled or disabled. </param>
+        /// <param name="startHour"> Start hour to be used for maintenance window. </param>
+        /// <param name="startMinute"> Start minute to be used for maintenance window. </param>
+        /// <param name="dayOfWeek"> Day of the week to be used for maintenance window. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerMaintenanceWindow(string customWindow, int? startHour, int? startMinute, int? dayOfWeek, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -80,28 +65,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Indicates whether custom window is enabled or disabled.
-        /// Serialized Name: MaintenanceWindow.customWindow
-        /// </summary>
+        /// <summary> Indicates whether custom window is enabled or disabled. </summary>
         [WirePath("customWindow")]
         public string CustomWindow { get; set; }
-        /// <summary>
-        /// Start hour to be used for maintenance window.
-        /// Serialized Name: MaintenanceWindow.startHour
-        /// </summary>
+        /// <summary> Start hour to be used for maintenance window. </summary>
         [WirePath("startHour")]
         public int? StartHour { get; set; }
-        /// <summary>
-        /// Start minute to be used for maintenance window.
-        /// Serialized Name: MaintenanceWindow.startMinute
-        /// </summary>
+        /// <summary> Start minute to be used for maintenance window. </summary>
         [WirePath("startMinute")]
         public int? StartMinute { get; set; }
-        /// <summary>
-        /// Day of the week to be used for maintenance window.
-        /// Serialized Name: MaintenanceWindow.dayOfWeek
-        /// </summary>
+        /// <summary> Day of the week to be used for maintenance window. </summary>
         [WirePath("dayOfWeek")]
         public int? DayOfWeek { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerMicrosoftEntraAdministratorCreateOrUpdateContent.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerMicrosoftEntraAdministratorCreateOrUpdateContent.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Server administrator associated to a Microsoft Entra principal.
-    /// Serialized Name: AdministratorMicrosoftEntraAdd
-    /// </summary>
+    /// <summary> Server administrator associated to a Microsoft Entra principal. </summary>
     public partial class PostgreSqlFlexibleServerMicrosoftEntraAdministratorCreateOrUpdateContent
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerMicrosoftEntraAdministratorCreateOrUpdateContent"/>. </summary>
-        /// <param name="principalType">
-        /// Type of Microsoft Entra principal to which the server administrator is associated.
-        /// Serialized Name: AdministratorMicrosoftEntraAdd.properties.principalType
-        /// </param>
-        /// <param name="principalName">
-        /// Name of the Microsoft Entra principal.
-        /// Serialized Name: AdministratorMicrosoftEntraAdd.properties.principalName
-        /// </param>
-        /// <param name="tenantId">
-        /// Identifier of the tenant in which the Microsoft Entra principal exists.
-        /// Serialized Name: AdministratorMicrosoftEntraAdd.properties.tenantId
-        /// </param>
+        /// <param name="principalType"> Type of Microsoft Entra principal to which the server administrator is associated. </param>
+        /// <param name="principalName"> Name of the Microsoft Entra principal. </param>
+        /// <param name="tenantId"> Identifier of the tenant in which the Microsoft Entra principal exists. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerMicrosoftEntraAdministratorCreateOrUpdateContent(PostgreSqlFlexibleServerPrincipalType? principalType, string principalName, Guid? tenantId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Type of Microsoft Entra principal to which the server administrator is associated.
-        /// Serialized Name: AdministratorMicrosoftEntraAdd.properties.principalType
-        /// </summary>
+        /// <summary> Type of Microsoft Entra principal to which the server administrator is associated. </summary>
         [WirePath("properties.principalType")]
         public PostgreSqlFlexibleServerPrincipalType? PrincipalType { get; set; }
-        /// <summary>
-        /// Name of the Microsoft Entra principal.
-        /// Serialized Name: AdministratorMicrosoftEntraAdd.properties.principalName
-        /// </summary>
+        /// <summary> Name of the Microsoft Entra principal. </summary>
         [WirePath("properties.principalName")]
         public string PrincipalName { get; set; }
-        /// <summary>
-        /// Identifier of the tenant in which the Microsoft Entra principal exists.
-        /// Serialized Name: AdministratorMicrosoftEntraAdd.properties.tenantId
-        /// </summary>
+        /// <summary> Identifier of the tenant in which the Microsoft Entra principal exists. </summary>
         [WirePath("properties.tenantId")]
         public Guid? TenantId { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNameAvailabilityContent.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNameAvailabilityContent.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The check availability request body.
-    /// Serialized Name: CheckNameAvailabilityRequest
-    /// </summary>
+    /// <summary> The check availability request body. </summary>
     public partial class PostgreSqlFlexibleServerNameAvailabilityContent
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerNameAvailabilityContent"/>. </summary>
-        /// <param name="name">
-        /// The name of the resource for which availability needs to be checked.
-        /// Serialized Name: CheckNameAvailabilityRequest.name
-        /// </param>
+        /// <param name="name"> The name of the resource for which availability needs to be checked. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
         public PostgreSqlFlexibleServerNameAvailabilityContent(string name)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerNameAvailabilityContent"/>. </summary>
-        /// <param name="name">
-        /// The name of the resource for which availability needs to be checked.
-        /// Serialized Name: CheckNameAvailabilityRequest.name
-        /// </param>
-        /// <param name="resourceType">
-        /// The resource type.
-        /// Serialized Name: CheckNameAvailabilityRequest.type
-        /// </param>
+        /// <param name="name"> The name of the resource for which availability needs to be checked. </param>
+        /// <param name="resourceType"> The resource type. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerNameAvailabilityContent(string name, ResourceType? resourceType, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,16 +72,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The name of the resource for which availability needs to be checked.
-        /// Serialized Name: CheckNameAvailabilityRequest.name
-        /// </summary>
+        /// <summary> The name of the resource for which availability needs to be checked. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// The resource type.
-        /// Serialized Name: CheckNameAvailabilityRequest.type
-        /// </summary>
+        /// <summary> The resource type. </summary>
         [WirePath("type")]
         public ResourceType? ResourceType { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNameAvailabilityResponse.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNameAvailabilityResponse.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The check availability result.
-    /// Serialized Name: CheckNameAvailabilityResponse
-    /// </summary>
+    /// <summary> The check availability result. </summary>
     public partial class PostgreSqlFlexibleServerNameAvailabilityResponse
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerNameAvailabilityResponse"/>. </summary>
-        /// <param name="isNameAvailable">
-        /// Indicates if the resource name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.nameAvailable
-        /// </param>
-        /// <param name="reason">
-        /// The reason why the given name is not available.
-        /// Serialized Name: CheckNameAvailabilityResponse.reason
-        /// </param>
-        /// <param name="message">
-        /// Detailed reason why the given name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.message
-        /// </param>
+        /// <param name="isNameAvailable"> Indicates if the resource name is available. </param>
+        /// <param name="reason"> The reason why the given name is not available. </param>
+        /// <param name="message"> Detailed reason why the given name is available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerNameAvailabilityResponse(bool? isNameAvailable, PostgreSqlFlexibleServerNameUnavailableReason? reason, string message, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Indicates if the resource name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.nameAvailable
-        /// </summary>
+        /// <summary> Indicates if the resource name is available. </summary>
         [WirePath("nameAvailable")]
         public bool? IsNameAvailable { get; }
-        /// <summary>
-        /// The reason why the given name is not available.
-        /// Serialized Name: CheckNameAvailabilityResponse.reason
-        /// </summary>
+        /// <summary> The reason why the given name is not available. </summary>
         [WirePath("reason")]
         public PostgreSqlFlexibleServerNameUnavailableReason? Reason { get; }
-        /// <summary>
-        /// Detailed reason why the given name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.message
-        /// </summary>
+        /// <summary> Detailed reason why the given name is available. </summary>
         [WirePath("message")]
         public string Message { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNameAvailabilityResult.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNameAvailabilityResult.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Availability of a name.
-    /// Serialized Name: NameAvailabilityModel
-    /// </summary>
+    /// <summary> Availability of a name. </summary>
     public partial class PostgreSqlFlexibleServerNameAvailabilityResult : PostgreSqlFlexibleServerNameAvailabilityResponse
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerNameAvailabilityResult"/>. </summary>
@@ -23,43 +20,22 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerNameAvailabilityResult"/>. </summary>
-        /// <param name="isNameAvailable">
-        /// Indicates if the resource name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.nameAvailable
-        /// </param>
-        /// <param name="reason">
-        /// The reason why the given name is not available.
-        /// Serialized Name: CheckNameAvailabilityResponse.reason
-        /// </param>
-        /// <param name="message">
-        /// Detailed reason why the given name is available.
-        /// Serialized Name: CheckNameAvailabilityResponse.message
-        /// </param>
+        /// <param name="isNameAvailable"> Indicates if the resource name is available. </param>
+        /// <param name="reason"> The reason why the given name is not available. </param>
+        /// <param name="message"> Detailed reason why the given name is available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="name">
-        /// Name for which validity and availability was checked.
-        /// Serialized Name: NameAvailabilityModel.name
-        /// </param>
-        /// <param name="resourceType">
-        /// Type of resource. It can be 'Microsoft.DBforPostgreSQL/flexibleServers' or 'Microsoft.DBforPostgreSQL/flexibleServers/virtualendpoints'.
-        /// Serialized Name: NameAvailabilityModel.type
-        /// </param>
+        /// <param name="name"> Name for which validity and availability was checked. </param>
+        /// <param name="resourceType"> Type of resource. It can be 'Microsoft.DBforPostgreSQL/flexibleServers' or 'Microsoft.DBforPostgreSQL/flexibleServers/virtualendpoints'. </param>
         internal PostgreSqlFlexibleServerNameAvailabilityResult(bool? isNameAvailable, PostgreSqlFlexibleServerNameUnavailableReason? reason, string message, IDictionary<string, BinaryData> serializedAdditionalRawData, string name, ResourceType? resourceType) : base(isNameAvailable, reason, message, serializedAdditionalRawData)
         {
             Name = name;
             ResourceType = resourceType;
         }
 
-        /// <summary>
-        /// Name for which validity and availability was checked.
-        /// Serialized Name: NameAvailabilityModel.name
-        /// </summary>
+        /// <summary> Name for which validity and availability was checked. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// Type of resource. It can be 'Microsoft.DBforPostgreSQL/flexibleServers' or 'Microsoft.DBforPostgreSQL/flexibleServers/virtualendpoints'.
-        /// Serialized Name: NameAvailabilityModel.type
-        /// </summary>
+        /// <summary> Type of resource. It can be 'Microsoft.DBforPostgreSQL/flexibleServers' or 'Microsoft.DBforPostgreSQL/flexibleServers/virtualendpoints'. </summary>
         [WirePath("type")]
         public ResourceType? ResourceType { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNameUnavailableReason.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNameUnavailableReason.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The reason why the given name is not available.
-    /// Serialized Name: CheckNameAvailabilityReason
-    /// </summary>
+    /// <summary> The reason why the given name is not available. </summary>
     public readonly partial struct PostgreSqlFlexibleServerNameUnavailableReason : IEquatable<PostgreSqlFlexibleServerNameUnavailableReason>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string InvalidValue = "Invalid";
         private const string AlreadyExistsValue = "AlreadyExists";
 
-        /// <summary>
-        /// Invalid
-        /// Serialized Name: CheckNameAvailabilityReason.Invalid
-        /// </summary>
+        /// <summary> Invalid. </summary>
         public static PostgreSqlFlexibleServerNameUnavailableReason Invalid { get; } = new PostgreSqlFlexibleServerNameUnavailableReason(InvalidValue);
-        /// <summary>
-        /// AlreadyExists
-        /// Serialized Name: CheckNameAvailabilityReason.AlreadyExists
-        /// </summary>
+        /// <summary> AlreadyExists. </summary>
         public static PostgreSqlFlexibleServerNameUnavailableReason AlreadyExists { get; } = new PostgreSqlFlexibleServerNameUnavailableReason(AlreadyExistsValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerNameUnavailableReason"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerNameUnavailableReason left, PostgreSqlFlexibleServerNameUnavailableReason right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNetwork.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerNetwork.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Network properties of a server.
-    /// Serialized Name: Network
-    /// </summary>
+    /// <summary> Network properties of a server. </summary>
     public partial class PostgreSqlFlexibleServerNetwork
     {
         /// <summary>
@@ -55,18 +52,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerNetwork"/>. </summary>
-        /// <param name="publicNetworkAccess">
-        /// Indicates if public network access is enabled or not. This is only supported for servers that are not integrated into a virtual network which is owned and provided by customer when server is deployed.
-        /// Serialized Name: Network.publicNetworkAccess
-        /// </param>
-        /// <param name="delegatedSubnetResourceId">
-        /// Resource identifier of the delegated subnet. Required during creation of a new server, in case you want the server to be integrated into your own virtual network. For an update operation, you only have to provide this property if you want to change the value assigned for the private DNS zone.
-        /// Serialized Name: Network.delegatedSubnetResourceId
-        /// </param>
-        /// <param name="privateDnsZoneArmResourceId">
-        /// Identifier of the private DNS zone. Required during creation of a new server, in case you want the server to be integrated into your own virtual network. For an update operation, you only have to provide this property if you want to change the value assigned for the private DNS zone.
-        /// Serialized Name: Network.privateDnsZoneArmResourceId
-        /// </param>
+        /// <param name="publicNetworkAccess"> Indicates if public network access is enabled or not. This is only supported for servers that are not integrated into a virtual network which is owned and provided by customer when server is deployed. </param>
+        /// <param name="delegatedSubnetResourceId"> Resource identifier of the delegated subnet. Required during creation of a new server, in case you want the server to be integrated into your own virtual network. For an update operation, you only have to provide this property if you want to change the value assigned for the private DNS zone. </param>
+        /// <param name="privateDnsZoneArmResourceId"> Identifier of the private DNS zone. Required during creation of a new server, in case you want the server to be integrated into your own virtual network. For an update operation, you only have to provide this property if you want to change the value assigned for the private DNS zone. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerNetwork(PostgreSqlFlexibleServerPublicNetworkAccessState? publicNetworkAccess, ResourceIdentifier delegatedSubnetResourceId, ResourceIdentifier privateDnsZoneArmResourceId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -76,22 +64,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Indicates if public network access is enabled or not. This is only supported for servers that are not integrated into a virtual network which is owned and provided by customer when server is deployed.
-        /// Serialized Name: Network.publicNetworkAccess
-        /// </summary>
+        /// <summary> Indicates if public network access is enabled or not. This is only supported for servers that are not integrated into a virtual network which is owned and provided by customer when server is deployed. </summary>
         [WirePath("publicNetworkAccess")]
         public PostgreSqlFlexibleServerPublicNetworkAccessState? PublicNetworkAccess { get; set; }
-        /// <summary>
-        /// Resource identifier of the delegated subnet. Required during creation of a new server, in case you want the server to be integrated into your own virtual network. For an update operation, you only have to provide this property if you want to change the value assigned for the private DNS zone.
-        /// Serialized Name: Network.delegatedSubnetResourceId
-        /// </summary>
+        /// <summary> Resource identifier of the delegated subnet. Required during creation of a new server, in case you want the server to be integrated into your own virtual network. For an update operation, you only have to provide this property if you want to change the value assigned for the private DNS zone. </summary>
         [WirePath("delegatedSubnetResourceId")]
         public ResourceIdentifier DelegatedSubnetResourceId { get; set; }
-        /// <summary>
-        /// Identifier of the private DNS zone. Required during creation of a new server, in case you want the server to be integrated into your own virtual network. For an update operation, you only have to provide this property if you want to change the value assigned for the private DNS zone.
-        /// Serialized Name: Network.privateDnsZoneArmResourceId
-        /// </summary>
+        /// <summary> Identifier of the private DNS zone. Required during creation of a new server, in case you want the server to be integrated into your own virtual network. For an update operation, you only have to provide this property if you want to change the value assigned for the private DNS zone. </summary>
         [WirePath("privateDnsZoneArmResourceId")]
         public ResourceIdentifier PrivateDnsZoneArmResourceId { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerOnlineResizeSupported.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerOnlineResizeSupported.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if resizing the storage, without interrupting the operation of the database engine, is supported in this location for the given subscription. 'Enabled' means resizing the storage without interrupting the operation of the database engine is supported. 'Disabled' means resizing the storage without interrupting the operation of the database engine is not supported. Will be deprecated in the future. Look to Supported Features for 'OnlineResize'.
-    /// Serialized Name: OnlineStorageResizeSupport
-    /// </summary>
+    /// <summary> Indicates if resizing the storage, without interrupting the operation of the database engine, is supported in this location for the given subscription. 'Enabled' means resizing the storage without interrupting the operation of the database engine is supported. 'Disabled' means resizing the storage without interrupting the operation of the database engine is not supported. Will be deprecated in the future. Look to Supported Features for 'OnlineResize'. </summary>
     public readonly partial struct PostgreSqlFlexibleServerOnlineResizeSupported : IEquatable<PostgreSqlFlexibleServerOnlineResizeSupported>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: OnlineStorageResizeSupport.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerOnlineResizeSupported Enabled { get; } = new PostgreSqlFlexibleServerOnlineResizeSupported(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: OnlineStorageResizeSupport.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerOnlineResizeSupported Disabled { get; } = new PostgreSqlFlexibleServerOnlineResizeSupported(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerOnlineResizeSupported"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerOnlineResizeSupported left, PostgreSqlFlexibleServerOnlineResizeSupported right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerPasswordAuthEnum.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerPasswordAuthEnum.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if the server supports password based authentication.
-    /// Serialized Name: PasswordBasedAuth
-    /// </summary>
+    /// <summary> Indicates if the server supports password based authentication. </summary>
     public readonly partial struct PostgreSqlFlexibleServerPasswordAuthEnum : IEquatable<PostgreSqlFlexibleServerPasswordAuthEnum>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: PasswordBasedAuth.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerPasswordAuthEnum Enabled { get; } = new PostgreSqlFlexibleServerPasswordAuthEnum(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: PasswordBasedAuth.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerPasswordAuthEnum Disabled { get; } = new PostgreSqlFlexibleServerPasswordAuthEnum(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerPasswordAuthEnum"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerPasswordAuthEnum left, PostgreSqlFlexibleServerPasswordAuthEnum right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerPatch.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerPatch.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Represents a server to be updated.
-    /// Serialized Name: ServerForPatch
-    /// </summary>
+    /// <summary> Represents a server to be updated. </summary>
     public partial class PostgreSqlFlexibleServerPatch
     {
         /// <summary>
@@ -56,82 +53,25 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerPatch"/>. </summary>
-        /// <param name="sku">
-        /// Compute tier and size of a server.
-        /// Serialized Name: ServerForPatch.sku
-        /// </param>
-        /// <param name="identity">
-        /// Describes the identity of the application.
-        /// Serialized Name: ServerForPatch.identity
-        /// </param>
-        /// <param name="tags">
-        /// Application-specific metadata in the form of key-value pairs.
-        /// Serialized Name: ServerForPatch.tags
-        /// </param>
-        /// <param name="location">
-        /// The location the resource resides in.
-        /// Serialized Name: ServerForPatch.location
-        /// </param>
-        /// <param name="administratorLogin">
-        /// Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted.
-        /// Serialized Name: ServerForPatch.properties.administratorLogin
-        /// </param>
-        /// <param name="administratorLoginPassword">
-        /// Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time.
-        /// Serialized Name: ServerForPatch.properties.administratorLoginPassword
-        /// </param>
-        /// <param name="version">
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: ServerForPatch.properties.version
-        /// </param>
-        /// <param name="storage">
-        /// Storage properties of a server.
-        /// Serialized Name: ServerForPatch.properties.storage
-        /// </param>
-        /// <param name="backup">
-        /// Backup properties of a server.
-        /// Serialized Name: ServerForPatch.properties.backup
-        /// </param>
-        /// <param name="highAvailability">
-        /// High availability properties of a server.
-        /// Serialized Name: ServerForPatch.properties.highAvailability
-        /// </param>
-        /// <param name="maintenanceWindow">
-        /// Maintenance window properties of a server.
-        /// Serialized Name: ServerForPatch.properties.maintenanceWindow
-        /// </param>
-        /// <param name="authConfig">
-        /// Authentication configuration properties of a server.
-        /// Serialized Name: ServerForPatch.properties.authConfig
-        /// </param>
-        /// <param name="dataEncryption">
-        /// Data encryption properties of a server.
-        /// Serialized Name: ServerForPatch.properties.dataEncryption
-        /// </param>
-        /// <param name="availabilityZone">
-        /// Availability zone of a server.
-        /// Serialized Name: ServerForPatch.properties.availabilityZone
-        /// </param>
-        /// <param name="createMode">
-        /// Update mode of an existing server.
-        /// Serialized Name: ServerForPatch.properties.createMode
-        /// </param>
-        /// <param name="replicationRole">
-        /// Role of the server in a replication set.
-        /// Serialized Name: ServerForPatch.properties.replicationRole
-        /// </param>
-        /// <param name="replica">
-        /// Read replica properties of a server. Required only in case that you want to promote a server.
-        /// Serialized Name: ServerForPatch.properties.replica
-        /// </param>
-        /// <param name="network">
-        /// Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer.
-        /// Serialized Name: ServerForPatch.properties.network
-        /// </param>
-        /// <param name="cluster">
-        /// Cluster properties of a server.
-        /// Serialized Name: ServerForPatch.properties.cluster
-        /// </param>
+        /// <param name="sku"> Compute tier and size of a server. </param>
+        /// <param name="identity"> Describes the identity of the application. </param>
+        /// <param name="tags"> Application-specific metadata in the form of key-value pairs. </param>
+        /// <param name="location"> The location the resource resides in. </param>
+        /// <param name="administratorLogin"> Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted. </param>
+        /// <param name="administratorLoginPassword"> Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time. </param>
+        /// <param name="version"> Major version of PostgreSQL database engine. </param>
+        /// <param name="storage"> Storage properties of a server. </param>
+        /// <param name="backup"> Backup properties of a server. </param>
+        /// <param name="highAvailability"> High availability properties of a server. </param>
+        /// <param name="maintenanceWindow"> Maintenance window properties of a server. </param>
+        /// <param name="authConfig"> Authentication configuration properties of a server. </param>
+        /// <param name="dataEncryption"> Data encryption properties of a server. </param>
+        /// <param name="availabilityZone"> Availability zone of a server. </param>
+        /// <param name="createMode"> Update mode of an existing server. </param>
+        /// <param name="replicationRole"> Role of the server in a replication set. </param>
+        /// <param name="replica"> Read replica properties of a server. Required only in case that you want to promote a server. </param>
+        /// <param name="network"> Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer. </param>
+        /// <param name="cluster"> Cluster properties of a server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerPatch(PostgreSqlFlexibleServerSku sku, PostgreSqlFlexibleServerUserAssignedIdentity identity, IDictionary<string, string> tags, AzureLocation? location, string administratorLogin, string administratorLoginPassword, PostgreSqlFlexibleServerVersion? version, PostgreSqlFlexibleServerStorage storage, PostgreSqlFlexibleServerBackupProperties backup, PostgreSqlFlexibleServerHighAvailability highAvailability, PostgreSqlFlexibleServerMaintenanceWindow maintenanceWindow, PostgreSqlFlexibleServerAuthConfig authConfig, PostgreSqlFlexibleServerDataEncryption dataEncryption, string availabilityZone, PostgreSqlFlexibleServerCreateModeForUpdate? createMode, PostgreSqlFlexibleServerReplicationRole? replicationRole, PostgreSqlFlexibleServersReplica replica, PostgreSqlFlexibleServerNetwork network, PostgreSqlFlexibleServerClusterProperties cluster, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -157,118 +97,61 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Compute tier and size of a server.
-        /// Serialized Name: ServerForPatch.sku
-        /// </summary>
+        /// <summary> Compute tier and size of a server. </summary>
         [WirePath("sku")]
         public PostgreSqlFlexibleServerSku Sku { get; set; }
-        /// <summary>
-        /// Describes the identity of the application.
-        /// Serialized Name: ServerForPatch.identity
-        /// </summary>
+        /// <summary> Describes the identity of the application. </summary>
         [WirePath("identity")]
         public PostgreSqlFlexibleServerUserAssignedIdentity Identity { get; set; }
-        /// <summary>
-        /// Application-specific metadata in the form of key-value pairs.
-        /// Serialized Name: ServerForPatch.tags
-        /// </summary>
+        /// <summary> Application-specific metadata in the form of key-value pairs. </summary>
         [WirePath("tags")]
         public IDictionary<string, string> Tags { get; }
-        /// <summary>
-        /// The location the resource resides in.
-        /// Serialized Name: ServerForPatch.location
-        /// </summary>
+        /// <summary> The location the resource resides in. </summary>
         [WirePath("location")]
         public AzureLocation? Location { get; set; }
-        /// <summary>
-        /// Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted.
-        /// Serialized Name: ServerForPatch.properties.administratorLogin
-        /// </summary>
+        /// <summary> Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted. </summary>
         [WirePath("properties.administratorLogin")]
         public string AdministratorLogin { get; set; }
-        /// <summary>
-        /// Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time.
-        /// Serialized Name: ServerForPatch.properties.administratorLoginPassword
-        /// </summary>
+        /// <summary> Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time. </summary>
         [WirePath("properties.administratorLoginPassword")]
         public string AdministratorLoginPassword { get; set; }
-        /// <summary>
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: ServerForPatch.properties.version
-        /// </summary>
+        /// <summary> Major version of PostgreSQL database engine. </summary>
         [WirePath("properties.version")]
         public PostgreSqlFlexibleServerVersion? Version { get; set; }
-        /// <summary>
-        /// Storage properties of a server.
-        /// Serialized Name: ServerForPatch.properties.storage
-        /// </summary>
+        /// <summary> Storage properties of a server. </summary>
         [WirePath("properties.storage")]
         public PostgreSqlFlexibleServerStorage Storage { get; set; }
-        /// <summary>
-        /// Backup properties of a server.
-        /// Serialized Name: ServerForPatch.properties.backup
-        /// </summary>
+        /// <summary> Backup properties of a server. </summary>
         [WirePath("properties.backup")]
         public PostgreSqlFlexibleServerBackupProperties Backup { get; set; }
-        /// <summary>
-        /// High availability properties of a server.
-        /// Serialized Name: ServerForPatch.properties.highAvailability
-        /// </summary>
+        /// <summary> High availability properties of a server. </summary>
         [WirePath("properties.highAvailability")]
         public PostgreSqlFlexibleServerHighAvailability HighAvailability { get; set; }
-        /// <summary>
-        /// Maintenance window properties of a server.
-        /// Serialized Name: ServerForPatch.properties.maintenanceWindow
-        /// </summary>
+        /// <summary> Maintenance window properties of a server. </summary>
         [WirePath("properties.maintenanceWindow")]
         public PostgreSqlFlexibleServerMaintenanceWindow MaintenanceWindow { get; set; }
-        /// <summary>
-        /// Authentication configuration properties of a server.
-        /// Serialized Name: ServerForPatch.properties.authConfig
-        /// </summary>
+        /// <summary> Authentication configuration properties of a server. </summary>
         [WirePath("properties.authConfig")]
         public PostgreSqlFlexibleServerAuthConfig AuthConfig { get; set; }
-        /// <summary>
-        /// Data encryption properties of a server.
-        /// Serialized Name: ServerForPatch.properties.dataEncryption
-        /// </summary>
+        /// <summary> Data encryption properties of a server. </summary>
         [WirePath("properties.dataEncryption")]
         public PostgreSqlFlexibleServerDataEncryption DataEncryption { get; set; }
-        /// <summary>
-        /// Availability zone of a server.
-        /// Serialized Name: ServerForPatch.properties.availabilityZone
-        /// </summary>
+        /// <summary> Availability zone of a server. </summary>
         [WirePath("properties.availabilityZone")]
         public string AvailabilityZone { get; set; }
-        /// <summary>
-        /// Update mode of an existing server.
-        /// Serialized Name: ServerForPatch.properties.createMode
-        /// </summary>
+        /// <summary> Update mode of an existing server. </summary>
         [WirePath("properties.createMode")]
         public PostgreSqlFlexibleServerCreateModeForUpdate? CreateMode { get; set; }
-        /// <summary>
-        /// Role of the server in a replication set.
-        /// Serialized Name: ServerForPatch.properties.replicationRole
-        /// </summary>
+        /// <summary> Role of the server in a replication set. </summary>
         [WirePath("properties.replicationRole")]
         public PostgreSqlFlexibleServerReplicationRole? ReplicationRole { get; set; }
-        /// <summary>
-        /// Read replica properties of a server. Required only in case that you want to promote a server.
-        /// Serialized Name: ServerForPatch.properties.replica
-        /// </summary>
+        /// <summary> Read replica properties of a server. Required only in case that you want to promote a server. </summary>
         [WirePath("properties.replica")]
         public PostgreSqlFlexibleServersReplica Replica { get; set; }
-        /// <summary>
-        /// Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer.
-        /// Serialized Name: ServerForPatch.properties.network
-        /// </summary>
+        /// <summary> Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer. </summary>
         [WirePath("properties.network")]
         public PostgreSqlFlexibleServerNetwork Network { get; set; }
-        /// <summary>
-        /// Cluster properties of a server.
-        /// Serialized Name: ServerForPatch.properties.cluster
-        /// </summary>
+        /// <summary> Cluster properties of a server. </summary>
         [WirePath("properties.cluster")]
         public PostgreSqlFlexibleServerClusterProperties Cluster { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerPrincipalType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerPrincipalType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Type of Microsoft Entra principal to which the server administrator is associated.
-    /// Serialized Name: PrincipalType
-    /// </summary>
+    /// <summary> Type of Microsoft Entra principal to which the server administrator is associated. </summary>
     public readonly partial struct PostgreSqlFlexibleServerPrincipalType : IEquatable<PostgreSqlFlexibleServerPrincipalType>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string GroupValue = "Group";
         private const string ServicePrincipalValue = "ServicePrincipal";
 
-        /// <summary>
-        /// The principal type is not known or not specified.
-        /// Serialized Name: PrincipalType.Unknown
-        /// </summary>
+        /// <summary> The principal type is not known or not specified. </summary>
         public static PostgreSqlFlexibleServerPrincipalType Unknown { get; } = new PostgreSqlFlexibleServerPrincipalType(UnknownValue);
-        /// <summary>
-        /// A Microsoft Entra user.
-        /// Serialized Name: PrincipalType.User
-        /// </summary>
+        /// <summary> A Microsoft Entra user. </summary>
         public static PostgreSqlFlexibleServerPrincipalType User { get; } = new PostgreSqlFlexibleServerPrincipalType(UserValue);
-        /// <summary>
-        /// A Microsoft Entra group.
-        /// Serialized Name: PrincipalType.Group
-        /// </summary>
+        /// <summary> A Microsoft Entra group. </summary>
         public static PostgreSqlFlexibleServerPrincipalType Group { get; } = new PostgreSqlFlexibleServerPrincipalType(GroupValue);
-        /// <summary>
-        /// A Microsoft Entra service principal, typically representing an application or service identity
-        /// Serialized Name: PrincipalType.ServicePrincipal
-        /// </summary>
+        /// <summary> A Microsoft Entra service principal, typically representing an application or service identity. </summary>
         public static PostgreSqlFlexibleServerPrincipalType ServicePrincipal { get; } = new PostgreSqlFlexibleServerPrincipalType(ServicePrincipalValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerPrincipalType"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerPrincipalType left, PostgreSqlFlexibleServerPrincipalType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerPublicNetworkAccessState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerPublicNetworkAccessState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if public network access is enabled or not.
-    /// Serialized Name: ServerPublicNetworkAccessState
-    /// </summary>
+    /// <summary> Indicates if public network access is enabled or not. </summary>
     public readonly partial struct PostgreSqlFlexibleServerPublicNetworkAccessState : IEquatable<PostgreSqlFlexibleServerPublicNetworkAccessState>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: ServerPublicNetworkAccessState.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerPublicNetworkAccessState Enabled { get; } = new PostgreSqlFlexibleServerPublicNetworkAccessState(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: ServerPublicNetworkAccessState.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerPublicNetworkAccessState Disabled { get; } = new PostgreSqlFlexibleServerPublicNetworkAccessState(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerPublicNetworkAccessState"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerPublicNetworkAccessState left, PostgreSqlFlexibleServerPublicNetworkAccessState right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerQuotaUsage.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerQuotaUsage.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Quota usage for servers
-    /// Serialized Name: QuotaUsage
-    /// </summary>
+    /// <summary> Quota usage for servers. </summary>
     public partial class PostgreSqlFlexibleServerQuotaUsage
     {
         /// <summary>
@@ -54,26 +51,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerQuotaUsage"/>. </summary>
-        /// <param name="name">
-        /// Name of quota usage for servers
-        /// Serialized Name: QuotaUsage.name
-        /// </param>
-        /// <param name="limit">
-        /// Quota limit
-        /// Serialized Name: QuotaUsage.limit
-        /// </param>
-        /// <param name="unit">
-        /// Quota unit
-        /// Serialized Name: QuotaUsage.unit
-        /// </param>
-        /// <param name="currentValue">
-        /// Current Quota usage value
-        /// Serialized Name: QuotaUsage.currentValue
-        /// </param>
-        /// <param name="id">
-        /// Fully qualified ARM resource Id
-        /// Serialized Name: QuotaUsage.id
-        /// </param>
+        /// <param name="name"> Name of quota usage for servers. </param>
+        /// <param name="limit"> Quota limit. </param>
+        /// <param name="unit"> Quota unit. </param>
+        /// <param name="currentValue"> Current Quota usage value. </param>
+        /// <param name="id"> Fully qualified ARM resource Id. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerQuotaUsage(QuotaUsageNameProperty name, long? limit, string unit, long? currentValue, string id, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -85,34 +67,19 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Name of quota usage for servers
-        /// Serialized Name: QuotaUsage.name
-        /// </summary>
+        /// <summary> Name of quota usage for servers. </summary>
         [WirePath("name")]
         public QuotaUsageNameProperty Name { get; }
-        /// <summary>
-        /// Quota limit
-        /// Serialized Name: QuotaUsage.limit
-        /// </summary>
+        /// <summary> Quota limit. </summary>
         [WirePath("limit")]
         public long? Limit { get; }
-        /// <summary>
-        /// Quota unit
-        /// Serialized Name: QuotaUsage.unit
-        /// </summary>
+        /// <summary> Quota unit. </summary>
         [WirePath("unit")]
         public string Unit { get; }
-        /// <summary>
-        /// Current Quota usage value
-        /// Serialized Name: QuotaUsage.currentValue
-        /// </summary>
+        /// <summary> Current Quota usage value. </summary>
         [WirePath("currentValue")]
         public long? CurrentValue { get; }
-        /// <summary>
-        /// Fully qualified ARM resource Id
-        /// Serialized Name: QuotaUsage.id
-        /// </summary>
+        /// <summary> Fully qualified ARM resource Id. </summary>
         [WirePath("id")]
         public string Id { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerRecommendationFilterType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerRecommendationFilterType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The PostgreSqlFlexibleServerRecommendationFilterType.
-    /// Serialized Name: RecommendationTypeParameterEnum
-    /// </summary>
+    /// <summary> The PostgreSqlFlexibleServerRecommendationFilterType. </summary>
     public readonly partial struct PostgreSqlFlexibleServerRecommendationFilterType : IEquatable<PostgreSqlFlexibleServerRecommendationFilterType>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string ReIndexValue = "ReIndex";
         private const string AnalyzeTableValue = "AnalyzeTable";
 
-        /// <summary>
-        /// CreateIndex
-        /// Serialized Name: RecommendationTypeParameterEnum.CreateIndex
-        /// </summary>
+        /// <summary> CreateIndex. </summary>
         public static PostgreSqlFlexibleServerRecommendationFilterType CreateIndex { get; } = new PostgreSqlFlexibleServerRecommendationFilterType(CreateIndexValue);
-        /// <summary>
-        /// DropIndex
-        /// Serialized Name: RecommendationTypeParameterEnum.DropIndex
-        /// </summary>
+        /// <summary> DropIndex. </summary>
         public static PostgreSqlFlexibleServerRecommendationFilterType DropIndex { get; } = new PostgreSqlFlexibleServerRecommendationFilterType(DropIndexValue);
-        /// <summary>
-        /// ReIndex
-        /// Serialized Name: RecommendationTypeParameterEnum.ReIndex
-        /// </summary>
+        /// <summary> ReIndex. </summary>
         public static PostgreSqlFlexibleServerRecommendationFilterType ReIndex { get; } = new PostgreSqlFlexibleServerRecommendationFilterType(ReIndexValue);
-        /// <summary>
-        /// AnalyzeTable
-        /// Serialized Name: RecommendationTypeParameterEnum.AnalyzeTable
-        /// </summary>
+        /// <summary> AnalyzeTable. </summary>
         public static PostgreSqlFlexibleServerRecommendationFilterType AnalyzeTable { get; } = new PostgreSqlFlexibleServerRecommendationFilterType(AnalyzeTableValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerRecommendationFilterType"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerRecommendationFilterType left, PostgreSqlFlexibleServerRecommendationFilterType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerRecommendationType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerRecommendationType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Type for this recommendation.
-    /// Serialized Name: RecommendationTypeEnum
-    /// </summary>
+    /// <summary> Type for this recommendation. </summary>
     public readonly partial struct PostgreSqlFlexibleServerRecommendationType : IEquatable<PostgreSqlFlexibleServerRecommendationType>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string ReIndexValue = "ReIndex";
         private const string AnalyzeTableValue = "AnalyzeTable";
 
-        /// <summary>
-        /// CreateIndex
-        /// Serialized Name: RecommendationTypeEnum.CreateIndex
-        /// </summary>
+        /// <summary> CreateIndex. </summary>
         public static PostgreSqlFlexibleServerRecommendationType CreateIndex { get; } = new PostgreSqlFlexibleServerRecommendationType(CreateIndexValue);
-        /// <summary>
-        /// DropIndex
-        /// Serialized Name: RecommendationTypeEnum.DropIndex
-        /// </summary>
+        /// <summary> DropIndex. </summary>
         public static PostgreSqlFlexibleServerRecommendationType DropIndex { get; } = new PostgreSqlFlexibleServerRecommendationType(DropIndexValue);
-        /// <summary>
-        /// ReIndex
-        /// Serialized Name: RecommendationTypeEnum.ReIndex
-        /// </summary>
+        /// <summary> ReIndex. </summary>
         public static PostgreSqlFlexibleServerRecommendationType ReIndex { get; } = new PostgreSqlFlexibleServerRecommendationType(ReIndexValue);
-        /// <summary>
-        /// AnalyzeTable
-        /// Serialized Name: RecommendationTypeEnum.AnalyzeTable
-        /// </summary>
+        /// <summary> AnalyzeTable. </summary>
         public static PostgreSqlFlexibleServerRecommendationType AnalyzeTable { get; } = new PostgreSqlFlexibleServerRecommendationType(AnalyzeTableValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerRecommendationType"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerRecommendationType left, PostgreSqlFlexibleServerRecommendationType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerReplicationRole.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerReplicationRole.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Role of the server in a replication set.
-    /// Serialized Name: ReplicationRole
-    /// </summary>
+    /// <summary> Role of the server in a replication set. </summary>
     public readonly partial struct PostgreSqlFlexibleServerReplicationRole : IEquatable<PostgreSqlFlexibleServerReplicationRole>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string AsyncReplicaValue = "AsyncReplica";
         private const string GeoAsyncReplicaValue = "GeoAsyncReplica";
 
-        /// <summary>
-        /// None
-        /// Serialized Name: ReplicationRole.None
-        /// </summary>
+        /// <summary> None. </summary>
         public static PostgreSqlFlexibleServerReplicationRole None { get; } = new PostgreSqlFlexibleServerReplicationRole(NoneValue);
-        /// <summary>
-        /// Primary
-        /// Serialized Name: ReplicationRole.Primary
-        /// </summary>
+        /// <summary> Primary. </summary>
         public static PostgreSqlFlexibleServerReplicationRole Primary { get; } = new PostgreSqlFlexibleServerReplicationRole(PrimaryValue);
-        /// <summary>
-        /// AsyncReplica
-        /// Serialized Name: ReplicationRole.AsyncReplica
-        /// </summary>
+        /// <summary> AsyncReplica. </summary>
         public static PostgreSqlFlexibleServerReplicationRole AsyncReplica { get; } = new PostgreSqlFlexibleServerReplicationRole(AsyncReplicaValue);
-        /// <summary>
-        /// GeoAsyncReplica
-        /// Serialized Name: ReplicationRole.GeoAsyncReplica
-        /// </summary>
+        /// <summary> GeoAsyncReplica. </summary>
         public static PostgreSqlFlexibleServerReplicationRole GeoAsyncReplica { get; } = new PostgreSqlFlexibleServerReplicationRole(GeoAsyncReplicaValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerReplicationRole"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerReplicationRole left, PostgreSqlFlexibleServerReplicationRole right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerRestartParameter.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerRestartParameter.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// PostgreSQL database engine restart parameters.
-    /// Serialized Name: RestartParameter
-    /// </summary>
+    /// <summary> PostgreSQL database engine restart parameters. </summary>
     public partial class PostgreSqlFlexibleServerRestartParameter
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerRestartParameter"/>. </summary>
-        /// <param name="restartWithFailover">
-        /// Indicates if restart the PostgreSQL database engine should failover or switch over from primary to standby. This only works if server has high availability enabled.
-        /// Serialized Name: RestartParameter.restartWithFailover
-        /// </param>
-        /// <param name="failoverMode">
-        /// Failover mode.
-        /// Serialized Name: RestartParameter.failoverMode
-        /// </param>
+        /// <param name="restartWithFailover"> Indicates if restart the PostgreSQL database engine should failover or switch over from primary to standby. This only works if server has high availability enabled. </param>
+        /// <param name="failoverMode"> Failover mode. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerRestartParameter(bool? restartWithFailover, PostgreSqlFlexibleServerFailoverMode? failoverMode, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Indicates if restart the PostgreSQL database engine should failover or switch over from primary to standby. This only works if server has high availability enabled.
-        /// Serialized Name: RestartParameter.restartWithFailover
-        /// </summary>
+        /// <summary> Indicates if restart the PostgreSQL database engine should failover or switch over from primary to standby. This only works if server has high availability enabled. </summary>
         [WirePath("restartWithFailover")]
         public bool? RestartWithFailover { get; set; }
-        /// <summary>
-        /// Failover mode.
-        /// Serialized Name: RestartParameter.failoverMode
-        /// </summary>
+        /// <summary> Failover mode. </summary>
         [WirePath("failoverMode")]
         public PostgreSqlFlexibleServerFailoverMode? FailoverMode { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerServerVersionCapability.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerServerVersionCapability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Capabilities in terms of major versions of PostgreSQL database engine.
-    /// Serialized Name: ServerVersionCapability
-    /// </summary>
+    /// <summary> Capabilities in terms of major versions of PostgreSQL database engine. </summary>
     public partial class PostgreSqlFlexibleServerServerVersionCapability : PostgreSqlBaseCapability
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerServerVersionCapability"/>. </summary>
@@ -24,27 +21,12 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerServerVersionCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="name">
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: ServerVersionCapability.name
-        /// </param>
-        /// <param name="supportedVersionsToUpgrade">
-        /// Major versions of PostgreSQL database engine to which this version can be automatically upgraded.
-        /// Serialized Name: ServerVersionCapability.supportedVersionsToUpgrade
-        /// </param>
-        /// <param name="supportedFeatures">
-        /// Features supported.
-        /// Serialized Name: ServerVersionCapability.supportedFeatures
-        /// </param>
+        /// <param name="name"> Major version of PostgreSQL database engine. </param>
+        /// <param name="supportedVersionsToUpgrade"> Major versions of PostgreSQL database engine to which this version can be automatically upgraded. </param>
+        /// <param name="supportedFeatures"> Features supported. </param>
         internal PostgreSqlFlexibleServerServerVersionCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData, string name, IReadOnlyList<string> supportedVersionsToUpgrade, IReadOnlyList<PostgreSqlFlexibleServerSupportedFeature> supportedFeatures) : base(capabilityStatus, reason, serializedAdditionalRawData)
         {
             Name = name;
@@ -52,22 +34,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             SupportedFeatures = supportedFeatures;
         }
 
-        /// <summary>
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: ServerVersionCapability.name
-        /// </summary>
+        /// <summary> Major version of PostgreSQL database engine. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// Major versions of PostgreSQL database engine to which this version can be automatically upgraded.
-        /// Serialized Name: ServerVersionCapability.supportedVersionsToUpgrade
-        /// </summary>
+        /// <summary> Major versions of PostgreSQL database engine to which this version can be automatically upgraded. </summary>
         [WirePath("supportedVersionsToUpgrade")]
         public IReadOnlyList<string> SupportedVersionsToUpgrade { get; }
-        /// <summary>
-        /// Features supported.
-        /// Serialized Name: ServerVersionCapability.supportedFeatures
-        /// </summary>
+        /// <summary> Features supported. </summary>
         [WirePath("supportedFeatures")]
         public IReadOnlyList<PostgreSqlFlexibleServerSupportedFeature> SupportedFeatures { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerSku.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerSku.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Compute information of a server.
-    /// Serialized Name: Sku
-    /// </summary>
+    /// <summary> Compute information of a server. </summary>
     public partial class PostgreSqlFlexibleServerSku
     {
         /// <summary>
@@ -49,14 +46,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerSku"/>. </summary>
-        /// <param name="name">
-        /// Name by which is known a given compute size assigned to a server.
-        /// Serialized Name: Sku.name
-        /// </param>
-        /// <param name="tier">
-        /// Tier of the compute assigned to a server.
-        /// Serialized Name: Sku.tier
-        /// </param>
+        /// <param name="name"> Name by which is known a given compute size assigned to a server. </param>
+        /// <param name="tier"> Tier of the compute assigned to a server. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
         public PostgreSqlFlexibleServerSku(string name, PostgreSqlFlexibleServerSkuTier tier)
         {
@@ -67,14 +58,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerSku"/>. </summary>
-        /// <param name="name">
-        /// Name by which is known a given compute size assigned to a server.
-        /// Serialized Name: Sku.name
-        /// </param>
-        /// <param name="tier">
-        /// Tier of the compute assigned to a server.
-        /// Serialized Name: Sku.tier
-        /// </param>
+        /// <param name="name"> Name by which is known a given compute size assigned to a server. </param>
+        /// <param name="tier"> Tier of the compute assigned to a server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerSku(string name, PostgreSqlFlexibleServerSkuTier tier, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -88,16 +73,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// Name by which is known a given compute size assigned to a server.
-        /// Serialized Name: Sku.name
-        /// </summary>
+        /// <summary> Name by which is known a given compute size assigned to a server. </summary>
         [WirePath("name")]
         public string Name { get; set; }
-        /// <summary>
-        /// Tier of the compute assigned to a server.
-        /// Serialized Name: Sku.tier
-        /// </summary>
+        /// <summary> Tier of the compute assigned to a server. </summary>
         [WirePath("tier")]
         public PostgreSqlFlexibleServerSkuTier Tier { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerSkuCapability.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerSkuCapability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Capabilities in terms of compute.
-    /// Serialized Name: ServerSkuCapability
-    /// </summary>
+    /// <summary> Capabilities in terms of compute. </summary>
     public partial class PostgreSqlFlexibleServerSkuCapability : PostgreSqlBaseCapability
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerSkuCapability"/>. </summary>
@@ -25,47 +22,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerSkuCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="name">
-        /// Name of the compute (SKU).
-        /// Serialized Name: ServerSkuCapability.name
-        /// </param>
-        /// <param name="vCores">
-        /// vCores available for this compute.
-        /// Serialized Name: ServerSkuCapability.vCores
-        /// </param>
-        /// <param name="supportedIops">
-        /// Maximum IOPS supported by this compute.
-        /// Serialized Name: ServerSkuCapability.supportedIops
-        /// </param>
-        /// <param name="supportedMemoryPerVcoreMb">
-        /// Supported memory (in MB) per virtual core assigned to this compute.
-        /// Serialized Name: ServerSkuCapability.supportedMemoryPerVcoreMb
-        /// </param>
-        /// <param name="supportedZones">
-        /// List of supported availability zones. E.g. '1', '2', '3'
-        /// Serialized Name: ServerSkuCapability.supportedZones
-        /// </param>
-        /// <param name="supportedHaMode">
-        /// Modes of high availability supported for this compute.
-        /// Serialized Name: ServerSkuCapability.supportedHaMode
-        /// </param>
-        /// <param name="supportedFeatures">
-        /// Features supported.
-        /// Serialized Name: ServerSkuCapability.supportedFeatures
-        /// </param>
-        /// <param name="securityProfile">
-        /// Security profile of the compute. Indicates if it's a Confidential Compute virtual machine.
-        /// Serialized Name: ServerSkuCapability.securityProfile
-        /// </param>
+        /// <param name="name"> Name of the compute (SKU). </param>
+        /// <param name="vCores"> vCores available for this compute. </param>
+        /// <param name="supportedIops"> Maximum IOPS supported by this compute. </param>
+        /// <param name="supportedMemoryPerVcoreMb"> Supported memory (in MB) per virtual core assigned to this compute. </param>
+        /// <param name="supportedZones"> List of supported availability zones. E.g. '1', '2', '3'. </param>
+        /// <param name="supportedHaMode"> Modes of high availability supported for this compute. </param>
+        /// <param name="supportedFeatures"> Features supported. </param>
+        /// <param name="securityProfile"> Security profile of the compute. Indicates if it's a Confidential Compute virtual machine. </param>
         internal PostgreSqlFlexibleServerSkuCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData, string name, int? vCores, int? supportedIops, long? supportedMemoryPerVcoreMb, IReadOnlyList<string> supportedZones, IReadOnlyList<PostgreSqlFlexibleServerHAMode> supportedHaMode, IReadOnlyList<PostgreSqlFlexibleServerSupportedFeature> supportedFeatures, string securityProfile) : base(capabilityStatus, reason, serializedAdditionalRawData)
         {
             Name = name;
@@ -78,52 +45,28 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             SecurityProfile = securityProfile;
         }
 
-        /// <summary>
-        /// Name of the compute (SKU).
-        /// Serialized Name: ServerSkuCapability.name
-        /// </summary>
+        /// <summary> Name of the compute (SKU). </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// vCores available for this compute.
-        /// Serialized Name: ServerSkuCapability.vCores
-        /// </summary>
+        /// <summary> vCores available for this compute. </summary>
         [WirePath("vCores")]
         public int? VCores { get; }
-        /// <summary>
-        /// Maximum IOPS supported by this compute.
-        /// Serialized Name: ServerSkuCapability.supportedIops
-        /// </summary>
+        /// <summary> Maximum IOPS supported by this compute. </summary>
         [WirePath("supportedIops")]
         public int? SupportedIops { get; }
-        /// <summary>
-        /// Supported memory (in MB) per virtual core assigned to this compute.
-        /// Serialized Name: ServerSkuCapability.supportedMemoryPerVcoreMb
-        /// </summary>
+        /// <summary> Supported memory (in MB) per virtual core assigned to this compute. </summary>
         [WirePath("supportedMemoryPerVcoreMb")]
         public long? SupportedMemoryPerVcoreMb { get; }
-        /// <summary>
-        /// List of supported availability zones. E.g. '1', '2', '3'
-        /// Serialized Name: ServerSkuCapability.supportedZones
-        /// </summary>
+        /// <summary> List of supported availability zones. E.g. '1', '2', '3'. </summary>
         [WirePath("supportedZones")]
         public IReadOnlyList<string> SupportedZones { get; }
-        /// <summary>
-        /// Modes of high availability supported for this compute.
-        /// Serialized Name: ServerSkuCapability.supportedHaMode
-        /// </summary>
+        /// <summary> Modes of high availability supported for this compute. </summary>
         [WirePath("supportedHaMode")]
         public IReadOnlyList<PostgreSqlFlexibleServerHAMode> SupportedHaMode { get; }
-        /// <summary>
-        /// Features supported.
-        /// Serialized Name: ServerSkuCapability.supportedFeatures
-        /// </summary>
+        /// <summary> Features supported. </summary>
         [WirePath("supportedFeatures")]
         public IReadOnlyList<PostgreSqlFlexibleServerSupportedFeature> SupportedFeatures { get; }
-        /// <summary>
-        /// Security profile of the compute. Indicates if it's a Confidential Compute virtual machine.
-        /// Serialized Name: ServerSkuCapability.securityProfile
-        /// </summary>
+        /// <summary> Security profile of the compute. Indicates if it's a Confidential Compute virtual machine. </summary>
         [WirePath("securityProfile")]
         public string SecurityProfile { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerSkuTier.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerSkuTier.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Tier of the compute assigned to a server.
-    /// Serialized Name: SkuTier
-    /// </summary>
+    /// <summary> Tier of the compute assigned to a server. </summary>
     public readonly partial struct PostgreSqlFlexibleServerSkuTier : IEquatable<PostgreSqlFlexibleServerSkuTier>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string GeneralPurposeValue = "GeneralPurpose";
         private const string MemoryOptimizedValue = "MemoryOptimized";
 
-        /// <summary>
-        /// Burstable
-        /// Serialized Name: SkuTier.Burstable
-        /// </summary>
+        /// <summary> Burstable. </summary>
         public static PostgreSqlFlexibleServerSkuTier Burstable { get; } = new PostgreSqlFlexibleServerSkuTier(BurstableValue);
-        /// <summary>
-        /// GeneralPurpose
-        /// Serialized Name: SkuTier.GeneralPurpose
-        /// </summary>
+        /// <summary> GeneralPurpose. </summary>
         public static PostgreSqlFlexibleServerSkuTier GeneralPurpose { get; } = new PostgreSqlFlexibleServerSkuTier(GeneralPurposeValue);
-        /// <summary>
-        /// MemoryOptimized
-        /// Serialized Name: SkuTier.MemoryOptimized
-        /// </summary>
+        /// <summary> MemoryOptimized. </summary>
         public static PostgreSqlFlexibleServerSkuTier MemoryOptimized { get; } = new PostgreSqlFlexibleServerSkuTier(MemoryOptimizedValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerSkuTier"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerSkuTier left, PostgreSqlFlexibleServerSkuTier right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Possible states of a server.
-    /// Serialized Name: ServerState
-    /// </summary>
+    /// <summary> Possible states of a server. </summary>
     public readonly partial struct PostgreSqlFlexibleServerState : IEquatable<PostgreSqlFlexibleServerState>
     {
         private readonly string _value;
@@ -36,55 +33,25 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string InaccessibleValue = "Inaccessible";
         private const string ProvisioningValue = "Provisioning";
 
-        /// <summary>
-        /// Ready
-        /// Serialized Name: ServerState.Ready
-        /// </summary>
+        /// <summary> Ready. </summary>
         public static PostgreSqlFlexibleServerState Ready { get; } = new PostgreSqlFlexibleServerState(ReadyValue);
-        /// <summary>
-        /// Dropping
-        /// Serialized Name: ServerState.Dropping
-        /// </summary>
+        /// <summary> Dropping. </summary>
         public static PostgreSqlFlexibleServerState Dropping { get; } = new PostgreSqlFlexibleServerState(DroppingValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: ServerState.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerState Disabled { get; } = new PostgreSqlFlexibleServerState(DisabledValue);
-        /// <summary>
-        /// Starting
-        /// Serialized Name: ServerState.Starting
-        /// </summary>
+        /// <summary> Starting. </summary>
         public static PostgreSqlFlexibleServerState Starting { get; } = new PostgreSqlFlexibleServerState(StartingValue);
-        /// <summary>
-        /// Stopping
-        /// Serialized Name: ServerState.Stopping
-        /// </summary>
+        /// <summary> Stopping. </summary>
         public static PostgreSqlFlexibleServerState Stopping { get; } = new PostgreSqlFlexibleServerState(StoppingValue);
-        /// <summary>
-        /// Stopped
-        /// Serialized Name: ServerState.Stopped
-        /// </summary>
+        /// <summary> Stopped. </summary>
         public static PostgreSqlFlexibleServerState Stopped { get; } = new PostgreSqlFlexibleServerState(StoppedValue);
-        /// <summary>
-        /// Updating
-        /// Serialized Name: ServerState.Updating
-        /// </summary>
+        /// <summary> Updating. </summary>
         public static PostgreSqlFlexibleServerState Updating { get; } = new PostgreSqlFlexibleServerState(UpdatingValue);
-        /// <summary>
-        /// Restarting
-        /// Serialized Name: ServerState.Restarting
-        /// </summary>
+        /// <summary> Restarting. </summary>
         public static PostgreSqlFlexibleServerState Restarting { get; } = new PostgreSqlFlexibleServerState(RestartingValue);
-        /// <summary>
-        /// Inaccessible
-        /// Serialized Name: ServerState.Inaccessible
-        /// </summary>
+        /// <summary> Inaccessible. </summary>
         public static PostgreSqlFlexibleServerState Inaccessible { get; } = new PostgreSqlFlexibleServerState(InaccessibleValue);
-        /// <summary>
-        /// Provisioning
-        /// Serialized Name: ServerState.Provisioning
-        /// </summary>
+        /// <summary> Provisioning. </summary>
         public static PostgreSqlFlexibleServerState Provisioning { get; } = new PostgreSqlFlexibleServerState(ProvisioningValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerState"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerState left, PostgreSqlFlexibleServerState right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorage.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorage.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Storage properties of a server.
-    /// Serialized Name: Storage
-    /// </summary>
+    /// <summary> Storage properties of a server. </summary>
     public partial class PostgreSqlFlexibleServerStorage
     {
         /// <summary>
@@ -54,30 +51,12 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerStorage"/>. </summary>
-        /// <param name="storageSizeInGB">
-        /// Size of storage assigned to a server.
-        /// Serialized Name: Storage.storageSizeGB
-        /// </param>
-        /// <param name="autoGrow">
-        /// Flag to enable or disable the automatic growth of storage size of a server when available space is nearing zero and conditions allow for automatically growing storage size.
-        /// Serialized Name: Storage.autoGrow
-        /// </param>
-        /// <param name="tier">
-        /// Storage tier of a server.
-        /// Serialized Name: Storage.tier
-        /// </param>
-        /// <param name="iops">
-        /// Maximum IOPS supported for storage. Required when type of storage is PremiumV2_LRS or UltraSSD_LRS.
-        /// Serialized Name: Storage.iops
-        /// </param>
-        /// <param name="throughput">
-        /// Maximum throughput supported for storage. Required when type of storage is PremiumV2_LRS or UltraSSD_LRS.
-        /// Serialized Name: Storage.throughput
-        /// </param>
-        /// <param name="storageType">
-        /// Type of storage assigned to a server. Allowed values are Premium_LRS, PremiumV2_LRS, or UltraSSD_LRS. If not specified, it defaults to Premium_LRS.
-        /// Serialized Name: Storage.type
-        /// </param>
+        /// <param name="storageSizeInGB"> Size of storage assigned to a server. </param>
+        /// <param name="autoGrow"> Flag to enable or disable the automatic growth of storage size of a server when available space is nearing zero and conditions allow for automatically growing storage size. </param>
+        /// <param name="tier"> Storage tier of a server. </param>
+        /// <param name="iops"> Maximum IOPS supported for storage. Required when type of storage is PremiumV2_LRS or UltraSSD_LRS. </param>
+        /// <param name="throughput"> Maximum throughput supported for storage. Required when type of storage is PremiumV2_LRS or UltraSSD_LRS. </param>
+        /// <param name="storageType"> Type of storage assigned to a server. Allowed values are Premium_LRS, PremiumV2_LRS, or UltraSSD_LRS. If not specified, it defaults to Premium_LRS. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerStorage(int? storageSizeInGB, StorageAutoGrow? autoGrow, PostgreSqlManagedDiskPerformanceTier? tier, int? iops, int? throughput, PostgreSqlFlexibleServersStorageType? storageType, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -90,40 +69,22 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Size of storage assigned to a server.
-        /// Serialized Name: Storage.storageSizeGB
-        /// </summary>
+        /// <summary> Size of storage assigned to a server. </summary>
         [WirePath("storageSizeGB")]
         public int? StorageSizeInGB { get; set; }
-        /// <summary>
-        /// Flag to enable or disable the automatic growth of storage size of a server when available space is nearing zero and conditions allow for automatically growing storage size.
-        /// Serialized Name: Storage.autoGrow
-        /// </summary>
+        /// <summary> Flag to enable or disable the automatic growth of storage size of a server when available space is nearing zero and conditions allow for automatically growing storage size. </summary>
         [WirePath("autoGrow")]
         public StorageAutoGrow? AutoGrow { get; set; }
-        /// <summary>
-        /// Storage tier of a server.
-        /// Serialized Name: Storage.tier
-        /// </summary>
+        /// <summary> Storage tier of a server. </summary>
         [WirePath("tier")]
         public PostgreSqlManagedDiskPerformanceTier? Tier { get; set; }
-        /// <summary>
-        /// Maximum IOPS supported for storage. Required when type of storage is PremiumV2_LRS or UltraSSD_LRS.
-        /// Serialized Name: Storage.iops
-        /// </summary>
+        /// <summary> Maximum IOPS supported for storage. Required when type of storage is PremiumV2_LRS or UltraSSD_LRS. </summary>
         [WirePath("iops")]
         public int? Iops { get; set; }
-        /// <summary>
-        /// Maximum throughput supported for storage. Required when type of storage is PremiumV2_LRS or UltraSSD_LRS.
-        /// Serialized Name: Storage.throughput
-        /// </summary>
+        /// <summary> Maximum throughput supported for storage. Required when type of storage is PremiumV2_LRS or UltraSSD_LRS. </summary>
         [WirePath("throughput")]
         public int? Throughput { get; set; }
-        /// <summary>
-        /// Type of storage assigned to a server. Allowed values are Premium_LRS, PremiumV2_LRS, or UltraSSD_LRS. If not specified, it defaults to Premium_LRS.
-        /// Serialized Name: Storage.type
-        /// </summary>
+        /// <summary> Type of storage assigned to a server. Allowed values are Premium_LRS, PremiumV2_LRS, or UltraSSD_LRS. If not specified, it defaults to Premium_LRS. </summary>
         [WirePath("type")]
         public PostgreSqlFlexibleServersStorageType? StorageType { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorageAutoGrowthSupported.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorageAutoGrowthSupported.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if storage autogrow is supported in this location. 'Enabled' means storage autogrow is supported. 'Disabled' stands for storage autogrow is not supported. Will be deprecated in the future. Look to Supported Features for 'StorageAutoGrowth'.
-    /// Serialized Name: StorageAutoGrowthSupport
-    /// </summary>
+    /// <summary> Indicates if storage autogrow is supported in this location. 'Enabled' means storage autogrow is supported. 'Disabled' stands for storage autogrow is not supported. Will be deprecated in the future. Look to Supported Features for 'StorageAutoGrowth'. </summary>
     public readonly partial struct PostgreSqlFlexibleServerStorageAutoGrowthSupported : IEquatable<PostgreSqlFlexibleServerStorageAutoGrowthSupported>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: StorageAutoGrowthSupport.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerStorageAutoGrowthSupported Enabled { get; } = new PostgreSqlFlexibleServerStorageAutoGrowthSupported(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: StorageAutoGrowthSupport.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerStorageAutoGrowthSupported Disabled { get; } = new PostgreSqlFlexibleServerStorageAutoGrowthSupported(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerStorageAutoGrowthSupported"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerStorageAutoGrowthSupported left, PostgreSqlFlexibleServerStorageAutoGrowthSupported right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorageCapability.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorageCapability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Storage size (in MB) capability.
-    /// Serialized Name: StorageMbCapability
-    /// </summary>
+    /// <summary> Storage size (in MB) capability. </summary>
     public partial class PostgreSqlFlexibleServerStorageCapability : PostgreSqlBaseCapability
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerStorageCapability"/>. </summary>
@@ -23,47 +20,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerStorageCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="supportedIops">
-        /// Minimum IOPS supported by the storage size.
-        /// Serialized Name: StorageMbCapability.supportedIops
-        /// </param>
-        /// <param name="supportedMaximumIops">
-        /// Maximum IOPS supported by the storage size.
-        /// Serialized Name: StorageMbCapability.supportedMaximumIops
-        /// </param>
-        /// <param name="storageSizeInMB">
-        /// Minimum supported size (in MB) of storage.
-        /// Serialized Name: StorageMbCapability.storageSizeMb
-        /// </param>
-        /// <param name="maximumStorageSizeMb">
-        /// Maximum supported size (in MB) of storage.
-        /// Serialized Name: StorageMbCapability.maximumStorageSizeMb
-        /// </param>
-        /// <param name="supportedThroughput">
-        /// Minimum supported throughput (in MB/s) of storage.
-        /// Serialized Name: StorageMbCapability.supportedThroughput
-        /// </param>
-        /// <param name="supportedMaximumThroughput">
-        /// Maximum supported throughput (in MB/s) of storage.
-        /// Serialized Name: StorageMbCapability.supportedMaximumThroughput
-        /// </param>
-        /// <param name="defaultIopsTier">
-        /// Default IOPS for this tier and storage size.
-        /// Serialized Name: StorageMbCapability.defaultIopsTier
-        /// </param>
-        /// <param name="supportedIopsTiers">
-        /// List of all supported storage tiers for this tier and storage size.
-        /// Serialized Name: StorageMbCapability.supportedIopsTiers
-        /// </param>
+        /// <param name="supportedIops"> Minimum IOPS supported by the storage size. </param>
+        /// <param name="supportedMaximumIops"> Maximum IOPS supported by the storage size. </param>
+        /// <param name="storageSizeInMB"> Minimum supported size (in MB) of storage. </param>
+        /// <param name="maximumStorageSizeMb"> Maximum supported size (in MB) of storage. </param>
+        /// <param name="supportedThroughput"> Minimum supported throughput (in MB/s) of storage. </param>
+        /// <param name="supportedMaximumThroughput"> Maximum supported throughput (in MB/s) of storage. </param>
+        /// <param name="defaultIopsTier"> Default IOPS for this tier and storage size. </param>
+        /// <param name="supportedIopsTiers"> List of all supported storage tiers for this tier and storage size. </param>
         internal PostgreSqlFlexibleServerStorageCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData, long? supportedIops, int? supportedMaximumIops, long? storageSizeInMB, long? maximumStorageSizeMb, int? supportedThroughput, int? supportedMaximumThroughput, string defaultIopsTier, IReadOnlyList<PostgreSqlFlexibleServerStorageTierCapability> supportedIopsTiers) : base(capabilityStatus, reason, serializedAdditionalRawData)
         {
             SupportedIops = supportedIops;
@@ -75,46 +42,25 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             DefaultIopsTier = defaultIopsTier;
             SupportedIopsTiers = supportedIopsTiers;
         }
-        /// <summary>
-        /// Maximum IOPS supported by the storage size.
-        /// Serialized Name: StorageMbCapability.supportedMaximumIops
-        /// </summary>
+        /// <summary> Maximum IOPS supported by the storage size. </summary>
         [WirePath("supportedMaximumIops")]
         public int? SupportedMaximumIops { get; }
-        /// <summary>
-        /// Minimum supported size (in MB) of storage.
-        /// Serialized Name: StorageMbCapability.storageSizeMb
-        /// </summary>
+        /// <summary> Minimum supported size (in MB) of storage. </summary>
         [WirePath("storageSizeMb")]
         public long? StorageSizeInMB { get; }
-        /// <summary>
-        /// Maximum supported size (in MB) of storage.
-        /// Serialized Name: StorageMbCapability.maximumStorageSizeMb
-        /// </summary>
+        /// <summary> Maximum supported size (in MB) of storage. </summary>
         [WirePath("maximumStorageSizeMb")]
         public long? MaximumStorageSizeMb { get; }
-        /// <summary>
-        /// Minimum supported throughput (in MB/s) of storage.
-        /// Serialized Name: StorageMbCapability.supportedThroughput
-        /// </summary>
+        /// <summary> Minimum supported throughput (in MB/s) of storage. </summary>
         [WirePath("supportedThroughput")]
         public int? SupportedThroughput { get; }
-        /// <summary>
-        /// Maximum supported throughput (in MB/s) of storage.
-        /// Serialized Name: StorageMbCapability.supportedMaximumThroughput
-        /// </summary>
+        /// <summary> Maximum supported throughput (in MB/s) of storage. </summary>
         [WirePath("supportedMaximumThroughput")]
         public int? SupportedMaximumThroughput { get; }
-        /// <summary>
-        /// Default IOPS for this tier and storage size.
-        /// Serialized Name: StorageMbCapability.defaultIopsTier
-        /// </summary>
+        /// <summary> Default IOPS for this tier and storage size. </summary>
         [WirePath("defaultIopsTier")]
         public string DefaultIopsTier { get; }
-        /// <summary>
-        /// List of all supported storage tiers for this tier and storage size.
-        /// Serialized Name: StorageMbCapability.supportedIopsTiers
-        /// </summary>
+        /// <summary> List of all supported storage tiers for this tier and storage size. </summary>
         [WirePath("supportedIopsTiers")]
         public IReadOnlyList<PostgreSqlFlexibleServerStorageTierCapability> SupportedIopsTiers { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorageEditionCapability.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorageEditionCapability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Capabilities in terms of storage tier.
-    /// Serialized Name: StorageEditionCapability
-    /// </summary>
+    /// <summary> Capabilities in terms of storage tier. </summary>
     public partial class PostgreSqlFlexibleServerStorageEditionCapability : PostgreSqlBaseCapability
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerStorageEditionCapability"/>. </summary>
@@ -23,27 +20,12 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerStorageEditionCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="name">
-        /// Name of storage tier.
-        /// Serialized Name: StorageEditionCapability.name
-        /// </param>
-        /// <param name="defaultStorageSizeMb">
-        /// Default storage size (in MB) for this storage tier.
-        /// Serialized Name: StorageEditionCapability.defaultStorageSizeMb
-        /// </param>
-        /// <param name="supportedStorageCapabilities">
-        /// Configurations of storage supported for this storage tier.
-        /// Serialized Name: StorageEditionCapability.supportedStorageMb
-        /// </param>
+        /// <param name="name"> Name of storage tier. </param>
+        /// <param name="defaultStorageSizeMb"> Default storage size (in MB) for this storage tier. </param>
+        /// <param name="supportedStorageCapabilities"> Configurations of storage supported for this storage tier. </param>
         internal PostgreSqlFlexibleServerStorageEditionCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData, string name, long? defaultStorageSizeMb, IReadOnlyList<PostgreSqlFlexibleServerStorageCapability> supportedStorageCapabilities) : base(capabilityStatus, reason, serializedAdditionalRawData)
         {
             Name = name;
@@ -51,22 +33,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             SupportedStorageCapabilities = supportedStorageCapabilities;
         }
 
-        /// <summary>
-        /// Name of storage tier.
-        /// Serialized Name: StorageEditionCapability.name
-        /// </summary>
+        /// <summary> Name of storage tier. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// Default storage size (in MB) for this storage tier.
-        /// Serialized Name: StorageEditionCapability.defaultStorageSizeMb
-        /// </summary>
+        /// <summary> Default storage size (in MB) for this storage tier. </summary>
         [WirePath("defaultStorageSizeMb")]
         public long? DefaultStorageSizeMb { get; }
-        /// <summary>
-        /// Configurations of storage supported for this storage tier.
-        /// Serialized Name: StorageEditionCapability.supportedStorageMb
-        /// </summary>
+        /// <summary> Configurations of storage supported for this storage tier. </summary>
         [WirePath("supportedStorageMb")]
         public IReadOnlyList<PostgreSqlFlexibleServerStorageCapability> SupportedStorageCapabilities { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorageTierCapability.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerStorageTierCapability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Capability of a storage tier.
-    /// Serialized Name: StorageTierCapability
-    /// </summary>
+    /// <summary> Capability of a storage tier. </summary>
     public partial class PostgreSqlFlexibleServerStorageTierCapability : PostgreSqlBaseCapability
     {
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerStorageTierCapability"/>. </summary>
@@ -22,33 +19,18 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerStorageTierCapability"/>. </summary>
-        /// <param name="capabilityStatus">
-        /// The status of the capability.
-        /// Serialized Name: CapabilityBase.status
-        /// </param>
-        /// <param name="reason">
-        /// The reason for the capability not being available.
-        /// Serialized Name: CapabilityBase.reason
-        /// </param>
+        /// <param name="capabilityStatus"> The status of the capability. </param>
+        /// <param name="reason"> The reason for the capability not being available. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="name">
-        /// Name of the storage tier.
-        /// Serialized Name: StorageTierCapability.name
-        /// </param>
-        /// <param name="iops">
-        /// Supported IOPS for the storage tier.
-        /// Serialized Name: StorageTierCapability.iops
-        /// </param>
+        /// <param name="name"> Name of the storage tier. </param>
+        /// <param name="iops"> Supported IOPS for the storage tier. </param>
         internal PostgreSqlFlexibleServerStorageTierCapability(PostgreSqlFlexbileServerCapabilityStatus? capabilityStatus, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData, string name, long? iops) : base(capabilityStatus, reason, serializedAdditionalRawData)
         {
             Name = name;
             Iops = iops;
         }
 
-        /// <summary>
-        /// Name of the storage tier.
-        /// Serialized Name: StorageTierCapability.name
-        /// </summary>
+        /// <summary> Name of the storage tier. </summary>
         [WirePath("name")]
         public string Name { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerSupportedFeature.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerSupportedFeature.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Features supported.
-    /// Serialized Name: SupportedFeature
-    /// </summary>
+    /// <summary> Features supported. </summary>
     public partial class PostgreSqlFlexibleServerSupportedFeature
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerSupportedFeature"/>. </summary>
-        /// <param name="name">
-        /// Name of the feature.
-        /// Serialized Name: SupportedFeature.name
-        /// </param>
-        /// <param name="status">
-        /// Status of the feature. Indicates if the feature is enabled or not.
-        /// Serialized Name: SupportedFeature.status
-        /// </param>
+        /// <param name="name"> Name of the feature. </param>
+        /// <param name="status"> Status of the feature. Indicates if the feature is enabled or not. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerSupportedFeature(string name, PostgreSqlFlexibleServerFeatureStatus? status, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Name of the feature.
-        /// Serialized Name: SupportedFeature.name
-        /// </summary>
+        /// <summary> Name of the feature. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// Status of the feature. Indicates if the feature is enabled or not.
-        /// Serialized Name: SupportedFeature.status
-        /// </summary>
+        /// <summary> Status of the feature. Indicates if the feature is enabled or not. </summary>
         [WirePath("status")]
         public PostgreSqlFlexibleServerFeatureStatus? Status { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerTuningOptionType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerTuningOptionType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The PostgreSqlFlexibleServerTuningOptionType.
-    /// Serialized Name: TuningOptionParameterEnum
-    /// </summary>
+    /// <summary> The PostgreSqlFlexibleServerTuningOptionType. </summary>
     public readonly partial struct PostgreSqlFlexibleServerTuningOptionType : IEquatable<PostgreSqlFlexibleServerTuningOptionType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string IndexValue = "index";
         private const string TableValue = "table";
 
-        /// <summary>
-        /// index
-        /// Serialized Name: TuningOptionParameterEnum.index
-        /// </summary>
+        /// <summary> index. </summary>
         public static PostgreSqlFlexibleServerTuningOptionType Index { get; } = new PostgreSqlFlexibleServerTuningOptionType(IndexValue);
-        /// <summary>
-        /// table
-        /// Serialized Name: TuningOptionParameterEnum.table
-        /// </summary>
+        /// <summary> table. </summary>
         public static PostgreSqlFlexibleServerTuningOptionType Table { get; } = new PostgreSqlFlexibleServerTuningOptionType(TableValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerTuningOptionType"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerTuningOptionType left, PostgreSqlFlexibleServerTuningOptionType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerUserAssignedIdentity.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerUserAssignedIdentity.cs
@@ -11,10 +11,7 @@ using Azure.ResourceManager.Models;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Identities associated with a server.
-    /// Serialized Name: UserAssignedIdentity
-    /// </summary>
+    /// <summary> Identities associated with a server. </summary>
     public partial class PostgreSqlFlexibleServerUserAssignedIdentity
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerUserAssignedIdentity"/>. </summary>
-        /// <param name="identityType">
-        /// Types of identities associated with a server.
-        /// Serialized Name: UserAssignedIdentity.type
-        /// </param>
+        /// <param name="identityType"> Types of identities associated with a server. </param>
         public PostgreSqlFlexibleServerUserAssignedIdentity(PostgreSqlFlexibleServerIdentityType identityType)
         {
             UserAssignedIdentities = new ChangeTrackingDictionary<string, UserAssignedIdentity>();
@@ -61,22 +55,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerUserAssignedIdentity"/>. </summary>
-        /// <param name="userAssignedIdentities">
-        /// Map of user assigned managed identities.
-        /// Serialized Name: UserAssignedIdentity.userAssignedIdentities
-        /// </param>
-        /// <param name="principalId">
-        /// Identifier of the object of the service principal associated to the user assigned managed identity.
-        /// Serialized Name: UserAssignedIdentity.principalId
-        /// </param>
-        /// <param name="identityType">
-        /// Types of identities associated with a server.
-        /// Serialized Name: UserAssignedIdentity.type
-        /// </param>
-        /// <param name="tenantId">
-        /// Identifier of the tenant of a server.
-        /// Serialized Name: UserAssignedIdentity.tenantId
-        /// </param>
+        /// <param name="userAssignedIdentities"> Map of user assigned managed identities. </param>
+        /// <param name="principalId"> Identifier of the object of the service principal associated to the user assigned managed identity. </param>
+        /// <param name="identityType"> Types of identities associated with a server. </param>
+        /// <param name="tenantId"> Identifier of the tenant of a server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerUserAssignedIdentity(IDictionary<string, UserAssignedIdentity> userAssignedIdentities, Guid? principalId, PostgreSqlFlexibleServerIdentityType identityType, Guid? tenantId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -92,28 +74,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// Map of user assigned managed identities.
-        /// Serialized Name: UserAssignedIdentity.userAssignedIdentities
-        /// </summary>
+        /// <summary> Map of user assigned managed identities. </summary>
         [WirePath("userAssignedIdentities")]
         public IDictionary<string, UserAssignedIdentity> UserAssignedIdentities { get; }
-        /// <summary>
-        /// Identifier of the object of the service principal associated to the user assigned managed identity.
-        /// Serialized Name: UserAssignedIdentity.principalId
-        /// </summary>
+        /// <summary> Identifier of the object of the service principal associated to the user assigned managed identity. </summary>
         [WirePath("principalId")]
         public Guid? PrincipalId { get; set; }
-        /// <summary>
-        /// Types of identities associated with a server.
-        /// Serialized Name: UserAssignedIdentity.type
-        /// </summary>
+        /// <summary> Types of identities associated with a server. </summary>
         [WirePath("type")]
         public PostgreSqlFlexibleServerIdentityType IdentityType { get; set; }
-        /// <summary>
-        /// Identifier of the tenant of a server.
-        /// Serialized Name: UserAssignedIdentity.tenantId
-        /// </summary>
+        /// <summary> Identifier of the tenant of a server. </summary>
         [WirePath("tenantId")]
         public Guid? TenantId { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerVersion.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerVersion.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Major version of PostgreSQL database engine.
-    /// Serialized Name: PostgresMajorVersion
-    /// </summary>
+    /// <summary> Major version of PostgreSQL database engine. </summary>
     public readonly partial struct PostgreSqlFlexibleServerVersion : IEquatable<PostgreSqlFlexibleServerVersion>
     {
         private readonly string _value;
@@ -34,20 +31,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string Ver12Value = "12";
         private const string Ver11Value = "11";
 
-        /// <summary>
-        /// 18
-        /// Serialized Name: PostgresMajorVersion.18
-        /// </summary>
+        /// <summary> 18. </summary>
         public static PostgreSqlFlexibleServerVersion Eighteen { get; } = new PostgreSqlFlexibleServerVersion(EighteenValue);
-        /// <summary>
-        /// 17
-        /// Serialized Name: PostgresMajorVersion.17
-        /// </summary>
+        /// <summary> 17. </summary>
         public static PostgreSqlFlexibleServerVersion Seventeen { get; } = new PostgreSqlFlexibleServerVersion(SeventeenValue);
-        /// <summary>
-        /// 16
-        /// Serialized Name: PostgresMajorVersion.16
-        /// </summary>
+        /// <summary> 16. </summary>
         public static PostgreSqlFlexibleServerVersion Sixteen { get; } = new PostgreSqlFlexibleServerVersion(SixteenValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerVersion"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerVersion left, PostgreSqlFlexibleServerVersion right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerVirtualNetworkSubnetUsageParameter.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerVirtualNetworkSubnetUsageParameter.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Virtual network subnet usage parameter
-    /// Serialized Name: VirtualNetworkSubnetUsageParameter
-    /// </summary>
+    /// <summary> Virtual network subnet usage parameter. </summary>
     public partial class PostgreSqlFlexibleServerVirtualNetworkSubnetUsageParameter
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerVirtualNetworkSubnetUsageParameter"/>. </summary>
-        /// <param name="virtualNetworkArmResourceId">
-        /// Virtual network resource id.
-        /// Serialized Name: VirtualNetworkSubnetUsageParameter.virtualNetworkArmResourceId
-        /// </param>
+        /// <param name="virtualNetworkArmResourceId"> Virtual network resource id. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerVirtualNetworkSubnetUsageParameter(ResourceIdentifier virtualNetworkArmResourceId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Virtual network resource id.
-        /// Serialized Name: VirtualNetworkSubnetUsageParameter.virtualNetworkArmResourceId
-        /// </summary>
+        /// <summary> Virtual network resource id. </summary>
         [WirePath("virtualNetworkArmResourceId")]
         public ResourceIdentifier VirtualNetworkArmResourceId { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerVirtualNetworkSubnetUsageResult.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerVirtualNetworkSubnetUsageResult.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Virtual network subnet usage data.
-    /// Serialized Name: VirtualNetworkSubnetUsageModel
-    /// </summary>
+    /// <summary> Virtual network subnet usage data. </summary>
     public partial class PostgreSqlFlexibleServerVirtualNetworkSubnetUsageResult
     {
         /// <summary>
@@ -56,15 +53,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerVirtualNetworkSubnetUsageResult"/>. </summary>
-        /// <param name="delegatedSubnetsUsage"> Serialized Name: VirtualNetworkSubnetUsageModel.delegatedSubnetsUsage. </param>
-        /// <param name="location">
-        /// location of the delegated subnet usage
-        /// Serialized Name: VirtualNetworkSubnetUsageModel.location
-        /// </param>
-        /// <param name="subscriptionId">
-        /// subscriptionId of the delegated subnet usage
-        /// Serialized Name: VirtualNetworkSubnetUsageModel.subscriptionId
-        /// </param>
+        /// <param name="delegatedSubnetsUsage"></param>
+        /// <param name="location"> location of the delegated subnet usage. </param>
+        /// <param name="subscriptionId"> subscriptionId of the delegated subnet usage. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerVirtualNetworkSubnetUsageResult(IReadOnlyList<PostgreSqlFlexibleServerDelegatedSubnetUsage> delegatedSubnetsUsage, AzureLocation? location, string subscriptionId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -74,19 +65,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary> Serialized Name: VirtualNetworkSubnetUsageModel.delegatedSubnetsUsage. </summary>
+        /// <summary> Gets the delegated subnets usage. </summary>
         [WirePath("delegatedSubnetsUsage")]
         public IReadOnlyList<PostgreSqlFlexibleServerDelegatedSubnetUsage> DelegatedSubnetsUsage { get; }
-        /// <summary>
-        /// location of the delegated subnet usage
-        /// Serialized Name: VirtualNetworkSubnetUsageModel.location
-        /// </summary>
+        /// <summary> location of the delegated subnet usage. </summary>
         [WirePath("location")]
         public AzureLocation? Location { get; }
-        /// <summary>
-        /// subscriptionId of the delegated subnet usage
-        /// Serialized Name: VirtualNetworkSubnetUsageModel.subscriptionId
-        /// </summary>
+        /// <summary> subscriptionId of the delegated subnet usage. </summary>
         [WirePath("subscriptionId")]
         public string SubscriptionId { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if high availability with zone redundancy is supported in conjunction with geographically redundant backups in this location. 'Enabled' means high availability with zone redundancy is supported in conjunction with geographically redundant backups is supported. 'Disabled' stands for high availability with zone redundancy is supported in conjunction with geographically redundant backups is not supported. Will be deprecated in the future. Look to Supported Features for 'ZoneRedundantHaAndGeoBackup'.
-    /// Serialized Name: ZoneRedundantHighAvailabilityAndGeographicallyRedundantBackupSupport
-    /// </summary>
+    /// <summary> Indicates if high availability with zone redundancy is supported in conjunction with geographically redundant backups in this location. 'Enabled' means high availability with zone redundancy is supported in conjunction with geographically redundant backups is supported. 'Disabled' stands for high availability with zone redundancy is supported in conjunction with geographically redundant backups is not supported. Will be deprecated in the future. Look to Supported Features for 'ZoneRedundantHaAndGeoBackup'. </summary>
     public readonly partial struct PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported : IEquatable<PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: ZoneRedundantHighAvailabilityAndGeographicallyRedundantBackupSupport.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported Enabled { get; } = new PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: ZoneRedundantHighAvailabilityAndGeographicallyRedundantBackupSupport.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported Disabled { get; } = new PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported left, PostgreSqlFlexibleServerZoneRedundantHaAndGeoBackupSupported right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerZoneRedundantHaSupported.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerZoneRedundantHaSupported.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if high availability with zone redundancy is supported in this location. 'Enabled' means high availability with zone redundancy is supported. 'Disabled' stands for high availability with zone redundancy is not supported. Will be deprecated in the future. Look to Supported Features for  'ZoneRedundantHa'.
-    /// Serialized Name: ZoneRedundantHighAvailabilitySupport
-    /// </summary>
+    /// <summary> Indicates if high availability with zone redundancy is supported in this location. 'Enabled' means high availability with zone redundancy is supported. 'Disabled' stands for high availability with zone redundancy is not supported. Will be deprecated in the future. Look to Supported Features for  'ZoneRedundantHa'. </summary>
     public readonly partial struct PostgreSqlFlexibleServerZoneRedundantHaSupported : IEquatable<PostgreSqlFlexibleServerZoneRedundantHaSupported>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: ZoneRedundantHighAvailabilitySupport.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerZoneRedundantHaSupported Enabled { get; } = new PostgreSqlFlexibleServerZoneRedundantHaSupported(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: ZoneRedundantHighAvailabilitySupport.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerZoneRedundantHaSupported Disabled { get; } = new PostgreSqlFlexibleServerZoneRedundantHaSupported(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerZoneRedundantHaSupported"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerZoneRedundantHaSupported left, PostgreSqlFlexibleServerZoneRedundantHaSupported right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerZoneRedundantRestricted.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServerZoneRedundantRestricted.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if this location is restricted. 'Enabled' means location is restricted. 'Disabled' stands for location is not restricted. Will be deprecated in the future. Look to Supported Features for 'Restricted'.
-    /// Serialized Name: LocationRestricted
-    /// </summary>
+    /// <summary> Indicates if this location is restricted. 'Enabled' means location is restricted. 'Disabled' stands for location is not restricted. Will be deprecated in the future. Look to Supported Features for 'Restricted'. </summary>
     public readonly partial struct PostgreSqlFlexibleServerZoneRedundantRestricted : IEquatable<PostgreSqlFlexibleServerZoneRedundantRestricted>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: LocationRestricted.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static PostgreSqlFlexibleServerZoneRedundantRestricted Enabled { get; } = new PostgreSqlFlexibleServerZoneRedundantRestricted(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: LocationRestricted.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static PostgreSqlFlexibleServerZoneRedundantRestricted Disabled { get; } = new PostgreSqlFlexibleServerZoneRedundantRestricted(DisabledValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServerZoneRedundantRestricted"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServerZoneRedundantRestricted left, PostgreSqlFlexibleServerZoneRedundantRestricted right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The current provisioning state.
-    /// Serialized Name: PrivateEndpointConnectionProvisioningState
-    /// </summary>
+    /// <summary> The current provisioning state. </summary>
     public readonly partial struct PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState : IEquatable<PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string DeletingValue = "Deleting";
         private const string FailedValue = "Failed";
 
-        /// <summary>
-        /// Succeeded
-        /// Serialized Name: PrivateEndpointConnectionProvisioningState.Succeeded
-        /// </summary>
+        /// <summary> Succeeded. </summary>
         public static PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState Succeeded { get; } = new PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState(SucceededValue);
-        /// <summary>
-        /// Creating
-        /// Serialized Name: PrivateEndpointConnectionProvisioningState.Creating
-        /// </summary>
+        /// <summary> Creating. </summary>
         public static PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState Creating { get; } = new PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState(CreatingValue);
-        /// <summary>
-        /// Deleting
-        /// Serialized Name: PrivateEndpointConnectionProvisioningState.Deleting
-        /// </summary>
+        /// <summary> Deleting. </summary>
         public static PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState Deleting { get; } = new PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState(DeletingValue);
-        /// <summary>
-        /// Failed
-        /// Serialized Name: PrivateEndpointConnectionProvisioningState.Failed
-        /// </summary>
+        /// <summary> Failed. </summary>
         public static PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState Failed { get; } = new PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState(FailedValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState left, PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The private endpoint connection status.
-    /// Serialized Name: PrivateEndpointServiceConnectionStatus
-    /// </summary>
+    /// <summary> The private endpoint connection status. </summary>
     public readonly partial struct PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus : IEquatable<PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string ApprovedValue = "Approved";
         private const string RejectedValue = "Rejected";
 
-        /// <summary>
-        /// Pending
-        /// Serialized Name: PrivateEndpointServiceConnectionStatus.Pending
-        /// </summary>
+        /// <summary> Pending. </summary>
         public static PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus Pending { get; } = new PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus(PendingValue);
-        /// <summary>
-        /// Approved
-        /// Serialized Name: PrivateEndpointServiceConnectionStatus.Approved
-        /// </summary>
+        /// <summary> Approved. </summary>
         public static PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus Approved { get; } = new PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus(ApprovedValue);
-        /// <summary>
-        /// Rejected
-        /// Serialized Name: PrivateEndpointServiceConnectionStatus.Rejected
-        /// </summary>
+        /// <summary> Rejected. </summary>
         public static PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus Rejected { get; } = new PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus(RejectedValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus left, PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersPrivateLinkServiceConnectionState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersPrivateLinkServiceConnectionState.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// A collection of information about the state of the connection between service consumer and provider.
-    /// Serialized Name: PrivateLinkServiceConnectionState
-    /// </summary>
+    /// <summary> A collection of information about the state of the connection between service consumer and provider. </summary>
     public partial class PostgreSqlFlexibleServersPrivateLinkServiceConnectionState
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServersPrivateLinkServiceConnectionState"/>. </summary>
-        /// <param name="status">
-        /// Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service.
-        /// Serialized Name: PrivateLinkServiceConnectionState.status
-        /// </param>
-        /// <param name="description">
-        /// The reason for approval/rejection of the connection.
-        /// Serialized Name: PrivateLinkServiceConnectionState.description
-        /// </param>
-        /// <param name="actionsRequired">
-        /// A message indicating if changes on the service provider require any updates on the consumer.
-        /// Serialized Name: PrivateLinkServiceConnectionState.actionsRequired
-        /// </param>
+        /// <param name="status"> Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. </param>
+        /// <param name="description"> The reason for approval/rejection of the connection. </param>
+        /// <param name="actionsRequired"> A message indicating if changes on the service provider require any updates on the consumer. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServersPrivateLinkServiceConnectionState(PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus? status, string description, string actionsRequired, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service.
-        /// Serialized Name: PrivateLinkServiceConnectionState.status
-        /// </summary>
+        /// <summary> Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service. </summary>
         [WirePath("status")]
         public PostgreSqlFlexibleServersPrivateEndpointServiceConnectionStatus? Status { get; set; }
-        /// <summary>
-        /// The reason for approval/rejection of the connection.
-        /// Serialized Name: PrivateLinkServiceConnectionState.description
-        /// </summary>
+        /// <summary> The reason for approval/rejection of the connection. </summary>
         [WirePath("description")]
         public string Description { get; set; }
-        /// <summary>
-        /// A message indicating if changes on the service provider require any updates on the consumer.
-        /// Serialized Name: PrivateLinkServiceConnectionState.actionsRequired
-        /// </summary>
+        /// <summary> A message indicating if changes on the service provider require any updates on the consumer. </summary>
         [WirePath("actionsRequired")]
         public string ActionsRequired { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersReplica.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersReplica.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Replica properties of a server.
-    /// Serialized Name: Replica
-    /// </summary>
+    /// <summary> Replica properties of a server. </summary>
     public partial class PostgreSqlFlexibleServersReplica
     {
         /// <summary>
@@ -54,26 +51,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServersReplica"/>. </summary>
-        /// <param name="role">
-        /// Role of the server in a replication set.
-        /// Serialized Name: Replica.role
-        /// </param>
-        /// <param name="capacity">
-        /// Maximum number of read replicas allowed for a server.
-        /// Serialized Name: Replica.capacity
-        /// </param>
-        /// <param name="replicationState">
-        /// Indicates the replication state of a read replica. This property is returned only when the target server is a read replica. Possible  values are Active, Broken, Catchup, Provisioning, Reconfiguring, and Updating
-        /// Serialized Name: Replica.replicationState
-        /// </param>
-        /// <param name="promoteMode">
-        /// Type of operation to apply on the read replica. This property is write only. Standalone means that the read replica will be promoted to a standalone server, and will become a completely independent entity from the replication set. Switchover means that the read replica will roles with the primary server.
-        /// Serialized Name: Replica.promoteMode
-        /// </param>
-        /// <param name="promoteOption">
-        /// Data synchronization option to use when processing the operation specified in the promoteMode property. This property is write only.
-        /// Serialized Name: Replica.promoteOption
-        /// </param>
+        /// <param name="role"> Role of the server in a replication set. </param>
+        /// <param name="capacity"> Maximum number of read replicas allowed for a server. </param>
+        /// <param name="replicationState"> Indicates the replication state of a read replica. This property is returned only when the target server is a read replica. Possible  values are Active, Broken, Catchup, Provisioning, Reconfiguring, and Updating. </param>
+        /// <param name="promoteMode"> Type of operation to apply on the read replica. This property is write only. Standalone means that the read replica will be promoted to a standalone server, and will become a completely independent entity from the replication set. Switchover means that the read replica will roles with the primary server. </param>
+        /// <param name="promoteOption"> Data synchronization option to use when processing the operation specified in the promoteMode property. This property is write only. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServersReplica(PostgreSqlFlexibleServerReplicationRole? role, int? capacity, PostgreSqlFlexibleServersReplicationState? replicationState, ReadReplicaPromoteMode? promoteMode, ReplicationPromoteOption? promoteOption, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -85,34 +67,19 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Role of the server in a replication set.
-        /// Serialized Name: Replica.role
-        /// </summary>
+        /// <summary> Role of the server in a replication set. </summary>
         [WirePath("role")]
         public PostgreSqlFlexibleServerReplicationRole? Role { get; set; }
-        /// <summary>
-        /// Maximum number of read replicas allowed for a server.
-        /// Serialized Name: Replica.capacity
-        /// </summary>
+        /// <summary> Maximum number of read replicas allowed for a server. </summary>
         [WirePath("capacity")]
         public int? Capacity { get; }
-        /// <summary>
-        /// Indicates the replication state of a read replica. This property is returned only when the target server is a read replica. Possible  values are Active, Broken, Catchup, Provisioning, Reconfiguring, and Updating
-        /// Serialized Name: Replica.replicationState
-        /// </summary>
+        /// <summary> Indicates the replication state of a read replica. This property is returned only when the target server is a read replica. Possible  values are Active, Broken, Catchup, Provisioning, Reconfiguring, and Updating. </summary>
         [WirePath("replicationState")]
         public PostgreSqlFlexibleServersReplicationState? ReplicationState { get; }
-        /// <summary>
-        /// Type of operation to apply on the read replica. This property is write only. Standalone means that the read replica will be promoted to a standalone server, and will become a completely independent entity from the replication set. Switchover means that the read replica will roles with the primary server.
-        /// Serialized Name: Replica.promoteMode
-        /// </summary>
+        /// <summary> Type of operation to apply on the read replica. This property is write only. Standalone means that the read replica will be promoted to a standalone server, and will become a completely independent entity from the replication set. Switchover means that the read replica will roles with the primary server. </summary>
         [WirePath("promoteMode")]
         public ReadReplicaPromoteMode? PromoteMode { get; set; }
-        /// <summary>
-        /// Data synchronization option to use when processing the operation specified in the promoteMode property. This property is write only.
-        /// Serialized Name: Replica.promoteOption
-        /// </summary>
+        /// <summary> Data synchronization option to use when processing the operation specified in the promoteMode property. This property is write only. </summary>
         [WirePath("promoteOption")]
         public ReplicationPromoteOption? PromoteOption { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersReplicationState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersReplicationState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates the replication state of a read replica. This property is returned only when the target server is a read replica. Possible  values are Active, Broken, Catchup, Provisioning, Reconfiguring, and Updating
-    /// Serialized Name: ReplicationState
-    /// </summary>
+    /// <summary> Indicates the replication state of a read replica. This property is returned only when the target server is a read replica. Possible  values are Active, Broken, Catchup, Provisioning, Reconfiguring, and Updating. </summary>
     public readonly partial struct PostgreSqlFlexibleServersReplicationState : IEquatable<PostgreSqlFlexibleServersReplicationState>
     {
         private readonly string _value;
@@ -32,35 +29,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string BrokenValue = "Broken";
         private const string ReconfiguringValue = "Reconfiguring";
 
-        /// <summary>
-        /// The read replica server is fully synchronized and actively replicating data from the primary server.
-        /// Serialized Name: ReplicationState.Active
-        /// </summary>
+        /// <summary> The read replica server is fully synchronized and actively replicating data from the primary server. </summary>
         public static PostgreSqlFlexibleServersReplicationState Active { get; } = new PostgreSqlFlexibleServersReplicationState(ActiveValue);
-        /// <summary>
-        /// The read replica server is behind the primary server and is currently catching up with pending changes.
-        /// Serialized Name: ReplicationState.Catchup
-        /// </summary>
+        /// <summary> The read replica server is behind the primary server and is currently catching up with pending changes. </summary>
         public static PostgreSqlFlexibleServersReplicationState Catchup { get; } = new PostgreSqlFlexibleServersReplicationState(CatchupValue);
-        /// <summary>
-        /// The read replica server is being created and is in process of getting initialized.
-        /// Serialized Name: ReplicationState.Provisioning
-        /// </summary>
+        /// <summary> The read replica server is being created and is in process of getting initialized. </summary>
         public static PostgreSqlFlexibleServersReplicationState Provisioning { get; } = new PostgreSqlFlexibleServersReplicationState(ProvisioningValue);
-        /// <summary>
-        /// The read replica server is undergoing some changes it can be changing compute size of promoting it to primary server.
-        /// Serialized Name: ReplicationState.Updating
-        /// </summary>
+        /// <summary> The read replica server is undergoing some changes it can be changing compute size of promoting it to primary server. </summary>
         public static PostgreSqlFlexibleServersReplicationState Updating { get; } = new PostgreSqlFlexibleServersReplicationState(UpdatingValue);
-        /// <summary>
-        /// Replication has failed or been interrupted.
-        /// Serialized Name: ReplicationState.Broken
-        /// </summary>
+        /// <summary> Replication has failed or been interrupted. </summary>
         public static PostgreSqlFlexibleServersReplicationState Broken { get; } = new PostgreSqlFlexibleServersReplicationState(BrokenValue);
-        /// <summary>
-        /// The read replica server is being reconfigured, possibly due to changes in source or settings.
-        /// Serialized Name: ReplicationState.Reconfiguring
-        /// </summary>
+        /// <summary> The read replica server is being reconfigured, possibly due to changes in source or settings. </summary>
         public static PostgreSqlFlexibleServersReplicationState Reconfiguring { get; } = new PostgreSqlFlexibleServersReplicationState(ReconfiguringValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServersReplicationState"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServersReplicationState left, PostgreSqlFlexibleServersReplicationState right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersServerSku.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersServerSku.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Compute information of a server.
-    /// Serialized Name: ServerSku
-    /// </summary>
+    /// <summary> Compute information of a server. </summary>
     public partial class PostgreSqlFlexibleServersServerSku
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServersServerSku"/>. </summary>
-        /// <param name="name">
-        /// Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server.
-        /// Serialized Name: ServerSku.name
-        /// </param>
-        /// <param name="tier">
-        /// Tier of the compute assigned to a server.
-        /// Serialized Name: ServerSku.tier
-        /// </param>
+        /// <param name="name"> Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server. </param>
+        /// <param name="tier"> Tier of the compute assigned to a server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServersServerSku(string name, PostgreSqlFlexibleServerSkuTier? tier, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server.
-        /// Serialized Name: ServerSku.name
-        /// </summary>
+        /// <summary> Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// Tier of the compute assigned to a server.
-        /// Serialized Name: ServerSku.tier
-        /// </summary>
+        /// <summary> Tier of the compute assigned to a server. </summary>
         [WirePath("tier")]
         public PostgreSqlFlexibleServerSkuTier? Tier { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersSourceType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersSourceType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Source server type used for the migration: ApsaraDB_RDS, AWS, AWS_AURORA, AWS_EC2, AWS_RDS, AzureVM, Crunchy_PostgreSQL, Digital_Ocean_Droplets, Digital_Ocean_PostgreSQL, EDB, EDB_Oracle_Server, EDB_PostgreSQL, GCP, GCP_AlloyDB, GCP_CloudSQL, GCP_Compute, Heroku_PostgreSQL, Huawei_Compute, Huawei_RDS, OnPremises, PostgreSQLCosmosDB, PostgreSQLFlexibleServer, PostgreSQLSingleServer, or Supabase_PostgreSQL
-    /// Serialized Name: SourceType
-    /// </summary>
+    /// <summary> Source server type used for the migration: ApsaraDB_RDS, AWS, AWS_AURORA, AWS_EC2, AWS_RDS, AzureVM, Crunchy_PostgreSQL, Digital_Ocean_Droplets, Digital_Ocean_PostgreSQL, EDB, EDB_Oracle_Server, EDB_PostgreSQL, GCP, GCP_AlloyDB, GCP_CloudSQL, GCP_Compute, Heroku_PostgreSQL, Huawei_Compute, Huawei_RDS, OnPremises, PostgreSQLCosmosDB, PostgreSQLFlexibleServer, PostgreSQLSingleServer, or Supabase_PostgreSQL. </summary>
     public readonly partial struct PostgreSqlFlexibleServersSourceType : IEquatable<PostgreSqlFlexibleServersSourceType>
     {
         private readonly string _value;
@@ -50,125 +47,53 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string DigitalOceanPostgreSQLValue = "Digital_Ocean_PostgreSQL";
         private const string SupabasePostgreSQLValue = "Supabase_PostgreSQL";
 
-        /// <summary>
-        /// OnPremises
-        /// Serialized Name: SourceType.OnPremises
-        /// </summary>
+        /// <summary> OnPremises. </summary>
         public static PostgreSqlFlexibleServersSourceType OnPremises { get; } = new PostgreSqlFlexibleServersSourceType(OnPremisesValue);
-        /// <summary>
-        /// AWS
-        /// Serialized Name: SourceType.AWS
-        /// </summary>
+        /// <summary> AWS. </summary>
         public static PostgreSqlFlexibleServersSourceType AWS { get; } = new PostgreSqlFlexibleServersSourceType(AWSValue);
-        /// <summary>
-        /// GCP
-        /// Serialized Name: SourceType.GCP
-        /// </summary>
+        /// <summary> GCP. </summary>
         public static PostgreSqlFlexibleServersSourceType GCP { get; } = new PostgreSqlFlexibleServersSourceType(GCPValue);
-        /// <summary>
-        /// AzureVM
-        /// Serialized Name: SourceType.AzureVM
-        /// </summary>
+        /// <summary> AzureVM. </summary>
         public static PostgreSqlFlexibleServersSourceType AzureVm { get; } = new PostgreSqlFlexibleServersSourceType(AzureVmValue);
-        /// <summary>
-        /// PostgreSQLSingleServer
-        /// Serialized Name: SourceType.PostgreSQLSingleServer
-        /// </summary>
+        /// <summary> PostgreSQLSingleServer. </summary>
         public static PostgreSqlFlexibleServersSourceType PostgreSQLSingleServer { get; } = new PostgreSqlFlexibleServersSourceType(PostgreSQLSingleServerValue);
-        /// <summary>
-        /// AWS_RDS
-        /// Serialized Name: SourceType.AWS_RDS
-        /// </summary>
+        /// <summary> AWS_RDS. </summary>
         public static PostgreSqlFlexibleServersSourceType AWSRDS { get; } = new PostgreSqlFlexibleServersSourceType(AWSRDSValue);
-        /// <summary>
-        /// AWS_AURORA
-        /// Serialized Name: SourceType.AWS_AURORA
-        /// </summary>
+        /// <summary> AWS_AURORA. </summary>
         public static PostgreSqlFlexibleServersSourceType AWSAurora { get; } = new PostgreSqlFlexibleServersSourceType(AWSAuroraValue);
-        /// <summary>
-        /// AWS_EC2
-        /// Serialized Name: SourceType.AWS_EC2
-        /// </summary>
+        /// <summary> AWS_EC2. </summary>
         public static PostgreSqlFlexibleServersSourceType AWSEC2 { get; } = new PostgreSqlFlexibleServersSourceType(AWSEC2Value);
-        /// <summary>
-        /// GCP_CloudSQL
-        /// Serialized Name: SourceType.GCP_CloudSQL
-        /// </summary>
+        /// <summary> GCP_CloudSQL. </summary>
         public static PostgreSqlFlexibleServersSourceType GCPCloudSQL { get; } = new PostgreSqlFlexibleServersSourceType(GCPCloudSQLValue);
-        /// <summary>
-        /// GCP_AlloyDB
-        /// Serialized Name: SourceType.GCP_AlloyDB
-        /// </summary>
+        /// <summary> GCP_AlloyDB. </summary>
         public static PostgreSqlFlexibleServersSourceType GCPAlloyDB { get; } = new PostgreSqlFlexibleServersSourceType(GCPAlloyDBValue);
-        /// <summary>
-        /// GCP_Compute
-        /// Serialized Name: SourceType.GCP_Compute
-        /// </summary>
+        /// <summary> GCP_Compute. </summary>
         public static PostgreSqlFlexibleServersSourceType GCPCompute { get; } = new PostgreSqlFlexibleServersSourceType(GCPComputeValue);
-        /// <summary>
-        /// EDB
-        /// Serialized Name: SourceType.EDB
-        /// </summary>
+        /// <summary> EDB. </summary>
         public static PostgreSqlFlexibleServersSourceType EDB { get; } = new PostgreSqlFlexibleServersSourceType(EDBValue);
-        /// <summary>
-        /// EDB_Oracle_Server
-        /// Serialized Name: SourceType.EDB_Oracle_Server
-        /// </summary>
+        /// <summary> EDB_Oracle_Server. </summary>
         public static PostgreSqlFlexibleServersSourceType EDBOracleServer { get; } = new PostgreSqlFlexibleServersSourceType(EDBOracleServerValue);
-        /// <summary>
-        /// EDB_PostgreSQL
-        /// Serialized Name: SourceType.EDB_PostgreSQL
-        /// </summary>
+        /// <summary> EDB_PostgreSQL. </summary>
         public static PostgreSqlFlexibleServersSourceType EDBPostgreSQL { get; } = new PostgreSqlFlexibleServersSourceType(EDBPostgreSQLValue);
-        /// <summary>
-        /// PostgreSQLFlexibleServer
-        /// Serialized Name: SourceType.PostgreSQLFlexibleServer
-        /// </summary>
+        /// <summary> PostgreSQLFlexibleServer. </summary>
         public static PostgreSqlFlexibleServersSourceType PostgreSQLFlexibleServer { get; } = new PostgreSqlFlexibleServersSourceType(PostgreSQLFlexibleServerValue);
-        /// <summary>
-        /// PostgreSQLCosmosDB
-        /// Serialized Name: SourceType.PostgreSQLCosmosDB
-        /// </summary>
+        /// <summary> PostgreSQLCosmosDB. </summary>
         public static PostgreSqlFlexibleServersSourceType PostgreSQLCosmosDB { get; } = new PostgreSqlFlexibleServersSourceType(PostgreSQLCosmosDBValue);
-        /// <summary>
-        /// Huawei_RDS
-        /// Serialized Name: SourceType.Huawei_RDS
-        /// </summary>
+        /// <summary> Huawei_RDS. </summary>
         public static PostgreSqlFlexibleServersSourceType HuaweiRDS { get; } = new PostgreSqlFlexibleServersSourceType(HuaweiRDSValue);
-        /// <summary>
-        /// Huawei_Compute
-        /// Serialized Name: SourceType.Huawei_Compute
-        /// </summary>
+        /// <summary> Huawei_Compute. </summary>
         public static PostgreSqlFlexibleServersSourceType HuaweiCompute { get; } = new PostgreSqlFlexibleServersSourceType(HuaweiComputeValue);
-        /// <summary>
-        /// Heroku_PostgreSQL
-        /// Serialized Name: SourceType.Heroku_PostgreSQL
-        /// </summary>
+        /// <summary> Heroku_PostgreSQL. </summary>
         public static PostgreSqlFlexibleServersSourceType HerokuPostgreSQL { get; } = new PostgreSqlFlexibleServersSourceType(HerokuPostgreSQLValue);
-        /// <summary>
-        /// Crunchy_PostgreSQL
-        /// Serialized Name: SourceType.Crunchy_PostgreSQL
-        /// </summary>
+        /// <summary> Crunchy_PostgreSQL. </summary>
         public static PostgreSqlFlexibleServersSourceType CrunchyPostgreSQL { get; } = new PostgreSqlFlexibleServersSourceType(CrunchyPostgreSQLValue);
-        /// <summary>
-        /// ApsaraDB_RDS
-        /// Serialized Name: SourceType.ApsaraDB_RDS
-        /// </summary>
+        /// <summary> ApsaraDB_RDS. </summary>
         public static PostgreSqlFlexibleServersSourceType ApsaraDBRDS { get; } = new PostgreSqlFlexibleServersSourceType(ApsaraDBRDSValue);
-        /// <summary>
-        /// Digital_Ocean_Droplets
-        /// Serialized Name: SourceType.Digital_Ocean_Droplets
-        /// </summary>
+        /// <summary> Digital_Ocean_Droplets. </summary>
         public static PostgreSqlFlexibleServersSourceType DigitalOceanDroplets { get; } = new PostgreSqlFlexibleServersSourceType(DigitalOceanDropletsValue);
-        /// <summary>
-        /// Digital_Ocean_PostgreSQL
-        /// Serialized Name: SourceType.Digital_Ocean_PostgreSQL
-        /// </summary>
+        /// <summary> Digital_Ocean_PostgreSQL. </summary>
         public static PostgreSqlFlexibleServersSourceType DigitalOceanPostgreSQL { get; } = new PostgreSqlFlexibleServersSourceType(DigitalOceanPostgreSQLValue);
-        /// <summary>
-        /// Supabase_PostgreSQL
-        /// Serialized Name: SourceType.Supabase_PostgreSQL
-        /// </summary>
+        /// <summary> Supabase_PostgreSQL. </summary>
         public static PostgreSqlFlexibleServersSourceType SupabasePostgreSQL { get; } = new PostgreSqlFlexibleServersSourceType(SupabasePostgreSQLValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServersSourceType"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServersSourceType left, PostgreSqlFlexibleServersSourceType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersSslMode.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersSslMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// SSL mode used by a migration. Default SSL mode for 'PostgreSQLSingleServer' is 'VerifyFull'. Default SSL mode for other source types is 'Prefer'.
-    /// Serialized Name: SslMode
-    /// </summary>
+    /// <summary> SSL mode used by a migration. Default SSL mode for 'PostgreSQLSingleServer' is 'VerifyFull'. Default SSL mode for other source types is 'Prefer'. </summary>
     public readonly partial struct PostgreSqlFlexibleServersSslMode : IEquatable<PostgreSqlFlexibleServersSslMode>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string VerifyCAValue = "VerifyCA";
         private const string VerifyFullValue = "VerifyFull";
 
-        /// <summary>
-        /// Prefer
-        /// Serialized Name: SslMode.Prefer
-        /// </summary>
+        /// <summary> Prefer. </summary>
         public static PostgreSqlFlexibleServersSslMode Prefer { get; } = new PostgreSqlFlexibleServersSslMode(PreferValue);
-        /// <summary>
-        /// Require
-        /// Serialized Name: SslMode.Require
-        /// </summary>
+        /// <summary> Require. </summary>
         public static PostgreSqlFlexibleServersSslMode Require { get; } = new PostgreSqlFlexibleServersSslMode(RequireValue);
-        /// <summary>
-        /// VerifyCA
-        /// Serialized Name: SslMode.VerifyCA
-        /// </summary>
+        /// <summary> VerifyCA. </summary>
         public static PostgreSqlFlexibleServersSslMode VerifyCA { get; } = new PostgreSqlFlexibleServersSslMode(VerifyCAValue);
-        /// <summary>
-        /// VerifyFull
-        /// Serialized Name: SslMode.VerifyFull
-        /// </summary>
+        /// <summary> VerifyFull. </summary>
         public static PostgreSqlFlexibleServersSslMode VerifyFull { get; } = new PostgreSqlFlexibleServersSslMode(VerifyFullValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServersSslMode"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServersSslMode left, PostgreSqlFlexibleServersSslMode right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersStorageType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersStorageType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Type of storage assigned to a server. Allowed values are Premium_LRS, PremiumV2_LRS, or UltraSSD_LRS. If not specified, it defaults to Premium_LRS.
-    /// Serialized Name: StorageType
-    /// </summary>
+    /// <summary> Type of storage assigned to a server. Allowed values are Premium_LRS, PremiumV2_LRS, or UltraSSD_LRS. If not specified, it defaults to Premium_LRS. </summary>
     public readonly partial struct PostgreSqlFlexibleServersStorageType : IEquatable<PostgreSqlFlexibleServersStorageType>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string PremiumV2LRSValue = "PremiumV2_LRS";
         private const string UltraSSDLRSValue = "UltraSSD_LRS";
 
-        /// <summary>
-        /// Premium_LRS
-        /// Serialized Name: StorageType.Premium_LRS
-        /// </summary>
+        /// <summary> Premium_LRS. </summary>
         public static PostgreSqlFlexibleServersStorageType PremiumLRS { get; } = new PostgreSqlFlexibleServersStorageType(PremiumLRSValue);
-        /// <summary>
-        /// PremiumV2_LRS
-        /// Serialized Name: StorageType.PremiumV2_LRS
-        /// </summary>
+        /// <summary> PremiumV2_LRS. </summary>
         public static PostgreSqlFlexibleServersStorageType PremiumV2LRS { get; } = new PostgreSqlFlexibleServersStorageType(PremiumV2LRSValue);
-        /// <summary>
-        /// UltraSSD_LRS
-        /// Serialized Name: StorageType.UltraSSD_LRS
-        /// </summary>
+        /// <summary> UltraSSD_LRS. </summary>
         public static PostgreSqlFlexibleServersStorageType UltraSSDLRS { get; } = new PostgreSqlFlexibleServersStorageType(UltraSSDLRSValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServersStorageType"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServersStorageType left, PostgreSqlFlexibleServersStorageType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersValidationDetails.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersValidationDetails.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Details for the validation for migration.
-    /// Serialized Name: ValidationDetails
-    /// </summary>
+    /// <summary> Details for the validation for migration. </summary>
     public partial class PostgreSqlFlexibleServersValidationDetails
     {
         /// <summary>
@@ -56,26 +53,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServersValidationDetails"/>. </summary>
-        /// <param name="status">
-        /// Validation status for migration.
-        /// Serialized Name: ValidationDetails.status
-        /// </param>
-        /// <param name="validationStartTimeInUtc">
-        /// Start time (UTC) for validation.
-        /// Serialized Name: ValidationDetails.validationStartTimeInUtc
-        /// </param>
-        /// <param name="validationEndTimeInUtc">
-        /// End time (UTC) for validation.
-        /// Serialized Name: ValidationDetails.validationEndTimeInUtc
-        /// </param>
-        /// <param name="serverLevelValidationDetails">
-        /// Details of server level validations.
-        /// Serialized Name: ValidationDetails.serverLevelValidationDetails
-        /// </param>
-        /// <param name="dbLevelValidationDetails">
-        /// Details of server level validations.
-        /// Serialized Name: ValidationDetails.dbLevelValidationDetails
-        /// </param>
+        /// <param name="status"> Validation status for migration. </param>
+        /// <param name="validationStartTimeInUtc"> Start time (UTC) for validation. </param>
+        /// <param name="validationEndTimeInUtc"> End time (UTC) for validation. </param>
+        /// <param name="serverLevelValidationDetails"> Details of server level validations. </param>
+        /// <param name="dbLevelValidationDetails"> Details of server level validations. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServersValidationDetails(PostgreSqlFlexibleServersValidationState? status, DateTimeOffset? validationStartTimeInUtc, DateTimeOffset? validationEndTimeInUtc, IReadOnlyList<ValidationSummaryItem> serverLevelValidationDetails, IReadOnlyList<DbLevelValidationStatus> dbLevelValidationDetails, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -87,34 +69,19 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Validation status for migration.
-        /// Serialized Name: ValidationDetails.status
-        /// </summary>
+        /// <summary> Validation status for migration. </summary>
         [WirePath("status")]
         public PostgreSqlFlexibleServersValidationState? Status { get; }
-        /// <summary>
-        /// Start time (UTC) for validation.
-        /// Serialized Name: ValidationDetails.validationStartTimeInUtc
-        /// </summary>
+        /// <summary> Start time (UTC) for validation. </summary>
         [WirePath("validationStartTimeInUtc")]
         public DateTimeOffset? ValidationStartTimeInUtc { get; }
-        /// <summary>
-        /// End time (UTC) for validation.
-        /// Serialized Name: ValidationDetails.validationEndTimeInUtc
-        /// </summary>
+        /// <summary> End time (UTC) for validation. </summary>
         [WirePath("validationEndTimeInUtc")]
         public DateTimeOffset? ValidationEndTimeInUtc { get; }
-        /// <summary>
-        /// Details of server level validations.
-        /// Serialized Name: ValidationDetails.serverLevelValidationDetails
-        /// </summary>
+        /// <summary> Details of server level validations. </summary>
         [WirePath("serverLevelValidationDetails")]
         public IReadOnlyList<ValidationSummaryItem> ServerLevelValidationDetails { get; }
-        /// <summary>
-        /// Details of server level validations.
-        /// Serialized Name: ValidationDetails.dbLevelValidationDetails
-        /// </summary>
+        /// <summary> Details of server level validations. </summary>
         [WirePath("dbLevelValidationDetails")]
         public IReadOnlyList<DbLevelValidationStatus> DbLevelValidationDetails { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersValidationMessage.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersValidationMessage.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Validation message object.
-    /// Serialized Name: ValidationMessage
-    /// </summary>
+    /// <summary> Validation message object. </summary>
     public partial class PostgreSqlFlexibleServersValidationMessage
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServersValidationMessage"/>. </summary>
-        /// <param name="state">
-        /// Severity of validation message.
-        /// Serialized Name: ValidationMessage.state
-        /// </param>
-        /// <param name="message">
-        /// Validation message string.
-        /// Serialized Name: ValidationMessage.message
-        /// </param>
+        /// <param name="state"> Severity of validation message. </param>
+        /// <param name="message"> Validation message string. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServersValidationMessage(PostgreSqlFlexibleServersValidationState? state, string message, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Severity of validation message.
-        /// Serialized Name: ValidationMessage.state
-        /// </summary>
+        /// <summary> Severity of validation message. </summary>
         [WirePath("state")]
         public PostgreSqlFlexibleServersValidationState? State { get; }
-        /// <summary>
-        /// Validation message string.
-        /// Serialized Name: ValidationMessage.message
-        /// </summary>
+        /// <summary> Validation message string. </summary>
         [WirePath("message")]
         public string Message { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersValidationState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlFlexibleServersValidationState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Validation status for migration.
-    /// Serialized Name: ValidationState
-    /// </summary>
+    /// <summary> Validation status for migration. </summary>
     public readonly partial struct PostgreSqlFlexibleServersValidationState : IEquatable<PostgreSqlFlexibleServersValidationState>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string SucceededValue = "Succeeded";
         private const string WarningValue = "Warning";
 
-        /// <summary>
-        /// Failed
-        /// Serialized Name: ValidationState.Failed
-        /// </summary>
+        /// <summary> Failed. </summary>
         public static PostgreSqlFlexibleServersValidationState Failed { get; } = new PostgreSqlFlexibleServersValidationState(FailedValue);
-        /// <summary>
-        /// Succeeded
-        /// Serialized Name: ValidationState.Succeeded
-        /// </summary>
+        /// <summary> Succeeded. </summary>
         public static PostgreSqlFlexibleServersValidationState Succeeded { get; } = new PostgreSqlFlexibleServersValidationState(SucceededValue);
-        /// <summary>
-        /// Warning
-        /// Serialized Name: ValidationState.Warning
-        /// </summary>
+        /// <summary> Warning. </summary>
         public static PostgreSqlFlexibleServersValidationState Warning { get; } = new PostgreSqlFlexibleServersValidationState(WarningValue);
         /// <summary> Determines if two <see cref="PostgreSqlFlexibleServersValidationState"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlFlexibleServersValidationState left, PostgreSqlFlexibleServersValidationState right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlKeyStatus.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlKeyStatus.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Status of key used by a server configured with data encryption based on customer managed key, to encrypt the primary storage associated to the server.
-    /// Serialized Name: EncryptionKeyStatus
-    /// </summary>
+    /// <summary> Status of key used by a server configured with data encryption based on customer managed key, to encrypt the primary storage associated to the server. </summary>
     public readonly partial struct PostgreSqlKeyStatus : IEquatable<PostgreSqlKeyStatus>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string ValidValue = "Valid";
         private const string InvalidValue = "Invalid";
 
-        /// <summary>
-        /// Valid
-        /// Serialized Name: EncryptionKeyStatus.Valid
-        /// </summary>
+        /// <summary> Valid. </summary>
         public static PostgreSqlKeyStatus Valid { get; } = new PostgreSqlKeyStatus(ValidValue);
-        /// <summary>
-        /// Invalid
-        /// Serialized Name: EncryptionKeyStatus.Invalid
-        /// </summary>
+        /// <summary> Invalid. </summary>
         public static PostgreSqlKeyStatus Invalid { get; } = new PostgreSqlKeyStatus(InvalidValue);
         /// <summary> Determines if two <see cref="PostgreSqlKeyStatus"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlKeyStatus left, PostgreSqlKeyStatus right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlLtrServerBackupOperationList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlLtrServerBackupOperationList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// A list of long term retention backup operations for server.
-    /// Serialized Name: LtrServerBackupOperationList
-    /// </summary>
+    /// <summary> A list of long term retention backup operations for server. </summary>
     internal partial class PostgreSqlLtrServerBackupOperationList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlLtrServerBackupOperationList"/>. </summary>
-        /// <param name="value">
-        /// The BackupsLongTermRetentionOperation items on this page
-        /// Serialized Name: LtrServerBackupOperationList.value
-        /// </param>
+        /// <param name="value"> The BackupsLongTermRetentionOperation items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal PostgreSqlLtrServerBackupOperationList(IEnumerable<PostgreSqlLtrServerBackupOperationData> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlLtrServerBackupOperationList"/>. </summary>
-        /// <param name="value">
-        /// The BackupsLongTermRetentionOperation items on this page
-        /// Serialized Name: LtrServerBackupOperationList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: LtrServerBackupOperationList.nextLink
-        /// </param>
+        /// <param name="value"> The BackupsLongTermRetentionOperation items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlLtrServerBackupOperationList(IReadOnlyList<PostgreSqlLtrServerBackupOperationData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The BackupsLongTermRetentionOperation items on this page
-        /// Serialized Name: LtrServerBackupOperationList.value
-        /// </summary>
+        /// <summary> The BackupsLongTermRetentionOperation items on this page. </summary>
         public IReadOnlyList<PostgreSqlLtrServerBackupOperationData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: LtrServerBackupOperationList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlManagedDiskPerformanceTier.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlManagedDiskPerformanceTier.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Storage tier of a server.
-    /// Serialized Name: AzureManagedDiskPerformanceTier
-    /// </summary>
+    /// <summary> Storage tier of a server. </summary>
     public readonly partial struct PostgreSqlManagedDiskPerformanceTier : IEquatable<PostgreSqlManagedDiskPerformanceTier>
     {
         private readonly string _value;
@@ -40,75 +37,33 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string P70Value = "P70";
         private const string P80Value = "P80";
 
-        /// <summary>
-        /// P1
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P1
-        /// </summary>
+        /// <summary> P1. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P1 { get; } = new PostgreSqlManagedDiskPerformanceTier(P1Value);
-        /// <summary>
-        /// P2
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P2
-        /// </summary>
+        /// <summary> P2. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P2 { get; } = new PostgreSqlManagedDiskPerformanceTier(P2Value);
-        /// <summary>
-        /// P3
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P3
-        /// </summary>
+        /// <summary> P3. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P3 { get; } = new PostgreSqlManagedDiskPerformanceTier(P3Value);
-        /// <summary>
-        /// P4
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P4
-        /// </summary>
+        /// <summary> P4. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P4 { get; } = new PostgreSqlManagedDiskPerformanceTier(P4Value);
-        /// <summary>
-        /// P6
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P6
-        /// </summary>
+        /// <summary> P6. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P6 { get; } = new PostgreSqlManagedDiskPerformanceTier(P6Value);
-        /// <summary>
-        /// P10
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P10
-        /// </summary>
+        /// <summary> P10. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P10 { get; } = new PostgreSqlManagedDiskPerformanceTier(P10Value);
-        /// <summary>
-        /// P15
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P15
-        /// </summary>
+        /// <summary> P15. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P15 { get; } = new PostgreSqlManagedDiskPerformanceTier(P15Value);
-        /// <summary>
-        /// P20
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P20
-        /// </summary>
+        /// <summary> P20. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P20 { get; } = new PostgreSqlManagedDiskPerformanceTier(P20Value);
-        /// <summary>
-        /// P30
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P30
-        /// </summary>
+        /// <summary> P30. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P30 { get; } = new PostgreSqlManagedDiskPerformanceTier(P30Value);
-        /// <summary>
-        /// P40
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P40
-        /// </summary>
+        /// <summary> P40. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P40 { get; } = new PostgreSqlManagedDiskPerformanceTier(P40Value);
-        /// <summary>
-        /// P50
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P50
-        /// </summary>
+        /// <summary> P50. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P50 { get; } = new PostgreSqlManagedDiskPerformanceTier(P50Value);
-        /// <summary>
-        /// P60
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P60
-        /// </summary>
+        /// <summary> P60. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P60 { get; } = new PostgreSqlManagedDiskPerformanceTier(P60Value);
-        /// <summary>
-        /// P70
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P70
-        /// </summary>
+        /// <summary> P70. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P70 { get; } = new PostgreSqlManagedDiskPerformanceTier(P70Value);
-        /// <summary>
-        /// P80
-        /// Serialized Name: AzureManagedDiskPerformanceTier.P80
-        /// </summary>
+        /// <summary> P80. </summary>
         public static PostgreSqlManagedDiskPerformanceTier P80 { get; } = new PostgreSqlManagedDiskPerformanceTier(P80Value);
         /// <summary> Determines if two <see cref="PostgreSqlManagedDiskPerformanceTier"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlManagedDiskPerformanceTier left, PostgreSqlManagedDiskPerformanceTier right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationAdminCredentials.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationAdminCredentials.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Credentials of administrator users for source and target servers.
-    /// Serialized Name: AdminCredentials
-    /// </summary>
+    /// <summary> Credentials of administrator users for source and target servers. </summary>
     public partial class PostgreSqlMigrationAdminCredentials
     {
         /// <summary>
@@ -49,14 +46,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlMigrationAdminCredentials"/>. </summary>
-        /// <param name="sourceServerPassword">
-        /// Password for the user of the source server.
-        /// Serialized Name: AdminCredentials.sourceServerPassword
-        /// </param>
-        /// <param name="targetServerPassword">
-        /// Password for the user of the target server.
-        /// Serialized Name: AdminCredentials.targetServerPassword
-        /// </param>
+        /// <param name="sourceServerPassword"> Password for the user of the source server. </param>
+        /// <param name="targetServerPassword"> Password for the user of the target server. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="sourceServerPassword"/> or <paramref name="targetServerPassword"/> is null. </exception>
         public PostgreSqlMigrationAdminCredentials(string sourceServerPassword, string targetServerPassword)
         {
@@ -68,14 +59,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlMigrationAdminCredentials"/>. </summary>
-        /// <param name="sourceServerPassword">
-        /// Password for the user of the source server.
-        /// Serialized Name: AdminCredentials.sourceServerPassword
-        /// </param>
-        /// <param name="targetServerPassword">
-        /// Password for the user of the target server.
-        /// Serialized Name: AdminCredentials.targetServerPassword
-        /// </param>
+        /// <param name="sourceServerPassword"> Password for the user of the source server. </param>
+        /// <param name="targetServerPassword"> Password for the user of the target server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlMigrationAdminCredentials(string sourceServerPassword, string targetServerPassword, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -89,16 +74,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// Password for the user of the source server.
-        /// Serialized Name: AdminCredentials.sourceServerPassword
-        /// </summary>
+        /// <summary> Password for the user of the source server. </summary>
         [WirePath("sourceServerPassword")]
         public string SourceServerPassword { get; set; }
-        /// <summary>
-        /// Password for the user of the target server.
-        /// Serialized Name: AdminCredentials.targetServerPassword
-        /// </summary>
+        /// <summary> Password for the user of the target server. </summary>
         [WirePath("targetServerPassword")]
         public string TargetServerPassword { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationCancel.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationCancel.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if cancel must be triggered for the entire migration.
-    /// Serialized Name: Cancel
-    /// </summary>
+    /// <summary> Indicates if cancel must be triggered for the entire migration. </summary>
     public readonly partial struct PostgreSqlMigrationCancel : IEquatable<PostgreSqlMigrationCancel>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string TrueValue = "True";
         private const string FalseValue = "False";
 
-        /// <summary>
-        /// True
-        /// Serialized Name: Cancel.True
-        /// </summary>
+        /// <summary> True. </summary>
         public static PostgreSqlMigrationCancel True { get; } = new PostgreSqlMigrationCancel(TrueValue);
-        /// <summary>
-        /// False
-        /// Serialized Name: Cancel.False
-        /// </summary>
+        /// <summary> False. </summary>
         public static PostgreSqlMigrationCancel False { get; } = new PostgreSqlMigrationCancel(FalseValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationCancel"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationCancel left, PostgreSqlMigrationCancel right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationListFilter.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationListFilter.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The PostgreSqlMigrationListFilter.
-    /// Serialized Name: MigrationListFilter
-    /// </summary>
+    /// <summary> The PostgreSqlMigrationListFilter. </summary>
     public readonly partial struct PostgreSqlMigrationListFilter : IEquatable<PostgreSqlMigrationListFilter>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string ActiveValue = "Active";
         private const string AllValue = "All";
 
-        /// <summary>
-        /// Active
-        /// Serialized Name: MigrationListFilter.Active
-        /// </summary>
+        /// <summary> Active. </summary>
         public static PostgreSqlMigrationListFilter Active { get; } = new PostgreSqlMigrationListFilter(ActiveValue);
-        /// <summary>
-        /// All
-        /// Serialized Name: MigrationListFilter.All
-        /// </summary>
+        /// <summary> All. </summary>
         public static PostgreSqlMigrationListFilter All { get; } = new PostgreSqlMigrationListFilter(AllValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationListFilter"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationListFilter left, PostgreSqlMigrationListFilter right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationLogicalReplicationOnSourceDb.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationLogicalReplicationOnSourceDb.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates whether to setup logical replication on source server, if needed.
-    /// Serialized Name: LogicalReplicationOnSourceServer
-    /// </summary>
+    /// <summary> Indicates whether to setup logical replication on source server, if needed. </summary>
     public readonly partial struct PostgreSqlMigrationLogicalReplicationOnSourceDb : IEquatable<PostgreSqlMigrationLogicalReplicationOnSourceDb>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string TrueValue = "True";
         private const string FalseValue = "False";
 
-        /// <summary>
-        /// True
-        /// Serialized Name: LogicalReplicationOnSourceServer.True
-        /// </summary>
+        /// <summary> True. </summary>
         public static PostgreSqlMigrationLogicalReplicationOnSourceDb True { get; } = new PostgreSqlMigrationLogicalReplicationOnSourceDb(TrueValue);
-        /// <summary>
-        /// False
-        /// Serialized Name: LogicalReplicationOnSourceServer.False
-        /// </summary>
+        /// <summary> False. </summary>
         public static PostgreSqlMigrationLogicalReplicationOnSourceDb False { get; } = new PostgreSqlMigrationLogicalReplicationOnSourceDb(FalseValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationLogicalReplicationOnSourceDb"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationLogicalReplicationOnSourceDb left, PostgreSqlMigrationLogicalReplicationOnSourceDb right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationMode.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Mode used to perform the migration: Online or Offline.
-    /// Serialized Name: MigrationMode
-    /// </summary>
+    /// <summary> Mode used to perform the migration: Online or Offline. </summary>
     public readonly partial struct PostgreSqlMigrationMode : IEquatable<PostgreSqlMigrationMode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string OfflineValue = "Offline";
         private const string OnlineValue = "Online";
 
-        /// <summary>
-        /// Offline
-        /// Serialized Name: MigrationMode.Offline
-        /// </summary>
+        /// <summary> Offline. </summary>
         public static PostgreSqlMigrationMode Offline { get; } = new PostgreSqlMigrationMode(OfflineValue);
-        /// <summary>
-        /// Online
-        /// Serialized Name: MigrationMode.Online
-        /// </summary>
+        /// <summary> Online. </summary>
         public static PostgreSqlMigrationMode Online { get; } = new PostgreSqlMigrationMode(OnlineValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationMode"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationMode left, PostgreSqlMigrationMode right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationNameUnavailableReason.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationNameUnavailableReason.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Migration name availability reason.
-    /// Serialized Name: MigrationNameAvailabilityReason
-    /// </summary>
+    /// <summary> Migration name availability reason. </summary>
     public readonly partial struct PostgreSqlMigrationNameUnavailableReason : IEquatable<PostgreSqlMigrationNameUnavailableReason>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string InvalidValue = "Invalid";
         private const string AlreadyExistsValue = "AlreadyExists";
 
-        /// <summary>
-        /// Invalid
-        /// Serialized Name: MigrationNameAvailabilityReason.Invalid
-        /// </summary>
+        /// <summary> Invalid. </summary>
         public static PostgreSqlMigrationNameUnavailableReason Invalid { get; } = new PostgreSqlMigrationNameUnavailableReason(InvalidValue);
-        /// <summary>
-        /// AlreadyExists
-        /// Serialized Name: MigrationNameAvailabilityReason.AlreadyExists
-        /// </summary>
+        /// <summary> AlreadyExists. </summary>
         public static PostgreSqlMigrationNameUnavailableReason AlreadyExists { get; } = new PostgreSqlMigrationNameUnavailableReason(AlreadyExistsValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationNameUnavailableReason"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationNameUnavailableReason left, PostgreSqlMigrationNameUnavailableReason right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationOverwriteDbsInTarget.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationOverwriteDbsInTarget.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation.
-    /// Serialized Name: OverwriteDatabasesOnTargetServer
-    /// </summary>
+    /// <summary> Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation. </summary>
     public readonly partial struct PostgreSqlMigrationOverwriteDbsInTarget : IEquatable<PostgreSqlMigrationOverwriteDbsInTarget>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string TrueValue = "True";
         private const string FalseValue = "False";
 
-        /// <summary>
-        /// True
-        /// Serialized Name: OverwriteDatabasesOnTargetServer.True
-        /// </summary>
+        /// <summary> True. </summary>
         public static PostgreSqlMigrationOverwriteDbsInTarget True { get; } = new PostgreSqlMigrationOverwriteDbsInTarget(TrueValue);
-        /// <summary>
-        /// False
-        /// Serialized Name: OverwriteDatabasesOnTargetServer.False
-        /// </summary>
+        /// <summary> False. </summary>
         public static PostgreSqlMigrationOverwriteDbsInTarget False { get; } = new PostgreSqlMigrationOverwriteDbsInTarget(FalseValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationOverwriteDbsInTarget"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationOverwriteDbsInTarget left, PostgreSqlMigrationOverwriteDbsInTarget right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationPatch.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationPatch.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Migration.
-    /// Serialized Name: MigrationResourceForPatch
-    /// </summary>
+    /// <summary> Migration. </summary>
     public partial class PostgreSqlMigrationPatch
     {
         /// <summary>
@@ -59,70 +56,22 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlMigrationPatch"/>. </summary>
-        /// <param name="tags">
-        /// Application-specific metadata in the form of key-value pairs.
-        /// Serialized Name: MigrationResourceForPatch.tags
-        /// </param>
-        /// <param name="sourceDbServerResourceId">
-        /// Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username.
-        /// Serialized Name: MigrationResourceForPatch.properties.sourceDbServerResourceId
-        /// </param>
-        /// <param name="sourceDbServerFullyQualifiedDomainName">
-        /// Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server.
-        /// Serialized Name: MigrationResourceForPatch.properties.sourceDbServerFullyQualifiedDomainName
-        /// </param>
-        /// <param name="targetDbServerFullyQualifiedDomainName">
-        /// Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server.
-        /// Serialized Name: MigrationResourceForPatch.properties.targetDbServerFullyQualifiedDomainName
-        /// </param>
-        /// <param name="secretParameters">
-        /// Migration secret parameters.
-        /// Serialized Name: MigrationResourceForPatch.properties.secretParameters
-        /// </param>
-        /// <param name="dbsToMigrate">
-        /// Names of databases to migrate.
-        /// Serialized Name: MigrationResourceForPatch.properties.dbsToMigrate
-        /// </param>
-        /// <param name="setupLogicalReplicationOnSourceDbIfNeeded">
-        /// Indicates whether to setup logical replication on source server, if needed.
-        /// Serialized Name: MigrationResourceForPatch.properties.setupLogicalReplicationOnSourceDbIfNeeded
-        /// </param>
-        /// <param name="overwriteDbsInTarget">
-        /// Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation.
-        /// Serialized Name: MigrationResourceForPatch.properties.overwriteDbsInTarget
-        /// </param>
-        /// <param name="migrationWindowStartTimeInUtc">
-        /// Start time (UTC) for migration window.
-        /// Serialized Name: MigrationResourceForPatch.properties.migrationWindowStartTimeInUtc
-        /// </param>
-        /// <param name="migrateRoles">
-        /// Indicates if roles and permissions must be migrated.
-        /// Serialized Name: MigrationResourceForPatch.properties.migrateRoles
-        /// </param>
-        /// <param name="startDataMigration">
-        /// Indicates if data migration must start right away.
-        /// Serialized Name: MigrationResourceForPatch.properties.startDataMigration
-        /// </param>
-        /// <param name="triggerCutover">
-        /// Indicates if cutover must be triggered for the entire migration.
-        /// Serialized Name: MigrationResourceForPatch.properties.triggerCutover
-        /// </param>
-        /// <param name="dbsToTriggerCutoverOn">
-        /// When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: MigrationResourceForPatch.properties.dbsToTriggerCutoverOn
-        /// </param>
-        /// <param name="cancel">
-        /// Indicates if cancel must be triggered for the entire migration.
-        /// Serialized Name: MigrationResourceForPatch.properties.cancel
-        /// </param>
-        /// <param name="dbsToCancelMigrationOn">
-        /// When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: MigrationResourceForPatch.properties.dbsToCancelMigrationOn
-        /// </param>
-        /// <param name="migrationMode">
-        /// Mode used to perform the migration: Online or Offline.
-        /// Serialized Name: MigrationResourceForPatch.properties.migrationMode
-        /// </param>
+        /// <param name="tags"> Application-specific metadata in the form of key-value pairs. </param>
+        /// <param name="sourceDbServerResourceId"> Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username. </param>
+        /// <param name="sourceDbServerFullyQualifiedDomainName"> Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server. </param>
+        /// <param name="targetDbServerFullyQualifiedDomainName"> Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server. </param>
+        /// <param name="secretParameters"> Migration secret parameters. </param>
+        /// <param name="dbsToMigrate"> Names of databases to migrate. </param>
+        /// <param name="setupLogicalReplicationOnSourceDbIfNeeded"> Indicates whether to setup logical replication on source server, if needed. </param>
+        /// <param name="overwriteDbsInTarget"> Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation. </param>
+        /// <param name="migrationWindowStartTimeInUtc"> Start time (UTC) for migration window. </param>
+        /// <param name="migrateRoles"> Indicates if roles and permissions must be migrated. </param>
+        /// <param name="startDataMigration"> Indicates if data migration must start right away. </param>
+        /// <param name="triggerCutover"> Indicates if cutover must be triggered for the entire migration. </param>
+        /// <param name="dbsToTriggerCutoverOn"> When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </param>
+        /// <param name="cancel"> Indicates if cancel must be triggered for the entire migration. </param>
+        /// <param name="dbsToCancelMigrationOn"> When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </param>
+        /// <param name="migrationMode"> Mode used to perform the migration: Online or Offline. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlMigrationPatch(IDictionary<string, string> tags, ResourceIdentifier sourceDbServerResourceId, string sourceDbServerFullyQualifiedDomainName, string targetDbServerFullyQualifiedDomainName, PostgreSqlMigrationSecretParameters secretParameters, IList<string> dbsToMigrate, PostgreSqlMigrationLogicalReplicationOnSourceDb? setupLogicalReplicationOnSourceDbIfNeeded, PostgreSqlMigrationOverwriteDbsInTarget? overwriteDbsInTarget, DateTimeOffset? migrationWindowStartTimeInUtc, MigrateRolesEnum? migrateRoles, PostgreSqlMigrationStartDataMigration? startDataMigration, PostgreSqlMigrationTriggerCutover? triggerCutover, IList<string> dbsToTriggerCutoverOn, PostgreSqlMigrationCancel? cancel, IList<string> dbsToCancelMigrationOn, PostgreSqlMigrationMode? migrationMode, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -145,100 +94,52 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Application-specific metadata in the form of key-value pairs.
-        /// Serialized Name: MigrationResourceForPatch.tags
-        /// </summary>
+        /// <summary> Application-specific metadata in the form of key-value pairs. </summary>
         [WirePath("tags")]
         public IDictionary<string, string> Tags { get; }
-        /// <summary>
-        /// Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username.
-        /// Serialized Name: MigrationResourceForPatch.properties.sourceDbServerResourceId
-        /// </summary>
+        /// <summary> Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username. </summary>
         [WirePath("properties.sourceDbServerResourceId")]
         public ResourceIdentifier SourceDbServerResourceId { get; set; }
-        /// <summary>
-        /// Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server.
-        /// Serialized Name: MigrationResourceForPatch.properties.sourceDbServerFullyQualifiedDomainName
-        /// </summary>
+        /// <summary> Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server. </summary>
         [WirePath("properties.sourceDbServerFullyQualifiedDomainName")]
         public string SourceDbServerFullyQualifiedDomainName { get; set; }
-        /// <summary>
-        /// Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server.
-        /// Serialized Name: MigrationResourceForPatch.properties.targetDbServerFullyQualifiedDomainName
-        /// </summary>
+        /// <summary> Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server. </summary>
         [WirePath("properties.targetDbServerFullyQualifiedDomainName")]
         public string TargetDbServerFullyQualifiedDomainName { get; set; }
-        /// <summary>
-        /// Migration secret parameters.
-        /// Serialized Name: MigrationResourceForPatch.properties.secretParameters
-        /// </summary>
+        /// <summary> Migration secret parameters. </summary>
         [WirePath("properties.secretParameters")]
         public PostgreSqlMigrationSecretParameters SecretParameters { get; set; }
-        /// <summary>
-        /// Names of databases to migrate.
-        /// Serialized Name: MigrationResourceForPatch.properties.dbsToMigrate
-        /// </summary>
+        /// <summary> Names of databases to migrate. </summary>
         [WirePath("properties.dbsToMigrate")]
         public IList<string> DbsToMigrate { get; }
-        /// <summary>
-        /// Indicates whether to setup logical replication on source server, if needed.
-        /// Serialized Name: MigrationResourceForPatch.properties.setupLogicalReplicationOnSourceDbIfNeeded
-        /// </summary>
+        /// <summary> Indicates whether to setup logical replication on source server, if needed. </summary>
         [WirePath("properties.setupLogicalReplicationOnSourceDbIfNeeded")]
         public PostgreSqlMigrationLogicalReplicationOnSourceDb? SetupLogicalReplicationOnSourceDbIfNeeded { get; set; }
-        /// <summary>
-        /// Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation.
-        /// Serialized Name: MigrationResourceForPatch.properties.overwriteDbsInTarget
-        /// </summary>
+        /// <summary> Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation. </summary>
         [WirePath("properties.overwriteDbsInTarget")]
         public PostgreSqlMigrationOverwriteDbsInTarget? OverwriteDbsInTarget { get; set; }
-        /// <summary>
-        /// Start time (UTC) for migration window.
-        /// Serialized Name: MigrationResourceForPatch.properties.migrationWindowStartTimeInUtc
-        /// </summary>
+        /// <summary> Start time (UTC) for migration window. </summary>
         [WirePath("properties.migrationWindowStartTimeInUtc")]
         public DateTimeOffset? MigrationWindowStartTimeInUtc { get; set; }
-        /// <summary>
-        /// Indicates if roles and permissions must be migrated.
-        /// Serialized Name: MigrationResourceForPatch.properties.migrateRoles
-        /// </summary>
+        /// <summary> Indicates if roles and permissions must be migrated. </summary>
         [WirePath("properties.migrateRoles")]
         public MigrateRolesEnum? MigrateRoles { get; set; }
-        /// <summary>
-        /// Indicates if data migration must start right away.
-        /// Serialized Name: MigrationResourceForPatch.properties.startDataMigration
-        /// </summary>
+        /// <summary> Indicates if data migration must start right away. </summary>
         [WirePath("properties.startDataMigration")]
         public PostgreSqlMigrationStartDataMigration? StartDataMigration { get; set; }
-        /// <summary>
-        /// Indicates if cutover must be triggered for the entire migration.
-        /// Serialized Name: MigrationResourceForPatch.properties.triggerCutover
-        /// </summary>
+        /// <summary> Indicates if cutover must be triggered for the entire migration. </summary>
         [WirePath("properties.triggerCutover")]
         public PostgreSqlMigrationTriggerCutover? TriggerCutover { get; set; }
-        /// <summary>
-        /// When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: MigrationResourceForPatch.properties.dbsToTriggerCutoverOn
-        /// </summary>
+        /// <summary> When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </summary>
         [WirePath("properties.dbsToTriggerCutoverOn")]
         public IList<string> DbsToTriggerCutoverOn { get; }
-        /// <summary>
-        /// Indicates if cancel must be triggered for the entire migration.
-        /// Serialized Name: MigrationResourceForPatch.properties.cancel
-        /// </summary>
+        /// <summary> Indicates if cancel must be triggered for the entire migration. </summary>
         [WirePath("properties.cancel")]
         public PostgreSqlMigrationCancel? Cancel { get; set; }
-        /// <summary>
-        /// When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: MigrationResourceForPatch.properties.dbsToCancelMigrationOn
-        /// </summary>
+        /// <summary> When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </summary>
         [WirePath("properties.dbsToCancelMigrationOn")]
         public IList<string> DbsToCancelMigrationOn { get; }
-        /// <summary>
-        /// Mode used to perform the migration: Online or Offline.
-        /// Serialized Name: MigrationResourceForPatch.properties.migrationMode
-        /// </summary>
+        /// <summary> Mode used to perform the migration: Online or Offline. </summary>
         [WirePath("properties.migrationMode")]
         public PostgreSqlMigrationMode? MigrationMode { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationSecretParameters.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationSecretParameters.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Migration secret parameters.
-    /// Serialized Name: MigrationSecretParameters
-    /// </summary>
+    /// <summary> Migration secret parameters. </summary>
     public partial class PostgreSqlMigrationSecretParameters
     {
         /// <summary>
@@ -49,10 +46,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlMigrationSecretParameters"/>. </summary>
-        /// <param name="adminCredentials">
-        /// Credentials of administrator users for source and target servers.
-        /// Serialized Name: MigrationSecretParameters.adminCredentials
-        /// </param>
+        /// <param name="adminCredentials"> Credentials of administrator users for source and target servers. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="adminCredentials"/> is null. </exception>
         public PostgreSqlMigrationSecretParameters(PostgreSqlMigrationAdminCredentials adminCredentials)
         {
@@ -62,18 +56,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlMigrationSecretParameters"/>. </summary>
-        /// <param name="adminCredentials">
-        /// Credentials of administrator users for source and target servers.
-        /// Serialized Name: MigrationSecretParameters.adminCredentials
-        /// </param>
-        /// <param name="sourceServerUsername">
-        /// Gets or sets the name of the user for the source server. This user doesn't need to be an administrator.
-        /// Serialized Name: MigrationSecretParameters.sourceServerUsername
-        /// </param>
-        /// <param name="targetServerUsername">
-        /// Gets or sets the name of the user for the target server. This user doesn't need to be an administrator.
-        /// Serialized Name: MigrationSecretParameters.targetServerUsername
-        /// </param>
+        /// <param name="adminCredentials"> Credentials of administrator users for source and target servers. </param>
+        /// <param name="sourceServerUsername"> Gets or sets the name of the user for the source server. This user doesn't need to be an administrator. </param>
+        /// <param name="targetServerUsername"> Gets or sets the name of the user for the target server. This user doesn't need to be an administrator. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlMigrationSecretParameters(PostgreSqlMigrationAdminCredentials adminCredentials, string sourceServerUsername, string targetServerUsername, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -88,22 +73,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// Credentials of administrator users for source and target servers.
-        /// Serialized Name: MigrationSecretParameters.adminCredentials
-        /// </summary>
+        /// <summary> Credentials of administrator users for source and target servers. </summary>
         [WirePath("adminCredentials")]
         public PostgreSqlMigrationAdminCredentials AdminCredentials { get; set; }
-        /// <summary>
-        /// Gets or sets the name of the user for the source server. This user doesn't need to be an administrator.
-        /// Serialized Name: MigrationSecretParameters.sourceServerUsername
-        /// </summary>
+        /// <summary> Gets or sets the name of the user for the source server. This user doesn't need to be an administrator. </summary>
         [WirePath("sourceServerUsername")]
         public string SourceServerUsername { get; set; }
-        /// <summary>
-        /// Gets or sets the name of the user for the target server. This user doesn't need to be an administrator.
-        /// Serialized Name: MigrationSecretParameters.targetServerUsername
-        /// </summary>
+        /// <summary> Gets or sets the name of the user for the target server. This user doesn't need to be an administrator. </summary>
         [WirePath("targetServerUsername")]
         public string TargetServerUsername { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationStartDataMigration.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationStartDataMigration.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if data migration must start right away.
-    /// Serialized Name: StartDataMigration
-    /// </summary>
+    /// <summary> Indicates if data migration must start right away. </summary>
     public readonly partial struct PostgreSqlMigrationStartDataMigration : IEquatable<PostgreSqlMigrationStartDataMigration>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string TrueValue = "True";
         private const string FalseValue = "False";
 
-        /// <summary>
-        /// True
-        /// Serialized Name: StartDataMigration.True
-        /// </summary>
+        /// <summary> True. </summary>
         public static PostgreSqlMigrationStartDataMigration True { get; } = new PostgreSqlMigrationStartDataMigration(TrueValue);
-        /// <summary>
-        /// False
-        /// Serialized Name: StartDataMigration.False
-        /// </summary>
+        /// <summary> False. </summary>
         public static PostgreSqlMigrationStartDataMigration False { get; } = new PostgreSqlMigrationStartDataMigration(FalseValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationStartDataMigration"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationStartDataMigration left, PostgreSqlMigrationStartDataMigration right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// State of migration.
-    /// Serialized Name: MigrationState
-    /// </summary>
+    /// <summary> State of migration. </summary>
     public readonly partial struct PostgreSqlMigrationState : IEquatable<PostgreSqlMigrationState>
     {
         private readonly string _value;
@@ -33,40 +30,19 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string ValidationFailedValue = "ValidationFailed";
         private const string CleaningUpValue = "CleaningUp";
 
-        /// <summary>
-        /// InProgress
-        /// Serialized Name: MigrationState.InProgress
-        /// </summary>
+        /// <summary> InProgress. </summary>
         public static PostgreSqlMigrationState InProgress { get; } = new PostgreSqlMigrationState(InProgressValue);
-        /// <summary>
-        /// WaitingForUserAction
-        /// Serialized Name: MigrationState.WaitingForUserAction
-        /// </summary>
+        /// <summary> WaitingForUserAction. </summary>
         public static PostgreSqlMigrationState WaitingForUserAction { get; } = new PostgreSqlMigrationState(WaitingForUserActionValue);
-        /// <summary>
-        /// Canceled
-        /// Serialized Name: MigrationState.Canceled
-        /// </summary>
+        /// <summary> Canceled. </summary>
         public static PostgreSqlMigrationState Canceled { get; } = new PostgreSqlMigrationState(CanceledValue);
-        /// <summary>
-        /// Failed
-        /// Serialized Name: MigrationState.Failed
-        /// </summary>
+        /// <summary> Failed. </summary>
         public static PostgreSqlMigrationState Failed { get; } = new PostgreSqlMigrationState(FailedValue);
-        /// <summary>
-        /// Succeeded
-        /// Serialized Name: MigrationState.Succeeded
-        /// </summary>
+        /// <summary> Succeeded. </summary>
         public static PostgreSqlMigrationState Succeeded { get; } = new PostgreSqlMigrationState(SucceededValue);
-        /// <summary>
-        /// ValidationFailed
-        /// Serialized Name: MigrationState.ValidationFailed
-        /// </summary>
+        /// <summary> ValidationFailed. </summary>
         public static PostgreSqlMigrationState ValidationFailed { get; } = new PostgreSqlMigrationState(ValidationFailedValue);
-        /// <summary>
-        /// CleaningUp
-        /// Serialized Name: MigrationState.CleaningUp
-        /// </summary>
+        /// <summary> CleaningUp. </summary>
         public static PostgreSqlMigrationState CleaningUp { get; } = new PostgreSqlMigrationState(CleaningUpValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationState"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationState left, PostgreSqlMigrationState right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationStatus.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationStatus.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// State of migration.
-    /// Serialized Name: MigrationStatus
-    /// </summary>
+    /// <summary> State of migration. </summary>
     public partial class PostgreSqlMigrationStatus
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlMigrationStatus"/>. </summary>
-        /// <param name="state">
-        /// State of migration.
-        /// Serialized Name: MigrationStatus.state
-        /// </param>
-        /// <param name="error">
-        /// Error message, if any, for the migration state.
-        /// Serialized Name: MigrationStatus.error
-        /// </param>
-        /// <param name="currentSubStateDetails">
-        /// Current migration sub state details.
-        /// Serialized Name: MigrationStatus.currentSubStateDetails
-        /// </param>
+        /// <param name="state"> State of migration. </param>
+        /// <param name="error"> Error message, if any, for the migration state. </param>
+        /// <param name="currentSubStateDetails"> Current migration sub state details. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlMigrationStatus(PostgreSqlMigrationState? state, string error, PostgreSqlMigrationSubStateDetails currentSubStateDetails, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// State of migration.
-        /// Serialized Name: MigrationStatus.state
-        /// </summary>
+        /// <summary> State of migration. </summary>
         [WirePath("state")]
         public PostgreSqlMigrationState? State { get; }
-        /// <summary>
-        /// Error message, if any, for the migration state.
-        /// Serialized Name: MigrationStatus.error
-        /// </summary>
+        /// <summary> Error message, if any, for the migration state. </summary>
         [WirePath("error")]
         public string Error { get; }
-        /// <summary>
-        /// Current migration sub state details.
-        /// Serialized Name: MigrationStatus.currentSubStateDetails
-        /// </summary>
+        /// <summary> Current migration sub state details. </summary>
         [WirePath("currentSubStateDetails")]
         public PostgreSqlMigrationSubStateDetails CurrentSubStateDetails { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationSubState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationSubState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Substate of migration.
-    /// Serialized Name: MigrationSubstate
-    /// </summary>
+    /// <summary> Substate of migration. </summary>
     public readonly partial struct PostgreSqlMigrationSubState : IEquatable<PostgreSqlMigrationSubState>
     {
         private readonly string _value;
@@ -38,65 +35,29 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string CancelingRequestedDBMigrationsValue = "CancelingRequestedDBMigrations";
         private const string ValidationInProgressValue = "ValidationInProgress";
 
-        /// <summary>
-        /// PerformingPreRequisiteSteps
-        /// Serialized Name: MigrationSubstate.PerformingPreRequisiteSteps
-        /// </summary>
+        /// <summary> PerformingPreRequisiteSteps. </summary>
         public static PostgreSqlMigrationSubState PerformingPreRequisiteSteps { get; } = new PostgreSqlMigrationSubState(PerformingPreRequisiteStepsValue);
-        /// <summary>
-        /// WaitingForLogicalReplicationSetupRequestOnSourceDB
-        /// Serialized Name: MigrationSubstate.WaitingForLogicalReplicationSetupRequestOnSourceDB
-        /// </summary>
+        /// <summary> WaitingForLogicalReplicationSetupRequestOnSourceDB. </summary>
         public static PostgreSqlMigrationSubState WaitingForLogicalReplicationSetupRequestOnSourceDB { get; } = new PostgreSqlMigrationSubState(WaitingForLogicalReplicationSetupRequestOnSourceDBValue);
-        /// <summary>
-        /// WaitingForDBsToMigrateSpecification
-        /// Serialized Name: MigrationSubstate.WaitingForDBsToMigrateSpecification
-        /// </summary>
+        /// <summary> WaitingForDBsToMigrateSpecification. </summary>
         public static PostgreSqlMigrationSubState WaitingForDBsToMigrateSpecification { get; } = new PostgreSqlMigrationSubState(WaitingForDBsToMigrateSpecificationValue);
-        /// <summary>
-        /// WaitingForTargetDBOverwriteConfirmation
-        /// Serialized Name: MigrationSubstate.WaitingForTargetDBOverwriteConfirmation
-        /// </summary>
+        /// <summary> WaitingForTargetDBOverwriteConfirmation. </summary>
         public static PostgreSqlMigrationSubState WaitingForTargetDBOverwriteConfirmation { get; } = new PostgreSqlMigrationSubState(WaitingForTargetDBOverwriteConfirmationValue);
-        /// <summary>
-        /// WaitingForDataMigrationScheduling
-        /// Serialized Name: MigrationSubstate.WaitingForDataMigrationScheduling
-        /// </summary>
+        /// <summary> WaitingForDataMigrationScheduling. </summary>
         public static PostgreSqlMigrationSubState WaitingForDataMigrationScheduling { get; } = new PostgreSqlMigrationSubState(WaitingForDataMigrationSchedulingValue);
-        /// <summary>
-        /// WaitingForDataMigrationWindow
-        /// Serialized Name: MigrationSubstate.WaitingForDataMigrationWindow
-        /// </summary>
+        /// <summary> WaitingForDataMigrationWindow. </summary>
         public static PostgreSqlMigrationSubState WaitingForDataMigrationWindow { get; } = new PostgreSqlMigrationSubState(WaitingForDataMigrationWindowValue);
-        /// <summary>
-        /// MigratingData
-        /// Serialized Name: MigrationSubstate.MigratingData
-        /// </summary>
+        /// <summary> MigratingData. </summary>
         public static PostgreSqlMigrationSubState MigratingData { get; } = new PostgreSqlMigrationSubState(MigratingDataValue);
-        /// <summary>
-        /// WaitingForCutoverTrigger
-        /// Serialized Name: MigrationSubstate.WaitingForCutoverTrigger
-        /// </summary>
+        /// <summary> WaitingForCutoverTrigger. </summary>
         public static PostgreSqlMigrationSubState WaitingForCutoverTrigger { get; } = new PostgreSqlMigrationSubState(WaitingForCutoverTriggerValue);
-        /// <summary>
-        /// CompletingMigration
-        /// Serialized Name: MigrationSubstate.CompletingMigration
-        /// </summary>
+        /// <summary> CompletingMigration. </summary>
         public static PostgreSqlMigrationSubState CompletingMigration { get; } = new PostgreSqlMigrationSubState(CompletingMigrationValue);
-        /// <summary>
-        /// Completed
-        /// Serialized Name: MigrationSubstate.Completed
-        /// </summary>
+        /// <summary> Completed. </summary>
         public static PostgreSqlMigrationSubState Completed { get; } = new PostgreSqlMigrationSubState(CompletedValue);
-        /// <summary>
-        /// CancelingRequestedDBMigrations
-        /// Serialized Name: MigrationSubstate.CancelingRequestedDBMigrations
-        /// </summary>
+        /// <summary> CancelingRequestedDBMigrations. </summary>
         public static PostgreSqlMigrationSubState CancelingRequestedDBMigrations { get; } = new PostgreSqlMigrationSubState(CancelingRequestedDBMigrationsValue);
-        /// <summary>
-        /// ValidationInProgress
-        /// Serialized Name: MigrationSubstate.ValidationInProgress
-        /// </summary>
+        /// <summary> ValidationInProgress. </summary>
         public static PostgreSqlMigrationSubState ValidationInProgress { get; } = new PostgreSqlMigrationSubState(ValidationInProgressValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationSubState"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationSubState left, PostgreSqlMigrationSubState right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationSubStateDetails.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationSubStateDetails.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Details of migration substate.
-    /// Serialized Name: MigrationSubstateDetails
-    /// </summary>
+    /// <summary> Details of migration substate. </summary>
     public partial class PostgreSqlMigrationSubStateDetails
     {
         /// <summary>
@@ -55,18 +52,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlMigrationSubStateDetails"/>. </summary>
-        /// <param name="currentSubState">
-        /// Substate of migration.
-        /// Serialized Name: MigrationSubstateDetails.currentSubState
-        /// </param>
-        /// <param name="dbDetails">
-        /// Dictionary of &lt;DatabaseMigrationState&gt;
-        /// Serialized Name: MigrationSubstateDetails.dbDetails
-        /// </param>
-        /// <param name="validationDetails">
-        /// Details for the validation for migration.
-        /// Serialized Name: MigrationSubstateDetails.validationDetails
-        /// </param>
+        /// <param name="currentSubState"> Substate of migration. </param>
+        /// <param name="dbDetails"> Dictionary of &lt;DatabaseMigrationState&gt;. </param>
+        /// <param name="validationDetails"> Details for the validation for migration. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlMigrationSubStateDetails(PostgreSqlMigrationSubState? currentSubState, IReadOnlyDictionary<string, DbMigrationStatus> dbDetails, PostgreSqlFlexibleServersValidationDetails validationDetails, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -76,22 +64,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Substate of migration.
-        /// Serialized Name: MigrationSubstateDetails.currentSubState
-        /// </summary>
+        /// <summary> Substate of migration. </summary>
         [WirePath("currentSubState")]
         public PostgreSqlMigrationSubState? CurrentSubState { get; }
-        /// <summary>
-        /// Dictionary of &lt;DatabaseMigrationState&gt;
-        /// Serialized Name: MigrationSubstateDetails.dbDetails
-        /// </summary>
+        /// <summary> Dictionary of &lt;DatabaseMigrationState&gt;. </summary>
         [WirePath("dbDetails")]
         public IReadOnlyDictionary<string, DbMigrationStatus> DbDetails { get; }
-        /// <summary>
-        /// Details for the validation for migration.
-        /// Serialized Name: MigrationSubstateDetails.validationDetails
-        /// </summary>
+        /// <summary> Details for the validation for migration. </summary>
         [WirePath("validationDetails")]
         public PostgreSqlFlexibleServersValidationDetails ValidationDetails { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationTriggerCutover.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlMigrationTriggerCutover.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Indicates if cutover must be triggered for the entire migration.
-    /// Serialized Name: TriggerCutover
-    /// </summary>
+    /// <summary> Indicates if cutover must be triggered for the entire migration. </summary>
     public readonly partial struct PostgreSqlMigrationTriggerCutover : IEquatable<PostgreSqlMigrationTriggerCutover>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string TrueValue = "True";
         private const string FalseValue = "False";
 
-        /// <summary>
-        /// True
-        /// Serialized Name: TriggerCutover.True
-        /// </summary>
+        /// <summary> True. </summary>
         public static PostgreSqlMigrationTriggerCutover True { get; } = new PostgreSqlMigrationTriggerCutover(TrueValue);
-        /// <summary>
-        /// False
-        /// Serialized Name: TriggerCutover.False
-        /// </summary>
+        /// <summary> False. </summary>
         public static PostgreSqlMigrationTriggerCutover False { get; } = new PostgreSqlMigrationTriggerCutover(FalseValue);
         /// <summary> Determines if two <see cref="PostgreSqlMigrationTriggerCutover"/> values are the same. </summary>
         public static bool operator ==(PostgreSqlMigrationTriggerCutover left, PostgreSqlMigrationTriggerCutover right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlServerMetadata.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PostgreSqlServerMetadata.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Database server metadata.
-    /// Serialized Name: DbServerMetadata
-    /// </summary>
+    /// <summary> Database server metadata. </summary>
     public partial class PostgreSqlServerMetadata
     {
         /// <summary>
@@ -55,22 +52,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlServerMetadata"/>. </summary>
-        /// <param name="location">
-        /// Location of database server.
-        /// Serialized Name: DbServerMetadata.location
-        /// </param>
-        /// <param name="version">
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: DbServerMetadata.version
-        /// </param>
-        /// <param name="storageMb">
-        /// Storage size (in MB) for database server.
-        /// Serialized Name: DbServerMetadata.storageMb
-        /// </param>
-        /// <param name="sku">
-        /// Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server.
-        /// Serialized Name: DbServerMetadata.sku
-        /// </param>
+        /// <param name="location"> Location of database server. </param>
+        /// <param name="version"> Major version of PostgreSQL database engine. </param>
+        /// <param name="storageMb"> Storage size (in MB) for database server. </param>
+        /// <param name="sku"> Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlServerMetadata(AzureLocation? location, string version, int? storageMb, PostgreSqlFlexibleServersServerSku sku, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,28 +66,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Location of database server.
-        /// Serialized Name: DbServerMetadata.location
-        /// </summary>
+        /// <summary> Location of database server. </summary>
         [WirePath("location")]
         public AzureLocation? Location { get; }
-        /// <summary>
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: DbServerMetadata.version
-        /// </summary>
+        /// <summary> Major version of PostgreSQL database engine. </summary>
         [WirePath("version")]
         public string Version { get; }
-        /// <summary>
-        /// Storage size (in MB) for database server.
-        /// Serialized Name: DbServerMetadata.storageMb
-        /// </summary>
+        /// <summary> Storage size (in MB) for database server. </summary>
         [WirePath("storageMb")]
         public int? StorageMb { get; }
-        /// <summary>
-        /// Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server.
-        /// Serialized Name: DbServerMetadata.sku
-        /// </summary>
+        /// <summary> Compute tier and size of the database server. This object is empty for an Azure Database for PostgreSQL single server. </summary>
         [WirePath("sku")]
         public PostgreSqlFlexibleServersServerSku Sku { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PrivateEndpointConnectionList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PrivateEndpointConnectionList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of private endpoint connections.
-    /// Serialized Name: PrivateEndpointConnectionList
-    /// </summary>
+    /// <summary> List of private endpoint connections. </summary>
     internal partial class PrivateEndpointConnectionList
     {
         /// <summary>
@@ -50,24 +47,15 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PrivateEndpointConnectionList"/>. </summary>
-        /// <param name="value">
-        /// The PrivateEndpointConnection items on this page
-        /// Serialized Name: PrivateEndpointConnectionList.value
-        /// </param>
+        /// <param name="value"> The PrivateEndpointConnection items on this page. </param>
         internal PrivateEndpointConnectionList(IEnumerable<PostgreSqlFlexibleServersPrivateEndpointConnectionData> value)
         {
             Value = value.ToList();
         }
 
         /// <summary> Initializes a new instance of <see cref="PrivateEndpointConnectionList"/>. </summary>
-        /// <param name="value">
-        /// The PrivateEndpointConnection items on this page
-        /// Serialized Name: PrivateEndpointConnectionList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: PrivateEndpointConnectionList.nextLink
-        /// </param>
+        /// <param name="value"> The PrivateEndpointConnection items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PrivateEndpointConnectionList(IReadOnlyList<PostgreSqlFlexibleServersPrivateEndpointConnectionData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,15 +69,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The PrivateEndpointConnection items on this page
-        /// Serialized Name: PrivateEndpointConnectionList.value
-        /// </summary>
+        /// <summary> The PrivateEndpointConnection items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServersPrivateEndpointConnectionData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: PrivateEndpointConnectionList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PrivateLinkResourceList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/PrivateLinkResourceList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// A list of private link resources
-    /// Serialized Name: PrivateLinkResourceList
-    /// </summary>
+    /// <summary> A list of private link resources. </summary>
     internal partial class PrivateLinkResourceList
     {
         /// <summary>
@@ -50,24 +47,15 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PrivateLinkResourceList"/>. </summary>
-        /// <param name="value">
-        /// The PrivateLinkResource items on this page
-        /// Serialized Name: PrivateLinkResourceList.value
-        /// </param>
+        /// <param name="value"> The PrivateLinkResource items on this page. </param>
         internal PrivateLinkResourceList(IEnumerable<PostgreSqlFlexibleServersPrivateLinkResourceData> value)
         {
             Value = value.ToList();
         }
 
         /// <summary> Initializes a new instance of <see cref="PrivateLinkResourceList"/>. </summary>
-        /// <param name="value">
-        /// The PrivateLinkResource items on this page
-        /// Serialized Name: PrivateLinkResourceList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: PrivateLinkResourceList.nextLink
-        /// </param>
+        /// <param name="value"> The PrivateLinkResource items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PrivateLinkResourceList(IReadOnlyList<PostgreSqlFlexibleServersPrivateLinkResourceData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,15 +69,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The PrivateLinkResource items on this page
-        /// Serialized Name: PrivateLinkResourceList.value
-        /// </summary>
+        /// <summary> The PrivateLinkResource items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServersPrivateLinkResourceData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: PrivateLinkResourceList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/QuotaUsageList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/QuotaUsageList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Capability for the PostgreSQL server
-    /// Serialized Name: QuotaUsageList
-    /// </summary>
+    /// <summary> Capability for the PostgreSQL server. </summary>
     internal partial class QuotaUsageList
     {
         /// <summary>
@@ -50,24 +47,15 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="QuotaUsageList"/>. </summary>
-        /// <param name="value">
-        /// The QuotaUsage items on this page
-        /// Serialized Name: QuotaUsageList.value
-        /// </param>
+        /// <param name="value"> The QuotaUsage items on this page. </param>
         internal QuotaUsageList(IEnumerable<PostgreSqlFlexibleServerQuotaUsage> value)
         {
             Value = value.ToList();
         }
 
         /// <summary> Initializes a new instance of <see cref="QuotaUsageList"/>. </summary>
-        /// <param name="value">
-        /// The QuotaUsage items on this page
-        /// Serialized Name: QuotaUsageList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: QuotaUsageList.nextLink
-        /// </param>
+        /// <param name="value"> The QuotaUsage items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal QuotaUsageList(IReadOnlyList<PostgreSqlFlexibleServerQuotaUsage> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,15 +69,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The QuotaUsage items on this page
-        /// Serialized Name: QuotaUsageList.value
-        /// </summary>
+        /// <summary> The QuotaUsage items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerQuotaUsage> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: QuotaUsageList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/QuotaUsageNameProperty.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/QuotaUsageNameProperty.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Name property for quota usage
-    /// Serialized Name: NameProperty
-    /// </summary>
+    /// <summary> Name property for quota usage. </summary>
     public partial class QuotaUsageNameProperty
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="QuotaUsageNameProperty"/>. </summary>
-        /// <param name="value">
-        /// Name value
-        /// Serialized Name: NameProperty.value
-        /// </param>
-        /// <param name="localizedValue">
-        /// Localized name
-        /// Serialized Name: NameProperty.localizedValue
-        /// </param>
+        /// <param name="value"> Name value. </param>
+        /// <param name="localizedValue"> Localized name. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal QuotaUsageNameProperty(string value, string localizedValue, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Name value
-        /// Serialized Name: NameProperty.value
-        /// </summary>
+        /// <summary> Name value. </summary>
         [WirePath("value")]
         public string Value { get; }
-        /// <summary>
-        /// Localized name
-        /// Serialized Name: NameProperty.localizedValue
-        /// </summary>
+        /// <summary> Localized name. </summary>
         [WirePath("localizedValue")]
         public string LocalizedValue { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ReadReplicaPromoteMode.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ReadReplicaPromoteMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Type of operation to apply on the read replica. This property is write only. Standalone means that the read replica will be promoted to a standalone server, and will become a completely independent entity from the replication set. Switchover means that the read replica will roles with the primary server.
-    /// Serialized Name: ReadReplicaPromoteMode
-    /// </summary>
+    /// <summary> Type of operation to apply on the read replica. This property is write only. Standalone means that the read replica will be promoted to a standalone server, and will become a completely independent entity from the replication set. Switchover means that the read replica will roles with the primary server. </summary>
     public readonly partial struct ReadReplicaPromoteMode : IEquatable<ReadReplicaPromoteMode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string StandaloneValue = "Standalone";
         private const string SwitchoverValue = "Switchover";
 
-        /// <summary>
-        /// Read replica will become an independent server.
-        /// Serialized Name: ReadReplicaPromoteMode.Standalone
-        /// </summary>
+        /// <summary> Read replica will become an independent server. </summary>
         public static ReadReplicaPromoteMode Standalone { get; } = new ReadReplicaPromoteMode(StandaloneValue);
-        /// <summary>
-        /// Read replica will swap roles with primary server.
-        /// Serialized Name: ReadReplicaPromoteMode.Switchover
-        /// </summary>
+        /// <summary> Read replica will swap roles with primary server. </summary>
         public static ReadReplicaPromoteMode Switchover { get; } = new ReadReplicaPromoteMode(SwitchoverValue);
         /// <summary> Determines if two <see cref="ReadReplicaPromoteMode"/> values are the same. </summary>
         public static bool operator ==(ReadReplicaPromoteMode left, ReadReplicaPromoteMode right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/RecommendationImpactRecord.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/RecommendationImpactRecord.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Impact on some metric if this recommended action is applied.
-    /// Serialized Name: ImpactRecord
-    /// </summary>
+    /// <summary> Impact on some metric if this recommended action is applied. </summary>
     public partial class RecommendationImpactRecord
     {
         /// <summary>
@@ -54,22 +51,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="RecommendationImpactRecord"/>. </summary>
-        /// <param name="dimensionName">
-        /// Dimension name.
-        /// Serialized Name: ImpactRecord.dimensionName
-        /// </param>
-        /// <param name="unit">
-        /// Dimension unit.
-        /// Serialized Name: ImpactRecord.unit
-        /// </param>
-        /// <param name="queryId">
-        /// Optional property that can be used to store the identifier of the query, if the metric is for a specific query.
-        /// Serialized Name: ImpactRecord.queryId
-        /// </param>
-        /// <param name="absoluteValue">
-        /// Absolute value.
-        /// Serialized Name: ImpactRecord.absoluteValue
-        /// </param>
+        /// <param name="dimensionName"> Dimension name. </param>
+        /// <param name="unit"> Dimension unit. </param>
+        /// <param name="queryId"> Optional property that can be used to store the identifier of the query, if the metric is for a specific query. </param>
+        /// <param name="absoluteValue"> Absolute value. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal RecommendationImpactRecord(string dimensionName, string unit, long? queryId, double? absoluteValue, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -80,28 +65,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Dimension name.
-        /// Serialized Name: ImpactRecord.dimensionName
-        /// </summary>
+        /// <summary> Dimension name. </summary>
         [WirePath("dimensionName")]
         public string DimensionName { get; }
-        /// <summary>
-        /// Dimension unit.
-        /// Serialized Name: ImpactRecord.unit
-        /// </summary>
+        /// <summary> Dimension unit. </summary>
         [WirePath("unit")]
         public string Unit { get; }
-        /// <summary>
-        /// Optional property that can be used to store the identifier of the query, if the metric is for a specific query.
-        /// Serialized Name: ImpactRecord.queryId
-        /// </summary>
+        /// <summary> Optional property that can be used to store the identifier of the query, if the metric is for a specific query. </summary>
         [WirePath("queryId")]
         public long? QueryId { get; }
-        /// <summary>
-        /// Absolute value.
-        /// Serialized Name: ImpactRecord.absoluteValue
-        /// </summary>
+        /// <summary> Absolute value. </summary>
         [WirePath("absoluteValue")]
         public double? AbsoluteValue { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ReplicationPromoteOption.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ReplicationPromoteOption.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Data synchronization option to use when processing the operation specified in the promoteMode property. This property is write only.
-    /// Serialized Name: ReadReplicaPromoteOption
-    /// </summary>
+    /// <summary> Data synchronization option to use when processing the operation specified in the promoteMode property. This property is write only. </summary>
     public readonly partial struct ReplicationPromoteOption : IEquatable<ReplicationPromoteOption>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string PlannedValue = "Planned";
         private const string ForcedValue = "Forced";
 
-        /// <summary>
-        /// The operation will wait for data in the read replica to be fully synchronized with its source server, before it initiates the operation.
-        /// Serialized Name: ReadReplicaPromoteOption.Planned
-        /// </summary>
+        /// <summary> The operation will wait for data in the read replica to be fully synchronized with its source server, before it initiates the operation. </summary>
         public static ReplicationPromoteOption Planned { get; } = new ReplicationPromoteOption(PlannedValue);
-        /// <summary>
-        /// The operation will not wait for data in the read replica to be synchronized with its source server, before it initiates the operation.
-        /// Serialized Name: ReadReplicaPromoteOption.Forced
-        /// </summary>
+        /// <summary> The operation will not wait for data in the read replica to be synchronized with its source server, before it initiates the operation. </summary>
         public static ReplicationPromoteOption Forced { get; } = new ReplicationPromoteOption(ForcedValue);
         /// <summary> Determines if two <see cref="ReplicationPromoteOption"/> values are the same. </summary>
         public static bool operator ==(ReplicationPromoteOption left, ReplicationPromoteOption right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ServerList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ServerList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// A list of servers.
-    /// Serialized Name: ServerList
-    /// </summary>
+    /// <summary> A list of servers. </summary>
     internal partial class ServerList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ServerList"/>. </summary>
-        /// <param name="value">
-        /// The Server items on this page
-        /// Serialized Name: ServerList.value
-        /// </param>
+        /// <param name="value"> The Server items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal ServerList(IEnumerable<PostgreSqlFlexibleServerData> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ServerList"/>. </summary>
-        /// <param name="value">
-        /// The Server items on this page
-        /// Serialized Name: ServerList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: ServerList.nextLink
-        /// </param>
+        /// <param name="value"> The Server items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ServerList(IReadOnlyList<PostgreSqlFlexibleServerData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The Server items on this page
-        /// Serialized Name: ServerList.value
-        /// </summary>
+        /// <summary> The Server items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: ServerList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/StorageAutoGrow.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/StorageAutoGrow.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Flag to enable or disable the automatic growth of storage size of a server when available space is nearing zero and conditions allow for automatically growing storage size.
-    /// Serialized Name: StorageAutoGrow
-    /// </summary>
+    /// <summary> Flag to enable or disable the automatic growth of storage size of a server when available space is nearing zero and conditions allow for automatically growing storage size. </summary>
     public readonly partial struct StorageAutoGrow : IEquatable<StorageAutoGrow>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: StorageAutoGrow.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static StorageAutoGrow Enabled { get; } = new StorageAutoGrow(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: StorageAutoGrow.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static StorageAutoGrow Disabled { get; } = new StorageAutoGrow(DisabledValue);
         /// <summary> Determines if two <see cref="StorageAutoGrow"/> values are the same. </summary>
         public static bool operator ==(StorageAutoGrow left, StorageAutoGrow right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ThreatProtectionName.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ThreatProtectionName.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// The ThreatProtectionName.
-    /// Serialized Name: ThreatProtectionName
-    /// </summary>
+    /// <summary> The ThreatProtectionName. </summary>
     public readonly partial struct ThreatProtectionName : IEquatable<ThreatProtectionName>
     {
         private readonly string _value;
@@ -27,10 +24,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 
         private const string DefaultValue = "Default";
 
-        /// <summary>
-        /// Default
-        /// Serialized Name: ThreatProtectionName.Default
-        /// </summary>
+        /// <summary> Default. </summary>
         public static ThreatProtectionName Default { get; } = new ThreatProtectionName(DefaultValue);
         /// <summary> Determines if two <see cref="ThreatProtectionName"/> values are the same. </summary>
         public static bool operator ==(ThreatProtectionName left, ThreatProtectionName right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ThreatProtectionState.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ThreatProtectionState.cs
@@ -7,21 +7,12 @@
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Specifies the state of the advanced threat protection, whether it is enabled, disabled, or a state has not been applied yet on the server.
-    /// Serialized Name: ThreatProtectionState
-    /// </summary>
+    /// <summary> Specifies the state of the advanced threat protection, whether it is enabled, disabled, or a state has not been applied yet on the server. </summary>
     public enum ThreatProtectionState
     {
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: ThreatProtectionState.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         Enabled,
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: ThreatProtectionState.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         Disabled
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/TuningOptionsList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/TuningOptionsList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of server tuning options.
-    /// Serialized Name: TuningOptionsList
-    /// </summary>
+    /// <summary> List of server tuning options. </summary>
     internal partial class TuningOptionsList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="TuningOptionsList"/>. </summary>
-        /// <param name="value">
-        /// The TuningOptions items on this page
-        /// Serialized Name: TuningOptionsList.value
-        /// </param>
+        /// <param name="value"> The TuningOptions items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal TuningOptionsList(IEnumerable<PostgreSqlFlexibleServerTuningOptionData> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="TuningOptionsList"/>. </summary>
-        /// <param name="value">
-        /// The TuningOptions items on this page
-        /// Serialized Name: TuningOptionsList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: TuningOptionsList.nextLink
-        /// </param>
+        /// <param name="value"> The TuningOptions items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal TuningOptionsList(IReadOnlyList<PostgreSqlFlexibleServerTuningOptionData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The TuningOptions items on this page
-        /// Serialized Name: TuningOptionsList.value
-        /// </summary>
+        /// <summary> The TuningOptions items on this page. </summary>
         public IReadOnlyList<PostgreSqlFlexibleServerTuningOptionData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: TuningOptionsList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ValidationSummaryItem.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/ValidationSummaryItem.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Validation summary object.
-    /// Serialized Name: ValidationSummaryItem
-    /// </summary>
+    /// <summary> Validation summary object. </summary>
     public partial class ValidationSummaryItem
     {
         /// <summary>
@@ -55,18 +52,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ValidationSummaryItem"/>. </summary>
-        /// <param name="validationSummaryItemType">
-        /// Validation type.
-        /// Serialized Name: ValidationSummaryItem.type
-        /// </param>
-        /// <param name="state">
-        /// Validation status for migration.
-        /// Serialized Name: ValidationSummaryItem.state
-        /// </param>
-        /// <param name="messages">
-        /// Validation messages.
-        /// Serialized Name: ValidationSummaryItem.messages
-        /// </param>
+        /// <param name="validationSummaryItemType"> Validation type. </param>
+        /// <param name="state"> Validation status for migration. </param>
+        /// <param name="messages"> Validation messages. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ValidationSummaryItem(string validationSummaryItemType, PostgreSqlFlexibleServersValidationState? state, IReadOnlyList<PostgreSqlFlexibleServersValidationMessage> messages, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -76,22 +64,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Validation type.
-        /// Serialized Name: ValidationSummaryItem.type
-        /// </summary>
+        /// <summary> Validation type. </summary>
         [WirePath("type")]
         public string ValidationSummaryItemType { get; }
-        /// <summary>
-        /// Validation status for migration.
-        /// Serialized Name: ValidationSummaryItem.state
-        /// </summary>
+        /// <summary> Validation status for migration. </summary>
         [WirePath("state")]
         public PostgreSqlFlexibleServersValidationState? State { get; }
-        /// <summary>
-        /// Validation messages.
-        /// Serialized Name: ValidationSummaryItem.messages
-        /// </summary>
+        /// <summary> Validation messages. </summary>
         [WirePath("messages")]
         public IReadOnlyList<PostgreSqlFlexibleServersValidationMessage> Messages { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/VirtualEndpointResourcePatch.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/VirtualEndpointResourcePatch.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Pair of virtual endpoints for a server.
-    /// Serialized Name: VirtualEndpointResourceForPatch
-    /// </summary>
+    /// <summary> Pair of virtual endpoints for a server. </summary>
     public partial class VirtualEndpointResourcePatch
     {
         /// <summary>
@@ -56,18 +53,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="VirtualEndpointResourcePatch"/>. </summary>
-        /// <param name="endpointType">
-        /// Type of endpoint for the virtual endpoints.
-        /// Serialized Name: VirtualEndpointResourceForPatch.properties.endpointType
-        /// </param>
-        /// <param name="members">
-        /// List of servers that one of the virtual endpoints can refer to.
-        /// Serialized Name: VirtualEndpointResourceForPatch.properties.members
-        /// </param>
-        /// <param name="virtualEndpoints">
-        /// List of virtual endpoints for a server.
-        /// Serialized Name: VirtualEndpointResourceForPatch.properties.virtualEndpoints
-        /// </param>
+        /// <param name="endpointType"> Type of endpoint for the virtual endpoints. </param>
+        /// <param name="members"> List of servers that one of the virtual endpoints can refer to. </param>
+        /// <param name="virtualEndpoints"> List of virtual endpoints for a server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal VirtualEndpointResourcePatch(VirtualEndpointType? endpointType, IList<string> members, IReadOnlyList<string> virtualEndpoints, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -77,22 +65,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Type of endpoint for the virtual endpoints.
-        /// Serialized Name: VirtualEndpointResourceForPatch.properties.endpointType
-        /// </summary>
+        /// <summary> Type of endpoint for the virtual endpoints. </summary>
         [WirePath("properties.endpointType")]
         public VirtualEndpointType? EndpointType { get; set; }
-        /// <summary>
-        /// List of servers that one of the virtual endpoints can refer to.
-        /// Serialized Name: VirtualEndpointResourceForPatch.properties.members
-        /// </summary>
+        /// <summary> List of servers that one of the virtual endpoints can refer to. </summary>
         [WirePath("properties.members")]
         public IList<string> Members { get; }
-        /// <summary>
-        /// List of virtual endpoints for a server.
-        /// Serialized Name: VirtualEndpointResourceForPatch.properties.virtualEndpoints
-        /// </summary>
+        /// <summary> List of virtual endpoints for a server. </summary>
         [WirePath("properties.virtualEndpoints")]
         public IReadOnlyList<string> VirtualEndpoints { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/VirtualEndpointType.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/VirtualEndpointType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// Type of endpoint for the virtual endpoints.
-    /// Serialized Name: VirtualEndpointType
-    /// </summary>
+    /// <summary> Type of endpoint for the virtual endpoints. </summary>
     public readonly partial struct VirtualEndpointType : IEquatable<VirtualEndpointType>
     {
         private readonly string _value;
@@ -27,10 +24,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 
         private const string ReadWriteValue = "ReadWrite";
 
-        /// <summary>
-        /// ReadWrite
-        /// Serialized Name: VirtualEndpointType.ReadWrite
-        /// </summary>
+        /// <summary> ReadWrite. </summary>
         public static VirtualEndpointType ReadWrite { get; } = new VirtualEndpointType(ReadWriteValue);
         /// <summary> Determines if two <see cref="VirtualEndpointType"/> values are the same. </summary>
         public static bool operator ==(VirtualEndpointType left, VirtualEndpointType right) => left.Equals(right);

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/VirtualEndpointsList.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/Models/VirtualEndpointsList.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
 {
-    /// <summary>
-    /// List of virtual endpoints.
-    /// Serialized Name: VirtualEndpointsList
-    /// </summary>
+    /// <summary> List of virtual endpoints. </summary>
     internal partial class VirtualEndpointsList
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="VirtualEndpointsList"/>. </summary>
-        /// <param name="value">
-        /// The VirtualEndpoint items on this page
-        /// Serialized Name: VirtualEndpointsList.value
-        /// </param>
+        /// <param name="value"> The VirtualEndpoint items on this page. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal VirtualEndpointsList(IEnumerable<VirtualEndpointResourceData> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="VirtualEndpointsList"/>. </summary>
-        /// <param name="value">
-        /// The VirtualEndpoint items on this page
-        /// Serialized Name: VirtualEndpointsList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The link to the next page of items
-        /// Serialized Name: VirtualEndpointsList.nextLink
-        /// </param>
+        /// <param name="value"> The VirtualEndpoint items on this page. </param>
+        /// <param name="nextLink"> The link to the next page of items. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal VirtualEndpointsList(IReadOnlyList<VirtualEndpointResourceData> value, Uri nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers.Models
         {
         }
 
-        /// <summary>
-        /// The VirtualEndpoint items on this page
-        /// Serialized Name: VirtualEndpointsList.value
-        /// </summary>
+        /// <summary> The VirtualEndpoint items on this page. </summary>
         public IReadOnlyList<VirtualEndpointResourceData> Value { get; }
-        /// <summary>
-        /// The link to the next page of items
-        /// Serialized Name: VirtualEndpointsList.nextLink
-        /// </summary>
+        /// <summary> The link to the next page of items. </summary>
         public Uri NextLink { get; }
     }
 }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerBackupData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerBackupData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlFlexibleServerBackup data model.
     /// Properties of a backup.
-    /// Serialized Name: BackupAutomaticAndOnDemand
     /// </summary>
     public partial class PostgreSqlFlexibleServerBackupData : ResourceData
     {
@@ -62,18 +61,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="backupType">
-        /// Type of backup.
-        /// Serialized Name: BackupAutomaticAndOnDemand.properties.backupType
-        /// </param>
-        /// <param name="completedOn">
-        /// Time(ISO8601 format) at which the backup was completed.
-        /// Serialized Name: BackupAutomaticAndOnDemand.properties.completedTime
-        /// </param>
-        /// <param name="source">
-        /// Source of the backup.
-        /// Serialized Name: BackupAutomaticAndOnDemand.properties.source
-        /// </param>
+        /// <param name="backupType"> Type of backup. </param>
+        /// <param name="completedOn"> Time(ISO8601 format) at which the backup was completed. </param>
+        /// <param name="source"> Source of the backup. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerBackupData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, PostgreSqlFlexibleServerBackupOrigin? backupType, DateTimeOffset? completedOn, string source, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -83,22 +73,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Type of backup.
-        /// Serialized Name: BackupAutomaticAndOnDemand.properties.backupType
-        /// </summary>
+        /// <summary> Type of backup. </summary>
         [WirePath("properties.backupType")]
         public PostgreSqlFlexibleServerBackupOrigin? BackupType { get; set; }
-        /// <summary>
-        /// Time(ISO8601 format) at which the backup was completed.
-        /// Serialized Name: BackupAutomaticAndOnDemand.properties.completedTime
-        /// </summary>
+        /// <summary> Time(ISO8601 format) at which the backup was completed. </summary>
         [WirePath("properties.completedTime")]
         public DateTimeOffset? CompletedOn { get; set; }
-        /// <summary>
-        /// Source of the backup.
-        /// Serialized Name: BackupAutomaticAndOnDemand.properties.source
-        /// </summary>
+        /// <summary> Source of the backup. </summary>
         [WirePath("properties.source")]
         public string Source { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerConfigurationData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerConfigurationData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlFlexibleServerConfiguration data model.
     /// Configuration (also known as server parameter).
-    /// Serialized Name: Configuration
     /// </summary>
     public partial class PostgreSqlFlexibleServerConfigurationData : ResourceData
     {
@@ -62,50 +61,17 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="value">
-        /// Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: Configuration.properties.value
-        /// </param>
-        /// <param name="description">
-        /// Description of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.description
-        /// </param>
-        /// <param name="defaultValue">
-        /// Value assigned by default to the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.defaultValue
-        /// </param>
-        /// <param name="dataType">
-        /// Data type of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.dataType
-        /// </param>
-        /// <param name="allowedValues">
-        /// Allowed values of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.allowedValues
-        /// </param>
-        /// <param name="source">
-        /// Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: Configuration.properties.source
-        /// </param>
-        /// <param name="isDynamicConfig">
-        /// Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect.
-        /// Serialized Name: Configuration.properties.isDynamicConfig
-        /// </param>
-        /// <param name="isReadOnly">
-        /// Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.isReadOnly
-        /// </param>
-        /// <param name="isConfigPendingRestart">
-        /// Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect.
-        /// Serialized Name: Configuration.properties.isConfigPendingRestart
-        /// </param>
-        /// <param name="unit">
-        /// Units in which the configuration (also known as server parameter) value is expressed.
-        /// Serialized Name: Configuration.properties.unit
-        /// </param>
-        /// <param name="documentationLink">
-        /// Link pointing to the documentation of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.documentationLink
-        /// </param>
+        /// <param name="value"> Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </param>
+        /// <param name="description"> Description of the configuration (also known as server parameter). </param>
+        /// <param name="defaultValue"> Value assigned by default to the configuration (also known as server parameter). </param>
+        /// <param name="dataType"> Data type of the configuration (also known as server parameter). </param>
+        /// <param name="allowedValues"> Allowed values of the configuration (also known as server parameter). </param>
+        /// <param name="source"> Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </param>
+        /// <param name="isDynamicConfig"> Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect. </param>
+        /// <param name="isReadOnly"> Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter). </param>
+        /// <param name="isConfigPendingRestart"> Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect. </param>
+        /// <param name="unit"> Units in which the configuration (also known as server parameter) value is expressed. </param>
+        /// <param name="documentationLink"> Link pointing to the documentation of the configuration (also known as server parameter). </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerConfigurationData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string value, string description, string defaultValue, PostgreSqlFlexibleServerConfigurationDataType? dataType, string allowedValues, string source, bool? isDynamicConfig, bool? isReadOnly, bool? isConfigPendingRestart, string unit, string documentationLink, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -123,70 +89,37 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: Configuration.properties.value
-        /// </summary>
+        /// <summary> Value of the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </summary>
         [WirePath("properties.value")]
         public string Value { get; set; }
-        /// <summary>
-        /// Description of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.description
-        /// </summary>
+        /// <summary> Description of the configuration (also known as server parameter). </summary>
         [WirePath("properties.description")]
         public string Description { get; }
-        /// <summary>
-        /// Value assigned by default to the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.defaultValue
-        /// </summary>
+        /// <summary> Value assigned by default to the configuration (also known as server parameter). </summary>
         [WirePath("properties.defaultValue")]
         public string DefaultValue { get; }
-        /// <summary>
-        /// Data type of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.dataType
-        /// </summary>
+        /// <summary> Data type of the configuration (also known as server parameter). </summary>
         [WirePath("properties.dataType")]
         public PostgreSqlFlexibleServerConfigurationDataType? DataType { get; }
-        /// <summary>
-        /// Allowed values of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.allowedValues
-        /// </summary>
+        /// <summary> Allowed values of the configuration (also known as server parameter). </summary>
         [WirePath("properties.allowedValues")]
         public string AllowedValues { get; }
-        /// <summary>
-        /// Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration.
-        /// Serialized Name: Configuration.properties.source
-        /// </summary>
+        /// <summary> Source of the value assigned to the configuration (also known as server parameter). Required to update the value assigned to a specific modifiable configuration. </summary>
         [WirePath("properties.source")]
         public string Source { get; set; }
-        /// <summary>
-        /// Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect.
-        /// Serialized Name: Configuration.properties.isDynamicConfig
-        /// </summary>
+        /// <summary> Indicates if it's a dynamic (true) or static (false) configuration (also known as server parameter). Static server parameters require a server restart after changing the value assigned to them, for the change to take effect. Dynamic server parameters do not require a server restart after changing the value assigned to them, for the change to take effect. </summary>
         [WirePath("properties.isDynamicConfig")]
         public bool? IsDynamicConfig { get; }
-        /// <summary>
-        /// Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.isReadOnly
-        /// </summary>
+        /// <summary> Indicates if it's a read-only (true) or modifiable (false) configuration (also known as server parameter). </summary>
         [WirePath("properties.isReadOnly")]
         public bool? IsReadOnly { get; }
-        /// <summary>
-        /// Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect.
-        /// Serialized Name: Configuration.properties.isConfigPendingRestart
-        /// </summary>
+        /// <summary> Indicates if the value assigned to the configuration (also known as server parameter) is pending a server restart for it to take effect. </summary>
         [WirePath("properties.isConfigPendingRestart")]
         public bool? IsConfigPendingRestart { get; }
-        /// <summary>
-        /// Units in which the configuration (also known as server parameter) value is expressed.
-        /// Serialized Name: Configuration.properties.unit
-        /// </summary>
+        /// <summary> Units in which the configuration (also known as server parameter) value is expressed. </summary>
         [WirePath("properties.unit")]
         public string Unit { get; }
-        /// <summary>
-        /// Link pointing to the documentation of the configuration (also known as server parameter).
-        /// Serialized Name: Configuration.properties.documentationLink
-        /// </summary>
+        /// <summary> Link pointing to the documentation of the configuration (also known as server parameter). </summary>
         [WirePath("properties.documentationLink")]
         public string DocumentationLink { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlFlexibleServer data model.
     /// Properties of a server.
-    /// Serialized Name: Server
     /// </summary>
     public partial class PostgreSqlFlexibleServerData : TrackedResourceData
     {
@@ -66,102 +65,30 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="sku">
-        /// Compute tier and size of a server.
-        /// Serialized Name: Server.sku
-        /// </param>
-        /// <param name="identity">
-        /// User assigned managed identities assigned to the server.
-        /// Serialized Name: Server.identity
-        /// </param>
-        /// <param name="administratorLogin">
-        /// Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted.
-        /// Serialized Name: Server.properties.administratorLogin
-        /// </param>
-        /// <param name="administratorLoginPassword">
-        /// Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time.
-        /// Serialized Name: Server.properties.administratorLoginPassword
-        /// </param>
-        /// <param name="version">
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: Server.properties.version
-        /// </param>
-        /// <param name="minorVersion">
-        /// Minor version of PostgreSQL database engine.
-        /// Serialized Name: Server.properties.minorVersion
-        /// </param>
-        /// <param name="state">
-        /// Possible states of a server.
-        /// Serialized Name: Server.properties.state
-        /// </param>
-        /// <param name="fullyQualifiedDomainName">
-        /// Fully qualified domain name of a server.
-        /// Serialized Name: Server.properties.fullyQualifiedDomainName
-        /// </param>
-        /// <param name="storage">
-        /// Storage properties of a server.
-        /// Serialized Name: Server.properties.storage
-        /// </param>
-        /// <param name="authConfig">
-        /// Authentication configuration properties of a server.
-        /// Serialized Name: Server.properties.authConfig
-        /// </param>
-        /// <param name="dataEncryption">
-        /// Data encryption properties of a server.
-        /// Serialized Name: Server.properties.dataEncryption
-        /// </param>
-        /// <param name="backup">
-        /// Backup properties of a server.
-        /// Serialized Name: Server.properties.backup
-        /// </param>
-        /// <param name="network">
-        /// Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer.
-        /// Serialized Name: Server.properties.network
-        /// </param>
-        /// <param name="highAvailability">
-        /// High availability properties of a server.
-        /// Serialized Name: Server.properties.highAvailability
-        /// </param>
-        /// <param name="maintenanceWindow">
-        /// Maintenance window properties of a server.
-        /// Serialized Name: Server.properties.maintenanceWindow
-        /// </param>
-        /// <param name="sourceServerResourceId">
-        /// Identifier of the server to be used as the source of the new server. Required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', 'Replica', or 'ReviveDropped'. This property is returned only when the target server is a read replica.
-        /// Serialized Name: Server.properties.sourceServerResourceId
-        /// </param>
-        /// <param name="pointInTimeUtc">
-        /// Creation time (in ISO8601 format) of the backup which you want to restore in the new server. It's required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', or 'ReviveDropped'.
-        /// Serialized Name: Server.properties.pointInTimeUTC
-        /// </param>
-        /// <param name="availabilityZone">
-        /// Availability zone of a server.
-        /// Serialized Name: Server.properties.availabilityZone
-        /// </param>
-        /// <param name="replicationRole">
-        /// Role of the server in a replication set.
-        /// Serialized Name: Server.properties.replicationRole
-        /// </param>
-        /// <param name="replicaCapacity">
-        /// Maximum number of read replicas allowed for a server.
-        /// Serialized Name: Server.properties.replicaCapacity
-        /// </param>
-        /// <param name="replica">
-        /// Read replica properties of a server. Required only in case that you want to promote a server.
-        /// Serialized Name: Server.properties.replica
-        /// </param>
-        /// <param name="createMode">
-        /// Creation mode of a new server.
-        /// Serialized Name: Server.properties.createMode
-        /// </param>
-        /// <param name="privateEndpointConnections">
-        /// List of private endpoint connections associated with the specified server.
-        /// Serialized Name: Server.properties.privateEndpointConnections
-        /// </param>
-        /// <param name="cluster">
-        /// Cluster properties of a server.
-        /// Serialized Name: Server.properties.cluster
-        /// </param>
+        /// <param name="sku"> Compute tier and size of a server. </param>
+        /// <param name="identity"> User assigned managed identities assigned to the server. </param>
+        /// <param name="administratorLogin"> Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted. </param>
+        /// <param name="administratorLoginPassword"> Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time. </param>
+        /// <param name="version"> Major version of PostgreSQL database engine. </param>
+        /// <param name="minorVersion"> Minor version of PostgreSQL database engine. </param>
+        /// <param name="state"> Possible states of a server. </param>
+        /// <param name="fullyQualifiedDomainName"> Fully qualified domain name of a server. </param>
+        /// <param name="storage"> Storage properties of a server. </param>
+        /// <param name="authConfig"> Authentication configuration properties of a server. </param>
+        /// <param name="dataEncryption"> Data encryption properties of a server. </param>
+        /// <param name="backup"> Backup properties of a server. </param>
+        /// <param name="network"> Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer. </param>
+        /// <param name="highAvailability"> High availability properties of a server. </param>
+        /// <param name="maintenanceWindow"> Maintenance window properties of a server. </param>
+        /// <param name="sourceServerResourceId"> Identifier of the server to be used as the source of the new server. Required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', 'Replica', or 'ReviveDropped'. This property is returned only when the target server is a read replica. </param>
+        /// <param name="pointInTimeUtc"> Creation time (in ISO8601 format) of the backup which you want to restore in the new server. It's required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', or 'ReviveDropped'. </param>
+        /// <param name="availabilityZone"> Availability zone of a server. </param>
+        /// <param name="replicationRole"> Role of the server in a replication set. </param>
+        /// <param name="replicaCapacity"> Maximum number of read replicas allowed for a server. </param>
+        /// <param name="replica"> Read replica properties of a server. Required only in case that you want to promote a server. </param>
+        /// <param name="createMode"> Creation mode of a new server. </param>
+        /// <param name="privateEndpointConnections"> List of private endpoint connections associated with the specified server. </param>
+        /// <param name="cluster"> Cluster properties of a server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IDictionary<string, string> tags, AzureLocation location, PostgreSqlFlexibleServerSku sku, PostgreSqlFlexibleServerUserAssignedIdentity identity, string administratorLogin, string administratorLoginPassword, PostgreSqlFlexibleServerVersion? version, string minorVersion, PostgreSqlFlexibleServerState? state, string fullyQualifiedDomainName, PostgreSqlFlexibleServerStorage storage, PostgreSqlFlexibleServerAuthConfig authConfig, PostgreSqlFlexibleServerDataEncryption dataEncryption, PostgreSqlFlexibleServerBackupProperties backup, PostgreSqlFlexibleServerNetwork network, PostgreSqlFlexibleServerHighAvailability highAvailability, PostgreSqlFlexibleServerMaintenanceWindow maintenanceWindow, ResourceIdentifier sourceServerResourceId, DateTimeOffset? pointInTimeUtc, string availabilityZone, PostgreSqlFlexibleServerReplicationRole? replicationRole, int? replicaCapacity, PostgreSqlFlexibleServersReplica replica, PostgreSqlFlexibleServerCreateMode? createMode, IReadOnlyList<PostgreSqlFlexibleServersPrivateEndpointConnectionData> privateEndpointConnections, PostgreSqlFlexibleServerClusterProperties cluster, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData, tags, location)
         {
@@ -197,142 +124,73 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         {
         }
 
-        /// <summary>
-        /// Compute tier and size of a server.
-        /// Serialized Name: Server.sku
-        /// </summary>
+        /// <summary> Compute tier and size of a server. </summary>
         [WirePath("sku")]
         public PostgreSqlFlexibleServerSku Sku { get; set; }
-        /// <summary>
-        /// User assigned managed identities assigned to the server.
-        /// Serialized Name: Server.identity
-        /// </summary>
+        /// <summary> User assigned managed identities assigned to the server. </summary>
         [WirePath("identity")]
         public PostgreSqlFlexibleServerUserAssignedIdentity Identity { get; set; }
-        /// <summary>
-        /// Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted.
-        /// Serialized Name: Server.properties.administratorLogin
-        /// </summary>
+        /// <summary> Name of the login designated as the first password based administrator assigned to your instance of PostgreSQL. Must be specified the first time that you enable password based authentication on a server. Once set to a given value, it cannot be changed for the rest of the life of a server. If you disable password based authentication on a server which had it enabled, this password based role isn't deleted. </summary>
         [WirePath("properties.administratorLogin")]
         public string AdministratorLogin { get; set; }
-        /// <summary>
-        /// Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time.
-        /// Serialized Name: Server.properties.administratorLoginPassword
-        /// </summary>
+        /// <summary> Password assigned to the administrator login. As long as password authentication is enabled, this password can be changed at any time. </summary>
         [WirePath("properties.administratorLoginPassword")]
         public string AdministratorLoginPassword { get; set; }
-        /// <summary>
-        /// Major version of PostgreSQL database engine.
-        /// Serialized Name: Server.properties.version
-        /// </summary>
+        /// <summary> Major version of PostgreSQL database engine. </summary>
         [WirePath("properties.version")]
         public PostgreSqlFlexibleServerVersion? Version { get; set; }
-        /// <summary>
-        /// Minor version of PostgreSQL database engine.
-        /// Serialized Name: Server.properties.minorVersion
-        /// </summary>
+        /// <summary> Minor version of PostgreSQL database engine. </summary>
         [WirePath("properties.minorVersion")]
         public string MinorVersion { get; }
-        /// <summary>
-        /// Possible states of a server.
-        /// Serialized Name: Server.properties.state
-        /// </summary>
+        /// <summary> Possible states of a server. </summary>
         [WirePath("properties.state")]
         public PostgreSqlFlexibleServerState? State { get; }
-        /// <summary>
-        /// Fully qualified domain name of a server.
-        /// Serialized Name: Server.properties.fullyQualifiedDomainName
-        /// </summary>
+        /// <summary> Fully qualified domain name of a server. </summary>
         [WirePath("properties.fullyQualifiedDomainName")]
         public string FullyQualifiedDomainName { get; }
-        /// <summary>
-        /// Storage properties of a server.
-        /// Serialized Name: Server.properties.storage
-        /// </summary>
+        /// <summary> Storage properties of a server. </summary>
         [WirePath("properties.storage")]
         public PostgreSqlFlexibleServerStorage Storage { get; set; }
-        /// <summary>
-        /// Authentication configuration properties of a server.
-        /// Serialized Name: Server.properties.authConfig
-        /// </summary>
+        /// <summary> Authentication configuration properties of a server. </summary>
         [WirePath("properties.authConfig")]
         public PostgreSqlFlexibleServerAuthConfig AuthConfig { get; set; }
-        /// <summary>
-        /// Data encryption properties of a server.
-        /// Serialized Name: Server.properties.dataEncryption
-        /// </summary>
+        /// <summary> Data encryption properties of a server. </summary>
         [WirePath("properties.dataEncryption")]
         public PostgreSqlFlexibleServerDataEncryption DataEncryption { get; set; }
-        /// <summary>
-        /// Backup properties of a server.
-        /// Serialized Name: Server.properties.backup
-        /// </summary>
+        /// <summary> Backup properties of a server. </summary>
         [WirePath("properties.backup")]
         public PostgreSqlFlexibleServerBackupProperties Backup { get; set; }
-        /// <summary>
-        /// Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer.
-        /// Serialized Name: Server.properties.network
-        /// </summary>
+        /// <summary> Network properties of a server. Only required if you want your server to be integrated into a virtual network provided by customer. </summary>
         [WirePath("properties.network")]
         public PostgreSqlFlexibleServerNetwork Network { get; set; }
-        /// <summary>
-        /// High availability properties of a server.
-        /// Serialized Name: Server.properties.highAvailability
-        /// </summary>
+        /// <summary> High availability properties of a server. </summary>
         [WirePath("properties.highAvailability")]
         public PostgreSqlFlexibleServerHighAvailability HighAvailability { get; set; }
-        /// <summary>
-        /// Maintenance window properties of a server.
-        /// Serialized Name: Server.properties.maintenanceWindow
-        /// </summary>
+        /// <summary> Maintenance window properties of a server. </summary>
         [WirePath("properties.maintenanceWindow")]
         public PostgreSqlFlexibleServerMaintenanceWindow MaintenanceWindow { get; set; }
-        /// <summary>
-        /// Identifier of the server to be used as the source of the new server. Required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', 'Replica', or 'ReviveDropped'. This property is returned only when the target server is a read replica.
-        /// Serialized Name: Server.properties.sourceServerResourceId
-        /// </summary>
+        /// <summary> Identifier of the server to be used as the source of the new server. Required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', 'Replica', or 'ReviveDropped'. This property is returned only when the target server is a read replica. </summary>
         [WirePath("properties.sourceServerResourceId")]
         public ResourceIdentifier SourceServerResourceId { get; set; }
-        /// <summary>
-        /// Creation time (in ISO8601 format) of the backup which you want to restore in the new server. It's required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', or 'ReviveDropped'.
-        /// Serialized Name: Server.properties.pointInTimeUTC
-        /// </summary>
+        /// <summary> Creation time (in ISO8601 format) of the backup which you want to restore in the new server. It's required when 'createMode' is 'PointInTimeRestore', 'GeoRestore', or 'ReviveDropped'. </summary>
         [WirePath("properties.pointInTimeUTC")]
         public DateTimeOffset? PointInTimeUtc { get; set; }
-        /// <summary>
-        /// Availability zone of a server.
-        /// Serialized Name: Server.properties.availabilityZone
-        /// </summary>
+        /// <summary> Availability zone of a server. </summary>
         [WirePath("properties.availabilityZone")]
         public string AvailabilityZone { get; set; }
-        /// <summary>
-        /// Role of the server in a replication set.
-        /// Serialized Name: Server.properties.replicationRole
-        /// </summary>
+        /// <summary> Role of the server in a replication set. </summary>
         [WirePath("properties.replicationRole")]
         public PostgreSqlFlexibleServerReplicationRole? ReplicationRole { get; set; }
-        /// <summary>
-        /// Read replica properties of a server. Required only in case that you want to promote a server.
-        /// Serialized Name: Server.properties.replica
-        /// </summary>
+        /// <summary> Read replica properties of a server. Required only in case that you want to promote a server. </summary>
         [WirePath("properties.replica")]
         public PostgreSqlFlexibleServersReplica Replica { get; set; }
-        /// <summary>
-        /// Creation mode of a new server.
-        /// Serialized Name: Server.properties.createMode
-        /// </summary>
+        /// <summary> Creation mode of a new server. </summary>
         [WirePath("properties.createMode")]
         public PostgreSqlFlexibleServerCreateMode? CreateMode { get; set; }
-        /// <summary>
-        /// List of private endpoint connections associated with the specified server.
-        /// Serialized Name: Server.properties.privateEndpointConnections
-        /// </summary>
+        /// <summary> List of private endpoint connections associated with the specified server. </summary>
         [WirePath("properties.privateEndpointConnections")]
         public IReadOnlyList<PostgreSqlFlexibleServersPrivateEndpointConnectionData> PrivateEndpointConnections { get; }
-        /// <summary>
-        /// Cluster properties of a server.
-        /// Serialized Name: Server.properties.cluster
-        /// </summary>
+        /// <summary> Cluster properties of a server. </summary>
         [WirePath("properties.cluster")]
         public PostgreSqlFlexibleServerClusterProperties Cluster { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerDatabaseData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerDatabaseData.cs
@@ -15,7 +15,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlFlexibleServerDatabase data model.
     /// Represents a database.
-    /// Serialized Name: Database
     /// </summary>
     public partial class PostgreSqlFlexibleServerDatabaseData : ResourceData
     {
@@ -61,14 +60,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="charset">
-        /// Character set of the database.
-        /// Serialized Name: Database.properties.charset
-        /// </param>
-        /// <param name="collation">
-        /// Collation of the database.
-        /// Serialized Name: Database.properties.collation
-        /// </param>
+        /// <param name="charset"> Character set of the database. </param>
+        /// <param name="collation"> Collation of the database. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerDatabaseData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string charset, string collation, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -77,16 +70,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Character set of the database.
-        /// Serialized Name: Database.properties.charset
-        /// </summary>
+        /// <summary> Character set of the database. </summary>
         [WirePath("properties.charset")]
         public string Charset { get; set; }
-        /// <summary>
-        /// Collation of the database.
-        /// Serialized Name: Database.properties.collation
-        /// </summary>
+        /// <summary> Collation of the database. </summary>
         [WirePath("properties.collation")]
         public string Collation { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerFirewallRuleData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerFirewallRuleData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlFlexibleServerFirewallRule data model.
     /// Firewall rule.
-    /// Serialized Name: FirewallRule
     /// </summary>
     public partial class PostgreSqlFlexibleServerFirewallRuleData : ResourceData
     {
@@ -53,14 +52,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="PostgreSqlFlexibleServerFirewallRuleData"/>. </summary>
-        /// <param name="startIPAddress">
-        /// IP address defining the start of the range of addresses of a firewall rule. Must be expressed in IPv4 format.
-        /// Serialized Name: FirewallRule.properties.startIpAddress
-        /// </param>
-        /// <param name="endIPAddress">
-        /// IP address defining the end of the range of addresses of a firewall rule. Must be expressed in IPv4 format.
-        /// Serialized Name: FirewallRule.properties.endIpAddress
-        /// </param>
+        /// <param name="startIPAddress"> IP address defining the start of the range of addresses of a firewall rule. Must be expressed in IPv4 format. </param>
+        /// <param name="endIPAddress"> IP address defining the end of the range of addresses of a firewall rule. Must be expressed in IPv4 format. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="startIPAddress"/> or <paramref name="endIPAddress"/> is null. </exception>
         public PostgreSqlFlexibleServerFirewallRuleData(IPAddress startIPAddress, IPAddress endIPAddress)
         {
@@ -76,14 +69,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="startIPAddress">
-        /// IP address defining the start of the range of addresses of a firewall rule. Must be expressed in IPv4 format.
-        /// Serialized Name: FirewallRule.properties.startIpAddress
-        /// </param>
-        /// <param name="endIPAddress">
-        /// IP address defining the end of the range of addresses of a firewall rule. Must be expressed in IPv4 format.
-        /// Serialized Name: FirewallRule.properties.endIpAddress
-        /// </param>
+        /// <param name="startIPAddress"> IP address defining the start of the range of addresses of a firewall rule. Must be expressed in IPv4 format. </param>
+        /// <param name="endIPAddress"> IP address defining the end of the range of addresses of a firewall rule. Must be expressed in IPv4 format. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerFirewallRuleData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IPAddress startIPAddress, IPAddress endIPAddress, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -97,16 +84,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         {
         }
 
-        /// <summary>
-        /// IP address defining the start of the range of addresses of a firewall rule. Must be expressed in IPv4 format.
-        /// Serialized Name: FirewallRule.properties.startIpAddress
-        /// </summary>
+        /// <summary> IP address defining the start of the range of addresses of a firewall rule. Must be expressed in IPv4 format. </summary>
         [WirePath("properties.startIpAddress")]
         public IPAddress StartIPAddress { get; set; }
-        /// <summary>
-        /// IP address defining the end of the range of addresses of a firewall rule. Must be expressed in IPv4 format.
-        /// Serialized Name: FirewallRule.properties.endIpAddress
-        /// </summary>
+        /// <summary> IP address defining the end of the range of addresses of a firewall rule. Must be expressed in IPv4 format. </summary>
         [WirePath("properties.endIpAddress")]
         public IPAddress EndIPAddress { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerMicrosoftEntraAdministratorData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerMicrosoftEntraAdministratorData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlFlexibleServerMicrosoftEntraAdministrator data model.
     /// Server administrator associated to a Microsoft Entra principal.
-    /// Serialized Name: AdministratorMicrosoftEntra
     /// </summary>
     public partial class PostgreSqlFlexibleServerMicrosoftEntraAdministratorData : ResourceData
     {
@@ -62,22 +61,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="principalType">
-        /// Type of Microsoft Entra principal to which the server administrator is associated.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.principalType
-        /// </param>
-        /// <param name="principalName">
-        /// Name of the Microsoft Entra principal.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.principalName
-        /// </param>
-        /// <param name="objectId">
-        /// Object identifier of the Microsoft Entra principal.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.objectId
-        /// </param>
-        /// <param name="tenantId">
-        /// Identifier of the tenant in which the Microsoft Entra principal exists.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.tenantId
-        /// </param>
+        /// <param name="principalType"> Type of Microsoft Entra principal to which the server administrator is associated. </param>
+        /// <param name="principalName"> Name of the Microsoft Entra principal. </param>
+        /// <param name="objectId"> Object identifier of the Microsoft Entra principal. </param>
+        /// <param name="tenantId"> Identifier of the tenant in which the Microsoft Entra principal exists. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServerMicrosoftEntraAdministratorData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, PostgreSqlFlexibleServerPrincipalType? principalType, string principalName, Guid? objectId, Guid? tenantId, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -88,28 +75,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Type of Microsoft Entra principal to which the server administrator is associated.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.principalType
-        /// </summary>
+        /// <summary> Type of Microsoft Entra principal to which the server administrator is associated. </summary>
         [WirePath("properties.principalType")]
         public PostgreSqlFlexibleServerPrincipalType? PrincipalType { get; set; }
-        /// <summary>
-        /// Name of the Microsoft Entra principal.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.principalName
-        /// </summary>
+        /// <summary> Name of the Microsoft Entra principal. </summary>
         [WirePath("properties.principalName")]
         public string PrincipalName { get; set; }
-        /// <summary>
-        /// Object identifier of the Microsoft Entra principal.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.objectId
-        /// </summary>
+        /// <summary> Object identifier of the Microsoft Entra principal. </summary>
         [WirePath("properties.objectId")]
         public Guid? ObjectId { get; set; }
-        /// <summary>
-        /// Identifier of the tenant in which the Microsoft Entra principal exists.
-        /// Serialized Name: AdministratorMicrosoftEntra.properties.tenantId
-        /// </summary>
+        /// <summary> Identifier of the tenant in which the Microsoft Entra principal exists. </summary>
         [WirePath("properties.tenantId")]
         public Guid? TenantId { get; set; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerTuningOptionData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServerTuningOptionData.cs
@@ -15,7 +15,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlFlexibleServerTuningOption data model.
     /// Impact on some metric if this recommended action is applied.
-    /// Serialized Name: TuningOptions
     /// </summary>
     public partial class PostgreSqlFlexibleServerTuningOptionData : ResourceData
     {

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServersPrivateEndpointConnectionData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServersPrivateEndpointConnectionData.cs
@@ -17,7 +17,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlFlexibleServersPrivateEndpointConnection data model.
     /// The private endpoint connection resource.
-    /// Serialized Name: PrivateEndpointConnection
     /// </summary>
     public partial class PostgreSqlFlexibleServersPrivateEndpointConnectionData : ResourceData
     {
@@ -64,22 +63,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="groupIds">
-        /// The group ids for the private endpoint resource.
-        /// Serialized Name: PrivateEndpointConnection.properties.groupIds
-        /// </param>
-        /// <param name="privateEndpoint">
-        /// The private endpoint resource.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateEndpoint
-        /// </param>
-        /// <param name="connectionState">
-        /// A collection of information about the state of the connection between service consumer and provider.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateLinkServiceConnectionState
-        /// </param>
-        /// <param name="provisioningState">
-        /// The provisioning state of the private endpoint connection resource.
-        /// Serialized Name: PrivateEndpointConnection.properties.provisioningState
-        /// </param>
+        /// <param name="groupIds"> The group ids for the private endpoint resource. </param>
+        /// <param name="privateEndpoint"> The private endpoint resource. </param>
+        /// <param name="connectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
+        /// <param name="provisioningState"> The provisioning state of the private endpoint connection resource. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServersPrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IReadOnlyList<string> groupIds, SubResource privateEndpoint, PostgreSqlFlexibleServersPrivateLinkServiceConnectionState connectionState, PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState? provisioningState, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -90,16 +77,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The group ids for the private endpoint resource.
-        /// Serialized Name: PrivateEndpointConnection.properties.groupIds
-        /// </summary>
+        /// <summary> The group ids for the private endpoint resource. </summary>
         [WirePath("properties.groupIds")]
         public IReadOnlyList<string> GroupIds { get; }
-        /// <summary>
-        /// The private endpoint resource.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateEndpoint
-        /// </summary>
+        /// <summary> The private endpoint resource. </summary>
         internal SubResource PrivateEndpoint { get; set; }
         /// <summary> Gets Id. </summary>
         [WirePath("properties.privateEndpoint.id")]
@@ -108,16 +89,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             get => PrivateEndpoint is null ? default : PrivateEndpoint.Id;
         }
 
-        /// <summary>
-        /// A collection of information about the state of the connection between service consumer and provider.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateLinkServiceConnectionState
-        /// </summary>
+        /// <summary> A collection of information about the state of the connection between service consumer and provider. </summary>
         [WirePath("properties.privateLinkServiceConnectionState")]
         public PostgreSqlFlexibleServersPrivateLinkServiceConnectionState ConnectionState { get; set; }
-        /// <summary>
-        /// The provisioning state of the private endpoint connection resource.
-        /// Serialized Name: PrivateEndpointConnection.properties.provisioningState
-        /// </summary>
+        /// <summary> The provisioning state of the private endpoint connection resource. </summary>
         [WirePath("properties.provisioningState")]
         public PostgreSqlFlexibleServersPrivateEndpointConnectionProvisioningState? ProvisioningState { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServersPrivateLinkResourceData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlFlexibleServersPrivateLinkResourceData.cs
@@ -15,7 +15,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlFlexibleServersPrivateLinkResource data model.
     /// A private link resource.
-    /// Serialized Name: PrivateLinkResource
     /// </summary>
     public partial class PostgreSqlFlexibleServersPrivateLinkResourceData : ResourceData
     {
@@ -63,18 +62,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="groupId">
-        /// The private link resource group id.
-        /// Serialized Name: PrivateLinkResource.properties.groupId
-        /// </param>
-        /// <param name="requiredMembers">
-        /// The private link resource required member names.
-        /// Serialized Name: PrivateLinkResource.properties.requiredMembers
-        /// </param>
-        /// <param name="requiredZoneNames">
-        /// The private link resource private link DNS zone name.
-        /// Serialized Name: PrivateLinkResource.properties.requiredZoneNames
-        /// </param>
+        /// <param name="groupId"> The private link resource group id. </param>
+        /// <param name="requiredMembers"> The private link resource required member names. </param>
+        /// <param name="requiredZoneNames"> The private link resource private link DNS zone name. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlFlexibleServersPrivateLinkResourceData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string groupId, IReadOnlyList<string> requiredMembers, IList<string> requiredZoneNames, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -84,22 +74,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The private link resource group id.
-        /// Serialized Name: PrivateLinkResource.properties.groupId
-        /// </summary>
+        /// <summary> The private link resource group id. </summary>
         [WirePath("properties.groupId")]
         public string GroupId { get; }
-        /// <summary>
-        /// The private link resource required member names.
-        /// Serialized Name: PrivateLinkResource.properties.requiredMembers
-        /// </summary>
+        /// <summary> The private link resource required member names. </summary>
         [WirePath("properties.requiredMembers")]
         public IReadOnlyList<string> RequiredMembers { get; }
-        /// <summary>
-        /// The private link resource private link DNS zone name.
-        /// Serialized Name: PrivateLinkResource.properties.requiredZoneNames
-        /// </summary>
+        /// <summary> The private link resource private link DNS zone name. </summary>
         [WirePath("properties.requiredZoneNames")]
         public IList<string> RequiredZoneNames { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlLtrServerBackupOperationData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlLtrServerBackupOperationData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlLtrServerBackupOperation data model.
     /// Response for the LTR backup Operation API call
-    /// Serialized Name: BackupsLongTermRetentionOperation
     /// </summary>
     public partial class PostgreSqlLtrServerBackupOperationData : ResourceData
     {
@@ -62,46 +61,16 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="datasourceSizeInBytes">
-        /// Size of datasource in bytes
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.datasourceSizeInBytes
-        /// </param>
-        /// <param name="dataTransferredInBytes">
-        /// Data transferred in bytes
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.dataTransferredInBytes
-        /// </param>
-        /// <param name="backupName">
-        /// Name of Backup operation
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.backupName
-        /// </param>
-        /// <param name="backupMetadata">
-        /// Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.backupMetadata
-        /// </param>
-        /// <param name="status">
-        /// Service-set extensible enum indicating the status of operation
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.status
-        /// </param>
-        /// <param name="startOn">
-        /// Start time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.startTime
-        /// </param>
-        /// <param name="endOn">
-        /// End time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.endTime
-        /// </param>
-        /// <param name="percentComplete">
-        /// PercentageCompleted
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.percentComplete
-        /// </param>
-        /// <param name="errorCode">
-        /// The error code.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.errorCode
-        /// </param>
-        /// <param name="errorMessage">
-        /// The error message.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.errorMessage
-        /// </param>
+        /// <param name="datasourceSizeInBytes"> Size of datasource in bytes. </param>
+        /// <param name="dataTransferredInBytes"> Data transferred in bytes. </param>
+        /// <param name="backupName"> Name of Backup operation. </param>
+        /// <param name="backupMetadata"> Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc. </param>
+        /// <param name="status"> Service-set extensible enum indicating the status of operation. </param>
+        /// <param name="startOn"> Start time of the operation. </param>
+        /// <param name="endOn"> End time of the operation. </param>
+        /// <param name="percentComplete"> PercentageCompleted. </param>
+        /// <param name="errorCode"> The error code. </param>
+        /// <param name="errorMessage"> The error message. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlLtrServerBackupOperationData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, long? datasourceSizeInBytes, long? dataTransferredInBytes, string backupName, string backupMetadata, PostgreSqlExecutionStatus? status, DateTimeOffset? startOn, DateTimeOffset? endOn, double? percentComplete, string errorCode, string errorMessage, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -118,64 +87,34 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Size of datasource in bytes
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.datasourceSizeInBytes
-        /// </summary>
+        /// <summary> Size of datasource in bytes. </summary>
         [WirePath("properties.datasourceSizeInBytes")]
         public long? DatasourceSizeInBytes { get; set; }
-        /// <summary>
-        /// Data transferred in bytes
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.dataTransferredInBytes
-        /// </summary>
+        /// <summary> Data transferred in bytes. </summary>
         [WirePath("properties.dataTransferredInBytes")]
         public long? DataTransferredInBytes { get; set; }
-        /// <summary>
-        /// Name of Backup operation
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.backupName
-        /// </summary>
+        /// <summary> Name of Backup operation. </summary>
         [WirePath("properties.backupName")]
         public string BackupName { get; set; }
-        /// <summary>
-        /// Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.backupMetadata
-        /// </summary>
+        /// <summary> Metadata to be stored in RP. Store everything that will be required to perform a successful restore using this Recovery point. e.g. Versions, DataFormat etc. </summary>
         [WirePath("properties.backupMetadata")]
         public string BackupMetadata { get; set; }
-        /// <summary>
-        /// Service-set extensible enum indicating the status of operation
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.status
-        /// </summary>
+        /// <summary> Service-set extensible enum indicating the status of operation. </summary>
         [WirePath("properties.status")]
         public PostgreSqlExecutionStatus? Status { get; set; }
-        /// <summary>
-        /// Start time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.startTime
-        /// </summary>
+        /// <summary> Start time of the operation. </summary>
         [WirePath("properties.startTime")]
         public DateTimeOffset? StartOn { get; set; }
-        /// <summary>
-        /// End time of the operation.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.endTime
-        /// </summary>
+        /// <summary> End time of the operation. </summary>
         [WirePath("properties.endTime")]
         public DateTimeOffset? EndOn { get; set; }
-        /// <summary>
-        /// PercentageCompleted
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.percentComplete
-        /// </summary>
+        /// <summary> PercentageCompleted. </summary>
         [WirePath("properties.percentComplete")]
         public double? PercentComplete { get; set; }
-        /// <summary>
-        /// The error code.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.errorCode
-        /// </summary>
+        /// <summary> The error code. </summary>
         [WirePath("properties.errorCode")]
         public string ErrorCode { get; }
-        /// <summary>
-        /// The error message.
-        /// Serialized Name: BackupsLongTermRetentionOperation.properties.errorMessage
-        /// </summary>
+        /// <summary> The error message. </summary>
         [WirePath("properties.errorMessage")]
         public string ErrorMessage { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlMigrationData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/PostgreSqlMigrationData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the PostgreSqlMigration data model.
     /// Properties of a migration.
-    /// Serialized Name: Migration
     /// </summary>
     public partial class PostgreSqlMigrationData : TrackedResourceData
     {
@@ -68,106 +67,31 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="migrationId">
-        /// Identifier of a migration.
-        /// Serialized Name: Migration.properties.migrationId
-        /// </param>
-        /// <param name="currentStatus">
-        /// Current status of a migration.
-        /// Serialized Name: Migration.properties.currentStatus
-        /// </param>
-        /// <param name="migrationInstanceResourceId">
-        /// Identifier of the private endpoint migration instance.
-        /// Serialized Name: Migration.properties.migrationInstanceResourceId
-        /// </param>
-        /// <param name="migrationMode">
-        /// Mode used to perform the migration: Online or Offline.
-        /// Serialized Name: Migration.properties.migrationMode
-        /// </param>
-        /// <param name="migrationOption">
-        /// Supported option for a migration.
-        /// Serialized Name: Migration.properties.migrationOption
-        /// </param>
-        /// <param name="sourceType">
-        /// Source server type used for the migration: ApsaraDB_RDS, AWS, AWS_AURORA, AWS_EC2, AWS_RDS, AzureVM, Crunchy_PostgreSQL, Digital_Ocean_Droplets, Digital_Ocean_PostgreSQL, EDB, EDB_Oracle_Server, EDB_PostgreSQL, GCP, GCP_AlloyDB, GCP_CloudSQL, GCP_Compute, Heroku_PostgreSQL, Huawei_Compute, Huawei_RDS, OnPremises, PostgreSQLCosmosDB, PostgreSQLFlexibleServer, PostgreSQLSingleServer, or Supabase_PostgreSQL
-        /// Serialized Name: Migration.properties.sourceType
-        /// </param>
-        /// <param name="sslMode">
-        /// SSL mode used by a migration. Default SSL mode for 'PostgreSQLSingleServer' is 'VerifyFull'. Default SSL mode for other source types is 'Prefer'.
-        /// Serialized Name: Migration.properties.sslMode
-        /// </param>
-        /// <param name="sourceDbServerMetadata">
-        /// Metadata of source database server.
-        /// Serialized Name: Migration.properties.sourceDbServerMetadata
-        /// </param>
-        /// <param name="targetDbServerMetadata">
-        /// Metadata of target database server.
-        /// Serialized Name: Migration.properties.targetDbServerMetadata
-        /// </param>
-        /// <param name="sourceDbServerResourceId">
-        /// Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username.
-        /// Serialized Name: Migration.properties.sourceDbServerResourceId
-        /// </param>
-        /// <param name="sourceDbServerFullyQualifiedDomainName">
-        /// Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server.
-        /// Serialized Name: Migration.properties.sourceDbServerFullyQualifiedDomainName
-        /// </param>
-        /// <param name="targetDbServerResourceId">
-        /// Identifier of the target database server resource.
-        /// Serialized Name: Migration.properties.targetDbServerResourceId
-        /// </param>
-        /// <param name="targetDbServerFullyQualifiedDomainName">
-        /// Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server.
-        /// Serialized Name: Migration.properties.targetDbServerFullyQualifiedDomainName
-        /// </param>
-        /// <param name="secretParameters">
-        /// Migration secret parameters.
-        /// Serialized Name: Migration.properties.secretParameters
-        /// </param>
-        /// <param name="dbsToMigrate">
-        /// Names of databases to migrate.
-        /// Serialized Name: Migration.properties.dbsToMigrate
-        /// </param>
-        /// <param name="setupLogicalReplicationOnSourceDbIfNeeded">
-        /// Indicates whether to setup logical replication on source server, if needed.
-        /// Serialized Name: Migration.properties.setupLogicalReplicationOnSourceDbIfNeeded
-        /// </param>
-        /// <param name="overwriteDbsInTarget">
-        /// Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation.
-        /// Serialized Name: Migration.properties.overwriteDbsInTarget
-        /// </param>
-        /// <param name="migrationWindowStartTimeInUtc">
-        /// Start time (UTC) for migration window.
-        /// Serialized Name: Migration.properties.migrationWindowStartTimeInUtc
-        /// </param>
-        /// <param name="migrationWindowEndTimeInUtc">
-        /// End time (UTC) for migration window.
-        /// Serialized Name: Migration.properties.migrationWindowEndTimeInUtc
-        /// </param>
-        /// <param name="migrateRoles">
-        /// Indicates if roles and permissions must be migrated.
-        /// Serialized Name: Migration.properties.migrateRoles
-        /// </param>
-        /// <param name="startDataMigration">
-        /// Indicates if data migration must start right away.
-        /// Serialized Name: Migration.properties.startDataMigration
-        /// </param>
-        /// <param name="triggerCutover">
-        /// Indicates if cutover must be triggered for the entire migration.
-        /// Serialized Name: Migration.properties.triggerCutover
-        /// </param>
-        /// <param name="dbsToTriggerCutoverOn">
-        /// When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: Migration.properties.dbsToTriggerCutoverOn
-        /// </param>
-        /// <param name="cancel">
-        /// Indicates if cancel must be triggered for the entire migration.
-        /// Serialized Name: Migration.properties.cancel
-        /// </param>
-        /// <param name="dbsToCancelMigrationOn">
-        /// When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: Migration.properties.dbsToCancelMigrationOn
-        /// </param>
+        /// <param name="migrationId"> Identifier of a migration. </param>
+        /// <param name="currentStatus"> Current status of a migration. </param>
+        /// <param name="migrationInstanceResourceId"> Identifier of the private endpoint migration instance. </param>
+        /// <param name="migrationMode"> Mode used to perform the migration: Online or Offline. </param>
+        /// <param name="migrationOption"> Supported option for a migration. </param>
+        /// <param name="sourceType"> Source server type used for the migration: ApsaraDB_RDS, AWS, AWS_AURORA, AWS_EC2, AWS_RDS, AzureVM, Crunchy_PostgreSQL, Digital_Ocean_Droplets, Digital_Ocean_PostgreSQL, EDB, EDB_Oracle_Server, EDB_PostgreSQL, GCP, GCP_AlloyDB, GCP_CloudSQL, GCP_Compute, Heroku_PostgreSQL, Huawei_Compute, Huawei_RDS, OnPremises, PostgreSQLCosmosDB, PostgreSQLFlexibleServer, PostgreSQLSingleServer, or Supabase_PostgreSQL. </param>
+        /// <param name="sslMode"> SSL mode used by a migration. Default SSL mode for 'PostgreSQLSingleServer' is 'VerifyFull'. Default SSL mode for other source types is 'Prefer'. </param>
+        /// <param name="sourceDbServerMetadata"> Metadata of source database server. </param>
+        /// <param name="targetDbServerMetadata"> Metadata of target database server. </param>
+        /// <param name="sourceDbServerResourceId"> Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username. </param>
+        /// <param name="sourceDbServerFullyQualifiedDomainName"> Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server. </param>
+        /// <param name="targetDbServerResourceId"> Identifier of the target database server resource. </param>
+        /// <param name="targetDbServerFullyQualifiedDomainName"> Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server. </param>
+        /// <param name="secretParameters"> Migration secret parameters. </param>
+        /// <param name="dbsToMigrate"> Names of databases to migrate. </param>
+        /// <param name="setupLogicalReplicationOnSourceDbIfNeeded"> Indicates whether to setup logical replication on source server, if needed. </param>
+        /// <param name="overwriteDbsInTarget"> Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation. </param>
+        /// <param name="migrationWindowStartTimeInUtc"> Start time (UTC) for migration window. </param>
+        /// <param name="migrationWindowEndTimeInUtc"> End time (UTC) for migration window. </param>
+        /// <param name="migrateRoles"> Indicates if roles and permissions must be migrated. </param>
+        /// <param name="startDataMigration"> Indicates if data migration must start right away. </param>
+        /// <param name="triggerCutover"> Indicates if cutover must be triggered for the entire migration. </param>
+        /// <param name="dbsToTriggerCutoverOn"> When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </param>
+        /// <param name="cancel"> Indicates if cancel must be triggered for the entire migration. </param>
+        /// <param name="dbsToCancelMigrationOn"> When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal PostgreSqlMigrationData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IDictionary<string, string> tags, AzureLocation location, string migrationId, PostgreSqlMigrationStatus currentStatus, ResourceIdentifier migrationInstanceResourceId, PostgreSqlMigrationMode? migrationMode, MigrationOption? migrationOption, PostgreSqlFlexibleServersSourceType? sourceType, PostgreSqlFlexibleServersSslMode? sslMode, PostgreSqlServerMetadata sourceDbServerMetadata, PostgreSqlServerMetadata targetDbServerMetadata, ResourceIdentifier sourceDbServerResourceId, string sourceDbServerFullyQualifiedDomainName, ResourceIdentifier targetDbServerResourceId, string targetDbServerFullyQualifiedDomainName, PostgreSqlMigrationSecretParameters secretParameters, IList<string> dbsToMigrate, PostgreSqlMigrationLogicalReplicationOnSourceDb? setupLogicalReplicationOnSourceDbIfNeeded, PostgreSqlMigrationOverwriteDbsInTarget? overwriteDbsInTarget, DateTimeOffset? migrationWindowStartTimeInUtc, DateTimeOffset? migrationWindowEndTimeInUtc, MigrateRolesEnum? migrateRoles, PostgreSqlMigrationStartDataMigration? startDataMigration, PostgreSqlMigrationTriggerCutover? triggerCutover, IList<string> dbsToTriggerCutoverOn, PostgreSqlMigrationCancel? cancel, IList<string> dbsToCancelMigrationOn, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData, tags, location)
         {
@@ -204,154 +128,79 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         {
         }
 
-        /// <summary>
-        /// Identifier of a migration.
-        /// Serialized Name: Migration.properties.migrationId
-        /// </summary>
+        /// <summary> Identifier of a migration. </summary>
         [WirePath("properties.migrationId")]
         public string MigrationId { get; }
-        /// <summary>
-        /// Current status of a migration.
-        /// Serialized Name: Migration.properties.currentStatus
-        /// </summary>
+        /// <summary> Current status of a migration. </summary>
         [WirePath("properties.currentStatus")]
         public PostgreSqlMigrationStatus CurrentStatus { get; }
-        /// <summary>
-        /// Identifier of the private endpoint migration instance.
-        /// Serialized Name: Migration.properties.migrationInstanceResourceId
-        /// </summary>
+        /// <summary> Identifier of the private endpoint migration instance. </summary>
         [WirePath("properties.migrationInstanceResourceId")]
         public ResourceIdentifier MigrationInstanceResourceId { get; set; }
-        /// <summary>
-        /// Mode used to perform the migration: Online or Offline.
-        /// Serialized Name: Migration.properties.migrationMode
-        /// </summary>
+        /// <summary> Mode used to perform the migration: Online or Offline. </summary>
         [WirePath("properties.migrationMode")]
         public PostgreSqlMigrationMode? MigrationMode { get; set; }
-        /// <summary>
-        /// Supported option for a migration.
-        /// Serialized Name: Migration.properties.migrationOption
-        /// </summary>
+        /// <summary> Supported option for a migration. </summary>
         [WirePath("properties.migrationOption")]
         public MigrationOption? MigrationOption { get; set; }
-        /// <summary>
-        /// Source server type used for the migration: ApsaraDB_RDS, AWS, AWS_AURORA, AWS_EC2, AWS_RDS, AzureVM, Crunchy_PostgreSQL, Digital_Ocean_Droplets, Digital_Ocean_PostgreSQL, EDB, EDB_Oracle_Server, EDB_PostgreSQL, GCP, GCP_AlloyDB, GCP_CloudSQL, GCP_Compute, Heroku_PostgreSQL, Huawei_Compute, Huawei_RDS, OnPremises, PostgreSQLCosmosDB, PostgreSQLFlexibleServer, PostgreSQLSingleServer, or Supabase_PostgreSQL
-        /// Serialized Name: Migration.properties.sourceType
-        /// </summary>
+        /// <summary> Source server type used for the migration: ApsaraDB_RDS, AWS, AWS_AURORA, AWS_EC2, AWS_RDS, AzureVM, Crunchy_PostgreSQL, Digital_Ocean_Droplets, Digital_Ocean_PostgreSQL, EDB, EDB_Oracle_Server, EDB_PostgreSQL, GCP, GCP_AlloyDB, GCP_CloudSQL, GCP_Compute, Heroku_PostgreSQL, Huawei_Compute, Huawei_RDS, OnPremises, PostgreSQLCosmosDB, PostgreSQLFlexibleServer, PostgreSQLSingleServer, or Supabase_PostgreSQL. </summary>
         [WirePath("properties.sourceType")]
         public PostgreSqlFlexibleServersSourceType? SourceType { get; set; }
-        /// <summary>
-        /// SSL mode used by a migration. Default SSL mode for 'PostgreSQLSingleServer' is 'VerifyFull'. Default SSL mode for other source types is 'Prefer'.
-        /// Serialized Name: Migration.properties.sslMode
-        /// </summary>
+        /// <summary> SSL mode used by a migration. Default SSL mode for 'PostgreSQLSingleServer' is 'VerifyFull'. Default SSL mode for other source types is 'Prefer'. </summary>
         [WirePath("properties.sslMode")]
         public PostgreSqlFlexibleServersSslMode? SslMode { get; set; }
-        /// <summary>
-        /// Metadata of source database server.
-        /// Serialized Name: Migration.properties.sourceDbServerMetadata
-        /// </summary>
+        /// <summary> Metadata of source database server. </summary>
         [WirePath("properties.sourceDbServerMetadata")]
         public PostgreSqlServerMetadata SourceDbServerMetadata { get; }
-        /// <summary>
-        /// Metadata of target database server.
-        /// Serialized Name: Migration.properties.targetDbServerMetadata
-        /// </summary>
+        /// <summary> Metadata of target database server. </summary>
         [WirePath("properties.targetDbServerMetadata")]
         public PostgreSqlServerMetadata TargetDbServerMetadata { get; }
-        /// <summary>
-        /// Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username.
-        /// Serialized Name: Migration.properties.sourceDbServerResourceId
-        /// </summary>
+        /// <summary> Identifier of the source database server resource, when 'sourceType' is 'PostgreSQLSingleServer'. For other source types this must be set to ipaddress:port@username or hostname:port@username. </summary>
         [WirePath("properties.sourceDbServerResourceId")]
         public ResourceIdentifier SourceDbServerResourceId { get; set; }
-        /// <summary>
-        /// Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server.
-        /// Serialized Name: Migration.properties.sourceDbServerFullyQualifiedDomainName
-        /// </summary>
+        /// <summary> Fully qualified domain name (FQDN) or IP address of the source server. This property is optional. When provided, the migration service will always use it to connect to the source server. </summary>
         [WirePath("properties.sourceDbServerFullyQualifiedDomainName")]
         public string SourceDbServerFullyQualifiedDomainName { get; set; }
-        /// <summary>
-        /// Identifier of the target database server resource.
-        /// Serialized Name: Migration.properties.targetDbServerResourceId
-        /// </summary>
+        /// <summary> Identifier of the target database server resource. </summary>
         [WirePath("properties.targetDbServerResourceId")]
         public ResourceIdentifier TargetDbServerResourceId { get; }
-        /// <summary>
-        /// Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server.
-        /// Serialized Name: Migration.properties.targetDbServerFullyQualifiedDomainName
-        /// </summary>
+        /// <summary> Fully qualified domain name (FQDN) or IP address of the target server. This property is optional. When provided, the migration service will always use it to connect to the target server. </summary>
         [WirePath("properties.targetDbServerFullyQualifiedDomainName")]
         public string TargetDbServerFullyQualifiedDomainName { get; set; }
-        /// <summary>
-        /// Migration secret parameters.
-        /// Serialized Name: Migration.properties.secretParameters
-        /// </summary>
+        /// <summary> Migration secret parameters. </summary>
         [WirePath("properties.secretParameters")]
         public PostgreSqlMigrationSecretParameters SecretParameters { get; set; }
-        /// <summary>
-        /// Names of databases to migrate.
-        /// Serialized Name: Migration.properties.dbsToMigrate
-        /// </summary>
+        /// <summary> Names of databases to migrate. </summary>
         [WirePath("properties.dbsToMigrate")]
         public IList<string> DbsToMigrate { get; }
-        /// <summary>
-        /// Indicates whether to setup logical replication on source server, if needed.
-        /// Serialized Name: Migration.properties.setupLogicalReplicationOnSourceDbIfNeeded
-        /// </summary>
+        /// <summary> Indicates whether to setup logical replication on source server, if needed. </summary>
         [WirePath("properties.setupLogicalReplicationOnSourceDbIfNeeded")]
         public PostgreSqlMigrationLogicalReplicationOnSourceDb? SetupLogicalReplicationOnSourceDbIfNeeded { get; set; }
-        /// <summary>
-        /// Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation.
-        /// Serialized Name: Migration.properties.overwriteDbsInTarget
-        /// </summary>
+        /// <summary> Indicates if databases on the target server can be overwritten when already present. If set to 'False', when the migration workflow detects that the database already exists on the target server, it will wait for a confirmation. </summary>
         [WirePath("properties.overwriteDbsInTarget")]
         public PostgreSqlMigrationOverwriteDbsInTarget? OverwriteDbsInTarget { get; set; }
-        /// <summary>
-        /// Start time (UTC) for migration window.
-        /// Serialized Name: Migration.properties.migrationWindowStartTimeInUtc
-        /// </summary>
+        /// <summary> Start time (UTC) for migration window. </summary>
         [WirePath("properties.migrationWindowStartTimeInUtc")]
         public DateTimeOffset? MigrationWindowStartTimeInUtc { get; set; }
-        /// <summary>
-        /// End time (UTC) for migration window.
-        /// Serialized Name: Migration.properties.migrationWindowEndTimeInUtc
-        /// </summary>
+        /// <summary> End time (UTC) for migration window. </summary>
         [WirePath("properties.migrationWindowEndTimeInUtc")]
         public DateTimeOffset? MigrationWindowEndTimeInUtc { get; set; }
-        /// <summary>
-        /// Indicates if roles and permissions must be migrated.
-        /// Serialized Name: Migration.properties.migrateRoles
-        /// </summary>
+        /// <summary> Indicates if roles and permissions must be migrated. </summary>
         [WirePath("properties.migrateRoles")]
         public MigrateRolesEnum? MigrateRoles { get; set; }
-        /// <summary>
-        /// Indicates if data migration must start right away.
-        /// Serialized Name: Migration.properties.startDataMigration
-        /// </summary>
+        /// <summary> Indicates if data migration must start right away. </summary>
         [WirePath("properties.startDataMigration")]
         public PostgreSqlMigrationStartDataMigration? StartDataMigration { get; set; }
-        /// <summary>
-        /// Indicates if cutover must be triggered for the entire migration.
-        /// Serialized Name: Migration.properties.triggerCutover
-        /// </summary>
+        /// <summary> Indicates if cutover must be triggered for the entire migration. </summary>
         [WirePath("properties.triggerCutover")]
         public PostgreSqlMigrationTriggerCutover? TriggerCutover { get; set; }
-        /// <summary>
-        /// When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: Migration.properties.dbsToTriggerCutoverOn
-        /// </summary>
+        /// <summary> When you want to trigger cutover for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </summary>
         [WirePath("properties.dbsToTriggerCutoverOn")]
         public IList<string> DbsToTriggerCutoverOn { get; }
-        /// <summary>
-        /// Indicates if cancel must be triggered for the entire migration.
-        /// Serialized Name: Migration.properties.cancel
-        /// </summary>
+        /// <summary> Indicates if cancel must be triggered for the entire migration. </summary>
         [WirePath("properties.cancel")]
         public PostgreSqlMigrationCancel? Cancel { get; set; }
-        /// <summary>
-        /// When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array.
-        /// Serialized Name: Migration.properties.dbsToCancelMigrationOn
-        /// </summary>
+        /// <summary> When you want to trigger cancel for specific databases set 'triggerCutover' to 'True' and the names of the specific databases in this array. </summary>
         [WirePath("properties.dbsToCancelMigrationOn")]
         public IList<string> DbsToCancelMigrationOn { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/ServerThreatProtectionSettingsModelData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/ServerThreatProtectionSettingsModelData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the ServerThreatProtectionSettingsModel data model.
     /// Advanced threat protection settings of the server.
-    /// Serialized Name: AdvancedThreatProtectionSettingsModel
     /// </summary>
     public partial class ServerThreatProtectionSettingsModelData : ResourceData
     {
@@ -62,14 +61,8 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="state">
-        /// Specifies the state of the advanced threat protection, whether it is enabled, disabled, or a state has not been applied yet on the server.
-        /// Serialized Name: AdvancedThreatProtectionSettingsModel.properties.state
-        /// </param>
-        /// <param name="createdOn">
-        /// Specifies the creation time (UTC) of the policy.
-        /// Serialized Name: AdvancedThreatProtectionSettingsModel.properties.creationTime
-        /// </param>
+        /// <param name="state"> Specifies the state of the advanced threat protection, whether it is enabled, disabled, or a state has not been applied yet on the server. </param>
+        /// <param name="createdOn"> Specifies the creation time (UTC) of the policy. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ServerThreatProtectionSettingsModelData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, ThreatProtectionState? state, DateTimeOffset? createdOn, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -78,16 +71,10 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Specifies the state of the advanced threat protection, whether it is enabled, disabled, or a state has not been applied yet on the server.
-        /// Serialized Name: AdvancedThreatProtectionSettingsModel.properties.state
-        /// </summary>
+        /// <summary> Specifies the state of the advanced threat protection, whether it is enabled, disabled, or a state has not been applied yet on the server. </summary>
         [WirePath("properties.state")]
         public ThreatProtectionState? State { get; set; }
-        /// <summary>
-        /// Specifies the creation time (UTC) of the policy.
-        /// Serialized Name: AdvancedThreatProtectionSettingsModel.properties.creationTime
-        /// </summary>
+        /// <summary> Specifies the creation time (UTC) of the policy. </summary>
         [WirePath("properties.creationTime")]
         public DateTimeOffset? CreatedOn { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/VirtualEndpointResourceData.cs
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/Generated/VirtualEndpointResourceData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
     /// <summary>
     /// A class representing the VirtualEndpointResource data model.
     /// Pair of virtual endpoints for a server.
-    /// Serialized Name: VirtualEndpoint
     /// </summary>
     public partial class VirtualEndpointResourceData : ResourceData
     {
@@ -64,18 +63,9 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="endpointType">
-        /// Type of endpoint for the virtual endpoints.
-        /// Serialized Name: VirtualEndpoint.properties.endpointType
-        /// </param>
-        /// <param name="members">
-        /// List of servers that one of the virtual endpoints can refer to.
-        /// Serialized Name: VirtualEndpoint.properties.members
-        /// </param>
-        /// <param name="virtualEndpoints">
-        /// List of virtual endpoints for a server.
-        /// Serialized Name: VirtualEndpoint.properties.virtualEndpoints
-        /// </param>
+        /// <param name="endpointType"> Type of endpoint for the virtual endpoints. </param>
+        /// <param name="members"> List of servers that one of the virtual endpoints can refer to. </param>
+        /// <param name="virtualEndpoints"> List of virtual endpoints for a server. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal VirtualEndpointResourceData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, VirtualEndpointType? endpointType, IList<string> members, IReadOnlyList<string> virtualEndpoints, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -85,22 +75,13 @@ namespace Azure.ResourceManager.PostgreSql.FlexibleServers
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Type of endpoint for the virtual endpoints.
-        /// Serialized Name: VirtualEndpoint.properties.endpointType
-        /// </summary>
+        /// <summary> Type of endpoint for the virtual endpoints. </summary>
         [WirePath("properties.endpointType")]
         public VirtualEndpointType? EndpointType { get; set; }
-        /// <summary>
-        /// List of servers that one of the virtual endpoints can refer to.
-        /// Serialized Name: VirtualEndpoint.properties.members
-        /// </summary>
+        /// <summary> List of servers that one of the virtual endpoints can refer to. </summary>
         [WirePath("properties.members")]
         public IList<string> Members { get; }
-        /// <summary>
-        /// List of virtual endpoints for a server.
-        /// Serialized Name: VirtualEndpoint.properties.virtualEndpoints
-        /// </summary>
+        /// <summary> List of virtual endpoints for a server. </summary>
         [WirePath("properties.virtualEndpoints")]
         public IReadOnlyList<string> VirtualEndpoints { get; }
     }

--- a/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/autorest.md
+++ b/sdk/postgresql/Azure.ResourceManager.PostgreSql/src/autorest.md
@@ -21,9 +21,6 @@ modelerfour:
 use-model-reader-writer: true
 enable-bicep-serialization: true
 
-mgmt-debug:
-  show-serialized-names: true
-
 format-by-name-rules:
   'tenantId': 'uuid'
   'ETag': 'etag'


### PR DESCRIPTION
## Description

Remove the show-serialized-names: true debug configuration from the PostgreSQL management library's autorest config and regenerate the code. This cleans up unnecessary \Serialized Name:\ annotations from XML doc comments throughout the generated code (~4500 lines removed).

## Changes

- Removed \mgmt-debug: show-serialized-names: true\ from \src/autorest.md\
- Regenerated code via \dotnet build /t:GenerateCode\ (153 files changed)
- Updated version to \1.4.1\ with release date \2026-02-12\
- Exported updated API listing

## Motivation

The \show-serialized-names\ option is a debugging aid that adds \Serialized Name: ...\ to every XML doc comment. This adds noise to the generated code and published NuGet package documentation without providing value to consumers.