### PR TITLE
Add ManagedIdentityAsFederatedIdentity credential support to ConfigurableCredentialProvider

### DIFF
--- a/sdk/identity/Azure.Identity/src/Constants.cs
+++ b/sdk/identity/Azure.Identity/src/Constants.cs
@@ -54,6 +54,7 @@ namespace Azure.Identity
         public const string InteractiveBrowserCredential = "interactivebrowsercredential";
         public const string BrokerCredential = "brokercredential";
         public const string AzurePipelinesCredential = "azurepipelinescredential";
+        public const string ManagedIdentityAsFederatedIdentityCredential = "managedidentityasfederatedidentitycredential";
         public const string MacBrokerRedirectUri = "msauth.com.msauth.unsignedapp://auth";
         public const string ApiKeyCredential = "ApiKey";
     }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -127,6 +127,11 @@ namespace Azure.Identity
                 AzurePipelinesSystemAccessToken = azurePipelinesSystemAccessToken;
             }
 
+            if (section[nameof(AzureCloud)] is string azureCloud)
+            {
+                AzureCloud = azureCloud;
+            }
+
             if (bool.TryParse(section[nameof(DisableAutomaticAuthentication)], out bool disableAutomaticAuthentication))
             {
                 DisableAutomaticAuthentication = disableAutomaticAuthentication;
@@ -205,6 +210,7 @@ namespace Azure.Identity
             "InteractiveBrowser" => Constants.InteractiveBrowserCredential,
             "Broker" => Constants.BrokerCredential,
             "AzurePipelines" => Constants.AzurePipelinesCredential,
+            "ManagedIdentityAsFederatedIdentity" => Constants.ManagedIdentityAsFederatedIdentityCredential,
             "ApiKey" => Constants.ApiKeyCredential,
             // Accept already-converted values (e.g. from Clone)
             Constants.VisualStudioCredential or
@@ -218,6 +224,7 @@ namespace Azure.Identity
             Constants.InteractiveBrowserCredential or
             Constants.BrokerCredential or
             Constants.AzurePipelinesCredential or
+            Constants.ManagedIdentityAsFederatedIdentityCredential or
             Constants.ApiKeyCredential => value,
             _ => throw new InvalidOperationException($"Unsupported CredentialSource found in configuration: {value}."),
         };
@@ -517,6 +524,11 @@ namespace Azure.Identity
         /// </summary>
         internal string AzurePipelinesSystemAccessToken { get; set; }
 
+        /// <summary>
+        /// Specifies the Azure cloud environment for Managed Identity as FIC. Valid values are "public", "usgov", "china".
+        /// </summary>
+        internal string AzureCloud { get; set; }
+
         internal bool DisableAutomaticAuthentication { get; set; }
 
         internal string LoginHint { get; set; }
@@ -581,6 +593,7 @@ namespace Azure.Identity
                 dacClone.ClientId = ClientId;
                 dacClone.AzurePipelinesServiceConnectionId = AzurePipelinesServiceConnectionId;
                 dacClone.AzurePipelinesSystemAccessToken = AzurePipelinesSystemAccessToken;
+                dacClone.AzureCloud = AzureCloud;
                 dacClone.DisableAutomaticAuthentication = DisableAutomaticAuthentication;
                 dacClone.LoginHint = LoginHint;
                 if (BrowserCustomization != null)

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -235,7 +235,7 @@ namespace Azure.Identity
         /// <returns>Array containing the specific TokenCredential instance.</returns>
         private TokenCredential[] CreateSpecificCredentialChain(string credentialSelection, string environmentVariableName)
         {
-            string validCredentials = $"'{Constants.DevCredentials}', '{Constants.ProdCredentials}', '{Constants.VisualStudioCredential}', '{Constants.VisualStudioCodeCredential}', '{Constants.AzureCliCredential}', '{Constants.AzurePowerShellCredential}', '{Constants.AzureDeveloperCliCredential}', '{Constants.EnvironmentCredential}', '{Constants.WorkloadIdentityCredential}', '{Constants.ManagedIdentityCredential}', '{Constants.InteractiveBrowserCredential}', '{Constants.BrokerCredential}', '{Constants.AzurePipelinesCredential}'";
+            string validCredentials = $"'{Constants.DevCredentials}', '{Constants.ProdCredentials}', '{Constants.VisualStudioCredential}', '{Constants.VisualStudioCodeCredential}', '{Constants.AzureCliCredential}', '{Constants.AzurePowerShellCredential}', '{Constants.AzureDeveloperCliCredential}', '{Constants.EnvironmentCredential}', '{Constants.WorkloadIdentityCredential}', '{Constants.ManagedIdentityCredential}', '{Constants.InteractiveBrowserCredential}', '{Constants.BrokerCredential}', '{Constants.AzurePipelinesCredential}', '{Constants.ManagedIdentityAsFederatedIdentityCredential}'";
 
             return credentialSelection switch
             {
@@ -250,6 +250,7 @@ namespace Azure.Identity
                 Constants.InteractiveBrowserCredential => [CreateInteractiveBrowserCredential()],
                 Constants.BrokerCredential => [CreateBrokerCredential()],
                 Constants.AzurePipelinesCredential => [CreateAzurePipelinesCredential()],
+                Constants.ManagedIdentityAsFederatedIdentityCredential => [CreateManagedIdentityAsFederatedIdentityCredential()],
                 _ => throw new InvalidOperationException($"Invalid value for environment variable {environmentVariableName}: {credentialSelection}. Valid values are {validCredentials}.{_troubleshootingMessage}")
             };
         }
@@ -462,6 +463,65 @@ namespace Azure.Identity
 
             return new AzurePipelinesCredential(tenantId, clientId, serviceConnectionId, systemAccessToken, options);
         }
+
+        public virtual TokenCredential CreateManagedIdentityAsFederatedIdentityCredential()
+        {
+            if (Options.CredentialSource == null)
+            {
+                throw new InvalidOperationException(
+                    "ManagedIdentityAsFederatedIdentityCredential is not supported via the AZURE_TOKEN_CREDENTIALS environment variable. " +
+                    "Use IConfiguration-based credential selection with DefaultAzureCredentialOptions to configure ManagedIdentityAsFederatedIdentityCredential, " +
+                    "as it requires additional properties (ClientId, AzureCloud, ManagedIdentityIdKind, ManagedIdentityId) " +
+                    "that cannot be specified through environment variables.");
+            }
+
+            ManagedIdentityId managedIdentityId;
+            if (!string.IsNullOrEmpty(Options.ManagedIdentityIdKind))
+            {
+                managedIdentityId = Options.ManagedIdentityIdKind switch
+                {
+                    "ClientId" => ManagedIdentityId.FromUserAssignedClientId(Options.ManagedIdentityId),
+                    "ResourceId" => ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(Options.ManagedIdentityId)),
+                    "ObjectId" => ManagedIdentityId.FromUserAssignedObjectId(Options.ManagedIdentityId),
+                    _ => throw new ArgumentException($"Invalid {nameof(Options.ManagedIdentityIdKind)} value: '{Options.ManagedIdentityIdKind}'. For ManagedIdentityAsFederatedIdentityCredential, valid values are 'ClientId', 'ResourceId', 'ObjectId'. SystemAssigned is not supported."),
+                };
+            }
+            else
+            {
+                throw new ArgumentException(
+                    "A user-assigned managed identity must be specified for ManagedIdentityAsFederatedIdentityCredential. " +
+                    "Set ManagedIdentityIdKind and ManagedIdentityId in the configuration.");
+            }
+
+            string tokenScope = TranslateCloudToTokenScope(Options.AzureCloud);
+            var managedIdentityCredential = new ManagedIdentityCredential(managedIdentityId);
+            var tokenContext = new TokenRequestContext(new[] { tokenScope });
+
+            var assertionOptions = Options.Clone<ClientAssertionCredentialOptions>();
+
+            if (Options.AdditionallyAllowedTenants?.Count > 0)
+            {
+                foreach (var tenant in Options.AdditionallyAllowedTenants)
+                {
+                    assertionOptions.AdditionallyAllowedTenants.Add(tenant);
+                }
+            }
+
+            return new ClientAssertionCredential(
+                Options.TenantId,
+                Options.ClientId,
+                async _ => (await managedIdentityCredential.GetTokenAsync(tokenContext).ConfigureAwait(false)).Token,
+                assertionOptions);
+        }
+
+        private static string TranslateCloudToTokenScope(string azureCloud) =>
+            azureCloud?.ToLowerInvariant() switch
+            {
+                "public" => "api://AzureADTokenExchange/.default",
+                "usgov" => "api://AzureADTokenExchangeUSGov/.default",
+                "china" => "api://AzureADTokenExchangeChina/.default",
+                _ => throw new ArgumentException($"Unknown Azure cloud: '{azureCloud}'. Valid values are 'public', 'usgov', 'china'.", nameof(azureCloud)),
+            };
 
         /// <summary>
         /// Creates a DevelopmentBrokerOptions instance if the Azure.Identity.Broker assembly is loaded.

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ClientAssertionCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ClientAssertionCredentialCreationTests.cs
@@ -1,0 +1,527 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.ClientAssertion
+{
+    /// <summary>
+    /// Validates that all properties required for ClientAssertionCredential
+    /// can be set via IConfiguration and that the correct priority order is honoured:
+    ///   1. IConfiguration value  (highest)
+    ///   2. Well-known environment variable
+    ///   3. Hard-coded default     (lowest)
+    /// </summary>
+    internal class ClientAssertionCredentialCreationTests : CredentialCreationTestBase<ClientAssertionCredential>
+    {
+        protected override string CredentialSource => "ManagedIdentityAsFederatedIdentity";
+
+        private static object GetMsalClient(ClientAssertionCredential cred)
+            => ReadProperty<object>(cred, "Client");
+
+        private static T ReadMsalProperty<T>(object msalClient, string propertyName)
+            => ReadProperty<T>(msalClient, propertyName);
+
+        /// <summary>
+        /// Returns env var dictionary with relevant vars nulled out.
+        /// </summary>
+        private static Dictionary<string, string> AllNulledEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_CLIENT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            { "AZURE_AUTHORITY_HOST", null },
+        };
+
+        /// <summary>
+        /// Minimum config required to create a ClientAssertionCredential via configurable flow.
+        /// </summary>
+        private static void SetRequiredConfig(IConfiguration config,
+            string tenantId = "test-tenant",
+            string clientId = "test-client",
+            string azureCloud = "public",
+            string managedIdentityIdKind = "ClientId",
+            string managedIdentityId = "test-mi-client-id")
+        {
+            config["MyClient:Credential:TenantId"] = tenantId;
+            config["MyClient:Credential:ClientId"] = clientId;
+            config["MyClient:Credential:AzureCloud"] = azureCloud;
+            config["MyClient:Credential:ManagedIdentityIdKind"] = managedIdentityIdKind;
+            config["MyClient:Credential:ManagedIdentityId"] = managedIdentityId;
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, tenantId: "config-tenant");
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+
+                Assert.IsNotNull(cred);
+                Assert.AreEqual("config-tenant", cred.TenantId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TenantId_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // TenantId intentionally not set in config — should fall back to env var.
+                config["MyClient:Credential:ClientId"] = "test-client";
+                config["MyClient:Credential:AzureCloud"] = "public";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityId"] = "test-mi-client-id";
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+
+                Assert.IsNotNull(cred);
+                Assert.AreEqual("env-tenant", cred.TenantId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientId_FromConfig()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, clientId: "my-sp-client-id");
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+
+                Assert.IsNotNull(cred);
+                Assert.AreEqual("my-sp-client-id", cred.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void MissingTenantId_Throws()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                // TenantId not set in config and env var is null.
+                config["MyClient:Credential:ClientId"] = "test-client";
+                config["MyClient:Credential:AzureCloud"] = "public";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityId"] = "test-mi-client-id";
+
+                Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void MissingClientId_Throws()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                // ClientId not set.
+                config["MyClient:Credential:AzureCloud"] = "public";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityId"] = "test-mi-client-id";
+
+                Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void MissingAzureCloud_Throws()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:ClientId"] = "test-client";
+                // AzureCloud not set.
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityId"] = "test-mi-client-id";
+
+                Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void MissingManagedIdentity_Throws()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:ClientId"] = "test-client";
+                config["MyClient:Credential:AzureCloud"] = "public";
+                // ManagedIdentityIdKind and ManagedIdentityId not set.
+
+                Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void InvalidAzureCloud_Throws()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, azureCloud: "invalid-cloud");
+
+                Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void SystemAssigned_ManagedIdentityIdKind_Throws()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, managedIdentityIdKind: "SystemAssigned", managedIdentityId: null);
+
+                Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ManagedIdentityIdKind_ClientId_CreatesCredential()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, managedIdentityIdKind: "ClientId", managedIdentityId: "mi-client-id-123");
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+
+                Assert.IsNotNull(cred);
+                Assert.AreEqual("test-tenant", cred.TenantId);
+                Assert.AreEqual("test-client", cred.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ManagedIdentityIdKind_ObjectId_CreatesCredential()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, managedIdentityIdKind: "ObjectId", managedIdentityId: "mi-object-id-456");
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+
+                Assert.IsNotNull(cred);
+                Assert.AreEqual("test-tenant", cred.TenantId);
+                Assert.AreEqual("test-client", cred.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ManagedIdentityIdKind_ResourceId_CreatesCredential()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, managedIdentityIdKind: "ResourceId",
+                    managedIdentityId: "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-name");
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+
+                Assert.IsNotNull(cred);
+                Assert.AreEqual("test-tenant", cred.TenantId);
+                Assert.AreEqual("test-client", cred.ClientId);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AzureCloud_Public_CreatesCredential()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, azureCloud: "public");
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AzureCloud_USGov_CreatesCredential()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, azureCloud: "usgov");
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AzureCloud_China_CreatesCredential()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config, azureCloud: "china");
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_AUTHORITY_HOST", AzureAuthorityHosts.AzureGovernment.ToString() },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config);
+                config["MyClient:Credential:AuthorityHost"] = AzureAuthorityHosts.AzureChina.ToString();
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+
+                Uri actual = ReadMsalProperty<Uri>(GetMsalClient(cred), "AuthorityHost");
+                Assert.AreEqual(AzureAuthorityHosts.AzureChina, actual);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_AUTHORITY_HOST", AzureAuthorityHosts.AzureGovernment.ToString() },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config);
+                // AuthorityHost intentionally not set in config.
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+
+                Uri actual = ReadMsalProperty<Uri>(GetMsalClient(cred), "AuthorityHost");
+                Assert.AreEqual(AzureAuthorityHosts.AzureGovernment, actual);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AuthorityHost_DefaultsToAzurePublicCloud()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config);
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+
+                Uri actual = ReadMsalProperty<Uri>(GetMsalClient(cred), "AuthorityHost");
+                Assert.AreEqual(AzureAuthorityHosts.AzurePublicCloud, actual);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_ConfigSetsTrue()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config);
+                config["MyClient:Credential:DisableInstanceDiscovery"] = "true";
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+                Assert.IsTrue(ReadMsalProperty<bool>(GetMsalClient(cred), "DisableInstanceDiscovery"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void DisableInstanceDiscovery_DefaultsFalse()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config);
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+                Assert.IsFalse(ReadMsalProperty<bool>(GetMsalClient(cred), "DisableInstanceDiscovery"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config);
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "config-tenant-a";
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+
+                var tenants = ReadField<string[]>(cred, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "config-tenant-a");
+                CollectionAssert.DoesNotContain(tenants, "env-tenant-x");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-tenant-x;env-tenant-y" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config);
+                // AdditionallyAllowedTenants intentionally not set in config.
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+
+                var tenants = ReadField<string[]>(cred, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                CollectionAssert.Contains(tenants, "env-tenant-x");
+                CollectionAssert.Contains(tenants, "env-tenant-y");
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AdditionallyAllowedTenants_DefaultsToEmpty()
+        {
+            var envVars = AllNulledEnvVars();
+            using (new TestEnvVar(envVars))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                SetRequiredConfig(config);
+
+                var cred = GetUnderlying(CreateFromConfig(config));
+                Assert.IsNotNull(cred);
+
+                var tenants = ReadField<string[]>(cred, "AdditionallyAllowedTenantIds");
+                Assert.IsNotNull(tenants);
+                Assert.IsEmpty(tenants);
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void AllOptions_ConfigWinsOverEnvVars()
+        {
+            string configTenant = Guid.NewGuid().ToString();
+            string configClient = Guid.NewGuid().ToString();
+            Uri configAuthority = AzureAuthorityHosts.AzureChina;
+
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", "env-tenant" },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_AUTHORITY_HOST", AzureAuthorityHosts.AzureGovernment.ToString() },
+                { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", "env-extra" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = configTenant;
+                config["MyClient:Credential:ClientId"] = configClient;
+                config["MyClient:Credential:AzureCloud"] = "usgov";
+                config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
+                config["MyClient:Credential:ManagedIdentityId"] = "mi-client-id-123";
+                config["MyClient:Credential:AuthorityHost"] = configAuthority.ToString();
+                config["MyClient:Credential:DisableInstanceDiscovery"] = "true";
+                config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
+
+                var credential = CreateFromConfig(config);
+                var cred = GetUnderlying(credential);
+                Assert.IsNotNull(cred);
+
+                Assert.AreEqual(configTenant, cred.TenantId);
+                Assert.AreEqual(configClient, cred.ClientId);
+
+                var tenants = ReadField<string[]>(cred, "AdditionallyAllowedTenantIds");
+                CollectionAssert.Contains(tenants, "*");
+                CollectionAssert.DoesNotContain(tenants, "env-extra");
+
+                var msal = GetMsalClient(cred);
+                Assert.AreEqual(configAuthority, ReadMsalProperty<Uri>(msal, "AuthorityHost"));
+                Assert.IsTrue(ReadMsalProperty<bool>(msal, "DisableInstanceDiscovery"));
+            }
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ClientAssertionCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ClientAssertionCredentialTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials.ClientAssertion
+{
+    internal class ClientAssertionCredentialTests : Tests.ClientAssertionCredentialTests
+    {
+        private readonly ConfigurableCredentialTestHelper<ClientAssertionCredential> _helper;
+
+        public ClientAssertionCredentialTests(bool isAsync) : base(isAsync)
+        {
+            _helper = new ConfigurableCredentialTestHelper<ClientAssertionCredential>(
+                "ManagedIdentityAsFederatedIdentity",
+                null,
+                null,
+                InstrumentClient);
+        }
+
+        private ConfigurableCredential CreateConfiguredCredential(string tenantId = null)
+        {
+            IConfiguration config = _helper.GetConfiguration();
+            if (tenantId != null)
+            {
+                config["MyClient:Credential:TenantId"] = tenantId;
+            }
+            config["MyClient:Credential:ClientId"] = ClientId;
+            config["MyClient:Credential:AzureCloud"] = "public";
+            config["MyClient:Credential:ManagedIdentityIdKind"] = "ClientId";
+            config["MyClient:Credential:ManagedIdentityId"] = Guid.NewGuid().ToString();
+
+            ConfigurableCredential credential;
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+            }))
+            {
+                credential = _helper.GetCredentialFromConfig(config);
+            }
+
+            return credential;
+        }
+
+        private static void InjectField(ClientAssertionCredential target, string fieldName, object value)
+        {
+            typeof(ClientAssertionCredential)
+                .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(target, value);
+        }
+
+        protected override TokenCredential CreateCredential(string tenantId, string clientId, string assertionValue, ClientAssertionCredentialOptions options)
+        {
+            // Create credential through the config path (validates config → factory → credential composition)
+            var configCredential = CreateConfiguredCredential(tenantId);
+            var underlying = _helper.GetUnderlyingCredential(configCredential);
+
+            // Restore pipeline with test transport
+            var pipeline = options?.Pipeline ?? CredentialPipeline.GetInstance(options);
+            InjectField(underlying, "<Pipeline>k__BackingField", pipeline);
+
+            // Inject MSAL client: use mock from options if provided,
+            // otherwise create a real one with simple assertion and test transport
+            // (so transport-based CredentialTestBase tests work correctly)
+            if (options?.MsalClient != null)
+            {
+                InjectField(underlying, "<Client>k__BackingField", options.MsalClient);
+            }
+            else
+            {
+                MsalConfidentialClient msalClient = IsAsync
+                    ? new MsalConfidentialClient(pipeline, tenantId, clientId, (Func<CancellationToken, Task<string>>)((_) => Task.FromResult(assertionValue)), options)
+                    : new MsalConfidentialClient(pipeline, tenantId, clientId, (Func<string>)(() => assertionValue), options);
+                InjectField(underlying, "<Client>k__BackingField", msalClient);
+            }
+
+            return InstrumentClient(configCredential);
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialFactoryTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialFactoryTests.cs
@@ -601,6 +601,24 @@ namespace Azure.Identity.Tests
         }
 
         [Test]
+        public void ManagedIdentityAsFederatedIdentityCredentialViaEnvVar_ThrowsHelpfulError()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_USERNAME", null },
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_TOKEN_CREDENTIALS", "managedidentityasfederatedidentitycredential" }
+            }))
+            {
+                var factory = new DefaultAzureCredentialFactory(null);
+                var ex = Assert.Throws<InvalidOperationException>(() => factory.CreateCredentialChain());
+                Assert.That(ex.Message, Does.Contain("ManagedIdentityAsFederatedIdentityCredential is not supported via the AZURE_TOKEN_CREDENTIALS environment variable"));
+                Assert.That(ex.Message, Does.Contain("IConfiguration"));
+            }
+        }
+
+        [Test]
         [TestCaseSource(nameof(ExcludeCredOptions))]
         public void ValidateExcludeOptionsHonoredWithAZURE_TOKEN_CREDENTIALS_DevMode(
             bool excludeEnvironmentCredential,


### PR DESCRIPTION
## Description

Implements #56268

Adds support for **Managed Identity as Federated Identity Credential (FIC)** to the \ConfigurableCredentialProvider\. This allows users to configure a \ClientAssertionCredential\ backed by a \ManagedIdentityCredential\ through \IConfiguration\.

### Changes

**Source:**
- \Constants.cs\: Added \ManagedIdentityAsFederatedIdentityCredential\ constant
- \DefaultAzureCredentialOptions.cs\: Added \ManagedIdentityAsFederatedIdentity\ credential source mapping, \AzureCloud\ config property with reading and cloning
- \DefaultAzureCredentialFactory.cs\: Added \CreateManagedIdentityAsFederatedIdentityCredential()\ factory method composing MI → ClientAssertion, \TranslateCloudToTokenScope()\ for public/usgov/china, env var blocking

**Tests:**
- \ClientAssertionCredentialTests.cs\ (base): Virtualized \CreateCredential\ method so configurable tests can override credential creation
- \ConfigurableCredentials/ClientAssertionCredentialCreationTests.cs\: 24 creation tests (config priority, required fields, MI identity kinds, cloud values, authority host)
- \ConfigurableCredentials/ClientAssertionCredentialTests.cs\: 32 inherited behavior tests via config path with MSAL mock injection
- \DefaultAzureCredentialFactoryTests.cs\: Env var error test

### Configuration

\\\json
{
  "MyClient": {
    "Credential": {
      "CredentialSource": "ManagedIdentityAsFederatedIdentity",
      "TenantId": "<tenant-id>",
      "ClientId": "<client-id>",
      "AzureCloud": "public",
      "ManagedIdentityIdKind": "ClientId",
      "ManagedIdentityId": "<managed-identity-client-id>"
    }
  }
}
\\\

Follows the same pattern as #56403 (AzurePipelinesCredential).