### PR TITLE
Accept full credential class names in CredentialSource configuration

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/tests/Azure.Identity.Broker.Tests.csproj
+++ b/sdk/identity/Azure.Identity.Broker/tests/Azure.Identity.Broker.Tests.csproj
@@ -27,6 +27,8 @@
     <Compile Include="$(AzureCoreSharedSources)ForwardsClientCallsAttribute.cs" LinkBase="Shared" />
     <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\ConfigurableCredentialTestHelper.cs" LinkBase="ConfigurableCredentials" />
     <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\CredentialCreationTestBase.cs" LinkBase="ConfigurableCredentials" />
+    <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\E2ETestSettings.cs" LinkBase="ConfigurableCredentials" />
+    <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\DITestClient.cs" LinkBase="ConfigurableCredentials" />
     <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\BrokerCredentialCreationTests.cs" LinkBase="ConfigurableCredentials" />
     <Compile Include="..\..\Azure.Identity\tests\ConfigurableCredentials\InteractiveBrowserCredentialCreationTests.cs" LinkBase="ConfigurableCredentials" />
     <Compile Include="*.cs" Exclude="*Manual*.cs" />

--- a/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
+++ b/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
@@ -46,7 +46,9 @@ namespace Azure.Identity
             foreach (KeyValuePair<string, string?> kvp in entries)
             {
                 sb.Append(kvp.Key, prefixLength, kvp.Key.Length - prefixLength);
-                sb.Append('=').Append(kvp.Value).Append(';');
+                sb.Append('=')
+                    .Append(DefaultAzureCredentialOptions.TryConvertCredentialSource(kvp.Value, out string normalized) ? normalized : kvp.Value)
+                    .Append(';');
             }
 
             byte[] inputBytes = Encoding.UTF8.GetBytes(sb.ToString());

--- a/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
+++ b/sdk/identity/Azure.Identity/src/ConfigurableCredentialCache.cs
@@ -45,8 +45,29 @@ namespace Azure.Identity
             StringBuilder sb = new();
             foreach (KeyValuePair<string, string?> kvp in entries)
             {
-                sb.Append(kvp.Key, prefixLength, kvp.Key.Length - prefixLength);
-                sb.Append('=').Append(kvp.Value).Append(';');
+                string relativeKey = kvp.Key.Substring(prefixLength);
+                sb.Append(relativeKey);
+                sb.Append('=');
+
+                // Normalize CredentialSource so that aliases (e.g. "AzureCli" vs "AzureCliCredential")
+                // produce the same cache key.
+                if (relativeKey.Equals("CredentialSource", StringComparison.Ordinal) && kvp.Value is not null)
+                {
+                    try
+                    {
+                        sb.Append(DefaultAzureCredentialOptions.ConvertCredentialSource(kvp.Value));
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        sb.Append(kvp.Value);
+                    }
+                }
+                else
+                {
+                    sb.Append(kvp.Value);
+                }
+
+                sb.Append(';');
             }
 
             byte[] inputBytes = Encoding.UTF8.GetBytes(sb.ToString());

--- a/sdk/identity/Azure.Identity/src/Constants.cs
+++ b/sdk/identity/Azure.Identity/src/Constants.cs
@@ -56,6 +56,6 @@ namespace Azure.Identity
         public const string AzurePipelinesCredential = "azurepipelinescredential";
         public const string ManagedIdentityAsFederatedIdentityCredential = "managedidentityasfederatedidentitycredential";
         public const string MacBrokerRedirectUri = "msauth.com.msauth.unsignedapp://auth";
-        public const string ApiKeyCredential = "ApiKey";
+        public const string ApiKeyCredential = "apikeycredential";
     }
 }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -196,7 +196,7 @@ namespace Azure.Identity
 
         internal string ApiKey { get; private set; }
 
-        private static string ConvertCredentialSource(string value) => value?.ToLowerInvariant() switch
+        internal static string ConvertCredentialSource(string value) => value?.ToLowerInvariant() switch
         {
             null => throw new InvalidOperationException("CredentialSource is required when configuring credentials. Specify a valid CredentialSource in the configuration."),
             // Full credential names and already-converted lowercase values match directly

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -196,39 +196,55 @@ namespace Azure.Identity
 
         internal string ApiKey { get; private set; }
 
-        private static string ConvertCredentialSource(string value) => value?.ToLowerInvariant() switch
+        internal static string ConvertCredentialSource(string value)
         {
-            null => throw new InvalidOperationException("CredentialSource is required when configuring credentials. Specify a valid CredentialSource in the configuration."),
-            // Full credential names and already-converted lowercase values match directly
-            Constants.VisualStudioCredential => Constants.VisualStudioCredential,
-            Constants.VisualStudioCodeCredential => Constants.VisualStudioCodeCredential,
-            Constants.AzureCliCredential => Constants.AzureCliCredential,
-            Constants.AzurePowerShellCredential => Constants.AzurePowerShellCredential,
-            Constants.AzureDeveloperCliCredential => Constants.AzureDeveloperCliCredential,
-            Constants.EnvironmentCredential => Constants.EnvironmentCredential,
-            Constants.WorkloadIdentityCredential => Constants.WorkloadIdentityCredential,
-            Constants.ManagedIdentityCredential => Constants.ManagedIdentityCredential,
-            Constants.InteractiveBrowserCredential => Constants.InteractiveBrowserCredential,
-            Constants.BrokerCredential => Constants.BrokerCredential,
-            Constants.AzurePipelinesCredential => Constants.AzurePipelinesCredential,
-            Constants.ManagedIdentityAsFederatedIdentityCredential => Constants.ManagedIdentityAsFederatedIdentityCredential,
-            Constants.ApiKeyCredential => Constants.ApiKeyCredential,
-            // Short names (back-compat)
-            "visualstudio" => Constants.VisualStudioCredential,
-            "visualstudiocode" => Constants.VisualStudioCodeCredential,
-            "azurecli" => Constants.AzureCliCredential,
-            "azurepowershell" => Constants.AzurePowerShellCredential,
-            "azuredevelopercli" => Constants.AzureDeveloperCliCredential,
-            "environment" => Constants.EnvironmentCredential,
-            "workloadidentity" => Constants.WorkloadIdentityCredential,
-            "managedidentity" => Constants.ManagedIdentityCredential,
-            "interactivebrowser" => Constants.InteractiveBrowserCredential,
-            "broker" => Constants.BrokerCredential,
-            "azurepipelines" => Constants.AzurePipelinesCredential,
-            "managedidentityasfederatedidentity" => Constants.ManagedIdentityAsFederatedIdentityCredential,
-            "apikey" => Constants.ApiKeyCredential,
-            _ => throw new InvalidOperationException($"Unsupported CredentialSource found in configuration: {value}."),
-        };
+            if (!TryConvertCredentialSource(value, out string result))
+            {
+                throw new InvalidOperationException(value is null
+                    ? "CredentialSource is required when configuring credentials. Specify a valid CredentialSource in the configuration."
+                    : $"Unsupported CredentialSource found in configuration: {value}.");
+            }
+
+            return result;
+        }
+
+        internal static bool TryConvertCredentialSource(string value, out string result)
+        {
+            result = value?.ToLowerInvariant() switch
+            {
+                // Full credential names and already-converted lowercase values match directly
+                Constants.VisualStudioCredential => Constants.VisualStudioCredential,
+                Constants.VisualStudioCodeCredential => Constants.VisualStudioCodeCredential,
+                Constants.AzureCliCredential => Constants.AzureCliCredential,
+                Constants.AzurePowerShellCredential => Constants.AzurePowerShellCredential,
+                Constants.AzureDeveloperCliCredential => Constants.AzureDeveloperCliCredential,
+                Constants.EnvironmentCredential => Constants.EnvironmentCredential,
+                Constants.WorkloadIdentityCredential => Constants.WorkloadIdentityCredential,
+                Constants.ManagedIdentityCredential => Constants.ManagedIdentityCredential,
+                Constants.InteractiveBrowserCredential => Constants.InteractiveBrowserCredential,
+                Constants.BrokerCredential => Constants.BrokerCredential,
+                Constants.AzurePipelinesCredential => Constants.AzurePipelinesCredential,
+                Constants.ManagedIdentityAsFederatedIdentityCredential => Constants.ManagedIdentityAsFederatedIdentityCredential,
+                Constants.ApiKeyCredential => Constants.ApiKeyCredential,
+                // Short names (back-compat)
+                "visualstudio" => Constants.VisualStudioCredential,
+                "visualstudiocode" => Constants.VisualStudioCodeCredential,
+                "azurecli" => Constants.AzureCliCredential,
+                "azurepowershell" => Constants.AzurePowerShellCredential,
+                "azuredevelopercli" => Constants.AzureDeveloperCliCredential,
+                "environment" => Constants.EnvironmentCredential,
+                "workloadidentity" => Constants.WorkloadIdentityCredential,
+                "managedidentity" => Constants.ManagedIdentityCredential,
+                "interactivebrowser" => Constants.InteractiveBrowserCredential,
+                "broker" => Constants.BrokerCredential,
+                "azurepipelines" => Constants.AzurePipelinesCredential,
+                "managedidentityasfederatedidentity" => Constants.ManagedIdentityAsFederatedIdentityCredential,
+                "apikey" => Constants.ApiKeyCredential,
+                _ => null,
+            };
+
+            return result is not null;
+        }
 
         /// <summary>
         /// The ID of the tenant to which the credential will authenticate by default. If not specified, the credential will authenticate to any requested tenant, and will default to the tenant to which the chosen authentication method was originally authenticated.

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -196,36 +196,37 @@ namespace Azure.Identity
 
         internal string ApiKey { get; private set; }
 
-        private static string ConvertCredentialSource(string value) => value switch
+        private static string ConvertCredentialSource(string value) => value?.ToLowerInvariant() switch
         {
             null => throw new InvalidOperationException("CredentialSource is required when configuring credentials. Specify a valid CredentialSource in the configuration."),
-            "VisualStudio" => Constants.VisualStudioCredential,
-            "VisualStudioCode" => Constants.VisualStudioCodeCredential,
-            "AzureCli" => Constants.AzureCliCredential,
-            "AzurePowerShell" => Constants.AzurePowerShellCredential,
-            "AzureDeveloperCli" => Constants.AzureDeveloperCliCredential,
-            "Environment" => Constants.EnvironmentCredential,
-            "WorkloadIdentity" => Constants.WorkloadIdentityCredential,
-            "ManagedIdentity" => Constants.ManagedIdentityCredential,
-            "InteractiveBrowser" => Constants.InteractiveBrowserCredential,
-            "Broker" => Constants.BrokerCredential,
-            "AzurePipelines" => Constants.AzurePipelinesCredential,
-            "ManagedIdentityAsFederatedIdentity" => Constants.ManagedIdentityAsFederatedIdentityCredential,
-            "ApiKey" => Constants.ApiKeyCredential,
-            // Accept already-converted values (e.g. from Clone)
-            Constants.VisualStudioCredential or
-            Constants.VisualStudioCodeCredential or
-            Constants.AzureCliCredential or
-            Constants.AzurePowerShellCredential or
-            Constants.AzureDeveloperCliCredential or
-            Constants.EnvironmentCredential or
-            Constants.WorkloadIdentityCredential or
-            Constants.ManagedIdentityCredential or
-            Constants.InteractiveBrowserCredential or
-            Constants.BrokerCredential or
-            Constants.AzurePipelinesCredential or
-            Constants.ManagedIdentityAsFederatedIdentityCredential or
-            Constants.ApiKeyCredential => value,
+            // Full credential names and already-converted lowercase values match directly
+            Constants.VisualStudioCredential => Constants.VisualStudioCredential,
+            Constants.VisualStudioCodeCredential => Constants.VisualStudioCodeCredential,
+            Constants.AzureCliCredential => Constants.AzureCliCredential,
+            Constants.AzurePowerShellCredential => Constants.AzurePowerShellCredential,
+            Constants.AzureDeveloperCliCredential => Constants.AzureDeveloperCliCredential,
+            Constants.EnvironmentCredential => Constants.EnvironmentCredential,
+            Constants.WorkloadIdentityCredential => Constants.WorkloadIdentityCredential,
+            Constants.ManagedIdentityCredential => Constants.ManagedIdentityCredential,
+            Constants.InteractiveBrowserCredential => Constants.InteractiveBrowserCredential,
+            Constants.BrokerCredential => Constants.BrokerCredential,
+            Constants.AzurePipelinesCredential => Constants.AzurePipelinesCredential,
+            Constants.ManagedIdentityAsFederatedIdentityCredential => Constants.ManagedIdentityAsFederatedIdentityCredential,
+            Constants.ApiKeyCredential => Constants.ApiKeyCredential,
+            // Short names (back-compat)
+            "visualstudio" => Constants.VisualStudioCredential,
+            "visualstudiocode" => Constants.VisualStudioCodeCredential,
+            "azurecli" => Constants.AzureCliCredential,
+            "azurepowershell" => Constants.AzurePowerShellCredential,
+            "azuredevelopercli" => Constants.AzureDeveloperCliCredential,
+            "environment" => Constants.EnvironmentCredential,
+            "workloadidentity" => Constants.WorkloadIdentityCredential,
+            "managedidentity" => Constants.ManagedIdentityCredential,
+            "interactivebrowser" => Constants.InteractiveBrowserCredential,
+            "broker" => Constants.BrokerCredential,
+            "azurepipelines" => Constants.AzurePipelinesCredential,
+            "managedidentityasfederatedidentity" => Constants.ManagedIdentityAsFederatedIdentityCredential,
+            "apikey" => Constants.ApiKeyCredential,
             _ => throw new InvalidOperationException($"Unsupported CredentialSource found in configuration: {value}."),
         };
 

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureCli
     /// </summary>
     internal class AzureCliCredentialCreationTests : CredentialCreationTestBase<AzureCliCredential>
     {
-        protected override string CredentialSource => "AzureCli";
+        protected override string CredentialSource => "AzureCliCredential";
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureCli
     /// </summary>
     internal class AzureCliCredentialCreationTests : CredentialCreationTestBase<AzureCliCredential>
     {
-        protected override string CredentialSource => "AzureCliCredential";
+        protected override string CredentialSource => nameof(AzureCliCredential);
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureDeveloperCli
     /// </summary>
     internal class AzureDeveloperCliCredentialCreationTests : CredentialCreationTestBase<AzureDeveloperCliCredential>
     {
-        protected override string CredentialSource => "AzureDeveloperCli";
+        protected override string CredentialSource => "AzureDeveloperCliCredential";
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureDeveloperCli
     /// </summary>
     internal class AzureDeveloperCliCredentialCreationTests : CredentialCreationTestBase<AzureDeveloperCliCredential>
     {
-        protected override string CredentialSource => "AzureDeveloperCliCredential";
+        protected override string CredentialSource => nameof(AzureDeveloperCliCredential);
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePipelinesCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePipelinesCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
     /// </summary>
     internal class AzurePipelinesCredentialCreationTests : CredentialCreationTestBase<AzurePipelinesCredential>
     {
-        protected override string CredentialSource => "AzurePipelinesCredential";
+        protected override string CredentialSource => nameof(AzurePipelinesCredential);
 
         protected override Dictionary<string, string> GetRequiredConfigValues() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePipelinesCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePipelinesCredentialCreationTests.cs
@@ -18,7 +18,24 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
     /// </summary>
     internal class AzurePipelinesCredentialCreationTests : CredentialCreationTestBase<AzurePipelinesCredential>
     {
-        protected override string CredentialSource => "AzurePipelines";
+        protected override string CredentialSource => "AzurePipelinesCredential";
+
+        protected override Dictionary<string, string> GetRequiredConfigValues() => new()
+        {
+            { "TenantId", "test-tenant" },
+            { "ClientId", "test-client" },
+            { "AzurePipelinesServiceConnectionId", "test-connection" },
+            { "AzurePipelinesSystemAccessToken", "test-token" },
+        };
+
+        protected override Dictionary<string, string> GetRequiredEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_CLIENT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+            { "AZURE_AUTHORITY_HOST", null },
+            { "SYSTEM_OIDCREQUESTURI", "https://dev.azure.com/myorg/_apis" },
+        };
 
         private static object GetMsalClient(AzurePipelinesCredential cred)
             => ReadProperty<object>(cred, "Client");

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePowerShell
     /// </summary>
     internal class AzurePowerShellCredentialCreationTests : CredentialCreationTestBase<AzurePowerShellCredential>
     {
-        protected override string CredentialSource => "AzurePowerShellCredential";
+        protected override string CredentialSource => nameof(AzurePowerShellCredential);
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePowerShell
     /// </summary>
     internal class AzurePowerShellCredentialCreationTests : CredentialCreationTestBase<AzurePowerShellCredential>
     {
-        protected override string CredentialSource => "AzurePowerShell";
+        protected override string CredentialSource => "AzurePowerShellCredential";
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.Broker
     /// </summary>
     internal class BrokerCredentialCreationTests : CredentialCreationTestBase<BrokerCredential>
     {
-        protected override string CredentialSource => "Broker";
+        protected override string CredentialSource => "BrokerCredential";
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.Broker
     /// </summary>
     internal class BrokerCredentialCreationTests : CredentialCreationTestBase<BrokerCredential>
     {
-        protected override string CredentialSource => "BrokerCredential";
+        protected override string CredentialSource => nameof(BrokerCredential);
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ClientAssertionCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ClientAssertionCredentialCreationTests.cs
@@ -19,7 +19,16 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ClientAssertion
     /// </summary>
     internal class ClientAssertionCredentialCreationTests : CredentialCreationTestBase<ClientAssertionCredential>
     {
-        protected override string CredentialSource => "ManagedIdentityAsFederatedIdentity";
+        protected override string CredentialSource => "ManagedIdentityAsFederatedIdentityCredential";
+
+        protected override Dictionary<string, string> GetRequiredConfigValues() => new()
+        {
+            { "TenantId", "test-tenant" },
+            { "ClientId", "test-client" },
+            { "AzureCloud", "public" },
+            { "ManagedIdentityIdKind", "ClientId" },
+            { "ManagedIdentityId", "test-mi-client-id" },
+        };
 
         private static object GetMsalClient(ClientAssertionCredential cred)
             => ReadProperty<object>(cred, "Client");

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialCacheTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialCacheTests.cs
@@ -218,5 +218,47 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
 
             Assert.AreNotSame(cred1, cred2);
         }
+
+        [Test]
+        public void GetOrAdd_ShortAndFullCredentialSourceAliases_ReturnsSameInstance()
+        {
+            string nonce = Unique();
+            var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "AzureCli",
+                ["TenantId"] = nonce,
+            });
+            var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "AzureCliCredential",
+                ["TenantId"] = nonce,
+            });
+
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () => new ConfigurableCredential());
+
+            Assert.AreSame(cred1, cred2);
+        }
+
+        [Test]
+        public void GetOrAdd_CaseInsensitiveCredentialSource_ReturnsSameInstance()
+        {
+            string nonce = Unique();
+            var section1 = BuildCredentialSection("Client1:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "AzureCliCredential",
+                ["TenantId"] = nonce,
+            });
+            var section2 = BuildCredentialSection("Client2:Credential", new Dictionary<string, string>
+            {
+                ["CredentialSource"] = "azureclicredential",
+                ["TenantId"] = nonce,
+            });
+
+            var cred1 = ConfigurableCredentialCache.GetOrAdd(section1, () => new ConfigurableCredential());
+            var cred2 = ConfigurableCredentialCache.GetOrAdd(section2, () => new ConfigurableCredential());
+
+            Assert.AreSame(cred1, cred2);
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/CredentialCreationTestBase.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/CredentialCreationTestBase.cs
@@ -2,8 +2,14 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
 using System.Reflection;
+using Azure.Core.TestFramework;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NUnit.Framework;
 
 namespace Azure.Identity.Tests.ConfigurableCredentials
@@ -31,6 +37,204 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
 
         protected TCredential GetUnderlying(ConfigurableCredential credential)
             => Helper.GetUnderlyingCredential(credential);
+
+        /// <summary>
+        /// Returns additional config key-value pairs required to create this credential.
+        /// Override in subclasses that need more than just CredentialSource (e.g. TenantId, ClientId).
+        /// </summary>
+        protected virtual Dictionary<string, string> GetRequiredConfigValues() => new();
+
+        /// <summary>
+        /// Returns environment variables to control during e2e creation.
+        /// Override in subclasses that need specific env vars set.
+        /// </summary>
+        protected virtual Dictionary<string, string> GetRequiredEnvVars() => new()
+        {
+            { "AZURE_TENANT_ID", null },
+            { "AZURE_ADDITIONALLY_ALLOWED_TENANTS", null },
+        };
+
+        /// <summary>
+        /// Verifies the credential can be created end-to-end from IConfiguration
+        /// using the GetAzureClientSettings / WithAzureCredential flow.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public void CreatesCredentialFromConfiguration_E2E()
+        {
+            using (new TestEnvVar(GetRequiredEnvVars()))
+            {
+                var configValues = new Dictionary<string, string>
+                {
+                    ["MyClient:Endpoint"] = "https://test.example.com",
+                    ["MyClient:Credential:CredentialSource"] = CredentialSource,
+                };
+
+                foreach (var kvp in GetRequiredConfigValues())
+                {
+                    configValues[$"MyClient:Credential:{kvp.Key}"] = kvp.Value;
+                }
+
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(configValues)
+                    .Build();
+
+                var settings = config.GetAzureClientSettings<E2ETestSettings>("MyClient");
+                Assert.IsNotNull(settings.CredentialProvider, $"CredentialProvider should be set for {CredentialSource}");
+                Assert.IsInstanceOf<ConfigurableCredential>(settings.CredentialProvider, $"CredentialProvider should be ConfigurableCredential for {CredentialSource}");
+
+                var configurableCredential = (ConfigurableCredential)settings.CredentialProvider;
+                var underlying = GetUnderlying(configurableCredential);
+                Assert.IsInstanceOf<TCredential>(underlying, $"Underlying credential should be {typeof(TCredential).Name} for {CredentialSource}");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that without WithAzureCredential, CredentialProvider is null
+        /// and AuthenticationPolicy.Create throws the appropriate error.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public void WithoutWithAzureCredential_AuthenticationPolicyCreateThrows()
+        {
+            using (new TestEnvVar(GetRequiredEnvVars()))
+            {
+                var configValues = new Dictionary<string, string>
+                {
+                    ["MyClient:Endpoint"] = "https://test.example.com",
+                    ["MyClient:Credential:CredentialSource"] = CredentialSource,
+                    ["MyClient:Credential:AdditionalProperties:Scope"] = "https://test.example.com/.default",
+                };
+
+                foreach (var kvp in GetRequiredConfigValues())
+                {
+                    configValues[$"MyClient:Credential:{kvp.Key}"] = kvp.Value;
+                }
+
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(configValues)
+                    .Build();
+
+                var settings = config.GetClientSettings<E2ETestSettings>("MyClient");
+                Assert.IsNull(settings.CredentialProvider, $"CredentialProvider should be null without WithAzureCredential for {CredentialSource}");
+
+                var ex = Assert.Throws<InvalidOperationException>(() => AuthenticationPolicy.Create(settings));
+                Assert.That(ex.Message, Does.Contain("No AuthenticationTokenProvider was provided."));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that AddClient with WithAzureCredential resolves a working client from DI.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public void AddClient_WithAzureCredential_ResolvesClient()
+        {
+            using (new TestEnvVar(GetRequiredEnvVars()))
+            {
+                HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+                var configValues = BuildConfigValues();
+
+                builder.Configuration.AddInMemoryCollection(configValues);
+                builder.AddClient<DITestClient, E2ETestSettings>("MyClient").WithAzureCredential();
+
+                IHost host = builder.Build();
+                var client = host.Services.GetRequiredService<DITestClient>();
+
+                Assert.IsNotNull(client);
+                Assert.IsNotNull(client.Endpoint);
+                Assert.IsNotNull(client.Credential);
+                Assert.IsInstanceOf<ConfigurableCredential>(client.Credential);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that AddClient without WithAzureCredential throws ArgumentNullException
+        /// because the credential is null when the DI container resolves the client.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public void AddClient_WithoutWithAzureCredential_ThrowsOnResolve()
+        {
+            using (new TestEnvVar(GetRequiredEnvVars()))
+            {
+                HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+                var configValues = BuildConfigValues();
+
+                builder.Configuration.AddInMemoryCollection(configValues);
+                builder.AddClient<DITestClient, E2ETestSettings>("MyClient");
+
+                IHost host = builder.Build();
+                var ex = Assert.Throws<ArgumentNullException>(() => host.Services.GetRequiredService<DITestClient>());
+                Assert.That(ex.ParamName, Is.EqualTo("credential"));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that AddKeyedClient with WithAzureCredential resolves a working client from DI.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public void AddKeyedClient_WithAzureCredential_ResolvesClient()
+        {
+            using (new TestEnvVar(GetRequiredEnvVars()))
+            {
+                HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+                var configValues = BuildConfigValues();
+
+                builder.Configuration.AddInMemoryCollection(configValues);
+                builder.AddKeyedClient<DITestClient, E2ETestSettings>("myKey", "MyClient").WithAzureCredential();
+
+                IHost host = builder.Build();
+                var client = host.Services.GetRequiredKeyedService<DITestClient>("myKey");
+
+                Assert.IsNotNull(client);
+                Assert.IsNotNull(client.Endpoint);
+                Assert.IsNotNull(client.Credential);
+                Assert.IsInstanceOf<ConfigurableCredential>(client.Credential);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that AddKeyedClient without WithAzureCredential throws ArgumentNullException
+        /// because the credential is null when the DI container resolves the client.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public void AddKeyedClient_WithoutWithAzureCredential_ThrowsOnResolve()
+        {
+            using (new TestEnvVar(GetRequiredEnvVars()))
+            {
+                HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+                var configValues = BuildConfigValues();
+
+                builder.Configuration.AddInMemoryCollection(configValues);
+                builder.AddKeyedClient<DITestClient, E2ETestSettings>("myKey", "MyClient");
+
+                IHost host = builder.Build();
+                var ex = Assert.Throws<ArgumentNullException>(() => host.Services.GetRequiredKeyedService<DITestClient>("myKey"));
+                Assert.That(ex.ParamName, Is.EqualTo("credential"));
+            }
+        }
+
+        /// <summary>
+        /// Builds the config dictionary for DI tests, including CredentialSource and any required config values.
+        /// </summary>
+        private Dictionary<string, string> BuildConfigValues()
+        {
+            var configValues = new Dictionary<string, string>
+            {
+                ["MyClient:Endpoint"] = "https://test.example.com",
+                ["MyClient:Credential:CredentialSource"] = CredentialSource,
+            };
+
+            foreach (var kvp in GetRequiredConfigValues())
+            {
+                configValues[$"MyClient:Credential:{kvp.Key}"] = kvp.Value;
+            }
+
+            return configValues;
+        }
 
         /// <summary>
         /// Reads an internal/private property by walking the type hierarchy.

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/DITestClient.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/DITestClient.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials
+{
+    /// <summary>
+    /// Simulates a real Azure SDK client with standard constructor patterns.
+    /// Used by DI integration tests to verify AddClient/AddKeyedClient flows.
+    /// </summary>
+    internal class DITestClient
+    {
+        public Uri Endpoint { get; }
+        public TokenCredential Credential { get; }
+        public TestOptions Options { get; }
+
+        public DITestClient(Uri endpoint, TokenCredential credential, TestOptions options = null)
+        {
+            Argument.AssertNotNull(endpoint, nameof(endpoint));
+            Argument.AssertNotNull(credential, nameof(credential));
+
+            Endpoint = endpoint;
+            Credential = credential;
+            Options = options ?? new TestOptions();
+        }
+
+        public DITestClient(E2ETestSettings settings)
+            : this(
+                  settings?.Endpoint != null ? new Uri(settings.Endpoint) : null,
+                  settings?.CredentialProvider as TokenCredential,
+                  null)
+        {
+        }
+
+        /// <summary>
+        /// Minimal options type for DITestClient.
+        /// </summary>
+        internal class TestOptions
+        {
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/E2ETestSettings.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/E2ETestSettings.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ClientModel.Primitives;
+using Microsoft.Extensions.Configuration;
+
+namespace Azure.Identity.Tests.ConfigurableCredentials
+{
+    /// <summary>
+    /// Minimal ClientSettings for e2e creation tests.
+    /// </summary>
+    internal class E2ETestSettings : ClientSettings
+    {
+        public string Endpoint { get; set; }
+
+        protected override void BindCore(IConfigurationSection section)
+        {
+            Endpoint = section["Endpoint"];
+        }
+    }
+}

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Environment
     /// </summary>
     internal class EnvironmentCredentialCreationTests : CredentialCreationTestBase<EnvironmentCredential>
     {
-        protected override string CredentialSource => "Environment";
+        protected override string CredentialSource => "EnvironmentCredential";
 
         /// <summary>
         /// Env vars needed for EnvironmentCredential to construct a ClientSecretCredential internally.

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Environment
     /// </summary>
     internal class EnvironmentCredentialCreationTests : CredentialCreationTestBase<EnvironmentCredential>
     {
-        protected override string CredentialSource => "EnvironmentCredential";
+        protected override string CredentialSource => nameof(EnvironmentCredential);
 
         /// <summary>
         /// Env vars needed for EnvironmentCredential to construct a ClientSecretCredential internally.

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialCreationTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.InteractiveBrowser
     /// </summary>
     internal class InteractiveBrowserCredentialCreationTests : CredentialCreationTestBase<InteractiveBrowserCredential>
     {
-        protected override string CredentialSource => "InteractiveBrowserCredential";
+        protected override string CredentialSource => nameof(InteractiveBrowserCredential);
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/InteractiveBrowserCredentialCreationTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.InteractiveBrowser
     /// </summary>
     internal class InteractiveBrowserCredentialCreationTests : CredentialCreationTestBase<InteractiveBrowserCredential>
     {
-        protected override string CredentialSource => "InteractiveBrowser";
+        protected override string CredentialSource => "InteractiveBrowserCredential";
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
@@ -17,7 +17,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
     /// </summary>
     internal class ManagedIdentityCredentialCreationTests : CredentialCreationTestBase<ManagedIdentityCredential>
     {
-        protected override string CredentialSource => "ManagedIdentityCredential";
+        protected override string CredentialSource => nameof(ManagedIdentityCredential);
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ManagedIdentityCredentialCreationTests.cs
@@ -17,7 +17,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.ManagedIdentity
     /// </summary>
     internal class ManagedIdentityCredentialCreationTests : CredentialCreationTestBase<ManagedIdentityCredential>
     {
-        protected override string CredentialSource => "ManagedIdentity";
+        protected override string CredentialSource => "ManagedIdentityCredential";
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCodeCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCodeCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudioCode
     /// </summary>
     internal class VisualStudioCodeCredentialCreationTests : CredentialCreationTestBase<VisualStudioCodeCredential>
     {
-        protected override string CredentialSource => "VisualStudioCodeCredential";
+        protected override string CredentialSource => nameof(VisualStudioCodeCredential);
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCodeCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCodeCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudioCode
     /// </summary>
     internal class VisualStudioCodeCredentialCreationTests : CredentialCreationTestBase<VisualStudioCodeCredential>
     {
-        protected override string CredentialSource => "VisualStudioCode";
+        protected override string CredentialSource => "VisualStudioCodeCredential";
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudio
     /// </summary>
     internal class VisualStudioCredentialCreationTests : CredentialCreationTestBase<VisualStudioCredential>
     {
-        protected override string CredentialSource => "VisualStudioCredential";
+        protected override string CredentialSource => nameof(VisualStudioCredential);
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudio
     /// </summary>
     internal class VisualStudioCredentialCreationTests : CredentialCreationTestBase<VisualStudioCredential>
     {
-        protected override string CredentialSource => "VisualStudio";
+        protected override string CredentialSource => "VisualStudioCredential";
 
         private static Dictionary<string, string> AllNulledEnvVars() => new()
         {

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.WorkloadIdentity
     /// </summary>
     internal class WorkloadIdentityCredentialCreationTests : CredentialCreationTestBase<WorkloadIdentityCredential>
     {
-        protected override string CredentialSource => "WorkloadIdentity";
+        protected override string CredentialSource => "WorkloadIdentityCredential";
 
         private static ClientAssertionCredential GetClientAssertionCredential(WorkloadIdentityCredential wic)
             => ReadField<ClientAssertionCredential>(wic, "_clientAssertionCredential");

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.WorkloadIdentity
     /// </summary>
     internal class WorkloadIdentityCredentialCreationTests : CredentialCreationTestBase<WorkloadIdentityCredential>
     {
-        protected override string CredentialSource => "WorkloadIdentityCredential";
+        protected override string CredentialSource => nameof(WorkloadIdentityCredential);
 
         private static ClientAssertionCredential GetClientAssertionCredential(WorkloadIdentityCredential wic)
             => ReadField<ClientAssertionCredential>(wic, "_clientAssertionCredential");

--- a/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialOptionsTests.cs
+++ b/sdk/identity/Azure.Identity/tests/DefaultAzureCredentialOptionsTests.cs
@@ -21,7 +21,6 @@ namespace Azure.Identity.Tests
             yield return null;
         }
 
-        [Test]
         [TestCaseSource(nameof(IdTestValues))]
         public void ValidateAzureTenantIdEnvVarDefaultHonored(string envVarValue)
         {
@@ -39,7 +38,6 @@ namespace Azure.Identity.Tests
             }
         }
 
-        [Test]
         [TestCaseSource(nameof(IdTestValues))]
         public void ValidateAzureUsernameEnvVarDefaultHonored(string envVarValue)
         {
@@ -53,7 +51,6 @@ namespace Azure.Identity.Tests
             }
         }
 
-        [Test]
         [TestCaseSource(nameof(IdTestValues))]
         public void ValidateAzureClientIdEnvVarDefaultHonored(string envVarValue)
         {
@@ -75,7 +72,6 @@ namespace Azure.Identity.Tests
             yield return String.Empty;
             yield return null;
         }
-        [Test]
         [TestCaseSource(nameof(IdListTestValues))]
         public void ValidateAzureAdditionallyAllowedTenantsEnvVarDefaultHonored(string envVarValue)
         {
@@ -272,7 +268,20 @@ namespace Azure.Identity.Tests
             Assert.That(ex.Message, Does.Contain(credentialSource));
         }
 
-        [Test]
+        [TestCase("AzureCliCredential", "azureclicredential")]
+        [TestCase("VisualStudioCredential", "visualstudiocredential")]
+        [TestCase("VisualStudioCodeCredential", "visualstudiocodecredential")]
+        [TestCase("AzurePowerShellCredential", "azurepowershellcredential")]
+        [TestCase("AzureDeveloperCliCredential", "azuredeveloperclicredential")]
+        [TestCase("EnvironmentCredential", "environmentcredential")]
+        [TestCase("WorkloadIdentityCredential", "workloadidentitycredential")]
+        [TestCase("ManagedIdentityCredential", "managedidentitycredential")]
+        [TestCase("InteractiveBrowserCredential", "interactivebrowsercredential")]
+        [TestCase("BrokerCredential", "brokercredential")]
+        [TestCase("AzurePipelinesCredential", "azurepipelinescredential")]
+        [TestCase("ManagedIdentityAsFederatedIdentityCredential", "managedidentityasfederatedidentitycredential")]
+        [TestCase("ApiKeyCredential", "apikeycredential")]
+        // Back-compat short names
         [TestCase("AzureCli", "azureclicredential")]
         [TestCase("VisualStudio", "visualstudiocredential")]
         [TestCase("VisualStudioCode", "visualstudiocodecredential")]
@@ -283,7 +292,9 @@ namespace Azure.Identity.Tests
         [TestCase("ManagedIdentity", "managedidentitycredential")]
         [TestCase("InteractiveBrowser", "interactivebrowsercredential")]
         [TestCase("Broker", "brokercredential")]
-        [TestCase("ApiKey", "ApiKey")]
+        [TestCase("AzurePipelines", "azurepipelinescredential")]
+        [TestCase("ManagedIdentityAsFederatedIdentity", "managedidentityasfederatedidentitycredential")]
+        [TestCase("ApiKey", "apikeycredential")]
         public void CredentialSourceMapping_CorrectlyMapsKnownValues(string input, string expected)
         {
             var mockSection = new Moq.Mock<IConfigurationSection>();
@@ -365,6 +376,30 @@ namespace Azure.Identity.Tests
             Assert.AreEqual(original.ApiKey, clone.ApiKey);
             Assert.AreEqual("azureclicredential", clone.CredentialSource);
             Assert.AreEqual(apiKey, clone.ApiKey);
+        }
+
+        [TestCase(nameof(VisualStudioCredential))]
+        [TestCase(nameof(VisualStudioCodeCredential))]
+        [TestCase(nameof(AzureCliCredential))]
+        [TestCase(nameof(AzurePowerShellCredential))]
+        [TestCase(nameof(AzureDeveloperCliCredential))]
+        [TestCase(nameof(EnvironmentCredential))]
+        [TestCase(nameof(WorkloadIdentityCredential))]
+        [TestCase(nameof(ManagedIdentityCredential))]
+        [TestCase(nameof(InteractiveBrowserCredential))]
+        [TestCase(nameof(BrokerCredential))]
+        [TestCase(nameof(AzurePipelinesCredential))]
+        [TestCase(nameof(Constants.ManagedIdentityAsFederatedIdentityCredential))]
+        [TestCase(nameof(Constants.ApiKeyCredential))]
+        public void CredentialConstant_MatchesNameOfToLowerInvariant(string credentialTypeName)
+        {
+            string expected = credentialTypeName.ToLowerInvariant();
+            string actual = typeof(Constants)
+                .GetField(credentialTypeName, BindingFlags.Public | BindingFlags.Static)
+                ?.GetValue(null) as string;
+
+            Assert.IsNotNull(actual, $"Constants.{credentialTypeName} field not found.");
+            Assert.AreEqual(expected, actual, $"Constants.{credentialTypeName} should equal \"{expected}\" but was \"{actual}\".");
         }
     }
 }


### PR DESCRIPTION
## Description

Resolves #56397

Updates ConvertCredentialSource in DefaultAzureCredentialOptions to accept full credential type names (e.g., \AzureCliCredential\) alongside existing short names (e.g., \AzureCli\) for backward compatibility.

### Key Changes

**Source changes:**
- Refactored \ConvertCredentialSource\ switch to use \alue?.ToLowerInvariant()\, enabling case-insensitive matching of full credential names without redundant switch arms
- Added full credential name entries for all 13 credential types
- Normalized \Constants.ApiKeyCredential\ to lowercase (\pikeycredential\) for consistency with other constants

**Test changes:**
- Updated all 12 credential creation test classes to use full names as primary \CredentialSource\
- Added \CredentialConstant_MatchesNameOfToLowerInvariant\ test validating all 13 constants match \
ameof().ToLowerInvariant()\
- Added back-compat \TestCase\ entries for short names across all test suites
- Added E2E creation tests using \GetAzureClientSettings\/\WithAzureCredential\ for all 13 credential types
- Added without-\WithAzureCredential\ tests verifying \AuthenticationPolicy.Create\ throws appropriately
- Added DI integration tests (\AddClient\/\AddKeyedClient\ with and without \WithAzureCredential\) using a \DITestClient\ that simulates real SDK client constructor patterns
- Removed redundant \[Test]\ attributes alongside \[TestCase]\ attributes
- Removed redundant test methods that were subsets of existing tests