### PR TITLE
Fix IsChainedCredential for single credential selection in DACFactory

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -158,6 +158,7 @@ namespace Azure.Identity
 
         private static string ConvertCredentialSource(string value) => value switch
         {
+            null => throw new InvalidOperationException("CredentialSource is required when configuring credentials. Specify a valid CredentialSource in the configuration."),
             "VisualStudio" => Constants.VisualStudioCredential,
             "VisualStudioCode" => Constants.VisualStudioCodeCredential,
             "AzureCli" => Constants.AzureCliCredential,
@@ -169,6 +170,18 @@ namespace Azure.Identity
             "InteractiveBrowser" => Constants.InteractiveBrowserCredential,
             "Broker" => Constants.BrokerCredential,
             "ApiKey" => Constants.ApiKeyCredential,
+            // Accept already-converted values (e.g. from Clone)
+            Constants.VisualStudioCredential or
+            Constants.VisualStudioCodeCredential or
+            Constants.AzureCliCredential or
+            Constants.AzurePowerShellCredential or
+            Constants.AzureDeveloperCliCredential or
+            Constants.EnvironmentCredential or
+            Constants.WorkloadIdentityCredential or
+            Constants.ManagedIdentityCredential or
+            Constants.InteractiveBrowserCredential or
+            Constants.BrokerCredential or
+            Constants.ApiKeyCredential => value,
             _ => throw new InvalidOperationException($"Unsupported CredentialSource found in configuration: {value}."),
         };
 
@@ -494,7 +507,10 @@ namespace Azure.Identity
                 dacClone.ExcludeAzurePowerShellCredential = ExcludeAzurePowerShellCredential;
                 dacClone.IsForceRefreshEnabled = IsForceRefreshEnabled;
                 dacClone.ExcludeBrokerCredential = ExcludeBrokerCredential;
-                dacClone.CredentialSource = CredentialSource;
+                if (CredentialSource is not null)
+                {
+                    dacClone.CredentialSource = CredentialSource;
+                }
                 dacClone.ApiKey = ApiKey;
                 if (!string.IsNullOrEmpty(Subscription))
                 {

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -169,7 +169,7 @@ namespace Azure.Identity
             "InteractiveBrowser" => Constants.InteractiveBrowserCredential,
             "Broker" => Constants.BrokerCredential,
             "ApiKey" => Constants.ApiKeyCredential,
-            _ => value,
+            _ => throw new InvalidOperationException($"Unsupported CredentialSource found in configuration: {value}."),
         };
 
         /// <summary>

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -276,10 +276,10 @@ namespace Azure.Identity
             return new WorkloadIdentityCredential(options);
         }
 
-        public virtual TokenCredential CreateManagedIdentityCredential(bool isProbeEnabled = true)
+        public virtual TokenCredential CreateManagedIdentityCredential(bool isChained = true)
         {
             var options = Options.Clone<DefaultAzureCredentialOptions>();
-            options.IsChainedCredential = isProbeEnabled;
+            options.IsChainedCredential = isChained && Options.CredentialSource == null;
 
             if (options.ManagedIdentityClientId != null && options.ManagedIdentityResourceId != null)
             {
@@ -361,7 +361,7 @@ namespace Azure.Identity
             var options = Options.Clone<DevelopmentBrokerOptions>();
             options.TokenCachePersistenceOptions = new TokenCachePersistenceOptions();
             options.TenantId = Options.InteractiveBrowserTenantId;
-            options.IsChainedCredential = true;
+            options.IsChainedCredential = Options.CredentialSource == null;
 
             return new BrokerCredential(options);
         }
@@ -371,7 +371,7 @@ namespace Azure.Identity
             var options = Options.Clone<AzureDeveloperCliCredentialOptions>();
             options.TenantId = Options.TenantId;
             options.ProcessTimeout = Options.CredentialProcessTimeout;
-            options.IsChainedCredential = true;
+            options.IsChainedCredential = Options.CredentialSource == null;
 
             return new AzureDeveloperCliCredential(Pipeline, default, options);
         }
@@ -385,7 +385,7 @@ namespace Azure.Identity
             {
                 options.Subscription = Options.Subscription;
             }
-            options.IsChainedCredential = true;
+            options.IsChainedCredential = Options.CredentialSource == null;
 
             return new AzureCliCredential(Pipeline, default, options);
         }
@@ -395,7 +395,7 @@ namespace Azure.Identity
             var options = Options.Clone<VisualStudioCredentialOptions>();
             options.TenantId = Options.VisualStudioTenantId;
             options.ProcessTimeout = Options.CredentialProcessTimeout;
-            options.IsChainedCredential = true;
+            options.IsChainedCredential = Options.CredentialSource == null;
 
             return new VisualStudioCredential(Options.VisualStudioTenantId, Pipeline, default, default, options);
         }
@@ -404,7 +404,7 @@ namespace Azure.Identity
         {
             var options = Options.Clone<VisualStudioCodeCredentialOptions>();
             options.TenantId = Options.VisualStudioCodeTenantId;
-            options.IsChainedCredential = true;
+            options.IsChainedCredential = Options.CredentialSource == null;
 
             return new VisualStudioCodeCredential(options);
         }
@@ -414,7 +414,7 @@ namespace Azure.Identity
             var options = Options.Clone<AzurePowerShellCredentialOptions>();
             options.TenantId = Options.TenantId;
             options.ProcessTimeout = Options.CredentialProcessTimeout;
-            options.IsChainedCredential = true;
+            options.IsChainedCredential = Options.CredentialSource == null;
 
             return new AzurePowerShellCredential(options, Pipeline, default);
         }

--- a/sdk/identity/Azure.Identity/tests/AzureCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzureCliCredentialTests.cs
@@ -86,10 +86,11 @@ namespace Azure.Identity.Tests
         /// <summary>
         /// Returns the expected exception type for error scenarios.
         /// Base: AuthenticationFailedException when not chained, CredentialUnavailableException when chained.
-        /// ConfigurableCredential always wraps in DefaultAzureCredential (chained), so always CredentialUnavailableException.
         /// </summary>
-        protected virtual Type GetExpectedExceptionType(bool isChained)
+        protected Type GetExpectedExceptionType(bool isChained)
             => isChained ? typeof(CredentialUnavailableException) : typeof(AuthenticationFailedException);
+
+        protected virtual bool IsChainedCredentialSupported => true;
         #endregion
 
         [Test]
@@ -223,6 +224,10 @@ namespace Azure.Identity.Tests
         [TestCaseSource(nameof(AzureCliExceptionScenarios_IsChained))]
         public void AuthenticateWithCliCredential_ExceptionScenarios_IsChained(Action<object> exceptionOnStartHandler, string errorMessage, string expectedMessage, bool isChained)
         {
+            if (!IsChainedCredentialSupported)
+            {
+                Assert.Ignore("ConfigurableCredential with CredentialSource does not support chained credential scenarios.");
+            }
             var testProcess = new TestProcess { Error = errorMessage, ExceptionOnStartHandler = exceptionOnStartHandler };
             var credential = CreateCredentialWithChainedOption(new TestProcessService(testProcess), isChained: true);
             var ex = Assert.ThrowsAsync(GetExpectedExceptionType(isChained),
@@ -244,6 +249,10 @@ namespace Azure.Identity.Tests
         [Test]
         public void ConfigureCliProcessTimeout_ProcessTimeout([Values(true, false)] bool isChainedCredential)
         {
+            if (!IsChainedCredentialSupported && isChainedCredential)
+            {
+                Assert.Ignore("ConfigurableCredential with CredentialSource does not support chained credential scenarios.");
+            }
             var testProcess = new TestProcess { Timeout = 10000 };
             var credential = CreateCredentialWithTimeout(new TestProcessService(testProcess), TimeSpan.Zero, isChainedCredential);
             var ex = Assert.ThrowsAsync(GetExpectedExceptionType(isChainedCredential),

--- a/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/AzurePowerShellCredentialsTests.cs
@@ -86,10 +86,11 @@ namespace Azure.Identity.Tests
         /// <summary>
         /// Returns the expected exception type for error scenarios.
         /// Base: AuthenticationFailedException when not chained, CredentialUnavailableException when chained.
-        /// ConfigurableCredential always wraps in DefaultAzureCredential (chained), so always CredentialUnavailableException.
         /// </summary>
-        protected virtual Type GetExpectedExceptionType(bool isChained)
+        protected Type GetExpectedExceptionType(bool isChained)
             => isChained ? typeof(CredentialUnavailableException) : typeof(AuthenticationFailedException);
+
+        protected virtual bool IsChainedCredentialSupported => true;
         #endregion
 
         [Test]
@@ -175,6 +176,10 @@ namespace Azure.Identity.Tests
         [TestCaseSource(nameof(ErrorScenarios_IsChained))]
         public void AuthenticateWithAzurePowerShellCredential_ErrorScenarios_IsChained(Action<object> exceptionOnStartHandler, string errorMessage, string expectedError, bool isChained)
         {
+            if (!IsChainedCredentialSupported)
+            {
+                Assert.Ignore("ConfigurableCredential with CredentialSource does not support chained credential scenarios.");
+            }
             var testProcess = new TestProcess { Error = errorMessage, ExceptionOnStartHandler = exceptionOnStartHandler };
             var credential = CreateCredentialWithChainedOption(new TestProcessService(testProcess), true);
             var ex = Assert.ThrowsAsync(GetExpectedExceptionType(isChained), async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
@@ -278,6 +283,10 @@ namespace Azure.Identity.Tests
         [Test]
         public void AuthenticateWithAzurePowerShellCredential_AzurePowerShellUnknownError([Values(true, false)] bool isChainedCredential)
         {
+            if (!IsChainedCredentialSupported && isChainedCredential)
+            {
+                Assert.Ignore("ConfigurableCredential with CredentialSource does not support chained credential scenarios.");
+            }
             string mockResult = "mock-result";
             var testProcess = new TestProcess { Error = mockResult };
             var credential = CreateCredentialWithChainedOption(new TestProcessService(testProcess), isChainedCredential);

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialTests.cs
@@ -72,10 +72,9 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureCli
         protected override TokenCredential CreateBareCredential()
             => CreateConfiguredCredential();
 
-        // ConfigurableCredential wraps in DefaultAzureCredential (always chained),
-        // so the expected exception is always CredentialUnavailableException.
-        protected override Type GetExpectedExceptionType(bool isChained)
-            => typeof(CredentialUnavailableException);
+        // ConfigurableCredential with CredentialSource creates a single (non-chained) credential,
+        // so chained credential scenarios are not applicable.
+        protected override bool IsChainedCredentialSupported => false;
 
         protected override void CreateCredentialForTenantValidation(string tenantId)
             => _helper.CreateCredentialForTenantValidation(tenantId);

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialTests.cs
@@ -66,10 +66,9 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureDeveloperCli
         protected override TokenCredential CreateBareCredential()
             => CreateConfiguredCredential();
 
-        // ConfigurableCredential wraps in DefaultAzureCredential (always chained),
-        // so the expected exception is always CredentialUnavailableException.
-        protected override Type GetExpectedExceptionType(bool isChained)
-            => typeof(CredentialUnavailableException);
+        // ConfigurableCredential with CredentialSource creates a single (non-chained) credential,
+        // so chained credential scenarios are not applicable.
+        protected override bool IsChainedCredentialSupported => false;
 
         protected override void CreateCredentialForTenantValidation(string tenantId)
             => _helper.CreateCredentialForTenantValidation(tenantId);

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialTests.cs
@@ -66,10 +66,9 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePowerShell
         protected override TokenCredential CreateBareCredential()
             => CreateConfiguredCredential();
 
-        // ConfigurableCredential wraps in DefaultAzureCredential (always chained),
-        // so the expected exception is always CredentialUnavailableException.
-        protected override Type GetExpectedExceptionType(bool isChained)
-            => typeof(CredentialUnavailableException);
+        // ConfigurableCredential with CredentialSource creates a single (non-chained) credential,
+        // so chained credential scenarios are not applicable.
+        protected override bool IsChainedCredentialSupported => false;
 
         protected override void CreateCredentialForTenantValidation(string tenantId)
             => _helper.CreateCredentialForTenantValidation(tenantId);

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialTests.cs
@@ -156,19 +156,12 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
         }
 
         [Test]
-        public void Constructor_WithNullCredentialSource_CreatesAllDefaultCredentials()
+        public void Constructor_WithNullCredentialSource_Throws()
         {
             var settings = CreateCredentialSettings(null, null);
 
-            var credential = new ConfigurableCredential(settings);
-            var innerCredential = GetInnerCredential(credential) as DefaultAzureCredential;
-
-            Assert.IsNotNull(innerCredential);
-
-            var sources = GetDefaultAzureCredentialSources(innerCredential);
-            Assert.IsNotNull(sources);
-            // When no credential source is specified, DefaultAzureCredential should include all default credentials
-            Assert.GreaterOrEqual(sources.Length, 8, "Expected multiple default credentials when no specific source is specified");
+            var ex = Assert.Throws<InvalidOperationException>(() => new ConfigurableCredential(settings));
+            Assert.That(ex.Message, Does.Contain("CredentialSource is required"));
         }
 
         [Test]

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialTests.cs
@@ -73,5 +73,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudio
 
         protected override TokenCredential CreateCredentialWithChainedOption(IProcessService processService, IFileSystemService fileSystem, bool isChained)
             => CreateConfiguredCredential(processService, fileSystem);
+
+        protected override bool IsChainedCredentialSupported => false;
     }
 }

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialOptionsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialOptionsTests.cs
@@ -218,7 +218,7 @@ namespace Azure.Identity.Tests
         {
             var apiKey = "test-api-key-12345";
             var mockSection = new Moq.Mock<IConfigurationSection>();
-            mockSection.Setup(s => s["CredentialSource"]).Returns((string)null);
+            mockSection.Setup(s => s["CredentialSource"]).Returns("ApiKey");
             mockSection.Setup(s => s["Key"]).Returns(apiKey);
             mockSection.Setup(s => s.GetSection("AdditionalProperties")).Returns(Moq.Mock.Of<IConfigurationSection>());
 
@@ -245,7 +245,7 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
-        public void ConstructorWithCredentialSettings_HandlesNullValues()
+        public void ConstructorWithCredentialSettings_NullCredentialSourceThrows()
         {
             var mockSection = new Moq.Mock<IConfigurationSection>();
             mockSection.Setup(s => s["CredentialSource"]).Returns((string)null);
@@ -253,14 +253,12 @@ namespace Azure.Identity.Tests
             mockSection.Setup(s => s.GetSection("AdditionalProperties")).Returns(Moq.Mock.Of<IConfigurationSection>());
 
             var credentialSettings = new CredentialSettings(mockSection.Object);
-            var options = new DefaultAzureCredentialOptions(credentialSettings, mockSection.Object);
-
-            Assert.IsNull(options.CredentialSource);
-            Assert.IsNull(options.ApiKey);
+            var ex = Assert.Throws<InvalidOperationException>(() => new DefaultAzureCredentialOptions(credentialSettings, mockSection.Object));
+            Assert.That(ex.Message, Does.Contain("CredentialSource is required"));
         }
 
         [Test]
-        public void ConstructorWithCredentialSettings_UnmappedCredentialSourcePassesThrough()
+        public void ConstructorWithCredentialSettings_UnmappedCredentialSourceThrows()
         {
             var credentialSource = "CustomCredential";
             var mockSection = new Moq.Mock<IConfigurationSection>();
@@ -269,9 +267,9 @@ namespace Azure.Identity.Tests
             mockSection.Setup(s => s.GetSection("AdditionalProperties")).Returns(Moq.Mock.Of<IConfigurationSection>());
 
             var credentialSettings = new CredentialSettings(mockSection.Object);
-            var options = new DefaultAzureCredentialOptions(credentialSettings, mockSection.Object);
-
-            Assert.AreEqual(credentialSource, options.CredentialSource);
+            var ex = Assert.Throws<InvalidOperationException>(() => new DefaultAzureCredentialOptions(credentialSettings, mockSection.Object));
+            Assert.That(ex.Message, Does.Contain("Unsupported CredentialSource"));
+            Assert.That(ex.Message, Does.Contain(credentialSource));
         }
 
         [Test]
@@ -286,7 +284,6 @@ namespace Azure.Identity.Tests
         [TestCase("InteractiveBrowser", "interactivebrowsercredential")]
         [TestCase("Broker", "brokercredential")]
         [TestCase("ApiKey", "ApiKey")]
-        [TestCase("UnknownCredential", "UnknownCredential")] // Fallthrough case
         public void CredentialSourceMapping_CorrectlyMapsKnownValues(string input, string expected)
         {
             var mockSection = new Moq.Mock<IConfigurationSection>();
@@ -304,7 +301,7 @@ namespace Azure.Identity.Tests
         public void ConstructorWithCredentialSettings_EmptyStringApiKey()
         {
             var mockSection = new Moq.Mock<IConfigurationSection>();
-            mockSection.Setup(s => s["CredentialSource"]).Returns((string)null);
+            mockSection.Setup(s => s["CredentialSource"]).Returns("ApiKey");
             mockSection.Setup(s => s["Key"]).Returns(string.Empty);
             mockSection.Setup(s => s.GetSection("AdditionalProperties")).Returns(Moq.Mock.Of<IConfigurationSection>());
 
@@ -315,7 +312,7 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
-        public void ConstructorWithCredentialSettings_EmptyStringCredentialSource()
+        public void ConstructorWithCredentialSettings_EmptyStringCredentialSourceThrows()
         {
             var mockSection = new Moq.Mock<IConfigurationSection>();
             mockSection.Setup(s => s["CredentialSource"]).Returns(string.Empty);
@@ -323,9 +320,8 @@ namespace Azure.Identity.Tests
             mockSection.Setup(s => s.GetSection("AdditionalProperties")).Returns(Moq.Mock.Of<IConfigurationSection>());
 
             var credentialSettings = new CredentialSettings(mockSection.Object);
-            var options = new DefaultAzureCredentialOptions(credentialSettings, mockSection.Object);
-
-            Assert.AreEqual(string.Empty, options.CredentialSource);
+            var ex = Assert.Throws<InvalidOperationException>(() => new DefaultAzureCredentialOptions(credentialSettings, mockSection.Object));
+            Assert.That(ex.Message, Does.Contain("Unsupported CredentialSource"));
         }
 
         [Test]

--- a/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/VisualStudioCredentialTests.cs
@@ -66,6 +66,8 @@ namespace Azure.Identity.Tests
             return InstrumentClient(new VisualStudioCredential(default, default, fileSystem, processService, options));
         }
 
+        protected virtual bool IsChainedCredentialSupported => true;
+
         [Test]
         public async Task AuthenticateWithVsCredential([Values(null, TenantIdHint)] string tenantId, [Values(true)] bool allowMultiTenantAuthentication)
         {
@@ -327,6 +329,10 @@ namespace Azure.Identity.Tests
         [Test]
         public void OperationCanceledException_throws_CredentialUnavailableException_WhenChained()
         {
+            if (!IsChainedCredentialSupported)
+            {
+                Assert.Ignore("ConfigurableCredential with CredentialSource does not support chained credential scenarios.");
+            }
             var testProcess = new TestProcess() { ExceptionOnStartHandler = p => throw new OperationCanceledException("Test exception") };
             var fileSystem = CredentialTestHelpers.CreateFileSystemForVisualStudio();
             var credential = CreateCredentialWithChainedOption(new TestProcessService(testProcess), fileSystem, isChained: true);


### PR DESCRIPTION
## Description

When `CredentialSource` selects a specific single credential (not a chain), the credential's `IsChainedCredential` should be `false`. Previously, all `Create*` methods in `DefaultAzureCredentialFactory` hardcoded `IsChainedCredential = true`.

Each `Create*` method now checks `Options.CredentialSource == null` to determine whether the credential is part of a chain or a standalone selection. For `CreateManagedIdentityCredential`, the existing `isChained` parameter is also considered to handle the environment variable path.

### Changes
- **DefaultAzureCredentialFactory.cs**: Each `Create*` method sets `IsChainedCredential = Options.CredentialSource == null` instead of hardcoding `true`
- **Test base classes**: Added `IsChainedCredentialSupported` property and skip guards for chained-only test scenarios
- **Configurable credential tests**: Set `IsChainedCredentialSupported => false` since `CredentialSource` always creates non-chained credentials

Fixes #56324