### PR TITLE
Fix AOT warning regression in Azure.Monitor.OpenTelemetry.Exporter

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An OpenTelemetry .NET exporter that exports to Azure Monitor</Description>
     <AssemblyTitle>AzureMonitor OpenTelemetry Exporter</AssemblyTitle>
@@ -9,6 +9,12 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <AotCompatOptOut>true</AotCompatOptOut>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <!-- The configuration binding source generator emits warnings for properties inherited from
+         Azure.Core.ClientOptions (e.g. TokenCredential, Transport) that cannot be bound from
+         configuration. These are expected and safe to suppress since those properties are never
+         set via IConfiguration. -->
+    <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
     <DefineConstants>$(DefineConstants);AZURE_MONITOR_EXPORTER;</DefineConstants>
     <IncludeAutorestDependency>true</IncludeAutorestDependency>
   </PropertyGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Azure.Monitor.OpenTelemetry.Exporter.csproj
@@ -10,10 +10,11 @@
     <IncludeOperationsSharedSource>true</IncludeOperationsSharedSource>
     <AotCompatOptOut>true</AotCompatOptOut>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-    <!-- The configuration binding source generator emits warnings for properties inherited from
-         Azure.Core.ClientOptions (e.g. TokenCredential, Transport) that cannot be bound from
-         configuration. These are expected and safe to suppress since those properties are never
-         set via IConfiguration. -->
+    <!-- The configuration binding source generator emits SYSLIB1100/SYSLIB1101 for options
+         properties that cannot be bound from configuration (for example, the Credential
+         (TokenCredential) and Transport properties used by Azure.Core.ClientOptions). These
+         warnings are expected and safe to suppress since those properties are never set via
+         IConfiguration. -->
     <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
     <DefineConstants>$(DefineConstants);AZURE_MONITOR_EXPORTER;</DefineConstants>
     <IncludeAutorestDependency>true</IncludeAutorestDependency>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
@@ -127,13 +126,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
             {
                 AzureMonitorExporterEventSource.Log.ConfigureFailed(ex);
             }
-        }
-
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Binding options is a known source of trim warnings; this is a deliberate usage.")]
-        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Binding options is a known source of AOT warnings; this is a deliberate usage.")]
-        private static void BindIConfigurationOptions(IConfiguration configuration, AzureMonitorExporterOptions options)
-        {
-            configuration.GetSection(AzureMonitorExporterSectionFromConfig).Bind(options);
         }
     }
 }


### PR DESCRIPTION
With change https://github.com/Azure/azure-sdk-for-net/pull/54942, new AOT warnings are being introduced due to using ConfigurationBinder Bind calls without using the source generator. Prior to that, this warning was suppressed, which wasn't correct either.

The real fix is to use the source generator.

Fix #56365

NOTE: I can't re-enable AOT checks for this library because of https://github.com/Azure/azure-sdk-for-net/issues/56367. We will need to fix that to re-enable the checks.

cc @m-redding @harsimar