### PR TITLE
Add Copilot skill for Azure.Provisioning library regeneration

### DIFF
--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: provisioning-library-regeneration
+description: Regenerate Azure.Provisioning.* libraries when the underlying Azure.ResourceManager.* management library is updated. Use when adding new features (e.g., new enum values, API versions) to provisioning libraries.
+---
+
+# Provisioning Library Regeneration
+
+This skill guides the process of regenerating `Azure.Provisioning.*` libraries when the underlying `Azure.ResourceManager.*` management library is updated. This is typically needed when:
+
+- New enum values are added (e.g., new PostgreSQL server versions)
+- New API versions bring new properties or types
+- The management library has a new release with features needed in provisioning
+
+## Summary of the Process
+
+The provisioning libraries (`sdk/provisioning/Azure.Provisioning.*`) are generated from the management libraries (`sdk/*/Azure.ResourceManager.*`). When a management library is updated, you need to:
+
+1. Update the management library version in `eng/Packages.Data.props`
+2. Run the provisioning generator
+3. Handle any breaking changes via backward-compatible customizations
+4. Fix any spell check, API compatibility, or CI issues
+5. Run pre-commit checks
+
+## Prerequisites
+
+- .NET 10 SDK installed
+- PowerShell 7+ installed
+- The management library update must already be published to NuGet (or the version must be available in `eng/Packages.Data.props`)
+
+## Step 1: Update Management Library Version
+
+Edit `eng/Packages.Data.props` to update the management library version:
+
+```xml
+<PackageReference Update="Azure.ResourceManager.{ServiceName}" Version="{NewVersion}" />
+```
+
+For example, to update PostgreSql from 1.3.1 to 1.4.1:
+```xml
+<PackageReference Update="Azure.ResourceManager.PostgreSql" Version="1.4.1" />
+```
+
+## Step 2: Run the Provisioning Generator
+
+Navigate to the generator directory and run:
+
+```shell
+cd sdk/provisioning/Generator/src
+dotnet run --framework net10.0 -- --filter {ServiceName}
+```
+
+For example:
+```shell
+dotnet run --framework net10.0 -- --filter PostgreSql
+```
+
+**Important:** The generator reads from NuGet packages, NOT local source code. The version in `eng/Packages.Data.props` determines which package version is used.
+
+### Generator Errors
+
+If you encounter errors:
+
+1. **CS0618 (Obsolete type)**: Add `#pragma warning disable CS0618` at the top of the specification file (`sdk/provisioning/Generator/src/Specifications/{ServiceName}Specification.cs`)
+
+2. **Schema tree conflict**: If you see "already has a property at path" errors, this may require a fix in `sdk/provisioning/Generator/src/Model/Specification.Schema.cs` to handle leaf-vs-container conflicts
+
+## Step 3: Handle Breaking Changes
+
+Compare the generated code with the previous version. Common breaking changes include:
+
+### Type Removed
+If a type is removed from the management library:
+- Create a backward-compatible stub in `sdk/provisioning/Azure.Provisioning.{Service}/src/BackwardCompatible/Models/`
+- Mark it with `[EditorBrowsable(EditorBrowsableState.Never)]` and `[Obsolete]`
+
+### Property Type Changed
+If a property type changes:
+1. In the specification file, use `CustomizeProperty` to rename the new property:
+   ```csharp
+   CustomizeProperty("ResourceName", "PropertyName", p => p.PropertyName = "NewPropertyName");
+   ```
+2. Use `CustomizeResource` with `GeneratePartialPropertyDefinition = true`:
+   ```csharp
+   CustomizeResource("ResourceName", r => r.GeneratePartialPropertyDefinition = true);
+   ```
+3. Create a partial class in `BackwardCompatible/` that implements `DefineAdditionalProperties()` to add the old property name
+
+### Enum Ordinal Shift
+If enum member ordering changes (affecting implicit numeric values):
+- Use `OrderEnum<T>()` in the specification file to preserve the original ordering:
+  ```csharp
+  OrderEnum<PostgreSqlFlexibleServerVersion>("Ver15", "Ver14", "Ver13", "Ver12", "Ver11", "Sixteen");
+  ```
+
+### DataMember Attribute Removed
+If `[DataMember]` attributes are removed from enums:
+- Create `ApiCompatBaseline.txt` in the package's `src/` directory to suppress the compatibility errors:
+  ```
+  CP0002:M:Azure.Provisioning.{Service}.{EnumType}.{Member}.get->System.Runtime.Serialization.DataMemberAttribute
+  ```
+
+## Step 4: Fix Spell Check Issues
+
+If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspell.yaml`:
+
+```yaml
+  - filename: '**/sdk/provisioning/Azure.Provisioning.{Service}/**/*.cs'
+    words:
+      - newword1
+      - newword2
+```
+
+**Important:** Use `sdk/provisioning/cspell.yaml`, NOT `.vscode/cspell.json`.
+
+## Step 5: Fix README Issues
+
+If CI fails with "No beta installation instructions found":
+- Ensure the README has `--prerelease` flag if the package has a beta changelog entry:
+  ```
+  dotnet add package Azure.Provisioning.{Service} --prerelease
+  ```
+
+## Step 6: Run Pre-Commit Checks
+
+Before committing, run:
+
+```shell
+pwsh eng\scripts\CodeChecks.ps1 -ServiceDirectory provisioning
+```
+
+This runs:
+- Code generation verification
+- API export
+- Snippet updates
+- Spell check
+- Installation instruction validation
+
+All checks must pass with 0 errors.
+
+## Step 7: Export API and Update Snippets
+
+```shell
+pwsh eng\scripts\Export-API.ps1 provisioning
+pwsh eng\scripts\Update-Snippets.ps1 provisioning
+```
+
+## Step 8: Commit and Push
+
+Stage all changes and commit with a descriptive message:
+
+```shell
+git add -A
+git commit -m "Regenerate Azure.Provisioning.{Service} from updated management library"
+```
+
+## Example: PostgreSQL Server Versions 17 and 18
+
+Here's what was done to add PostgreSQL versions 17 and 18:
+
+1. **Updated `eng/Packages.Data.props`**: Changed `Azure.ResourceManager.PostgreSql` from 1.3.1 to 1.4.1
+
+2. **Ran generator**: `dotnet run --framework net10.0 -- --filter PostgreSql`
+
+3. **Fixed generator issues**:
+   - Added `#pragma warning disable CS0618` for obsolete `ActiveDirectoryAdministratorResource`
+   - Fixed schema tree conflict in `Specification.Schema.cs`
+
+4. **Handled breaking changes**:
+   - Renamed `PrivateEndpointConnections` property via `CustomizeProperty`
+   - Created backward-compatible old property via `DefineAdditionalProperties()`
+   - Created obsolete stub for removed `PostgreSqlFlexibleServersPrivateEndpointConnectionData` type
+   - Used `OrderEnum<PostgreSqlFlexibleServerVersion>()` to preserve enum ordinal values
+   - Created `ApiCompatBaseline.txt` to suppress DataMember removal errors
+
+5. **Fixed CI issues**:
+   - Added "apsara", "dbrds", "ssdlrs" to `sdk/provisioning/cspell.yaml`
+   - Fixed Kusto README missing `--prerelease` flag
+
+6. **Ran pre-commit checks**: `pwsh eng\scripts\CodeChecks.ps1 -ServiceDirectory provisioning`
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `eng/Packages.Data.props` | Management library version |
+| `sdk/provisioning/Generator/src/Specifications/{Service}Specification.cs` | Generator customizations |
+| `sdk/provisioning/Generator/src/Model/Specification.Schema.cs` | Schema tree builder |
+| `sdk/provisioning/Generator/src/Model/Specification.Customize.cs` | Customization API (`OrderEnum`, `CustomizeResource`, etc.) |
+| `sdk/provisioning/Azure.Provisioning.{Service}/src/BackwardCompatible/` | Backward-compatible customizations |
+| `sdk/provisioning/Azure.Provisioning.{Service}/src/ApiCompatBaseline.txt` | API compatibility suppressions |
+| `sdk/provisioning/cspell.yaml` | Spell check configuration |
+
+## Troubleshooting
+
+### Generator fails to find types
+- Ensure the management library version in `eng/Packages.Data.props` is correct and published
+- Try running `dotnet restore` before the generator
+
+### API compatibility errors
+- Use `ApiCompatBaseline.txt` to suppress expected breaking changes
+- Or create backward-compatible stubs/properties
+
+### Enum values in wrong order
+- Use `OrderEnum<T>()` in the specification file to control ordering
+
+### Build fails after regeneration
+- Check for missing using statements
+- Check for type name conflicts
+- Review the specification customizations

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -58,11 +58,13 @@ dotnet run --framework net10.0 -- --filter PostgreSql
 
 ### Generator Errors
 
-If you encounter errors:
+If the generator fails with errors:
 
-1. **CS0618 (Obsolete type)**: Add `#pragma warning disable CS0618` at the top of the specification file (`sdk/provisioning/Generator/src/Specifications/{ServiceName}Specification.cs`)
+1. **Capture the full error output** including stack traces and error messages
+2. **Report the error to the user** with enough context to understand what went wrong
+3. **Stop and let the user decide** how to proceed — generator errors often require code changes to the generator itself or the specification files, which may need human judgment
 
-2. **Schema tree conflict**: If you see "already has a property at path" errors, this may require a fix in `sdk/provisioning/Generator/src/Model/Specification.Schema.cs` to handle leaf-vs-container conflicts
+Do NOT attempt to automatically fix generator errors without user guidance.
 
 ## Step 3: Handle Breaking Changes
 

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -66,6 +66,23 @@ dotnet run --framework net10.0 -- --filter {ServiceName}
 
 **Important:** The generator reads from NuGet packages, NOT local source code. The version in `eng/Packages.Data.props` determines which package version is used.
 
+### Verify Only Target Library Changed
+
+After running the generator, verify that only the target provisioning library was modified:
+
+```shell
+git status --short -- sdk/provisioning/
+```
+
+The generator may regenerate other libraries (e.g., `Azure.Provisioning`) due to shared dependencies. **Revert any changes to libraries other than the target:**
+
+```shell
+# Example: If you're adding features to Azure.Provisioning.Network, revert changes to Azure.Provisioning
+git checkout main -- sdk/provisioning/Azure.Provisioning/
+```
+
+Only keep changes to `Azure.Provisioning.{TargetService}/`.
+
 ### Generator Errors
 
 If the generator fails with errors:

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -199,19 +199,16 @@ CP0002:M:Azure.Provisioning.{Service}.{EnumType}.{Member}.get->System.Runtime.Se
 
 ## Step 6: Fix Spell Check Issues
 
-If CI fails with "Unknown word" errors, add the words to `.vscode/cspell.json` in the `words` array:
+If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspell.yaml`:
 
-```json
-{
-  "words": [
-    "existingword",
-    "newword1",
-    "newword2"
-  ]
-}
+```yaml
+  - filename: '**/sdk/provisioning/Azure.Provisioning.{Service}/**/*.cs'
+    words:
+      - newword1
+      - newword2
 ```
 
-Alternatively, if there's a service-specific override in `sdk/provisioning/cspell.yaml`, you can add words there for the specific package.
+**Important:** Use `sdk/provisioning/cspell.yaml`, NOT `.vscode/cspell.json`.
 
 ## Step 7: Export API and Update Snippets
 
@@ -291,7 +288,7 @@ The requirement was to add NetworkSecurityPerimeter support. The resources alrea
 | `sdk/provisioning/Generator/src/Model/Specification.Customize.cs` | Customization API (`OrderEnum`, `CustomizeResource`, etc.) |
 | `sdk/provisioning/Azure.Provisioning.{Service}/src/BackwardCompatible/` | Backward-compatible customizations |
 | `sdk/provisioning/Azure.Provisioning.{Service}/src/ApiCompatBaseline.txt` | API compatibility suppressions (provisioning only) |
-| `.vscode/cspell.json` | Spell check configuration (CI uses this) |
+| `sdk/provisioning/cspell.yaml` | Spell check configuration for provisioning |
 
 ## Troubleshooting
 

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -172,7 +172,7 @@ If a type is removed from the management library:
 If a property type changes:
 1. In the specification file, use `CustomizeProperty` to rename the new property:
    ```csharp
-   CustomizeProperty("ResourceName", "PropertyName", p => p.PropertyName = "NewPropertyName");
+   CustomizeProperty("ResourceName", "PropertyName", p => p.Name = "NewPropertyName");
    ```
 2. Use `CustomizeResource` with `GeneratePartialPropertyDefinition = true`:
    ```csharp
@@ -188,24 +188,29 @@ If enum member ordering changes (affecting implicit numeric values):
   ```
 
 ### DataMember Attribute Removed
-If `[DataMember]` attributes are removed from enums:
-- Create `ApiCompatBaseline.txt` in the package's `src/` directory to suppress the compatibility errors:
-  ```
-  CP0002:M:Azure.Provisioning.{Service}.{EnumType}.{Member}.get->System.Runtime.Serialization.DataMemberAttribute
-  ```
+If `[DataMember]` attributes are removed from enums, ApiCompat will report `CP0002` errors.
+
+To resolve these errors:
+- Prefer restoring `[DataMember]` attributes on the affected enum members to preserve backward compatibility.
+- If the removal is an intentional breaking change, follow the normal breaking-change review and versioning process for the package.
+
+> Note: The specific suppression mechanism may vary. Check if the package supports `ApiCompatBaseline.txt` or similar baseline files, or consult with the team for the appropriate approach.
 
 ## Step 6: Fix Spell Check Issues
 
-If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspell.yaml`:
+If CI fails with "Unknown word" errors, add the words to `.vscode/cspell.json` in the `words` array:
 
-```yaml
-  - filename: '**/sdk/provisioning/Azure.Provisioning.{Service}/**/*.cs'
-    words:
-      - newword1
-      - newword2
+```json
+{
+  "words": [
+    "existingword",
+    "newword1",
+    "newword2"
+  ]
+}
 ```
 
-**Important:** Use `sdk/provisioning/cspell.yaml`, NOT `.vscode/cspell.json`.
+Alternatively, if there's a service-specific override in `sdk/provisioning/cspell.yaml`, you can add words there for the specific package.
 
 ## Step 7: Export API and Update Snippets
 
@@ -226,7 +231,6 @@ This runs:
 - Code generation verification
 - API export
 - Snippet updates
-- Spell check
 - Installation instruction validation
 
 All checks must pass with 0 errors.
@@ -285,8 +289,7 @@ The requirement was to add NetworkSecurityPerimeter support. The resources alrea
 | `sdk/provisioning/Generator/src/Specifications/{Service}Specification.cs` | Generator customizations and resource whitelist |
 | `sdk/provisioning/Generator/src/Model/Specification.Customize.cs` | Customization API (`OrderEnum`, `CustomizeResource`, etc.) |
 | `sdk/provisioning/Azure.Provisioning.{Service}/src/BackwardCompatible/` | Backward-compatible customizations |
-| `sdk/provisioning/Azure.Provisioning.{Service}/src/ApiCompatBaseline.txt` | API compatibility suppressions |
-| `sdk/provisioning/cspell.yaml` | Spell check configuration |
+| `.vscode/cspell.json` | Spell check configuration (CI uses this) |
 
 ## Troubleshooting
 
@@ -300,7 +303,7 @@ The requirement was to add NetworkSecurityPerimeter support. The resources alrea
 - Try running `dotnet restore` before the generator
 
 ### API compatibility errors
-- Use `ApiCompatBaseline.txt` to suppress expected breaking changes
+- Prefer restoring removed attributes to maintain backward compatibility
 - Or create backward-compatible stubs/properties
 
 ### Enum values in wrong order

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -190,11 +190,12 @@ If enum member ordering changes (affecting implicit numeric values):
 ### DataMember Attribute Removed
 If `[DataMember]` attributes are removed from enums, ApiCompat will report `CP0002` errors.
 
-To resolve these errors:
-- Prefer restoring `[DataMember]` attributes on the affected enum members to preserve backward compatibility.
-- If the removal is an intentional breaking change, follow the normal breaking-change review and versioning process for the package.
+For provisioning packages, create `ApiCompatBaseline.txt` in the package's `src/` directory to suppress the compatibility errors:
+```
+CP0002:M:Azure.Provisioning.{Service}.{EnumType}.{Member}.get->System.Runtime.Serialization.DataMemberAttribute
+```
 
-> Note: The specific suppression mechanism may vary. Check if the package supports `ApiCompatBaseline.txt` or similar baseline files, or consult with the team for the appropriate approach.
+> Note: This baseline file approach is specifically supported for provisioning packages and is the only option for suppressing these particular ApiCompat errors.
 
 ## Step 6: Fix Spell Check Issues
 
@@ -289,6 +290,7 @@ The requirement was to add NetworkSecurityPerimeter support. The resources alrea
 | `sdk/provisioning/Generator/src/Specifications/{Service}Specification.cs` | Generator customizations and resource whitelist |
 | `sdk/provisioning/Generator/src/Model/Specification.Customize.cs` | Customization API (`OrderEnum`, `CustomizeResource`, etc.) |
 | `sdk/provisioning/Azure.Provisioning.{Service}/src/BackwardCompatible/` | Backward-compatible customizations |
+| `sdk/provisioning/Azure.Provisioning.{Service}/src/ApiCompatBaseline.txt` | API compatibility suppressions (provisioning only) |
 | `.vscode/cspell.json` | Spell check configuration (CI uses this) |
 
 ## Troubleshooting
@@ -303,7 +305,7 @@ The requirement was to add NetworkSecurityPerimeter support. The resources alrea
 - Try running `dotnet restore` before the generator
 
 ### API compatibility errors
-- Prefer restoring removed attributes to maintain backward compatibility
+- Use `ApiCompatBaseline.txt` to suppress expected breaking changes (provisioning packages only)
 - Or create backward-compatible stubs/properties
 
 ### Enum values in wrong order

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -76,7 +76,73 @@ If the generator fails with errors:
 
 Do NOT attempt to automatically fix generator errors without user guidance.
 
-## Step 4: Handle Breaking Changes (Version Updates Only)
+## Step 4: Validate Generated Schema Against Bicep Reference
+
+After the generator runs successfully, validate the generated resources against the official Azure Bicep documentation.
+
+### Locate the Schema Log
+
+The generator produces a `schema.log` file that contains the generated resource schemas:
+
+```
+sdk/provisioning/Azure.Provisioning.{Service}/src/Generated/schema.log
+```
+
+Each resource entry looks like:
+```
+resource NetworkSecurityPerimeter "Microsoft.Network/networkSecurityPerimeters@2025-05-01" = {
+  name: 'string'
+  location: 'string'
+  ...
+}
+```
+
+### Construct Bicep Reference URLs
+
+For each new resource type in the schema.log, construct the documentation URL:
+
+```
+https://learn.microsoft.com/en-us/azure/templates/{provider}/{resource-type}?pivots=deployment-language-bicep
+```
+
+**URL Construction Rules:**
+- Convert the resource type from the schema to lowercase
+- Use the provider and resource path from the `@` prefix (e.g., `Microsoft.Network/networkSecurityPerimeters`)
+
+**Examples:**
+| Schema Resource Type | Documentation URL |
+|---------------------|-------------------|
+| `Microsoft.Network/networkSecurityPerimeters` | `https://learn.microsoft.com/en-us/azure/templates/microsoft.network/networksecurityperimeters?pivots=deployment-language-bicep` |
+| `Microsoft.Network/networkSecurityPerimeters/profiles` | `https://learn.microsoft.com/en-us/azure/templates/microsoft.network/networksecurityperimeters/profiles?pivots=deployment-language-bicep` |
+| `Microsoft.DBforPostgreSQL/flexibleServers` | `https://learn.microsoft.com/en-us/azure/templates/microsoft.dbforpostgresql/flexibleservers?pivots=deployment-language-bicep` |
+
+### Compare and Validate
+
+For each new resource:
+1. **Fetch the Bicep reference** from the constructed URL
+2. **Compare property names** between schema.log and the Bicep reference
+3. **Check for**:
+   - **Incorrect property names**: Properties in schema.log that don't match the Bicep reference
+   - **Missing properties**: Properties in the Bicep reference that are not in schema.log
+   - **Extra writable properties**: Properties that are NOT marked `readonly` in schema.log but do NOT exist in the Bicep reference — these are potential issues since users could try to set properties that the service doesn't accept
+   - **Type mismatches**: Properties with different types
+
+**Note on readonly properties**: Properties marked `readonly` in schema.log (e.g., `provisioningState: readonly 'string'`) are output-only and don't need to match the Bicep reference for input validation.
+
+### If Discrepancies Are Found
+
+1. **Report the discrepancies** to the user with:
+   - Which resource type has issues
+   - Which properties are incorrect/missing
+   - Links to the Bicep reference
+2. **Stop and let the user decide** how to proceed — discrepancies may indicate:
+   - Issues with the management library
+   - Need for specification customizations
+   - Documentation being out of sync (less common)
+
+Do NOT attempt to automatically fix schema discrepancies without user guidance.
+
+## Step 5: Handle Breaking Changes (Version Updates Only)
 
 When updating management library versions, compare the generated code with the previous version. Common breaking changes include:
 
@@ -111,7 +177,7 @@ If `[DataMember]` attributes are removed from enums:
   CP0002:M:Azure.Provisioning.{Service}.{EnumType}.{Member}.get->System.Runtime.Serialization.DataMemberAttribute
   ```
 
-## Step 5: Fix Spell Check Issues
+## Step 6: Fix Spell Check Issues
 
 If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspell.yaml`:
 
@@ -124,14 +190,14 @@ If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspel
 
 **Important:** Use `sdk/provisioning/cspell.yaml`, NOT `.vscode/cspell.json`.
 
-## Step 6: Export API and Update Snippets
+## Step 7: Export API and Update Snippets
 
 ```shell
 pwsh eng\scripts\Export-API.ps1 provisioning
 pwsh eng\scripts\Update-Snippets.ps1 provisioning
 ```
 
-## Step 7: Run Pre-Commit Checks
+## Step 8: Run Pre-Commit Checks
 
 Before committing, run:
 
@@ -148,7 +214,7 @@ This runs:
 
 All checks must pass with 0 errors.
 
-## Step 8: Update CHANGELOG and Commit
+## Step 9: Update CHANGELOG and Commit
 
 1. Update the CHANGELOG at `sdk/provisioning/Azure.Provisioning.{Service}/CHANGELOG.md`:
    ```markdown

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -114,15 +114,7 @@ If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspel
 
 **Important:** Use `sdk/provisioning/cspell.yaml`, NOT `.vscode/cspell.json`.
 
-## Step 5: Fix README Issues
-
-If CI fails with "No beta installation instructions found":
-- Ensure the README has `--prerelease` flag if the package has a beta changelog entry:
-  ```
-  dotnet add package Azure.Provisioning.{Service} --prerelease
-  ```
-
-## Step 6: Run Pre-Commit Checks
+## Step 5: Run Pre-Commit Checks
 
 Before committing, run:
 
@@ -139,14 +131,14 @@ This runs:
 
 All checks must pass with 0 errors.
 
-## Step 7: Export API and Update Snippets
+## Step 6: Export API and Update Snippets
 
 ```shell
 pwsh eng\scripts\Export-API.ps1 provisioning
 pwsh eng\scripts\Update-Snippets.ps1 provisioning
 ```
 
-## Step 8: Commit and Push
+## Step 7: Commit and Push
 
 Stage all changes and commit with a descriptive message:
 

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -1,33 +1,33 @@
 ---
 name: provisioning-library-regeneration
-description: Regenerate Azure.Provisioning.* libraries when the underlying Azure.ResourceManager.* management library is updated. Use when adding new features (e.g., new enum values, API versions) to provisioning libraries.
+description: Regenerate Azure.Provisioning.* libraries to add new resources or features. Use when adding new resource types, enum values, or API versions to provisioning libraries.
 ---
 
 # Provisioning Library Regeneration
 
-This skill guides the process of regenerating `Azure.Provisioning.*` libraries when the underlying `Azure.ResourceManager.*` management library is updated. This is typically needed when:
+This skill guides the process of regenerating `Azure.Provisioning.*` libraries to add new resources or features. This is typically needed when:
 
+- New resource types need to be added to provisioning (e.g., NetworkSecurityPerimeter)
 - New enum values are added (e.g., new PostgreSQL server versions)
 - New API versions bring new properties or types
 - The management library has a new release with features needed in provisioning
 
-## Summary of the Process
+## Step 1: Determine If Management Library Version Update Is Needed
 
-The provisioning libraries (`sdk/provisioning/Azure.Provisioning.*`) are generated from the management libraries (`sdk/*/Azure.ResourceManager.*`). When a management library is updated, you need to:
+**Key principle**: Only update the management library version if explicitly requested or if the feature doesn't exist in the current version. Prefer not updating to reduce the amount of changes.
 
-1. Update the management library version in `eng/Packages.Data.props`
-2. Run the provisioning generator
-3. Handle any breaking changes via backward-compatible customizations
-4. Fix any spell check, API compatibility, or CI issues
-5. Run pre-commit checks
+1. **If the requirement explicitly says "update the version"** → Update the version (proceed to Step 2A)
 
-## Prerequisites
+2. **If the requirement does NOT explicitly request a version update**:
+   - Check if the feature already exists in the current management library:
+     ```shell
+     # Search for the resource/feature in the management library
+     grep -r "NetworkSecurityPerimeterResource" sdk/{service}/Azure.ResourceManager.{Service}/
+     ```
+   - If the feature exists → Skip version update, proceed to Step 2B
+   - If the feature doesn't exist → You'll need to update the version (proceed to Step 2A)
 
-- .NET 10 SDK installed
-- PowerShell 7+ installed
-- The management library update must already be published to NuGet (or the version must be available in `eng/Packages.Data.props`)
-
-## Step 1: Update Management Library Version
+## Step 2A: Update Management Library Version (If Needed)
 
 Edit `eng/Packages.Data.props` to update the management library version:
 
@@ -35,23 +35,33 @@ Edit `eng/Packages.Data.props` to update the management library version:
 <PackageReference Update="Azure.ResourceManager.{ServiceName}" Version="{NewVersion}" />
 ```
 
-For example, to update PostgreSql from 1.3.1 to 1.4.1:
-```xml
-<PackageReference Update="Azure.ResourceManager.PostgreSql" Version="1.4.1" />
+## Step 2B: Check for Resource Whitelist (If Applicable)
+
+Some specifications (like Network) use a whitelist to limit which resources are generated. Check the specification file:
+
+```shell
+cat sdk/provisioning/Generator/src/Specifications/{Service}Specification.cs
 ```
 
-## Step 2: Run the Provisioning Generator
+If you see a `_generatedResources` HashSet, add the new resource types to it:
+
+```csharp
+private readonly HashSet<Type> _generatedResources = new()
+{
+    // ... existing resources ...
+    typeof(NetworkSecurityPerimeterResource),
+    typeof(NetworkSecurityPerimeterAccessRuleResource),
+    // ... add all related resource types ...
+};
+```
+
+## Step 3: Run the Provisioning Generator
 
 Navigate to the generator directory and run:
 
 ```shell
 cd sdk/provisioning/Generator/src
 dotnet run --framework net10.0 -- --filter {ServiceName}
-```
-
-For example:
-```shell
-dotnet run --framework net10.0 -- --filter PostgreSql
 ```
 
 **Important:** The generator reads from NuGet packages, NOT local source code. The version in `eng/Packages.Data.props` determines which package version is used.
@@ -66,9 +76,9 @@ If the generator fails with errors:
 
 Do NOT attempt to automatically fix generator errors without user guidance.
 
-## Step 3: Handle Breaking Changes
+## Step 4: Handle Breaking Changes (Version Updates Only)
 
-Compare the generated code with the previous version. Common breaking changes include:
+When updating management library versions, compare the generated code with the previous version. Common breaking changes include:
 
 ### Type Removed
 If a type is removed from the management library:
@@ -101,7 +111,7 @@ If `[DataMember]` attributes are removed from enums:
   CP0002:M:Azure.Provisioning.{Service}.{EnumType}.{Member}.get->System.Runtime.Serialization.DataMemberAttribute
   ```
 
-## Step 4: Fix Spell Check Issues
+## Step 5: Fix Spell Check Issues
 
 If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspell.yaml`:
 
@@ -114,14 +124,14 @@ If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspel
 
 **Important:** Use `sdk/provisioning/cspell.yaml`, NOT `.vscode/cspell.json`.
 
-## Step 5: Export API and Update Snippets
+## Step 6: Export API and Update Snippets
 
 ```shell
 pwsh eng\scripts\Export-API.ps1 provisioning
 pwsh eng\scripts\Update-Snippets.ps1 provisioning
 ```
 
-## Step 6: Run Pre-Commit Checks
+## Step 7: Run Pre-Commit Checks
 
 Before committing, run:
 
@@ -138,53 +148,69 @@ This runs:
 
 All checks must pass with 0 errors.
 
-## Step 7: Commit and Push
+## Step 8: Update CHANGELOG and Commit
 
-Stage all changes and commit with a descriptive message:
+1. Update the CHANGELOG at `sdk/provisioning/Azure.Provisioning.{Service}/CHANGELOG.md`:
+   ```markdown
+   ## X.X.X-beta.X (Unreleased)
 
-```shell
-git add -A
-git commit -m "Regenerate Azure.Provisioning.{Service} from updated management library"
-```
+   ### Features Added
 
-## Example: PostgreSQL Server Versions 17 and 18
+   - Added support for `{NewResource}` resources and related types.
+   ```
 
-Here's what was done to add PostgreSQL versions 17 and 18:
+2. Stage all changes and commit:
+   ```shell
+   git add -A
+   git commit -m "Add {Feature} to Azure.Provisioning.{Service}"
+   ```
+
+## Example A: PostgreSQL Server Versions 17 and 18 (Version Update Required)
+
+The requirement was to add PostgreSQL versions 17 and 18, which required updating the management library.
 
 1. **Updated `eng/Packages.Data.props`**: Changed `Azure.ResourceManager.PostgreSql` from 1.3.1 to 1.4.1
-
 2. **Ran generator**: `dotnet run --framework net10.0 -- --filter PostgreSql`
+3. **Handled breaking changes**: Property renames, obsolete stubs, enum ordering, ApiCompatBaseline
+4. **Fixed CI issues**: Added spell check words to `cspell.yaml`
+5. **Ran pre-commit checks**: `pwsh eng\scripts\CodeChecks.ps1 -ServiceDirectory provisioning`
 
-3. **Fixed generator issues**:
-   - Added `#pragma warning disable CS0618` for obsolete `ActiveDirectoryAdministratorResource`
-   - Fixed schema tree conflict in `Specification.Schema.cs`
+## Example B: NetworkSecurityPerimeter Resources (No Version Update Needed)
 
-4. **Handled breaking changes**:
-   - Renamed `PrivateEndpointConnections` property via `CustomizeProperty`
-   - Created backward-compatible old property via `DefineAdditionalProperties()`
-   - Created obsolete stub for removed `PostgreSqlFlexibleServersPrivateEndpointConnectionData` type
-   - Used `OrderEnum<PostgreSqlFlexibleServerVersion>()` to preserve enum ordinal values
-   - Created `ApiCompatBaseline.txt` to suppress DataMember removal errors
+The requirement was to add NetworkSecurityPerimeter support. The resources already existed in the current management library but weren't being generated due to a whitelist.
 
-5. **Fixed CI issues**:
-   - Added "apsara", "dbrds", "ssdlrs" to `sdk/provisioning/cspell.yaml`
-   - Fixed Kusto README missing `--prerelease` flag
-
-6. **Ran pre-commit checks**: `pwsh eng\scripts\CodeChecks.ps1 -ServiceDirectory provisioning`
+1. **Checked management library**: Resources already existed in `Azure.ResourceManager.Network`
+2. **Updated `NetworkSpecification.cs`**: Added 7 resource types to `_generatedResources`:
+   ```csharp
+   typeof(NetworkSecurityPerimeterResource),
+   typeof(NetworkSecurityPerimeterAccessRuleResource),
+   typeof(NetworkSecurityPerimeterAssociationResource),
+   typeof(NetworkSecurityPerimeterLinkResource),
+   typeof(NetworkSecurityPerimeterLinkReferenceResource),
+   typeof(NetworkSecurityPerimeterLoggingConfigurationResource),
+   typeof(NetworkSecurityPerimeterProfileResource),
+   ```
+3. **Ran generator**: `dotnet run --framework net10.0 -- --filter Network`
+4. **Ran pre-commit checks**: No breaking changes (new resources only)
+5. **Updated CHANGELOG**: Documented new NetworkSecurityPerimeter support
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
 | `eng/Packages.Data.props` | Management library version |
-| `sdk/provisioning/Generator/src/Specifications/{Service}Specification.cs` | Generator customizations |
-| `sdk/provisioning/Generator/src/Model/Specification.Schema.cs` | Schema tree builder |
+| `sdk/provisioning/Generator/src/Specifications/{Service}Specification.cs` | Generator customizations and resource whitelist |
 | `sdk/provisioning/Generator/src/Model/Specification.Customize.cs` | Customization API (`OrderEnum`, `CustomizeResource`, etc.) |
 | `sdk/provisioning/Azure.Provisioning.{Service}/src/BackwardCompatible/` | Backward-compatible customizations |
 | `sdk/provisioning/Azure.Provisioning.{Service}/src/ApiCompatBaseline.txt` | API compatibility suppressions |
 | `sdk/provisioning/cspell.yaml` | Spell check configuration |
 
 ## Troubleshooting
+
+### Resources not being generated
+- Check if the specification uses a whitelist (`_generatedResources`)
+- Verify the resource types are added to the whitelist
+- Ensure the management library version is correct
 
 ### Generator fails to find types
 - Ensure the management library version in `eng/Packages.Data.props` is correct and published

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -114,7 +114,14 @@ If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspel
 
 **Important:** Use `sdk/provisioning/cspell.yaml`, NOT `.vscode/cspell.json`.
 
-## Step 5: Run Pre-Commit Checks
+## Step 5: Export API and Update Snippets
+
+```shell
+pwsh eng\scripts\Export-API.ps1 provisioning
+pwsh eng\scripts\Update-Snippets.ps1 provisioning
+```
+
+## Step 6: Run Pre-Commit Checks
 
 Before committing, run:
 
@@ -130,13 +137,6 @@ This runs:
 - Installation instruction validation
 
 All checks must pass with 0 errors.
-
-## Step 6: Export API and Update Snippets
-
-```shell
-pwsh eng\scripts\Export-API.ps1 provisioning
-pwsh eng\scripts\Update-Snippets.ps1 provisioning
-```
 
 ## Step 7: Commit and Push
 

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -302,8 +302,11 @@ The requirement was to add NetworkSecurityPerimeter support. The resources alrea
 - Try running `dotnet restore` before the generator
 
 ### API compatibility errors
-- Use `ApiCompatBaseline.txt` to suppress expected breaking changes (provisioning packages only)
-- Or create backward-compatible stubs/properties
+- Use customization code to maintain backward compatibility (preferred approach):
+  - Create backward-compatible stubs in `BackwardCompatible/Models/`
+  - Use `CustomizeProperty` and `CustomizeResource` in specification files
+  - Add partial classes with `DefineAdditionalProperties()` for property renames
+- Only `[DataMember]` attribute removal errors can be suppressed via `ApiCompatBaseline.txt`
 
 ### Enum values in wrong order
 - Use `OrderEnum<T>()` in the specification file to control ordering


### PR DESCRIPTION
## Description

Add a new Copilot skill document that guides the process of regenerating `Azure.Provisioning.*` libraries to add new resources or features.

## Use Cases

This skill is useful when:
- New resource types need to be added to provisioning (e.g., `NetworkSecurityPerimeter`)
- New enum values are added (e.g., new PostgreSQL server versions)
- New API versions bring new properties or types
- The management library has a new release with features needed in provisioning

## Skill Workflow

The skill covers the complete workflow:
1. Determine if management library version update is needed
2. Update version in `eng/Packages.Data.props` (if needed)
3. Check for resource whitelist in specification files (if applicable)
4. Run the provisioning generator with `--filter {ServiceName}`
5. Verify only target library changed (revert unintended changes)
6. Validate generated schema against Azure Bicep reference documentation
7. Handle breaking changes with backward-compatible customizations
8. Fix spell check issues in `sdk/provisioning/cspell.yaml`
9. Export API and update snippets
10. Run pre-commit checks
11. Update CHANGELOG and commit

## Key Files

| File | Purpose |
|------|---------|
| `.github/skills/provisioning-library-regeneration/SKILL.md` | The skill document |

## Testing

This skill was developed and validated while fixing:
- [#55583](https://github.com/Azure/azure-sdk-for-net/issues/55583) - PostgreSQL versions 17 and 18
- [#56426](https://github.com/Azure/azure-sdk-for-net/issues/56426) - NetworkSecurityPerimeter resources