### PR TITLE
Typespec update (before folder move)

### DIFF
--- a/sdk/ai/Azure.AI.VoiceLive/tsp-location.yaml
+++ b/sdk/ai/Azure.AI.VoiceLive/tsp-location.yaml
@@ -1,5 +1,5 @@
 directory: specification/ai/data-plane/VoiceLive
-commit: e8f3c52913011644cf294c7c4546df12f7db7c6b
+commit: 046afa44ad7dc3552f46cb6f975549320f362e57
 repo: rhurey/azure-rest-api-specs
 additionalDirectories: 
 - specification/ai/data-plane/VoiceLive


### PR DESCRIPTION
Issue was I never updated typespec and generated files manually. Pipelines didn't detect this since the files were the exact same, so there was no blocker in merging previous PR.