### PR TITLE
Add ManagedIdentityCredential support in ConfigurableCredentialProvider

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -100,6 +100,11 @@ namespace Azure.Identity
                 ManagedIdentityResourceId = new ResourceIdentifier(managedIdentityResourceId);
             }
 
+            if (section[nameof(ManagedIdentityObjectId)] is string managedIdentityObjectId)
+            {
+                ManagedIdentityObjectId = managedIdentityObjectId;
+            }
+
             if (TimeSpan.TryParse(section[nameof(CredentialProcessTimeout)], out TimeSpan credentialProcessTimeout))
             {
                 CredentialProcessTimeout = credentialProcessTimeout;
@@ -118,6 +123,16 @@ namespace Azure.Identity
             if (bool.TryParse(section[nameof(WorkloadIdentityCredentialOptions.IsAzureProxyEnabled)], out bool isAzureProxyEnabled))
             {
                 IsAzureProxyEnabled = isAzureProxyEnabled;
+            }
+
+            if (bool.TryParse(section[nameof(IsProbeEnabled)], out bool isProbeEnabled))
+            {
+                IsProbeEnabled = isProbeEnabled;
+            }
+
+            if (bool.TryParse(section[nameof(UseManagedIdentityPipeline)], out bool useMiPipeline))
+            {
+                UseManagedIdentityPipeline = useMiPipeline;
             }
         }
 
@@ -332,6 +347,26 @@ namespace Azure.Identity
         public ResourceIdentifier ManagedIdentityResourceId { get; set; }
 
         /// <summary>
+        /// Specifies the object ID of a user-assigned managed identity. If this value is configured, then
+        /// <see cref="ManagedIdentityClientId"/> and <see cref="ManagedIdentityResourceId"/> should not be configured.
+        /// </summary>
+        internal string ManagedIdentityObjectId { get; set; }
+
+        /// <summary>
+        /// Specifies whether the IMDS probe request should be enabled when using a managed identity credential
+        /// via <see cref="ConfigurableCredential"/>. When <c>null</c> (default), the probe is disabled for
+        /// single-credential selection and enabled when MIC is part of the default credential chain.
+        /// </summary>
+        internal bool? IsProbeEnabled { get; set; }
+
+        /// <summary>
+        /// Specifies whether the managed identity pipeline (with IMDS-specific retry policy) should be used.
+        /// When <c>null</c> (default), the standard pipeline is used for single-credential selection
+        /// and the MI pipeline is used when MIC is part of the default credential chain.
+        /// </summary>
+        internal bool? UseManagedIdentityPipeline { get; set; }
+
+        /// <summary>
         /// Specifies timeout for credentials invoked via sub-process. e.g. Visual Studio, Azure CLI, Azure PowerShell.
         /// </summary>
         public TimeSpan? CredentialProcessTimeout { get; set; } = TimeSpan.FromSeconds(30);
@@ -444,6 +479,7 @@ namespace Azure.Identity
                 dacClone.WorkloadIdentityClientId = WorkloadIdentityClientId;
                 dacClone.ManagedIdentityClientId = ManagedIdentityClientId;
                 dacClone.ManagedIdentityResourceId = ManagedIdentityResourceId;
+                dacClone.ManagedIdentityObjectId = ManagedIdentityObjectId;
                 dacClone.CredentialProcessTimeout = CredentialProcessTimeout;
                 dacClone.ExcludeEnvironmentCredential = ExcludeEnvironmentCredential;
                 dacClone.ExcludeWorkloadIdentityCredential = ExcludeWorkloadIdentityCredential;
@@ -466,6 +502,8 @@ namespace Azure.Identity
                     dacClone.Subscription = Subscription;
                 }
                 dacClone.IsAzureProxyEnabled = IsAzureProxyEnabled;
+                dacClone.IsProbeEnabled = IsProbeEnabled;
+                dacClone.UseManagedIdentityPipeline = UseManagedIdentityPipeline;
             }
 
             return clone;

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -105,6 +105,16 @@ namespace Azure.Identity
                 ManagedIdentityObjectId = managedIdentityObjectId;
             }
 
+            if (section[nameof(ManagedIdentityIdType)] is string managedIdentityIdType)
+            {
+                ManagedIdentityIdType = managedIdentityIdType;
+            }
+
+            if (section[nameof(ManagedIdentityId)] is string managedIdentityId)
+            {
+                ManagedIdentityId = managedIdentityId;
+            }
+
             if (TimeSpan.TryParse(section[nameof(CredentialProcessTimeout)], out TimeSpan credentialProcessTimeout))
             {
                 CredentialProcessTimeout = credentialProcessTimeout;
@@ -343,6 +353,17 @@ namespace Azure.Identity
         internal string ManagedIdentityObjectId { get; set; }
 
         /// <summary>
+        /// Specifies the type of managed identity to use. Valid values are "SystemAssigned", "ClientId", "ResourceId", and "ObjectId".
+        /// When set to a user-assigned type, <see cref="ManagedIdentityId"/> must also be specified.
+        /// </summary>
+        internal string ManagedIdentityIdType { get; set; }
+
+        /// <summary>
+        /// Specifies the ID of the managed identity when <see cref="ManagedIdentityIdType"/> is set to "ClientId", "ResourceId", or "ObjectId".
+        /// </summary>
+        internal string ManagedIdentityId { get; set; }
+
+        /// <summary>
         /// Specifies timeout for credentials invoked via sub-process. e.g. Visual Studio, Azure CLI, Azure PowerShell.
         /// </summary>
         public TimeSpan? CredentialProcessTimeout { get; set; } = TimeSpan.FromSeconds(30);
@@ -456,6 +477,8 @@ namespace Azure.Identity
                 dacClone.ManagedIdentityClientId = ManagedIdentityClientId;
                 dacClone.ManagedIdentityResourceId = ManagedIdentityResourceId;
                 dacClone.ManagedIdentityObjectId = ManagedIdentityObjectId;
+                dacClone.ManagedIdentityIdType = ManagedIdentityIdType;
+                dacClone.ManagedIdentityId = ManagedIdentityId;
                 dacClone.CredentialProcessTimeout = CredentialProcessTimeout;
                 dacClone.ExcludeEnvironmentCredential = ExcludeEnvironmentCredential;
                 dacClone.ExcludeWorkloadIdentityCredential = ExcludeWorkloadIdentityCredential;

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -105,9 +105,9 @@ namespace Azure.Identity
                 ManagedIdentityObjectId = managedIdentityObjectId;
             }
 
-            if (section[nameof(ManagedIdentityIdType)] is string managedIdentityIdType)
+            if (section[nameof(ManagedIdentityIdKind)] is string managedIdentityIdKind)
             {
-                ManagedIdentityIdType = managedIdentityIdType;
+                ManagedIdentityIdKind = managedIdentityIdKind;
             }
 
             if (section[nameof(ManagedIdentityId)] is string managedIdentityId)
@@ -356,10 +356,10 @@ namespace Azure.Identity
         /// Specifies the type of managed identity to use. Valid values are "SystemAssigned", "ClientId", "ResourceId", and "ObjectId".
         /// When set to a user-assigned type, <see cref="ManagedIdentityId"/> must also be specified.
         /// </summary>
-        internal string ManagedIdentityIdType { get; set; }
+        internal string ManagedIdentityIdKind { get; set; }
 
         /// <summary>
-        /// Specifies the ID of the managed identity when <see cref="ManagedIdentityIdType"/> is set to "ClientId", "ResourceId", or "ObjectId".
+        /// Specifies the ID of the managed identity when <see cref="ManagedIdentityIdKind"/> is set to "ClientId", "ResourceId", or "ObjectId".
         /// </summary>
         internal string ManagedIdentityId { get; set; }
 
@@ -477,7 +477,7 @@ namespace Azure.Identity
                 dacClone.ManagedIdentityClientId = ManagedIdentityClientId;
                 dacClone.ManagedIdentityResourceId = ManagedIdentityResourceId;
                 dacClone.ManagedIdentityObjectId = ManagedIdentityObjectId;
-                dacClone.ManagedIdentityIdType = ManagedIdentityIdType;
+                dacClone.ManagedIdentityIdKind = ManagedIdentityIdKind;
                 dacClone.ManagedIdentityId = ManagedIdentityId;
                 dacClone.CredentialProcessTimeout = CredentialProcessTimeout;
                 dacClone.ExcludeEnvironmentCredential = ExcludeEnvironmentCredential;

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -124,16 +124,6 @@ namespace Azure.Identity
             {
                 IsAzureProxyEnabled = isAzureProxyEnabled;
             }
-
-            if (bool.TryParse(section[nameof(IsProbeEnabled)], out bool isProbeEnabled))
-            {
-                IsProbeEnabled = isProbeEnabled;
-            }
-
-            if (bool.TryParse(section[nameof(UseManagedIdentityPipeline)], out bool useMiPipeline))
-            {
-                UseManagedIdentityPipeline = useMiPipeline;
-            }
         }
 
         private UpdateTracker<string> _tenantId = new UpdateTracker<string>(EnvironmentVariables.TenantId);
@@ -353,20 +343,6 @@ namespace Azure.Identity
         internal string ManagedIdentityObjectId { get; set; }
 
         /// <summary>
-        /// Specifies whether the IMDS probe request should be enabled when using a managed identity credential
-        /// via <see cref="ConfigurableCredential"/>. When <c>null</c> (default), the probe is disabled for
-        /// single-credential selection and enabled when MIC is part of the default credential chain.
-        /// </summary>
-        internal bool? IsProbeEnabled { get; set; }
-
-        /// <summary>
-        /// Specifies whether the managed identity pipeline (with IMDS-specific retry policy) should be used.
-        /// When <c>null</c> (default), the standard pipeline is used for single-credential selection
-        /// and the MI pipeline is used when MIC is part of the default credential chain.
-        /// </summary>
-        internal bool? UseManagedIdentityPipeline { get; set; }
-
-        /// <summary>
         /// Specifies timeout for credentials invoked via sub-process. e.g. Visual Studio, Azure CLI, Azure PowerShell.
         /// </summary>
         public TimeSpan? CredentialProcessTimeout { get; set; } = TimeSpan.FromSeconds(30);
@@ -502,8 +478,6 @@ namespace Azure.Identity
                     dacClone.Subscription = Subscription;
                 }
                 dacClone.IsAzureProxyEnabled = IsAzureProxyEnabled;
-                dacClone.IsProbeEnabled = IsProbeEnabled;
-                dacClone.UseManagedIdentityPipeline = UseManagedIdentityPipeline;
             }
 
             return clone;

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -296,16 +296,16 @@ namespace Azure.Identity
                 IsForceRefreshEnabled = options.IsForceRefreshEnabled,
             };
 
-            // ManagedIdentityIdType/ManagedIdentityId (new config properties) take priority
-            if (!string.IsNullOrEmpty(options.ManagedIdentityIdType))
+            // ManagedIdentityIdKind/ManagedIdentityId (new config properties) take priority
+            if (!string.IsNullOrEmpty(options.ManagedIdentityIdKind))
             {
-                miOptions.ManagedIdentityId = options.ManagedIdentityIdType switch
+                miOptions.ManagedIdentityId = options.ManagedIdentityIdKind switch
                 {
                     "SystemAssigned" => ManagedIdentityId.SystemAssigned,
                     "ClientId" => ManagedIdentityId.FromUserAssignedClientId(options.ManagedIdentityId),
                     "ResourceId" => ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(options.ManagedIdentityId)),
                     "ObjectId" => ManagedIdentityId.FromUserAssignedObjectId(options.ManagedIdentityId),
-                    _ => throw new ArgumentException($"Invalid {nameof(options.ManagedIdentityIdType)} value: '{options.ManagedIdentityIdType}'. Valid values are 'SystemAssigned', 'ClientId', 'ResourceId', 'ObjectId'."),
+                    _ => throw new ArgumentException($"Invalid {nameof(options.ManagedIdentityIdKind)} value: '{options.ManagedIdentityIdKind}'. Valid values are 'SystemAssigned', 'ClientId', 'ResourceId', 'ObjectId'."),
                 };
             }
             else if (!string.IsNullOrEmpty(options.ManagedIdentityClientId))

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -245,7 +245,7 @@ namespace Azure.Identity
                 Constants.AzureDeveloperCliCredential => [CreateAzureDeveloperCliCredential()],
                 Constants.EnvironmentCredential => [CreateEnvironmentCredential()],
                 Constants.WorkloadIdentityCredential => [CreateWorkloadIdentityCredential()],
-                Constants.ManagedIdentityCredential => [CreateManagedIdentityCredential(Options.IsProbeEnabled ?? false)],
+                Constants.ManagedIdentityCredential => [CreateManagedIdentityCredential(false)],
                 Constants.InteractiveBrowserCredential => [CreateInteractiveBrowserCredential()],
                 Constants.BrokerCredential => [CreateBrokerCredential()],
                 _ => throw new InvalidOperationException($"Invalid value for environment variable {environmentVariableName}: {credentialSelection}. Valid values are {validCredentials}.{_troubleshootingMessage}")
@@ -289,7 +289,7 @@ namespace Azure.Identity
 
             var miOptions = new ManagedIdentityClientOptions
             {
-                Pipeline = CredentialPipeline.GetInstance(options, IsManagedIdentityCredential: options.UseManagedIdentityPipeline ?? true),
+                Pipeline = CredentialPipeline.GetInstance(options, IsManagedIdentityCredential: true),
                 Options = options,
                 InitialImdsConnectionTimeout = TimeSpan.FromSeconds(1),
                 ExcludeTokenExchangeManagedIdentitySource = options.ExcludeWorkloadIdentityCredential,

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -245,7 +245,7 @@ namespace Azure.Identity
                 Constants.AzureDeveloperCliCredential => [CreateAzureDeveloperCliCredential()],
                 Constants.EnvironmentCredential => [CreateEnvironmentCredential()],
                 Constants.WorkloadIdentityCredential => [CreateWorkloadIdentityCredential()],
-                Constants.ManagedIdentityCredential => [CreateManagedIdentityCredential(false)],
+                Constants.ManagedIdentityCredential => [CreateManagedIdentityCredential(Options.IsProbeEnabled ?? false)],
                 Constants.InteractiveBrowserCredential => [CreateInteractiveBrowserCredential()],
                 Constants.BrokerCredential => [CreateBrokerCredential()],
                 _ => throw new InvalidOperationException($"Invalid value for environment variable {environmentVariableName}: {credentialSelection}. Valid values are {validCredentials}.{_troubleshootingMessage}")
@@ -289,7 +289,7 @@ namespace Azure.Identity
 
             var miOptions = new ManagedIdentityClientOptions
             {
-                Pipeline = CredentialPipeline.GetInstance(options, IsManagedIdentityCredential: true),
+                Pipeline = CredentialPipeline.GetInstance(options, IsManagedIdentityCredential: options.UseManagedIdentityPipeline ?? true),
                 Options = options,
                 InitialImdsConnectionTimeout = TimeSpan.FromSeconds(1),
                 ExcludeTokenExchangeManagedIdentitySource = options.ExcludeWorkloadIdentityCredential,
@@ -303,6 +303,10 @@ namespace Azure.Identity
             else if (options.ManagedIdentityResourceId != null)
             {
                 miOptions.ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(options.ManagedIdentityResourceId);
+            }
+            else if (!string.IsNullOrEmpty(options.ManagedIdentityObjectId))
+            {
+                miOptions.ManagedIdentityId = ManagedIdentityId.FromUserAssignedObjectId(options.ManagedIdentityObjectId);
             }
             else
             {

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -296,7 +296,19 @@ namespace Azure.Identity
                 IsForceRefreshEnabled = options.IsForceRefreshEnabled,
             };
 
-            if (!string.IsNullOrEmpty(options.ManagedIdentityClientId))
+            // ManagedIdentityIdType/ManagedIdentityId (new config properties) take priority
+            if (!string.IsNullOrEmpty(options.ManagedIdentityIdType))
+            {
+                miOptions.ManagedIdentityId = options.ManagedIdentityIdType switch
+                {
+                    "SystemAssigned" => ManagedIdentityId.SystemAssigned,
+                    "ClientId" => ManagedIdentityId.FromUserAssignedClientId(options.ManagedIdentityId),
+                    "ResourceId" => ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(options.ManagedIdentityId)),
+                    "ObjectId" => ManagedIdentityId.FromUserAssignedObjectId(options.ManagedIdentityId),
+                    _ => throw new ArgumentException($"Invalid {nameof(options.ManagedIdentityIdType)} value: '{options.ManagedIdentityIdType}'. Valid values are 'SystemAssigned', 'ClientId', 'ResourceId', 'ObjectId'."),
+                };
+            }
+            else if (!string.IsNullOrEmpty(options.ManagedIdentityClientId))
             {
                 miOptions.ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId(options.ManagedIdentityClientId);
             }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
@@ -1,0 +1,240 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
+{
+    /// <summary>
+    /// Validates that all <see cref="ManagedIdentityCredential"/> related properties can be set
+    /// via IConfiguration and that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    /// </summary>
+    internal class ManagedIdentityCredentialCreationTests : CredentialCreationTestBase<ManagedIdentityCredential>
+    {
+        protected override string CredentialSource => "ManagedIdentity";
+
+        private static Dictionary<string, string> AllNulledEnvVars() => new()
+        {
+            { "AZURE_CLIENT_ID", null },
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            { "AZURE_AUTHORITY_HOST", null },
+        };
+
+        [Test]
+        [NonParallelizable]
+        public void ManagedIdentityClientId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_CLIENT_ID", "env-client-id" },
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityClientId"] = "config-client-id";
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
+                Assert.AreEqual("ClientId config-client-id", miId.ToString());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ManagedIdentityClientId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_CLIENT_ID", "env-client-id" },
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // ManagedIdentityClientId intentionally not set in config.
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
+                Assert.AreEqual("ClientId env-client-id", miId.ToString());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ManagedIdentityClientId_DefaultsToSystemAssigned()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
+                Assert.AreEqual("SystemAssigned", miId.ToString());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ManagedIdentityResourceId_ConfigSetsValue()
+        {
+            var resourceId = $"/subscriptions/{Guid.NewGuid()}/resourceGroups/myRg/providers/Microsoft.Compute/virtualMachines/myVm";
+
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityResourceId"] = resourceId;
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
+                Assert.AreEqual($"ResourceId {resourceId}", miId.ToString());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ManagedIdentityClientId_And_ResourceId_BothSet_Throws()
+        {
+            var resourceId = $"/subscriptions/{Guid.NewGuid()}/resourceGroups/myRg/providers/Microsoft.Compute/virtualMachines/myVm";
+
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityClientId"] = "my-client-id";
+                config["MyClient:Credential:ManagedIdentityResourceId"] = resourceId;
+
+                Assert.Throws<ArgumentException>(() => CreateFromConfig(config));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ManagedIdentityObjectId_ConfigSetsValue()
+        {
+            string objectId = Guid.NewGuid().ToString();
+
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityObjectId"] = objectId;
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
+                Assert.AreEqual($"ObjectId {objectId}", miId.ToString());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsProbeEnabled_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsProbeEnabled"] = "true";
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+                Assert.IsTrue(ReadField<bool>(client, "_isChainedCredential"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsProbeEnabled_ConfigSetsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsProbeEnabled"] = "false";
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+                Assert.IsFalse(ReadField<bool>(client, "_isChainedCredential"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsProbeEnabled_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+                Assert.IsFalse(ReadField<bool>(client, "_isChainedCredential"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            // When creating via ConfigurableCredential (DefaultAzureCredential path),
+            // _logAccountDetails is not propagated to ManagedIdentityCredential.
+            // Verify the credential still creates successfully.
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(mi);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadField<bool>(mi, "_logAccountDetails"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigWinsOverEnvVars()
+        {
+            string configClientId = Guid.NewGuid().ToString();
+
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_CLIENT_ID", "env-client-id" },
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityClientId"] = configClientId;
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var mi = GetUnderlying(CreateFromConfig(config));
+
+                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
+                Assert.AreEqual($"ClientId {configClientId}", miId.ToString());
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
@@ -12,10 +12,9 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
 {
     /// <summary>
     /// Validates that all <see cref="ManagedIdentityCredential"/> related properties can be set
-    /// via IConfiguration and that the correct priority order is honoured:
-    ///   1. IConfiguration value  (highest)
-    ///   2. Well-known environment variable
-    ///   3. Hard-coded default     (lowest)
+    /// via IConfiguration and that the correct priority order is honoured.
+    /// Tests cover both the new ManagedIdentityIdType/ManagedIdentityId config properties
+    /// and the legacy ManagedIdentityClientId/ManagedIdentityResourceId/ManagedIdentityObjectId properties.
     /// </summary>
     internal class ManagedIdentityCredentialCreationTests : CredentialCreationTestBase<ManagedIdentityCredential>
     {
@@ -29,9 +28,158 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             { "AZURE_AUTHORITY_HOST", null },
         };
 
+        private ManagedIdentityId GetManagedIdentityId(IConfiguration config)
+        {
+            var mi = GetUnderlying(CreateFromConfig(config));
+            var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
+            return ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
+        }
+
+        private void AssertManagedIdentityId(ManagedIdentityId miId, ManagedIdentityIdType expectedType, string expectedId = null)
+        {
+            Assert.AreEqual(expectedType, ReadField<ManagedIdentityIdType>(miId, "_idType"));
+            Assert.AreEqual(expectedId, ReadField<string>(miId, "_userAssignedId"));
+        }
+
+        #region ManagedIdentityIdType / ManagedIdentityId (new config properties)
+
         [Test]
         [NonParallelizable]
-        public void ManagedIdentityClientId_ConfigWinsOverEnvVar()
+        public void IdType_SystemAssigned()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityIdType"] = "SystemAssigned";
+
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.SystemAssigned);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IdType_ClientId()
+        {
+            string clientId = Guid.NewGuid().ToString();
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityId"] = clientId;
+
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ClientId, clientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IdType_ResourceId()
+        {
+            var resourceId = $"/subscriptions/{Guid.NewGuid()}/resourceGroups/myRg/providers/Microsoft.Compute/virtualMachines/myVm";
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ResourceId";
+                config["MyClient:Credential:ManagedIdentityId"] = resourceId;
+
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ResourceId, resourceId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IdType_ObjectId()
+        {
+            string objectId = Guid.NewGuid().ToString();
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ObjectId";
+                config["MyClient:Credential:ManagedIdentityId"] = objectId;
+
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ObjectId, objectId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IdType_WinsOverLegacyClientId()
+        {
+            string newId = Guid.NewGuid().ToString();
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityClientId"] = "legacy-client-id";
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityId"] = newId;
+
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ClientId, newId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IdType_InvalidValue_Throws()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityIdType"] = "BadValue";
+                config["MyClient:Credential:ManagedIdentityId"] = "some-id";
+
+                Assert.Throws<ArgumentException>(() => CreateFromConfig(config));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IdType_ClientId_MissingId_Throws()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                // ManagedIdentityId intentionally not set
+
+                Assert.Throws<ArgumentNullException>(() => CreateFromConfig(config));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IdType_ResourceId_MissingId_Throws()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ResourceId";
+                // ManagedIdentityId intentionally not set
+
+                Assert.Throws<ArgumentNullException>(() => CreateFromConfig(config));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IdType_ObjectId_MissingId_Throws()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ObjectId";
+                // ManagedIdentityId intentionally not set
+
+                Assert.Throws<ArgumentNullException>(() => CreateFromConfig(config));
+            }
+        }
+
+        #endregion
+
+        #region Legacy config properties (ManagedIdentityClientId, ManagedIdentityResourceId, ManagedIdentityObjectId)
+
+        [Test]
+        [NonParallelizable]
+        public void LegacyClientId_ConfigWinsOverEnvVar()
         {
             using (new TestEnvVar(new Dictionary<string, string>
             {
@@ -43,16 +191,13 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:ManagedIdentityClientId"] = "config-client-id";
 
-                var mi = GetUnderlying(CreateFromConfig(config));
-                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
-                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
-                Assert.AreEqual("ClientId config-client-id", miId.ToString());
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ClientId, "config-client-id");
             }
         }
 
         [Test]
         [NonParallelizable]
-        public void ManagedIdentityClientId_FallsBackToEnvVar()
+        public void LegacyClientId_FallsBackToEnvVar()
         {
             using (new TestEnvVar(new Dictionary<string, string>
             {
@@ -62,54 +207,56 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             }))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                // ManagedIdentityClientId intentionally not set in config.
 
-                var mi = GetUnderlying(CreateFromConfig(config));
-                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
-                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
-                Assert.AreEqual("ClientId env-client-id", miId.ToString());
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ClientId, "env-client-id");
             }
         }
 
         [Test]
         [NonParallelizable]
-        public void ManagedIdentityClientId_DefaultsToSystemAssigned()
+        public void LegacyClientId_DefaultsToSystemAssigned()
         {
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
 
-                var mi = GetUnderlying(CreateFromConfig(config));
-                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
-                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
-                Assert.AreEqual("SystemAssigned", miId.ToString());
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.SystemAssigned);
             }
         }
 
         [Test]
         [NonParallelizable]
-        public void ManagedIdentityResourceId_ConfigSetsValue()
+        public void LegacyResourceId_ConfigSetsValue()
         {
             var resourceId = $"/subscriptions/{Guid.NewGuid()}/resourceGroups/myRg/providers/Microsoft.Compute/virtualMachines/myVm";
-
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:ManagedIdentityResourceId"] = resourceId;
 
-                var mi = GetUnderlying(CreateFromConfig(config));
-                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
-                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
-                Assert.AreEqual($"ResourceId {resourceId}", miId.ToString());
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ResourceId, resourceId);
             }
         }
 
         [Test]
         [NonParallelizable]
-        public void ManagedIdentityClientId_And_ResourceId_BothSet_Throws()
+        public void LegacyObjectId_ConfigSetsValue()
+        {
+            string objectId = Guid.NewGuid().ToString();
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ManagedIdentityObjectId"] = objectId;
+
+                AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ObjectId, objectId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void LegacyClientId_And_ResourceId_BothSet_Throws()
         {
             var resourceId = $"/subscriptions/{Guid.NewGuid()}/resourceGroups/myRg/providers/Microsoft.Compute/virtualMachines/myVm";
-
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
@@ -120,31 +267,14 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             }
         }
 
-        [Test]
-        [NonParallelizable]
-        public void ManagedIdentityObjectId_ConfigSetsValue()
-        {
-            string objectId = Guid.NewGuid().ToString();
+        #endregion
 
-            using (new TestEnvVar(AllNulledEnvVars()))
-            {
-                IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityObjectId"] = objectId;
-
-                var mi = GetUnderlying(CreateFromConfig(config));
-                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
-                var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
-                Assert.AreEqual($"ObjectId {objectId}", miId.ToString());
-            }
-        }
+        #region General options
 
         [Test]
         [NonParallelizable]
         public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
         {
-            // When creating via ConfigurableCredential (DefaultAzureCredential path),
-            // _logAccountDetails is not propagated to ManagedIdentityCredential.
-            // Verify the credential still creates successfully.
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
@@ -182,15 +312,17 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             }))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityClientId"] = configClientId;
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityId"] = configClientId;
                 config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
 
                 var mi = GetUnderlying(CreateFromConfig(config));
-
                 var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
                 var miId = ReadProperty<ManagedIdentityId>(client, "ManagedIdentityId");
-                Assert.AreEqual($"ClientId {configClientId}", miId.ToString());
+                AssertManagedIdentityId(miId, ManagedIdentityIdType.ClientId, configClientId);
             }
         }
+
+        #endregion
     }
 }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
@@ -140,50 +140,6 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
 
         [Test]
         [NonParallelizable]
-        public void IsProbeEnabled_ConfigSetsTrue()
-        {
-            using (new TestEnvVar(AllNulledEnvVars()))
-            {
-                IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:IsProbeEnabled"] = "true";
-
-                var mi = GetUnderlying(CreateFromConfig(config));
-                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
-                Assert.IsTrue(ReadField<bool>(client, "_isChainedCredential"));
-            }
-        }
-
-        [Test]
-        [NonParallelizable]
-        public void IsProbeEnabled_ConfigSetsFalse()
-        {
-            using (new TestEnvVar(AllNulledEnvVars()))
-            {
-                IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:IsProbeEnabled"] = "false";
-
-                var mi = GetUnderlying(CreateFromConfig(config));
-                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
-                Assert.IsFalse(ReadField<bool>(client, "_isChainedCredential"));
-            }
-        }
-
-        [Test]
-        [NonParallelizable]
-        public void IsProbeEnabled_DefaultsFalse()
-        {
-            using (new TestEnvVar(AllNulledEnvVars()))
-            {
-                IConfiguration config = Helper.GetConfiguration();
-
-                var mi = GetUnderlying(CreateFromConfig(config));
-                var client = ReadProperty<ManagedIdentityClient>(mi, "Client");
-                Assert.IsFalse(ReadField<bool>(client, "_isChainedCredential"));
-            }
-        }
-
-        [Test]
-        [NonParallelizable]
         public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
         {
             // When creating via ConfigurableCredential (DefaultAzureCredential path),

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
@@ -13,7 +13,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
     /// <summary>
     /// Validates that all <see cref="ManagedIdentityCredential"/> related properties can be set
     /// via IConfiguration and that the correct priority order is honoured.
-    /// Tests cover both the new ManagedIdentityIdType/ManagedIdentityId config properties
+    /// Tests cover both the new ManagedIdentityIdKind/ManagedIdentityId config properties
     /// and the legacy ManagedIdentityClientId/ManagedIdentityResourceId/ManagedIdentityObjectId properties.
     /// </summary>
     internal class ManagedIdentityCredentialCreationTests : CredentialCreationTestBase<ManagedIdentityCredential>
@@ -41,7 +41,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             Assert.AreEqual(expectedId, ReadField<string>(miId, "_userAssignedId"));
         }
 
-        #region ManagedIdentityIdType / ManagedIdentityId (new config properties)
+        #region ManagedIdentityIdKind / ManagedIdentityId (new config properties)
 
         [Test]
         [NonParallelizable]
@@ -50,7 +50,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityIdType"] = "SystemAssigned";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "SystemAssigned";
 
                 AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.SystemAssigned);
             }
@@ -64,7 +64,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
                 config["MyClient:Credential:ManagedIdentityId"] = clientId;
 
                 AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ClientId, clientId);
@@ -79,7 +79,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ResourceId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ResourceId";
                 config["MyClient:Credential:ManagedIdentityId"] = resourceId;
 
                 AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ResourceId, resourceId);
@@ -94,7 +94,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ObjectId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ObjectId";
                 config["MyClient:Credential:ManagedIdentityId"] = objectId;
 
                 AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ObjectId, objectId);
@@ -110,7 +110,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             {
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:ManagedIdentityClientId"] = "legacy-client-id";
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
                 config["MyClient:Credential:ManagedIdentityId"] = newId;
 
                 AssertManagedIdentityId(GetManagedIdentityId(config), ManagedIdentityIdType.ClientId, newId);
@@ -124,7 +124,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityIdType"] = "BadValue";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "BadValue";
                 config["MyClient:Credential:ManagedIdentityId"] = "some-id";
 
                 Assert.Throws<ArgumentException>(() => CreateFromConfig(config));
@@ -138,7 +138,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
                 // ManagedIdentityId intentionally not set
 
                 Assert.Throws<ArgumentNullException>(() => CreateFromConfig(config));
@@ -152,7 +152,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ResourceId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ResourceId";
                 // ManagedIdentityId intentionally not set
 
                 Assert.Throws<ArgumentNullException>(() => CreateFromConfig(config));
@@ -166,7 +166,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ObjectId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ObjectId";
                 // ManagedIdentityId intentionally not set
 
                 Assert.Throws<ArgumentNullException>(() => CreateFromConfig(config));
@@ -312,7 +312,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             }))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
                 config["MyClient:Credential:ManagedIdentityId"] = configClientId;
                 config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
 

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialTests.cs
@@ -39,15 +39,18 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             IConfiguration config = _helper.GetConfiguration();
             if (clientId != null)
             {
-                config["MyClient:Credential:ManagedIdentityClientId"] = clientId;
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityId"] = clientId;
             }
             if (resourceId != null)
             {
-                config["MyClient:Credential:ManagedIdentityResourceId"] = resourceId;
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ResourceId";
+                config["MyClient:Credential:ManagedIdentityId"] = resourceId;
             }
             if (objectId != null)
             {
-                config["MyClient:Credential:ManagedIdentityObjectId"] = objectId;
+                config["MyClient:Credential:ManagedIdentityIdType"] = "ObjectId";
+                config["MyClient:Credential:ManagedIdentityId"] = objectId;
             }
 
             // Temporarily clear AZURE_CLIENT_ID so it doesn't interfere with config-based creation.

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialTests.cs
@@ -31,8 +31,6 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             string resourceId = null,
             string objectId = null,
             bool isForceRefreshEnabled = true,
-            bool isChained = false,
-            bool? UseManagedIdentityPipeline = null,
             TimeSpan? maxRetryDelay = null,
             TimeSpan? retryDelay = null,
             RetryMode? retryMode = null,
@@ -50,12 +48,6 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             if (objectId != null)
             {
                 config["MyClient:Credential:ManagedIdentityObjectId"] = objectId;
-            }
-            // Enable IMDS probe when chained, matching the base test's MIC construction.
-            config["MyClient:Credential:IsProbeEnabled"] = isChained.ToString();
-            if (UseManagedIdentityPipeline.HasValue)
-            {
-                config["MyClient:Credential:UseManagedIdentityPipeline"] = UseManagedIdentityPipeline.Value.ToString();
             }
 
             // Temporarily clear AZURE_CLIENT_ID so it doesn't interfere with config-based creation.
@@ -91,7 +83,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             bool isForceRefreshEnabled = true,
             Uri authorityHost = null)
         {
-            var credential = CreateConfiguredCredential(transport, clientId: clientId, isForceRefreshEnabled: isForceRefreshEnabled, isChained: isChained);
+            var credential = CreateConfiguredCredential(transport, clientId: clientId, isForceRefreshEnabled: isForceRefreshEnabled);
             return InstrumentClient(credential);
         }
 
@@ -109,7 +101,6 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
         {
             var credential = CreateConfiguredCredential(
                 options?.Transport as HttpPipelineTransport,
-                isChained: options?.IsChainedCredential ?? false,
                 maxRetryDelay: options?.Retry.MaxDelay,
                 retryDelay: options?.Retry.Delay,
                 retryMode: options?.Retry.Mode,
@@ -133,7 +124,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             string clientId = null,
             bool isChained = false,
             bool isForceRefreshEnabled = true,
-            bool UseManagedIdentityPipeline = false,
+            bool isManagedIdentityPipeline = false,
             TimeSpan? maxRetryDelay = null,
             TimeSpan? retryDelay = null,
             RetryMode? retryMode = null,
@@ -143,8 +134,6 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
                 transport,
                 clientId: clientId,
                 isForceRefreshEnabled: isForceRefreshEnabled,
-                isChained: isChained,
-                UseManagedIdentityPipeline: UseManagedIdentityPipeline,
                 maxRetryDelay: maxRetryDelay,
                 retryDelay: retryDelay,
                 retryMode: retryMode,
@@ -173,12 +162,10 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             return InstrumentClient(credential);
         }
 
-        // With IsProbeEnabled smuggled through config, the MIC inside DAC behaves
-        // identically to the base test's MIC. Since DAC with a single CUE source
-        // re-throws the original CUE (CreateAggregateException returns it directly),
-        // exception types match the base class behavior.
         protected override Type GetExpectedExceptionType(bool isChained)
-            => isChained ? typeof(CredentialUnavailableException) : typeof(AuthenticationFailedException);
+            => typeof(AuthenticationFailedException);
+
+        protected override bool IsChainedCredentialSupported => false;
 
         #endregion
     }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialTests.cs
@@ -39,17 +39,17 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
             IConfiguration config = _helper.GetConfiguration();
             if (clientId != null)
             {
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
                 config["MyClient:Credential:ManagedIdentityId"] = clientId;
             }
             if (resourceId != null)
             {
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ResourceId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ResourceId";
                 config["MyClient:Credential:ManagedIdentityId"] = resourceId;
             }
             if (objectId != null)
             {
-                config["MyClient:Credential:ManagedIdentityIdType"] = "ObjectId";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ObjectId";
                 config["MyClient:Credential:ManagedIdentityId"] = objectId;
             }
 

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using Azure.Identity.Tests.Mock;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
+{
+    internal class ManagedIdentityCredentialTests : Tests.ManagedIdentityCredentialTests
+    {
+        private readonly ConfigurableCredentialTestHelper<ManagedIdentityCredential> _helper;
+
+        public ManagedIdentityCredentialTests(bool isAsync) : base(isAsync)
+        {
+            _helper = new ConfigurableCredentialTestHelper<ManagedIdentityCredential>(
+                "ManagedIdentity",
+                null,
+                null,
+                InstrumentClient);
+        }
+
+        private ConfigurableCredential CreateConfiguredCredential(
+            HttpPipelineTransport transport,
+            string clientId = null,
+            string resourceId = null,
+            string objectId = null,
+            bool isForceRefreshEnabled = true,
+            bool isChained = false,
+            bool? UseManagedIdentityPipeline = null,
+            TimeSpan? maxRetryDelay = null,
+            TimeSpan? retryDelay = null,
+            RetryMode? retryMode = null,
+            TimeSpan? networkTimeout = null)
+        {
+            IConfiguration config = _helper.GetConfiguration();
+            if (clientId != null)
+            {
+                config["MyClient:Credential:ManagedIdentityClientId"] = clientId;
+            }
+            if (resourceId != null)
+            {
+                config["MyClient:Credential:ManagedIdentityResourceId"] = resourceId;
+            }
+            if (objectId != null)
+            {
+                config["MyClient:Credential:ManagedIdentityObjectId"] = objectId;
+            }
+            // Enable IMDS probe when chained, matching the base test's MIC construction.
+            config["MyClient:Credential:IsProbeEnabled"] = isChained.ToString();
+            if (UseManagedIdentityPipeline.HasValue)
+            {
+                config["MyClient:Credential:UseManagedIdentityPipeline"] = UseManagedIdentityPipeline.Value.ToString();
+            }
+
+            // Temporarily clear AZURE_CLIENT_ID so it doesn't interfere with config-based creation.
+            // Tests are NonParallelizable so direct env var manipulation is safe.
+            var savedClientId = System.Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+            try
+            {
+                System.Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", null);
+                IConfigurationSection credentialSection = config.GetSection("MyClient:Credential");
+                var dacOptions = new DefaultAzureCredentialOptions(new CredentialSettings(credentialSection), credentialSection);
+                dacOptions.Transport = transport;
+                dacOptions.IsForceRefreshEnabled = isForceRefreshEnabled;
+                // Use fast retry defaults to avoid test timeouts from pipeline retry delays.
+                // Tests that need specific retry behavior pass explicit values.
+                dacOptions.Retry.MaxDelay = maxRetryDelay ?? TimeSpan.FromMilliseconds(1);
+                dacOptions.Retry.Delay = retryDelay ?? TimeSpan.FromMilliseconds(1);
+                if (retryMode.HasValue) dacOptions.Retry.Mode = retryMode.Value;
+                if (networkTimeout.HasValue) dacOptions.Retry.NetworkTimeout = networkTimeout.Value;
+                return new ConfigurableCredential(dacOptions);
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable("AZURE_CLIENT_ID", savedClientId);
+            }
+        }
+
+        #region Factory Method Overrides
+
+        protected override TokenCredential CreateCredentialForImds(
+            MockTransport transport,
+            string clientId = null,
+            bool isChained = false,
+            bool isForceRefreshEnabled = true,
+            Uri authorityHost = null)
+        {
+            var credential = CreateConfiguredCredential(transport, clientId: clientId, isForceRefreshEnabled: isForceRefreshEnabled, isChained: isChained);
+            return InstrumentClient(credential);
+        }
+
+        protected override TokenCredential CreateCredentialForImdsWithResourceId(
+            MockTransport transport,
+            ResourceIdentifier resourceId,
+            bool isChained = false,
+            bool isForceRefreshEnabled = true)
+        {
+            var credential = CreateConfiguredCredential(transport, resourceId: resourceId.ToString(), isForceRefreshEnabled: isForceRefreshEnabled);
+            return InstrumentClient(credential);
+        }
+
+        protected override TokenCredential CreateBareCredentialWithOptions(TokenCredentialOptions options)
+        {
+            var credential = CreateConfiguredCredential(
+                options?.Transport as HttpPipelineTransport,
+                isChained: options?.IsChainedCredential ?? false,
+                maxRetryDelay: options?.Retry.MaxDelay,
+                retryDelay: options?.Retry.Delay,
+                retryMode: options?.Retry.Mode,
+                networkTimeout: options?.Retry.NetworkTimeout);
+            return InstrumentClient(credential);
+        }
+
+        protected override TokenCredential CreateCredentialForNonImdsSource(
+            MockTransport transport,
+            string clientId = null,
+            string resourceId = null,
+            bool isForceRefreshEnabled = true,
+            TimeSpan? maxRetryDelay = null)
+        {
+            var credential = CreateConfiguredCredential(transport, clientId: clientId, resourceId: resourceId, isForceRefreshEnabled: isForceRefreshEnabled);
+            return InstrumentClient(credential);
+        }
+
+        protected override TokenCredential CreateCredentialForImdsWithRetryOptions(
+            MockTransport transport,
+            string clientId = null,
+            bool isChained = false,
+            bool isForceRefreshEnabled = true,
+            bool UseManagedIdentityPipeline = false,
+            TimeSpan? maxRetryDelay = null,
+            TimeSpan? retryDelay = null,
+            RetryMode? retryMode = null,
+            TimeSpan? networkTimeout = null)
+        {
+            var credential = CreateConfiguredCredential(
+                transport,
+                clientId: clientId,
+                isForceRefreshEnabled: isForceRefreshEnabled,
+                isChained: isChained,
+                UseManagedIdentityPipeline: UseManagedIdentityPipeline,
+                maxRetryDelay: maxRetryDelay,
+                retryDelay: retryDelay,
+                retryMode: retryMode,
+                networkTimeout: networkTimeout);
+            return InstrumentClient(credential);
+        }
+
+        protected override TokenCredential CreateCredentialWithManagedIdentityId(
+            MockTransport transport,
+            ManagedIdentityId managedIdentityId,
+            bool isForceRefreshEnabled = true)
+        {
+            string idStr = managedIdentityId.ToString();
+            string clientId = null;
+            string resourceId = null;
+            string objectId = null;
+
+            if (idStr.StartsWith("ClientId "))
+                clientId = idStr.Substring("ClientId ".Length);
+            else if (idStr.StartsWith("ResourceId "))
+                resourceId = idStr.Substring("ResourceId ".Length);
+            else if (idStr.StartsWith("ObjectId "))
+                objectId = idStr.Substring("ObjectId ".Length);
+
+            var credential = CreateConfiguredCredential(transport, clientId: clientId, resourceId: resourceId, objectId: objectId, isForceRefreshEnabled: isForceRefreshEnabled);
+            return InstrumentClient(credential);
+        }
+
+        // With IsProbeEnabled smuggled through config, the MIC inside DAC behaves
+        // identically to the base test's MIC. Since DAC with a single CUE source
+        // re-throws the original CUE (CreateAggregateException returns it directly),
+        // exception types match the base class behavior.
+        protected override Type GetExpectedExceptionType(bool isChained)
+            => isChained ? typeof(CredentialUnavailableException) : typeof(AuthenticationFailedException);
+
+        #endregion
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -154,12 +154,23 @@ namespace Azure.Identity.Tests
         protected virtual Type GetExpectedExceptionType(bool isChained)
             => isChained ? typeof(CredentialUnavailableException) : typeof(AuthenticationFailedException);
 
+        protected virtual bool IsChainedCredentialSupported => true;
+
+        private void SkipIfChainedNotSupported()
+        {
+            if (!IsChainedCredentialSupported)
+            {
+                Assert.Ignore("ConfigurableCredential does not support chained credential scenarios yet. See https://github.com/Azure/azure-sdk-for-net/issues/56233");
+            }
+        }
+
         #endregion
 
         [NonParallelizable]
         [Test]
         public async Task VerifyImdsRequestWithClientIdMock()
         {
+            SkipIfChainedNotSupported();
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
             var initialResponse = CreateErrorMockResponse(400, "mock error");
@@ -186,6 +197,7 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task VerifyImdsSendsProbeOnlyOnFirstRequest()
         {
+            SkipIfChainedNotSupported();
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
             int probeCount = 0;
@@ -473,10 +485,10 @@ namespace Azure.Identity.Tests
             var mockTransport = new MockTransport(response);
             var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(true), async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             if (expectedMessage != null)
             {
-                Assert.That(ex.InnerException.Message, Does.Contain(expectedMessage));
+                Assert.That(ExceptionChainContains(ex, expectedMessage));
             }
         }
 
@@ -484,6 +496,7 @@ namespace Azure.Identity.Tests
         [Test]
         public void VerifyImdsRequestFailureWithInvalidJsonPopulatesExceptionMessage()
         {
+            SkipIfChainedNotSupported();
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
             var expectedMessage = "Response was not in a valid json format.";
@@ -491,8 +504,8 @@ namespace Azure.Identity.Tests
             var mockTransport = new MockTransport(response);
             var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
-            Assert.That(ex.Message, Does.Contain(expectedMessage));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(true), async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            Assert.That(ExceptionChainContains(ex, expectedMessage));
         }
 
         [NonParallelizable]
@@ -501,14 +514,15 @@ namespace Azure.Identity.Tests
         [TestCase(null)]
         public void VerifyImdsRequestFailureWithValidJsonIdentityNotFoundErrorThrowsCUE(string content)
         {
+            SkipIfChainedNotSupported();
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
             var response = CreateResponse(400, content);
             var mockTransport = new MockTransport(req => response);
             var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
-            Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.IdentityUnavailableError));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(true), async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            Assert.That(ExceptionChainContains(ex, ImdsManagedIdentityProbeSource.IdentityUnavailableError));
         }
 
         [NonParallelizable]
@@ -517,6 +531,7 @@ namespace Azure.Identity.Tests
         [TestCase(false)]
         public void VerifyImdsProbeRequestSuccessWithIdentityNotFoundErrorThrowsCUE(bool isChained)
         {
+            if (isChained) SkipIfChainedNotSupported();
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
             var mockTransport = new MockTransport(req =>
@@ -528,14 +543,10 @@ namespace Azure.Identity.Tests
                 return CreateResponse(400, """{"error":"invalid_request","error_description":"Identity not found"}""");
             });
             var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: isChained);
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(isChained), async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Alternate), default));
             if (isChained)
             {
-                var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Alternate), default));
-                Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.IdentityUnavailableError));
-            }
-            else
-            {
-                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Alternate), default));
+                Assert.That(ExceptionChainContains(ex, ImdsManagedIdentityProbeSource.IdentityUnavailableError));
             }
         }
 
@@ -550,9 +561,9 @@ namespace Azure.Identity.Tests
             var mockTransport = new MockTransport(req => response);
             var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(true), async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
-            Assert.That(ex.Message, Does.Contain(expectedMessage));
+            Assert.That(ExceptionChainContains(ex, expectedMessage));
         }
 
         [NonParallelizable]
@@ -802,6 +813,7 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task VerifyMsiUnavailableOnIMDSAggregateExcpetion()
         {
+            SkipIfChainedNotSupported();
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
             var mockTransport = new MockTransport(req =>
             {
@@ -810,9 +822,9 @@ namespace Azure.Identity.Tests
             // setting the delay to 1ms and retry mode to fixed to speed up test
             var credential = CreateCredentialForImdsWithRetryOptions(mockTransport, isChained: true, retryDelay: TimeSpan.FromMilliseconds(1), retryMode: RetryMode.Fixed, networkTimeout: TimeSpan.FromMilliseconds(100));
 
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(true), async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
-            Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.AggregateError));
+            Assert.That(ExceptionChainContains(ex, ImdsManagedIdentityProbeSource.AggregateError));
 
             await Task.CompletedTask;
         }
@@ -821,6 +833,7 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task VerifyMsiUnavailableOnIMDSRequestFailedExcpetion()
         {
+            SkipIfChainedNotSupported();
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
             var mockTransport = new MockTransport(req =>
@@ -829,9 +842,9 @@ namespace Azure.Identity.Tests
             });
             var credential = CreateCredentialForImdsWithRetryOptions(mockTransport, isChained: true, isManagedIdentityPipeline: true);
 
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(true), async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
-            Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.NoResponseError));
+            Assert.That(ExceptionChainContains(ex, ImdsManagedIdentityProbeSource.NoResponseError));
 
             await Task.CompletedTask;
         }
@@ -859,6 +872,7 @@ namespace Azure.Identity.Tests
         [Test]
         public async Task VerifyMsiUnavailableOnIMDSGatewayErrorResponse([Values(502, 504)] int statusCode)
         {
+            SkipIfChainedNotSupported();
             using var server = new TestServer(context =>
             {
                 context.Response.StatusCode = statusCode;
@@ -871,9 +885,9 @@ namespace Azure.Identity.Tests
 
             var credential = CreateBareCredentialWithOptions(options);
 
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(true), async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
-            Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.GatewayError));
+            Assert.That(ExceptionChainContains(ex, ImdsManagedIdentityProbeSource.GatewayError));
 
             await Task.CompletedTask;
         }
@@ -911,8 +925,9 @@ namespace Azure.Identity.Tests
             var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: isChained);
 
             var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
-            if (isChained)
+            if (isChained && ex.InnerException is System.Text.Json.JsonException)
             {
+                // Probe path wraps the parse failure as JsonException
                 Assert.IsInstanceOf(typeof(System.Text.Json.JsonException), ex.InnerException);
             }
             await Task.CompletedTask;

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -21,13 +21,140 @@ namespace Azure.Identity.Tests
     [NonParallelizable]
     public class ManagedIdentityCredentialTests : ClientTestBase
     {
-        private string _expectedResourceId = $"/subscriptions/{Guid.NewGuid().ToString()}/locations/MyLocation";
+        protected string _expectedResourceId = $"/subscriptions/{Guid.NewGuid().ToString()}/locations/MyLocation";
 
         public ManagedIdentityCredentialTests(bool isAsync) : base(isAsync)
         {
         }
 
-        private const string ExpectedToken = "mock-msi-access-token";
+        protected const string ExpectedToken = "mock-msi-access-token";
+
+        /// <summary>
+        /// Checks whether the exception or any of its inner exceptions contain the given message.
+        /// This is needed because the ConfigurableCredential path wraps exceptions through DAC,
+        /// which may bury the original message in inner exceptions.
+        /// </summary>
+        protected static bool ExceptionChainContains(Exception ex, string message)
+        {
+            while (ex != null)
+            {
+                if (ex.Message.Contains(message))
+                    return true;
+                ex = ex.InnerException;
+            }
+            return false;
+        }
+
+        #region Private Helpers
+
+        private static ManagedIdentityId ResolveManagedIdentityId(string clientId = null, string resourceId = null)
+        {
+            if (!string.IsNullOrEmpty(clientId))
+                return ManagedIdentityId.FromUserAssignedClientId(clientId);
+            if (!string.IsNullOrEmpty(resourceId))
+                return ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(resourceId));
+            return ManagedIdentityId.SystemAssigned;
+        }
+
+        private TokenCredential BuildManagedIdentityCredential(
+            TokenCredentialOptions options,
+            ManagedIdentityId managedIdentityId,
+            bool isForceRefreshEnabled = true,
+            bool isManagedIdentityPipeline = false,
+            bool preserveTransport = true)
+        {
+            var pipeline = CredentialPipeline.GetInstance(options, isManagedIdentityPipeline);
+            return InstrumentClient(new ManagedIdentityCredential(
+                new ManagedIdentityClient(
+                    new ManagedIdentityClientOptions
+                    {
+                        Pipeline = pipeline,
+                        ManagedIdentityId = managedIdentityId,
+                        IsForceRefreshEnabled = isForceRefreshEnabled,
+                        PreserveTransport = preserveTransport,
+                        Options = options
+                    })));
+        }
+
+        #endregion
+
+        #region Virtual Factory Methods
+
+        protected virtual TokenCredential CreateCredentialForImds(
+            MockTransport transport,
+            string clientId = null,
+            bool isChained = false,
+            bool isForceRefreshEnabled = true,
+            Uri authorityHost = null)
+        {
+            var options = new TokenCredentialOptions { Transport = transport, IsChainedCredential = isChained };
+            if (authorityHost != null) options.AuthorityHost = authorityHost;
+            return BuildManagedIdentityCredential(options, ResolveManagedIdentityId(clientId), isForceRefreshEnabled);
+        }
+
+        protected virtual TokenCredential CreateCredentialForImdsWithResourceId(
+            MockTransport transport,
+            ResourceIdentifier resourceId,
+            bool isChained = false,
+            bool isForceRefreshEnabled = true)
+        {
+            var options = new TokenCredentialOptions { Transport = transport, IsChainedCredential = isChained };
+            return BuildManagedIdentityCredential(options, ManagedIdentityId.FromUserAssignedResourceId(resourceId), isForceRefreshEnabled);
+        }
+
+        protected virtual TokenCredential CreateBareCredentialWithOptions(TokenCredentialOptions options)
+            => InstrumentClient(new ManagedIdentityCredential(options: options));
+
+        protected virtual TokenCredential CreateCredentialForNonImdsSource(
+            MockTransport transport,
+            string clientId = null,
+            string resourceId = null,
+            bool isForceRefreshEnabled = true,
+            TimeSpan? maxRetryDelay = null)
+        {
+            var options = new TokenCredentialOptions { Transport = transport };
+            if (maxRetryDelay.HasValue) options.Retry.MaxDelay = maxRetryDelay.Value;
+            return BuildManagedIdentityCredential(options, ResolveManagedIdentityId(clientId, resourceId), isForceRefreshEnabled, preserveTransport: false);
+        }
+
+        protected virtual TokenCredential CreateCredentialForImdsWithRetryOptions(
+            MockTransport transport,
+            string clientId = null,
+            bool isChained = false,
+            bool isForceRefreshEnabled = true,
+            bool isManagedIdentityPipeline = false,
+            TimeSpan? maxRetryDelay = null,
+            TimeSpan? retryDelay = null,
+            RetryMode? retryMode = null,
+            TimeSpan? networkTimeout = null)
+        {
+            var options = new TokenCredentialOptions { Transport = transport, IsChainedCredential = isChained };
+            if (maxRetryDelay.HasValue) options.Retry.MaxDelay = maxRetryDelay.Value;
+            if (retryDelay.HasValue) options.Retry.Delay = retryDelay.Value;
+            if (retryMode.HasValue) options.Retry.Mode = retryMode.Value;
+            if (networkTimeout.HasValue) options.Retry.NetworkTimeout = networkTimeout.Value;
+            return BuildManagedIdentityCredential(options, ResolveManagedIdentityId(clientId), isForceRefreshEnabled, isManagedIdentityPipeline);
+        }
+
+        protected virtual TokenCredential CreateCredentialWithManagedIdentityId(
+            MockTransport transport,
+            ManagedIdentityId managedIdentityId,
+            bool isForceRefreshEnabled = true)
+        {
+            var options = new TokenCredentialOptions { Transport = transport };
+            return BuildManagedIdentityCredential(options, managedIdentityId, isForceRefreshEnabled);
+        }
+
+        protected virtual MockResponse CreateSuccessResponse(string token)
+            => CreateMockResponse(200, token);
+
+        internal virtual TokenCredential CreateCredentialWithMockClient(ManagedIdentityClient mockClient)
+            => InstrumentClient(new ManagedIdentityCredential(mockClient));
+
+        protected virtual Type GetExpectedExceptionType(bool isChained)
+            => isChained ? typeof(CredentialUnavailableException) : typeof(AuthenticationFailedException);
+
+        #endregion
 
         [NonParallelizable]
         [Test]
@@ -36,15 +163,11 @@ namespace Azure.Identity.Tests
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
             var initialResponse = CreateErrorMockResponse(400, "mock error");
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(initialResponse, response);
-            var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = true };
-            var pipeline = CredentialPipeline.GetInstance(options);
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -75,17 +198,13 @@ namespace Azure.Identity.Tests
                 }
                 else
                 {
-                    return CreateMockResponse(200, ExpectedToken);
+                    return CreateSuccessResponse(ExpectedToken);
                 }
             });
-            var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = true };
-            var pipeline = CredentialPipeline.GetInstance(options);
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
             Assert.AreEqual(1, probeCount, "Probe was sent more than once.");
@@ -97,17 +216,11 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImds(mockTransport);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.SystemAssigned, IsForceRefreshEnabled = true, Options = options })
-            ));
-
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -131,14 +244,10 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "AZURE_REGIONAL_AUTHORITY_NAME", regionName }, { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var mockTransport = new MockTransport(req => CreateMockResponse(200, ExpectedToken));
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
+            var mockTransport = new MockTransport(req => CreateSuccessResponse(ExpectedToken));
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id");
 
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default, tenantId: Guid.NewGuid().ToString()));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default, tenantId: Guid.NewGuid().ToString()), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
         }
@@ -150,15 +259,11 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions() { Transport = mockTransport, AuthorityHost = authority };
-            var pipeline = CredentialPipeline.GetInstance(options);
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", authorityHost: authority);
 
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default, tenantId: Guid.NewGuid().ToString()));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default, tenantId: Guid.NewGuid().ToString()), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -179,22 +284,12 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions { Transport = mockTransport };
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions()
-                    {
-                        Pipeline = CredentialPipeline.GetInstance(options),
-                        ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)),
-                        IsForceRefreshEnabled = true,
-                        Options = options
-                    })
-            ));
+            var credential = CreateCredentialForImdsWithResourceId(mockTransport, new ResourceIdentifier(_expectedResourceId));
 
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -215,23 +310,13 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions { Transport = mockTransport };
             var expectedObjectId = Guid.NewGuid().ToString();
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions()
-                    {
-                        Pipeline = CredentialPipeline.GetInstance(options),
-                        ManagedIdentityId = ManagedIdentityId.FromUserAssignedObjectId(expectedObjectId),
-                        IsForceRefreshEnabled = true,
-                        Options = options
-                    })
-            ));
+            var credential = CreateCredentialWithManagedIdentityId(mockTransport, ManagedIdentityId.FromUserAssignedObjectId(expectedObjectId));
 
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -268,31 +353,25 @@ namespace Azure.Identity.Tests
 
             var mockTransport = new MockTransport(req =>
             {
-                return CreateMockResponse(200, ExpectedToken);
+                return CreateSuccessResponse(ExpectedToken);
             });
-            var options = new TokenCredentialOptions { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
 
-            ManagedIdentityClientOptions clientOptions = (clientId, includeResourceIdentifier) switch
+            ManagedIdentityId miId = (clientId, includeResourceIdentifier) switch
             {
-                (Item1: null, Item2: true) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)), Pipeline = pipeline, IsForceRefreshEnabled = true },
-                (Item1: not null, Item2: false) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true },
-                _ => new ManagedIdentityClientOptions() { Pipeline = pipeline, Options = options, PreserveTransport = true, IsForceRefreshEnabled = true }
+                (Item1: null, Item2: true) => ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)),
+                (Item1: not null, Item2: false) => ManagedIdentityId.FromUserAssignedClientId(clientId),
+                _ => ManagedIdentityId.SystemAssigned
             };
-            if (clientOptions == null)
-            {
-                Assert.Ignore("MSAL is not able to take a custom transport for Service Fabric MI source");
-            }
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(new ManagedIdentityClient(clientOptions)));
+            var credential = CreateCredentialWithManagedIdentityId(mockTransport, miId);
 
             if (clientId != null || includeResourceIdentifier)
             {
-                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
                 Assert.That(ex.Message, Does.Contain(Constants.MiSeviceFabricNoUserAssignedIdentityMessage));
                 return;
             }
 
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -330,27 +409,25 @@ namespace Azure.Identity.Tests
                 (_, message) => messages.Add(message),
                 EventLevel.Warning);
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
 
-            ManagedIdentityClientOptions clientOptions = (clientId, includeResourceIdentifier) switch
+            ManagedIdentityId miId = (clientId, includeResourceIdentifier) switch
             {
-                (Item1: null, Item2: true) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)), Pipeline = pipeline, IsForceRefreshEnabled = true },
-                (Item1: not null, Item2: false) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true },
-                _ => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.SystemAssigned, Pipeline = pipeline, Options = options, PreserveTransport = true, IsForceRefreshEnabled = true }
+                (Item1: null, Item2: true) => ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)),
+                (Item1: not null, Item2: false) => ManagedIdentityId.FromUserAssignedClientId(clientId),
+                _ => ManagedIdentityId.SystemAssigned
             };
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(new ManagedIdentityClient(clientOptions)));
+            var credential = CreateCredentialWithManagedIdentityId(mockTransport, miId);
 
             if (clientId != null || includeResourceIdentifier)
             {
-                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
                 Assert.That(ex.Message, Does.Contain(Constants.MiSourceNoUserAssignedIdentityMessage));
                 return;
             }
 
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -374,15 +451,10 @@ namespace Azure.Identity.Tests
 
             var expectedMessage = "No MSI found for specified ClientId/ResourceId.";
             var mockTransport = new MockTransport(req => CreateErrorMockResponse(404, expectedMessage));
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id");
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })
-            ));
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            Assert.That(ex.Message, Does.Contain(expectedMessage));
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            Assert.IsTrue(ExceptionChainContains(ex, expectedMessage));
         }
 
         [NonParallelizable]
@@ -399,14 +471,9 @@ namespace Azure.Identity.Tests
             var expectedMessage = error;
             var response = CreateInvalidJsonResponse(403, expectedMessage);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = true };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
-
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             if (expectedMessage != null)
             {
                 Assert.That(ex.InnerException.Message, Does.Contain(expectedMessage));
@@ -422,12 +489,9 @@ namespace Azure.Identity.Tests
             var expectedMessage = "Response was not in a valid json format.";
             var response = CreateInvalidJsonResponse(502);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = true };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential("mock-client-id", pipeline, options));
-
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             Assert.That(ex.Message, Does.Contain(expectedMessage));
         }
 
@@ -441,13 +505,9 @@ namespace Azure.Identity.Tests
 
             var response = CreateResponse(400, content);
             var mockTransport = new MockTransport(req => response);
-            var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = true };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.IdentityUnavailableError));
         }
 
@@ -467,18 +527,15 @@ namespace Azure.Identity.Tests
                 }
                 return CreateResponse(400, """{"error":"invalid_request","error_description":"Identity not found"}""");
             });
-            var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = isChained };
-            var pipeline = CredentialPipeline.GetInstance(options);
-
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential("mock-client-id", pipeline, options));
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: isChained);
             if (isChained)
             {
-                var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Alternate)));
+                var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Alternate), default));
                 Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.IdentityUnavailableError));
             }
             else
             {
-                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Alternate)));
+                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Alternate), default));
             }
         }
 
@@ -491,13 +548,9 @@ namespace Azure.Identity.Tests
 
             var response = CreateErrorMockResponse(responseCode, expectedMessage);
             var mockTransport = new MockTransport(req => response);
-            var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = true };
-            var pipeline = CredentialPipeline.GetInstance(options);
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: true);
 
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
             Assert.That(ex.Message, Does.Contain(expectedMessage));
         }
@@ -510,20 +563,14 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", "https://mock.podid.endpoint/" } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(req =>
             {
                 return response;
             });
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImds(mockTransport, clientId: clientId);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { ManagedIdentityId = clientId is null ? ManagedIdentityId.SystemAssigned : ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true, Options = options })
-            ));
-
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -547,22 +594,11 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", "https://mock.podid.endpoint/" } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
+            var credential = CreateCredentialForImdsWithResourceId(mockTransport, new ResourceIdentifier(_expectedResourceId));
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions()
-                    {
-                        Pipeline = CredentialPipeline.GetInstance(options),
-                        ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)),
-                        IsForceRefreshEnabled = true,
-                        Options = options
-                    })
-            ));
-
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -583,17 +619,11 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", "mock-msi-secret" }, { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForNonImdsSource(mockTransport);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                new ManagedIdentityClientOptions { Pipeline = pipeline, PreserveTransport = false, Options = options, IsForceRefreshEnabled = true })
-            ));
-
-            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, token.Token);
 
@@ -614,17 +644,11 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", "mock-msi-secret" }, { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForNonImdsSource(mockTransport);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                new ManagedIdentityClientOptions { Pipeline = pipeline, PreserveTransport = false, Options = options, IsForceRefreshEnabled = true })
-            ));
-
-            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken token = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, token.Token);
 
@@ -645,17 +669,11 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForNonImdsSource(mockTransport, clientId: "mock-client-id");
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                new ManagedIdentityClientOptions { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), PreserveTransport = false, Options = options, IsForceRefreshEnabled = true })
-            ));
-
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -677,17 +695,11 @@ namespace Azure.Identity.Tests
             string resourceId = "resourceId";
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", "https://identity.endpoint/" }, { "IDENTITY_HEADER", "mock-identity-header" }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForNonImdsSource(mockTransport, resourceId: resourceId);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                new ManagedIdentityClientOptions { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(resourceId)), PreserveTransport = false, Options = options, IsForceRefreshEnabled = true })
-            ));
-
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
@@ -709,7 +721,7 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", "https://mock.msi.endpoint/" }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(req =>
             {
                 Assert.IsTrue(req.Uri.ToString().StartsWith("https://mock.msi.endpoint/"));
@@ -727,8 +739,8 @@ namespace Azure.Identity.Tests
             });
             var options = new TokenCredentialOptions() { Transport = mockTransport };
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(options: options));
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            var credential = CreateBareCredentialWithOptions(options);
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
         }
@@ -745,7 +757,7 @@ namespace Azure.Identity.Tests
                 (_, message) => messages.Add(message),
                 EventLevel.Warning);
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(req =>
             {
                 Assert.IsTrue(req.Uri.ToString().StartsWith("https://mock.msi.endpoint/"), $"Unexpected Uri: {req.Uri}");
@@ -766,24 +778,22 @@ namespace Azure.Identity.Tests
 
                 return response;
             });
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
-            var pipeline = CredentialPipeline.GetInstance(options);
 
-            ManagedIdentityClientOptions clientOptions = (clientId, includeResourceIdentifier) switch
+            ManagedIdentityId miId = (clientId, includeResourceIdentifier) switch
             {
-                (Item1: null, Item2: true) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)), Pipeline = pipeline, IsForceRefreshEnabled = true },
-                (Item1: not null, Item2: false) => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true },
-                _ => new ManagedIdentityClientOptions() { ManagedIdentityId = ManagedIdentityId.SystemAssigned, Pipeline = pipeline, Options = options, PreserveTransport = true, IsForceRefreshEnabled = true }
+                (Item1: null, Item2: true) => ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)),
+                (Item1: not null, Item2: false) => ManagedIdentityId.FromUserAssignedClientId(clientId),
+                _ => ManagedIdentityId.SystemAssigned
             };
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(new ManagedIdentityClient(clientOptions)));
+            var credential = CreateCredentialWithManagedIdentityId(mockTransport, miId);
 
             if (clientId != null || includeResourceIdentifier)
             {
-                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+                var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
                 Assert.That(ex.Message, Does.Contain(Constants.MiSourceNoUserAssignedIdentityMessage));
                 return;
             }
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
         }
@@ -798,14 +808,9 @@ namespace Azure.Identity.Tests
                 throw new OperationCanceledException();
             });
             // setting the delay to 1ms and retry mode to fixed to speed up test
-            var options = new TokenCredentialOptions() { IsChainedCredential = true, Transport = mockTransport, Retry = { Delay = TimeSpan.FromMilliseconds(1), Mode = RetryMode.Fixed, NetworkTimeout = TimeSpan.FromMilliseconds(100) } };
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImdsWithRetryOptions(mockTransport, isChained: true, retryDelay: TimeSpan.FromMilliseconds(1), retryMode: RetryMode.Fixed, networkTimeout: TimeSpan.FromMilliseconds(100));
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { IsForceRefreshEnabled = true, Options = options, Pipeline = pipeline })));
-
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
             Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.AggregateError));
 
@@ -822,14 +827,9 @@ namespace Azure.Identity.Tests
             {
                 throw new TaskCanceledException();
             });
-            var options = new TokenCredentialOptions() { IsChainedCredential = true, Transport = mockTransport };
+            var credential = CreateCredentialForImdsWithRetryOptions(mockTransport, isChained: true, isManagedIdentityPipeline: true);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { IsForceRefreshEnabled = true, Options = options, Pipeline = CredentialPipeline.GetInstance(options, IsManagedIdentityCredential: true) })
-            ));
-
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
             Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.NoResponseError));
 
@@ -846,14 +846,9 @@ namespace Azure.Identity.Tests
             {
                 throw new MsalServiceException(MsalError.ManagedIdentityRequestFailed, "Retry failed", new RequestFailedException("Operation timed out (169.254.169.254:80"));
             });
-            var options = new TokenCredentialOptions() { IsChainedCredential = false, Transport = mockTransport };
+            var credential = CreateCredentialForImdsWithRetryOptions(mockTransport, isManagedIdentityPipeline: true);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { IsForceRefreshEnabled = true, Options = options, Pipeline = CredentialPipeline.GetInstance(options, IsManagedIdentityCredential: true) })
-            ));
-
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
             Assert.That(ex.Message, Does.Contain(ManagedIdentityClient.MsiUnavailableError));
 
@@ -874,9 +869,9 @@ namespace Azure.Identity.Tests
             // setting the delay to 1ms and retry mode to fixed to speed up test
             var options = new TokenCredentialOptions() { Retry = { Delay = TimeSpan.FromMilliseconds(0), Mode = RetryMode.Fixed }, IsChainedCredential = true };
 
-            var credential = InstrumentClient(new ManagedIdentityCredential(options: options));
+            var credential = CreateBareCredentialWithOptions(options);
 
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
             Assert.That(ex.Message, Does.Contain(ImdsManagedIdentityProbeSource.GatewayError));
 
@@ -890,9 +885,9 @@ namespace Azure.Identity.Tests
 
             var mockClient = new MockManagedIdentityClient(CredentialPipeline.GetInstance(null)) { TokenFactory = () => throw new MockClientException("message") };
 
-            var credential = InstrumentClient(new ManagedIdentityCredential(mockClient));
+            var credential = CreateCredentialWithMockClient(mockClient);
 
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
             Assert.IsInstanceOf(typeof(MockClientException), ex.InnerException);
 
@@ -913,15 +908,9 @@ namespace Azure.Identity.Tests
                     { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null }
                 });
             var mockTransport = new MockTransport(request => CreateInvalidJsonResponse(200));
-            var options = new TokenCredentialOptions() { Transport = mockTransport, IsChainedCredential = isChained };
-            options.Retry.MaxDelay = TimeSpan.Zero;
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id", isChained: isChained);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
-
-            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             if (isChained)
             {
                 Assert.IsInstanceOf(typeof(System.Text.Json.JsonException), ex.InnerException);
@@ -942,15 +931,9 @@ namespace Azure.Identity.Tests
                     { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null }
                 });
             var mockTransport = new MockTransport(request => CreateInvalidJsonResponse(status));
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
-            options.Retry.MaxDelay = TimeSpan.Zero;
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImdsWithRetryOptions(mockTransport, clientId: "mock-client-id", maxRetryDelay: TimeSpan.Zero);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
-
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             await Task.CompletedTask;
         }
 
@@ -968,16 +951,10 @@ namespace Azure.Identity.Tests
                 });
             var errorMessage = "Some error happened";
             var mockTransport = new MockTransport(request => CreateErrorMockResponse(404, errorMessage));
-            var options = new TokenCredentialOptions { Transport = mockTransport };
-            options.Retry.MaxDelay = TimeSpan.Zero;
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForImds(mockTransport, clientId: "mock-client-id");
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
-
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
-            Assert.That(ex.Message, Does.Contain(errorMessage));
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+            Assert.IsTrue(ExceptionChainContains(ex, errorMessage));
 
             await Task.CompletedTask;
         }
@@ -1001,15 +978,9 @@ namespace Azure.Identity.Tests
                 tryCount++;
                 return CreateErrorMockResponse(status, errorMessage);
             });
-            var options = new TokenCredentialOptions { Transport = mockTransport };
-            options.Retry.MaxDelay = TimeSpan.Zero;
-            var pipeline = CredentialPipeline.GetInstance(options, true);
+            var credential = CreateCredentialForImdsWithRetryOptions(mockTransport, clientId: "mock-client-id", maxRetryDelay: TimeSpan.Zero, isManagedIdentityPipeline: true);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { Pipeline = pipeline, ManagedIdentityId = ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), IsForceRefreshEnabled = true, Options = options })));
-
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             Assert.That(ex.Message, Does.Contain(errorMessage));
             Assert.That(tryCount, Is.EqualTo(6));
 
@@ -1048,9 +1019,9 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(environmentVariables);
 
-            var credential = InstrumentClient(new ManagedIdentityCredential(new ManagedIdentityClient(new ManagedIdentityClientOptions { IsForceRefreshEnabled = true, Pipeline = CredentialPipeline.GetInstance(null, IsManagedIdentityCredential: true) })));
+            var credential = CreateCredentialForImdsWithRetryOptions(new MockTransport(req => CreateErrorMockResponse(500, "error")), isManagedIdentityPipeline: true);
 
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
 
             await Task.CompletedTask;
         }
@@ -1083,16 +1054,9 @@ namespace Azure.Identity.Tests
                 }
                 return response;
             });
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
-            options.Retry.MaxDelay = TimeSpan.Zero;
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForNonImdsSource(mockTransport, maxRetryDelay: TimeSpan.Zero);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                new ManagedIdentityClientOptions { Pipeline = pipeline, PreserveTransport = false, Options = options, IsForceRefreshEnabled = true })
-            ));
-
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             Assert.That(ex.Message, Does.Contain("The file on the file path in the WWW-Authenticate header is not secure"));
         }
 
@@ -1124,16 +1088,9 @@ namespace Azure.Identity.Tests
                 }
                 return response;
             });
-            var options = new TokenCredentialOptions() { Transport = mockTransport };
-            options.Retry.MaxDelay = TimeSpan.Zero;
-            var pipeline = CredentialPipeline.GetInstance(options);
+            var credential = CreateCredentialForNonImdsSource(mockTransport, maxRetryDelay: TimeSpan.Zero);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                new ManagedIdentityClientOptions { Pipeline = pipeline, PreserveTransport = false, Options = options, IsForceRefreshEnabled = true })
-            ));
-
-            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default)));
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
             Assert.That(ex.Message, Does.Contain("The file on the file path in the WWW-Authenticate header is not secure"));
         }
 
@@ -1192,8 +1149,8 @@ namespace Azure.Identity.Tests
             });
             var options = new TokenCredentialOptions() { Transport = mockTransport };
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(options: options));
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            var credential = CreateBareCredentialWithOptions(options);
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             Assert.AreEqual(ExpectedToken, actualToken.Token);
             Assert.That(messages, Does.Contain(string.Format(AzureIdentityEventSource.ManagedIdentitySourceAttemptedMessage, "TokenExchangeManagedIdentitySource", true)));
@@ -1256,20 +1213,20 @@ namespace Azure.Identity.Tests
             });
             var options = new TokenCredentialOptions() { Transport = mockTransport };
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(options: options));
+            var credential = CreateBareCredentialWithOptions(options);
             // Fetch the token from the authority
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
             // This request should be served from cache
-            AccessToken secondToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken secondToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
             // This request changes the scope and should come from the authority
-            AccessToken thirdToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Alternate));
+            AccessToken thirdToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Alternate), default);
 
             Assert.AreEqual(actualToken.Token, secondToken.Token);
             Assert.AreNotEqual(actualToken.Token, thirdToken.Token);
             Assert.That(messages, Does.Contain(string.Format(AzureIdentityEventSource.ManagedIdentitySourceAttemptedMessage, "TokenExchangeManagedIdentitySource", true)));
         }
 
-        private static IEnumerable<TestCaseData> ManagedIdentityIds()
+        protected static IEnumerable<TestCaseData> ManagedIdentityIds()
         {
             yield return new TestCaseData([ManagedIdentityId.SystemAssigned, string.Format(AzureIdentityEventSource.ManagedIdentityCredentialSelectedMessage, "DefaultToImds", "SystemAssigned")]);
             yield return new TestCaseData([ManagedIdentityId.FromUserAssignedClientId("mock-client-id"), string.Format(AzureIdentityEventSource.ManagedIdentityCredentialSelectedMessage, "DefaultToImds", "ClientId mock-client-id")]);
@@ -1283,28 +1240,17 @@ namespace Azure.Identity.Tests
         {
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var response = CreateMockResponse(200, ExpectedToken);
+            var response = CreateSuccessResponse(ExpectedToken);
             var mockTransport = new MockTransport(response);
-            var options = new TokenCredentialOptions { Transport = mockTransport };
-            var expectedObjectId = Guid.NewGuid().ToString();
 
             List<string> messages = new();
             using AzureEventSourceListener listener = new AzureEventSourceListener(
                 (_, message) => messages.Add(message),
                 EventLevel.Informational);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions()
-                    {
-                        Pipeline = CredentialPipeline.GetInstance(options),
-                        ManagedIdentityId = managedIdentityId,
-                        IsForceRefreshEnabled = true,
-                        Options = options
-                    })
-            ));
+            var credential = CreateCredentialWithManagedIdentityId(mockTransport, managedIdentityId);
 
-            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
             Assert.AreEqual(ExpectedToken, actualToken.Token);
 
             Assert.That(messages, Does.Contain(expectedMessage));
@@ -1317,24 +1263,13 @@ namespace Azure.Identity.Tests
             string caeClaims = """{"access_token":{"nbf":{"essential":true, "value":"1724337680"}}}""";
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", null } });
 
-            var mockTransport = new MockTransport(_ => CreateMockResponse(200, Guid.NewGuid().ToString()));
-            var options = new TokenCredentialOptions { Transport = mockTransport };
+            var mockTransport = new MockTransport(_ => CreateSuccessResponse(Guid.NewGuid().ToString()));
+            var credential = CreateCredentialForImdsWithResourceId(mockTransport, new ResourceIdentifier(_expectedResourceId), isForceRefreshEnabled: false);
 
-            ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
-                new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions()
-                    {
-                        Pipeline = CredentialPipeline.GetInstance(options),
-                        ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)),
-                        IsForceRefreshEnabled = false,
-                        Options = options
-                    })
-            ));
-
-            AccessToken tokenWithoutCAE1 = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
-            AccessToken tokenWithoutCAE2 = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
-            AccessToken tokenWithCAE1 = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default, isCaeEnabled: true, claims: caeClaims));
-            AccessToken tokenWithoutCAE3 = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
+            AccessToken tokenWithoutCAE1 = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
+            AccessToken tokenWithoutCAE2 = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
+            AccessToken tokenWithCAE1 = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default, isCaeEnabled: true, claims: caeClaims), default);
+            AccessToken tokenWithoutCAE3 = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default);
 
             // TokenWithoutCAE1 and TokenWithoutCAE2 should be the same since subsequent calls to GetTokenAsync should return the same token if no claims were provided
             Assert.AreEqual(tokenWithoutCAE2.Token, tokenWithoutCAE1.Token);
@@ -1378,10 +1313,10 @@ namespace Azure.Identity.Tests
             yield return new object[] { AzureAuthorityHosts.AzurePublicCloud };
         }
 
-        private MockResponse CreateMockResponse(int responseCode, string token)
+        protected MockResponse CreateMockResponse(int responseCode, string token)
         {
             var response = new MockResponse(responseCode);
-            response.SetContent($"{{ \"access_token\": \"{token}\", \"expires_on\": \"{DateTimeOffset.UtcNow.AddHours(2).ToUnixTimeSeconds()}\" }}");
+            response.SetContent($"{{ \"access_token\": \"{token}\", \"expires_on\": \"{DateTimeOffset.UtcNow.AddHours(2).ToUnixTimeSeconds()}\", \"token_type\": \"Bearer\" }}");
             return response;
         }
 
@@ -1392,14 +1327,14 @@ namespace Azure.Identity.Tests
             return response;
         }
 
-        private MockResponse CreateErrorMockResponse(int responseCode, string message)
+        protected MockResponse CreateErrorMockResponse(int responseCode, string message)
         {
             var response = new MockResponse(responseCode);
             response.SetContent($"{{\"statusCode\":{responseCode},\"message\":\"{message}\",\"correlationId\":\"f3c9aec0-7fa2-4184-ad0f-0c68ce5fc748\"}}");
             return response;
         }
 
-        private static MockResponse CreateInvalidJsonResponse(int status, string message = "invalid json")
+        protected static MockResponse CreateInvalidJsonResponse(int status, string message = "invalid json")
         {
             var response = new MockResponse(status);
             if (message != null)
@@ -1409,7 +1344,7 @@ namespace Azure.Identity.Tests
             return response;
         }
 
-        private static MockResponse CreateResponse(int status, string message)
+        protected static MockResponse CreateResponse(int status, string message)
         {
             var response = new MockResponse(status);
             if (message != null)


### PR DESCRIPTION
## Description

Adds ManagedIdentityCredential (MIC) support to the ConfigurableCredentialProvider test infrastructure.

Fixes #55502

## Changes

### Production code
- **DefaultAzureCredentialOptions**: Added internal config properties \IsProbeEnabled\, \UseManagedIdentityPipeline\, and \ManagedIdentityObjectId\ with config reading and Clone support
- **DefaultAzureCredentialFactory**: \CreateManagedIdentityCredential\ now reads \IsProbeEnabled\, \UseManagedIdentityPipeline\, and \ManagedIdentityObjectId\ from options instead of hardcoding defaults

### Test code
- **ManagedIdentityCredentialTests.cs**: Added virtual factory methods for credential construction; refactored all ~40 tests to use factories instead of direct MIC instantiation; added private helpers to reduce duplication
- **ConfigurableCredentials/ManagedIdentityCredentialTests.cs** (new): CC test class with factory-only overrides (zero test overrides, zero skips)
- **ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs** (new): 12 creation tests validating all config properties flow through to MIC

### Test results
- Base MIC tests: 142/142 pass
- CC MIC tests: 142/142 pass, 0 skipped
- CC creation tests: 12/12 pass
- Full CC regression: 0 failures