### PR TITLE
Add ConfigurableCredential test coverage for all credential types

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -114,6 +114,11 @@ namespace Azure.Identity
             {
                 Subscription = subscription;
             }
+
+            if (bool.TryParse(section[nameof(WorkloadIdentityCredentialOptions.IsAzureProxyEnabled)], out bool isAzureProxyEnabled))
+            {
+                IsAzureProxyEnabled = isAzureProxyEnabled;
+            }
         }
 
         private UpdateTracker<string> _tenantId = new UpdateTracker<string>(EnvironmentVariables.TenantId);
@@ -419,6 +424,8 @@ namespace Azure.Identity
 
         internal bool IsForceRefreshEnabled { get; set; }
 
+        internal bool IsAzureProxyEnabled { get; set; }
+
         internal override T Clone<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>()
         {
             var clone = base.Clone<T>();
@@ -458,6 +465,7 @@ namespace Azure.Identity
                 {
                     dacClone.Subscription = Subscription;
                 }
+                dacClone.IsAzureProxyEnabled = IsAzureProxyEnabled;
             }
 
             return clone;

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -271,6 +271,7 @@ namespace Azure.Identity
             options.ClientId = Options.WorkloadIdentityClientId;
             options.TenantId = Options.TenantId;
             options.Pipeline = Pipeline;
+            options.IsAzureProxyEnabled = Options.IsAzureProxyEnabled;
 
             return new WorkloadIdentityCredential(options);
         }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialCreationTests.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.AzureCli
+{
+    /// <summary>
+    /// Validates that all <see cref="AzureCliCredentialOptions"/> properties can be set
+    /// via IConfiguration and that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    /// </summary>
+    internal class AzureCliCredentialCreationTests : CredentialCreationTestBase<AzureCliCredential>
+    {
+        protected override string CredentialSource => "AzureCli";
+
+        private static Dictionary<string, string> AllNulledEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+        };
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(cli, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // TenantId intentionally not set in config.
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("env-tenant", ReadProperty<string>(cli, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(cli, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-tenant-a";
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(cli, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "config-tenant-a");
+                CollectionAssert.DoesNotContain(tenants, "env-tenant-x");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // AdditionallyAllowedTenants intentionally not set in config.
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(cli, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "env-tenant-x");
+                CollectionAssert.Contains(tenants, "env-tenant-y");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(cli, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ProcessTimeout_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:CredentialProcessTimeout"] = "00:00:45";
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual(TimeSpan.FromSeconds(45), ReadProperty<TimeSpan>(cli, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ProcessTimeout_DefaultsToThirtySeconds()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                // DefaultAzureCredentialOptions.CredentialProcessTimeout defaults to 30s.
+                Assert.AreEqual(TimeSpan.FromSeconds(30), ReadProperty<TimeSpan>(cli, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void Subscription_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:Subscription"] = "my-sub-id";
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("my-sub-id", ReadProperty<string>(cli, "Subscription"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void Subscription_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(cli, "Subscription"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigWinsOverEnvVars()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-extra" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+                config["MyClient:Credential:CredentialProcessTimeout"] = "00:01:00";
+                config["MyClient:Credential:Subscription"] = "config-sub";
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+
+                Assert.AreEqual(configTenant, ReadProperty<string>(cli, "TenantId"));
+
+                var tenants = ReadProperty<string[]>(cli, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+
+                Assert.AreEqual(TimeSpan.FromMinutes(1), ReadProperty<TimeSpan>(cli, "ProcessTimeout"));
+                Assert.AreEqual("config-sub", ReadProperty<string>(cli, "Subscription"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadField<bool>(cli, "_logPII"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var cli = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadField<bool>(cli, "_logPII"));
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialCreationTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.AzureDeveloperCli
+{
+    /// <summary>
+    /// Validates that all <see cref="AzureDeveloperCliCredentialOptions"/> properties can be set
+    /// via IConfiguration and that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    /// </summary>
+    internal class AzureDeveloperCliCredentialCreationTests : CredentialCreationTestBase<AzureDeveloperCliCredential>
+    {
+        protected override string CredentialSource => "AzureDeveloperCli";
+
+        private static Dictionary<string, string> AllNulledEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+        };
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(azd, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // TenantId intentionally not set in config.
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("env-tenant", ReadProperty<string>(azd, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(azd, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-tenant-a";
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(azd, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "config-tenant-a");
+                CollectionAssert.DoesNotContain(tenants, "env-tenant-x");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // AdditionallyAllowedTenants intentionally not set in config.
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(azd, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "env-tenant-x");
+                CollectionAssert.Contains(tenants, "env-tenant-y");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(azd, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ProcessTimeout_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:CredentialProcessTimeout"] = "00:00:45";
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual(TimeSpan.FromSeconds(45), ReadProperty<TimeSpan>(azd, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ProcessTimeout_DefaultsToThirtySeconds()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                // DefaultAzureCredentialOptions.CredentialProcessTimeout defaults to 30s.
+                Assert.AreEqual(TimeSpan.FromSeconds(30), ReadProperty<TimeSpan>(azd, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigWinsOverEnvVars()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-extra" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+                config["MyClient:Credential:CredentialProcessTimeout"] = "00:01:00";
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+
+                Assert.AreEqual(configTenant, ReadProperty<string>(azd, "TenantId"));
+
+                var tenants = ReadProperty<string[]>(azd, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+
+                Assert.AreEqual(TimeSpan.FromMinutes(1), ReadProperty<TimeSpan>(azd, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadField<bool>(azd, "_logPII"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var azd = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadField<bool>(azd, "_logPII"));
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialCreationTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePowerShell
+{
+    /// <summary>
+    /// Validates that all <see cref="AzurePowerShellCredentialOptions"/> properties can be set
+    /// via IConfiguration and that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    /// </summary>
+    internal class AzurePowerShellCredentialCreationTests : CredentialCreationTestBase<AzurePowerShellCredential>
+    {
+        protected override string CredentialSource => "AzurePowerShell";
+
+        private static Dictionary<string, string> AllNulledEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+        };
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(ps, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // TenantId intentionally not set in config.
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("env-tenant", ReadProperty<string>(ps, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(ps, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-tenant-a";
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(ps, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "config-tenant-a");
+                CollectionAssert.DoesNotContain(tenants, "env-tenant-x");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // AdditionallyAllowedTenants intentionally not set in config.
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(ps, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "env-tenant-x");
+                CollectionAssert.Contains(tenants, "env-tenant-y");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(ps, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ProcessTimeout_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:CredentialProcessTimeout"] = "00:00:45";
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual(TimeSpan.FromSeconds(45), ReadProperty<TimeSpan>(ps, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ProcessTimeout_DefaultsToThirtySeconds()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                // DefaultAzureCredentialOptions.CredentialProcessTimeout defaults to 30s.
+                Assert.AreEqual(TimeSpan.FromSeconds(30), ReadProperty<TimeSpan>(ps, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigWinsOverEnvVars()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-extra" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+                config["MyClient:Credential:CredentialProcessTimeout"] = "00:01:00";
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+
+                Assert.AreEqual(configTenant, ReadProperty<string>(ps, "TenantId"));
+
+                var tenants = ReadProperty<string[]>(ps, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+
+                Assert.AreEqual(TimeSpan.FromMinutes(1), ReadProperty<TimeSpan>(ps, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadField<bool>(ps, "_logPII"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ps = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadField<bool>(ps, "_logPII"));
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/CredentialCreationTestBase.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/CredentialCreationTestBase.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials
+{
+    /// <summary>
+    /// Shared base for credential creation/priority tests.
+    /// Provides common helpers for creating credentials from IConfiguration
+    /// and reading internal properties/fields via reflection.
+    /// </summary>
+    internal abstract class CredentialCreationTestBase<TCredential>
+        where TCredential : Azure.Core.TokenCredential
+    {
+        protected ConfigurableCredentialTestHelper<TCredential> Helper { get; private set; }
+
+        protected abstract string CredentialSource { get; }
+
+        [SetUp]
+        public void Setup()
+        {
+            Helper = new ConfigurableCredentialTestHelper<TCredential>(CredentialSource);
+        }
+
+        protected ConfigurableCredential CreateFromConfig(IConfiguration config)
+            => Helper.GetCredentialFromConfig(config);
+
+        protected TCredential GetUnderlying(ConfigurableCredential credential)
+            => Helper.GetUnderlyingCredential(credential);
+
+        /// <summary>
+        /// Reads an internal/private property by walking the type hierarchy.
+        /// </summary>
+        protected static T ReadProperty<T>(object target, string name)
+        {
+            var type = target.GetType();
+            while (type != null)
+            {
+                var prop = type.GetProperty(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly);
+                if (prop != null)
+                    return (T)prop.GetValue(target);
+                type = type.BaseType;
+            }
+            throw new InvalidOperationException($"Property '{name}' not found on {target.GetType().Name} or its base types.");
+        }
+
+        /// <summary>
+        /// Reads an internal/private field by walking the type hierarchy.
+        /// </summary>
+        protected static T ReadField<T>(object target, string name)
+        {
+            var type = target.GetType();
+            while (type != null)
+            {
+                var field = type.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly);
+                if (field != null)
+                    return (T)field.GetValue(target);
+                type = type.BaseType;
+            }
+            throw new InvalidOperationException($"Field '{name}' not found on {target.GetType().Name} or its base types.");
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
@@ -1,0 +1,306 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.Environment
+{
+    /// <summary>
+    /// Validates that all <see cref="EnvironmentCredentialOptions"/> properties can be set
+    /// via IConfiguration and that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    /// </summary>
+    internal class EnvironmentCredentialCreationTests : CredentialCreationTestBase<EnvironmentCredential>
+    {
+        protected override string CredentialSource => "Environment";
+
+        /// <summary>
+        /// Env vars needed for EnvironmentCredential to construct a ClientSecretCredential internally.
+        /// TenantId, ClientId, and ClientSecret must all be non-empty.
+        /// </summary>
+        private static Dictionary<string, string> BaseEnvVars(
+            string tenantId = "env-tenant",
+            string clientId = "env-client",
+            string clientSecret = "env-secret") => new()
+        {
+            { "AZURE_TENANT_ID", tenantId },
+            { "AZURE_CLIENT_ID", clientId },
+            { "AZURE_CLIENT_SECRET", clientSecret },
+            { "AZURE_CLIENT_CERTIFICATE_PATH", null },
+            { "AZURE_CLIENT_CERTIFICATE_PASSWORD", null },
+            { "AZURE_CLIENT_SEND_CERTIFICATE_CHAIN", null },
+            { "AZURE_USERNAME", null },
+            { "AZURE_PASSWORD", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            { "AZURE_AUTHORITY_HOST", null },
+        };
+
+        /// <summary>
+        /// Gets the inner ClientSecretCredential from an EnvironmentCredential.
+        /// </summary>
+        private static ClientSecretCredential GetInner(EnvironmentCredential envCred)
+        {
+            var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as ClientSecretCredential;
+            Assert.IsNotNull(inner, "EnvironmentCredential should contain a ClientSecretCredential when TENANT+CLIENT+SECRET are set.");
+            return inner;
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(inner, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            var env = BaseEnvVars(tenantId: "env-tenant");
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                Assert.AreEqual("env-tenant", ReadProperty<string>(inner, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientId_ComesFromEnvVar()
+        {
+            var env = BaseEnvVars(clientId: "my-client-id");
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                Assert.AreEqual("my-client-id", ReadProperty<string>(inner, "ClientId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void NoCredential_WhenRequiredEnvVarsMissing()
+        {
+            var env = BaseEnvVars(tenantId: null, clientId: null, clientSecret: null);
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential");
+                Assert.IsNull(inner, "EnvironmentCredential should not create an inner credential when env vars are missing.");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars();
+            env["AZURE_AUTHORITY_HOST"] = AzureAuthorityHosts.AzureGovernment.ToString();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AuthorityHost"] = AzureAuthorityHosts.AzureChina.ToString();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.AreEqual(AzureAuthorityHosts.AzureChina, ReadProperty<Uri>(msal, "AuthorityHost"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_FallsBackToEnvVar()
+        {
+            var env = BaseEnvVars();
+            env["AZURE_AUTHORITY_HOST"] = AzureAuthorityHosts.AzureGovernment.ToString();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.AreEqual(AzureAuthorityHosts.AzureGovernment, ReadProperty<Uri>(msal, "AuthorityHost"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_DefaultsToAzurePublicCloud()
+        {
+            var env = BaseEnvVars();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.AreEqual(AzureAuthorityHosts.AzurePublicCloud, ReadProperty<Uri>(msal, "AuthorityHost"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_ConfigSetsTrue()
+        {
+            var env = BaseEnvVars();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:DisableInstanceDiscovery"] = "true";
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.IsTrue(ReadProperty<bool>(msal, "DisableInstanceDiscovery"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_DefaultsFalse()
+        {
+            var env = BaseEnvVars();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.IsFalse(ReadProperty<bool>(msal, "DisableInstanceDiscovery"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            var env = BaseEnvVars();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.IsTrue(ReadProperty<bool>(msal, "IsSupportLoggingEnabled"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            var env = BaseEnvVars();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.IsFalse(ReadProperty<bool>(msal, "IsSupportLoggingEnabled"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars();
+            env["AZURE_ADDITIONALLY_ALLOWED_TENANTS"] = "env-t1;env-t2";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-t1";
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var tenants = ReadField<string[]>(inner, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "config-t1");
+                CollectionAssert.DoesNotContain(tenants, "env-t1");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            var env = BaseEnvVars();
+            env["AZURE_ADDITIONALLY_ALLOWED_TENANTS"] = "env-t1;env-t2";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var tenants = ReadField<string[]>(inner, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "env-t1");
+                CollectionAssert.Contains(tenants, "env-t2");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            var env = BaseEnvVars();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                var tenants = ReadField<string[]>(inner, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigWinsOverEnvVars()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+
+            var env = BaseEnvVars();
+            env["AZURE_ADDITIONALLY_ALLOWED_TENANTS"] = "env-extra";
+            env["AZURE_AUTHORITY_HOST"] = AzureAuthorityHosts.AzureGovernment.ToString();
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:AuthorityHost"] = AzureAuthorityHosts.AzureChina.ToString();
+                config["MyClient:Credential:DisableInstanceDiscovery"] = "true";
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+
+                Assert.AreEqual(configTenant, ReadProperty<string>(inner, "TenantId"));
+
+                var tenants = ReadField<string[]>(inner, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.AreEqual(AzureAuthorityHosts.AzureChina, ReadProperty<Uri>(msal, "AuthorityHost"));
+                Assert.IsTrue(ReadProperty<bool>(msal, "DisableInstanceDiscovery"));
+                Assert.IsTrue(ReadProperty<bool>(msal, "IsSupportLoggingEnabled"));
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCodeCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCodeCredentialCreationTests.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudioCode
+{
+    /// <summary>
+    /// Validates that all <see cref="VisualStudioCodeCredentialOptions"/> properties can be set
+    /// via IConfiguration and that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    /// </summary>
+    internal class VisualStudioCodeCredentialCreationTests : CredentialCreationTestBase<VisualStudioCodeCredential>
+    {
+        protected override string CredentialSource => "VisualStudioCode";
+
+        private static Dictionary<string, string> AllNulledEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+        };
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(vsc, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // TenantId intentionally not set in config.
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("env-tenant", ReadProperty<string>(vsc, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(vsc, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-tenant-a";
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(vsc, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "config-tenant-a");
+                CollectionAssert.DoesNotContain(tenants, "env-tenant-x");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // AdditionallyAllowedTenants intentionally not set in config.
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(vsc, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "env-tenant-x");
+                CollectionAssert.Contains(tenants, "env-tenant-y");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(vsc, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigWinsOverEnvVars()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-extra" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+
+                Assert.AreEqual(configTenant, ReadProperty<string>(vsc, "TenantId"));
+
+                var tenants = ReadProperty<string[]>(vsc, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+                { "AZURE_AUTHORITY_HOST", AzureAuthorityHosts.AzureGovernment.ToString() },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AuthorityHost"] = AzureAuthorityHosts.AzureChina.ToString();
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                var msal = ReadProperty<object>(vsc, "Client");
+                Assert.AreEqual(AzureAuthorityHosts.AzureChina, ReadProperty<Uri>(msal, "AuthorityHost"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+                { "AZURE_AUTHORITY_HOST", AzureAuthorityHosts.AzureGovernment.ToString() },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                var msal = ReadProperty<object>(vsc, "Client");
+                Assert.AreEqual(AzureAuthorityHosts.AzureGovernment, ReadProperty<Uri>(msal, "AuthorityHost"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_DefaultsToAzurePublicCloud()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+                { "AZURE_AUTHORITY_HOST", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                var msal = ReadProperty<object>(vsc, "Client");
+                Assert.AreEqual(AzureAuthorityHosts.AzurePublicCloud, ReadProperty<Uri>(msal, "AuthorityHost"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                var msal = ReadProperty<object>(vsc, "Client");
+                Assert.IsTrue(ReadProperty<bool>(msal, "IsSupportLoggingEnabled"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var vsc = GetUnderlying(CreateFromConfig(config));
+                var msal = ReadProperty<object>(vsc, "Client");
+                Assert.IsFalse(ReadProperty<bool>(msal, "IsSupportLoggingEnabled"));
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialCreationTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudio
+{
+    /// <summary>
+    /// Validates that all <see cref="VisualStudioCredentialOptions"/> properties can be set
+    /// via IConfiguration and that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    /// </summary>
+    internal class VisualStudioCredentialCreationTests : CredentialCreationTestBase<VisualStudioCredential>
+    {
+        protected override string CredentialSource => "VisualStudio";
+
+        private static Dictionary<string, string> AllNulledEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+        };
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(vs, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // TenantId intentionally not set in config.
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("env-tenant", ReadProperty<string>(vs, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(vs, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-tenant-a";
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(vs, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "config-tenant-a");
+                CollectionAssert.DoesNotContain(tenants, "env-tenant-x");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // AdditionallyAllowedTenants intentionally not set in config.
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(vs, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "env-tenant-x");
+                CollectionAssert.Contains(tenants, "env-tenant-y");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(vs, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ProcessTimeout_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:CredentialProcessTimeout"] = "00:00:45";
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual(TimeSpan.FromSeconds(45), ReadProperty<TimeSpan>(vs, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ProcessTimeout_DefaultsToThirtySeconds()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                // DefaultAzureCredentialOptions.CredentialProcessTimeout defaults to 30s.
+                Assert.AreEqual(TimeSpan.FromSeconds(30), ReadProperty<TimeSpan>(vs, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigWinsOverEnvVars()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-extra" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+                config["MyClient:Credential:CredentialProcessTimeout"] = "00:01:00";
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+
+                Assert.AreEqual(configTenant, ReadProperty<string>(vs, "TenantId"));
+
+                var tenants = ReadProperty<string[]>(vs, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+
+                Assert.AreEqual(TimeSpan.FromMinutes(1), ReadProperty<TimeSpan>(vs, "ProcessTimeout"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadField<bool>(vs, "_logPII"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var vs = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadField<bool>(vs, "_logPII"));
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
@@ -1,0 +1,492 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.WorkloadIdentity
+{
+    /// <summary>
+    /// Validates that all <see cref="WorkloadIdentityCredentialOptions"/> properties can be set
+    /// via IConfiguration and that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    /// </summary>
+    internal class WorkloadIdentityCredentialCreationTests : CredentialCreationTestBase<WorkloadIdentityCredential>
+    {
+        protected override string CredentialSource => "WorkloadIdentity";
+
+        private static ClientAssertionCredential GetClientAssertionCredential(WorkloadIdentityCredential wic)
+            => ReadField<ClientAssertionCredential>(wic, "_clientAssertionCredential");
+
+        private static object GetMsalClient(ClientAssertionCredential cac)
+            => ReadProperty<object>(cac, "Client");
+
+        private static T ReadMsalProperty<T>(object msalClient, string propertyName)
+            => ReadProperty<T>(msalClient, propertyName);
+
+        /// <summary>
+        /// Returns env var dictionary with all relevant vars nulled out, plus
+        /// AZURE_FEDERATED_TOKEN_FILE set so the WIC constructor creates its inner credential.
+        /// </summary>
+        private static Dictionary<string, string> AllNulledEnvVars(string tokenFilePath = "/fake/token") => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_CLIENT_ID", null },
+            { "AZURE_FEDERATED_TOKEN_FILE", tokenFilePath },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            { "AZURE_AUTHORITY_HOST", null },
+            { "AZURE_KUBERNETES_TOKEN_PROXY", null },
+        };
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+
+                Assert.IsNotNull(cac);
+                Assert.AreEqual("config-tenant", cac.TenantId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_CLIENT_ID", "env-client" },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // TenantId intentionally not set in config.
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+
+                Assert.IsNotNull(cac);
+                Assert.AreEqual("env-tenant", cac.TenantId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", "env-client" },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "config-client";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+
+                Assert.IsNotNull(cac);
+                Assert.AreEqual("config-client", cac.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_CLIENT_ID", "env-client" },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                // WorkloadIdentityClientId intentionally not set in config.
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+
+                Assert.IsNotNull(cac);
+                Assert.AreEqual("env-client", cac.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TokenFilePath_CreatesCredentialWhenEnvVarSet()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/my/token" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+
+                Assert.IsNotNull(cac, "ClientAssertionCredential should be created when AZURE_FEDERATED_TOKEN_FILE is set");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TokenFilePath_NoCredentialWhenEnvVarMissing()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+
+                Assert.IsNull(cac, "ClientAssertionCredential should not be created when AZURE_FEDERATED_TOKEN_FILE is missing");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+                { "AZURE_AUTHORITY_HOST", AzureAuthorityHosts.AzureGovernment.ToString() },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+                config["MyClient:Credential:AuthorityHost"] = AzureAuthorityHosts.AzureChina.ToString();
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+
+                Uri actual = ReadMsalProperty<Uri>(GetMsalClient(cac), "AuthorityHost");
+                Assert.AreEqual(AzureAuthorityHosts.AzureChina, actual);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+                { "AZURE_AUTHORITY_HOST", AzureAuthorityHosts.AzureGovernment.ToString() },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+                // AuthorityHost intentionally not set in config.
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+
+                Uri actual = ReadMsalProperty<Uri>(GetMsalClient(cac), "AuthorityHost");
+                Assert.AreEqual(AzureAuthorityHosts.AzureGovernment, actual);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_DefaultsToAzurePublicCloud()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+                { "AZURE_AUTHORITY_HOST", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+
+                Uri actual = ReadMsalProperty<Uri>(GetMsalClient(cac), "AuthorityHost");
+                Assert.AreEqual(AzureAuthorityHosts.AzurePublicCloud, actual);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_ConfigSetsTrue()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+                config["MyClient:Credential:DisableInstanceDiscovery"] = "true";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+                Assert.IsTrue(ReadMsalProperty<bool>(GetMsalClient(cac), "DisableInstanceDiscovery"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_DefaultsFalse()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+                Assert.IsFalse(ReadMsalProperty<bool>(GetMsalClient(cac), "DisableInstanceDiscovery"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+                Assert.IsTrue(ReadMsalProperty<bool>(GetMsalClient(cac), "IsSupportLoggingEnabled"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+                Assert.IsFalse(ReadMsalProperty<bool>(GetMsalClient(cac), "IsSupportLoggingEnabled"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-tenant-a";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+
+                var tenants = ReadField<string[]>(cac, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "config-tenant-a");
+                CollectionAssert.DoesNotContain(tenants, "env-tenant-x");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_CLIENT_ID", "env-client" },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+                // AdditionallyAllowedTenants intentionally not set in config.
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+
+                var tenants = ReadField<string[]>(cac, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "env-tenant-x");
+                CollectionAssert.Contains(tenants, "env-tenant-y");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+
+                var cac = GetClientAssertionCredential(GetUnderlying(CreateFromConfig(config)));
+                Assert.IsNotNull(cac);
+
+                var tenants = ReadField<string[]>(cac, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsAzureProxyEnabled_ConfigSetsTrue()
+        {
+            // Set an invalid proxy URL so the WIC constructor throws, proving the option was read.
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+                { "AZURE_KUBERNETES_TOKEN_PROXY", "http://not-https" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+                config["MyClient:Credential:IsAzureProxyEnabled"] = "true";
+
+                var ex = Assert.Throws<InvalidOperationException>(() => CreateFromConfig(config));
+                Assert.That(ex.Message, Does.Contain("HTTPS"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsAzureProxyEnabled_DefaultsFalse_InvalidProxyIgnored()
+        {
+            // Invalid proxy URL is present but IsAzureProxyEnabled defaults to false, so no error.
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+                { "AZURE_KUBERNETES_TOKEN_PROXY", "http://not-https" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:WorkloadIdentityClientId"] = "test-client";
+
+                var credential = CreateFromConfig(config);
+                Assert.IsNotNull(GetUnderlying(credential));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigWinsOverEnvVars()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+            string configClient = Guid.NewGuid().ToString();
+            Uri configAuthority = AzureAuthorityHosts.AzureChina;
+
+            // Set competing env var values for everything.
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_CLIENT_ID", "env-client" },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/fake/token" },
+                { "AZURE_AUTHORITY_HOST", AzureAuthorityHosts.AzureGovernment.ToString() },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-extra" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:WorkloadIdentityClientId"] = configClient;
+                config["MyClient:Credential:AuthorityHost"] = configAuthority.ToString();
+                config["MyClient:Credential:DisableInstanceDiscovery"] = "true";
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+
+                var credential = CreateFromConfig(config);
+                var wic = GetUnderlying(credential);
+                var cac = GetClientAssertionCredential(wic);
+                Assert.IsNotNull(cac);
+
+                // TenantId and ClientId from config, not env var.
+                Assert.AreEqual(configTenant, cac.TenantId);
+                Assert.AreEqual(configClient, cac.ClientId);
+
+                // AdditionallyAllowedTenants from config, not env var.
+                var tenants = ReadField<string[]>(cac, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+
+                // MSAL-level options from config.
+                var msal = GetMsalClient(cac);
+                Assert.AreEqual(configAuthority, ReadMsalProperty<Uri>(msal, "AuthorityHost"));
+                Assert.IsTrue(ReadMsalProperty<bool>(msal, "DisableInstanceDiscovery"));
+                Assert.IsTrue(ReadMsalProperty<bool>(msal, "IsSupportLoggingEnabled"));
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Identity.Tests.Mock;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.WorkloadIdentity
+{
+    internal class WorkloadIdentityCredentialTests : Tests.WorkloadIdentityCredentialTests
+    {
+        private readonly ConfigurableCredentialTestHelper<WorkloadIdentityCredential> _helper;
+
+        public WorkloadIdentityCredentialTests(bool isAsync) : base(isAsync)
+        {
+            _helper = new ConfigurableCredentialTestHelper<WorkloadIdentityCredential>(
+                "WorkloadIdentity",
+                null,
+                null,
+                InstrumentClient);
+        }
+
+        private string SetupTokenFile(string tenantId, Uri authorityHost)
+        {
+            var certificatePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "cert.pfx");
+#if NET9_0_OR_GREATER
+            var mockCert = X509CertificateLoader.LoadPkcs12FromFile(certificatePath, null);
+#else
+            var mockCert = new X509Certificate2(certificatePath);
+#endif
+            var tokenFilePath = TempFiles.GetTempFilePath();
+            string assertion = CredentialTestHelpers.CreateClientAssertionJWT(authorityHost, ClientId, tenantId, mockCert);
+            File.WriteAllText(tokenFilePath, assertion);
+            return tokenFilePath;
+        }
+
+        private ConfigurableCredential CreateConfiguredCredential(string tenantId = null, Action<IConfiguration> configureExtra = null)
+        {
+            var tokenFilePath = SetupTokenFile(tenantId ?? TenantId, AzureAuthorityHosts.AzurePublicCloud);
+
+            IConfiguration config = _helper.GetConfiguration();
+            if (tenantId != null)
+            {
+                config["MyClient:Credential:TenantId"] = tenantId;
+            }
+            config["MyClient:Credential:WorkloadIdentityClientId"] = ClientId;
+            configureExtra?.Invoke(config);
+
+            ConfigurableCredential credential;
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", tokenFilePath }
+            }))
+            {
+                credential = _helper.GetCredentialFromConfig(config);
+            }
+
+            return credential;
+        }
+
+        private void InjectMsalClient(ConfigurableCredential credential, MsalConfidentialClient msalClient)
+        {
+            var wic = _helper.GetUnderlyingCredential(credential);
+            var clientAssertionCred = (ClientAssertionCredential)typeof(WorkloadIdentityCredential)
+                .GetField("_clientAssertionCredential", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(wic);
+            if (clientAssertionCred != null && msalClient != null)
+            {
+                typeof(ClientAssertionCredential)
+                    .GetField("<Client>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .SetValue(clientAssertionCred, msalClient);
+            }
+        }
+
+        public override TokenCredential GetTokenCredential(TokenCredentialOptions options)
+        {
+            var credential = CreateConfiguredCredential(TenantId,
+                config => config["MyClient:Credential:Diagnostics:IsAccountIdentifierLoggingEnabled"] =
+                    options.Diagnostics.IsAccountIdentifierLoggingEnabled.ToString());
+            InjectMsalClient(credential, mockConfidentialMsalClient);
+            return _helper.InstrumentCredential(credential);
+        }
+
+        public override TokenCredential GetTokenCredential(CommonCredentialTestConfig config)
+        {
+            if (config.TenantId == null)
+            {
+                Assert.Ignore("Null TenantId test does not apply to this credential");
+            }
+
+            var tokenFilePath = SetupTokenFile(
+                config.TenantId,
+                config.AuthorityHost ?? AzureAuthorityHosts.AzurePublicCloud);
+
+            IConfiguration configuration = _helper.GetConfigurationFromCommonCredentialTestConfig<WorkloadIdentityCredentialOptions>(config);
+            configuration["MyClient:Credential:WorkloadIdentityClientId"] = ClientId;
+
+            ConfigurableCredential credential;
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", tokenFilePath }
+            }))
+            {
+                credential = _helper.GetCredentialFromConfig(configuration, config.Transport);
+            }
+
+            if (config.MockConfidentialMsalClient != null)
+            {
+                InjectMsalClient(credential, config.MockConfidentialMsalClient);
+            }
+            return _helper.InstrumentCredential(credential);
+        }
+
+        protected override TokenCredential CreateCredentialForValidation(string tenantId, string clientId, string tokenFilePath)
+        {
+            IConfiguration config = _helper.GetConfiguration();
+            if (tenantId != null)
+            {
+                config["MyClient:Credential:TenantId"] = tenantId;
+            }
+            if (clientId != null)
+            {
+                config["MyClient:Credential:WorkloadIdentityClientId"] = clientId;
+            }
+
+            ConfigurableCredential credential;
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", tokenFilePath }
+            }))
+            {
+                credential = _helper.GetCredentialFromConfig(config);
+            }
+
+            return _helper.InstrumentCredential(credential);
+        }
+
+        protected override TokenCredential CreateProxyTestCredential(bool isAzureProxyEnabled = false)
+        {
+            IConfiguration config = _helper.GetConfiguration();
+            config["MyClient:Credential:TenantId"] = TenantId;
+            config["MyClient:Credential:WorkloadIdentityClientId"] = ClientId;
+            config["MyClient:Credential:IsAzureProxyEnabled"] = isAzureProxyEnabled.ToString();
+
+            // The factory creates WorkloadIdentityCredentialOptions whose TokenFilePath defaults to
+            // AZURE_FEDERATED_TOKEN_FILE. A non-null value is needed so the WIC constructor enters
+            // the code path that validates proxy configuration.
+            var oldTokenFile = System.Environment.GetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE");
+            try
+            {
+                System.Environment.SetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE", "/fake/path/token");
+                var credential = _helper.GetCredentialFromConfig(config);
+                InjectMsalClient(credential, mockConfidentialMsalClient);
+                return _helper.InstrumentCredential(credential);
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable("AZURE_FEDERATED_TOKEN_FILE", oldTokenFile);
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
+++ b/sdk/identity/Azure.Identity/tests/CredentialTestHelpers.cs
@@ -7,8 +7,8 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -562,6 +562,13 @@ namespace Azure.Identity.Tests
         private static Type GetMsalClientType(TokenCredential cred)
         {
             var targetCred = cred is EnvironmentCredential environmentCredential ? environmentCredential.Credential : cred;
+
+            if (targetCred is ConfigurableCredential configCred)
+            {
+                targetCred = new ConfigurableCredentials.ConfigurableCredentialTestHelper<TokenCredential>(string.Empty)
+                    .GetUnderlyingCredential(configCred);
+            }
+
             return targetCred.GetType().GetProperty("Client", BindingFlags.Instance | BindingFlags.NonPublic)?.PropertyType;
         }
 

--- a/sdk/identity/Azure.Identity/tests/WorkloadIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/WorkloadIdentityCredentialTests.cs
@@ -22,6 +22,32 @@ namespace Azure.Identity.Tests
         public WorkloadIdentityCredentialTests(bool isAsync) : base(isAsync)
         { }
 
+        #region Virtual Factory Methods
+        protected virtual TokenCredential CreateCredentialForValidation(string tenantId, string clientId, string tokenFilePath)
+        {
+            var options = new WorkloadIdentityCredentialOptions
+            {
+                TenantId = tenantId,
+                ClientId = clientId,
+                TokenFilePath = tokenFilePath
+            };
+            return InstrumentClient(new WorkloadIdentityCredential(options));
+        }
+
+        protected virtual TokenCredential CreateProxyTestCredential(bool isAzureProxyEnabled = false)
+        {
+            return new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions
+            {
+                TenantId = TenantId,
+                ClientId = ClientId,
+                TokenFilePath = "/fake/path/token",
+                IsAzureProxyEnabled = isAzureProxyEnabled,
+                MsalClient = mockConfidentialMsalClient,
+                Pipeline = CredentialPipeline.GetInstance(null)
+            });
+        }
+        #endregion
+
         [Test]
         [NonParallelizable]
         public void VerifyInvalidConfigurationThrowsCredentialUnavailable([Values] bool specifyTenantId, [Values] bool specifyClientId, [Values] bool specifyTokenFilePath)
@@ -31,18 +57,14 @@ namespace Azure.Identity.Tests
                 Assert.Pass();
             }
 
-            WorkloadIdentityCredentialOptions options = new WorkloadIdentityCredentialOptions
-            {
-                TenantId = specifyTenantId ? Guid.NewGuid().ToString() : null,
-                ClientId = specifyClientId ? Guid.NewGuid().ToString() : null,
-                TokenFilePath = specifyTokenFilePath ? Guid.NewGuid().ToString() : null
-            };
-
-            WorkloadIdentityCredential credential = InstrumentClient(new WorkloadIdentityCredential(options));
+            var credential = CreateCredentialForValidation(
+                specifyTenantId ? Guid.NewGuid().ToString() : null,
+                specifyClientId ? Guid.NewGuid().ToString() : null,
+                specifyTokenFilePath ? Guid.NewGuid().ToString() : null);
 
             var tokenRequestContext = new TokenRequestContext(MockScopes.Default);
 
-            Assert.ThrowsAsync<CredentialUnavailableException>(() => credential.GetTokenAsync(tokenRequestContext).AsTask());
+            Assert.ThrowsAsync<CredentialUnavailableException>(() => credential.GetTokenAsync(tokenRequestContext, default).AsTask());
         }
 
         public override TokenCredential GetTokenCredential(TokenCredentialOptions options)
@@ -102,17 +124,6 @@ namespace Azure.Identity.Tests
         [NonParallelizable]
         public void KubernetesProxy_DisabledByDefault()
         {
-            var tokenFilePath = "/fake/path/token";
-
-            var options = new WorkloadIdentityCredentialOptions
-            {
-                TenantId = TenantId,
-                ClientId = ClientId,
-                TokenFilePath = tokenFilePath,
-                MsalClient = mockConfidentialMsalClient,
-                Pipeline = CredentialPipeline.GetInstance(null)
-            };
-
             // Should not throw even with invalid proxy config
             using (new TestEnvVar(new Dictionary<string, string>
             {
@@ -120,7 +131,7 @@ namespace Azure.Identity.Tests
                 { "AZURE_KUBERNETES_CA_DATA", "invalid-cert-data" },
             }))
             {
-                var credential = new WorkloadIdentityCredential(options);
+                var credential = CreateProxyTestCredential();
                 Assert.IsNotNull(credential);
             }
         }
@@ -129,20 +140,8 @@ namespace Azure.Identity.Tests
         [NonParallelizable]
         public void KubernetesProxy_OptInWithoutEnvVars_NoError()
         {
-            var tokenFilePath = "/fake/path/token";
-
-            var options = new WorkloadIdentityCredentialOptions
-            {
-                TenantId = TenantId,
-                ClientId = ClientId,
-                TokenFilePath = tokenFilePath,
-                IsAzureProxyEnabled = true,
-                MsalClient = mockConfidentialMsalClient,
-                Pipeline = CredentialPipeline.GetInstance(null)
-            };
-
             // Should not throw when proxy is enabled but env vars are not set
-            var credential = new WorkloadIdentityCredential(options);
+            var credential = CreateProxyTestCredential(isAzureProxyEnabled: true);
             Assert.IsNotNull(credential);
         }
 
@@ -150,36 +149,24 @@ namespace Azure.Identity.Tests
         [NonParallelizable]
         public void KubernetesProxy_InvalidProxyUrl_ThrowsInvalidOperation()
         {
-            var tokenFilePath = "/fake/path/token";
-
-            var options = new WorkloadIdentityCredentialOptions
-            {
-                TenantId = TenantId,
-                ClientId = ClientId,
-                TokenFilePath = tokenFilePath,
-                IsAzureProxyEnabled = true,
-                MsalClient = mockConfidentialMsalClient,
-                Pipeline = CredentialPipeline.GetInstance(null)
-            };
-
             // Invalid URL schemes
             using (new TestEnvVar("AZURE_KUBERNETES_TOKEN_PROXY", "http://not-https"))
             {
-                var ex = Assert.Throws<InvalidOperationException>(() => new WorkloadIdentityCredential(options));
+                var ex = Assert.Throws<InvalidOperationException>(() => CreateProxyTestCredential(isAzureProxyEnabled: true));
                 Assert.That(ex.Message, Does.Contain("HTTPS"));
             }
 
             // URL with query string
             using (new TestEnvVar("AZURE_KUBERNETES_TOKEN_PROXY", "https://proxy.local?query=value"))
             {
-                var ex = Assert.Throws<InvalidOperationException>(() => new WorkloadIdentityCredential(options));
+                var ex = Assert.Throws<InvalidOperationException>(() => CreateProxyTestCredential(isAzureProxyEnabled: true));
                 Assert.That(ex.Message, Does.Contain("query"));
             }
 
             // URL with fragment
             using (new TestEnvVar("AZURE_KUBERNETES_TOKEN_PROXY", "https://proxy.local#fragment"))
             {
-                var ex = Assert.Throws<InvalidOperationException>(() => new WorkloadIdentityCredential(options));
+                var ex = Assert.Throws<InvalidOperationException>(() => CreateProxyTestCredential(isAzureProxyEnabled: true));
                 Assert.That(ex.Message, Does.Contain("fragment"));
             }
         }
@@ -188,20 +175,8 @@ namespace Azure.Identity.Tests
         [NonParallelizable]
         public void KubernetesProxy_BothCaFileAndCaData_ThrowsInvalidOperation()
         {
-            var tokenFilePath = "/fake/path/token";
-
             var caFilePath = _tempFiles.GetTempFilePath();
             File.WriteAllText(caFilePath, "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----");
-
-            var options = new WorkloadIdentityCredentialOptions
-            {
-                TenantId = TenantId,
-                ClientId = ClientId,
-                TokenFilePath = tokenFilePath,
-                IsAzureProxyEnabled = true,
-                MsalClient = mockConfidentialMsalClient,
-                Pipeline = CredentialPipeline.GetInstance(null)
-            };
 
             using (new TestEnvVar(new Dictionary<string, string>
             {
@@ -210,7 +185,7 @@ namespace Azure.Identity.Tests
                 { "AZURE_KUBERNETES_CA_DATA", "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t" },
             }))
             {
-                var ex = Assert.Throws<InvalidOperationException>(() => new WorkloadIdentityCredential(options));
+                var ex = Assert.Throws<InvalidOperationException>(() => CreateProxyTestCredential(isAzureProxyEnabled: true));
                 Assert.That(ex.Message, Does.Contain("ambiguous"));
             }
         }
@@ -219,25 +194,13 @@ namespace Azure.Identity.Tests
         [NonParallelizable]
         public void KubernetesProxy_CaFileDoesNotExist_ThrowsInvalidOperation()
         {
-            var tokenFilePath = "/fake/path/token";
-
-            var options = new WorkloadIdentityCredentialOptions
-            {
-                TenantId = TenantId,
-                ClientId = ClientId,
-                TokenFilePath = tokenFilePath,
-                IsAzureProxyEnabled = true,
-                MsalClient = mockConfidentialMsalClient,
-                Pipeline = CredentialPipeline.GetInstance(null)
-            };
-
             using (new TestEnvVar(new Dictionary<string, string>
             {
                 { "AZURE_KUBERNETES_TOKEN_PROXY", "https://proxy.local" },
                 { "AZURE_KUBERNETES_CA_FILE",  "/path/does/not/exist.pem"},
             }))
             {
-                var ex = Assert.Throws<InvalidOperationException>(() => new WorkloadIdentityCredential(options));
+                var ex = Assert.Throws<InvalidOperationException>(() => CreateProxyTestCredential(isAzureProxyEnabled: true));
                 Assert.That(ex.Message, Does.Contain("does not exist"));
             }
         }
@@ -249,5 +212,6 @@ namespace Azure.Identity.Tests
         }
 
         private TestTempFileHandler _tempFiles = new TestTempFileHandler();
+        protected TestTempFileHandler TempFiles => _tempFiles;
     }
 }


### PR DESCRIPTION
## Resolves #55501

### What this PR does

Adds comprehensive test coverage for creating Azure Identity credentials via IConfiguration and the internal ConfigurableCredential class, ensuring both direct instantiation and configuration-based creation paths produce identical behavior.

### Changes

**Source (2 files):**
- DefaultAzureCredentialOptions.cs — Added internal \IsAzureProxyEnabled\ property with IConfig reading and Clone support
- DefaultAzureCredentialFactory.cs — Copies \IsAzureProxyEnabled\ to WIC options

**Test infrastructure (3 files modified):**
- \WorkloadIdentityCredentialTests.cs\ — Added virtual factory methods for credential creation
- \CredentialTestHelpers.cs\ — \GetMsalClientType\ unwraps \ConfigurableCredential\
- \ConfigurableCredentialTestHelper.cs\ — Castle proxy unwrap, public config mapping, transport support

**New test files (9 files):**
- \CredentialCreationTestBase<T>\ — Shared base with \ReadProperty\/\ReadField\ reflection helpers
- Configurable \WorkloadIdentityCredentialTests\ — Credential creation via IConfiguration (54 pass, 2 skipped — matches base class)
- **7 creation test classes** validating option priority (IConfig > env var > default):
  | Credential | Tests | Properties Covered |
  |---|---|---|
  | WorkloadIdentity | 19 | TenantId, ClientId, TokenFilePath, AuthorityHost, DisableInstanceDiscovery, IsUnsafeSupportLoggingEnabled, AdditionallyAllowedTenants, IsAzureProxyEnabled |
  | AzureCli | 15 | TenantId, Subscription, ProcessTimeout, AdditionallyAllowedTenants, IsUnsafeSupportLoggingEnabled |
  | AzurePowerShell | 12 | TenantId, ProcessTimeout, AdditionallyAllowedTenants, IsUnsafeSupportLoggingEnabled |
  | AzureDeveloperCli | 12 | TenantId, ProcessTimeout, AdditionallyAllowedTenants, IsUnsafeSupportLoggingEnabled |
  | VisualStudio | 12 | TenantId, ProcessTimeout, AdditionallyAllowedTenants, IsUnsafeSupportLoggingEnabled |
  | VisualStudioCode | 12 | TenantId, AdditionallyAllowedTenants, AuthorityHost, IsUnsafeSupportLoggingEnabled |
  | Environment | 15 | TenantId, ClientId, AuthorityHost, DisableInstanceDiscovery, IsUnsafeSupportLoggingEnabled, AdditionallyAllowedTenants |

**Total: 92 creation tests + 56 configurable WIC tests, all passing**