### PR TITLE
Fix keyvault sample test project missing net9.0 target framework

### DIFF
--- a/sdk/keyvault/samples/keyvaultproxy/tests/AzureSamples.Security.KeyVault.Proxy.Tests.csproj
+++ b/sdk/keyvault/samples/keyvaultproxy/tests/AzureSamples.Security.KeyVault.Proxy.Tests.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(RequiredRunnableTargetFrameworks)</TargetFrameworks>
-    <SupportsNetStandard20>false</SupportsNetStandard20>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);$(NetFxTargetFramework)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Problem

The `AzureSamples.Security.KeyVault.Proxy.Tests` project was failing in CI with:

```
error NETSDK1005: Assets file '...project.assets.json' doesn't have a target for 'net9.0'.
Ensure that restore has run and that you have included 'net9.0' in the TargetFrameworks for your project.
```

Pipeline failure: [Build 5920203 - Log 600](https://dev.azure.com/azure-sdk/590cfd2a-581c-4dcb-a12e-6568ce786175/_apis/build/builds/5920203/logs/600)

## Root Cause

The project explicitly set `TargetFrameworks=$(RequiredRunnableTargetFrameworks)` which resolves to `net10.0;net8.0` — missing `net9.0`. When CI runs `dotnet test --framework net9.0` for the keyvault service directory, this project fails because it has no `net9.0` target.

## Fix

Remove the explicit `TargetFrameworks` and `SupportsNetStandard20` overrides from the project file. The build infrastructure (`eng/Directory.Build.Common.props`) already detects this as a test project (via `Microsoft.NET.Test.Sdk` reference -> `IsTestProject=true`) and automatically sets `TargetFrameworks=$(AllActiveCurrentTargetFrameworks)` = `net10.0;net8.0;net9.0` (plus `net462` on Windows).

## Verification

- :x: **Before fix:** `dotnet build --framework net9.0` -> `NETSDK1005` error
- :white_check_mark: **After fix:** `dotnet build --framework net9.0` -> Build succeeded, 0 errors
