### PR TITLE
fix: update contentunderstanding spec & regen

### DIFF
--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/ContentUnderstandingClient.RestClient.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/ContentUnderstandingClient.RestClient.cs
@@ -35,7 +35,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/analyzers/", false);
             uri.AppendPath(analyzerId, true);
             uri.AppendPath(":analyze", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             if (stringEncoding != null)
             {
                 uri.AppendQuery("stringEncoding", stringEncoding, true);
@@ -62,7 +65,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/analyzers/", false);
             uri.AppendPath(analyzerId, true);
             uri.AppendPath(":analyzeBinary", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             if (stringEncoding != null)
             {
                 uri.AppendQuery("stringEncoding", stringEncoding, true);
@@ -93,12 +99,15 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/analyzers/", false);
             uri.AppendPath(analyzerId, true);
             uri.AppendPath(":copy", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             if (allowReplace != null)
             {
                 uri.AppendQuery("allowReplace", TypeFormatters.ConvertToString(allowReplace), true);
             }
-            HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200201);
+            HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier202);
             Request request = message.Request;
             request.Uri = uri;
             request.Method = RequestMethod.Post;
@@ -115,7 +124,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/contentunderstanding", false);
             uri.AppendPath("/analyzers/", false);
             uri.AppendPath(analyzerId, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             if (allowReplace != null)
             {
                 uri.AppendQuery("allowReplace", TypeFormatters.ConvertToString(allowReplace), true);
@@ -137,7 +149,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/contentunderstanding", false);
             uri.AppendPath("/analyzers/", false);
             uri.AppendPath(analyzerId, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier204);
             Request request = message.Request;
             request.Uri = uri;
@@ -152,7 +167,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/contentunderstanding", false);
             uri.AppendPath("/analyzerResults/", false);
             uri.AppendPath(operationId, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier204);
             Request request = message.Request;
             request.Uri = uri;
@@ -167,7 +185,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/contentunderstanding", false);
             uri.AppendPath("/analyzers/", false);
             uri.AppendPath(analyzerId, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;
@@ -182,7 +203,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.Reset(_endpoint);
             uri.AppendPath("/contentunderstanding", false);
             uri.AppendPath("/defaults", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;
@@ -200,7 +224,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath(analyzerId, true);
             uri.AppendPath("/operations/", false);
             uri.AppendPath(operationId, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;
@@ -216,7 +243,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/contentunderstanding", false);
             uri.AppendPath("/analyzerResults/", false);
             uri.AppendPath(operationId, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;
@@ -234,7 +264,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath(operationId, true);
             uri.AppendPath("/files/", false);
             uri.AppendPath(path, false);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;
@@ -251,7 +284,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/analyzers/", false);
             uri.AppendPath(analyzerId, true);
             uri.AppendPath(":grantCopyAuthorization", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;
@@ -268,7 +304,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.Reset(_endpoint);
             uri.AppendPath("/contentunderstanding", false);
             uri.AppendPath("/analyzers", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;
@@ -288,7 +327,10 @@ namespace Azure.AI.ContentUnderstanding
             {
                 uri.Reset(new Uri(_endpoint, nextPage));
             }
-            uri.UpdateQuery("api-version", _apiVersion);
+            if (_apiVersion != null)
+            {
+                uri.UpdateQuery("api-version", _apiVersion);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;
@@ -304,7 +346,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.AppendPath("/contentunderstanding", false);
             uri.AppendPath("/analyzers/", false);
             uri.AppendPath(analyzerId, true);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;
@@ -321,7 +366,10 @@ namespace Azure.AI.ContentUnderstanding
             uri.Reset(_endpoint);
             uri.AppendPath("/contentunderstanding", false);
             uri.AppendPath("/defaults", false);
-            uri.AppendQuery("api-version", _apiVersion, true);
+            if (_apiVersion != null)
+            {
+                uri.AppendQuery("api-version", _apiVersion, true);
+            }
             HttpMessage message = Pipeline.CreateMessage(context, PipelineMessageClassifier200);
             Request request = message.Request;
             request.Uri = uri;

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/AnalyzeInput.Serialization.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/AnalyzeInput.Serialization.cs
@@ -154,7 +154,7 @@ namespace Azure.AI.ContentUnderstanding
                     {
                         continue;
                     }
-                    url = string.IsNullOrEmpty(prop.Value.GetString()) ? null : new Uri(prop.Value.GetString());
+                    url = string.IsNullOrEmpty(prop.Value.GetString()) ? null : new Uri(prop.Value.GetString(), UriKind.RelativeOrAbsolute);
                     continue;
                 }
                 if (prop.NameEquals("data"u8))

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/LabeledDataKnowledgeSource.Serialization.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/LabeledDataKnowledgeSource.Serialization.cs
@@ -129,7 +129,7 @@ namespace Azure.AI.ContentUnderstanding
                 }
                 if (prop.NameEquals("containerUrl"u8))
                 {
-                    containerUrl = string.IsNullOrEmpty(prop.Value.GetString()) ? null : new Uri(prop.Value.GetString());
+                    containerUrl = string.IsNullOrEmpty(prop.Value.GetString()) ? null : new Uri(prop.Value.GetString(), UriKind.RelativeOrAbsolute);
                     continue;
                 }
                 if (prop.NameEquals("prefix"u8))

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/PagedContentAnalyzer.Serialization.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/PagedContentAnalyzer.Serialization.cs
@@ -162,7 +162,7 @@ namespace Azure.AI.ContentUnderstanding
                     {
                         continue;
                     }
-                    nextLink = string.IsNullOrEmpty(prop.Value.GetString()) ? null : new Uri(prop.Value.GetString());
+                    nextLink = string.IsNullOrEmpty(prop.Value.GetString()) ? null : new Uri(prop.Value.GetString(), UriKind.RelativeOrAbsolute);
                     continue;
                 }
                 if (options.Format != "W")

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/SupportedModels.Serialization.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/SupportedModels.Serialization.cs
@@ -15,6 +15,11 @@ namespace Azure.AI.ContentUnderstanding
     /// <summary> Chat completion and embedding models supported by the analyzer. </summary>
     public partial class SupportedModels : IJsonModel<SupportedModels>
     {
+        /// <summary> Initializes a new instance of <see cref="SupportedModels"/> for deserialization. </summary>
+        internal SupportedModels()
+        {
+        }
+
         /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
         protected virtual SupportedModels PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
@@ -73,36 +78,30 @@ namespace Azure.AI.ContentUnderstanding
             {
                 throw new FormatException($"The model {nameof(SupportedModels)} does not support writing '{format}' format.");
             }
-            if (Optional.IsCollectionDefined(Completion))
+            writer.WritePropertyName("completion"u8);
+            writer.WriteStartArray();
+            foreach (string item in Completion)
             {
-                writer.WritePropertyName("completion"u8);
-                writer.WriteStartArray();
-                foreach (string item in Completion)
+                if (item == null)
                 {
-                    if (item == null)
-                    {
-                        writer.WriteNullValue();
-                        continue;
-                    }
-                    writer.WriteStringValue(item);
+                    writer.WriteNullValue();
+                    continue;
                 }
-                writer.WriteEndArray();
+                writer.WriteStringValue(item);
             }
-            if (Optional.IsCollectionDefined(Embedding))
+            writer.WriteEndArray();
+            writer.WritePropertyName("embedding"u8);
+            writer.WriteStartArray();
+            foreach (string item in Embedding)
             {
-                writer.WritePropertyName("embedding"u8);
-                writer.WriteStartArray();
-                foreach (string item in Embedding)
+                if (item == null)
                 {
-                    if (item == null)
-                    {
-                        writer.WriteNullValue();
-                        continue;
-                    }
-                    writer.WriteStringValue(item);
+                    writer.WriteNullValue();
+                    continue;
                 }
-                writer.WriteEndArray();
+                writer.WriteStringValue(item);
             }
+            writer.WriteEndArray();
             if (options.Format != "W" && _additionalBinaryDataProperties != null)
             {
                 foreach (var item in _additionalBinaryDataProperties)
@@ -152,10 +151,6 @@ namespace Azure.AI.ContentUnderstanding
             {
                 if (prop.NameEquals("completion"u8))
                 {
-                    if (prop.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<string> array = new List<string>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
@@ -173,10 +168,6 @@ namespace Azure.AI.ContentUnderstanding
                 }
                 if (prop.NameEquals("embedding"u8))
                 {
-                    if (prop.Value.ValueKind == JsonValueKind.Null)
-                    {
-                        continue;
-                    }
                     List<string> array = new List<string>();
                     foreach (var item in prop.Value.EnumerateArray())
                     {
@@ -197,7 +188,7 @@ namespace Azure.AI.ContentUnderstanding
                     additionalBinaryDataProperties.Add(prop.Name, BinaryData.FromString(prop.Value.GetRawText()));
                 }
             }
-            return new SupportedModels(completion ?? new ChangeTrackingList<string>(), embedding ?? new ChangeTrackingList<string>(), additionalBinaryDataProperties);
+            return new SupportedModels(completion, embedding, additionalBinaryDataProperties);
         }
     }
 }

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/SupportedModels.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Generated/Models/SupportedModels.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Azure.AI.ContentUnderstanding
 {
@@ -17,10 +18,12 @@ namespace Azure.AI.ContentUnderstanding
         private protected readonly IDictionary<string, BinaryData> _additionalBinaryDataProperties;
 
         /// <summary> Initializes a new instance of <see cref="SupportedModels"/>. </summary>
-        internal SupportedModels()
+        /// <param name="completion"> Chat completion models supported by the analyzer. </param>
+        /// <param name="embedding"> Embedding models supported by the analyzer. </param>
+        internal SupportedModels(IEnumerable<string> completion, IEnumerable<string> embedding)
         {
-            Completion = new ChangeTrackingList<string>();
-            Embedding = new ChangeTrackingList<string>();
+            Completion = completion.ToList();
+            Embedding = embedding.ToList();
         }
 
         /// <summary> Initializes a new instance of <see cref="SupportedModels"/>. </summary>

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/tsp-location.yaml
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/ai/ContentUnderstanding
-commit: a3291026612253abe544704a27bfad1dbdd5dcc2
+commit: 797bd2f4e64e2e29b63bb177933669345fc875b3
 repo: Azure/azure-rest-api-specs
 additionalDirectories:
 


### PR DESCRIPTION
Regenerates the contentunderstanding library on the latest version of the spec due to the current commit leading to tsp compilation errors:

```
Diagnostics were reported during compilation. Use the `--debug` flag to see if there is warning diagnostic output.
    C:/Users/jorgerangel/Development/AzureSdk/azure-sdk-for-net/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/TempTypeSpecFiles/ContentUnderstanding/routes.tsp:94:3 - error @azure-tools/typespec-azure-core/polling-operation-return-model: An operation annotated with @pollingOperation must return a model or union of model.
````