### PR TITLE
Add support for KeepAlive updates in streaming system

### DIFF
--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/KeepAliveUpdate.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/KeepAliveUpdate.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Azure.AI.Agents.Persistent;
+
+/// <summary>
+/// Represents a streaming update that serves as a keep-alive signal within a sequence of run steps.
+/// </summary>
+/// <remarks>A KeepAliveUpdate is used to indicate ongoing activity or maintain a connection during streaming
+/// operations. It does not contain any run step data and is typically used internally to prevent timeouts or signal
+/// liveness in long-running processes.</remarks>
+public class KeepAliveUpdate : StreamingUpdate<RunStep>
+{
+    internal KeepAliveUpdate() : base(null, StreamingUpdateReason.KeepAlive) { }
+    internal static IEnumerable<StreamingUpdate> GetRunSteps()
+    {
+        return new List<StreamingUpdate> { new KeepAliveUpdate() };
+    }
+}

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdate.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdate.cs
@@ -46,7 +46,14 @@ public abstract partial class StreamingUpdate
 
     internal static IEnumerable<StreamingUpdate> FromEvent(SseItem<byte[]> sseItem)
     {
-        StreamingUpdateReason updateKind = StreamingUpdateReasonExtensions.FromSseEventLabel(sseItem.EventType);
+        var eventType = sseItem.EventType;
+        var updateKind = StreamingUpdateReasonExtensions.FromSseEventLabel(eventType);
+
+        if (updateKind == StreamingUpdateReason.KeepAlive)
+        {
+            return KeepAliveUpdate.GetRunSteps();
+        }
+
         using JsonDocument dataDocument = JsonDocument.Parse(sseItem.Data);
         JsonElement e = dataDocument.RootElement;
 

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdateReason.Serialization.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdateReason.Serialization.cs
@@ -31,6 +31,7 @@ internal static class StreamingUpdateReasonExtensions
         StreamingUpdateReason.MessageFailed => "thread.message.incomplete",
         StreamingUpdateReason.Error => "error",
         StreamingUpdateReason.Done => "done",
+        StreamingUpdateReason.KeepAlive => "keepalive",
         _ => string.Empty
     };
 
@@ -61,6 +62,7 @@ internal static class StreamingUpdateReasonExtensions
         "thread.message.incomplete" => StreamingUpdateReason.MessageFailed,
         "error" => StreamingUpdateReason.Error,
         "done" => StreamingUpdateReason.Done,
+        "keepalive" => StreamingUpdateReason.KeepAlive,
         _ => StreamingUpdateReason.Unknown,
     };
 }

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdateReason.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Custom/Streaming/StreamingUpdateReason.cs
@@ -127,4 +127,8 @@ public enum StreamingUpdateReason
     /// Indicates the end of streaming update events. This value should never be typically observed.
     /// </summary>
     Done,
+    /// <summary>
+    /// Indicates that a keep-alive message was received, signifying that the connection is still active.
+    /// </summary>
+    KeepAlive,
 }


### PR DESCRIPTION
# Relates to issue #55585 and #55561 where KeepAlive updates are not handled.

Introduced a new `KeepAlive` update reason to signify active connections during streaming operations. Updated the `StreamingUpdateReason` enum and its serialization/deserialization logic to handle the new `KeepAlive` reason.

Modified the `StreamingUpdate.FromEvent` method to return a `KeepAliveUpdate` instance when a keep-alive message is received.

Added a new `KeepAliveUpdate` class to represent keep-alive signals within streaming updates. This class includes a static method to generate keep-alive updates and is fully documented.

Improved code organization and added comments to ensure seamless integration of the `KeepAlive` update reason into the existing streaming update system.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
