### PR TITLE
Replace `azd config list` with `azd auth status` in TROUBLESHOOTING.md

### DIFF
--- a/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
+++ b/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
@@ -288,10 +288,10 @@ az account get-access-token --output json --resource https://management.core.win
 
 ### Verify the Azure Developer CLI can obtain tokens
 
-You can manually verify that the Azure Developer CLI is properly authenticated and can obtain tokens. First, use the `config` command to verify the account that is currently logged in to the Azure Developer CLI.
+You can manually verify that the Azure Developer CLI is properly authenticated and can obtain tokens. First, use the `auth status` command to verify the account that is currently logged in to the Azure Developer CLI.
 
 ```bash
-azd config list
+azd auth status
 ```
 
 Once you've verified the Azure Developer CLI is using correct account, you can validate that it's able to obtain tokens for this account.

--- a/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
+++ b/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
@@ -284,7 +284,7 @@ az account get-access-token --output json --resource https://management.core.win
 | Error Message |Description| Mitigation |
 |---|---|---|
 |Azure Developer CLI not installed|The Azure Developer CLI isn't installed or couldn't be found.|<ul><li>Ensure the Azure Developer CLI is properly installed. Installation instructions can be found at [Install or update the Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd).</li><li>Validate the installation location has been added to the `PATH` environment variable.</li></ul>|
-|Please run 'azd login' to set up account|No account is currently logged into the Azure Developer CLI, or the login has expired.|<ul><li>Log in to the Azure Developer CLI using the `azd login` command.</li><li>Validate that the Azure Developer CLI can obtain tokens. For instructions, see [Verify the Azure Developer CLI can obtain tokens](#verify-the-azure-developer-cli-can-obtain-tokens).</li></ul>|
+|Please run 'azd auth login' to set up account|No account is currently logged into the Azure Developer CLI, or the login has expired.|<ul><li>Log in to the Azure Developer CLI using the `azd auth login` command.</li><li>Validate that the Azure Developer CLI can obtain tokens. For instructions, see [Verify the Azure Developer CLI can obtain tokens](#verify-the-azure-developer-cli-can-obtain-tokens).</li></ul>|
 
 ### Verify the Azure Developer CLI can obtain tokens
 

--- a/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
+++ b/sdk/identity/Azure.Identity/TROUBLESHOOTING.md
@@ -288,17 +288,26 @@ az account get-access-token --output json --resource https://management.core.win
 
 ### Verify the Azure Developer CLI can obtain tokens
 
-You can manually verify that the Azure Developer CLI is properly authenticated and can obtain tokens. First, use the `auth status` command to verify the account that is currently logged in to the Azure Developer CLI.
+You can manually verify that the Azure Developer CLI is properly authenticated and can obtain tokens. Execute the command corresponding to your CLI version to verify the account currently logged in.
 
-```bash
-azd auth status
-```
+- In Azure Developer CLI versions >= 1.23.0:
+
+    ```sh
+    azd auth status
+    ```
+
+- In Azure Developer CLI versions < 1.23.0:
+
+    ```sh
+    azd config list
+    ```
 
 Once you've verified the Azure Developer CLI is using correct account, you can validate that it's able to obtain tokens for this account.
 
 ```bash
 azd auth token --output json --scope https://management.core.windows.net/.default
 ```
+
 >Note that output of this command will contain a valid access token, and SHOULD NOT BE SHARED to avoid compromising account security.
 
 ## Troubleshoot `AzurePowerShellCredential` authentication issues


### PR DESCRIPTION
The `azd config list` command is no longer the recommended way to verify the logged-in Azure Developer CLI account. Update the troubleshooting guide to use `azd auth status` instead. Also replace `azd login` with the recommended `azd auth login` command.
