### PR TITLE
Add SecretClientSettings and experimental constructor to SecretClient

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net10.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net10.0.cs
@@ -60,6 +60,8 @@ namespace Azure.Security.KeyVault.Secrets
     public partial class SecretClient
     {
         protected SecretClient() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public SecretClient(Azure.Security.KeyVault.Secrets.SecretClientSettings settings) { }
         public SecretClient(System.Uri vaultUri, Azure.Core.TokenCredential credential) { }
         public SecretClient(System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Security.KeyVault.Secrets.SecretClientOptions options) { }
         public virtual System.Uri VaultUri { get { throw null; } }
@@ -108,6 +110,14 @@ namespace Azure.Security.KeyVault.Secrets
             V7_6 = 6,
             V2025_07_01 = 7,
         }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+    public partial class SecretClientSettings : System.ClientModel.Primitives.ClientSettings
+    {
+        public SecretClientSettings() { }
+        public Azure.Security.KeyVault.Secrets.SecretClientOptions? Options { get { throw null; } set { } }
+        public System.Uri? VaultUri { get { throw null; } set { } }
+        protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SecretContentType : System.IEquatable<Azure.Security.KeyVault.Secrets.SecretContentType>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net8.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net8.0.cs
@@ -60,6 +60,8 @@ namespace Azure.Security.KeyVault.Secrets
     public partial class SecretClient
     {
         protected SecretClient() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public SecretClient(Azure.Security.KeyVault.Secrets.SecretClientSettings settings) { }
         public SecretClient(System.Uri vaultUri, Azure.Core.TokenCredential credential) { }
         public SecretClient(System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Security.KeyVault.Secrets.SecretClientOptions options) { }
         public virtual System.Uri VaultUri { get { throw null; } }
@@ -108,6 +110,14 @@ namespace Azure.Security.KeyVault.Secrets
             V7_6 = 6,
             V2025_07_01 = 7,
         }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+    public partial class SecretClientSettings : System.ClientModel.Primitives.ClientSettings
+    {
+        public SecretClientSettings() { }
+        public Azure.Security.KeyVault.Secrets.SecretClientOptions? Options { get { throw null; } set { } }
+        public System.Uri? VaultUri { get { throw null; } set { } }
+        protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SecretContentType : System.IEquatable<Azure.Security.KeyVault.Secrets.SecretContentType>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.netstandard2.0.cs
@@ -60,6 +60,7 @@ namespace Azure.Security.KeyVault.Secrets
     public partial class SecretClient
     {
         protected SecretClient() { }
+        public SecretClient(Azure.Security.KeyVault.Secrets.SecretClientSettings settings) { }
         public SecretClient(System.Uri vaultUri, Azure.Core.TokenCredential credential) { }
         public SecretClient(System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Security.KeyVault.Secrets.SecretClientOptions options) { }
         public virtual System.Uri VaultUri { get { throw null; } }
@@ -108,6 +109,13 @@ namespace Azure.Security.KeyVault.Secrets
             V7_6 = 6,
             V2025_07_01 = 7,
         }
+    }
+    public partial class SecretClientSettings : System.ClientModel.Primitives.ClientSettings
+    {
+        public SecretClientSettings() { }
+        public Azure.Security.KeyVault.Secrets.SecretClientOptions? Options { get { throw null; } set { } }
+        public System.Uri? VaultUri { get { throw null; } set { } }
+        protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct SecretContentType : System.IEquatable<Azure.Security.KeyVault.Secrets.SecretContentType>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)CallerShouldAuditAttribute.cs" LinkBase="Shared\Core" />
+    <Compile Include="$(AzureCoreSharedSources)ExperimentalAttribute.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)PageResponseEnumerator.cs" LinkBase="Shared\Core" />
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" LinkBase="Shared\Core" />
   </ItemGroup>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
@@ -69,6 +70,17 @@ namespace Azure.Security.KeyVault.Secrets
                     new ChallengeBasedAuthenticationPolicy(credential, options.DisableChallengeResourceVerification));
 
             _pipeline = new KeyVaultPipeline(vaultUri, apiVersion, pipeline, new ClientDiagnostics(options));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecretClient"/> class for the specified vault using the provided settings.
+        /// </summary>
+        /// <param name="settings">The <see cref="SecretClientSettings"/> used to configure the client.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="settings"/> is null, or the endpoint or credential in the settings is null.</exception>
+        [Experimental("SCME0002")]
+        public SecretClient(SecretClientSettings settings)
+            : this(settings?.VaultUri, (TokenCredential)settings?.CredentialProvider, settings?.Options)
+        {
         }
 
         /// <summary>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -79,7 +79,7 @@ namespace Azure.Security.KeyVault.Secrets
         /// <exception cref="ArgumentNullException"><paramref name="settings"/> is null, or the endpoint or credential in the settings is null.</exception>
         [Experimental("SCME0002")]
         public SecretClient(SecretClientSettings settings)
-            : this(settings?.VaultUri, (TokenCredential)settings?.CredentialProvider, settings?.Options)
+            : this(settings?.VaultUri, settings?.CredentialProvider as TokenCredential, settings?.Options)
         {
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Azure.Core;
+using Microsoft.Extensions.Configuration;
 
 namespace Azure.Security.KeyVault.Secrets
 {
@@ -83,6 +85,20 @@ namespace Azure.Security.KeyVault.Secrets
         public SecretClientOptions(ServiceVersion version = LatestVersion)
         {
             Version = version;
+
+            this.ConfigureLogging();
+        }
+
+        [Experimental("SCME0002")]
+        internal SecretClientOptions(IConfigurationSection section)
+            : base(section, null)
+        {
+            Version = LatestVersion;
+
+            if (bool.TryParse(section["DisableChallengeResourceVerification"], out bool disableChallengeResourceVerification))
+            {
+                DisableChallengeResourceVerification = disableChallengeResourceVerification;
+            }
 
             this.ConfigureLogging();
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientSettings.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientSettings.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Configuration;
+
+#nullable enable
+
+namespace Azure.Security.KeyVault.Secrets
+{
+    /// <summary>
+    /// Represents the settings used to configure a <see cref="SecretClient"/> that can be loaded from an <see cref="IConfigurationSection"/>.
+    /// </summary>
+    [Experimental("SCME0002")]
+    public class SecretClientSettings : ClientSettings
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="Uri"/> to the vault on which the client operates.
+        /// Appears as "DNS Name" in the Azure portal.
+        /// </summary>
+        public Uri? VaultUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="SecretClientOptions"/> used to configure requests sent to Key Vault.
+        /// </summary>
+        public SecretClientOptions? Options { get; set; }
+
+        /// <inheritdoc/>
+        protected override void BindCore(IConfigurationSection section)
+        {
+            string? endpoint = section["VaultUri"];
+            if (!string.IsNullOrEmpty(endpoint))
+            {
+                VaultUri = new Uri(endpoint);
+            }
+
+            IConfigurationSection optionsSection = section.GetSection("Options");
+            if (optionsSection.Exists())
+            {
+                Options = new SecretClientOptions(optionsSection);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Creates SecretClientSettings extending ClientSettings and adds a new [Experimental("SCME0002")] constructor to SecretClient that delegates to the existing URI/credential/options constructor.

### Changes
- **SecretClientSettings.cs** (new): Settings class with VaultUri and Options properties, plus BindCore for configuration binding
- **SecretClient.cs**: New experimental constructor SecretClient(SecretClientSettings settings) that delegates to existing ctor
- **SecretClientOptions.cs**: Internal IConfigurationSection constructor for binding options from config
- **csproj**: Added shared ExperimentalAttribute.cs for netstandard2.0 compatibility
- **API files**: Updated for all target frameworks

Fixes #56402