### PR TITLE
Support credential instance reuse in WithAzureCredential DI path

### DIFF
--- a/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
+++ b/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -8,19 +10,22 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using Microsoft.Extensions.Configuration;
 
 namespace Azure.Identity
 {
     [Experimental("SCME0002")]
-    internal class ConfigurableCredentialCache
+    internal static class ConfigurableCredentialCache
     {
-        private readonly ConcurrentDictionary<string, ConfigurableCredential> _cache = new();
+        private static ConcurrentDictionary<string, ConfigurableCredential>? s_cache;
+        private static ConcurrentDictionary<string, ConfigurableCredential> Cache =>
+            LazyInitializer.EnsureInitialized(ref s_cache, static () => new ConcurrentDictionary<string, ConfigurableCredential>())!;
 
-        public ConfigurableCredential GetOrAdd(IConfigurationSection credentialSection, Func<ConfigurableCredential> factory)
+        public static ConfigurableCredential GetOrAdd(IConfigurationSection credentialSection, Func<ConfigurableCredential> factory)
         {
             string key = CreateKey(credentialSection);
-            return _cache.GetOrAdd(key, _ => factory());
+            return Cache.GetOrAdd(key, _ => factory());
         }
 
         /// <summary>
@@ -33,12 +38,12 @@ namespace Azure.Identity
             string basePath = section.Path;
             int prefixLength = basePath.Length > 0 ? basePath.Length + 1 : 0; // +1 for the ':' separator
 
-            IEnumerable<KeyValuePair<string, string>> entries = section.AsEnumerable()
+            IEnumerable<KeyValuePair<string, string?>> entries = section.AsEnumerable()
                 .Where(kvp => kvp.Value is not null)
                 .OrderBy(kvp => kvp.Key, StringComparer.Ordinal);
 
             StringBuilder sb = new();
-            foreach (KeyValuePair<string, string> kvp in entries)
+            foreach (KeyValuePair<string, string?> kvp in entries)
             {
                 sb.Append(kvp.Key, prefixLength, kvp.Key.Length - prefixLength);
                 sb.Append('=').Append(kvp.Value).Append(';');

--- a/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
+++ b/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace Azure.Identity
+{
+    [Experimental("SCME0002")]
+    internal class ConfigurableCredentialCache
+    {
+        private readonly ConcurrentDictionary<string, ConfigurableCredential> _cache = new();
+
+        public ConfigurableCredential GetOrAdd(string key, Func<ConfigurableCredential> factory)
+        {
+            return _cache.GetOrAdd(key, _ => factory());
+        }
+
+        /// <summary>
+        /// Creates a deterministic cache key from the content of an <see cref="IConfigurationSection"/>.
+        /// Two sections at different paths but with identical values will produce the same key.
+        /// The key is a SHA256 hash to avoid leaking secrets that may be present in configuration values.
+        /// </summary>
+        internal static string CreateKey(IConfigurationSection section)
+        {
+            string basePath = section.Path;
+            int prefixLength = basePath.Length > 0 ? basePath.Length + 1 : 0; // +1 for the ':' separator
+
+            StringBuilder sb = new();
+            foreach (KeyValuePair<string, string> kvp in section.AsEnumerable()
+                .Where(kvp => kvp.Value is not null)
+                .OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
+            {
+                string relativeKey = kvp.Key.Length > prefixLength
+                    ? kvp.Key.Substring(prefixLength)
+                    : string.Empty;
+
+                sb.Append(relativeKey).Append('=').Append(kvp.Value).Append(';');
+            }
+
+            byte[] inputBytes = Encoding.UTF8.GetBytes(sb.ToString());
+#if NETSTANDARD2_0
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                byte[] hash = sha256.ComputeHash(inputBytes);
+                return BitConverter.ToString(hash).Replace("-", string.Empty);
+            }
+#else
+            byte[] hash = SHA256.HashData(inputBytes);
+            return Convert.ToHexString(hash);
+#endif
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
+++ b/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
@@ -17,8 +17,9 @@ namespace Azure.Identity
     {
         private readonly ConcurrentDictionary<string, ConfigurableCredential> _cache = new();
 
-        public ConfigurableCredential GetOrAdd(string key, Func<ConfigurableCredential> factory)
+        public ConfigurableCredential GetOrAdd(IConfigurationSection credentialSection, Func<ConfigurableCredential> factory)
         {
+            string key = CreateKey(credentialSection);
             return _cache.GetOrAdd(key, _ => factory());
         }
 
@@ -27,21 +28,20 @@ namespace Azure.Identity
         /// Two sections at different paths but with identical values will produce the same key.
         /// The key is a SHA256 hash to avoid leaking secrets that may be present in configuration values.
         /// </summary>
-        internal static string CreateKey(IConfigurationSection section)
+        private static string CreateKey(IConfigurationSection section)
         {
             string basePath = section.Path;
             int prefixLength = basePath.Length > 0 ? basePath.Length + 1 : 0; // +1 for the ':' separator
 
-            StringBuilder sb = new();
-            foreach (KeyValuePair<string, string> kvp in section.AsEnumerable()
+            IEnumerable<KeyValuePair<string, string>> entries = section.AsEnumerable()
                 .Where(kvp => kvp.Value is not null)
-                .OrderBy(kvp => kvp.Key, StringComparer.Ordinal))
-            {
-                string relativeKey = kvp.Key.Length > prefixLength
-                    ? kvp.Key.Substring(prefixLength)
-                    : string.Empty;
+                .OrderBy(kvp => kvp.Key, StringComparer.Ordinal);
 
-                sb.Append(relativeKey).Append('=').Append(kvp.Value).Append(';');
+            StringBuilder sb = new();
+            foreach (KeyValuePair<string, string> kvp in entries)
+            {
+                sb.Append(kvp.Key, prefixLength, kvp.Key.Length - prefixLength);
+                sb.Append('=').Append(kvp.Value).Append(';');
             }
 
             byte[] inputBytes = Encoding.UTF8.GetBytes(sb.ToString());

--- a/sdk/identity/Azure.Identity/src/ConfigurationExtensions.cs
+++ b/sdk/identity/Azure.Identity/src/ConfigurationExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using Azure.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,8 +18,6 @@ namespace Azure.Identity
     [Experimental("SCME0002")]
     public static class ConfigurationExtensions
     {
-        private static readonly ConditionalWeakTable<IServiceCollection, ConfigurableCredentialCache> s_credentialCaches = new();
-
         /// <summary>
         /// Creates an instance of <typeparamref name="T"/> and sets its properties from the specified <see cref="IConfiguration"/>.
         /// </summary>
@@ -112,8 +109,12 @@ namespace Azure.Identity
 
             settings.PostConfigure(config =>
             {
-                DefaultAzureCredentialOptions options = new(settings.Credential, config.GetSection("Credential"));
-                settings.CredentialProvider = new ConfigurableCredential(options);
+                IConfigurationSection credentialSection = config.GetSection("Credential");
+                settings.CredentialProvider = ConfigurableCredentialCache.GetOrAdd(credentialSection, () =>
+                {
+                    DefaultAzureCredentialOptions options = new(settings.Credential, credentialSection);
+                    return new ConfigurableCredential(options);
+                });
             });
             return settings;
         }
@@ -146,15 +147,13 @@ namespace Azure.Identity
         /// <param name="clientBuilder">The <see cref="IClientBuilder"/> to add the credential to.</param>
         public static IHostApplicationBuilder WithAzureCredential(this IClientBuilder clientBuilder)
         {
-            var cache = s_credentialCaches.GetValue(clientBuilder.Services, _ => new ConfigurableCredentialCache());
-
             return clientBuilder.PostConfigure(settings =>
             {
                 AddDefaultScope(settings);
                 settings.PostConfigure(config =>
                 {
                     IConfigurationSection credentialSection = config.GetSection("Credential");
-                    settings.CredentialProvider = cache.GetOrAdd(credentialSection, () =>
+                    settings.CredentialProvider = ConfigurableCredentialCache.GetOrAdd(credentialSection, () =>
                     {
                         DefaultAzureCredentialOptions options = new(settings.Credential, credentialSection);
                         return new ConfigurableCredential(options);

--- a/sdk/identity/Azure.Identity/src/ConfigurationExtensions.cs
+++ b/sdk/identity/Azure.Identity/src/ConfigurationExtensions.cs
@@ -154,8 +154,7 @@ namespace Azure.Identity
                 settings.PostConfigure(config =>
                 {
                     IConfigurationSection credentialSection = config.GetSection("Credential");
-                    string cacheKey = ConfigurableCredentialCache.CreateKey(credentialSection);
-                    settings.CredentialProvider = cache.GetOrAdd(cacheKey, () =>
+                    settings.CredentialProvider = cache.GetOrAdd(credentialSection, () =>
                     {
                         DefaultAzureCredentialOptions options = new(settings.Credential, credentialSection);
                         return new ConfigurableCredential(options);

--- a/sdk/identity/Azure.Identity/src/ConfigurationExtensions.cs
+++ b/sdk/identity/Azure.Identity/src/ConfigurationExtensions.cs
@@ -5,8 +5,10 @@ using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Azure.Core;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Azure.Identity
@@ -17,6 +19,8 @@ namespace Azure.Identity
     [Experimental("SCME0002")]
     public static class ConfigurationExtensions
     {
+        private static readonly ConditionalWeakTable<IServiceCollection, ConfigurableCredentialCache> s_credentialCaches = new();
+
         /// <summary>
         /// Creates an instance of <typeparamref name="T"/> and sets its properties from the specified <see cref="IConfiguration"/>.
         /// </summary>
@@ -137,17 +141,27 @@ namespace Azure.Identity
 
         /// <summary>
         /// Registers a credential factory to return a <see cref="TokenCredential"/> to use for the current <see cref="IClientBuilder"/>.
+        /// If the same credential configuration has already been registered, the existing credential instance is reused.
         /// </summary>
         /// <param name="clientBuilder">The <see cref="IClientBuilder"/> to add the credential to.</param>
         public static IHostApplicationBuilder WithAzureCredential(this IClientBuilder clientBuilder)
-            => clientBuilder.PostConfigure(settings =>
+        {
+            var cache = s_credentialCaches.GetValue(clientBuilder.Services, _ => new ConfigurableCredentialCache());
+
+            return clientBuilder.PostConfigure(settings =>
             {
                 AddDefaultScope(settings);
                 settings.PostConfigure(config =>
                 {
-                    DefaultAzureCredentialOptions options = new(settings.Credential, config.GetSection("Credential"));
-                    settings.CredentialProvider = new ConfigurableCredential(options);
+                    IConfigurationSection credentialSection = config.GetSection("Credential");
+                    string cacheKey = ConfigurableCredentialCache.CreateKey(credentialSection);
+                    settings.CredentialProvider = cache.GetOrAdd(cacheKey, () =>
+                    {
+                        DefaultAzureCredentialOptions options = new(settings.Credential, credentialSection);
+                        return new ConfigurableCredential(options);
+                    });
                 });
             });
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/Azure.Identity.Tests.csproj
+++ b/sdk/identity/Azure.Identity/tests/Azure.Identity.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="Azure.Messaging.EventHubs" />
     <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 <!-- Remove before shipping GA -->
   <PropertyGroup>

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialCacheTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialCacheTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials
+{
+    public class ConfigurableCredentialCacheTests
+    {
+        private static IConfigurationSection BuildCredentialSection(string sectionPath, Dictionary<string, string> values)
+        {
+            var configData = new Dictionary<string, string>();
+            foreach (var kvp in values)
+            {
+                configData[$"{sectionPath}:{kvp.Key}"] = kvp.Value;
+            }
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+
+            return configuration.GetSection(sectionPath);
+        }
+
+        [Test]
+        public void CreateKey_SameValuesDifferentPaths_ProducesSameKey()
+        {
+            var values = new Dictionary<string, string>
+            {
+                ["TenantId"] = "abc-123",
+                ["CredentialSource"] = "AzureCli"
+            };
+
+            var section1 = BuildCredentialSection("Client1:Credential", values);
+            var section2 = BuildCredentialSection("Client2:Credential", values);
+
+            string key1 = ConfigurableCredentialCache.CreateKey(section1);
+            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+
+            Assert.AreEqual(key1, key2);
+        }
+
+        [Test]
+        public void CreateKey_DifferentValues_ProducesDifferentKeys()
+        {
+            var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
+            {
+                ["TenantId"] = "tenant-a"
+            });
+            var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
+            {
+                ["TenantId"] = "tenant-b"
+            });
+
+            string key1 = ConfigurableCredentialCache.CreateKey(section1);
+            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+
+            Assert.AreNotEqual(key1, key2);
+        }
+
+        [Test]
+        public void CreateKey_EmptySection_ProducesConsistentKey()
+        {
+            var section = BuildCredentialSection("Client:Credential", new Dictionary<string, string>());
+
+            string key = ConfigurableCredentialCache.CreateKey(section);
+
+            Assert.IsNotNull(key);
+            Assert.IsNotEmpty(key);
+            // Same empty section should produce the same hash
+            var section2 = BuildCredentialSection("Other:Credential", new Dictionary<string, string>());
+            Assert.AreEqual(key, ConfigurableCredentialCache.CreateKey(section2));
+        }
+
+        [Test]
+        public void CreateKey_OrderIndependent_ProducesSameKey()
+        {
+            // Build two sections with the same values but inserted in different order
+            var section1 = BuildCredentialSection("A:Credential", new Dictionary<string, string>
+            {
+                ["Zebra"] = "z",
+                ["Alpha"] = "a"
+            });
+            var section2 = BuildCredentialSection("B:Credential", new Dictionary<string, string>
+            {
+                ["Alpha"] = "a",
+                ["Zebra"] = "z"
+            });
+
+            string key1 = ConfigurableCredentialCache.CreateKey(section1);
+            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+
+            Assert.AreEqual(key1, key2);
+        }
+
+        [Test]
+        public void GetOrAdd_SameKey_ReturnsSameInstance()
+        {
+            var cache = new ConfigurableCredentialCache();
+            int factoryCallCount = 0;
+
+            var cred1 = cache.GetOrAdd("key1", () =>
+            {
+                factoryCallCount++;
+                return new ConfigurableCredential();
+            });
+
+            var cred2 = cache.GetOrAdd("key1", () =>
+            {
+                factoryCallCount++;
+                return new ConfigurableCredential();
+            });
+
+            Assert.AreSame(cred1, cred2);
+            Assert.AreEqual(1, factoryCallCount);
+        }
+
+        [Test]
+        public void GetOrAdd_DifferentKeys_ReturnsDifferentInstances()
+        {
+            var cache = new ConfigurableCredentialCache();
+
+            var cred1 = cache.GetOrAdd("key1", () => new ConfigurableCredential());
+            var cred2 = cache.GetOrAdd("key2", () => new ConfigurableCredential());
+
+            Assert.AreNotSame(cred1, cred2);
+        }
+
+        [Test]
+        public void CreateKey_NestedValues_ProducesSameKeyRegardlessOfPath()
+        {
+            var configData1 = new Dictionary<string, string>
+            {
+                ["Client1:Credential:TenantId"] = "abc",
+                ["Client1:Credential:Nested:Value"] = "deep"
+            };
+            var configData2 = new Dictionary<string, string>
+            {
+                ["Client2:Credential:TenantId"] = "abc",
+                ["Client2:Credential:Nested:Value"] = "deep"
+            };
+
+            var config1 = new ConfigurationBuilder().AddInMemoryCollection(configData1).Build();
+            var config2 = new ConfigurationBuilder().AddInMemoryCollection(configData2).Build();
+
+            string key1 = ConfigurableCredentialCache.CreateKey(config1.GetSection("Client1:Credential"));
+            string key2 = ConfigurableCredentialCache.CreateKey(config2.GetSection("Client2:Credential"));
+
+            Assert.AreEqual(key1, key2);
+        }
+
+        [Test]
+        public void CreateKey_SameArrayValues_ProducesSameKey()
+        {
+            var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "AzureCli",
+                ["AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["AdditionallyAllowedTenants:1"] = "tenant-b",
+            });
+            var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "AzureCli",
+                ["AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["AdditionallyAllowedTenants:1"] = "tenant-b",
+            });
+
+            string key1 = ConfigurableCredentialCache.CreateKey(section1);
+            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+
+            Assert.AreEqual(key1, key2);
+        }
+
+        [Test]
+        public void CreateKey_DifferentArrayValues_ProducesDifferentKeys()
+        {
+            var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "AzureCli",
+                ["AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["AdditionallyAllowedTenants:1"] = "tenant-b",
+            });
+            var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "AzureCli",
+                ["AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["AdditionallyAllowedTenants:1"] = "tenant-c",
+            });
+
+            string key1 = ConfigurableCredentialCache.CreateKey(section1);
+            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+
+            Assert.AreNotEqual(key1, key2);
+        }
+
+        [Test]
+        public void CreateKey_DifferentArrayLength_ProducesDifferentKeys()
+        {
+            var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "AzureCli",
+                ["AdditionallyAllowedTenants:0"] = "tenant-a",
+            });
+            var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "AzureCli",
+                ["AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["AdditionallyAllowedTenants:1"] = "tenant-b",
+            });
+
+            string key1 = ConfigurableCredentialCache.CreateKey(section1);
+            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+
+            Assert.AreNotEqual(key1, key2);
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialCacheTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialCacheTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
@@ -24,21 +25,24 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
             return configuration.GetSection(sectionPath);
         }
 
+        // Each test uses a unique nonce in its values to avoid interference from the global static cache.
+        private static string Unique() => Guid.NewGuid().ToString("N");
+
         [Test]
         public void GetOrAdd_SameValuesDifferentPaths_ReturnsSameInstance()
         {
-            var cache = new ConfigurableCredentialCache();
+            string nonce = Unique();
             var values = new Dictionary<string, string>
             {
-                ["TenantId"] = "abc-123",
+                ["TenantId"] = nonce,
                 ["CredentialSource"] = "AzureCli"
             };
 
             var section1 = BuildCredentialSection("Client1:Credential", values);
             var section2 = BuildCredentialSection("Client2:Credential", values);
 
-            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
-            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () => new ConfigurableCredential());
 
             Assert.AreSame(cred1, cred2);
         }
@@ -46,19 +50,17 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         [Test]
         public void GetOrAdd_DifferentValues_ReturnsDifferentInstances()
         {
-            var cache = new ConfigurableCredentialCache();
-
             var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
             {
-                ["TenantId"] = "tenant-a"
+                ["TenantId"] = Unique()
             });
             var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
             {
-                ["TenantId"] = "tenant-b"
+                ["TenantId"] = Unique()
             });
 
-            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
-            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () => new ConfigurableCredential());
 
             Assert.AreNotSame(cred1, cred2);
         }
@@ -66,13 +68,11 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         [Test]
         public void GetOrAdd_EmptySections_ReturnsSameInstance()
         {
-            var cache = new ConfigurableCredentialCache();
-
             var section1 = BuildCredentialSection("Client:Credential", new Dictionary<string, string>());
             var section2 = BuildCredentialSection("Other:Credential", new Dictionary<string, string>());
 
-            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
-            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () => new ConfigurableCredential());
 
             Assert.AreSame(cred1, cred2);
         }
@@ -80,47 +80,46 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         [Test]
         public void GetOrAdd_OrderIndependent_ReturnsSameInstance()
         {
-            var cache = new ConfigurableCredentialCache();
-
+            string nonce = Unique();
             var section1 = BuildCredentialSection("A:Credential", new Dictionary<string, string>
             {
-                ["Zebra"] = "z",
+                ["Zebra"] = nonce,
                 ["Alpha"] = "a"
             });
             var section2 = BuildCredentialSection("B:Credential", new Dictionary<string, string>
             {
                 ["Alpha"] = "a",
-                ["Zebra"] = "z"
+                ["Zebra"] = nonce
             });
 
-            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
-            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () => new ConfigurableCredential());
 
             Assert.AreSame(cred1, cred2);
         }
 
         [Test]
-        public void GetOrAdd_SameSection_FactoryCalledOnce()
+        public void GetOrAdd_SameValues_FactoryCalledOnce()
         {
-            var cache = new ConfigurableCredentialCache();
+            string nonce = Unique();
             int factoryCallCount = 0;
 
             var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
             {
-                ["TenantId"] = "abc"
+                ["TenantId"] = nonce
             });
             var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
             {
-                ["TenantId"] = "abc"
+                ["TenantId"] = nonce
             });
 
-            var cred1 = cache.GetOrAdd(section1, () =>
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () =>
             {
                 factoryCallCount++;
                 return new ConfigurableCredential();
             });
 
-            var cred2 = cache.GetOrAdd(section2, () =>
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () =>
             {
                 factoryCallCount++;
                 return new ConfigurableCredential();
@@ -133,24 +132,23 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         [Test]
         public void GetOrAdd_NestedValues_SameContentReturnsSameInstance()
         {
-            var cache = new ConfigurableCredentialCache();
-
+            string nonce = Unique();
             var configData1 = new Dictionary<string, string>
             {
-                ["Client1:Credential:TenantId"] = "abc",
+                ["Client1:Credential:TenantId"] = nonce,
                 ["Client1:Credential:Nested:Value"] = "deep"
             };
             var configData2 = new Dictionary<string, string>
             {
-                ["Client2:Credential:TenantId"] = "abc",
+                ["Client2:Credential:TenantId"] = nonce,
                 ["Client2:Credential:Nested:Value"] = "deep"
             };
 
             var config1 = new ConfigurationBuilder().AddInMemoryCollection(configData1).Build();
             var config2 = new ConfigurationBuilder().AddInMemoryCollection(configData2).Build();
 
-            var cred1 = cache.GetOrAdd(config1.GetSection("Client1:Credential"), () => new ConfigurableCredential());
-            var cred2 = cache.GetOrAdd(config2.GetSection("Client2:Credential"), () => new ConfigurableCredential());
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(config1.GetSection("Client1:Credential"), () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(config2.GetSection("Client2:Credential"), () => new ConfigurableCredential());
 
             Assert.AreSame(cred1, cred2);
         }
@@ -158,23 +156,22 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         [Test]
         public void GetOrAdd_SameArrayValues_ReturnsSameInstance()
         {
-            var cache = new ConfigurableCredentialCache();
-
+            string nonce = Unique();
             var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
             {
-                ["CredentialSource"] = "AzureCli",
+                ["CredentialSource"] = nonce,
                 ["AdditionallyAllowedTenants:0"] = "tenant-a",
                 ["AdditionallyAllowedTenants:1"] = "tenant-b",
             });
             var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
             {
-                ["CredentialSource"] = "AzureCli",
+                ["CredentialSource"] = nonce,
                 ["AdditionallyAllowedTenants:0"] = "tenant-a",
                 ["AdditionallyAllowedTenants:1"] = "tenant-b",
             });
 
-            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
-            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () => new ConfigurableCredential());
 
             Assert.AreSame(cred1, cred2);
         }
@@ -182,23 +179,20 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         [Test]
         public void GetOrAdd_DifferentArrayValues_ReturnsDifferentInstances()
         {
-            var cache = new ConfigurableCredentialCache();
-
+            string nonce = Unique();
             var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
             {
-                ["CredentialSource"] = "AzureCli",
-                ["AdditionallyAllowedTenants:0"] = "tenant-a",
-                ["AdditionallyAllowedTenants:1"] = "tenant-b",
+                ["CredentialSource"] = nonce,
+                ["AdditionallyAllowedTenants:0"] = Unique(),
             });
             var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
             {
-                ["CredentialSource"] = "AzureCli",
-                ["AdditionallyAllowedTenants:0"] = "tenant-a",
-                ["AdditionallyAllowedTenants:1"] = "tenant-c",
+                ["CredentialSource"] = nonce,
+                ["AdditionallyAllowedTenants:0"] = Unique(),
             });
 
-            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
-            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () => new ConfigurableCredential());
 
             Assert.AreNotSame(cred1, cred2);
         }
@@ -206,22 +200,21 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         [Test]
         public void GetOrAdd_DifferentArrayLength_ReturnsDifferentInstances()
         {
-            var cache = new ConfigurableCredentialCache();
-
+            string nonce = Unique();
             var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
             {
-                ["CredentialSource"] = "AzureCli",
+                ["CredentialSource"] = nonce,
                 ["AdditionallyAllowedTenants:0"] = "tenant-a",
             });
             var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
             {
-                ["CredentialSource"] = "AzureCli",
+                ["CredentialSource"] = nonce,
                 ["AdditionallyAllowedTenants:0"] = "tenant-a",
                 ["AdditionallyAllowedTenants:1"] = "tenant-b",
             });
 
-            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
-            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () => new ConfigurableCredential());
 
             Assert.AreNotSame(cred1, cred2);
         }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialCacheTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialCacheTests.cs
@@ -25,8 +25,9 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         }
 
         [Test]
-        public void CreateKey_SameValuesDifferentPaths_ProducesSameKey()
+        public void GetOrAdd_SameValuesDifferentPaths_ReturnsSameInstance()
         {
+            var cache = new ConfigurableCredentialCache();
             var values = new Dictionary<string, string>
             {
                 ["TenantId"] = "abc-123",
@@ -36,15 +37,17 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
             var section1 = BuildCredentialSection("Client1:Credential", values);
             var section2 = BuildCredentialSection("Client2:Credential", values);
 
-            string key1 = ConfigurableCredentialCache.CreateKey(section1);
-            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
 
-            Assert.AreEqual(key1, key2);
+            Assert.AreSame(cred1, cred2);
         }
 
         [Test]
-        public void CreateKey_DifferentValues_ProducesDifferentKeys()
+        public void GetOrAdd_DifferentValues_ReturnsDifferentInstances()
         {
+            var cache = new ConfigurableCredentialCache();
+
             var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
             {
                 ["TenantId"] = "tenant-a"
@@ -54,30 +57,31 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
                 ["TenantId"] = "tenant-b"
             });
 
-            string key1 = ConfigurableCredentialCache.CreateKey(section1);
-            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
 
-            Assert.AreNotEqual(key1, key2);
+            Assert.AreNotSame(cred1, cred2);
         }
 
         [Test]
-        public void CreateKey_EmptySection_ProducesConsistentKey()
+        public void GetOrAdd_EmptySections_ReturnsSameInstance()
         {
-            var section = BuildCredentialSection("Client:Credential", new Dictionary<string, string>());
+            var cache = new ConfigurableCredentialCache();
 
-            string key = ConfigurableCredentialCache.CreateKey(section);
-
-            Assert.IsNotNull(key);
-            Assert.IsNotEmpty(key);
-            // Same empty section should produce the same hash
+            var section1 = BuildCredentialSection("Client:Credential", new Dictionary<string, string>());
             var section2 = BuildCredentialSection("Other:Credential", new Dictionary<string, string>());
-            Assert.AreEqual(key, ConfigurableCredentialCache.CreateKey(section2));
+
+            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
+
+            Assert.AreSame(cred1, cred2);
         }
 
         [Test]
-        public void CreateKey_OrderIndependent_ProducesSameKey()
+        public void GetOrAdd_OrderIndependent_ReturnsSameInstance()
         {
-            // Build two sections with the same values but inserted in different order
+            var cache = new ConfigurableCredentialCache();
+
             var section1 = BuildCredentialSection("A:Credential", new Dictionary<string, string>
             {
                 ["Zebra"] = "z",
@@ -89,25 +93,34 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
                 ["Zebra"] = "z"
             });
 
-            string key1 = ConfigurableCredentialCache.CreateKey(section1);
-            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
 
-            Assert.AreEqual(key1, key2);
+            Assert.AreSame(cred1, cred2);
         }
 
         [Test]
-        public void GetOrAdd_SameKey_ReturnsSameInstance()
+        public void GetOrAdd_SameSection_FactoryCalledOnce()
         {
             var cache = new ConfigurableCredentialCache();
             int factoryCallCount = 0;
 
-            var cred1 = cache.GetOrAdd("key1", () =>
+            var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
+            {
+                ["TenantId"] = "abc"
+            });
+            var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
+            {
+                ["TenantId"] = "abc"
+            });
+
+            var cred1 = cache.GetOrAdd(section1, () =>
             {
                 factoryCallCount++;
                 return new ConfigurableCredential();
             });
 
-            var cred2 = cache.GetOrAdd("key1", () =>
+            var cred2 = cache.GetOrAdd(section2, () =>
             {
                 factoryCallCount++;
                 return new ConfigurableCredential();
@@ -118,19 +131,10 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         }
 
         [Test]
-        public void GetOrAdd_DifferentKeys_ReturnsDifferentInstances()
+        public void GetOrAdd_NestedValues_SameContentReturnsSameInstance()
         {
             var cache = new ConfigurableCredentialCache();
 
-            var cred1 = cache.GetOrAdd("key1", () => new ConfigurableCredential());
-            var cred2 = cache.GetOrAdd("key2", () => new ConfigurableCredential());
-
-            Assert.AreNotSame(cred1, cred2);
-        }
-
-        [Test]
-        public void CreateKey_NestedValues_ProducesSameKeyRegardlessOfPath()
-        {
             var configData1 = new Dictionary<string, string>
             {
                 ["Client1:Credential:TenantId"] = "abc",
@@ -145,15 +149,17 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
             var config1 = new ConfigurationBuilder().AddInMemoryCollection(configData1).Build();
             var config2 = new ConfigurationBuilder().AddInMemoryCollection(configData2).Build();
 
-            string key1 = ConfigurableCredentialCache.CreateKey(config1.GetSection("Client1:Credential"));
-            string key2 = ConfigurableCredentialCache.CreateKey(config2.GetSection("Client2:Credential"));
+            var cred1 = cache.GetOrAdd(config1.GetSection("Client1:Credential"), () => new ConfigurableCredential());
+            var cred2 = cache.GetOrAdd(config2.GetSection("Client2:Credential"), () => new ConfigurableCredential());
 
-            Assert.AreEqual(key1, key2);
+            Assert.AreSame(cred1, cred2);
         }
 
         [Test]
-        public void CreateKey_SameArrayValues_ProducesSameKey()
+        public void GetOrAdd_SameArrayValues_ReturnsSameInstance()
         {
+            var cache = new ConfigurableCredentialCache();
+
             var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
             {
                 ["CredentialSource"] = "AzureCli",
@@ -167,15 +173,17 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
                 ["AdditionallyAllowedTenants:1"] = "tenant-b",
             });
 
-            string key1 = ConfigurableCredentialCache.CreateKey(section1);
-            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
 
-            Assert.AreEqual(key1, key2);
+            Assert.AreSame(cred1, cred2);
         }
 
         [Test]
-        public void CreateKey_DifferentArrayValues_ProducesDifferentKeys()
+        public void GetOrAdd_DifferentArrayValues_ReturnsDifferentInstances()
         {
+            var cache = new ConfigurableCredentialCache();
+
             var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
             {
                 ["CredentialSource"] = "AzureCli",
@@ -189,15 +197,17 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
                 ["AdditionallyAllowedTenants:1"] = "tenant-c",
             });
 
-            string key1 = ConfigurableCredentialCache.CreateKey(section1);
-            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
 
-            Assert.AreNotEqual(key1, key2);
+            Assert.AreNotSame(cred1, cred2);
         }
 
         [Test]
-        public void CreateKey_DifferentArrayLength_ProducesDifferentKeys()
+        public void GetOrAdd_DifferentArrayLength_ReturnsDifferentInstances()
         {
+            var cache = new ConfigurableCredentialCache();
+
             var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
             {
                 ["CredentialSource"] = "AzureCli",
@@ -210,10 +220,10 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
                 ["AdditionallyAllowedTenants:1"] = "tenant-b",
             });
 
-            string key1 = ConfigurableCredentialCache.CreateKey(section1);
-            string key2 = ConfigurableCredentialCache.CreateKey(section2);
+            var cred1 = cache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = cache.GetOrAdd(section2, () => new ConfigurableCredential());
 
-            Assert.AreNotEqual(key1, key2);
+            Assert.AreNotSame(cred1, cred2);
         }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WithAzureCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WithAzureCredentialTests.cs
@@ -230,7 +230,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         }
 
         [Test]
-        public void SeparateHosts_SameCredentialConfig_DoNotShareCredentialInstances()
+        public void SeparateHosts_SameCredentialConfig_SharesCredentialInstance()
         {
             var sharedConfig = new Dictionary<string, string>
             {
@@ -254,11 +254,11 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
 
             Assert.That(client1.Settings.CredentialProvider, Is.Not.Null);
             Assert.That(client2.Settings.CredentialProvider, Is.Not.Null);
-            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+            Assert.That(client1.Settings.CredentialProvider, Is.SameAs(client2.Settings.CredentialProvider));
         }
 
         [Test]
-        public void SeparateHosts_KeyedClients_DoNotShareCredentialInstances()
+        public void SeparateHosts_KeyedClients_SameConfig_SharesCredentialInstance()
         {
             var sharedConfig = new Dictionary<string, string>
             {
@@ -280,7 +280,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
             var client1 = host1.Services.GetRequiredKeyedService<SimpleTestClient>("k1");
             var client2 = host2.Services.GetRequiredKeyedService<SimpleTestClient>("k1");
 
-            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+            Assert.That(client1.Settings.CredentialProvider, Is.SameAs(client2.Settings.CredentialProvider));
         }
 
         [Test]
@@ -447,6 +447,110 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
             var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
 
             Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void DirectAndDI_SameCredentialConfig_SharesCredentialInstance()
+        {
+            // Create a credential via the direct ClientSettings path
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["DirectClient:Endpoint"] = "https://direct.example.com",
+                    ["DirectClient:Credential:CredentialSource"] = "AzureCli",
+                    ["DirectClient:Credential:TenantId"] = "cross-path-tenant",
+                })
+                .Build();
+            var directSettings = config.GetAzureClientSettings<SimpleTestSettings>("DirectClient");
+
+            // Create a credential via the DI path with the same credential values
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["DIClient:Endpoint"] = "https://di.example.com",
+                ["DIClient:Credential:CredentialSource"] = "AzureCli",
+                ["DIClient:Credential:TenantId"] = "cross-path-tenant",
+            });
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("DIClient").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var diClient = host.Services.GetRequiredService<SimpleTestClient>();
+
+            Assert.That(directSettings.CredentialProvider, Is.Not.Null);
+            Assert.That(diClient.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(directSettings.CredentialProvider, Is.SameAs(diClient.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void DirectAndDI_DifferentCredentialConfig_ReturnsDifferentInstances()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["DirectClient:Endpoint"] = "https://direct.example.com",
+                    ["DirectClient:Credential:CredentialSource"] = "AzureCli",
+                    ["DirectClient:Credential:TenantId"] = "direct-tenant",
+                })
+                .Build();
+            var directSettings = config.GetAzureClientSettings<SimpleTestSettings>("DirectClient");
+
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["DIClient:Endpoint"] = "https://di.example.com",
+                ["DIClient:Credential:CredentialSource"] = "AzureCli",
+                ["DIClient:Credential:TenantId"] = "di-tenant",
+            });
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("DIClient").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var diClient = host.Services.GetRequiredService<SimpleTestClient>();
+
+            Assert.That(directSettings.CredentialProvider, Is.Not.SameAs(diClient.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void DirectPath_SameCredentialConfig_SharesCredentialInstance()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client1:Endpoint"] = "https://one.example.com",
+                    ["Client1:Credential:CredentialSource"] = "AzureCli",
+                    ["Client1:Credential:TenantId"] = "direct-shared-tenant",
+                    ["Client2:Endpoint"] = "https://two.example.com",
+                    ["Client2:Credential:CredentialSource"] = "AzureCli",
+                    ["Client2:Credential:TenantId"] = "direct-shared-tenant",
+                })
+                .Build();
+
+            var settings1 = config.GetAzureClientSettings<SimpleTestSettings>("Client1");
+            var settings2 = config.GetAzureClientSettings<SimpleTestSettings>("Client2");
+
+            Assert.That(settings1.CredentialProvider, Is.Not.Null);
+            Assert.That(settings2.CredentialProvider, Is.Not.Null);
+            Assert.That(settings1.CredentialProvider, Is.SameAs(settings2.CredentialProvider));
+        }
+
+        [Test]
+        public void DirectPath_DifferentCredentialConfig_ReturnsDifferentInstances()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client1:Endpoint"] = "https://one.example.com",
+                    ["Client1:Credential:CredentialSource"] = "AzureCli",
+                    ["Client1:Credential:TenantId"] = "direct-tenant-a",
+                    ["Client2:Endpoint"] = "https://two.example.com",
+                    ["Client2:Credential:CredentialSource"] = "AzureCli",
+                    ["Client2:Credential:TenantId"] = "direct-tenant-b",
+                })
+                .Build();
+
+            var settings1 = config.GetAzureClientSettings<SimpleTestSettings>("Client1");
+            var settings2 = config.GetAzureClientSettings<SimpleTestSettings>("Client2");
+
+            Assert.That(settings1.CredentialProvider, Is.Not.SameAs(settings2.CredentialProvider));
         }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WithAzureCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WithAzureCredentialTests.cs
@@ -1,0 +1,452 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials
+{
+    public class WithAzureCredentialTests
+    {
+        internal class SimpleTestClient
+        {
+            public SimpleTestClient(SimpleTestSettings settings)
+            {
+                Settings = settings;
+            }
+
+            public SimpleTestSettings Settings { get; }
+        }
+
+        internal class SimpleTestClient2
+        {
+            public SimpleTestClient2(SimpleTestSettings2 settings)
+            {
+                Settings = settings;
+            }
+
+            public SimpleTestSettings2 Settings { get; }
+        }
+
+        internal class SimpleTestSettings : ClientSettings
+        {
+            public string Endpoint { get; set; }
+
+            protected override void BindCore(IConfigurationSection section)
+            {
+                Endpoint = section["Endpoint"];
+            }
+        }
+
+        internal class SimpleTestSettings2 : ClientSettings
+        {
+            public string Endpoint { get; set; }
+
+            protected override void BindCore(IConfigurationSection section)
+            {
+                Endpoint = section["Endpoint"];
+            }
+        }
+
+        [Test]
+        public void SameCredentialConfig_ReturnsSharedCredentialInstance()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client1:Credential:TenantId"] = "tenant-abc",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Credential:TenantId"] = "tenant-abc",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddClient<SimpleTestClient2, SimpleTestSettings2>("Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client2.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client1.Settings.CredentialProvider, Is.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void DifferentCredentialConfig_ReturnsDifferentCredentialInstances()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client1:Credential:TenantId"] = "tenant-abc",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Credential:TenantId"] = "tenant-xyz",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddClient<SimpleTestClient2, SimpleTestSettings2>("Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client2.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void SameCredentialConfig_ApiKey_ReturnsSharedInstance()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "ApiKey",
+                ["Client1:Credential:Key"] = "my-shared-key",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "ApiKey",
+                ["Client2:Credential:Key"] = "my-shared-key",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddClient<SimpleTestClient2, SimpleTestSettings2>("Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void DifferentApiKeys_ReturnsDifferentInstances()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "ApiKey",
+                ["Client1:Credential:Key"] = "key-one",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "ApiKey",
+                ["Client2:Credential:Key"] = "key-two",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddClient<SimpleTestClient2, SimpleTestSettings2>("Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void KeyedClients_SameCredentialConfig_ReturnsSharedInstance()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client1:Credential:TenantId"] = "tenant-abc",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Credential:TenantId"] = "tenant-abc",
+            });
+
+            builder.AddKeyedClient<SimpleTestClient, SimpleTestSettings>("key1", "Client1").WithAzureCredential();
+            builder.AddKeyedClient<SimpleTestClient, SimpleTestSettings>("key2", "Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredKeyedService<SimpleTestClient>("key1");
+            var client2 = host.Services.GetRequiredKeyedService<SimpleTestClient>("key2");
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client2.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client1.Settings.CredentialProvider, Is.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void KeyedClients_DifferentCredentialConfig_ReturnsDifferentInstances()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client1:Credential:TenantId"] = "tenant-abc",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Credential:TenantId"] = "tenant-xyz",
+            });
+
+            builder.AddKeyedClient<SimpleTestClient, SimpleTestSettings>("key1", "Client1").WithAzureCredential();
+            builder.AddKeyedClient<SimpleTestClient, SimpleTestSettings>("key2", "Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredKeyedService<SimpleTestClient>("key1");
+            var client2 = host.Services.GetRequiredKeyedService<SimpleTestClient>("key2");
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client2.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void MixedKeyedAndNonKeyed_SameCredentialConfig_ReturnsSharedInstance()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client1:Credential:TenantId"] = "tenant-abc",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Credential:TenantId"] = "tenant-abc",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddKeyedClient<SimpleTestClient2, SimpleTestSettings2>("keyed", "Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredKeyedService<SimpleTestClient2>("keyed");
+
+            Assert.That(client1.Settings.CredentialProvider, Is.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void SeparateHosts_SameCredentialConfig_DoNotShareCredentialInstances()
+        {
+            var sharedConfig = new Dictionary<string, string>
+            {
+                ["MyClient:Endpoint"] = "https://test.example.com",
+                ["MyClient:Credential:CredentialSource"] = "AzureCli",
+                ["MyClient:Credential:TenantId"] = "tenant-abc",
+            };
+
+            HostApplicationBuilder builder1 = Host.CreateApplicationBuilder();
+            builder1.Configuration.AddInMemoryCollection(sharedConfig);
+            builder1.AddClient<SimpleTestClient, SimpleTestSettings>("MyClient").WithAzureCredential();
+
+            HostApplicationBuilder builder2 = Host.CreateApplicationBuilder();
+            builder2.Configuration.AddInMemoryCollection(sharedConfig);
+            builder2.AddClient<SimpleTestClient, SimpleTestSettings>("MyClient").WithAzureCredential();
+
+            IHost host1 = builder1.Build();
+            IHost host2 = builder2.Build();
+            var client1 = host1.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host2.Services.GetRequiredService<SimpleTestClient>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client2.Settings.CredentialProvider, Is.Not.Null);
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void SeparateHosts_KeyedClients_DoNotShareCredentialInstances()
+        {
+            var sharedConfig = new Dictionary<string, string>
+            {
+                ["MyClient:Endpoint"] = "https://test.example.com",
+                ["MyClient:Credential:CredentialSource"] = "ApiKey",
+                ["MyClient:Credential:Key"] = "shared-key",
+            };
+
+            HostApplicationBuilder builder1 = Host.CreateApplicationBuilder();
+            builder1.Configuration.AddInMemoryCollection(sharedConfig);
+            builder1.AddKeyedClient<SimpleTestClient, SimpleTestSettings>("k1", "MyClient").WithAzureCredential();
+
+            HostApplicationBuilder builder2 = Host.CreateApplicationBuilder();
+            builder2.Configuration.AddInMemoryCollection(sharedConfig);
+            builder2.AddKeyedClient<SimpleTestClient, SimpleTestSettings>("k1", "MyClient").WithAzureCredential();
+
+            IHost host1 = builder1.Build();
+            IHost host2 = builder2.Build();
+            var client1 = host1.Services.GetRequiredKeyedService<SimpleTestClient>("k1");
+            var client2 = host2.Services.GetRequiredKeyedService<SimpleTestClient>("k1");
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void SameConfigSectionPath_SharesCredentialInstance()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["SharedSection:Endpoint"] = "https://test.example.com",
+                ["SharedSection:Credential:CredentialSource"] = "AzureCli",
+                ["SharedSection:Credential:TenantId"] = "tenant-abc",
+            });
+
+            // Two different client types pointing at the exact same config section
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("SharedSection").WithAzureCredential();
+            builder.AddKeyedClient<SimpleTestClient2, SimpleTestSettings2>("keyed", "SharedSection").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredKeyedService<SimpleTestClient2>("keyed");
+
+            Assert.That(client1.Settings.CredentialProvider, Is.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void SingleClient_CredentialProviderIsSet()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["MyClient:Endpoint"] = "https://test.example.com",
+                ["MyClient:Credential:CredentialSource"] = "AzureCli",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("MyClient").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client = host.Services.GetRequiredService<SimpleTestClient>();
+
+            Assert.That(client.Settings.CredentialProvider, Is.Not.Null);
+        }
+
+        [Test]
+        public void CredentialSourceDifference_ReturnsDifferentInstances()
+        {
+            // Same TenantId but different CredentialSource should produce different credentials
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client1:Credential:TenantId"] = "tenant-abc",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzurePowerShell",
+                ["Client2:Credential:TenantId"] = "tenant-abc",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddClient<SimpleTestClient2, SimpleTestSettings2>("Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void ExtraCredentialProperty_ReturnsDifferentInstances()
+        {
+            // One section has an extra property the other doesn't — they should not share
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Credential:TenantId"] = "extra-tenant",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddClient<SimpleTestClient2, SimpleTestSettings2>("Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void SameAllowedTenants_ReturnsSharedInstance()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client1:Credential:AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["Client1:Credential:AdditionallyAllowedTenants:1"] = "tenant-b",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Credential:AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["Client2:Credential:AdditionallyAllowedTenants:1"] = "tenant-b",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddClient<SimpleTestClient2, SimpleTestSettings2>("Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void DifferentAllowedTenants_ReturnsDifferentInstances()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client1:Credential:AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["Client1:Credential:AdditionallyAllowedTenants:1"] = "tenant-b",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Credential:AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["Client2:Credential:AdditionallyAllowedTenants:1"] = "tenant-c",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddClient<SimpleTestClient2, SimpleTestSettings2>("Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+
+        [Test]
+        public void DifferentAllowedTenantsLength_ReturnsDifferentInstances()
+        {
+            HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Client1:Endpoint"] = "https://one.example.com",
+                ["Client1:Credential:CredentialSource"] = "AzureCli",
+                ["Client1:Credential:AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["Client2:Endpoint"] = "https://two.example.com",
+                ["Client2:Credential:CredentialSource"] = "AzureCli",
+                ["Client2:Credential:AdditionallyAllowedTenants:0"] = "tenant-a",
+                ["Client2:Credential:AdditionallyAllowedTenants:1"] = "tenant-b",
+            });
+
+            builder.AddClient<SimpleTestClient, SimpleTestSettings>("Client1").WithAzureCredential();
+            builder.AddClient<SimpleTestClient2, SimpleTestSettings2>("Client2").WithAzureCredential();
+
+            IHost host = builder.Build();
+            var client1 = host.Services.GetRequiredService<SimpleTestClient>();
+            var client2 = host.Services.GetRequiredService<SimpleTestClient2>();
+
+            Assert.That(client1.Settings.CredentialProvider, Is.Not.SameAs(client2.Settings.CredentialProvider));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #56231

## What

When multiple Azure clients are registered via DI with identical credential configuration, they now share the same \ConfigurableCredential\ instance. This enables MSAL token cache reuse across clients, improving resilience per [Azure Identity best practices](https://learn.microsoft.com/dotnet/azure/sdk/authentication/best-practices?tabs=aspdotnet#reuse-credential-instances).

## How

- Added \ConfigurableCredentialCache\ (internal) that caches \ConfigurableCredential\ instances keyed by a SHA256 hash of the credential config section's flattened key-value pairs
- Updated \WithAzureCredential(IClientBuilder)\ to use the cache via a \ConditionalWeakTable<IServiceCollection, ConfigurableCredentialCache>\ scoped per host builder
- Cache keys are content-based: two different config section paths with identical values produce the same key and share the credential
- Separate host builders get separate caches (no cross-host leakage)
- SHA256 hashing avoids leaking secrets in cache keys
- \#if NETSTANDARD2_0\ conditional for optimal hashing APIs on modern TFs

## Scope

Only the \WithAzureCredential(IClientBuilder)\ overload (DI path) is changed. The direct \ClientSettings\ overload is unchanged.

## Tests

- 10 unit tests for cache key generation (arrays, nested values, ordering, empty sections)
- 16 integration tests exercising the full DI pipeline (same/different config, keyed/non-keyed clients, mixed registration, separate hosts, array configs)