### PR TITLE
[Azure Monitor AspNetCore] Plumb EnableStandardMetrics and EnablePerfCounters

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features Added
 
+* Add ability to specify EnableStandardMetrics and EnablePerfCounters
+  ([#56438](https://github.com/Azure/azure-sdk-for-net/pull/56438))
+
 ### Breaking Changes
 
 *  **Default Sampler Changed**: The default sampling behavior has been changed from
@@ -15,7 +18,7 @@
   traces exported by default.
   **Migration**: To maintain the previous behavior (100% sampling), explicitly
   configure the sampler:
-  
+
   ```csharp
   // Option 1: Set SamplingRatio and clear TracesPerSecond
   builder.Services.AddOpenTelemetry()
@@ -78,7 +81,7 @@
   - `preview.item.dropped.count`
   - `preview.item.retry.count`
   ([#53010](https://github.com/Azure/azure-sdk-for-net/pull/53010))
-* Add `enduser.pseudo.id` as ai.user.id 
+* Add `enduser.pseudo.id` as ai.user.id
 ([#52722](https://github.com/Azure/azure-sdk-for-net/pull/52722))
 * Add `ai.location.ip` mapping for all telemetry types ([#52211](https://github.com/Azure/azure-sdk-for-net/pull/52211))
 

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net10.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net10.0.cs
@@ -7,6 +7,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
+        public bool EnablePerfCounters { get { throw null; } set { } }
+        public bool EnableStandardMetrics { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }
         public string StorageDirectory { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net8.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net8.0.cs
@@ -7,6 +7,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
+        public bool EnablePerfCounters { get { throw null; } set { } }
+        public bool EnableStandardMetrics { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }
         public string StorageDirectory { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.netstandard2.0.cs
@@ -7,6 +7,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
+        public bool EnablePerfCounters { get { throw null; } set { } }
+        public bool EnableStandardMetrics { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }
         public string StorageDirectory { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
@@ -49,6 +49,18 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         public bool EnableLiveMetrics { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether standard metrics should be collected.
+        /// Default is true.
+        /// </summary>
+        public bool EnableStandardMetrics { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether performance counters should be collected.
+        /// Default is true.
+        /// </summary>
+        public bool EnablePerfCounters { get; set; } = true;
+
+        /// <summary>
         /// Enables or disables filtering logs based on trace sampling decisions.
         /// </summary>
         /// <remarks>
@@ -95,6 +107,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             exporterOptions.TracesPerSecond = TracesPerSecond;
             exporterOptions.StorageDirectory = StorageDirectory;
             exporterOptions.EnableLiveMetrics = EnableLiveMetrics;
+            exporterOptions.EnableStandardMetrics = EnableStandardMetrics;
+            exporterOptions.EnablePerfCounters = EnablePerfCounters;
             exporterOptions.EnableTraceBasedLogsSampler = EnableTraceBasedLogsSampler;
             if (Transport != null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureMonitorOptionsTests.cs
@@ -142,6 +142,262 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
         }
 
         [Fact]
+        public void AzureMonitorOptions_EnableStandardMetrics_DefaultValue_IsTrue()
+        {
+            // Arrange & Act
+            var options = new AzureMonitorOptions();
+
+            // Assert
+            Assert.True(options.EnableStandardMetrics);
+        }
+
+        [Fact]
+        public void AzureMonitorOptions_EnableStandardMetrics_CanBeDisabled()
+        {
+            // Arrange & Act
+            var options = new AzureMonitorOptions
+            {
+                EnableStandardMetrics = false
+            };
+
+            // Assert
+            Assert.False(options.EnableStandardMetrics);
+        }
+
+        [Fact]
+        public void AzureMonitorOptions_SetValueToExporterOptions_CopiesEnableStandardMetrics()
+        {
+            // Arrange
+            var azureMonitorOptions = new AzureMonitorOptions
+            {
+                ConnectionString = TestConnectionString,
+                EnableStandardMetrics = false
+            };
+
+            var exporterOptions = new AzureMonitorExporterOptions();
+
+            // Act
+            azureMonitorOptions.SetValueToExporterOptions(exporterOptions);
+
+            // Assert
+            Assert.False(exporterOptions.EnableStandardMetrics);
+            Assert.Equal(TestConnectionString, exporterOptions.ConnectionString);
+        }
+
+        [Fact]
+        public void UseAzureMonitor_DefaultEnableStandardMetrics()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            // Act
+            serviceCollection.AddOpenTelemetry()
+                .UseAzureMonitor(options =>
+                {
+                    options.ConnectionString = TestConnectionString;
+                    options.DisableOfflineStorage = true;
+                });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var azureMonitorOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.True(azureMonitorOptions.EnableStandardMetrics);
+
+            var exporterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.True(exporterOptions.EnableStandardMetrics);
+        }
+
+        [Fact]
+        public void UseAzureMonitor_CanDisableStandardMetrics()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            // Act
+            serviceCollection.AddOpenTelemetry()
+                .UseAzureMonitor(options =>
+                {
+                    options.ConnectionString = TestConnectionString;
+                    options.EnableStandardMetrics = false;
+                    options.DisableOfflineStorage = true;
+                });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var azureMonitorOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.False(azureMonitorOptions.EnableStandardMetrics);
+
+            var exporterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.False(exporterOptions.EnableStandardMetrics);
+        }
+
+        [Fact]
+        public void UseAzureMonitor_EnableStandardMetrics_PropagatesCorrectly()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            // Act - Test with true
+            serviceCollection.AddOpenTelemetry()
+                .UseAzureMonitor(options =>
+                {
+                    options.ConnectionString = TestConnectionString;
+                    options.EnableStandardMetrics = true;
+                    options.DisableOfflineStorage = true;
+                });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var azureMonitorOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorOptions>>()
+                .Get(Options.DefaultName);
+
+            var exporterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.Equal(azureMonitorOptions.EnableStandardMetrics, exporterOptions.EnableStandardMetrics);
+            Assert.True(exporterOptions.EnableStandardMetrics);
+        }
+
+        [Fact]
+        public void AzureMonitorOptions_EnablePerfCounters_DefaultValue_IsTrue()
+        {
+            // Arrange & Act
+            var options = new AzureMonitorOptions();
+
+            // Assert
+            Assert.True(options.EnablePerfCounters);
+        }
+
+        [Fact]
+        public void AzureMonitorOptions_EnablePerfCounters_CanBeDisabled()
+        {
+            // Arrange & Act
+            var options = new AzureMonitorOptions
+            {
+                EnablePerfCounters = false
+            };
+
+            // Assert
+            Assert.False(options.EnablePerfCounters);
+        }
+
+        [Fact]
+        public void AzureMonitorOptions_SetValueToExporterOptions_CopiesEnablePerfCounters()
+        {
+            // Arrange
+            var azureMonitorOptions = new AzureMonitorOptions
+            {
+                ConnectionString = TestConnectionString,
+                EnablePerfCounters = false
+            };
+
+            var exporterOptions = new AzureMonitorExporterOptions();
+
+            // Act
+            azureMonitorOptions.SetValueToExporterOptions(exporterOptions);
+
+            // Assert
+            Assert.False(exporterOptions.EnablePerfCounters);
+            Assert.Equal(TestConnectionString, exporterOptions.ConnectionString);
+        }
+
+        [Fact]
+        public void UseAzureMonitor_DefaultEnablePerfCounters()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            // Act
+            serviceCollection.AddOpenTelemetry()
+                .UseAzureMonitor(options =>
+                {
+                    options.ConnectionString = TestConnectionString;
+                    options.DisableOfflineStorage = true;
+                });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var azureMonitorOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.True(azureMonitorOptions.EnablePerfCounters);
+
+            var exporterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.True(exporterOptions.EnablePerfCounters);
+        }
+
+        [Fact]
+        public void UseAzureMonitor_CanDisablePerfCounters()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            // Act
+            serviceCollection.AddOpenTelemetry()
+                .UseAzureMonitor(options =>
+                {
+                    options.ConnectionString = TestConnectionString;
+                    options.EnablePerfCounters = false;
+                    options.DisableOfflineStorage = true;
+                });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var azureMonitorOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.False(azureMonitorOptions.EnablePerfCounters);
+
+            var exporterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.False(exporterOptions.EnablePerfCounters);
+        }
+
+        [Fact]
+        public void UseAzureMonitor_EnablePerfCounters_PropagatesCorrectly()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+
+            // Act - Test with true
+            serviceCollection.AddOpenTelemetry()
+                .UseAzureMonitor(options =>
+                {
+                    options.ConnectionString = TestConnectionString;
+                    options.EnablePerfCounters = true;
+                    options.DisableOfflineStorage = true;
+                });
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // Assert
+            var azureMonitorOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorOptions>>()
+                .Get(Options.DefaultName);
+
+            var exporterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>()
+                .Get(Options.DefaultName);
+
+            Assert.Equal(azureMonitorOptions.EnablePerfCounters, exporterOptions.EnablePerfCounters);
+            Assert.True(exporterOptions.EnablePerfCounters);
+        }
+
+        [Fact]
         public void UseAzureMonitor_WithoutConfiguration_UsesDefaultValue()
         {
             // Arrange


### PR DESCRIPTION
This adds the recently-made-public config options EnableStandardMetrics and EnablePerfCounters of Azure Monitor Exporter into the AspNetCore distribution.