### PR TITLE
Replace spell check, API export, and pre-commit steps with pre-commit-checks skill in provisioning-library-regeneration

### DIFF
--- a/.github/skills/pre-commit-checks/SKILL.md
+++ b/.github/skills/pre-commit-checks/SKILL.md
@@ -31,6 +31,8 @@ Identify affected csproj files by looking at the full changed file list: include
 
 ## 3. Conditionally run `dotnet build /t:GenerateCode` (per src csproj)
 
+**Exclusion:** Skip this step entirely for the `provisioning` service directory. Provisioning libraries use their own generator and are not generated via TypeSpec/AutoRest.
+
 **Trigger condition — for each affected package's src csproj:** Run this if ANY of the following files are in the changed file list:
 
 - Any file matching `sdk/{service}/{package}/src/Generated/**`

--- a/.github/skills/provisioning-library-regeneration/SKILL.md
+++ b/.github/skills/provisioning-library-regeneration/SKILL.md
@@ -210,30 +210,11 @@ If CI fails with "Unknown word" errors, add the words to `sdk/provisioning/cspel
 
 **Important:** Use `sdk/provisioning/cspell.yaml`, NOT `.vscode/cspell.json`.
 
-## Step 7: Export API and Update Snippets
+## Step 7: Run Pre-Commit Checks
 
-```shell
-pwsh eng\scripts\Export-API.ps1 provisioning
-pwsh eng\scripts\Update-Snippets.ps1 provisioning
-```
+Before committing, invoke the `pre-commit-checks` skill with the service directory set to `provisioning`. This will handle code formatting, API export, and snippet updates.
 
-## Step 8: Run Pre-Commit Checks
-
-Before committing, run:
-
-```shell
-pwsh eng\scripts\CodeChecks.ps1 -ServiceDirectory provisioning
-```
-
-This runs:
-- Code generation verification
-- API export
-- Snippet updates
-- Installation instruction validation
-
-All checks must pass with 0 errors.
-
-## Step 9: Update CHANGELOG and Commit
+## Step 8: Update CHANGELOG and Commit
 
 1. Update the CHANGELOG at `sdk/provisioning/Azure.Provisioning.{Service}/CHANGELOG.md`:
    ```markdown


### PR DESCRIPTION
Steps 6 (spell check), 7 (export API/update snippets), and 8 (pre-commit checks) in the provisioning-library-regeneration skill are now consolidated into a single step that invokes the \pre-commit-checks\ skill, which already handles all of these tasks.