### PR TITLE
Add InteractiveBrowserCredential support to ConfigurableCredentialProvider

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/tests/Azure.Identity.Broker.Tests.csproj
+++ b/sdk/identity/Azure.Identity.Broker/tests/Azure.Identity.Broker.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);SCME0002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +14,7 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,7 +25,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)ForwardsClientCallsAttribute.cs" LinkBase="Shared" />
+    <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\ConfigurableCredentialTestHelper.cs" LinkBase="ConfigurableCredentials" />
     <Compile Include="*.cs" Exclude="*Manual*.cs" />
+    <Compile Include="ConfigurableCredentials\*.cs" />
     <Compile Include="ManualInteractiveBrowserCredentialBrokerTests.cs" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
     <Compile Include="ManualSharedTokenCacheCredentialBrokerTests.cs" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
     <Compile Include="ManualInteractiveBrowserCredentialBrokerTestsLinux.cs" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />

--- a/sdk/identity/Azure.Identity.Broker/tests/ConfigurableCredentials/InteractiveBrowserCredentialBrokerTests.cs
+++ b/sdk/identity/Azure.Identity.Broker/tests/ConfigurableCredentials/InteractiveBrowserCredentialBrokerTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Identity.Tests.ConfigurableCredentials;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Identity.Client;
+
+namespace Azure.Identity.Broker.Tests.ConfigurableCredentials
+{
+    /// <summary>
+    /// Tests for broker-mode InteractiveBrowserCredential accessed through ConfigurableCredential.
+    /// Inherits from InteractiveBrowserCredentialBrokerTests to get broker-specific test cases.
+    /// Overrides factory methods to create credentials via IConfiguration.
+    /// </summary>
+    internal class InteractiveBrowserCredentialBrokerTests : Tests.InteractiveBrowserCredentialBrokerTests
+    {
+        private readonly ConfigurableCredentialTestHelper<InteractiveBrowserCredential> _helper;
+
+        public InteractiveBrowserCredentialBrokerTests()
+        {
+            _helper = new ConfigurableCredentialTestHelper<InteractiveBrowserCredential>(
+                "InteractiveBrowser");
+        }
+
+        protected override TokenCredential CreateCredentialWithBeforeBuildClient(Action<PublicClientApplicationBuilder> beforeBuildClient)
+            => CreateFromConfig(beforeBuildClient);
+
+        protected override TokenCredential CreateCredentialWithBrokerMode(Action<PublicClientApplicationBuilder> beforeBuildClient)
+            => CreateFromConfig(beforeBuildClient, useDefaultBrokerAccount: true, isChainedCredential: true);
+
+        private TokenCredential CreateFromConfig(
+            Action<PublicClientApplicationBuilder> beforeBuildClient,
+            bool useDefaultBrokerAccount = false,
+            bool isChainedCredential = false)
+        {
+            IConfiguration config = _helper.GetConfiguration();
+            config["MyClient:Credential:InteractiveBrowserCredentialClientId"] = Guid.NewGuid().ToString();
+            if (useDefaultBrokerAccount)
+            {
+                config["MyClient:Credential:UseDefaultBrokerAccount"] = "True";
+            }
+
+            ConfigurableCredential ccCredential;
+            using (new TestEnvVar("AZURE_TENANT_ID", null))
+            {
+                ccCredential = _helper.GetCredentialFromConfig(config);
+            }
+
+            var ibc = _helper.GetUnderlyingCredential(ccCredential);
+            if (isChainedCredential)
+            {
+                ibc.IsChainedCredential = true;
+            }
+            typeof(MsalPublicClient)
+                .GetField("_beforeBuildClient", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(ibc.Client, beforeBuildClient);
+
+            return _helper.InstrumentCredential(ccCredential);
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity.Broker/tests/InteractiveBrowserCredentialBrokerTests.cs
+++ b/sdk/identity/Azure.Identity.Broker/tests/InteractiveBrowserCredentialBrokerTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.Identity.Client;
+using NUnit.Framework;
+
+namespace Azure.Identity.Broker.Tests
+{
+    internal class InteractiveBrowserCredentialBrokerTests
+    {
+        public class ExtendedInteractiveBrowserCredentialOptions : InteractiveBrowserCredentialOptions, IMsalPublicClientInitializerOptions
+        {
+            private Action<PublicClientApplicationBuilder> _beforeBuildClient;
+
+            public ExtendedInteractiveBrowserCredentialOptions(Action<PublicClientApplicationBuilder> beforeBuildClient)
+            {
+                _beforeBuildClient = beforeBuildClient;
+            }
+
+            public bool IsProofOfPossessionRequired { get; set; }
+
+            public bool UseDefaultBrokerAccount { get; set; }
+
+            Action<PublicClientApplicationBuilder> IMsalPublicClientInitializerOptions.BeforeBuildClient { get { return _beforeBuildClient; } }
+        }
+
+        [Test]
+        public async Task InvokesBeforeBuildClientOnExtendedOptions()
+        {
+            bool beforeBuildClientInvoked = false;
+
+            var cancelSource = new CancellationTokenSource(2000);
+
+            Action<PublicClientApplicationBuilder> beforeBuildClient = builder =>
+            {
+                Assert.NotNull(builder);
+                beforeBuildClientInvoked = true;
+                cancelSource.Cancel();
+            };
+
+            var credential = CreateCredentialWithBeforeBuildClient(beforeBuildClient);
+
+            try
+            {
+                await credential.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" }), cancelSource.Token);
+            }
+            catch (OperationCanceledException) { }
+            catch (CredentialUnavailableException) { }
+
+            Assert.True(beforeBuildClientInvoked);
+        }
+
+        [Test]
+        public void FailsWithCredentialUnavailableExceptionWhenChainedInBrokerMode()
+        {
+            bool beforeBuildClientInvoked = false;
+
+            var cancelSource = new CancellationTokenSource(2000);
+
+            Action<PublicClientApplicationBuilder> beforeBuildClient = builder =>
+            {
+                Assert.NotNull(builder);
+                beforeBuildClientInvoked = true;
+                cancelSource.Cancel();
+            };
+
+            var credential = CreateCredentialWithBrokerMode(beforeBuildClient);
+
+            Assert.ThrowsAsync<CredentialUnavailableException>(async () => await credential.GetTokenAsync(new TokenRequestContext(new string[] { "https://vault.azure.net/.default" }), cancelSource.Token));
+
+            Assert.True(beforeBuildClientInvoked);
+        }
+
+        protected virtual TokenCredential CreateCredentialWithBeforeBuildClient(Action<PublicClientApplicationBuilder> beforeBuildClient)
+        {
+            var options = new ExtendedInteractiveBrowserCredentialOptions(beforeBuildClient);
+            return new InteractiveBrowserCredential(options);
+        }
+
+        protected virtual TokenCredential CreateCredentialWithBrokerMode(Action<PublicClientApplicationBuilder> beforeBuildClient)
+        {
+            var options = new ExtendedInteractiveBrowserCredentialOptions(beforeBuildClient);
+            options.UseDefaultBrokerAccount = true;
+            options.IsChainedCredential = true;
+            return new InteractiveBrowserCredential(options);
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity.Broker/tests/InteractiveBrowserCredentialBrokerTests.cs
+++ b/sdk/identity/Azure.Identity.Broker/tests/InteractiveBrowserCredentialBrokerTests.cs
@@ -50,6 +50,7 @@ namespace Azure.Identity.Broker.Tests
             }
             catch (OperationCanceledException) { }
             catch (CredentialUnavailableException) { }
+            catch (AuthenticationFailedException) { }
 
             Assert.True(beforeBuildClientInvoked);
         }

--- a/sdk/identity/Azure.Identity/src/AuthenticationRecord.cs
+++ b/sdk/identity/Azure.Identity/src/AuthenticationRecord.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Identity.Client;
 
 namespace Azure.Identity
@@ -52,6 +53,23 @@ namespace Azure.Identity
             AccountId = BuildAccountIdFromString(homeAccountId);
             TenantId = tenantId;
             ClientId = clientId;
+        }
+
+        internal AuthenticationRecord(IConfigurationSection section)
+        {
+            if (section == null || !section.Exists())
+            {
+                return;
+            }
+
+            Username = section[nameof(Username)];
+            Authority = section[nameof(Authority)];
+            if (section[nameof(HomeAccountId)] is string homeAccountId)
+            {
+                AccountId = BuildAccountIdFromString(homeAccountId);
+            }
+            TenantId = section[nameof(TenantId)];
+            ClientId = section[nameof(ClientId)];
         }
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/Credentials/BrowserCustomizationOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/BrowserCustomizationOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Identity.Client;
 
 namespace Azure.Identity
@@ -14,6 +15,33 @@ namespace Azure.Identity
     /// </summary>
     public class BrowserCustomizationOptions
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BrowserCustomizationOptions"/> class.
+        /// </summary>
+        public BrowserCustomizationOptions() { }
+
+        internal BrowserCustomizationOptions(IConfigurationSection section)
+        {
+            if (section == null || !section.Exists())
+            {
+                return;
+            }
+            if (section[nameof(SuccessMessage)] is string successMessage)
+            {
+                SuccessMessage = successMessage;
+            }
+            if (section[nameof(ErrorMessage)] is string errorMessage)
+            {
+                ErrorMessage = errorMessage;
+            }
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (bool.TryParse(section[nameof(UseEmbeddedWebView)], out bool useEmbeddedWebView))
+            {
+                UseEmbeddedWebView = useEmbeddedWebView;
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
         /// <summary>
         /// Specifies if the public client application should used an embedded web browser
         /// or the system default browser
@@ -66,6 +94,19 @@ namespace Azure.Identity
             {
                 systemWebViewOptions.HtmlMessageError = value;
             }
+        }
+
+        internal BrowserCustomizationOptions Clone()
+        {
+            var clone = new BrowserCustomizationOptions
+            {
+                ErrorMessage = ErrorMessage,
+                SuccessMessage = SuccessMessage,
+#pragma warning disable CS0618 // Type or member is obsolete
+                UseEmbeddedWebView = UseEmbeddedWebView ?? false
+#pragma warning restore CS0618 // Type or member is obsolete
+            };
+            return clone;
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -134,6 +134,33 @@ namespace Azure.Identity
             {
                 IsAzureProxyEnabled = isAzureProxyEnabled;
             }
+
+            if (bool.TryParse(section[nameof(DisableAutomaticAuthentication)], out bool disableAutomaticAuthentication))
+            {
+                DisableAutomaticAuthentication = disableAutomaticAuthentication;
+            }
+
+            if (section[nameof(LoginHint)] is string loginHint)
+            {
+                LoginHint = loginHint;
+            }
+
+            var browserSection = section.GetSection(nameof(BrowserCustomization));
+            if (browserSection.Exists())
+            {
+                BrowserCustomization = new BrowserCustomizationOptions(browserSection);
+            }
+
+            var authRecordSection = section.GetSection(nameof(AuthenticationRecord));
+            if (authRecordSection.Exists())
+            {
+                AuthenticationRecord = new AuthenticationRecord(authRecordSection);
+            }
+
+            if (bool.TryParse(section[nameof(UseDefaultBrokerAccount)], out bool useDefaultBrokerAccount))
+            {
+                UseDefaultBrokerAccount = useDefaultBrokerAccount;
+            }
         }
 
         private UpdateTracker<string> _tenantId = new UpdateTracker<string>(EnvironmentVariables.TenantId);
@@ -458,6 +485,16 @@ namespace Azure.Identity
 
         internal bool IsAzureProxyEnabled { get; set; }
 
+        internal bool DisableAutomaticAuthentication { get; set; }
+
+        internal string LoginHint { get; set; }
+
+        internal BrowserCustomizationOptions BrowserCustomization { get; set; }
+
+        internal AuthenticationRecord AuthenticationRecord { get; set; }
+
+        internal bool UseDefaultBrokerAccount { get; set; }
+
         internal override T Clone<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>()
         {
             var clone = base.Clone<T>();
@@ -501,6 +538,14 @@ namespace Azure.Identity
                     dacClone.Subscription = Subscription;
                 }
                 dacClone.IsAzureProxyEnabled = IsAzureProxyEnabled;
+                dacClone.DisableAutomaticAuthentication = DisableAutomaticAuthentication;
+                dacClone.LoginHint = LoginHint;
+                if (BrowserCustomization != null)
+                {
+                    dacClone.BrowserCustomization = BrowserCustomization.Clone();
+                }
+                dacClone.AuthenticationRecord = AuthenticationRecord;
+                dacClone.UseDefaultBrokerAccount = UseDefaultBrokerAccount;
             }
 
             return clone;

--- a/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredential.cs
@@ -96,6 +96,7 @@ namespace Azure.Identity
             AdditionallyAllowedTenantIds = TenantIdResolver.ResolveAddionallyAllowedTenantIds((options as ISupportsAdditionallyAllowedTenants)?.AdditionallyAllowedTenants);
             Record = (options as InteractiveBrowserCredentialOptions)?.AuthenticationRecord;
             BrowserCustomization = (options as InteractiveBrowserCredentialOptions)?.BrowserCustomization;
+            DisableAutomaticAuthentication = (options as InteractiveBrowserCredentialOptions)?.DisableAutomaticAuthentication ?? false;
             UseOperatingSystemAccount = (options as IMsalPublicClientInitializerOptions)?.UseDefaultBrokerAccount ?? false;
             IsChainedCredential = options?.IsChainedCredential ?? false;
         }

--- a/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredentialOptions.cs
@@ -88,17 +88,23 @@ namespace Azure.Identity
                 ibcoClone.DisableInstanceDiscovery = DisableInstanceDiscovery;
                 if (BrowserCustomization != null)
                 {
-                    ibcoClone.BrowserCustomization = new BrowserCustomizationOptions
-                    {
-                        ErrorMessage = BrowserCustomization.ErrorMessage,
-                        SuccessMessage = BrowserCustomization.SuccessMessage,
-#pragma warning disable CS0618 // Type or member is obsolete
-                        UseEmbeddedWebView = BrowserCustomization.UseEmbeddedWebView ?? false
-#pragma warning restore CS0618 // Type or member is obsolete
-                    };
+                    ibcoClone.BrowserCustomization = BrowserCustomization.Clone();
                 }
             }
+            if (clone is IMsalSettablePublicClientInitializerOptions msalSettableClone && this is IMsalSettablePublicClientInitializerOptions thisAsInterface)
+            {
+                msalSettableClone.BeforeBuildClient = thisAsInterface.BeforeBuildClient;
+                msalSettableClone.UseDefaultBrokerAccount = thisAsInterface.UseDefaultBrokerAccount;
+            }
             return clone;
+        }
+
+        internal void CopyMsalSettableProperties(DefaultAzureCredentialOptions options)
+        {
+            if (this is IMsalSettablePublicClientInitializerOptions thisAsInterface)
+            {
+                thisAsInterface.UseDefaultBrokerAccount = options.UseDefaultBrokerAccount;
+            }
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -343,11 +343,36 @@ namespace Azure.Identity
 
         public virtual TokenCredential CreateInteractiveBrowserCredential()
         {
-            var options = Options.Clone<InteractiveBrowserCredentialOptions>();
+            InteractiveBrowserCredentialOptions brokerOptions = null;
+            if (Options.UseDefaultBrokerAccount && !TryCreateDevelopmentBrokerOptions(out brokerOptions))
+            {
+                throw new InvalidOperationException("Must reference the Azure.Identity.Broker package to use broker authentication with InteractiveBrowserCredential.");
+            }
+
+            brokerOptions?.CopyMsalSettableProperties(Options);
+
+            var options = brokerOptions ?? Options.Clone<InteractiveBrowserCredentialOptions>();
 
             options.TokenCachePersistenceOptions = new TokenCachePersistenceOptions();
 
             options.TenantId = Options.InteractiveBrowserTenantId;
+
+            options.DisableAutomaticAuthentication = Options.DisableAutomaticAuthentication;
+
+            if (!string.IsNullOrEmpty(Options.LoginHint))
+            {
+                options.LoginHint = Options.LoginHint;
+            }
+
+            if (Options.BrowserCustomization != null)
+            {
+                options.BrowserCustomization = Options.BrowserCustomization.Clone();
+            }
+
+            if (Options.AuthenticationRecord != null)
+            {
+                options.AuthenticationRecord = Options.AuthenticationRecord;
+            }
 
             return new InteractiveBrowserCredential(
                 Options.InteractiveBrowserTenantId,

--- a/sdk/identity/Azure.Identity/tests/Azure.Identity.Tests.csproj
+++ b/sdk/identity/Azure.Identity/tests/Azure.Identity.Tests.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 <!-- Remove before shipping GA -->
   <PropertyGroup>
-        <DefineConstants>PREVIEW_FEATURE_FLAG</DefineConstants>
+        <DefineConstants>PREVIEW_FEATURE_FLAG;IDENTITY_TESTS</DefineConstants>
   </PropertyGroup>
 <!-- End remove before shipping GA -->
   <ItemGroup>

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialCreationTests.cs
@@ -1,0 +1,361 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
+{
+    /// <summary>
+    /// Validates that all InteractiveBrowserCredential-specific properties can be set
+    /// via IConfiguration and that the correct values are passed through to the
+    /// underlying credential.
+    /// </summary>
+    internal class InteractiveBrowserCredentialCreationTests : CredentialCreationTestBase<InteractiveBrowserCredential>
+    {
+        protected override string CredentialSource => "InteractiveBrowser";
+
+        private static Dictionary<string, string> AllNulledEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+        };
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(ibc, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("env-tenant", ReadProperty<string>(ibc, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(ibc, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientId_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:InteractiveBrowserCredentialClientId"] = "my-client-id";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("my-client-id", ReadProperty<string>(ibc, "ClientId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientId_DefaultsToDeveloperSignOnClientId()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual(Constants.DeveloperSignOnClientId, ReadProperty<string>(ibc, "ClientId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-tenant-a";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(ibc, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "config-tenant-a");
+                CollectionAssert.DoesNotContain(tenants, "env-tenant-x");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(ibc, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "env-tenant-x");
+                CollectionAssert.Contains(tenants, "env-tenant-y");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(ibc, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableAutomaticAuthentication_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:DisableAutomaticAuthentication"] = "true";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadProperty<bool>(ibc, "DisableAutomaticAuthentication"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableAutomaticAuthentication_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadProperty<bool>(ibc, "DisableAutomaticAuthentication"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void LoginHint_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:LoginHint"] = "user@example.com";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("user@example.com", ReadProperty<string>(ibc, "LoginHint"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void LoginHint_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(ibc, "LoginHint"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void BrowserCustomization_SuccessMessage_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:BrowserCustomization:SuccessMessage"] = "<p>Login successful</p>";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var bc = ReadProperty<BrowserCustomizationOptions>(ibc, "BrowserCustomization");
+                Assert.IsNotNull(bc);
+                Assert.AreEqual("<p>Login successful</p>", bc.SuccessMessage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void BrowserCustomization_ErrorMessage_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:BrowserCustomization:ErrorMessage"] = "<p>Error: {0}</p>";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var bc = ReadProperty<BrowserCustomizationOptions>(ibc, "BrowserCustomization");
+                Assert.IsNotNull(bc);
+                Assert.AreEqual("<p>Error: {0}</p>", bc.ErrorMessage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void BrowserCustomization_UseEmbeddedWebView_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:BrowserCustomization:UseEmbeddedWebView"] = "true";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var bc = ReadProperty<BrowserCustomizationOptions>(ibc, "BrowserCustomization");
+                Assert.IsNotNull(bc);
+#pragma warning disable CS0618 // Type or member is obsolete
+                Assert.IsTrue(bc.UseEmbeddedWebView);
+#pragma warning restore CS0618
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void BrowserCustomization_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<BrowserCustomizationOptions>(ibc, "BrowserCustomization"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthenticationRecord_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AuthenticationRecord:Username"] = "user@contoso.com";
+                config["MyClient:Credential:AuthenticationRecord:Authority"] = "login.microsoftonline.com";
+                config["MyClient:Credential:AuthenticationRecord:HomeAccountId"] = "object-id.tenant-id";
+                config["MyClient:Credential:AuthenticationRecord:TenantId"] = "record-tenant";
+                config["MyClient:Credential:AuthenticationRecord:ClientId"] = "record-client";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var record = ReadProperty<AuthenticationRecord>(ibc, "Record");
+                Assert.IsNotNull(record);
+                Assert.AreEqual("user@contoso.com", record.Username);
+                Assert.AreEqual("login.microsoftonline.com", record.Authority);
+                Assert.AreEqual("object-id.tenant-id", record.HomeAccountId);
+                Assert.AreEqual("record-tenant", record.TenantId);
+                Assert.AreEqual("record-client", record.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthenticationRecord_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<AuthenticationRecord>(ibc, "Record"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigSetsAllValues()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-extra" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:InteractiveBrowserCredentialClientId"] = "my-client-id";
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+                config["MyClient:Credential:DisableAutomaticAuthentication"] = "true";
+                config["MyClient:Credential:LoginHint"] = "user@example.com";
+                config["MyClient:Credential:BrowserCustomization:SuccessMessage"] = "<p>OK</p>";
+                config["MyClient:Credential:BrowserCustomization:ErrorMessage"] = "<p>Fail</p>";
+                config["MyClient:Credential:AuthenticationRecord:Username"] = "user@contoso.com";
+                config["MyClient:Credential:AuthenticationRecord:Authority"] = "login.microsoftonline.com";
+                config["MyClient:Credential:AuthenticationRecord:HomeAccountId"] = "oid.tid";
+                config["MyClient:Credential:AuthenticationRecord:TenantId"] = "rec-tenant";
+                config["MyClient:Credential:AuthenticationRecord:ClientId"] = "rec-client";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+
+                Assert.AreEqual(configTenant, ReadProperty<string>(ibc, "TenantId"));
+                Assert.AreEqual("my-client-id", ReadProperty<string>(ibc, "ClientId"));
+
+                var tenants = ReadProperty<string[]>(ibc, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+
+                Assert.IsTrue(ReadProperty<bool>(ibc, "DisableAutomaticAuthentication"));
+                Assert.AreEqual("user@example.com", ReadProperty<string>(ibc, "LoginHint"));
+
+                var bc = ReadProperty<BrowserCustomizationOptions>(ibc, "BrowserCustomization");
+                Assert.IsNotNull(bc);
+                Assert.AreEqual("<p>OK</p>", bc.SuccessMessage);
+                Assert.AreEqual("<p>Fail</p>", bc.ErrorMessage);
+
+                var record = ReadProperty<AuthenticationRecord>(ibc, "Record");
+                Assert.IsNotNull(record);
+                Assert.AreEqual("user@contoso.com", record.Username);
+                Assert.AreEqual("login.microsoftonline.com", record.Authority);
+                Assert.AreEqual("oid.tid", record.HomeAccountId);
+                Assert.AreEqual("rec-tenant", record.TenantId);
+                Assert.AreEqual("rec-client", record.ClientId);
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using Azure.Identity.Tests.Mock;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
+{
+    /// <summary>
+    /// Tests for InteractiveBrowserCredential accessed through ConfigurableCredential.
+    /// Inherits from Tests.InteractiveBrowserCredentialTests to get all InteractiveBrowser-specific test cases.
+    /// Overrides factory methods to create credentials via IConfiguration.
+    /// </summary>
+    internal class InteractiveBrowserCredentialTests : Tests.InteractiveBrowserCredentialTests
+    {
+        private readonly ConfigurableCredentialTestHelper<InteractiveBrowserCredential> _helper;
+
+        public InteractiveBrowserCredentialTests(bool isAsync) : base(isAsync)
+        {
+            _helper = new ConfigurableCredentialTestHelper<InteractiveBrowserCredential>(
+                "InteractiveBrowser",
+                null,
+                null,
+                InstrumentClient);
+        }
+
+        /// <summary>
+        /// Creates a configured credential from IConfiguration, optionally injecting a mock MSAL client.
+        /// All factory methods delegate to this to avoid duplication.
+        /// </summary>
+        private TokenCredential CreateFromConfig(
+            MockMsalPublicClient msalClient = null,
+            string tenantId = null,
+            bool addTenantIdHint = false,
+            bool? isAccountIdentifierLoggingEnabled = null,
+            bool? disableAutomaticAuthentication = null,
+            string loginHint = null,
+            BrowserCustomizationOptions browserCustomization = null,
+            AuthenticationRecord authenticationRecord = null)
+        {
+            IConfiguration config = _helper.GetConfiguration();
+            config["MyClient:Credential:InteractiveBrowserCredentialClientId"] = ClientId;
+            if (tenantId != null)
+            {
+                config["MyClient:Credential:TenantId"] = tenantId;
+            }
+            if (addTenantIdHint)
+            {
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = TenantIdHint;
+            }
+            if (isAccountIdentifierLoggingEnabled != null)
+            {
+                config["MyClient:Credential:Diagnostics:IsAccountIdentifierLoggingEnabled"] = isAccountIdentifierLoggingEnabled.Value.ToString();
+            }
+            if (disableAutomaticAuthentication != null)
+            {
+                config["MyClient:Credential:DisableAutomaticAuthentication"] = disableAutomaticAuthentication.Value.ToString();
+            }
+            if (loginHint != null)
+            {
+                config["MyClient:Credential:LoginHint"] = loginHint;
+            }
+            if (browserCustomization?.SuccessMessage != null)
+            {
+                config["MyClient:Credential:BrowserCustomization:SuccessMessage"] = browserCustomization.SuccessMessage;
+            }
+            if (browserCustomization?.ErrorMessage != null)
+            {
+                config["MyClient:Credential:BrowserCustomization:ErrorMessage"] = browserCustomization.ErrorMessage;
+            }
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (browserCustomization?.UseEmbeddedWebView != null)
+            {
+                config["MyClient:Credential:BrowserCustomization:UseEmbeddedWebView"] = browserCustomization.UseEmbeddedWebView.Value.ToString();
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+            WriteAuthenticationRecord(config, authenticationRecord);
+
+            return CreateCredentialFromConfig(config, msalClient);
+        }
+
+        public override TokenCredential GetTokenCredential(TokenCredentialOptions options)
+            => CreateFromConfig(mockPublicMsalClient, tenantId: TenantId, isAccountIdentifierLoggingEnabled: options.Diagnostics.IsAccountIdentifierLoggingEnabled);
+
+        public override TokenCredential GetTokenCredential(CommonCredentialTestConfig config)
+        {
+            IConfiguration configuration = _helper.GetConfigurationFromCommonCredentialTestConfig<InteractiveBrowserCredentialOptions>(config);
+            configuration["MyClient:Credential:InteractiveBrowserCredentialClientId"] = ClientId;
+
+            string resolvedTenantId = config.RequestContext.TenantId ?? config.TenantId ?? TenantId;
+            var authRecord = config.AuthenticationRecord ?? new AuthenticationRecord(ExpectedUsername, "login.windows.net", $"{ObjectId}.{resolvedTenantId}", resolvedTenantId, ClientId);
+            WriteAuthenticationRecord(configuration, authRecord);
+
+            ConfigurableCredential credential;
+            using (new TestEnvVar("AZURE_TENANT_ID", null))
+            {
+                credential = _helper.GetCredentialFromConfig(configuration, config.Transport);
+            }
+
+            var ibc = _helper.GetUnderlyingCredential(credential);
+
+            if (config.MockPublicMsalClient != null)
+            {
+                // Inject the provided mock MSAL client directly.
+                typeof(InteractiveBrowserCredential)
+                    .GetField("<Client>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .SetValue(ibc, config.MockPublicMsalClient);
+            }
+            else
+            {
+                // Transport test: keep the real MsalPublicClient but patch its token cache
+                // so MSAL does silent auth via MockTransport instead of launching a browser.
+                var cacheOptions = config.TokenCachePersistenceOptions;
+                if (cacheOptions == null)
+                {
+                    var mockBytes = CredentialTestHelpers.GetMockCacheBytes(ObjectId, ExpectedUsername, ClientId, resolvedTenantId, "token", "refreshToken", config.AuthorityHost.Host);
+                    cacheOptions = new MockTokenCache(
+                        () => Task.FromResult<ReadOnlyMemory<byte>>(mockBytes),
+                        args => Task.FromResult<ReadOnlyMemory<byte>>(mockBytes));
+                }
+
+                var realClient = ibc.Client;
+                typeof(MsalPublicClient).BaseType
+                    .GetField("_tokenCachePersistenceOptions", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .SetValue(realClient, cacheOptions);
+            }
+
+            return _helper.InstrumentCredential(credential);
+        }
+
+        private static void WriteAuthenticationRecord(IConfiguration config, AuthenticationRecord authRecord)
+        {
+            if (authRecord == null)
+            {
+                return;
+            }
+            config["MyClient:Credential:AuthenticationRecord:Username"] = authRecord.Username;
+            config["MyClient:Credential:AuthenticationRecord:Authority"] = authRecord.Authority;
+            config["MyClient:Credential:AuthenticationRecord:HomeAccountId"] = authRecord.HomeAccountId;
+            config["MyClient:Credential:AuthenticationRecord:TenantId"] = authRecord.TenantId;
+            config["MyClient:Credential:AuthenticationRecord:ClientId"] = authRecord.ClientId;
+        }
+
+        private TokenCredential CreateCredentialFromConfig(IConfiguration config, MockMsalPublicClient msalClient, HttpPipelineTransport transport = null)
+        {
+            ConfigurableCredential credential;
+            using (new TestEnvVar("AZURE_TENANT_ID", null))
+            {
+                credential = _helper.GetCredentialFromConfig(config, transport);
+            }
+
+            if (msalClient != null)
+            {
+                var ibc = _helper.GetUnderlyingCredential(credential);
+                typeof(InteractiveBrowserCredential)
+                    .GetField("<Client>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .SetValue(ibc, msalClient);
+            }
+
+            return _helper.InstrumentCredential(credential);
+        }
+
+        protected override TokenCredential CreateCredential(MockMsalPublicClient msalClient, string tenantId = null, bool addTenantIdHint = false)
+            => CreateFromConfig(msalClient, tenantId: tenantId, addTenantIdHint: addTenantIdHint);
+
+        protected override TokenCredential CreateBareCredential()
+            => CreateFromConfig();
+
+        protected override Type GetExpectedExceptionType(bool isChained)
+            => typeof(CredentialUnavailableException);
+
+        protected override TokenCredential CreateCredentialWithDisableAutomaticAuth()
+            => CreateFromConfig(disableAutomaticAuthentication: true);
+
+        protected override TokenCredential CreateCredentialWithLoginHint(MockMsalPublicClient msalClient, string loginHint)
+            => CreateFromConfig(msalClient, loginHint: loginHint);
+
+        protected override TokenCredential CreateCredentialWithBrowserCustomization(MockMsalPublicClient msalClient, BrowserCustomizationOptions browserCustomization)
+            => CreateFromConfig(msalClient, browserCustomization: browserCustomization);
+
+        protected override void CreateCredentialForTenantValidation(string tenantId)
+            => _helper.CreateCredentialForTenantValidation(tenantId);
+
+        // ConfigurableCredential wraps in DefaultAzureCredential which catches AuthenticationRequiredException
+        // (a subclass of CredentialUnavailableException) and wraps it in an aggregate CredentialUnavailableException.
+        public override void DisableAutomaticAuthenticationException()
+        {
+            var cred = CreateCredentialWithDisableAutomaticAuth();
+            var expTokenRequestContext = new TokenRequestContext(new string[] { "https://vault.azure.net/.default" }, Guid.NewGuid().ToString());
+
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await cred.GetTokenAsync(expTokenRequestContext, default).ConfigureAwait(false));
+            Assert.IsNotNull(ex);
+        }
+
+        public override async Task InteractiveBrowserAcquireTokenInteractiveException()
+            => Assert.Ignore("MSAL-specific test does not apply to configurable credential");
+        public override async Task InteractiveBrowserAcquireTokenSilentException()
+            => Assert.Ignore("MSAL-specific test does not apply to configurable credential");
+        public override async Task InteractiveBrowserRefreshException()
+            => Assert.Ignore("MSAL-specific test does not apply to configurable credential");
+        public override async Task InteractiveBrowserValidateSyncWorkaroundCompatSwitch()
+            => Assert.Ignore("Compat switch test does not apply to configurable credential");
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
@@ -336,9 +336,11 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
-        [TestCase("TS003: Error, TS005: No accounts found.  Please go to Tools->Options->Azure Services Authentication, and add an account to be authenticated to Azure services during development.")]
-        public void GeneralExceptions_With_CertainErrors_throws_CredentialUnavailableException(string exceptionMessage)
+        public void GeneralExceptions_With_CertainErrors_throws_CredentialUnavailableException()
         {
+            // The error message is defined inline to avoid including ": Error" in the test name,
+            // which would be misinterpreted as a build error by the CI MSBuild log processor.
+            string exceptionMessage = "TS003: Error, TS005: No accounts found.  Please go to Tools->Options->Azure Services Authentication, and add an account to be authenticated to Azure services during development.";
             var testProcess = new TestProcess() { ExceptionOnStartHandler = p => throw new InvalidOperationException(exceptionMessage) };
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudio();
             var credential = CreateCredentialWithChainedOption(new TestProcessService(testProcess), fileSystem, isChained: false);


### PR DESCRIPTION
## Summary

Adds InteractiveBrowserCredential support to ConfigurableCredentialProvider, enabling IB-specific settings to be configured via IConfiguration.

### Changes

**New configurable properties (on DefaultAzureCredentialOptions, read from IConfiguration):**
- \DisableAutomaticAuthentication\ - Prevents automatic browser prompts
- \LoginHint\ - Pre-fills the login username
- \BrowserCustomization\ - Hierarchical section with SuccessMessage, ErrorMessage, UseEmbeddedWebView
- \AuthenticationRecord\ - Hierarchical section for silent auth (Username, Authority, HomeAccountId, TenantId, ClientId)
- \UseDefaultBrokerAccount\ - Enables broker authentication mode

**Source changes:**
- \AuthenticationRecord\ - Added internal ctor(IConfigurationSection)
- \BrowserCustomizationOptions\ - Added internal ctor(IConfigurationSection) and Clone()
- \DefaultAzureCredentialOptions\ - Added internal properties, reads from IConfigurationSection
- \DefaultAzureCredentialFactory\ - Passes new settings to IBC, conditionally creates DevelopmentBrokerOptions for broker mode
- \InteractiveBrowserCredential\ - Fixed DisableAutomaticAuthentication not flowing through internal constructor
- \InteractiveBrowserCredentialOptions\ - Clone() uses BrowserCustomization.Clone()

**Test changes:**
- Added configurable IB tests (58 passing) inheriting from base InteractiveBrowserCredentialTests
- Added 19 creation tests validating all properties pass through correctly
- Moved broker-path tests to Azure.Identity.Broker test project with CC variants
- Shared ConfigurableCredentialTestHelper across projects via Compile Include
- 4 tests remain ignored (MSAL-specific internal constructor tests not applicable to configurable path)

Closes #55503