### PR TITLE
Fix AZC0020: Propagate CancellationToken to RequestContext in 4 packages

### DIFF
--- a/sdk/batch/Azure.Compute.Batch/src/Custom/BatchClientCustom.cs
+++ b/sdk/batch/Azure.Compute.Batch/src/Custom/BatchClientCustom.cs
@@ -286,7 +286,7 @@ namespace Azure.Compute.Batch
             scope.Start();
             try
             {
-                Response response = await GetTaskFilePropertiesInternalAsync(jobId, taskId, filePath, timeOutInSeconds, ocpdate, null, null).ConfigureAwait(false);
+                Response response = await GetTaskFilePropertiesInternalAsync(jobId, taskId, filePath, timeOutInSeconds, ocpdate, null, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)
@@ -424,7 +424,7 @@ namespace Azure.Compute.Batch
             scope.Start();
             try
             {
-                Response response = GetNodeFilePropertiesInternal(poolId, nodeId, filePath, timeOutInSeconds, ocpdate, null, null);
+                Response response = GetNodeFilePropertiesInternal(poolId, nodeId, filePath, timeOutInSeconds, ocpdate, null, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)

--- a/sdk/batch/Azure.Compute.Batch/src/Custom/BatchClientCustom.cs
+++ b/sdk/batch/Azure.Compute.Batch/src/Custom/BatchClientCustom.cs
@@ -286,7 +286,7 @@ namespace Azure.Compute.Batch
             scope.Start();
             try
             {
-                Response response = await GetTaskFilePropertiesInternalAsync(jobId, taskId, filePath, timeOutInSeconds, ocpdate, null, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
+                Response response = await GetTaskFilePropertiesInternalAsync(jobId, taskId, filePath, timeOutInSeconds, ocpdate, null, new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)
@@ -335,7 +335,7 @@ namespace Azure.Compute.Batch
                     timeOutInSeconds,
                     ocpdate,
                     null,
-                    cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+                    new RequestContext { CancellationToken = cancellationToken });
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)
@@ -383,7 +383,7 @@ namespace Azure.Compute.Batch
                     timeOutInSeconds,
                     ocpdate,
                     null,
-                    cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
+                    new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)
@@ -424,7 +424,7 @@ namespace Azure.Compute.Batch
             scope.Start();
             try
             {
-                Response response = GetNodeFilePropertiesInternal(poolId, nodeId, filePath, timeOutInSeconds, ocpdate, null, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+                Response response = GetNodeFilePropertiesInternal(poolId, nodeId, filePath, timeOutInSeconds, ocpdate, null, new RequestContext { CancellationToken = cancellationToken });
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)
@@ -465,7 +465,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(pool, nameof(pool));
 
             using RequestContent content = pool;
-            Response response = await UpdatePoolAsync(poolId, pool, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
+            Response response = await UpdatePoolAsync(poolId, pool, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
             return response;
         }
 
@@ -500,7 +500,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(pool, nameof(pool));
 
             using RequestContent content = pool;
-            Response response = UpdatePool(poolId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+            Response response = UpdatePool(poolId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken });
             return response;
         }
 
@@ -535,7 +535,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(job, nameof(job));
 
             using RequestContent content = job;
-            Response response = await UpdateJobAsync(jobId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
+            Response response = await UpdateJobAsync(jobId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
             return response;
         }
 
@@ -570,7 +570,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(job, nameof(job));
 
             using RequestContent content = job;
-            Response response = UpdateJob(jobId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+            Response response = UpdateJob(jobId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken });
             return response;
         }
 
@@ -605,7 +605,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(jobSchedule, nameof(jobSchedule));
 
             using RequestContent content = jobSchedule;
-            Response response = await UpdateJobScheduleAsync(jobScheduleId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
+            Response response = await UpdateJobScheduleAsync(jobScheduleId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
             return response;
         }
 
@@ -640,7 +640,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(jobSchedule, nameof(jobSchedule));
 
             using RequestContent content = jobSchedule;
-            Response response = UpdateJobSchedule(jobScheduleId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+            Response response = UpdateJobSchedule(jobScheduleId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken });
             return response;
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultSettingsClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultSettingsClient.cs
@@ -170,7 +170,7 @@ namespace Azure.Security.KeyVault.Administration
             scope.Start();
             try
             {
-                Response response = _restClient.UpdateSetting(setting.Name, setting.ToRequestContent());
+                Response response = _restClient.UpdateSetting(setting.Name, setting.ToRequestContent(), new RequestContext { CancellationToken = cancellationToken });
 
                 KeyVaultSetting updatedSetting = default;
                 using var document = JsonDocument.Parse(response.ContentStream, default);
@@ -200,7 +200,7 @@ namespace Azure.Security.KeyVault.Administration
             scope.Start();
             try
             {
-                Response response = await _restClient.UpdateSettingAsync(setting.Name, setting.ToRequestContent()).ConfigureAwait(false);
+                Response response = await _restClient.UpdateSettingAsync(setting.Name, setting.ToRequestContent(), new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
 
                 KeyVaultSetting updatedSetting = default;
                 using var document = await JsonDocument.ParseAsync(response.ContentStream, default).ConfigureAwait(false);

--- a/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClient.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClient.cs
@@ -347,7 +347,8 @@ public class PlaywrightServiceBrowserClient : IDisposable
                 testRunId: testRunId,
                 content: content,
                 authorization: $"Bearer {authToken}",
-                xCorrelationId: Guid.NewGuid().ToString()
+                xCorrelationId: Guid.NewGuid().ToString(),
+                context: cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null
             ).ConfigureAwait(false);
             _logger?.LogInformation("Test run created successfully.");
         }

--- a/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClient.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClient.cs
@@ -348,7 +348,7 @@ public class PlaywrightServiceBrowserClient : IDisposable
                 content: content,
                 authorization: $"Bearer {authToken}",
                 xCorrelationId: Guid.NewGuid().ToString(),
-                context: cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null
+                context: new RequestContext { CancellationToken = cancellationToken }
             ).ConfigureAwait(false);
             _logger?.LogInformation("Test run created successfully.");
         }

--- a/sdk/monitor/Azure.Monitor.Ingestion/src/LogsIngestionClient.cs
+++ b/sdk/monitor/Azure.Monitor.Ingestion/src/LogsIngestionClient.cs
@@ -586,7 +586,7 @@ namespace Azure.Monitor.Ingestion
 
         private async Task<Response> UploadBatchListSyncOrAsync(BatchedLogs batch, string ruleId, string streamName, bool async, CancellationToken cancellationToken)
         {
-            using HttpMessage message = CreateUploadRequest(ruleId, streamName, batch.LogsData, Compression, null);
+            using HttpMessage message = CreateUploadRequest(ruleId, streamName, batch.LogsData, Compression, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
 
             if (async)
             {

--- a/sdk/monitor/Azure.Monitor.Ingestion/src/LogsIngestionClient.cs
+++ b/sdk/monitor/Azure.Monitor.Ingestion/src/LogsIngestionClient.cs
@@ -586,7 +586,7 @@ namespace Azure.Monitor.Ingestion
 
         private async Task<Response> UploadBatchListSyncOrAsync(BatchedLogs batch, string ruleId, string streamName, bool async, CancellationToken cancellationToken)
         {
-            using HttpMessage message = CreateUploadRequest(ruleId, streamName, batch.LogsData, Compression, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+            using HttpMessage message = CreateUploadRequest(ruleId, streamName, batch.LogsData, Compression, new RequestContext { CancellationToken = cancellationToken });
 
             if (async)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/Platform/EnvironmentVariableConstants.cs
@@ -17,6 +17,8 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
             APPLICATIONINSIGHTS_STATSBEAT_DISABLED,
             APPLICATIONINSIGHTS_SDKSTATS_DISABLED,
             APPLICATIONINSIGHTS_SDKSTATS_EXPORT_INTERVAL,
+            APPLICATIONINSIGHTS_CLOUD_ROLE_NAME,
+            APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE,
             FUNCTIONS_WORKER_RUNTIME,
             LOCALAPPDATA,
             TEMP,
@@ -140,5 +142,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform
         /// For microsoft.fixed_percentage sampler: sampling ratio (double from 0 to 1).
         /// </summary>
         public const string OTEL_TRACES_SAMPLER_ARG = "OTEL_TRACES_SAMPLER_ARG";
+
+        /// <summary>
+        /// Set by the Application Insights shim (TelemetryClient.Context.Cloud.RoleName) to override
+        /// the cloud role name after the OTel Resource has been built and is immutable.
+        /// </summary>
+        public const string APPLICATIONINSIGHTS_CLOUD_ROLE_NAME = "APPLICATIONINSIGHTS_CLOUD_ROLE_NAME";
+
+        /// <summary>
+        /// Set by the Application Insights shim (TelemetryClient.Context.Cloud.RoleInstance) to override
+        /// the cloud role instance after the OTel Resource has been built and is immutable.
+        /// </summary>
+        public const string APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE = "APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE";
     }
 }


### PR DESCRIPTION
## Description

Fixes missing CancellationToken propagation to RequestContext (AZC0020 analyzer rule) in 4 packages:

- **Azure.Security.KeyVault.Administration** — \UpdateSetting\/\UpdateSettingAsync\ in \KeyVaultSettingsClient.cs\
- **Azure.Developer.Playwright** — \CreateTestRunPatchCallAsync\ in \PlaywrightServiceBrowserClient.cs\
- **Azure.Monitor.Ingestion** — \UploadBatchListSyncOrAsync\ in \LogsIngestionClient.cs\
- **Azure.Compute.Batch** — \GetTaskFilePropertiesAsync\, \GetNodeFileProperties\ in \BatchClientCustom.cs\

All methods accept a \CancellationToken\ parameter but were not passing it through to the underlying \RequestContext\. This causes the AZC0020 analyzer to flag them as errors in CI builds.