### PR TITLE
[.NET SDK Global] Update min version

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Microsoft.Build.Traversal": "4.1.82"
   },
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.103",
     "rollForward": "feature"
   }
 }


### PR DESCRIPTION
# Summary

The focus of these changes is to bump the minimum version of the .NET 10 SDK in use for the repository, as v10.0.100 has an active security vulnerability.

## References and resources

- [Component Governance Report](https://dev.azure.com/azure-sdk/internal/_componentGovernance/98522/alert/14288367?branchMoniker=main) _(Microsoft internal)_