### PR TITLE
Support cloud role name/instance override via environment variable

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 
 using OpenTelemetry.Logs;
 
@@ -160,13 +161,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             Tags[ContextTagKeys.AiApplicationVer.ToString()] = resource?.ServiceVersion_Truncated;
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
 
-            var roleName = s_cloudRoleNameOverride ?? (s_cloudRoleNameOverride = Environment.GetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_NAME") ?? string.Empty);
+            var roleName = s_cloudRoleNameOverride ?? (s_cloudRoleNameOverride = Environment.GetEnvironmentVariable(EnvironmentVariableConstants.APPLICATIONINSIGHTS_CLOUD_ROLE_NAME) ?? string.Empty);
             if (roleName.Length > 0)
             {
                 Tags[ContextTagKeys.AiCloudRole.ToString()] = roleName.Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength);
             }
 
-            var roleInstance = s_cloudRoleInstanceOverride ?? (s_cloudRoleInstanceOverride = Environment.GetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE") ?? string.Empty);
+            var roleInstance = s_cloudRoleInstanceOverride ?? (s_cloudRoleInstanceOverride = Environment.GetEnvironmentVariable(EnvironmentVariableConstants.APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE) ?? string.Empty);
             if (roleInstance.Length > 0)
             {
                 Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = roleInstance.Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -14,6 +14,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class TelemetryItem
     {
+        private static volatile string? s_cloudRoleNameOverride;
+        private static volatile string? s_cloudRoleInstanceOverride;
+
         public TelemetryItem(Activity activity, ref ActivityTagsProcessor activityTagsProcessor, AzureMonitorResource? resource, string instrumentationKey, float sampleRate) :
             this(activity.GetTelemetryType() == TelemetryType.Request ? "Request" : "RemoteDependency", FormatUtcTimestamp(activity.StartTimeUtc))
         {
@@ -156,6 +159,27 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = resource?.RoleInstance_Truncated;
             Tags[ContextTagKeys.AiApplicationVer.ToString()] = resource?.ServiceVersion_Truncated;
             Tags[ContextTagKeys.AiInternalSdkVersion.ToString()] = SdkVersionUtils.s_sdkVersion.Truncate(SchemaConstants.Tags_AiInternalSdkVersion_MaxLength);
+
+            var roleName = s_cloudRoleNameOverride ?? (s_cloudRoleNameOverride = Environment.GetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_NAME") ?? string.Empty);
+            if (roleName.Length > 0)
+            {
+                Tags[ContextTagKeys.AiCloudRole.ToString()] = roleName.Truncate(SchemaConstants.Tags_AiCloudRole_MaxLength);
+            }
+
+            var roleInstance = s_cloudRoleInstanceOverride ?? (s_cloudRoleInstanceOverride = Environment.GetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE") ?? string.Empty);
+            if (roleInstance.Length > 0)
+            {
+                Tags[ContextTagKeys.AiCloudRoleInstance.ToString()] = roleInstance.Truncate(SchemaConstants.Tags_AiCloudRoleInstance_MaxLength);
+            }
+        }
+
+        /// <summary>
+        /// Resets the cached environment variable overrides. For testing only.
+        /// </summary>
+        internal static void ResetEnvironmentVariableOverrides()
+        {
+            s_cloudRoleNameOverride = null;
+            s_cloudRoleInstanceOverride = null;
         }
 
         internal static DateTimeOffset FormatUtcTimestamp(System.DateTime utcTimestamp)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -17,6 +17,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
             APPLICATIONINSIGHTS_STATSBEAT_DISABLED,
             APPLICATIONINSIGHTS_SDKSTATS_DISABLED,
             APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL,
+            APPLICATIONINSIGHTS_CLOUD_ROLE_NAME,
+            APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE,
             FUNCTIONS_WORKER_RUNTIME,
             LOCALAPPDATA,
             TEMP,
@@ -140,5 +142,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         /// For microsoft.fixed_percentage sampler: sampling ratio (double from 0 to 1).
         /// </summary>
         public const string OTEL_TRACES_SAMPLER_ARG = "OTEL_TRACES_SAMPLER_ARG";
+
+        /// <summary>
+        /// Set by the Application Insights shim (TelemetryClient.Context.Cloud.RoleName) to override
+        /// the cloud role name after the OTel Resource has been built and is immutable.
+        /// </summary>
+        public const string APPLICATIONINSIGHTS_CLOUD_ROLE_NAME = "APPLICATIONINSIGHTS_CLOUD_ROLE_NAME";
+
+        /// <summary>
+        /// Set by the Application Insights shim (TelemetryClient.Context.Cloud.RoleInstance) to override
+        /// the cloud role instance after the OTel Resource has been built and is immutable.
+        /// </summary>
+        public const string APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE = "APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE";
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -656,6 +656,39 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             Assert.NotEqual(telemetryItem1?.Time, telemetryItem2?.Time);
         }
 
+        [Fact]
+        public void CloudRoleNameOverriddenByEnvironmentVariable()
+        {
+            TelemetryItem.ResetEnvironmentVariableOverrides();
+            try
+            {
+                Environment.SetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_NAME", "EnvOverrideRole");
+                Environment.SetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE", "EnvOverrideInstance");
+
+                using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
+                using var activity = activitySource.StartActivity(
+                    ActivityName,
+                    ActivityKind.Client,
+                    parentContext: default,
+                    startTime: DateTime.UtcNow)
+                    ?? throw new Exception("Failed to create Activity");
+
+                var resource = CreateTestResource(serviceName: "original-service", serviceInstance: "original-instance");
+                var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+                var traceResource = resource.CreateAzureMonitorResource(instrumentationKey: null, platform: GetMockPlatform());
+                var telemetryItem = new TelemetryItem(activity, ref activityTagsProcessor, traceResource, "00000000-0000-0000-0000-000000000000", 1.0f);
+
+                Assert.Equal("EnvOverrideRole", telemetryItem.Tags[ContextTagKeys.AiCloudRole.ToString()]);
+                Assert.Equal("EnvOverrideInstance", telemetryItem.Tags[ContextTagKeys.AiCloudRoleInstance.ToString()]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_NAME", null);
+                Environment.SetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE", null);
+                TelemetryItem.ResetEnvironmentVariableOverrides();
+            }
+        }
+
         /// <summary>
         /// If SERVICE.NAME is not defined, it will fall-back to "unknown_service".
         /// (https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions#semantic-attributes-with-sdk-provided-default-value).

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/TelemetryItemTests.cs
@@ -659,11 +659,13 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [Fact]
         public void CloudRoleNameOverriddenByEnvironmentVariable()
         {
+            var priorRoleName = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_NAME");
+            var priorRoleInstance = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE");
             TelemetryItem.ResetEnvironmentVariableOverrides();
             try
             {
-                Environment.SetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_NAME", "EnvOverrideRole");
-                Environment.SetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE", "EnvOverrideInstance");
+                Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_NAME", "EnvOverrideRole");
+                Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE", "EnvOverrideInstance");
 
                 using ActivitySource activitySource = new ActivitySource(ActivitySourceName);
                 using var activity = activitySource.StartActivity(
@@ -683,8 +685,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             }
             finally
             {
-                Environment.SetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_NAME", null);
-                Environment.SetEnvironmentVariable("MICROSOFT_APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE", null);
+                Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_NAME", priorRoleName);
+                Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE", priorRoleInstance);
                 TelemetryItem.ResetEnvironmentVariableOverrides();
             }
         }


### PR DESCRIPTION
Allow `APPLICATIONINSIGHTS_CLOUD_ROLE_NAME` and `APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE` environment variables to override resource-derived cloud role tags. Value is read once and cached.

### Changes

- `TelemetryItem.cs` — cached env var read in `SetResourceSdkVersionAndIkey()`
- `TelemetryItemTests.cs` — test for env var override
