### PR TITLE
[Storage] [DataMovement] Removed usage of MemoryMappedFiles in Local Checkpointer to allow for File Handles to be Released Correctly

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -8,8 +8,10 @@
 
 ### Bugs Fixed
 - Fixed bug where `StorageResourceCreationMode.SkipIfExists` failed on existing destination directories during container transfers. Existing directories are now skipped without error.
+- Fixed file handle leaks in local checkpointer that prevented checkpoint files from being accessed after transfer pause or completion by replacing MemoryMappedFiles with direct file access.
 
 ### Other Changes
+- Made TransferManager.DisposeAsync public
 
 ## 12.3.0 (2025-10-21)
 

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net10.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net10.0.cs
@@ -156,13 +156,13 @@ namespace Azure.Storage.DataMovement
     {
         protected TransferManager() { }
         public TransferManager(Azure.Storage.DataMovement.TransferManagerOptions options = null) { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.TransferProperties> GetResumableTransfersAsync([System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.TransferOperation> GetTransfersAsync(System.Collections.Generic.ICollection<Azure.Storage.DataMovement.TransferStatus> filterByStatus = null, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task PauseTransferAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<Azure.Storage.DataMovement.TransferOperation>> ResumeAllTransfersAsync(Azure.Storage.DataMovement.TransferOptions transferOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> ResumeTransferAsync(string transferId, Azure.Storage.DataMovement.TransferOptions transferOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, Azure.Storage.DataMovement.StorageResource destinationResource, Azure.Storage.DataMovement.TransferOptions transferOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync() { throw null; }
     }
     public partial class TransferManagerOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.net8.0.cs
@@ -156,13 +156,13 @@ namespace Azure.Storage.DataMovement
     {
         protected TransferManager() { }
         public TransferManager(Azure.Storage.DataMovement.TransferManagerOptions options = null) { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.TransferProperties> GetResumableTransfersAsync([System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.TransferOperation> GetTransfersAsync(System.Collections.Generic.ICollection<Azure.Storage.DataMovement.TransferStatus> filterByStatus = null, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task PauseTransferAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<Azure.Storage.DataMovement.TransferOperation>> ResumeAllTransfersAsync(Azure.Storage.DataMovement.TransferOptions transferOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> ResumeTransferAsync(string transferId, Azure.Storage.DataMovement.TransferOptions transferOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, Azure.Storage.DataMovement.StorageResource destinationResource, Azure.Storage.DataMovement.TransferOptions transferOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync() { throw null; }
     }
     public partial class TransferManagerOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/api/Azure.Storage.DataMovement.netstandard2.0.cs
@@ -156,13 +156,13 @@ namespace Azure.Storage.DataMovement
     {
         protected TransferManager() { }
         public TransferManager(Azure.Storage.DataMovement.TransferManagerOptions options = null) { }
+        public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.TransferProperties> GetResumableTransfersAsync([System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.Storage.DataMovement.TransferOperation> GetTransfersAsync(System.Collections.Generic.ICollection<Azure.Storage.DataMovement.TransferStatus> filterByStatus = null, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task PauseTransferAsync(string transferId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<System.Collections.Generic.List<Azure.Storage.DataMovement.TransferOperation>> ResumeAllTransfersAsync(Azure.Storage.DataMovement.TransferOptions transferOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> ResumeTransferAsync(string transferId, Azure.Storage.DataMovement.TransferOptions transferOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Storage.DataMovement.TransferOperation> StartTransferAsync(Azure.Storage.DataMovement.StorageResource sourceResource, Azure.Storage.DataMovement.StorageResource destinationResource, Azure.Storage.DataMovement.TransferOptions transferOptions = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        System.Threading.Tasks.ValueTask System.IAsyncDisposable.DisposeAsync() { throw null; }
     }
     public partial class TransferManagerOptions
     {

--- a/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement/src/Azure.Storage.DataMovement.csproj
@@ -41,5 +41,7 @@
     <Compile Include="$(AzureStorageSharedSources)PooledMemoryStream.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)Argument.cs" LinkBase="Shared\Storage" />
     <Compile Include="$(AzureStorageSharedSources)SyncAsyncEventHandlerExtensions.cs" LinkBase="Shared\Storage" />
+    <Compile Include="$(AzureStorageSharedSources)StreamExtensions.cs" LinkBase="Shared\Storage" />
+    <Compile Include="$(AzureStorageSharedSources)BufferExtensions.cs" LinkBase="Shared\Storage" />
   </ItemGroup>
 </Project>

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPartPlanFile.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPartPlanFile.cs
@@ -62,7 +62,13 @@ namespace Azure.Storage.DataMovement.JobPlan
 
             try
             {
-                using (FileStream fileStream = File.Create(result.FileName.ToString()))
+                using (FileStream fileStream = new FileStream(
+                    result.FileName.ToString(),
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None,
+                    bufferSize: 4096,
+                    FileOptions.None))
                 using (MemoryStream ms = new())
                 {
                     header.Serialize(ms);
@@ -71,6 +77,7 @@ namespace Azure.Storage.DataMovement.JobPlan
                         fileStream,
                         DataMovementConstants.DefaultStreamCopyBufferSize,
                         cancellationToken).ConfigureAwait(false);
+                    await fileStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception)

--- a/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPlanFile.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/JobPlan/JobPlanFile.cs
@@ -64,12 +64,19 @@ namespace Azure.Storage.DataMovement.JobPlan
             JobPlanFile jobPlanFile = new(id, filePath);
             try
             {
-                using (FileStream fileStream = File.Create(jobPlanFile.FilePath))
+                using (FileStream fileStream = new FileStream(
+                    jobPlanFile.FilePath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None,
+                    bufferSize: 4096,
+                    FileOptions.None))
                 {
                     await headerStream.CopyToAsync(
                         fileStream,
                         DataMovementConstants.DefaultStreamCopyBufferSize,
                         cancellationToken).ConfigureAwait(false);
+                    await fileStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception)

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
@@ -483,7 +483,7 @@ namespace Azure.Storage.DataMovement
         /// </summary>
         private void RefreshCache()
         {
-            // Dispose all existing items, then clear _transferSates dicitonary
+            // Dispose all existing items, then clear _transferSates dictionary
             foreach (var planState in _transferStates)
             {
                 DisposeOfJobPartPlanAndPlanFile(planState.Value);

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -194,10 +193,34 @@ namespace Azure.Storage.DataMovement
             await jobPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPlanFile.FilePath))
-                using (MemoryMappedViewStream mmfStream = mmf.CreateViewStream(offset, length, MemoryMappedFileAccess.Read))
+                using (FileStream fileStream = new FileStream(
+                    jobPlanFile.FilePath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read))
                 {
-                    await mmfStream.CopyToAsync(copiedStream, bufferSize, cancellationToken).ConfigureAwait(false);
+                    if (offset > 0)
+                    {
+                        fileStream.Seek(offset, SeekOrigin.Begin);
+                    }
+
+                    if (length > 0)
+                    {
+                        byte[] buffer = ArrayPool<byte>.Shared.Rent(length);
+                        try
+                        {
+                            int bytesRead = await fileStream.ReadAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
+                            await copiedStream.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            ArrayPool<byte>.Shared.Return(buffer);
+                        }
+                    }
+                    else
+                    {
+                        await fileStream.CopyToAsync(copiedStream, bufferSize, cancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 copiedStream.Position = 0;
@@ -232,10 +255,34 @@ namespace Azure.Storage.DataMovement
             await jobPartPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPartPlanFile.FilePath))
-                using (MemoryMappedViewStream mmfStream = mmf.CreateViewStream(offset, length, MemoryMappedFileAccess.Read))
+                using (FileStream fileStream = new FileStream(
+                    jobPartPlanFile.FilePath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read))
                 {
-                    await mmfStream.CopyToAsync(copiedStream, bufferSize, cancellationToken).ConfigureAwait(false);
+                    if (offset > 0)
+                    {
+                        fileStream.Seek(offset, SeekOrigin.Begin);
+                    }
+
+                    if (length > 0)
+                    {
+                        byte[] buffer = ArrayPool<byte>.Shared.Rent(length);
+                        try
+                        {
+                            int bytesRead = await fileStream.ReadAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
+                            await copiedStream.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            ArrayPool<byte>.Shared.Return(buffer);
+                        }
+                    }
+                    else
+                    {
+                        await fileStream.CopyToAsync(copiedStream, bufferSize, cancellationToken).ConfigureAwait(false);
+                    }
                 }
 
                 copiedStream.Position = 0;
@@ -261,11 +308,15 @@ namespace Azure.Storage.DataMovement
                 await jobPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPlanFile.FilePath, FileMode.Open))
-                    using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(fileOffset, length, MemoryMappedFileAccess.Write))
+                    using (FileStream fileStream = new FileStream(
+                        jobPlanFile.FilePath,
+                        FileMode.Open,
+                        FileAccess.Write,
+                        FileShare.Read))
                     {
-                        accessor.WriteArray(0, buffer, bufferOffset, length);
-                        accessor.Flush();
+                        fileStream.Seek(fileOffset, SeekOrigin.Begin);
+                        await fileStream.WriteAsync(buffer, bufferOffset, length, cancellationToken).ConfigureAwait(false);
+                        await fileStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                     }
                 }
                 finally
@@ -339,7 +390,6 @@ namespace Azure.Storage.DataMovement
             TransferStatus status,
             CancellationToken cancellationToken = default)
         {
-            long length = DataMovementConstants.IntSizeInBytes;
             int offset = DataMovementConstants.JobPlanFile.JobStatusIndex;
 
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
@@ -359,11 +409,17 @@ namespace Azure.Storage.DataMovement
             await jobPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(jobPlanFile.FilePath, FileMode.Open))
-                using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(offset, length))
+                using (FileStream fileStream = new FileStream(
+                    jobPlanFile.FilePath,
+                    FileMode.Open,
+                    FileAccess.Write,
+                    FileShare.Read))
                 {
-                    accessor.Write(0, (int)status.ToJobPlanStatus());
-                    accessor.Flush();
+                    fileStream.Seek(offset, SeekOrigin.Begin);
+                    int statusValue = (int)status.ToJobPlanStatus();
+                    byte[] statusBytes = BitConverter.GetBytes(statusValue);
+                    await fileStream.WriteAsync(statusBytes, 0, statusBytes.Length, cancellationToken).ConfigureAwait(false);
+                    await fileStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
             finally
@@ -388,7 +444,6 @@ namespace Azure.Storage.DataMovement
             TransferStatus status,
             CancellationToken cancellationToken = default)
         {
-            long length = DataMovementConstants.IntSizeInBytes;
             int offset = DataMovementConstants.JobPartPlanFile.JobPartStatusIndex;
 
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
@@ -404,11 +459,17 @@ namespace Azure.Storage.DataMovement
             await file.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.FilePath, FileMode.Open))
-                using (MemoryMappedViewAccessor accessor = mmf.CreateViewAccessor(offset, length))
+                using (FileStream fileStream = new FileStream(
+                    file.FilePath,
+                    FileMode.Open,
+                    FileAccess.Write,
+                    FileShare.Read))
                 {
-                    accessor.Write(0, (int)status.ToJobPlanStatus());
-                    accessor.Flush();
+                    fileStream.Seek(offset, SeekOrigin.Begin);
+                    int statusValue = (int)status.ToJobPlanStatus();
+                    byte[] statusBytes = BitConverter.GetBytes(statusValue);
+                    await fileStream.WriteAsync(statusBytes, 0, statusBytes.Length, cancellationToken).ConfigureAwait(false);
+                    await fileStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
             finally

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
@@ -21,7 +21,7 @@ namespace Azure.Storage.DataMovement
     /// Creates a checkpointer which uses a locally stored file to obtain
     /// the information in order to resume transfers in the future.
     /// </summary>
-    internal class LocalTransferCheckpointer : SerializerTransferCheckpointer
+    internal class LocalTransferCheckpointer : SerializerTransferCheckpointer, IDisposable
     {
         internal string _pathToCheckpointer;
 
@@ -29,6 +29,7 @@ namespace Azure.Storage.DataMovement
         /// Stores references to the memory mapped files stored by IDs.
         /// </summary>
         internal readonly ConcurrentDictionary<string, JobPlanFile> _transferStates;
+        internal bool _disposed;
 
         /// <summary>
         /// Initializes a new instance of <see cref="LocalTransferCheckpointer"/> class.
@@ -36,6 +37,7 @@ namespace Azure.Storage.DataMovement
         /// <param name="folderPath">Path to the folder containing the checkpointing information to resume from.</param>
         public LocalTransferCheckpointer(string folderPath)
         {
+            _disposed = false;
             _transferStates = new ConcurrentDictionary<string, JobPlanFile>();
             if (string.IsNullOrEmpty(folderPath))
             {
@@ -54,6 +56,22 @@ namespace Azure.Storage.DataMovement
             {
                 _pathToCheckpointer = folderPath;
             }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            foreach (var kvp in _transferStates)
+            {
+                DisposeOfJobPartPlanAndPlanFile(kvp.Value);
+            }
+            _transferStates.Clear();
+
+            _disposed = true;
         }
 
         private bool TryGetJobPlanFile(string transferId, out JobPlanFile result)
@@ -267,19 +285,24 @@ namespace Azure.Storage.DataMovement
 
             List<string> filesToDelete = new List<string>();
 
-            if (TryGetJobPlanFile(transferId, out JobPlanFile jobPlanFile))
-            {
-                filesToDelete.Add(jobPlanFile.FilePath);
-            }
-            else
+            if (!TryGetJobPlanFile(transferId, out JobPlanFile jobPlanFile))
             {
                 return Task.FromResult(false);
             }
 
+            filesToDelete.Add(jobPlanFile.FilePath);
+
+            // Dispose of Job Plan Part Files and after the Job Plan File
             foreach (KeyValuePair<int, JobPartPlanFile> jobPartPair in jobPlanFile.JobParts)
             {
                 filesToDelete.Add(jobPartPair.Value.FilePath);
+                jobPartPair.Value.Dispose();
             }
+
+            jobPlanFile.Dispose();
+
+            // Remove from dictionary after disposing
+            _transferStates.TryRemove(transferId, out _);
 
             bool result = true;
             foreach (string file in filesToDelete)
@@ -302,8 +325,6 @@ namespace Azure.Storage.DataMovement
                     result = false;
                 }
             }
-
-            _transferStates.TryRemove(transferId, out _);
             return Task.FromResult(result);
         }
 
@@ -335,13 +356,6 @@ namespace Azure.Storage.DataMovement
                 return;
             }
 
-            // if paused or other completion state, remove the memory cache but still write state to the plan file for later resume
-            if (status.State == TransferState.Completed || status.State == TransferState.Paused)
-            {
-                // If TryRemove fails, it's fine it may be because it does not already exist or already has been removed
-                _transferStates.TryRemove(transferId, out _);
-            }
-
             await jobPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
@@ -355,6 +369,16 @@ namespace Azure.Storage.DataMovement
             finally
             {
                 jobPlanFile.WriteLock.Release();
+            }
+
+            // if paused or other completion state, remove the memory cache but still write state to the plan file for later resume
+            if (status.State == TransferState.Completed || status.State == TransferState.Paused)
+            {
+                // If TryRemove fails, it's fine it may be because it does not already exist or already has been removed
+                if (_transferStates.TryRemove(transferId, out JobPlanFile removedFile))
+                {
+                    DisposeOfJobPartPlanAndPlanFile(removedFile);
+                }
             }
         }
 
@@ -398,6 +422,11 @@ namespace Azure.Storage.DataMovement
         /// </summary>
         private void RefreshCache()
         {
+            // Dispose all existing items, then clear _transferSates dicitonary
+            foreach (var planState in _transferStates)
+            {
+                DisposeOfJobPartPlanAndPlanFile(planState.Value);
+            }
             _transferStates.Clear();
 
             // First, retrieve all valid job plan files
@@ -440,7 +469,11 @@ namespace Azure.Storage.DataMovement
         private void RefreshCache(string transferId)
         {
             // If TryRemove fails, it's fine it may be because it does not already exist or already has been removed
-            _transferStates.TryRemove(transferId, out _);
+            if (_transferStates.TryRemove(transferId, out JobPlanFile existingFile))
+            {
+                DisposeOfJobPartPlanAndPlanFile(existingFile);
+            }
+
             JobPlanFile jobPlanFile = JobPlanFile.LoadExistingJobPlanFile(_pathToCheckpointer, transferId);
             if (!File.Exists(jobPlanFile.FilePath))
             {
@@ -487,6 +520,17 @@ namespace Azure.Storage.DataMovement
             {
                 throw Errors.CollisionJobPlanFile(transferId);
             }
+        }
+
+        private void DisposeOfJobPartPlanAndPlanFile(JobPlanFile jobPlanFile)
+        {
+            // Dispose of all parts
+            foreach (var partKvp in jobPlanFile.JobParts)
+            {
+                partKvp.Value.Dispose();
+            }
+            // Dispose the plan file
+            jobPlanFile.Dispose();
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Storage;
 using Azure.Storage.Common;
 using Azure.Storage.DataMovement.JobPlan;
 using Azure.Storage.Shared;
@@ -180,55 +181,18 @@ namespace Azure.Storage.DataMovement
             int length,
             CancellationToken cancellationToken = default)
         {
-            int bufferSize = length > 0 ? length : DataMovementConstants.DefaultStreamCopyBufferSize;
-            Stream copiedStream = new PooledMemoryStream(ArrayPool<byte>.Shared, bufferSize);
-
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
             if (!TryGetJobPlanFile(transferId, out JobPlanFile jobPlanFile))
             {
                 throw Errors.MissingTransferIdCheckpointer(transferId);
             }
 
-            await jobPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                using (FileStream fileStream = new FileStream(
-                    jobPlanFile.FilePath,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.Read))
-                {
-                    if (offset > 0)
-                    {
-                        fileStream.Seek(offset, SeekOrigin.Begin);
-                    }
-
-                    if (length > 0)
-                    {
-                        byte[] buffer = ArrayPool<byte>.Shared.Rent(length);
-                        try
-                        {
-                            int bytesRead = await fileStream.ReadAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
-                            await copiedStream.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
-                        }
-                        finally
-                        {
-                            ArrayPool<byte>.Shared.Return(buffer);
-                        }
-                    }
-                    else
-                    {
-                        await fileStream.CopyToAsync(copiedStream, bufferSize, cancellationToken).ConfigureAwait(false);
-                    }
-                }
-
-                copiedStream.Position = 0;
-                return copiedStream;
-            }
-            finally
-            {
-                jobPlanFile.WriteLock.Release();
-            }
+            return await ReadFromPlanFileAsync(
+                jobPlanFile.FilePath,
+                jobPlanFile.WriteLock,
+                offset,
+                length,
+                cancellationToken).ConfigureAwait(false);
         }
 
         public override async Task<Stream> ReadJobPartPlanFileAsync(
@@ -248,14 +212,29 @@ namespace Azure.Storage.DataMovement
                 throw Errors.MissingPartNumberCheckpointer(transferId, partNumber);
             }
 
+            return await ReadFromPlanFileAsync(
+                jobPartPlanFile.FilePath,
+                jobPartPlanFile.WriteLock,
+                offset,
+                length,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task<Stream> ReadFromPlanFileAsync(
+            string filePath,
+            SemaphoreSlim writeLock,
+            int offset,
+            int length,
+            CancellationToken cancellationToken)
+        {
             int bufferSize = length > 0 ? length : DataMovementConstants.DefaultStreamCopyBufferSize;
             Stream copiedStream = new PooledMemoryStream(ArrayPool<byte>.Shared, bufferSize);
 
-            await jobPartPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            await writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 using (FileStream fileStream = new FileStream(
-                    jobPartPlanFile.FilePath,
+                    filePath,
                     FileMode.Open,
                     FileAccess.Read,
                     FileShare.Read))
@@ -267,16 +246,7 @@ namespace Azure.Storage.DataMovement
 
                     if (length > 0)
                     {
-                        byte[] buffer = ArrayPool<byte>.Shared.Rent(length);
-                        try
-                        {
-                            int bytesRead = await fileStream.ReadAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
-                            await copiedStream.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
-                        }
-                        finally
-                        {
-                            ArrayPool<byte>.Shared.Return(buffer);
-                        }
+                        await fileStream.CopyToExactInternal(copiedStream, length, async: true, cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
@@ -289,7 +259,7 @@ namespace Azure.Storage.DataMovement
             }
             finally
             {
-                jobPartPlanFile.WriteLock.Release();
+                writeLock.Release();
             }
         }
 
@@ -389,8 +359,6 @@ namespace Azure.Storage.DataMovement
             TransferStatus status,
             CancellationToken cancellationToken = default)
         {
-            int offset = DataMovementConstants.JobPlanFile.JobStatusIndex;
-
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
             if (!TryGetJobPlanFile(transferId, out JobPlanFile jobPlanFile))
@@ -405,26 +373,12 @@ namespace Azure.Storage.DataMovement
                 return;
             }
 
-            await jobPlanFile.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                using (FileStream fileStream = new FileStream(
-                    jobPlanFile.FilePath,
-                    FileMode.Open,
-                    FileAccess.Write,
-                    FileShare.Read))
-                {
-                    fileStream.Seek(offset, SeekOrigin.Begin);
-                    int statusValue = (int)status.ToJobPlanStatus();
-                    byte[] statusBytes = BitConverter.GetBytes(statusValue);
-                    await fileStream.WriteAsync(statusBytes, 0, statusBytes.Length, cancellationToken).ConfigureAwait(false);
-                    await fileStream.FlushAsync(cancellationToken).ConfigureAwait(false);
-                }
-            }
-            finally
-            {
-                jobPlanFile.WriteLock.Release();
-            }
+            await WriteStatusToPlanFileAsync(
+                jobPlanFile.FilePath,
+                jobPlanFile.WriteLock,
+                DataMovementConstants.JobPlanFile.JobStatusIndex,
+                status,
+                cancellationToken).ConfigureAwait(false);
 
             // if paused or other completion state, remove the memory cache but still write state to the plan file for later resume
             if (status.State == TransferState.Completed || status.State == TransferState.Paused)
@@ -443,8 +397,6 @@ namespace Azure.Storage.DataMovement
             TransferStatus status,
             CancellationToken cancellationToken = default)
         {
-            int offset = DataMovementConstants.JobPartPlanFile.JobPartStatusIndex;
-
             CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
             if (!TryGetJobPlanFile(transferId, out JobPlanFile jobPlanFile))
@@ -455,25 +407,42 @@ namespace Azure.Storage.DataMovement
             {
                 throw Errors.MissingPartNumberCheckpointer(transferId, partNumber);
             }
-            await file.WriteLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            await WriteStatusToPlanFileAsync(
+                file.FilePath,
+                file.WriteLock,
+                DataMovementConstants.JobPartPlanFile.JobPartStatusIndex,
+                status,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task WriteStatusToPlanFileAsync(
+            string filePath,
+            SemaphoreSlim writeLock,
+            int offset,
+            TransferStatus status,
+            CancellationToken cancellationToken)
+        {
+            await writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
                 using (FileStream fileStream = new FileStream(
-                    file.FilePath,
+                    filePath,
                     FileMode.Open,
                     FileAccess.Write,
                     FileShare.Read))
                 {
                     fileStream.Seek(offset, SeekOrigin.Begin);
-                    int statusValue = (int)status.ToJobPlanStatus();
-                    byte[] statusBytes = BitConverter.GetBytes(statusValue);
-                    await fileStream.WriteAsync(statusBytes, 0, statusBytes.Length, cancellationToken).ConfigureAwait(false);
+                    using (BinaryWriter writer = new BinaryWriter(fileStream, System.Text.Encoding.UTF8, leaveOpen: true))
+                    {
+                        writer.Write((int)status.ToJobPlanStatus());
+                    }
                     await fileStream.FlushAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
             finally
             {
-                file.WriteLock.Release();
+                writeLock.Release();
             }
         }
 

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.DataMovement
         /// <param name="folderPath">Path to the folder containing the checkpointing information to resume from.</param>
         public LocalTransferCheckpointer(string folderPath)
         {
-            _disposed = false;
+            _disposed = 0;
             _transferStates = new ConcurrentDictionary<string, JobPlanFile>();
             if (string.IsNullOrEmpty(folderPath))
             {

--- a/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/LocalTransferCheckpointer.cs
@@ -28,7 +28,7 @@ namespace Azure.Storage.DataMovement
         /// Stores references to the memory mapped files stored by IDs.
         /// </summary>
         internal readonly ConcurrentDictionary<string, JobPlanFile> _transferStates;
-        internal bool _disposed;
+        internal int _disposed;
 
         /// <summary>
         /// Initializes a new instance of <see cref="LocalTransferCheckpointer"/> class.
@@ -59,9 +59,10 @@ namespace Azure.Storage.DataMovement
 
         public void Dispose()
         {
-            if (_disposed)
+            // Atomically set _disposed to 1 and check if it was already 1
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
             {
-                return;
+                return; // Already disposed
             }
 
             foreach (var kvp in _transferStates)
@@ -69,8 +70,6 @@ namespace Azure.Storage.DataMovement
                 DisposeOfJobPartPlanAndPlanFile(kvp.Value);
             }
             _transferStates.Clear();
-
-            _disposed = true;
         }
 
         private bool TryGetJobPlanFile(string transferId, out JobPlanFile result)

--- a/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/TransferManager.cs
@@ -456,7 +456,7 @@ namespace Azure.Storage.DataMovement
         /// Disposes TransferManager and all its resources.
         /// </summary>
         /// <returns>A <see cref="ValueTask"/> of disposing the <see cref="TransferManager"/>.</returns>
-        async ValueTask IAsyncDisposable.DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             if (_jobsProcessor != default)
             {
@@ -470,6 +470,12 @@ namespace Azure.Storage.DataMovement
             {
                 await _chunksProcessor.CleanUpAsync().ConfigureAwait(false);
             }
+
+            if (_checkpointer is IDisposable disposableCheckpointer)
+            {
+                disposableCheckpointer.Dispose();
+            }
+
             _transfers.Clear();
             GC.SuppressFinalize(this);
         }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Storage.DataMovement.JobPlan;
 using NUnit.Framework;
@@ -89,7 +90,7 @@ namespace Azure.Storage.DataMovement.Tests
         [Test]
         public void Ctor()
         {
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(default);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(default);
 
             Assert.NotNull(transferCheckpointer);
         }
@@ -98,7 +99,7 @@ namespace Azure.Storage.DataMovement.Tests
         public void Ctor_CustomPath()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory(Guid.NewGuid().ToString());
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             Assert.NotNull(transferCheckpointer);
         }
@@ -118,7 +119,7 @@ namespace Azure.Storage.DataMovement.Tests
 
             // Arrange
             string transferId = GetNewTransferId();
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -134,7 +135,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
             // Arrange
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -150,7 +151,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange / Act
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             int jobCount = 3;
             List<string> expectedTransferIds = new();
@@ -175,7 +176,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -202,7 +203,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -234,7 +235,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -279,7 +280,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: 3);
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -320,7 +321,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: 1);
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -347,7 +348,7 @@ namespace Azure.Storage.DataMovement.Tests
         public async Task TryRemoveStoredTransferAsync()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -361,7 +362,7 @@ namespace Azure.Storage.DataMovement.Tests
         public async Task TryRemoveStoredTransferAsync_Error()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
 
@@ -375,7 +376,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             string transferId = GetNewTransferId();
             int partNumber = 0;
             JobPartPlanHeader header = CheckpointerTesting.CreateDefaultJobPartHeader(
@@ -396,7 +397,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -415,7 +416,7 @@ namespace Azure.Storage.DataMovement.Tests
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
             // Arrange
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             int jobCount = 3;
             List<string> expectedTransferIds = new();
@@ -442,7 +443,7 @@ namespace Azure.Storage.DataMovement.Tests
             // Arrange - populate checkpointer directory with existing jobs
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             string transferId = GetNewTransferId();
             string transferId2 = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -494,7 +495,7 @@ namespace Azure.Storage.DataMovement.Tests
             // Arrange
             string transferId = GetNewTransferId();
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -517,7 +518,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -553,7 +554,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: 3);
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
@@ -589,7 +590,7 @@ namespace Azure.Storage.DataMovement.Tests
             // Arrange
             string transferId = GetNewTransferId();
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act / Assert
             Assert.CatchAsync<ArgumentException>(
@@ -601,7 +602,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -626,7 +627,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -663,7 +664,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
             await transferCheckpointer.AddNewJobPartAsync(
@@ -684,7 +685,7 @@ namespace Azure.Storage.DataMovement.Tests
             string transferId = GetNewTransferId();
             int partNumber = 0;
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act
             Assert.CatchAsync<ArgumentException>(
@@ -700,7 +701,7 @@ namespace Azure.Storage.DataMovement.Tests
         {
             // Arrange
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -748,7 +749,7 @@ namespace Azure.Storage.DataMovement.Tests
             // Arrange
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
             string transferId = GetNewTransferId();
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act / Assert
             byte[] bytes = { 0x00 };
@@ -770,7 +771,7 @@ namespace Azure.Storage.DataMovement.Tests
             string transferId = GetNewTransferId();
             TransferStatus newStatus = PausedStatus;
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
             await AddJobToCheckpointer(transferCheckpointer, transferId);
 
             // Act
@@ -798,7 +799,7 @@ namespace Azure.Storage.DataMovement.Tests
             string transferId = GetNewTransferId();
             TransferStatus newStatus = SuccessfulCompletedStatus;
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act / Assert
             Assert.CatchAsync<ArgumentException>(
@@ -819,7 +820,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             await AddJobToCheckpointer(transferCheckpointer, transferId);
             await transferCheckpointer.AddNewJobPartAsync(
@@ -849,7 +850,7 @@ namespace Azure.Storage.DataMovement.Tests
                     transferId: transferId,
                     partNumber: partNumber);
 
-            SerializerTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
 
             // Act / Assert
             Assert.CatchAsync<ArgumentException>(
@@ -860,7 +861,7 @@ namespace Azure.Storage.DataMovement.Tests
         public async Task JobDeletedOnComplete()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            LocalTransferCheckpointer transferCheckpointer = new(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -876,7 +877,7 @@ namespace Azure.Storage.DataMovement.Tests
         public async Task JobUncachedOnPause()
         {
             using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
-            LocalTransferCheckpointer transferCheckpointer = new(test.DirectoryPath);
+            using LocalTransferCheckpointer transferCheckpointer = new(test.DirectoryPath);
 
             string transferId = GetNewTransferId();
             await AddJobToCheckpointer(transferCheckpointer, transferId);
@@ -888,6 +889,221 @@ namespace Azure.Storage.DataMovement.Tests
             Assert.That(transferCheckpointer._transferStates.ContainsKey(transferId), Is.False);
             Assert.That(await transferCheckpointer.GetJobStatusAsync(transferId), Is.Not.Null);
             Assert.That(transferCheckpointer._transferStates.ContainsKey(transferId), Is.True);
+        }
+
+        [Test]
+        public async Task TryRemoveStoredTransferAsync_ShouldReleaseFileHandles()
+        {
+            // This test verifies that after removing a transfer, all file handles
+            // and resources (like SemaphoreSlim) are properly released.
+            // If not disposed properly, the directory deletion will fail on Windows.
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+            string checkpointerPath = test.DirectoryPath;
+
+            // Arrange - Create checkpointer and add a job with multiple parts
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(checkpointerPath);
+
+            string transferId = GetNewTransferId();
+            await AddJobToCheckpointer(transferCheckpointer, transferId);
+
+            // Add multiple job parts to increase the chance of detecting resource leaks
+            for (int partNumber = 0; partNumber < 5; partNumber++)
+            {
+                JobPartPlanHeader header = CheckpointerTesting.CreateDefaultJobPartHeader(
+                    transferId: transferId,
+                    partNumber: partNumber);
+                await transferCheckpointer.AddNewJobPartAsync(transferId, partNumber, header);
+            }
+
+            // Verify files were created
+            string[] filesBeforeRemove = Directory.GetFiles(checkpointerPath);
+            Assert.AreEqual(6, filesBeforeRemove.Length); // 1 job file + 5 part files
+
+            // Act - Remove the transfer (this should dispose all resources)
+            bool removeResult = await transferCheckpointer.TryRemoveStoredTransferAsync(transferId);
+            Assert.IsTrue(removeResult);
+
+            // Assert - Verify all files were deleted
+            string[] filesAfterRemove = Directory.GetFiles(checkpointerPath);
+            Assert.AreEqual(0, filesAfterRemove.Length, "All checkpointer files should be deleted");
+
+            // Critical test: Try to delete the checkpointer directory itself.
+            // If file handles are still held, this will throw IOException on Windows.
+            Assert.DoesNotThrow(() =>
+            {
+                // Create a new file in the directory to verify we have full access
+                string testFilePath = Path.Combine(checkpointerPath, "test-access.tmp");
+                File.WriteAllText(testFilePath, "test");
+                File.Delete(testFilePath);
+            }, "Should be able to write/delete files in checkpointer directory after transfer removal");
+        }
+
+        [Test]
+        public async Task TryRemoveStoredTransferAsync_SemaphoreDisposed()
+        {
+            // This test verifies that the SemaphoreSlim in JobPlanFile and JobPartPlanFile
+            // are properly disposed after removing a transfer.
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+
+            // Arrange
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+
+            string transferId = GetNewTransferId();
+            await AddJobToCheckpointer(transferCheckpointer, transferId);
+
+            int partNumber = 0;
+            JobPartPlanHeader header = CheckpointerTesting.CreateDefaultJobPartHeader(
+                transferId: transferId,
+                partNumber: partNumber);
+            await transferCheckpointer.AddNewJobPartAsync(transferId, partNumber, header);
+
+            // Get reference to the internal state before removal
+            // (This requires InternalsVisibleTo or the test being in the same assembly)
+            Assert.IsTrue(transferCheckpointer._transferStates.TryGetValue(transferId, out JobPlanFile jobPlanFile));
+            Assert.IsTrue(jobPlanFile.JobParts.TryGetValue(partNumber, out JobPartPlanFile jobPartPlanFile));
+
+            // Store references to the semaphores
+            SemaphoreSlim jobPlanWriteLock = jobPlanFile.WriteLock;
+            SemaphoreSlim jobPartWriteLock = jobPartPlanFile.WriteLock;
+
+            // Act - Remove the transfer
+            await transferCheckpointer.TryRemoveStoredTransferAsync(transferId);
+
+            // Assert - Verify the semaphores are disposed
+            // A disposed SemaphoreSlim will throw ObjectDisposedException when accessed
+            Assert.Throws<ObjectDisposedException>(() => jobPlanWriteLock.Wait(0),
+                "JobPlanFile.WriteLock should be disposed after transfer removal");
+            Assert.Throws<ObjectDisposedException>(() => jobPartWriteLock.Wait(0),
+                "JobPartPlanFile.WriteLock should be disposed after transfer removal");
+        }
+
+        [Test]
+        public async Task RefreshCache_ShouldDisposeExistingResources()
+        {
+            // This test verifies that when RefreshCache is called, existing cached
+            // JobPlanFile and JobPartPlanFile instances are properly disposed.
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+
+            // Arrange
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+
+            string transferId = GetNewTransferId();
+            await AddJobToCheckpointer(transferCheckpointer, transferId);
+
+            int partNumber = 0;
+            JobPartPlanHeader header = CheckpointerTesting.CreateDefaultJobPartHeader(
+                transferId: transferId,
+                partNumber: partNumber);
+            await transferCheckpointer.AddNewJobPartAsync(transferId, partNumber, header);
+
+            // Get reference to the internal state before refresh
+            Assert.IsTrue(transferCheckpointer._transferStates.TryGetValue(transferId, out JobPlanFile jobPlanFile));
+            Assert.IsTrue(jobPlanFile.JobParts.TryGetValue(partNumber, out JobPartPlanFile jobPartPlanFile));
+
+            // Store references to the semaphores
+            SemaphoreSlim jobPlanWriteLock = jobPlanFile.WriteLock;
+            SemaphoreSlim jobPartWriteLock = jobPartPlanFile.WriteLock;
+
+            // Act - Force a refresh by calling GetStoredTransfersAsync which calls RefreshCache
+            await transferCheckpointer.GetStoredTransfersAsync();
+
+            // Assert - The old semaphores should be disposed (they are replaced with new instances)
+            // Note: This test will FAIL with the current implementation because RefreshCache
+            // does not dispose the old instances before clearing the dictionary
+            Assert.Throws<ObjectDisposedException>(() => jobPlanWriteLock.Wait(0),
+                "Old JobPlanFile.WriteLock should be disposed after RefreshCache");
+            Assert.Throws<ObjectDisposedException>(() => jobPartWriteLock.Wait(0),
+                "Old JobPartPlanFile.WriteLock should be disposed after RefreshCache");
+        }
+
+        [Test]
+        public async Task SetJobTransferStatusAsync_Paused_ShouldDisposeResources()
+        {
+            // This test verifies that when a job is paused and removed from memory cache,
+            // the resources are properly disposed.
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+
+            // Arrange
+            using LocalTransferCheckpointer transferCheckpointer = new LocalTransferCheckpointer(test.DirectoryPath);
+
+            string transferId = GetNewTransferId();
+            await AddJobToCheckpointer(transferCheckpointer, transferId);
+
+            int partNumber = 0;
+            JobPartPlanHeader header = CheckpointerTesting.CreateDefaultJobPartHeader(
+                transferId: transferId,
+                partNumber: partNumber);
+            await transferCheckpointer.AddNewJobPartAsync(transferId, partNumber, header);
+
+            // Get reference to the internal state before status change
+            Assert.IsTrue(transferCheckpointer._transferStates.TryGetValue(transferId, out JobPlanFile jobPlanFile));
+            SemaphoreSlim jobPlanWriteLock = jobPlanFile.WriteLock;
+
+            // Act - Set status to Paused (this removes from memory cache but keeps file)
+            await transferCheckpointer.SetJobTransferStatusAsync(transferId, PausedStatus);
+
+            // Assert - The transfer should be removed from cache
+            Assert.IsFalse(transferCheckpointer._transferStates.ContainsKey(transferId),
+                "Transfer should be removed from memory cache when paused");
+
+            // The semaphore should be disposed
+            // Note: This test will FAIL with the current implementation
+            Assert.Throws<ObjectDisposedException>(() => jobPlanWriteLock.Wait(0),
+                "JobPlanFile.WriteLock should be disposed when transfer is paused");
+
+            // But the file should still exist for resume
+            string expectedFilePath = Path.Combine(test.DirectoryPath, $"{transferId}.ndm");
+            Assert.IsTrue(File.Exists(expectedFilePath), "Job plan file should still exist for resume");
+        }
+
+        [Test]
+        public async Task MultipleCheckpointerInstances_ShouldNotConflict()
+        {
+            // This test verifies that creating multiple checkpointer instances
+            // pointing to the same directory doesn't cause resource conflicts
+            // due to undisposed semaphores or file handles.
+            using DisposingLocalDirectory test = DisposingLocalDirectory.GetTestDirectory();
+
+            string transferId = GetNewTransferId();
+
+            // First checkpointer - add and remove a transfer
+            {
+                using LocalTransferCheckpointer checkpointer1 = new LocalTransferCheckpointer(test.DirectoryPath);
+                await AddJobToCheckpointer(checkpointer1, transferId);
+
+                JobPartPlanHeader header = CheckpointerTesting.CreateDefaultJobPartHeader(
+                    transferId: transferId,
+                    partNumber: 0);
+                await checkpointer1.AddNewJobPartAsync(transferId, 0, header);
+
+                // Set to paused (removes from cache but keeps files)
+                await checkpointer1.SetJobTransferStatusAsync(transferId, PausedStatus);
+            }
+            // checkpointer1 is properly disposed here
+
+            // Second checkpointer - should be able to load and work with the same transfer
+            {
+                using LocalTransferCheckpointer checkpointer2 = new LocalTransferCheckpointer(test.DirectoryPath);
+
+                // Should be able to read the transfer
+                List<string> transfers = await checkpointer2.GetStoredTransfersAsync();
+                Assert.AreEqual(1, transfers.Count);
+                Assert.AreEqual(transferId, transfers[0]);
+
+                // Should be able to read the job plan file
+                using Stream jobPlanStream = await checkpointer2.ReadJobPlanFileAsync(
+                    transferId,
+                    offset: 0,
+                    length: DataMovementConstants.JobPlanFile.VariableLengthStartIndex);
+                Assert.IsNotNull(jobPlanStream);
+
+                // Should be able to remove it
+                bool removed = await checkpointer2.TryRemoveStoredTransferAsync(transferId);
+                Assert.IsTrue(removed, "Second checkpointer should be able to remove the transfer");
+            }
+
+            // Final verification - directory should be empty and accessible
+            Assert.AreEqual(0, Directory.GetFiles(test.DirectoryPath).Length);
         }
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
@@ -1008,8 +1008,6 @@ namespace Azure.Storage.DataMovement.Tests
             await transferCheckpointer.GetStoredTransfersAsync();
 
             // Assert - The old semaphores should be disposed (they are replaced with new instances)
-            // Note: This test will FAIL with the current implementation because RefreshCache
-            // does not dispose the old instances before clearing the dictionary
             Assert.Throws<ObjectDisposedException>(() => jobPlanWriteLock.Wait(0),
                 "Old JobPlanFile.WriteLock should be disposed after RefreshCache");
             Assert.Throws<ObjectDisposedException>(() => jobPartWriteLock.Wait(0),

--- a/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/LocalTransferCheckpointerTests.cs
@@ -1047,7 +1047,6 @@ namespace Azure.Storage.DataMovement.Tests
                 "Transfer should be removed from memory cache when paused");
 
             // The semaphore should be disposed
-            // Note: This test will FAIL with the current implementation
             Assert.Throws<ObjectDisposedException>(() => jobPlanWriteLock.Wait(0),
                 "JobPlanFile.WriteLock should be disposed when transfer is paused");
 

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
@@ -1278,7 +1278,17 @@ namespace Azure.Storage.DataMovement.Tests
         private void AssertCheckpointerFilesAreAccessible(string checkpointerPath, string transferId)
         {
             // Get all files related to this transfer
-            string[] allFiles = Directory.GetFiles(checkpointerPath, "*", SearchOption.TopDirectoryOnly);
+            string[] allFiles;
+            try
+            {
+                allFiles = Directory.GetFiles(checkpointerPath, "*", SearchOption.TopDirectoryOnly);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Directory was already cleaned up - that's fine
+                return;
+            }
+
             List<string> transferFiles = new List<string>();
 
             foreach (string file in allFiles)
@@ -1290,16 +1300,36 @@ namespace Azure.Storage.DataMovement.Tests
                 }
             }
 
+            // If no files exist, the transfer was cleaned up successfully
+            if (transferFiles.Count == 0)
+            {
+                return;
+            }
+
             // Verify we can open each file with exclusive access
             // This will fail if the checkpointer still has file handles open
             foreach (string filePath in transferFiles)
             {
+                // Check if file still exists (may have been deleted during iteration)
+                if (!File.Exists(filePath))
+                {
+                    continue;
+                }
+
                 try
                 {
                     using FileStream fs = File.Open(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
                     // Successfully opened with exclusive access - file handles are released
                 }
+                catch (FileNotFoundException)
+                {
+                    // File was deleted between our check and open - that's fine
+                }
                 catch (IOException ex)
+                {
+                    Assert.Fail($"Checkpointer file '{filePath}' is still locked. File handles were not released. Error: {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
                 {
                     Assert.Fail($"Checkpointer file '{filePath}' is still locked. File handles were not released. Error: {ex.Message}");
                 }
@@ -1389,6 +1419,10 @@ namespace Azure.Storage.DataMovement.Tests
             };
             TransferManager transferManager = new TransferManager(options);
 
+            // Create mock checkpoint details for source and destination
+            Mock<StorageResourceCheckpointDetails> mockCheckpointDetails = new Mock<StorageResourceCheckpointDetails>();
+            mockCheckpointDetails.SetupGet(c => c.Length).Returns(0);
+
             // Create a source resource that will fail during transfer
             Mock<StorageResourceItem> failingSource = new Mock<StorageResourceItem>(MockBehavior.Strict);
             failingSource.Setup(r => r.Uri).Returns(new Uri("file:///fake/source"));
@@ -1398,6 +1432,8 @@ namespace Azure.Storage.DataMovement.Tests
             failingSource.Setup(r => r.ShouldItemTransferAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
             failingSource.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Simulated failure for testing"));
+            failingSource.Setup(r => r.GetSourceCheckpointDetails())
+                .Returns(mockCheckpointDetails.Object);
 
             Mock<StorageResourceItem> destination = new Mock<StorageResourceItem>(MockBehavior.Strict);
             destination.Setup(r => r.Uri).Returns(new Uri("https://example.com/dest"));
@@ -1410,6 +1446,8 @@ namespace Azure.Storage.DataMovement.Tests
             destination.SetupGet(r => r.MaxSupportedChunkCount).Returns(int.MaxValue);
             destination.Setup(r => r.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
+            destination.Setup(r => r.GetDestinationCheckpointDetails())
+                .Returns(mockCheckpointDetails.Object);
 
             TransferOptions transferOptions = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
@@ -1270,5 +1270,310 @@ namespace Azure.Storage.DataMovement.Tests
             }
         }
         #endregion
+
+        #region Checkpointer File Access Tests
+        /// <summary>
+        /// Helper method to verify that checkpointer files are accessible (file handles released).
+        /// </summary>
+        private void AssertCheckpointerFilesAreAccessible(string checkpointerPath, string transferId)
+        {
+            // Get all files related to this transfer
+            string[] allFiles = Directory.GetFiles(checkpointerPath, "*", SearchOption.TopDirectoryOnly);
+            List<string> transferFiles = new List<string>();
+
+            foreach (string file in allFiles)
+            {
+                string fileName = Path.GetFileName(file);
+                if (fileName.StartsWith(transferId))
+                {
+                    transferFiles.Add(file);
+                }
+            }
+
+            // Verify we can open each file with exclusive access
+            // This will fail if the checkpointer still has file handles open
+            foreach (string filePath in transferFiles)
+            {
+                try
+                {
+                    using FileStream fs = File.Open(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                    // Successfully opened with exclusive access - file handles are released
+                }
+                catch (IOException ex)
+                {
+                    Assert.Fail($"Checkpointer file '{filePath}' is still locked. File handles were not released. Error: {ex.Message}");
+                }
+            }
+        }
+
+        [Test]
+        [LiveOnly]
+        [TestCase(TransferDirection.Upload)]
+        [TestCase(TransferDirection.Download)]
+        [TestCase(TransferDirection.Copy)]
+        public async Task TryPauseTransferAsync_CheckpointerFilesAreAccessible(TransferDirection transferType)
+        {
+            // Arrange
+            using DisposingLocalDirectory checkpointerDirectory = DisposingLocalDirectory.GetTestDirectory();
+            using DisposingLocalDirectory localDirectory = DisposingLocalDirectory.GetTestDirectory();
+            await using IDisposingContainer<TContainerClient> sourceContainer = await GetDisposingContainerAsync();
+            await using IDisposingContainer<TContainerClient> destinationContainer = await GetDisposingContainerAsync();
+
+            StorageResourceProvider provider = GetStorageResourceProvider();
+            TransferManagerOptions options = new TransferManagerOptions()
+            {
+                CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
+                ErrorMode = TransferErrorMode.ContinueOnFailure,
+                ProvidersForResuming = new List<StorageResourceProvider>() { provider },
+            };
+            TransferManager transferManager = new TransferManager(options);
+            TestProgressHandler progressHandler = new();
+            TransferOptions transferOptions = new TransferOptions
+            {
+                ProgressHandlerOptions = new TransferProgressHandlerOptions
+                {
+                    ProgressHandler = progressHandler,
+                    TrackBytesTransferred = true
+                }
+            };
+            TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
+
+            // Add long-running job to pause
+            TransferOperation transfer = await CreateSingleLongTransferAsync(
+                manager: transferManager,
+                transferType: transferType,
+                localDirectory: localDirectory.DirectoryPath,
+                sourceContainer: sourceContainer.Container,
+                destinationContainer: destinationContainer.Container,
+                size: DataMovementTestConstants.KB * 100,
+                transferOptions: transferOptions);
+
+            // Act - Pause the transfer
+            using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await transferManager.PauseTransferAsync(transfer.Id, cancellationTokenSource.Token);
+
+            // Assert
+            await testEventsRaised.AssertPausedCheck();
+            Assert.AreEqual(TransferState.Paused, transfer.Status.State);
+
+            // Verify checkpointer files are accessible (file handles released)
+            // Need to dispose the TransferManager first to release the checkpointer
+            await transferManager.DisposeAsync();
+
+            List<TransferProgress> progressUpdates = progressHandler.Updates;
+            if (HasFileTransferReachedInProgressState(progressUpdates))
+            {
+                AssertCheckpointerFilesAreAccessible(checkpointerDirectory.DirectoryPath, transfer.Id);
+            }
+        }
+
+        [Test]
+        [LiveOnly]
+        [TestCase(TransferDirection.Upload)]
+        [TestCase(TransferDirection.Download)]
+        [TestCase(TransferDirection.Copy)]
+        public async Task TransferCompletedWithFailures_CheckpointerFilesAreAccessible(TransferDirection transferType)
+        {
+            // Arrange
+            using DisposingLocalDirectory checkpointerDirectory = DisposingLocalDirectory.GetTestDirectory();
+            using DisposingLocalDirectory localDirectory = DisposingLocalDirectory.GetTestDirectory();
+            await using IDisposingContainer<TContainerClient> sourceContainer = await GetDisposingContainerAsync();
+            await using IDisposingContainer<TContainerClient> destinationContainer = await GetDisposingContainerAsync();
+
+            StorageResourceProvider provider = GetStorageResourceProvider();
+            TransferManagerOptions options = new TransferManagerOptions()
+            {
+                CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
+                ErrorMode = TransferErrorMode.ContinueOnFailure,
+                ProvidersForResuming = new List<StorageResourceProvider>() { provider },
+            };
+            TransferManager transferManager = new TransferManager(options);
+
+            // Create a source resource that will fail during transfer
+            Mock<StorageResourceItem> failingSource = new Mock<StorageResourceItem>(MockBehavior.Strict);
+            failingSource.Setup(r => r.Uri).Returns(new Uri("file:///fake/source"));
+            failingSource.SetupGet(r => r.ResourceId).Returns("Mock");
+            failingSource.SetupGet(r => r.ProviderId).Returns("mock");
+            failingSource.Setup(r => r.IsContainer).Returns(false);
+            failingSource.Setup(r => r.ShouldItemTransferAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
+            failingSource.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Simulated failure for testing"));
+
+            Mock<StorageResourceItem> destination = new Mock<StorageResourceItem>(MockBehavior.Strict);
+            destination.Setup(r => r.Uri).Returns(new Uri("https://example.com/dest"));
+            destination.SetupGet(r => r.ResourceId).Returns("Mock");
+            destination.SetupGet(r => r.ProviderId).Returns("mock");
+            destination.Setup(r => r.IsContainer).Returns(false);
+            destination.SetupGet(r => r.TransferType).Returns(default(TransferOrder));
+            destination.SetupGet(r => r.MaxSupportedSingleTransferSize).Returns(Constants.GB);
+            destination.SetupGet(r => r.MaxSupportedChunkSize).Returns(Constants.GB);
+            destination.SetupGet(r => r.MaxSupportedChunkCount).Returns(int.MaxValue);
+            destination.Setup(r => r.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            TransferOptions transferOptions = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
+
+            // Start transfer that will fail
+            TransferOperation transfer = await transferManager.StartTransferAsync(
+                failingSource.Object,
+                destination.Object,
+                transferOptions);
+
+            // Wait for transfer to complete (with failure)
+            using CancellationTokenSource waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await transfer.WaitForCompletionAsync(waitCts.Token);
+
+            // Assert transfer completed with failure
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.IsTrue(transfer.Status.HasFailedItems);
+
+            // Dispose the TransferManager to release the checkpointer
+            await transferManager.DisposeAsync();
+
+            // Verify checkpointer files are accessible (file handles released)
+            AssertCheckpointerFilesAreAccessible(checkpointerDirectory.DirectoryPath, transfer.Id);
+        }
+
+        [Test]
+        [LiveOnly]
+        [TestCase(TransferDirection.Upload)]
+        [TestCase(TransferDirection.Download)]
+        [TestCase(TransferDirection.Copy)]
+        public async Task TransferCompletedWithSkips_CheckpointerFilesAreAccessible(TransferDirection transferType)
+        {
+            // Arrange
+            using DisposingLocalDirectory checkpointerDirectory = DisposingLocalDirectory.GetTestDirectory();
+            using DisposingLocalDirectory localDirectory = DisposingLocalDirectory.GetTestDirectory();
+            await using IDisposingContainer<TContainerClient> sourceContainer = await GetDisposingContainerAsync();
+            await using IDisposingContainer<TContainerClient> destinationContainer = await GetDisposingContainerAsync();
+
+            StorageResourceProvider provider = GetStorageResourceProvider();
+            TransferManagerOptions options = new TransferManagerOptions()
+            {
+                CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
+                ErrorMode = TransferErrorMode.ContinueOnFailure,
+                ProvidersForResuming = new List<StorageResourceProvider>() { provider },
+            };
+            TransferManager transferManager = new TransferManager(options);
+
+            // Create a source and destination, then start a transfer with Skip creation mode
+            // The destination will already exist, so the transfer should skip
+            long size = DataMovementTestConstants.KB;
+            string itemName = GetNewItemName();
+
+            StorageResource source;
+            StorageResource destination;
+
+            if (transferType == TransferDirection.Upload)
+            {
+                string localFilePath = Path.Combine(localDirectory.DirectoryPath, itemName);
+                using (FileStream fs = File.Create(localFilePath))
+                {
+                    byte[] data = new byte[size];
+                    new Random().NextBytes(data);
+                    await fs.WriteAsync(data, 0, data.Length);
+                }
+                source = LocalFilesStorageResourceProvider.FromFile(localFilePath);
+                // Create destination first so it exists
+                destination = await CreateSourceStorageResourceItemAsync(size, itemName, destinationContainer.Container);
+            }
+            else if (transferType == TransferDirection.Download)
+            {
+                source = await CreateSourceStorageResourceItemAsync(size, itemName, sourceContainer.Container);
+                // Create destination file first so it exists
+                string localFilePath = Path.Combine(localDirectory.DirectoryPath, itemName);
+                using (FileStream fs = File.Create(localFilePath))
+                {
+                    byte[] data = new byte[size];
+                    new Random().NextBytes(data);
+                    await fs.WriteAsync(data, 0, data.Length);
+                }
+                destination = LocalFilesStorageResourceProvider.FromFile(localFilePath);
+            }
+            else // Copy
+            {
+                source = await CreateSourceStorageResourceItemAsync(size, itemName, sourceContainer.Container);
+                // Create destination first so it exists
+                destination = await CreateSourceStorageResourceItemAsync(size, itemName, destinationContainer.Container);
+            }
+
+            TransferOptions transferOptions = new TransferOptions()
+            {
+                CreationMode = StorageResourceCreationMode.SkipIfExists
+            };
+            TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
+
+            // Start transfer that should skip due to existing destination
+            TransferOperation transfer = await transferManager.StartTransferAsync(
+                source,
+                destination,
+                transferOptions);
+
+            // Wait for transfer to complete
+            using CancellationTokenSource waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await transfer.WaitForCompletionAsync(waitCts.Token);
+
+            // Assert transfer completed with skips
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.IsTrue(transfer.Status.HasSkippedItems);
+
+            // Dispose the TransferManager to release the checkpointer
+            await transferManager.DisposeAsync();
+
+            // Verify checkpointer files are accessible (file handles released)
+            AssertCheckpointerFilesAreAccessible(checkpointerDirectory.DirectoryPath, transfer.Id);
+        }
+
+        [Test]
+        [LiveOnly]
+        [TestCase(TransferDirection.Upload)]
+        [TestCase(TransferDirection.Download)]
+        [TestCase(TransferDirection.Copy)]
+        public async Task TransferManagerDispose_ReleasesCheckpointerFiles(TransferDirection transferType)
+        {
+            // Arrange
+            using DisposingLocalDirectory checkpointerDirectory = DisposingLocalDirectory.GetTestDirectory();
+            using DisposingLocalDirectory localDirectory = DisposingLocalDirectory.GetTestDirectory();
+            await using IDisposingContainer<TContainerClient> sourceContainer = await GetDisposingContainerAsync();
+            await using IDisposingContainer<TContainerClient> destinationContainer = await GetDisposingContainerAsync();
+
+            StorageResourceProvider provider = GetStorageResourceProvider();
+            TransferManagerOptions options = new TransferManagerOptions()
+            {
+                CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
+                ErrorMode = TransferErrorMode.ContinueOnFailure,
+                ProvidersForResuming = new List<StorageResourceProvider>() { provider },
+            };
+
+            string transferId;
+            {
+                TransferManager transferManager = new TransferManager(options);
+
+                // Create and complete a transfer
+                long size = DataMovementTestConstants.KB;
+                (StorageResource source, StorageResource dest) = await CreateStorageResourcesAsync(
+                    transferType: transferType,
+                    size: size,
+                    localDirectory: localDirectory.DirectoryPath,
+                    sourceContainer: sourceContainer.Container,
+                    destinationContainer: destinationContainer.Container);
+
+                TransferOperation transfer = await transferManager.StartTransferAsync(source, dest);
+                transferId = transfer.Id;
+
+                using CancellationTokenSource waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await transfer.WaitForCompletionAsync(waitCts.Token);
+
+                Assert.IsTrue(transfer.HasCompleted);
+
+                // Dispose the TransferManager
+                await transferManager.DisposeAsync();
+            }
+
+            // Assert - After TransferManager disposal, files should be accessible
+            AssertCheckpointerFilesAreAccessible(checkpointerDirectory.DirectoryPath, transferId);
+        }
+        #endregion Checkpointer File Access Tests
     }
 }

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -600,6 +600,167 @@ public class TransferManagerTests
         Assert.That(transfer.Status.HasCompletedSuccessfully);
     }
 
+    #region Dispose Tests
+
+    [Test]
+    public async Task DisposeAsync_DisposesCheckpointer()
+    {
+        // Arrange
+        (var jobsProcessor, var partsProcessor, var chunksProcessor) = StepProcessors();
+        JobBuilder jobBuilder = new(ArrayPool<byte>.Shared, default, new ClientDiagnostics(ClientOptions.Default));
+        Mock<ITransferCheckpointer> checkpointerMock = new(MockBehavior.Loose);
+        checkpointerMock.As<IDisposable>();
+
+        TransferManager transferManager = new(
+            jobsProcessor,
+            partsProcessor,
+            chunksProcessor,
+            jobBuilder,
+            checkpointerMock.Object,
+            default);
+
+        // Act
+        await transferManager.DisposeAsync();
+
+        // Assert
+        checkpointerMock.As<IDisposable>().Verify(c => c.Dispose(), Times.Once);
+    }
+
+    [Test]
+    public async Task DisposeAsync_WithLocalTransferCheckpointer_DisposesCheckpointer()
+    {
+        // Arrange
+        string testPath = Path.Combine(Path.GetTempPath(), "TransferManagerDisposeTest_" + Guid.NewGuid().ToString());
+        Directory.CreateDirectory(testPath);
+
+        try
+        {
+            (var jobsProcessor, var partsProcessor, var chunksProcessor) = StepProcessors();
+            JobBuilder jobBuilder = new(ArrayPool<byte>.Shared, default, new ClientDiagnostics(ClientOptions.Default));
+            LocalTransferCheckpointer checkpointer = new(testPath);
+
+            TransferManager transferManager = new(
+                jobsProcessor,
+                partsProcessor,
+                chunksProcessor,
+                jobBuilder,
+                checkpointer,
+                default);
+
+            // Add a transfer to create checkpoint files
+            Uri srcUri = new("file:///foo/bar");
+            Uri dstUri = new("https://example.com/fizz/buzz");
+
+            Mock<StorageResourceItem> srcResource = new(MockBehavior.Strict);
+            Mock<StorageResourceItem> dstResource = new(MockBehavior.Strict);
+            (srcResource, dstResource).BasicSetup(srcUri, dstUri);
+
+            TransferOperation transfer = await transferManager.StartTransferAsync(srcResource.Object, dstResource.Object);
+
+            // Process the transfer to create checkpoint data
+            await jobsProcessor.StepAll();
+            await partsProcessor.StepAll();
+            await chunksProcessor.StepAll();
+
+            // Act
+            await transferManager.DisposeAsync();
+
+            // Assert - Verify we can access files after disposal (checkpointer released handles)
+            // If disposal didn't work properly, the semaphores would still be held
+            string[] files = Directory.GetFiles(testPath, "*", SearchOption.AllDirectories);
+            foreach (string file in files)
+            {
+                // This should not throw if handles were properly released
+                using FileStream fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.None);
+            }
+        }
+        finally
+        {
+            // Cleanup
+            if (Directory.Exists(testPath))
+            {
+                Directory.Delete(testPath, true);
+            }
+        }
+    }
+
+    [Test]
+    public async Task DisposeAsync_MultipleDisposals_DoesNotThrow()
+    {
+        // Arrange
+        (var jobsProcessor, var partsProcessor, var chunksProcessor) = StepProcessors();
+        JobBuilder jobBuilder = new(ArrayPool<byte>.Shared, default, new ClientDiagnostics(ClientOptions.Default));
+        Mock<ITransferCheckpointer> checkpointerMock = new(MockBehavior.Loose);
+        checkpointerMock.As<IDisposable>();
+
+        TransferManager transferManager = new(
+            jobsProcessor,
+            partsProcessor,
+            chunksProcessor,
+            jobBuilder,
+            checkpointerMock.Object,
+            default);
+
+        // Act - Dispose multiple times
+        await transferManager.DisposeAsync();
+        await transferManager.DisposeAsync();
+
+        // Assert - Should have been called at least once per DisposeAsync call
+        // Note: The current implementation doesn't guard against multiple disposals,
+        // so Dispose will be called each time DisposeAsync is called
+        checkpointerMock.As<IDisposable>().Verify(c => c.Dispose(), Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task DisposeAsync_ClearsTransfers()
+    {
+        // Arrange
+        Uri srcUri = new("file:///foo/bar");
+        Uri dstUri = new("https://example.com/fizz/buzz");
+
+        (var jobsProcessor, var partsProcessor, var chunksProcessor) = StepProcessors();
+        JobBuilder jobBuilder = new(ArrayPool<byte>.Shared, default, new ClientDiagnostics(ClientOptions.Default));
+        MemoryTransferCheckpointer checkpointer = new();
+
+        TransferManager transferManager = new(
+            jobsProcessor,
+            partsProcessor,
+            chunksProcessor,
+            jobBuilder,
+            checkpointer,
+            default);
+
+        Mock<StorageResourceItem> srcResource = new(MockBehavior.Strict);
+        Mock<StorageResourceItem> dstResource = new(MockBehavior.Strict);
+        (srcResource, dstResource).BasicSetup(srcUri, dstUri);
+
+        // Add a transfer
+        TransferOperation transfer = await transferManager.StartTransferAsync(srcResource.Object, dstResource.Object);
+
+        // Verify transfer was added
+        IAsyncEnumerable<TransferOperation> transfers = transferManager.GetTransfersAsync();
+        int count = 0;
+        await foreach (var _ in transfers)
+        {
+            count++;
+        }
+        Assert.That(count, Is.EqualTo(1), "Transfer should be tracked.");
+
+        // Act
+        await transferManager.DisposeAsync();
+
+        // Assert - Transfers should be cleared after dispose
+        transfers = transferManager.GetTransfersAsync();
+        count = 0;
+        await foreach (var _ in transfers)
+        {
+            count++;
+        }
+        Assert.That(count, Is.EqualTo(0), "Transfers should be cleared after dispose.");
+    }
+
+    #endregion
+
     /// <summary>
     /// <see cref="TransferStatus"/> is stateful across transfer. This makes it difficult to verify mocks, as verifications
     /// are lazily performed. This captures deep copies of statuses for custom assertion.

--- a/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/TransferManagerTests.cs
@@ -737,26 +737,15 @@ public class TransferManagerTests
         // Add a transfer
         TransferOperation transfer = await transferManager.StartTransferAsync(srcResource.Object, dstResource.Object);
 
-        // Verify transfer was added
-        IAsyncEnumerable<TransferOperation> transfers = transferManager.GetTransfersAsync();
-        int count = 0;
-        await foreach (var _ in transfers)
-        {
-            count++;
-        }
-        Assert.That(count, Is.EqualTo(1), "Transfer should be tracked.");
+        // Verify transfer was added to internal dictionary
+        Assert.That(transferManager._transfers.Count, Is.EqualTo(1), "Transfer should be tracked.");
+        Assert.That(transferManager._transfers.ContainsKey(transfer.Id), Is.True, "Transfer should be in dictionary.");
 
         // Act
         await transferManager.DisposeAsync();
 
-        // Assert - Transfers should be cleared after dispose
-        transfers = transferManager.GetTransfersAsync();
-        count = 0;
-        await foreach (var _ in transfers)
-        {
-            count++;
-        }
-        Assert.That(count, Is.EqualTo(0), "Transfers should be cleared after dispose.");
+        // Assert - Internal transfers dictionary should be cleared after dispose
+        Assert.That(transferManager._transfers.Count, Is.EqualTo(0), "Transfers should be cleared after dispose.");
     }
 
     #endregion
@@ -835,6 +824,16 @@ internal static partial class MockExtensions
         items.Source.Setup(r => r.IsContainer).Returns(false);
 
         items.Source.Setup(r => r.ProviderId).Returns("mock");
+
+        // Setup checkpoint details for source and destination
+        items.Source.Setup(r => r.GetSourceCheckpointDetails())
+            .Returns(MockResourceCheckpointDetails.DefaultInstance);
+        items.Source.Setup(r => r.GetDestinationCheckpointDetails())
+            .Returns(MockResourceCheckpointDetails.DefaultInstance);
+        items.Destination.Setup(r => r.GetSourceCheckpointDetails())
+            .Returns(MockResourceCheckpointDetails.DefaultInstance);
+        items.Destination.Setup(r => r.GetDestinationCheckpointDetails())
+            .Returns(MockResourceCheckpointDetails.DefaultInstance);
 
         items.Destination.Setup(r => r.CopyFromStreamAsync(
             It.IsAny<Stream>(), It.IsAny<long>(), It.IsAny<bool>(), It.IsAny<long>(),


### PR DESCRIPTION
In order to support checkpointer files to be properly read in the `TransferState` of `Completed` or `Paused` we had to remove usage of `MemoryMappedFiles`.

Unfortunately the internal `FileStream` of the `MemoryMappedFiles` was either not being disposed of properly after the `MemoryMappedFile` Stream was disposed, or some sort of cache was clearing. This was replaced with using normal `FileStream` access.

Other Changes:
- Proper disposal of `SempahoreSlim` in `JobPlanFile` and `JobPartPlanFile`
- Made LocalTransferCheckpointer Disposable to properly dispose of semaphores within `JobPlanFile` and `JobPartPlanFile`
- Made `TransferManager.DisposeAsync` public in order to allow customers to properly dispose of the `TransferManager` without requiring a `using` statement
- Added Tests
- Updated changelog