### PR TITLE
Fix AZC0020: Propagate CancellationToken to RequestContext in 4 packages

### DIFF
--- a/sdk/batch/Azure.Compute.Batch/src/Custom/BatchClientCustom.cs
+++ b/sdk/batch/Azure.Compute.Batch/src/Custom/BatchClientCustom.cs
@@ -286,7 +286,7 @@ namespace Azure.Compute.Batch
             scope.Start();
             try
             {
-                Response response = await GetTaskFilePropertiesInternalAsync(jobId, taskId, filePath, timeOutInSeconds, ocpdate, null, null).ConfigureAwait(false);
+                Response response = await GetTaskFilePropertiesInternalAsync(jobId, taskId, filePath, timeOutInSeconds, ocpdate, null, new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)
@@ -335,7 +335,7 @@ namespace Azure.Compute.Batch
                     timeOutInSeconds,
                     ocpdate,
                     null,
-                    cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+                    new RequestContext { CancellationToken = cancellationToken });
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)
@@ -383,7 +383,7 @@ namespace Azure.Compute.Batch
                     timeOutInSeconds,
                     ocpdate,
                     null,
-                    cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
+                    new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)
@@ -424,7 +424,7 @@ namespace Azure.Compute.Batch
             scope.Start();
             try
             {
-                Response response = GetNodeFilePropertiesInternal(poolId, nodeId, filePath, timeOutInSeconds, ocpdate, null, null);
+                Response response = GetNodeFilePropertiesInternal(poolId, nodeId, filePath, timeOutInSeconds, ocpdate, null, new RequestContext { CancellationToken = cancellationToken });
                 return Response.FromValue(BatchFileProperties.FromResponse(response), response);
             }
             catch (Exception e)
@@ -465,7 +465,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(pool, nameof(pool));
 
             using RequestContent content = pool;
-            Response response = await UpdatePoolAsync(poolId, pool, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
+            Response response = await UpdatePoolAsync(poolId, pool, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
             return response;
         }
 
@@ -500,7 +500,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(pool, nameof(pool));
 
             using RequestContent content = pool;
-            Response response = UpdatePool(poolId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+            Response response = UpdatePool(poolId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken });
             return response;
         }
 
@@ -535,7 +535,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(job, nameof(job));
 
             using RequestContent content = job;
-            Response response = await UpdateJobAsync(jobId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
+            Response response = await UpdateJobAsync(jobId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
             return response;
         }
 
@@ -570,7 +570,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(job, nameof(job));
 
             using RequestContent content = job;
-            Response response = UpdateJob(jobId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+            Response response = UpdateJob(jobId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken });
             return response;
         }
 
@@ -605,7 +605,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(jobSchedule, nameof(jobSchedule));
 
             using RequestContent content = jobSchedule;
-            Response response = await UpdateJobScheduleAsync(jobScheduleId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null).ConfigureAwait(false);
+            Response response = await UpdateJobScheduleAsync(jobScheduleId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
             return response;
         }
 
@@ -640,7 +640,7 @@ namespace Azure.Compute.Batch
             Argument.AssertNotNull(jobSchedule, nameof(jobSchedule));
 
             using RequestContent content = jobSchedule;
-            Response response = UpdateJobSchedule(jobScheduleId, content, timeOutInSeconds, ocpdate, requestConditions, cancellationToken.CanBeCanceled ? new RequestContext { CancellationToken = cancellationToken } : null);
+            Response response = UpdateJobSchedule(jobScheduleId, content, timeOutInSeconds, ocpdate, requestConditions, new RequestContext { CancellationToken = cancellationToken });
             return response;
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultSettingsClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Administration/src/KeyVaultSettingsClient.cs
@@ -170,7 +170,7 @@ namespace Azure.Security.KeyVault.Administration
             scope.Start();
             try
             {
-                Response response = _restClient.UpdateSetting(setting.Name, setting.ToRequestContent());
+                Response response = _restClient.UpdateSetting(setting.Name, setting.ToRequestContent(), new RequestContext { CancellationToken = cancellationToken });
 
                 KeyVaultSetting updatedSetting = default;
                 using var document = JsonDocument.Parse(response.ContentStream, default);
@@ -200,7 +200,7 @@ namespace Azure.Security.KeyVault.Administration
             scope.Start();
             try
             {
-                Response response = await _restClient.UpdateSettingAsync(setting.Name, setting.ToRequestContent()).ConfigureAwait(false);
+                Response response = await _restClient.UpdateSettingAsync(setting.Name, setting.ToRequestContent(), new RequestContext { CancellationToken = cancellationToken }).ConfigureAwait(false);
 
                 KeyVaultSetting updatedSetting = default;
                 using var document = await JsonDocument.ParseAsync(response.ContentStream, default).ConfigureAwait(false);

--- a/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClient.cs
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/src/PlaywrightServiceBrowserClient.cs
@@ -347,7 +347,8 @@ public class PlaywrightServiceBrowserClient : IDisposable
                 testRunId: testRunId,
                 content: content,
                 authorization: $"Bearer {authToken}",
-                xCorrelationId: Guid.NewGuid().ToString()
+                xCorrelationId: Guid.NewGuid().ToString(),
+                context: new RequestContext { CancellationToken = cancellationToken }
             ).ConfigureAwait(false);
             _logger?.LogInformation("Test run created successfully.");
         }

--- a/sdk/monitor/Azure.Monitor.Ingestion/src/LogsIngestionClient.cs
+++ b/sdk/monitor/Azure.Monitor.Ingestion/src/LogsIngestionClient.cs
@@ -586,7 +586,7 @@ namespace Azure.Monitor.Ingestion
 
         private async Task<Response> UploadBatchListSyncOrAsync(BatchedLogs batch, string ruleId, string streamName, bool async, CancellationToken cancellationToken)
         {
-            using HttpMessage message = CreateUploadRequest(ruleId, streamName, batch.LogsData, Compression, null);
+            using HttpMessage message = CreateUploadRequest(ruleId, streamName, batch.LogsData, Compression, new RequestContext { CancellationToken = cancellationToken });
 
             if (async)
             {


### PR DESCRIPTION
## Description

Fix AZC0020 analyzer errors by replacing ternary conditional patterns and null arguments with direct \
ew RequestContext { CancellationToken = cancellationToken }\ creation. The new AZC0020 analyzer (PR #56230) doesn't recognize the ternary pattern \cancellationToken.CanBeCanceled ? new RequestContext { ... } : null\.

### Packages fixed:
- **Azure.Compute.Batch** — 10 methods in \BatchClientCustom.cs\ (GetTaskFileProperties/Async, GetNodeFileProperties/Async, UpdatePool/Async, UpdateJob/Async, UpdateJobSchedule/Async)
- **Azure.Security.KeyVault.Administration** — \UpdateSetting\/\UpdateSettingAsync\ in \KeyVaultSettingsClient.cs\
- **Azure.Developer.Playwright** — \CreateTestRunPatchCallAsync\ in \PlaywrightServiceBrowserClient.cs\
- **Azure.Monitor.Ingestion** — \UploadBatchListSyncOrAsync\ in \LogsIngestionClient.cs\

All changes verified locally with \/p:UseProjectReferenceToAzureClients=true\ to exercise the project-referenced analyzer.