### PR TITLE
Remove obsolete AOT CI parameters from planetarycomputer ci.yml

### DIFF
--- a/sdk/planetarycomputer/ci.yml
+++ b/sdk/planetarycomputer/ci.yml
@@ -20,7 +20,3 @@ extends:
     Artifacts:
     - name: Azure.Analytics.PlanetaryComputer
       safeName: AzureAnalyticsPlanetaryComputer
-    CheckAOTCompat: true
-    AOTTestInputs:
-    - ArtifactName: Azure.Analytics.PlanetaryComputer
-      ExpectedWarningsFilepath: "Azure.Analytics.PlanetaryComputer/tests/compatibility/ExpectedAotWarnings.txt"


### PR DESCRIPTION
# Remove obsolete AOT CI parameters from planetarycomputer ci.yml

## Description

Removes the `CheckAOTCompat` and `AOTTestInputs` parameters from `sdk/planetarycomputer/ci.yml` to align with the changes introduced in [PR #53752](https://github.com/Azure/azure-sdk-for-net/pull/53752).

PR #53752 simplified the AOT compatibility pipeline by consolidating AOT checking logic into the build scripts themselves, eliminating the need for explicit CI parameters. However, the `planetarycomputer` service directory was not included in that change.

## Changes

- Removed `CheckAOTCompat: true` from `sdk/planetarycomputer/ci.yml`
- Removed `AOTTestInputs` block from `sdk/planetarycomputer/ci.yml`

## Why

These parameters are no longer consumed by the pipeline templates. AOT compatibility is now automatically determined by:

- The `AotCompatOptOut` MSBuild property in project files
- The pipeline template iterating over `Artifacts` directly instead of requiring separate `AOTTestInputs`
