### PR TITLE
Remove explicit parameterless ctor and use atomic pooled array cleanup in ArrayBackedPropertyBag

### DIFF
--- a/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
+++ b/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
@@ -255,13 +255,13 @@ namespace Azure.Core
 
         public void Dispose()
         {
-        #if DEBUG
+#if DEBUG
             if (_disposed)
             {
                 return;
             }
             _disposed = true;
-        #endif
+#endif
             _count = 0;
             _first = default;
             _second = default;

--- a/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
+++ b/sdk/core/Azure.Core/src/Internal/ArrayBackedPropertyBag.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace Azure.Core
 {
@@ -20,14 +21,9 @@ namespace Azure.Core
         private (TKey Key, TValue Value) _second;
         private (TKey Key, TValue Value)[]? _rest;
         private int _count;
-        private readonly object _lock = new();
 #if DEBUG
         private bool _disposed;
 #endif
-
-        public ArrayBackedPropertyBag()
-        {
-        }
 
         public int Count
         {
@@ -259,28 +255,24 @@ namespace Azure.Core
 
         public void Dispose()
         {
-#if DEBUG
+        #if DEBUG
             if (_disposed)
             {
                 return;
             }
             _disposed = true;
-#endif
+        #endif
             _count = 0;
             _first = default;
             _second = default;
 
-            lock (_lock)
+            var rest = Interlocked.Exchange(ref _rest, default);
+            if (rest == default)
             {
-                if (_rest == default)
-                {
-                    return;
-                }
-
-                var rest = _rest;
-                _rest = default;
-                ArrayPool<(TKey Key, TValue Value)>.Shared.Return(rest, true);
+                return;
             }
+
+            ArrayPool<(TKey Key, TValue Value)>.Shared.Return(rest, true);
         }
 
         private (TKey Key, TValue Value)[] GetRest() => _rest ??


### PR DESCRIPTION
Simple fix for https://github.com/Azure/azure-sdk-for-net/issues/43500

by:
- removing the explicit parameterless ctor
- removes the _lock and _lock field initializer (cannot have field initializers without parameterless ctor)
- updates dispose to atomically clear and take ownership of the pooled backing array

Other option included lazy initializing the lock, but this solution avoids allocating a lock object and also avoids potential lazy initialization race conditions