### PR TITLE
Add BrokerCredential configurable credential support

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/tests/Azure.Identity.Broker.Tests.csproj
+++ b/sdk/identity/Azure.Identity.Broker/tests/Azure.Identity.Broker.Tests.csproj
@@ -26,6 +26,9 @@
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)ForwardsClientCallsAttribute.cs" LinkBase="Shared" />
     <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\ConfigurableCredentialTestHelper.cs" LinkBase="ConfigurableCredentials" />
+    <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\CredentialCreationTestBase.cs" LinkBase="ConfigurableCredentials" />
+    <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\BrokerCredentialCreationTests.cs" LinkBase="ConfigurableCredentials" />
+    <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\InteractiveBrowserCredentialCreationTests.cs" LinkBase="ConfigurableCredentials" />
     <Compile Include="*.cs" Exclude="*Manual*.cs" />
     <Compile Include="ConfigurableCredentials\*.cs" />
     <Compile Include="ManualInteractiveBrowserCredentialBrokerTests.cs" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />

--- a/sdk/identity/Azure.Identity.Broker/tests/BrokerCredentialTests.cs
+++ b/sdk/identity/Azure.Identity.Broker/tests/BrokerCredentialTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using NUnit.Framework;
+
+namespace Azure.Identity.Broker.Tests
+{
+    /// <summary>
+    /// Tests for BrokerCredential when the Azure.Identity.Broker package is available.
+    /// In this project, the broker is enabled, so BrokerCredential goes through the
+    /// MSAL/broker authentication flow. GetToken may succeed on machines with an active
+    /// broker account, so exception-asserting tests use a non-existent tenant to force failure.
+    /// </summary>
+    internal class BrokerCredentialTests
+    {
+        private static readonly string s_invalidTenantId = "00000000-0000-0000-0000-000000000000";
+        private static readonly TokenRequestContext s_requestContext = new(new[] { "https://management.azure.com/.default" });
+
+        #region Virtual Factory Methods
+        protected virtual TokenCredential CreateCredential(string tenantId = null, bool addTenantIdHint = false)
+        {
+            var options = new DevelopmentBrokerOptions();
+            if (tenantId != null)
+            {
+                options.TenantId = tenantId;
+            }
+            if (addTenantIdHint)
+            {
+                options.AdditionallyAllowedTenants.Add("*");
+            }
+            return new BrokerCredential(options);
+        }
+
+        protected virtual TokenCredential CreateBareCredential()
+            => new BrokerCredential(new DevelopmentBrokerOptions());
+
+        protected virtual void CreateCredentialForTenantValidation(string tenantId)
+            => new BrokerCredential(new DevelopmentBrokerOptions { TenantId = tenantId });
+
+        protected virtual Type GetExpectedExceptionType(bool isChained)
+            => typeof(CredentialUnavailableException);
+        #endregion
+
+        [Test]
+        public void GetToken_WithInvalidTenant_ThrowsCredentialUnavailableException()
+        {
+            var credential = CreateCredential(tenantId: s_invalidTenantId);
+            var ex = Assert.Throws<CredentialUnavailableException>(() =>
+                credential.GetToken(s_requestContext, default));
+            Assert.That(ex.Message, Does.Contain("BrokerCredential"));
+        }
+
+        [Test]
+        public async Task GetTokenAsync_WithInvalidTenant_ThrowsCredentialUnavailableException()
+        {
+            var credential = CreateCredential(tenantId: s_invalidTenantId);
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () =>
+                await credential.GetTokenAsync(s_requestContext, default));
+            Assert.That(ex.Message, Does.Contain("BrokerCredential"));
+        }
+
+        [Test]
+        public void GetToken_ExceptionType_MatchesExpected([Values(true, false)] bool isChained)
+        {
+            var credential = CreateCredential(tenantId: s_invalidTenantId);
+            var expectedType = GetExpectedExceptionType(isChained);
+            Assert.Throws(expectedType, () =>
+                credential.GetToken(s_requestContext, default));
+        }
+
+        [Test]
+        public void CanCreateCredential()
+        {
+            var credential = CreateBareCredential();
+            Assert.IsNotNull(credential);
+        }
+
+        [Test]
+        public void CanCreateCredentialWithTenantId()
+        {
+            var credential = CreateCredential(tenantId: Guid.NewGuid().ToString());
+            Assert.IsNotNull(credential);
+        }
+
+        [Test]
+        public void CanCreateCredentialWithAdditionalTenants()
+        {
+            var credential = CreateCredential(addTenantIdHint: true);
+            Assert.IsNotNull(credential);
+        }
+
+        [Test]
+        public void BrokerIsEnabled()
+        {
+            // Verify the broker package is available in this test project
+            bool success = DefaultAzureCredentialFactory.TryCreateDevelopmentBrokerOptions(out var options);
+            Assert.IsTrue(success, "Broker package should be available in this test project");
+            Assert.IsNotNull(options);
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity.Broker/tests/ConfigurableCredentials/BrokerCredentialTests.cs
+++ b/sdk/identity/Azure.Identity.Broker/tests/ConfigurableCredentials/BrokerCredentialTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Identity.Tests.ConfigurableCredentials;
+using Microsoft.Extensions.Configuration;
+
+namespace Azure.Identity.Broker.Tests.ConfigurableCredentials
+{
+    /// <summary>
+    /// Tests for BrokerCredential accessed through ConfigurableCredential when the
+    /// Azure.Identity.Broker package is available.
+    /// Inherits from Tests.BrokerCredentialTests to get all Broker-specific test cases.
+    /// Overrides factory methods to create credentials via IConfiguration.
+    /// </summary>
+    internal class BrokerCredentialTests : Tests.BrokerCredentialTests
+    {
+        private readonly ConfigurableCredentialTestHelper<BrokerCredential> _helper;
+
+        public BrokerCredentialTests()
+        {
+            _helper = new ConfigurableCredentialTestHelper<BrokerCredential>("Broker");
+        }
+
+        private TokenCredential CreateConfiguredCredential(string tenantId = null, bool addTenantIdHint = false)
+        {
+            IConfiguration config = _helper.GetConfiguration();
+            if (tenantId != null)
+            {
+                config["MyClient:Credential:TenantId"] = tenantId;
+            }
+            if (addTenantIdHint)
+            {
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+            }
+
+            ConfigurableCredential credential;
+            using (new TestEnvVar("AZURE_TENANT_ID", null))
+            {
+                credential = _helper.GetCredentialFromConfig(config);
+            }
+
+            return _helper.InstrumentCredential(credential);
+        }
+
+        protected override TokenCredential CreateCredential(string tenantId = null, bool addTenantIdHint = false)
+            => CreateConfiguredCredential(tenantId, addTenantIdHint);
+
+        protected override TokenCredential CreateBareCredential()
+            => CreateConfiguredCredential();
+
+        // ConfigurableCredential wraps in DefaultAzureCredential (always chained),
+        // so the expected exception is always CredentialUnavailableException.
+        protected override Type GetExpectedExceptionType(bool isChained)
+            => typeof(CredentialUnavailableException);
+
+        protected override void CreateCredentialForTenantValidation(string tenantId)
+            => _helper.CreateCredentialForTenantValidation(tenantId);
+    }
+}

--- a/sdk/identity/Azure.Identity/src/Credentials/CredentialOptionsMapper.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/CredentialOptionsMapper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.Extensions.Options;
 
 namespace Azure.Identity;
 
@@ -23,31 +24,7 @@ internal class CredentialOptionsMapper
 
         if (isBrokerEnabled && options != null)
         {
-            if (credentialOptions != null)
-            {
-                options.TenantId = (credentialOptions as ISupportsTenantId)?.TenantId;
-                options.AdditionallyAllowedTenants = (credentialOptions as ISupportsAdditionallyAllowedTenants)?.AdditionallyAllowedTenants;
-                options.AuthorityHost = credentialOptions.AuthorityHost;
-                options.IsUnsafeSupportLoggingEnabled = credentialOptions.IsUnsafeSupportLoggingEnabled;
-                options.IsChainedCredential = credentialOptions.IsChainedCredential;
-
-                if (credentialOptions is InteractiveBrowserCredentialOptions ibcOptions)
-                {
-                    options.ClientId = ibcOptions.ClientId;
-                    options.DisableAutomaticAuthentication = ibcOptions.DisableAutomaticAuthentication;
-                    options.LoginHint = ibcOptions.LoginHint;
-
-                    if (ibcOptions.BrowserCustomization != null)
-                    {
-                        options.BrowserCustomization = ibcOptions.BrowserCustomization;
-                    }
-
-                    if (ibcOptions.AuthenticationRecord != null)
-                    {
-                        options.AuthenticationRecord = ibcOptions.AuthenticationRecord;
-                    }
-                }
-            }
+            CopySharedProperties(options, credentialOptions);
 
             if (fileSystem is not null)
                 options.AuthenticationRecord = GetAuthenticationRecord(fileSystem);
@@ -105,33 +82,57 @@ internal class CredentialOptionsMapper
     internal static InteractiveBrowserCredentialOptions CreateFallbackOptions(TokenCredentialOptions credentialOptions = null)
     {
         var fallbackOptions = new InteractiveBrowserCredentialOptions();
+        CopySharedProperties(fallbackOptions, credentialOptions);
+        return fallbackOptions;
+    }
 
-        if (credentialOptions != null)
+    /// <summary>
+    /// Copies common credential properties from <paramref name="source"/> onto <paramref name="target"/>.
+    /// Used by both the broker and fallback option creation paths.
+    /// </summary>
+    private static void CopySharedProperties(InteractiveBrowserCredentialOptions target, TokenCredentialOptions source)
+    {
+        if (source == null)
         {
-            fallbackOptions.TenantId = (credentialOptions as ISupportsTenantId)?.TenantId;
-            fallbackOptions.AdditionallyAllowedTenants = (credentialOptions as ISupportsAdditionallyAllowedTenants)?.AdditionallyAllowedTenants;
-            fallbackOptions.AuthorityHost = credentialOptions.AuthorityHost;
-            fallbackOptions.IsUnsafeSupportLoggingEnabled = credentialOptions.IsUnsafeSupportLoggingEnabled;
-            fallbackOptions.IsChainedCredential = credentialOptions.IsChainedCredential;
-
-            if (credentialOptions is InteractiveBrowserCredentialOptions ibcOptions)
-            {
-                fallbackOptions.ClientId = ibcOptions.ClientId;
-                fallbackOptions.DisableAutomaticAuthentication = ibcOptions.DisableAutomaticAuthentication;
-                fallbackOptions.LoginHint = ibcOptions.LoginHint;
-
-                if (ibcOptions.BrowserCustomization != null)
-                {
-                    fallbackOptions.BrowserCustomization = ibcOptions.BrowserCustomization;
-                }
-
-                if (ibcOptions.AuthenticationRecord != null)
-                {
-                    fallbackOptions.AuthenticationRecord = ibcOptions.AuthenticationRecord;
-                }
-            }
+            return;
         }
 
-        return fallbackOptions;
+        target.TenantId = (source as ISupportsTenantId)?.TenantId;
+        target.AdditionallyAllowedTenants = (source as ISupportsAdditionallyAllowedTenants)?.AdditionallyAllowedTenants;
+        target.AuthorityHost = source.AuthorityHost;
+        target.IsUnsafeSupportLoggingEnabled = source.IsUnsafeSupportLoggingEnabled;
+        target.IsChainedCredential = source.IsChainedCredential;
+
+        if (source is ISupportsDisableInstanceDiscovery disableInstanceDiscoverySource)
+        {
+            target.DisableInstanceDiscovery = disableInstanceDiscoverySource.DisableInstanceDiscovery;
+        }
+
+        target.CopyMsalSettableProperties(source);
+
+        if (source is InteractiveBrowserCredentialOptions ibcOptions)
+        {
+            target.ClientId = ibcOptions.ClientId;
+            target.DisableAutomaticAuthentication = ibcOptions.DisableAutomaticAuthentication;
+            target.LoginHint = ibcOptions.LoginHint;
+
+            if (ibcOptions.BrowserCustomization != null)
+            {
+                target.BrowserCustomization = ibcOptions.BrowserCustomization.Clone();
+            }
+
+            if (ibcOptions.AuthenticationRecord != null)
+            {
+                target.AuthenticationRecord = ibcOptions.AuthenticationRecord;
+            }
+
+            if (ibcOptions.RedirectUri != null)
+            {
+                target.RedirectUri = ibcOptions.RedirectUri;
+            }
+
+            target.TokenCachePersistenceOptions = ibcOptions.TokenCachePersistenceOptions?.Clone()
+                ?? new TokenCachePersistenceOptions();
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/CredentialOptionsMapper.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/CredentialOptionsMapper.cs
@@ -30,6 +30,23 @@ internal class CredentialOptionsMapper
                 options.AuthorityHost = credentialOptions.AuthorityHost;
                 options.IsUnsafeSupportLoggingEnabled = credentialOptions.IsUnsafeSupportLoggingEnabled;
                 options.IsChainedCredential = credentialOptions.IsChainedCredential;
+
+                if (credentialOptions is InteractiveBrowserCredentialOptions ibcOptions)
+                {
+                    options.ClientId = ibcOptions.ClientId;
+                    options.DisableAutomaticAuthentication = ibcOptions.DisableAutomaticAuthentication;
+                    options.LoginHint = ibcOptions.LoginHint;
+
+                    if (ibcOptions.BrowserCustomization != null)
+                    {
+                        options.BrowserCustomization = ibcOptions.BrowserCustomization;
+                    }
+
+                    if (ibcOptions.AuthenticationRecord != null)
+                    {
+                        options.AuthenticationRecord = ibcOptions.AuthenticationRecord;
+                    }
+                }
             }
 
             if (fileSystem is not null)
@@ -96,6 +113,23 @@ internal class CredentialOptionsMapper
             fallbackOptions.AuthorityHost = credentialOptions.AuthorityHost;
             fallbackOptions.IsUnsafeSupportLoggingEnabled = credentialOptions.IsUnsafeSupportLoggingEnabled;
             fallbackOptions.IsChainedCredential = credentialOptions.IsChainedCredential;
+
+            if (credentialOptions is InteractiveBrowserCredentialOptions ibcOptions)
+            {
+                fallbackOptions.ClientId = ibcOptions.ClientId;
+                fallbackOptions.DisableAutomaticAuthentication = ibcOptions.DisableAutomaticAuthentication;
+                fallbackOptions.LoginHint = ibcOptions.LoginHint;
+
+                if (ibcOptions.BrowserCustomization != null)
+                {
+                    fallbackOptions.BrowserCustomization = ibcOptions.BrowserCustomization;
+                }
+
+                if (ibcOptions.AuthenticationRecord != null)
+                {
+                    fallbackOptions.AuthenticationRecord = ibcOptions.AuthenticationRecord;
+                }
+            }
         }
 
         return fallbackOptions;

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -588,6 +588,10 @@ namespace Azure.Identity
                 dacClone.UseDefaultBrokerAccount = UseDefaultBrokerAccount;
                 dacClone.IsLegacyMsaPassthroughEnabled = IsLegacyMsaPassthroughEnabled;
             }
+            else if (clone is InteractiveBrowserCredentialOptions ibcClone)
+            {
+                ibcClone.CopyFromDacOptions(this);
+            }
 
             return clone;
         }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -151,15 +151,31 @@ namespace Azure.Identity
                 BrowserCustomization = new BrowserCustomizationOptions(browserSection);
             }
 
+            if (Uri.TryCreate(section[nameof(RedirectUri)], UriKind.Absolute, out Uri redirectUri))
+            {
+                RedirectUri = redirectUri;
+            }
+
             var authRecordSection = section.GetSection(nameof(AuthenticationRecord));
             if (authRecordSection.Exists())
             {
                 AuthenticationRecord = new AuthenticationRecord(authRecordSection);
             }
 
+            var cacheSection = section.GetSection(nameof(TokenCachePersistenceOptions));
+            if (cacheSection.Exists())
+            {
+                TokenCachePersistenceOptions = new TokenCachePersistenceOptions(cacheSection);
+            }
+
             if (bool.TryParse(section[nameof(UseDefaultBrokerAccount)], out bool useDefaultBrokerAccount))
             {
                 UseDefaultBrokerAccount = useDefaultBrokerAccount;
+            }
+
+            if (bool.TryParse(section[nameof(IsLegacyMsaPassthroughEnabled)], out bool isLegacyMsaPassthroughEnabled))
+            {
+                IsLegacyMsaPassthroughEnabled = isLegacyMsaPassthroughEnabled;
             }
         }
 
@@ -506,7 +522,13 @@ namespace Azure.Identity
 
         internal AuthenticationRecord AuthenticationRecord { get; set; }
 
+        internal Uri RedirectUri { get; set; }
+
+        internal TokenCachePersistenceOptions TokenCachePersistenceOptions { get; set; }
+
         internal bool UseDefaultBrokerAccount { get; set; }
+
+        internal bool? IsLegacyMsaPassthroughEnabled { get; set; }
 
         internal override T Clone<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>()
         {
@@ -561,7 +583,10 @@ namespace Azure.Identity
                     dacClone.BrowserCustomization = BrowserCustomization.Clone();
                 }
                 dacClone.AuthenticationRecord = AuthenticationRecord;
+                dacClone.RedirectUri = RedirectUri;
+                dacClone.TokenCachePersistenceOptions = TokenCachePersistenceOptions?.Clone();
                 dacClone.UseDefaultBrokerAccount = UseDefaultBrokerAccount;
+                dacClone.IsLegacyMsaPassthroughEnabled = IsLegacyMsaPassthroughEnabled;
             }
 
             return clone;

--- a/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredentialOptions.cs
@@ -99,6 +99,28 @@ namespace Azure.Identity
             return clone;
         }
 
+        /// <summary>
+        /// Copies IBC-relevant properties from a DefaultAzureCredentialOptions source.
+        /// Called by DAC.Clone when the target type is an IBC-derived type.
+        /// </summary>
+        internal virtual void CopyFromDacOptions(DefaultAzureCredentialOptions source)
+        {
+            DisableAutomaticAuthentication = source.DisableAutomaticAuthentication;
+            TokenCachePersistenceOptions = source.TokenCachePersistenceOptions?.Clone();
+            AuthenticationRecord = source.AuthenticationRecord;
+            RedirectUri = source.RedirectUri;
+
+            if (!string.IsNullOrEmpty(source.LoginHint))
+            {
+                LoginHint = source.LoginHint;
+            }
+
+            if (source.BrowserCustomization != null)
+            {
+                BrowserCustomization = source.BrowserCustomization.Clone();
+            }
+        }
+
         internal virtual void CopyMsalSettableProperties(TokenCredentialOptions source)
         {
             if (source != null && this is IMsalSettablePublicClientInitializerOptions target)

--- a/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/InteractiveBrowserCredentialOptions.cs
@@ -99,11 +99,18 @@ namespace Azure.Identity
             return clone;
         }
 
-        internal void CopyMsalSettableProperties(DefaultAzureCredentialOptions options)
+        internal virtual void CopyMsalSettableProperties(TokenCredentialOptions source)
         {
-            if (this is IMsalSettablePublicClientInitializerOptions thisAsInterface)
+            if (source != null && this is IMsalSettablePublicClientInitializerOptions target)
             {
-                thisAsInterface.UseDefaultBrokerAccount = options.UseDefaultBrokerAccount;
+                if (source is DefaultAzureCredentialOptions dacOptions)
+                {
+                    target.UseDefaultBrokerAccount = dacOptions.UseDefaultBrokerAccount;
+                }
+                else if (source is IMsalPublicClientInitializerOptions msalSource)
+                {
+                    target.UseDefaultBrokerAccount = msalSource.UseDefaultBrokerAccount;
+                }
             }
         }
     }

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Azure.Core;
+using Microsoft.Identity.Client;
 
 namespace Azure.Identity
 {
@@ -353,7 +354,7 @@ namespace Azure.Identity
 
             var options = brokerOptions ?? Options.Clone<InteractiveBrowserCredentialOptions>();
 
-            options.TokenCachePersistenceOptions = new TokenCachePersistenceOptions();
+            options.TokenCachePersistenceOptions = Options.TokenCachePersistenceOptions?.Clone() ?? new TokenCachePersistenceOptions();
 
             options.TenantId = Options.InteractiveBrowserTenantId;
 
@@ -372,6 +373,11 @@ namespace Azure.Identity
             if (Options.AuthenticationRecord != null)
             {
                 options.AuthenticationRecord = Options.AuthenticationRecord;
+            }
+
+            if (Options.RedirectUri != null)
+            {
+                options.RedirectUri = Options.RedirectUri;
             }
 
             return new InteractiveBrowserCredential(
@@ -384,11 +390,13 @@ namespace Azure.Identity
         internal TokenCredential CreateBrokerCredential()
         {
             var options = Options.Clone<DevelopmentBrokerOptions>();
-            options.TokenCachePersistenceOptions = new TokenCachePersistenceOptions();
+            options.TokenCachePersistenceOptions = Options.TokenCachePersistenceOptions?.Clone() ?? new TokenCachePersistenceOptions();
             options.TenantId = Options.InteractiveBrowserTenantId;
             options.IsChainedCredential = Options.CredentialSource == null;
             options.ClientId = Options.InteractiveBrowserCredentialClientId ?? Constants.DeveloperSignOnClientId;
             options.DisableAutomaticAuthentication = Options.DisableAutomaticAuthentication;
+
+            options.CopyMsalSettableProperties(Options);
 
             if (!string.IsNullOrEmpty(Options.LoginHint))
             {
@@ -403,6 +411,16 @@ namespace Azure.Identity
             if (Options.AuthenticationRecord != null)
             {
                 options.AuthenticationRecord = Options.AuthenticationRecord;
+            }
+
+            if (Options.RedirectUri != null)
+            {
+                options.RedirectUri = Options.RedirectUri;
+            }
+
+            if (Options.IsLegacyMsaPassthroughEnabled.HasValue)
+            {
+                options.IsLegacyMsaPassthroughEnabled = Options.IsLegacyMsaPassthroughEnabled;
             }
 
             return new BrokerCredential(options);

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -354,31 +354,8 @@ namespace Azure.Identity
 
             var options = brokerOptions ?? Options.Clone<InteractiveBrowserCredentialOptions>();
 
-            options.TokenCachePersistenceOptions = Options.TokenCachePersistenceOptions?.Clone() ?? new TokenCachePersistenceOptions();
-
+            options.TokenCachePersistenceOptions ??= new TokenCachePersistenceOptions();
             options.TenantId = Options.InteractiveBrowserTenantId;
-
-            options.DisableAutomaticAuthentication = Options.DisableAutomaticAuthentication;
-
-            if (!string.IsNullOrEmpty(Options.LoginHint))
-            {
-                options.LoginHint = Options.LoginHint;
-            }
-
-            if (Options.BrowserCustomization != null)
-            {
-                options.BrowserCustomization = Options.BrowserCustomization.Clone();
-            }
-
-            if (Options.AuthenticationRecord != null)
-            {
-                options.AuthenticationRecord = Options.AuthenticationRecord;
-            }
-
-            if (Options.RedirectUri != null)
-            {
-                options.RedirectUri = Options.RedirectUri;
-            }
 
             return new InteractiveBrowserCredential(
                 Options.InteractiveBrowserTenantId,
@@ -390,33 +367,12 @@ namespace Azure.Identity
         internal TokenCredential CreateBrokerCredential()
         {
             var options = Options.Clone<DevelopmentBrokerOptions>();
-            options.TokenCachePersistenceOptions = Options.TokenCachePersistenceOptions?.Clone() ?? new TokenCachePersistenceOptions();
+            options.TokenCachePersistenceOptions ??= new TokenCachePersistenceOptions();
             options.TenantId = Options.InteractiveBrowserTenantId;
             options.IsChainedCredential = Options.CredentialSource == null;
             options.ClientId = Options.InteractiveBrowserCredentialClientId ?? Constants.DeveloperSignOnClientId;
-            options.DisableAutomaticAuthentication = Options.DisableAutomaticAuthentication;
 
             options.CopyMsalSettableProperties(Options);
-
-            if (!string.IsNullOrEmpty(Options.LoginHint))
-            {
-                options.LoginHint = Options.LoginHint;
-            }
-
-            if (Options.BrowserCustomization != null)
-            {
-                options.BrowserCustomization = Options.BrowserCustomization.Clone();
-            }
-
-            if (Options.AuthenticationRecord != null)
-            {
-                options.AuthenticationRecord = Options.AuthenticationRecord;
-            }
-
-            if (Options.RedirectUri != null)
-            {
-                options.RedirectUri = Options.RedirectUri;
-            }
 
             if (Options.IsLegacyMsaPassthroughEnabled.HasValue)
             {

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -387,6 +387,23 @@ namespace Azure.Identity
             options.TokenCachePersistenceOptions = new TokenCachePersistenceOptions();
             options.TenantId = Options.InteractiveBrowserTenantId;
             options.IsChainedCredential = Options.CredentialSource == null;
+            options.ClientId = Options.InteractiveBrowserCredentialClientId ?? Constants.DeveloperSignOnClientId;
+            options.DisableAutomaticAuthentication = Options.DisableAutomaticAuthentication;
+
+            if (!string.IsNullOrEmpty(Options.LoginHint))
+            {
+                options.LoginHint = Options.LoginHint;
+            }
+
+            if (Options.BrowserCustomization != null)
+            {
+                options.BrowserCustomization = Options.BrowserCustomization.Clone();
+            }
+
+            if (Options.AuthenticationRecord != null)
+            {
+                options.AuthenticationRecord = Options.AuthenticationRecord;
+            }
 
             return new BrokerCredential(options);
         }

--- a/sdk/identity/Azure.Identity/src/TokenCachePersistenceOptions.cs
+++ b/sdk/identity/Azure.Identity/src/TokenCachePersistenceOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Configuration;
+
 namespace Azure.Identity
 {
     /// <summary>
@@ -57,6 +59,13 @@ namespace Azure.Identity
     public class TokenCachePersistenceOptions
     {
         /// <summary>
+        /// Creates a new instance of <see cref="TokenCachePersistenceOptions"/>.
+        /// </summary>
+        public TokenCachePersistenceOptions()
+        {
+        }
+
+        /// <summary>
         /// Name uniquely identifying the <see cref="TokenCachePersistenceOptions"/>.
         /// </summary>
         public string Name { get; set; }
@@ -66,6 +75,24 @@ namespace Azure.Identity
         /// will throw a <see cref="CredentialUnavailableException"/> in the event no OS level user encryption is available.
         /// </summary>
         public bool UnsafeAllowUnencryptedStorage { get; set; }
+
+        internal TokenCachePersistenceOptions(IConfigurationSection section)
+        {
+            if (section == null || !section.Exists())
+            {
+                return;
+            }
+
+            if (section[nameof(Name)] is string name)
+            {
+                Name = name;
+            }
+
+            if (bool.TryParse(section[nameof(UnsafeAllowUnencryptedStorage)], out bool unsafeAllow))
+            {
+                UnsafeAllowUnencryptedStorage = unsafeAllow;
+            }
+        }
 
         /// <summary>
         /// Creates a copy of the <see cref="TokenCachePersistenceOptions"/>.

--- a/sdk/identity/Azure.Identity/tests/BrokerCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/BrokerCredentialTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests
+{
+    internal class BrokerCredentialTests
+    {
+        private static readonly TokenRequestContext s_requestContext = new(new[] { "https://management.azure.com/.default" });
+
+        #region Virtual Factory Methods
+        protected virtual TokenCredential CreateCredential(string tenantId = null, bool addTenantIdHint = false)
+        {
+            var options = new DevelopmentBrokerOptions();
+            if (tenantId != null)
+            {
+                options.TenantId = tenantId;
+            }
+            if (addTenantIdHint)
+            {
+                options.AdditionallyAllowedTenants.Add("*");
+            }
+            return new BrokerCredential(options);
+        }
+
+        protected virtual TokenCredential CreateBareCredential()
+            => new BrokerCredential(new DevelopmentBrokerOptions());
+
+        protected virtual void CreateCredentialForTenantValidation(string tenantId)
+            => new BrokerCredential(new DevelopmentBrokerOptions { TenantId = tenantId });
+
+        protected virtual Type GetExpectedExceptionType(bool isChained)
+            => typeof(CredentialUnavailableException);
+        #endregion
+
+        [Test]
+        public void GetToken_ThrowsCredentialUnavailableException()
+        {
+            var credential = CreateBareCredential();
+            var ex = Assert.Throws<CredentialUnavailableException>(() =>
+                credential.GetToken(s_requestContext, default));
+            Assert.That(ex.Message, Does.Contain("Azure.Identity.Broker"));
+        }
+
+        [Test]
+        public async Task GetTokenAsync_ThrowsCredentialUnavailableException()
+        {
+            var credential = CreateBareCredential();
+            var ex = Assert.ThrowsAsync<CredentialUnavailableException>(async () =>
+                await credential.GetTokenAsync(s_requestContext, default));
+            Assert.That(ex.Message, Does.Contain("Azure.Identity.Broker"));
+        }
+
+        [Test]
+        public void GetToken_WithTenantId_ThrowsCredentialUnavailableException()
+        {
+            var credential = CreateCredential(tenantId: Guid.NewGuid().ToString());
+            Assert.Throws<CredentialUnavailableException>(() =>
+                credential.GetToken(s_requestContext, default));
+        }
+
+        [Test]
+        public void GetToken_ExceptionType_MatchesExpected([Values(true, false)] bool isChained)
+        {
+            var credential = CreateBareCredential();
+            var expectedType = GetExpectedExceptionType(isChained);
+            Assert.Throws(expectedType, () =>
+                credential.GetToken(s_requestContext, default));
+        }
+
+        [Test]
+        public void CanCreateCredential()
+        {
+            var credential = CreateBareCredential();
+            Assert.IsNotNull(credential);
+        }
+
+        [Test]
+        public void CanCreateCredentialWithTenantId()
+        {
+            var credential = CreateCredential(tenantId: Guid.NewGuid().ToString());
+            Assert.IsNotNull(credential);
+        }
+
+        [Test]
+        public void CanCreateCredentialWithAdditionalTenants()
+        {
+            var credential = CreateCredential(addTenantIdHint: true);
+            Assert.IsNotNull(credential);
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
@@ -448,7 +448,7 @@ namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.Broker
                 if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
                     System.Runtime.InteropServices.OSPlatform.OSX))
                 {
-                    expectedRedirectUrl = Constants.MacBrokerRedirectUri;
+                    expectedRedirectUrl = new Uri(Constants.MacBrokerRedirectUri).ToString();
                 }
 #endif
 

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
@@ -441,9 +441,20 @@ namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.Broker
             {
                 IConfiguration config = Helper.GetConfiguration();
 
+                string expectedRedirectUrl = "http://localhost";
+#if !IDENTITY_TESTS
+                // When the broker package is available, the Broker DBO sets a
+                // platform-specific redirect URI on macOS.
+                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                    System.Runtime.InteropServices.OSPlatform.OSX))
+                {
+                    expectedRedirectUrl = Constants.MacBrokerRedirectUri;
+                }
+#endif
+
                 var broker = GetUnderlying(CreateFromConfig(config));
                 var client = ReadProperty<MsalPublicClient>(broker, "Client");
-                Assert.AreEqual("http://localhost", ReadProperty<string>(client, "RedirectUrl"));
+                Assert.AreEqual(expectedRedirectUrl, ReadProperty<string>(client, "RedirectUrl"));
             }
         }
 

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
@@ -6,8 +6,15 @@ using System.Collections.Generic;
 using Azure.Core.TestFramework;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
+#if !IDENTITY_TESTS
+using Azure.Identity.Tests.ConfigurableCredentials;
+#endif
 
+#if IDENTITY_TESTS
 namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
+#else
+namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.Broker
+#endif
 {
     /// <summary>
     /// Validates that BrokerCredential properties can be set via IConfiguration and
@@ -32,6 +39,20 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
         };
 
         // ── TenantId ───────────────────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(broker, "TenantId"));
+            }
+        }
 
         [Test]
         [NonParallelizable]
@@ -82,6 +103,57 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
         }
 
         // ── AdditionallyAllowedTenants ─────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigSetsSingleValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "tenant-a";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(broker, "AdditionallyAllowedTenantIds");
+                Assert.AreEqual(1, tenants.Length);
+                Assert.AreEqual("tenant-a", tenants[0]);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigSetsMultipleValues()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "tenant-a";
+                config["MyClient:Credential:AdditionallyAllowedTenants:1"] = "tenant-b";
+                config["MyClient:Credential:AdditionallyAllowedTenants:2"] = "tenant-c";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(broker, "AdditionallyAllowedTenantIds");
+                Assert.AreEqual(3, tenants.Length);
+                CollectionAssert.Contains(tenants, "tenant-a");
+                CollectionAssert.Contains(tenants, "tenant-b");
+                CollectionAssert.Contains(tenants, "tenant-c");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_Wildcard()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(broker, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+            }
+        }
 
         [Test]
         [NonParallelizable]
@@ -186,6 +258,20 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
 
         [Test]
         [NonParallelizable]
+        public void DisableAutomaticAuthentication_ConfigSetsFalseExplicitly()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:DisableAutomaticAuthentication"] = "false";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadProperty<bool>(broker, "DisableAutomaticAuthentication"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
         public void DisableAutomaticAuthentication_DefaultsFalse()
         {
             using (new TestEnvVar(AllNulledEnvVars()))
@@ -262,6 +348,24 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
 
         [Test]
         [NonParallelizable]
+        public void BrowserCustomization_BothFieldsSet()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:BrowserCustomization:SuccessMessage"] = "<p>OK</p>";
+                config["MyClient:Credential:BrowserCustomization:ErrorMessage"] = "<p>Fail</p>";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var bc = ReadProperty<BrowserCustomizationOptions>(broker, "BrowserCustomization");
+                Assert.IsNotNull(bc);
+                Assert.AreEqual("<p>OK</p>", bc.SuccessMessage);
+                Assert.AreEqual("<p>Fail</p>", bc.ErrorMessage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
         public void BrowserCustomization_DefaultsToNull()
         {
             using (new TestEnvVar(AllNulledEnvVars()))
@@ -277,7 +381,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
 
         [Test]
         [NonParallelizable]
-        public void AuthenticationRecord_ConfigSetsValue()
+        public void AuthenticationRecord_ConfigSetsAllFields()
         {
             using (new TestEnvVar(AllNulledEnvVars()))
             {
@@ -312,6 +416,289 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
             }
         }
 
+        // ── RedirectUri ─────────────────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void RedirectUri_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:RedirectUri"] = "http://localhost:12345/";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                Assert.AreEqual("http://localhost:12345/", ReadProperty<string>(client, "RedirectUrl"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void RedirectUri_DefaultsToLocalhost()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                Assert.AreEqual("http://localhost", ReadProperty<string>(client, "RedirectUrl"));
+            }
+        }
+
+        // ── TokenCachePersistenceOptions ────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void TokenCachePersistenceOptions_ConfigSetsName()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TokenCachePersistenceOptions:Name"] = "my-cache";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                var cacheOptions = ReadField<TokenCachePersistenceOptions>(client, "_tokenCachePersistenceOptions");
+                Assert.IsNotNull(cacheOptions);
+                Assert.AreEqual("my-cache", cacheOptions.Name);
+                Assert.IsFalse(cacheOptions.UnsafeAllowUnencryptedStorage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TokenCachePersistenceOptions_ConfigSetsUnsafeAllowUnencryptedStorage()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TokenCachePersistenceOptions:UnsafeAllowUnencryptedStorage"] = "true";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                var cacheOptions = ReadField<TokenCachePersistenceOptions>(client, "_tokenCachePersistenceOptions");
+                Assert.IsNotNull(cacheOptions);
+                Assert.IsNull(cacheOptions.Name);
+                Assert.IsTrue(cacheOptions.UnsafeAllowUnencryptedStorage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TokenCachePersistenceOptions_ConfigSetsBothProperties()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TokenCachePersistenceOptions:Name"] = "my-cache";
+                config["MyClient:Credential:TokenCachePersistenceOptions:UnsafeAllowUnencryptedStorage"] = "true";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                var cacheOptions = ReadField<TokenCachePersistenceOptions>(client, "_tokenCachePersistenceOptions");
+                Assert.IsNotNull(cacheOptions);
+                Assert.AreEqual("my-cache", cacheOptions.Name);
+                Assert.IsTrue(cacheOptions.UnsafeAllowUnencryptedStorage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TokenCachePersistenceOptions_DefaultsToEmptyInstance()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                var cacheOptions = ReadField<TokenCachePersistenceOptions>(client, "_tokenCachePersistenceOptions");
+                Assert.IsNotNull(cacheOptions);
+                Assert.IsNull(cacheOptions.Name);
+                Assert.IsFalse(cacheOptions.UnsafeAllowUnencryptedStorage);
+            }
+        }
+
+        // ── DisableInstanceDiscovery ────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:DisableInstanceDiscovery"] = "true";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                Assert.IsTrue(ReadProperty<bool>(client, "DisableInstanceDiscovery"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                Assert.IsFalse(ReadProperty<bool>(client, "DisableInstanceDiscovery"));
+            }
+        }
+
+        // ── AuthorityHost ──────────────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AuthorityHost"] = "https://login.microsoftonline.us/";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("https://management.usgovcloudapi.net/.default", ReadProperty<string>(broker, "DefaultScope"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_DefaultsToPublicCloud()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("https://management.azure.com//.default", ReadProperty<string>(broker, "DefaultScope"));
+            }
+        }
+
+        // ── IsUnsafeSupportLoggingEnabled ──────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                Assert.IsTrue(ReadProperty<bool>(client, "IsSupportLoggingEnabled"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(broker, "Client");
+                Assert.IsFalse(ReadProperty<bool>(client, "IsSupportLoggingEnabled"));
+            }
+        }
+
+        // ── UseDefaultBrokerAccount ────────────────────────────────────────
+
+#if !IDENTITY_TESTS
+        // UseDefaultBrokerAccount can only flow through to the underlying credential
+        // when the broker package is available, because the fallback IBC options do
+        // not implement IMsalSettablePublicClientInitializerOptions.
+        [Test]
+        [NonParallelizable]
+        public void UseDefaultBrokerAccount_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:UseDefaultBrokerAccount"] = "true";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadProperty<bool>(broker, "UseOperatingSystemAccount"));
+            }
+        }
+#endif
+
+        [Test]
+        [NonParallelizable]
+        public void UseDefaultBrokerAccount_ConfigSetsFalseExplicitly()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:UseDefaultBrokerAccount"] = "false";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadProperty<bool>(broker, "UseOperatingSystemAccount"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void UseDefaultBrokerAccount_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadProperty<bool>(broker, "UseOperatingSystemAccount"));
+            }
+        }
+
+        // ── IsLegacyMsaPassthroughEnabled ─────────────────────────────────
+
+#if !IDENTITY_TESTS
+        // IsLegacyMsaPassthroughEnabled is a DBO-only property that is only meaningful
+        // when the broker package is available. These tests require the Broker DBO to
+        // override CopyMsalSettableProperties, which will be added once Azure.Identity
+        // is published with the internal virtual method.
+        [Test]
+        [NonParallelizable]
+        [Ignore("Requires Broker DBO override of CopyMsalSettableProperties — see https://github.com/Azure/azure-sdk-for-net/issues/56384")]
+        public void IsLegacyMsaPassthroughEnabled_ConfigSetsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsLegacyMsaPassthroughEnabled"] = "false";
+
+                // Verify the credential is created without error and broker path is enabled.
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadField<bool>(broker, "_isBrokerOptionsEnabled"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        [Ignore("Requires Broker DBO override of CopyMsalSettableProperties — see https://github.com/Azure/azure-sdk-for-net/issues/56384")]
+        public void IsLegacyMsaPassthroughEnabled_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsLegacyMsaPassthroughEnabled"] = "true";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadField<bool>(broker, "_isBrokerOptionsEnabled"));
+            }
+        }
+#endif
+
         // ── AllOptions ─────────────────────────────────────────────────────
 
         [Test]
@@ -331,6 +718,9 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
                 config["MyClient:Credential:InteractiveBrowserCredentialClientId"] = "my-client-id";
                 config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
                 config["MyClient:Credential:DisableAutomaticAuthentication"] = "true";
+#if !IDENTITY_TESTS
+                config["MyClient:Credential:UseDefaultBrokerAccount"] = "true";
+#endif
                 config["MyClient:Credential:LoginHint"] = "user@example.com";
                 config["MyClient:Credential:BrowserCustomization:SuccessMessage"] = "<p>OK</p>";
                 config["MyClient:Credential:BrowserCustomization:ErrorMessage"] = "<p>Fail</p>";
@@ -350,6 +740,9 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
                 CollectionAssert.DoesNotContain(tenants, "env-extra");
 
                 Assert.IsTrue(ReadProperty<bool>(broker, "DisableAutomaticAuthentication"));
+#if !IDENTITY_TESTS
+                Assert.IsTrue(ReadProperty<bool>(broker, "UseOperatingSystemAccount"));
+#endif
                 Assert.AreEqual("user@example.com", ReadProperty<string>(broker, "LoginHint"));
 
                 var bc = ReadProperty<BrowserCustomizationOptions>(broker, "BrowserCustomization");
@@ -364,6 +757,29 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
                 Assert.AreEqual("oid.tid", record.HomeAccountId);
                 Assert.AreEqual("rec-tenant", record.TenantId);
                 Assert.AreEqual("rec-client", record.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_DefaultsWhenNothingSet()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+
+                Assert.IsNull(ReadProperty<string>(broker, "TenantId"));
+                Assert.AreEqual(Constants.DeveloperSignOnClientId, ReadProperty<string>(broker, "ClientId"));
+                Assert.IsEmpty(ReadProperty<string[]>(broker, "AdditionallyAllowedTenantIds"));
+                Assert.IsFalse(ReadProperty<bool>(broker, "DisableAutomaticAuthentication"));
+#if !IDENTITY_TESTS
+                Assert.IsFalse(ReadProperty<bool>(broker, "UseOperatingSystemAccount"));
+#endif
+                Assert.IsNull(ReadProperty<string>(broker, "LoginHint"));
+                Assert.IsNull(ReadProperty<BrowserCustomizationOptions>(broker, "BrowserCustomization"));
+                Assert.IsNull(ReadProperty<AuthenticationRecord>(broker, "Record"));
             }
         }
     }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
@@ -1,0 +1,370 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
+{
+    /// <summary>
+    /// Validates that BrokerCredential properties can be set via IConfiguration and
+    /// that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    ///
+    /// BrokerCredential inherits from InteractiveBrowserCredential, so these tests
+    /// cover all InteractiveBrowserCredentialOptions properties.  The broker factory
+    /// path (CreateBrokerCredential) passes through a subset of them; the remaining
+    /// IBC properties are verified to have their expected defaults.
+    /// </summary>
+    internal class BrokerCredentialCreationTests : CredentialCreationTestBase<BrokerCredential>
+    {
+        protected override string CredentialSource => "Broker";
+
+        private static Dictionary<string, string> AllNulledEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+        };
+
+        // ── TenantId ───────────────────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(broker, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("env-tenant", ReadProperty<string>(broker, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(broker, "TenantId"));
+            }
+        }
+
+        // ── AdditionallyAllowedTenants ─────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-tenant-a";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(broker, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "config-tenant-a");
+                CollectionAssert.DoesNotContain(tenants, "env-tenant-x");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(broker, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "env-tenant-x");
+                CollectionAssert.Contains(tenants, "env-tenant-y");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(broker, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        // ── ClientId ───────────────────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void ClientId_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:InteractiveBrowserCredentialClientId"] = "my-client-id";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("my-client-id", ReadProperty<string>(broker, "ClientId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientId_DefaultsToDeveloperSignOnClientId()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual(Constants.DeveloperSignOnClientId, ReadProperty<string>(broker, "ClientId"));
+            }
+        }
+
+        // ── DisableAutomaticAuthentication ─────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void DisableAutomaticAuthentication_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:DisableAutomaticAuthentication"] = "true";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadProperty<bool>(broker, "DisableAutomaticAuthentication"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableAutomaticAuthentication_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadProperty<bool>(broker, "DisableAutomaticAuthentication"));
+            }
+        }
+
+        // ── LoginHint ──────────────────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void LoginHint_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:LoginHint"] = "user@example.com";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("user@example.com", ReadProperty<string>(broker, "LoginHint"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void LoginHint_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<string>(broker, "LoginHint"));
+            }
+        }
+
+        // ── BrowserCustomization ───────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void BrowserCustomization_SuccessMessage_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:BrowserCustomization:SuccessMessage"] = "<p>Login successful</p>";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var bc = ReadProperty<BrowserCustomizationOptions>(broker, "BrowserCustomization");
+                Assert.IsNotNull(bc);
+                Assert.AreEqual("<p>Login successful</p>", bc.SuccessMessage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void BrowserCustomization_ErrorMessage_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:BrowserCustomization:ErrorMessage"] = "<p>Error: {0}</p>";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var bc = ReadProperty<BrowserCustomizationOptions>(broker, "BrowserCustomization");
+                Assert.IsNotNull(bc);
+                Assert.AreEqual("<p>Error: {0}</p>", bc.ErrorMessage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void BrowserCustomization_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<BrowserCustomizationOptions>(broker, "BrowserCustomization"));
+            }
+        }
+
+        // ── AuthenticationRecord ───────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void AuthenticationRecord_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AuthenticationRecord:Username"] = "user@contoso.com";
+                config["MyClient:Credential:AuthenticationRecord:Authority"] = "login.microsoftonline.com";
+                config["MyClient:Credential:AuthenticationRecord:HomeAccountId"] = "object-id.tenant-id";
+                config["MyClient:Credential:AuthenticationRecord:TenantId"] = "record-tenant";
+                config["MyClient:Credential:AuthenticationRecord:ClientId"] = "record-client";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                var record = ReadProperty<AuthenticationRecord>(broker, "Record");
+                Assert.IsNotNull(record);
+                Assert.AreEqual("user@contoso.com", record.Username);
+                Assert.AreEqual("login.microsoftonline.com", record.Authority);
+                Assert.AreEqual("object-id.tenant-id", record.HomeAccountId);
+                Assert.AreEqual("record-tenant", record.TenantId);
+                Assert.AreEqual("record-client", record.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthenticationRecord_DefaultsToNull()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNull(ReadProperty<AuthenticationRecord>(broker, "Record"));
+            }
+        }
+
+        // ── AllOptions ─────────────────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigSetsAllValues()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-extra" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:InteractiveBrowserCredentialClientId"] = "my-client-id";
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+                config["MyClient:Credential:DisableAutomaticAuthentication"] = "true";
+                config["MyClient:Credential:LoginHint"] = "user@example.com";
+                config["MyClient:Credential:BrowserCustomization:SuccessMessage"] = "<p>OK</p>";
+                config["MyClient:Credential:BrowserCustomization:ErrorMessage"] = "<p>Fail</p>";
+                config["MyClient:Credential:AuthenticationRecord:Username"] = "user@contoso.com";
+                config["MyClient:Credential:AuthenticationRecord:Authority"] = "login.microsoftonline.com";
+                config["MyClient:Credential:AuthenticationRecord:HomeAccountId"] = "oid.tid";
+                config["MyClient:Credential:AuthenticationRecord:TenantId"] = "rec-tenant";
+                config["MyClient:Credential:AuthenticationRecord:ClientId"] = "rec-client";
+
+                var broker = GetUnderlying(CreateFromConfig(config));
+
+                Assert.AreEqual(configTenant, ReadProperty<string>(broker, "TenantId"));
+                Assert.AreEqual("my-client-id", ReadProperty<string>(broker, "ClientId"));
+
+                var tenants = ReadProperty<string[]>(broker, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+
+                Assert.IsTrue(ReadProperty<bool>(broker, "DisableAutomaticAuthentication"));
+                Assert.AreEqual("user@example.com", ReadProperty<string>(broker, "LoginHint"));
+
+                var bc = ReadProperty<BrowserCustomizationOptions>(broker, "BrowserCustomization");
+                Assert.IsNotNull(bc);
+                Assert.AreEqual("<p>OK</p>", bc.SuccessMessage);
+                Assert.AreEqual("<p>Fail</p>", bc.ErrorMessage);
+
+                var record = ReadProperty<AuthenticationRecord>(broker, "Record");
+                Assert.IsNotNull(record);
+                Assert.AreEqual("user@contoso.com", record.Username);
+                Assert.AreEqual("login.microsoftonline.com", record.Authority);
+                Assert.AreEqual("oid.tid", record.HomeAccountId);
+                Assert.AreEqual("rec-tenant", record.TenantId);
+                Assert.AreEqual("rec-client", record.ClientId);
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.Broker
+{
+    /// <summary>
+    /// Tests for BrokerCredential accessed through ConfigurableCredential.
+    /// Inherits from Tests.BrokerCredentialTests to get all Broker-specific test cases.
+    /// Overrides factory methods to create credentials via IConfiguration.
+    /// </summary>
+    internal class BrokerCredentialTests : Tests.BrokerCredentialTests
+    {
+        private readonly ConfigurableCredentialTestHelper<BrokerCredential> _helper;
+
+        public BrokerCredentialTests()
+        {
+            _helper = new ConfigurableCredentialTestHelper<BrokerCredential>("Broker");
+        }
+
+        private TokenCredential CreateConfiguredCredential(string tenantId = null, bool addTenantIdHint = false)
+        {
+            IConfiguration config = _helper.GetConfiguration();
+            if (tenantId != null)
+            {
+                config["MyClient:Credential:TenantId"] = tenantId;
+            }
+            if (addTenantIdHint)
+            {
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+            }
+
+            ConfigurableCredential credential;
+            using (new TestEnvVar("AZURE_TENANT_ID", null))
+            {
+                credential = _helper.GetCredentialFromConfig(config);
+            }
+
+            return _helper.InstrumentCredential(credential);
+        }
+
+        protected override TokenCredential CreateCredential(string tenantId = null, bool addTenantIdHint = false)
+            => CreateConfiguredCredential(tenantId, addTenantIdHint);
+
+        protected override TokenCredential CreateBareCredential()
+            => CreateConfiguredCredential();
+
+        // ConfigurableCredential wraps in DefaultAzureCredential (always chained),
+        // so the expected exception is always CredentialUnavailableException.
+        protected override Type GetExpectedExceptionType(bool isChained)
+            => typeof(CredentialUnavailableException);
+
+        protected override void CreateCredentialForTenantValidation(string tenantId)
+            => _helper.CreateCredentialForTenantValidation(tenantId);
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialCreationTests.cs
@@ -6,8 +6,15 @@ using System.Collections.Generic;
 using Azure.Core.TestFramework;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
+#if !IDENTITY_TESTS
+using Azure.Identity.Tests.ConfigurableCredentials;
+#endif
 
+#if IDENTITY_TESTS
 namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
+#else
+namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.InteractiveBrowser
+#endif
 {
     /// <summary>
     /// Validates that all InteractiveBrowserCredential-specific properties can be set
@@ -29,6 +36,24 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
         public void TenantId_ConfigSetsValue()
         {
             using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "config-tenant";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("config-tenant", ReadProperty<string>(ibc, "TenantId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            }))
             {
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:TenantId"] = "config-tenant";
@@ -92,6 +117,57 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
 
                 var ibc = GetUnderlying(CreateFromConfig(config));
                 Assert.AreEqual(Constants.DeveloperSignOnClientId, ReadProperty<string>(ibc, "ClientId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigSetsSingleValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "tenant-a";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(ibc, "AdditionallyAllowedTenantIds");
+                Assert.AreEqual(1, tenants.Length);
+                Assert.AreEqual("tenant-a", tenants[0]);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigSetsMultipleValues()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "tenant-a";
+                config["MyClient:Credential:AdditionallyAllowedTenants:1"] = "tenant-b";
+                config["MyClient:Credential:AdditionallyAllowedTenants:2"] = "tenant-c";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(ibc, "AdditionallyAllowedTenantIds");
+                Assert.AreEqual(3, tenants.Length);
+                CollectionAssert.Contains(tenants, "tenant-a");
+                CollectionAssert.Contains(tenants, "tenant-b");
+                CollectionAssert.Contains(tenants, "tenant-c");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_Wildcard()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var tenants = ReadProperty<string[]>(ibc, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
             }
         }
 
@@ -162,6 +238,20 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
 
                 var ibc = GetUnderlying(CreateFromConfig(config));
                 Assert.IsTrue(ReadProperty<bool>(ibc, "DisableAutomaticAuthentication"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableAutomaticAuthentication_ConfigSetsFalseExplicitly()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:DisableAutomaticAuthentication"] = "false";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadProperty<bool>(ibc, "DisableAutomaticAuthentication"));
             }
         }
 
@@ -257,6 +347,24 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
 
         [Test]
         [NonParallelizable]
+        public void BrowserCustomization_BothFieldsSet()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:BrowserCustomization:SuccessMessage"] = "<p>OK</p>";
+                config["MyClient:Credential:BrowserCustomization:ErrorMessage"] = "<p>Fail</p>";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var bc = ReadProperty<BrowserCustomizationOptions>(ibc, "BrowserCustomization");
+                Assert.IsNotNull(bc);
+                Assert.AreEqual("<p>OK</p>", bc.SuccessMessage);
+                Assert.AreEqual("<p>Fail</p>", bc.ErrorMessage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
         public void BrowserCustomization_DefaultsToNull()
         {
             using (new TestEnvVar(AllNulledEnvVars()))
@@ -270,7 +378,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
 
         [Test]
         [NonParallelizable]
-        public void AuthenticationRecord_ConfigSetsValue()
+        public void AuthenticationRecord_ConfigSetsAllFields()
         {
             using (new TestEnvVar(AllNulledEnvVars()))
             {
@@ -302,6 +410,249 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
 
                 var ibc = GetUnderlying(CreateFromConfig(config));
                 Assert.IsNull(ReadProperty<AuthenticationRecord>(ibc, "Record"));
+            }
+        }
+
+        // ── RedirectUri ─────────────────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void RedirectUri_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:RedirectUri"] = "http://localhost:12345/";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                Assert.AreEqual("http://localhost:12345/", ReadProperty<string>(client, "RedirectUrl"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void RedirectUri_DefaultsToLocalhost()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                Assert.AreEqual("http://localhost", ReadProperty<string>(client, "RedirectUrl"));
+            }
+        }
+
+        // ── TokenCachePersistenceOptions ────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void TokenCachePersistenceOptions_ConfigSetsName()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TokenCachePersistenceOptions:Name"] = "my-cache";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                var cacheOptions = ReadField<TokenCachePersistenceOptions>(client, "_tokenCachePersistenceOptions");
+                Assert.IsNotNull(cacheOptions);
+                Assert.AreEqual("my-cache", cacheOptions.Name);
+                Assert.IsFalse(cacheOptions.UnsafeAllowUnencryptedStorage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TokenCachePersistenceOptions_ConfigSetsUnsafeAllowUnencryptedStorage()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TokenCachePersistenceOptions:UnsafeAllowUnencryptedStorage"] = "true";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                var cacheOptions = ReadField<TokenCachePersistenceOptions>(client, "_tokenCachePersistenceOptions");
+                Assert.IsNotNull(cacheOptions);
+                Assert.IsNull(cacheOptions.Name);
+                Assert.IsTrue(cacheOptions.UnsafeAllowUnencryptedStorage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TokenCachePersistenceOptions_ConfigSetsBothProperties()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TokenCachePersistenceOptions:Name"] = "my-cache";
+                config["MyClient:Credential:TokenCachePersistenceOptions:UnsafeAllowUnencryptedStorage"] = "true";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                var cacheOptions = ReadField<TokenCachePersistenceOptions>(client, "_tokenCachePersistenceOptions");
+                Assert.IsNotNull(cacheOptions);
+                Assert.AreEqual("my-cache", cacheOptions.Name);
+                Assert.IsTrue(cacheOptions.UnsafeAllowUnencryptedStorage);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TokenCachePersistenceOptions_DefaultsToEmptyInstance()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                var cacheOptions = ReadField<TokenCachePersistenceOptions>(client, "_tokenCachePersistenceOptions");
+                Assert.IsNotNull(cacheOptions);
+                Assert.IsNull(cacheOptions.Name);
+                Assert.IsFalse(cacheOptions.UnsafeAllowUnencryptedStorage);
+            }
+        }
+
+        // ── DisableInstanceDiscovery ────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:DisableInstanceDiscovery"] = "true";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                Assert.IsTrue(ReadProperty<bool>(client, "DisableInstanceDiscovery"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                Assert.IsFalse(ReadProperty<bool>(client, "DisableInstanceDiscovery"));
+            }
+        }
+
+        // ── AuthorityHost ──────────────────────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_ConfigSetsValue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:AuthorityHost"] = "https://login.microsoftonline.us/";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("https://management.usgovcloudapi.net/.default", ReadProperty<string>(ibc, "DefaultScope"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_DefaultsToPublicCloud()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.AreEqual("https://management.azure.com//.default", ReadProperty<string>(ibc, "DefaultScope"));
+            }
+        }
+
+        // ── IsUnsafeSupportLoggingEnabled ──────────────────────────────────
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:IsUnsafeSupportLoggingEnabled"] = "true";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                Assert.IsTrue(ReadProperty<bool>(client, "IsSupportLoggingEnabled"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void IsUnsafeSupportLoggingEnabled_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                var client = ReadProperty<MsalPublicClient>(ibc, "Client");
+                Assert.IsFalse(ReadProperty<bool>(client, "IsSupportLoggingEnabled"));
+            }
+        }
+
+        // ── UseDefaultBrokerAccount ────────────────────────────────────────
+
+#if !IDENTITY_TESTS
+        // UseDefaultBrokerAccount=true with InteractiveBrowser source requires
+        // the broker package. Without it, CreateInteractiveBrowserCredential throws.
+        [Test]
+        [NonParallelizable]
+        public void UseDefaultBrokerAccount_ConfigSetsTrue()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:UseDefaultBrokerAccount"] = "true";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsTrue(ReadProperty<bool>(ibc, "UseOperatingSystemAccount"));
+            }
+        }
+#endif
+
+        [Test]
+        [NonParallelizable]
+        public void UseDefaultBrokerAccount_ConfigSetsFalseExplicitly()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:UseDefaultBrokerAccount"] = "false";
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadProperty<bool>(ibc, "UseOperatingSystemAccount"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void UseDefaultBrokerAccount_DefaultsFalse()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+                Assert.IsFalse(ReadProperty<bool>(ibc, "UseOperatingSystemAccount"));
             }
         }
 
@@ -355,6 +706,26 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.InteractiveBrowser
                 Assert.AreEqual("oid.tid", record.HomeAccountId);
                 Assert.AreEqual("rec-tenant", record.TenantId);
                 Assert.AreEqual("rec-client", record.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_DefaultsWhenNothingSet()
+        {
+            using (new TestEnvVar(AllNulledEnvVars()))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var ibc = GetUnderlying(CreateFromConfig(config));
+
+                Assert.IsNull(ReadProperty<string>(ibc, "TenantId"));
+                Assert.AreEqual(Constants.DeveloperSignOnClientId, ReadProperty<string>(ibc, "ClientId"));
+                Assert.IsEmpty(ReadProperty<string[]>(ibc, "AdditionallyAllowedTenantIds"));
+                Assert.IsFalse(ReadProperty<bool>(ibc, "DisableAutomaticAuthentication"));
+                Assert.IsNull(ReadProperty<string>(ibc, "LoginHint"));
+                Assert.IsNull(ReadProperty<BrowserCustomizationOptions>(ibc, "BrowserCustomization"));
+                Assert.IsNull(ReadProperty<AuthenticationRecord>(ibc, "Record"));
             }
         }
     }


### PR DESCRIPTION
## Description

Adds configurable credential support for BrokerCredential, completing the last credential needed for issue #55504.

### Tests added
- **Azure.Identity**: Base + configurable BrokerCredentialTests (16 tests)
- **Azure.Identity**: BrokerCredentialCreationTests covering all IBC-inherited properties (16 tests)
- **Azure.Identity.Broker**: Base + configurable BrokerCredentialTests (16 tests)
- **Constructor_WithBrokerCredentialSource** integration tests (2 tests)

### Bug fix
Fixed CreateBrokerCredential() and CredentialOptionsMapper to properly pass through InteractiveBrowserCredentialOptions properties (ClientId, DisableAutomaticAuthentication, LoginHint, BrowserCustomization, AuthenticationRecord) that were previously lost during options cloning.

Fixes #55504