### PR TITLE
[provisioning] Replace ARM API version fetching with mgmt library extraction

### DIFF
--- a/sdk/provisioning/Generator/src/Generator.csproj
+++ b/sdk/provisioning/Generator/src/Generator.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" />
-    <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 
   <!-- Packages we're generating from -->

--- a/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
@@ -10,8 +10,10 @@ using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace Azure.Provisioning.Generator.Model;
@@ -20,6 +22,10 @@ public abstract partial class Specification
 {
     private void Analyze()
     {
+        // Cache all existing generated files upfront so version data is preserved
+        // even if a previous spec's Build() cleans the shared output directory.
+        CacheGenerationDirectory();
+
         ContextualException.WithContext(
             $"Analyzing resources of specification {Name}",
             () =>
@@ -92,37 +98,11 @@ public abstract partial class Specification
                 }
 
                 /**/
-                // Get the list of valid api-versions via ARM
-                // (it's specific to the subscription, but our dev playground is opted into everything good)
-                string subId = Arm.GetDefaultSubscription().Id.SubscriptionId ??
-                    throw new InvalidOperationException("Failed to find default subscription ID!");
-                foreach (string resourceNamespace in Resources.Select(r => r.ResourceNamespace).Where(ns => ns is not null).Distinct())
+                // Extract api-versions from the mgmt library's RestOperations
+                foreach (Resource resource in Resources)
                 {
-                    ResourceProviderResource rp = Arm.GetResourceProviderResource(
-                        ResourceProviderResource.CreateResourceIdentifier(subId, resourceNamespace));
-                    foreach (ProviderResourceType data in rp.Get().Value.Data.ResourceTypes)
-                    {
-                        ResourceType type = new($"{resourceNamespace}/{data.ResourceType}");
-                        Resource? resource = Resources.FirstOrDefault(r => string.Compare(r.ResourceType?.ToString(), type.ToString(), StringComparison.OrdinalIgnoreCase) == 0);
-                        if (resource is null) { continue; }
-
-                        // Filter out preview releases
-                        resource.ResourceVersions =
-                            [.. data.ApiVersions.OrderDescending().Where((v, i) =>
-                                !v.EndsWith("preview", StringComparison.OrdinalIgnoreCase)
-#if EXPERIMENTAL_PROVISIONING
-                                // Only keep the very latest preview if it's the most
-                                // recent release - otherwise people should use a GAed version
-                                || i == 0
-#endif
-                                )];
-
-                        resource.DefaultResourceVersion =
-                            // The latest versions are first - so let's take the first non-preview as the default
-                            resource.ResourceVersions.FirstOrDefault(v => !v.EndsWith("preview", StringComparison.OrdinalIgnoreCase)) ??
-                            // Otherwise we'll take the latest preview
-                            resource.ResourceVersions.FirstOrDefault();
-                    }
+                    if (resource.ResourceType is null) { continue; }
+                    resource.DefaultResourceVersion = FindMgmtApiVersion(resource);
                 }
 
                 // Try to resolve missing versions from related types
@@ -541,5 +521,316 @@ public abstract partial class Specification
 
             return model;
         }
+    }
+
+    /// <summary>
+    /// Resolve resource versions by combining existing versions from generated code
+    /// with the api-version extracted from the mgmt library.
+    /// Must be called after Customize() so resource names match generated file names.
+    /// </summary>
+    private void ResolveVersions()
+    {
+        ContextualException.WithContext(
+            $"Resolving versions for {Name}",
+            () =>
+            {
+                foreach (Resource resource in Resources)
+                {
+                    if (resource.ResourceType is null) { continue; }
+
+                    string? mgmtApiVersion = resource.DefaultResourceVersion;
+
+                    // Read existing versions from the generated provisioning code
+                    (List<string> existingVersions, List<string> existingHiddenVersions) = ReadExistingResourceVersions(resource);
+
+                    // Add the mgmt library version to the combined set
+                    if (mgmtApiVersion is not null &&
+                        !existingVersions.Contains(mgmtApiVersion) &&
+                        !existingHiddenVersions.Contains(mgmtApiVersion))
+                    {
+                        existingVersions.Add(mgmtApiVersion);
+                    }
+
+                    // Merge versions added by Customize() via IncludeVersions
+                    if (resource.ResourceVersions is not null)
+                    {
+                        foreach (string v in resource.ResourceVersions)
+                        {
+                            if (!existingVersions.Contains(v))
+                            {
+                                existingVersions.Add(v);
+                            }
+                        }
+                    }
+
+                    // Sort versions descending and prefer non-preview releases
+                    List<string> orderedVersions = [.. existingVersions.OrderDescending()];
+                    List<string> nonPreviewVersions =
+                        [.. orderedVersions.Where(v => !v.EndsWith("preview", StringComparison.OrdinalIgnoreCase))];
+
+                    // If there are any GA (non-preview) versions, use them; otherwise keep all (preview-only) versions
+                    resource.ResourceVersions = nonPreviewVersions.Count > 0 ? nonPreviewVersions : orderedVersions;
+
+                    // Choose default version: prefer mgmtApiVersion if it's present in ResourceVersions,
+                    // otherwise fall back to the first non-preview or, if none, the first available version
+                    string? defaultVersion = null;
+                    if (mgmtApiVersion is not null && resource.ResourceVersions.Contains(mgmtApiVersion))
+                    {
+                        defaultVersion = mgmtApiVersion;
+                    }
+                    else
+                    {
+                        defaultVersion = resource.ResourceVersions
+                            .FirstOrDefault(v => !v.EndsWith("preview", StringComparison.OrdinalIgnoreCase))
+                            ?? resource.ResourceVersions.FirstOrDefault();
+                    }
+
+                    resource.DefaultResourceVersion = defaultVersion;
+
+                    // Merge existing hidden versions with any added by Customize()
+                    if (existingHiddenVersions.Count > 0)
+                    {
+                        if (resource.HiddenResourceVersions is null)
+                        {
+                            resource.HiddenResourceVersions = existingHiddenVersions;
+                        }
+                        else
+                        {
+                            foreach (string v in existingHiddenVersions)
+                            {
+                                if (!resource.HiddenResourceVersions.Contains(v))
+                                {
+                                    resource.HiddenResourceVersions.Add(v);
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+    }
+
+    /// <summary>
+    /// Find the api-version used by the mgmt library for a given resource
+    /// by scanning the resource's Get method IL to identify the correct
+    /// RestOperations field, then extracting the version from its constructor.
+    /// A resource may have multiple RestOperations fields but only the one
+    /// referenced in Get (or CreateOrUpdate on the collection) is authoritative.
+    /// </summary>
+    private static string? FindMgmtApiVersion(Resource resource)
+    {
+        Type armType = resource.ArmType!;
+
+        // First, try to find the RestOperations used by the resource's Get method
+        Type? restOpsType = FindRestOperationsFromMethod(armType, "Get");
+
+        // Fall back to scanning all RestOperations fields
+        if (restOpsType is null)
+        {
+            foreach (FieldInfo field in armType.GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
+            {
+                if (field.FieldType.Name.EndsWith("RestOperations"))
+                {
+                    restOpsType = field.FieldType;
+                    break;
+                }
+            }
+        }
+
+        return restOpsType is not null ? ExtractApiVersionFromRestOperations(restOpsType) : null;
+    }
+
+    /// <summary>
+    /// Scan a method's IL to find which RestOperations field it references (via ldfld).
+    /// Returns the type of the first RestOperations field found.
+    /// </summary>
+    private static Type? FindRestOperationsFromMethod(Type declaringType, string methodName)
+    {
+        MethodInfo? method = declaringType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m => m.Name == methodName && !m.IsAbstract);
+        if (method is null) { return null; }
+
+        MethodBody? body = method.GetMethodBody();
+        if (body is null) { return null; }
+
+        byte[] il = body.GetILAsByteArray()!;
+        Module module = declaringType.Module;
+
+        // Search for ldfld opcodes (0x7B) that reference RestOperations fields
+        for (int i = 0; i < il.Length - 4; i++)
+        {
+            if (il[i] != 0x7B) { continue; } // OpCodes.Ldfld
+
+            int token = il[i + 1] | (il[i + 2] << 8) | (il[i + 3] << 16) | (il[i + 4] << 24);
+            try
+            {
+                FieldInfo? field = module.ResolveField(token);
+                if (field is not null && field.FieldType.Name.EndsWith("RestOperations"))
+                {
+                    return field.FieldType;
+                }
+            }
+            catch
+            {
+                // Skip invalid tokens
+            }
+            i += 4;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extract the default api-version string from a RestOperations constructor
+    /// by parsing its IL for string literals matching the api-version pattern.
+    /// </summary>
+    private static string? ExtractApiVersionFromRestOperations(Type restOperationsType)
+    {
+        ConstructorInfo? constructor = restOperationsType
+            .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault();
+        if (constructor is null) { return null; }
+
+        MethodBody? body = constructor.GetMethodBody();
+        if (body is null) { return null; }
+
+        byte[] il = body.GetILAsByteArray()!;
+        Module module = restOperationsType.Module;
+
+        // Search for ldstr opcodes (0x72) and find api-version string literals
+        for (int i = 0; i < il.Length - 4; i++)
+        {
+            if (il[i] != 0x72) { continue; } // OpCodes.Ldstr
+
+            int token = il[i + 1] | (il[i + 2] << 8) | (il[i + 3] << 16) | (il[i + 4] << 24);
+            try
+            {
+                string str = module.ResolveString(token);
+                // Match api-version pattern: YYYY-MM-DD with optional suffix
+                if (Regex.IsMatch(str, @"^\d{4}-\d{2}-\d{2}"))
+                {
+                    return str;
+                }
+            }
+            catch
+            {
+                // Skip invalid tokens
+            }
+            i += 4;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Static cache of file contents indexed by file path.
+    /// This ensures that when multiple specs share the same output directory,
+    /// version data is preserved even after the directory is cleaned by one spec's Build().
+    /// </summary>
+    private static readonly Dictionary<string, string[]> s_fileContentCache = [];
+    private static readonly HashSet<string> s_cachedDirectories = [];
+
+    /// <summary>
+    /// Cache all .cs files in the generation path directory.
+    /// Called once per directory to ensure shared directories have all files cached
+    /// before any spec cleans the directory.
+    /// </summary>
+    private void CacheGenerationDirectory()
+    {
+        string? generationPath = GetGenerationPath();
+        if (generationPath is null || s_cachedDirectories.Contains(generationPath)) { return; }
+        s_cachedDirectories.Add(generationPath);
+
+        if (!Directory.Exists(generationPath)) { return; }
+        foreach (string file in Directory.GetFiles(generationPath, "*.cs"))
+        {
+            if (!s_fileContentCache.ContainsKey(file))
+            {
+                s_fileContentCache[file] = File.ReadAllLines(file);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Read existing api-versions from the generated provisioning resource file.
+    /// Returns separate lists for regular and hidden versions.
+    /// Uses a static cache to handle shared output directories across specs.
+    /// </summary>
+    private (List<string> versions, List<string> hiddenVersions) ReadExistingResourceVersions(Resource resource)
+    {
+        List<string> versions = [];
+        List<string> hiddenVersions = [];
+
+        string? generationPath = GetGenerationPath();
+        if (generationPath is null) { return (versions, hiddenVersions); }
+
+        string filePath = Path.Combine(generationPath, $"{resource.Name}.cs");
+
+        // Use cached file contents
+        if (!s_fileContentCache.TryGetValue(filePath, out string[]? lines))
+        {
+            return (versions, hiddenVersions);
+        }
+
+        // Find the ResourceVersions class block
+        bool inResourceVersions = false;
+        int braceDepth = 0;
+        bool nextVersionIsHidden = false;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string line = lines[i].Trim();
+
+            if (!inResourceVersions)
+            {
+                if (line.Contains("class ResourceVersions"))
+                {
+                    inResourceVersions = true;
+                    braceDepth = 0;
+                }
+                continue;
+            }
+
+            // Track brace depth
+            foreach (char c in line)
+            {
+                if (c == '{') braceDepth++;
+                else if (c == '}') braceDepth--;
+            }
+
+            if (braceDepth <= 0 && line.Contains('}'))
+            {
+                break; // End of ResourceVersions class
+            }
+
+            // Check for EditorBrowsable attribute
+            if (line.Contains("[EditorBrowsable(EditorBrowsableState.Never)]"))
+            {
+                nextVersionIsHidden = true;
+                continue;
+            }
+
+            // Match version field declarations
+            Match match = Regex.Match(line, @"public static readonly string \w+ = ""([^""]+)"";");
+            if (match.Success)
+            {
+                string version = match.Groups[1].Value;
+                if (nextVersionIsHidden)
+                {
+                    hiddenVersions.Add(version);
+                }
+                else
+                {
+                    versions.Add(version);
+                }
+                nextVersionIsHidden = false;
+            }
+            else if (!line.StartsWith("///") && !string.IsNullOrEmpty(line) && !line.StartsWith("{"))
+            {
+                // Reset hidden flag if we hit a non-comment, non-version line
+                nextVersionIsHidden = false;
+            }
+        }
+
+        return (versions, hiddenVersions);
     }
 }

--- a/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
@@ -98,12 +98,23 @@ public abstract partial class Specification
                 }
 
                 /**/
-                // Extract api-versions from the CreateOrUpdate method's XML doc comments
+                // Extract api-versions from the CreateOrUpdate method's XML doc comments,
+                // falling back to the Get method if CreateOrUpdate has no version
                 foreach (Resource resource in Resources)
                 {
                     if (resource.ResourceType is null) { continue; }
                     MethodInfo creator = resources[resource.ArmType!];
                     resource.DefaultResourceVersion = ExtractApiVersionFromXmlDoc(creator);
+
+                    if (resource.DefaultResourceVersion is null)
+                    {
+                        // Try the Get method on the resource type itself
+                        MethodInfo? getter = resource.ArmType!.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance, null, [typeof(CancellationToken)], null);
+                        if (getter is not null)
+                        {
+                            resource.DefaultResourceVersion = ExtractApiVersionFromXmlDoc(getter);
+                        }
+                    }
                 }
 
                 // Try to resolve missing versions from related types

--- a/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
@@ -637,8 +637,9 @@ public abstract partial class Specification
         // Extract the version after the marker - it follows after some whitespace/punctuation
         string rest = summary[(idx + marker.Length)..].Trim().TrimStart('.').Trim();
 
-        // The version is the next token that looks like a date (YYYY-MM-DD with optional suffix)
-        Match match = Regex.Match(rest, @"(\d{4}-\d{2}-\d{2}[\w-]*)");
+        // Match YYYY-MM-DD, optionally followed by hyphenated suffix (e.g., "-preview", "-PREVIEW")
+        // The suffix must start with a hyphen to avoid greedily matching into subsequent text.
+        Match match = Regex.Match(rest, @"(\d{4}-\d{2}-\d{2}(?:-[a-zA-Z][\w.]*)*)");
         return match.Success ? match.Groups[1].Value.TrimEnd('.') : null;
     }
 

--- a/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Core;
+using Azure.Core.Pipeline;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
@@ -611,114 +612,84 @@ public abstract partial class Specification
 
     /// <summary>
     /// Find the api-version used by the mgmt library for a given resource
-    /// by scanning the resource's Get method IL to identify the correct
-    /// RestOperations field, then extracting the version from its constructor.
-    /// A resource may have multiple RestOperations fields but only the one
-    /// referenced in Get (or CreateOrUpdate on the collection) is authoritative.
+    /// by creating a RestOperations instance and reading its _apiVersion field.
+    /// All RestOperations classes within a library share the same default api-version,
+    /// so we can use any RestOperations field from the resource type.
     /// </summary>
     private static string? FindMgmtApiVersion(Resource resource)
     {
         Type armType = resource.ArmType!;
 
-        // First, try to find the RestOperations used by the resource's Get method
-        Type? restOpsType = FindRestOperationsFromMethod(armType, "Get");
-
-        // Fall back to scanning all RestOperations fields
-        if (restOpsType is null)
+        // Find any RestOperations field on the ArmResource type
+        foreach (FieldInfo field in armType.GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
         {
-            foreach (FieldInfo field in armType.GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
-            {
-                if (field.FieldType.Name.EndsWith("RestOperations"))
-                {
-                    restOpsType = field.FieldType;
-                    break;
-                }
-            }
-        }
+            if (!field.FieldType.Name.EndsWith("RestOperations")) { continue; }
 
-        return restOpsType is not null ? ExtractApiVersionFromRestOperations(restOpsType) : null;
-    }
-
-    /// <summary>
-    /// Scan a method's IL to find which RestOperations field it references (via ldfld).
-    /// Returns the type of the first RestOperations field found.
-    /// </summary>
-    private static Type? FindRestOperationsFromMethod(Type declaringType, string methodName)
-    {
-        MethodInfo? method = declaringType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-            .FirstOrDefault(m => m.Name == methodName && !m.IsAbstract);
-        if (method is null) { return null; }
-
-        MethodBody? body = method.GetMethodBody();
-        if (body is null) { return null; }
-
-        byte[] il = body.GetILAsByteArray()!;
-        Module module = declaringType.Module;
-
-        // Search for ldfld opcodes (0x7B) that reference RestOperations fields
-        for (int i = 0; i < il.Length - 4; i++)
-        {
-            if (il[i] != 0x7B) { continue; } // OpCodes.Ldfld
-
-            int token = il[i + 1] | (il[i + 2] << 8) | (il[i + 3] << 16) | (il[i + 4] << 24);
-            try
-            {
-                FieldInfo? field = module.ResolveField(token);
-                if (field is not null && field.FieldType.Name.EndsWith("RestOperations"))
-                {
-                    return field.FieldType;
-                }
-            }
-            catch
-            {
-                // Skip invalid tokens
-            }
-            i += 4;
+            string? version = ExtractApiVersionFromRestOperations(field.FieldType);
+            if (version is not null) { return version; }
         }
 
         return null;
     }
 
     /// <summary>
-    /// Extract the default api-version string from a RestOperations constructor
-    /// by parsing its IL for string literals matching the api-version pattern.
+    /// Extract the default api-version from a RestOperations type by creating
+    /// an instance with null apiVersion (triggering the hardcoded default)
+    /// and reading the private _apiVersion field via reflection.
     /// </summary>
     private static string? ExtractApiVersionFromRestOperations(Type restOperationsType)
     {
-        ConstructorInfo? constructor = restOperationsType
+        // Find a constructor that accepts HttpPipeline as the first parameter
+        ConstructorInfo? ctor = restOperationsType
             .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             .FirstOrDefault();
-        if (constructor is null) { return null; }
+        if (ctor is null) { return null; }
 
-        MethodBody? body = constructor.GetMethodBody();
-        if (body is null) { return null; }
-
-        byte[] il = body.GetILAsByteArray()!;
-        Module module = restOperationsType.Module;
-
-        // Search for ldstr opcodes (0x72) and find api-version string literals
-        for (int i = 0; i < il.Length - 4; i++)
+        try
         {
-            if (il[i] != 0x72) { continue; } // OpCodes.Ldstr
+            // Build parameter values: pipeline is required, everything else can be null/default.
+            // Constructor signature is typically:
+            //   (HttpPipeline pipeline, string applicationId, Uri endpoint = null, string apiVersion = default)
+            // or for older libraries:
+            //   (ClientDiagnostics diagnostics, HttpPipeline pipeline, Uri endpoint, string apiVersion = default)
+            ParameterInfo[] parameters = ctor.GetParameters();
+            object?[] args = new object?[parameters.Length];
 
-            int token = il[i + 1] | (il[i + 2] << 8) | (il[i + 3] << 16) | (il[i + 4] << 24);
-            try
+            ArmClientOptions options = new();
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(options);
+
+            for (int i = 0; i < parameters.Length; i++)
             {
-                string str = module.ResolveString(token);
-                // Match api-version pattern: YYYY-MM-DD with optional suffix
-                if (Regex.IsMatch(str, @"^\d{4}-\d{2}-\d{2}"))
+                Type paramType = parameters[i].ParameterType;
+                if (paramType == typeof(HttpPipeline))
                 {
-                    return str;
+                    args[i] = pipeline;
                 }
+                else if (paramType.Name == "ClientDiagnostics")
+                {
+                    // ClientDiagnostics is internal; create via reflection
+                    args[i] = Activator.CreateInstance(paramType,
+                        BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+                        binder: null,
+                        args: [options],
+                        culture: null);
+                }
+                // Leave apiVersion, applicationId, endpoint, etc. as null
+                // so the constructor falls through to its hardcoded default
             }
-            catch
-            {
-                // Skip invalid tokens
-            }
-            i += 4;
-        }
 
-        return null;
+            object? instance = ctor.Invoke(args);
+            if (instance is null) { return null; }
+
+            // Read the private _apiVersion field
+            FieldInfo? versionField = restOperationsType.GetField("_apiVersion",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            return versionField?.GetValue(instance) as string;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
@@ -572,19 +572,8 @@ public abstract partial class Specification
                     // If there are any GA (non-preview) versions, use them; otherwise keep all (preview-only) versions
                     resource.ResourceVersions = nonPreviewVersions.Count > 0 ? nonPreviewVersions : orderedVersions;
 
-                    // Choose default version: prefer mgmtApiVersion if it's present in ResourceVersions,
-                    // otherwise fall back to the first non-preview or, if none, the first available version
-                    string? defaultVersion = null;
-                    if (mgmtApiVersion is not null && resource.ResourceVersions.Contains(mgmtApiVersion))
-                    {
-                        defaultVersion = mgmtApiVersion;
-                    }
-                    else
-                    {
-                        defaultVersion = resource.ResourceVersions
-                            .FirstOrDefault(v => !v.EndsWith("preview", StringComparison.OrdinalIgnoreCase))
-                            ?? resource.ResourceVersions.FirstOrDefault();
-                    }
+                    // Choose default version: use the latest (first after descending sort) available version
+                    string? defaultVersion = resource.ResourceVersions.FirstOrDefault();
 
                     resource.DefaultResourceVersion = defaultVersion;
 

--- a/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.Analyze.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Azure.Core;
-using Azure.Core.Pipeline;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
@@ -99,11 +98,12 @@ public abstract partial class Specification
                 }
 
                 /**/
-                // Extract api-versions from the mgmt library's RestOperations
+                // Extract api-versions from the CreateOrUpdate method's XML doc comments
                 foreach (Resource resource in Resources)
                 {
                     if (resource.ResourceType is null) { continue; }
-                    resource.DefaultResourceVersion = FindMgmtApiVersion(resource);
+                    MethodInfo creator = resources[resource.ArmType!];
+                    resource.DefaultResourceVersion = ExtractApiVersionFromXmlDoc(creator);
                 }
 
                 // Try to resolve missing versions from related types
@@ -611,85 +611,35 @@ public abstract partial class Specification
     }
 
     /// <summary>
-    /// Find the api-version used by the mgmt library for a given resource
-    /// by creating a RestOperations instance and reading its _apiVersion field.
-    /// All RestOperations classes within a library share the same default api-version,
-    /// so we can use any RestOperations field from the resource type.
+    /// Extract the default api-version from a CreateOrUpdate method's XML doc comment.
+    /// The generated mgmt libraries include a "Default Api Version" item in the
+    /// method's summary XML doc list, e.g.:
+    /// <code>
+    ///   &lt;item&gt;
+    ///     &lt;term&gt;Default Api Version&lt;/term&gt;
+    ///     &lt;description&gt;2025-06-01&lt;/description&gt;
+    ///   &lt;/item&gt;
+    /// </code>
     /// </summary>
-    private static string? FindMgmtApiVersion(Resource resource)
+    private string? ExtractApiVersionFromXmlDoc(MethodInfo method)
     {
-        Type armType = resource.ArmType!;
+        // Use the Specification's existing DocComments reader which has
+        // already loaded the XML doc file for the mgmt assembly
+        string? summary = DocComments.GetSummary(method);
+        if (summary is null) { return null; }
 
-        // Find any RestOperations field on the ArmResource type
-        foreach (FieldInfo field in armType.GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
-        {
-            if (!field.FieldType.Name.EndsWith("RestOperations")) { continue; }
+        // The summary text contains the flattened content including
+        // "Default Api Version" followed by the version string.
+        const string marker = "Default Api Version";
+        int idx = summary.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (idx < 0) { return null; }
 
-            string? version = ExtractApiVersionFromRestOperations(field.FieldType);
-            if (version is not null) { return version; }
-        }
+        // Extract the version after the marker - it follows after some whitespace/punctuation
+        string rest = summary[(idx + marker.Length)..].Trim().TrimStart('.').Trim();
 
-        return null;
-    }
-
-    /// <summary>
-    /// Extract the default api-version from a RestOperations type by creating
-    /// an instance with null apiVersion (triggering the hardcoded default)
-    /// and reading the private _apiVersion field via reflection.
-    /// </summary>
-    private static string? ExtractApiVersionFromRestOperations(Type restOperationsType)
-    {
-        // Find a constructor that accepts HttpPipeline as the first parameter
-        ConstructorInfo? ctor = restOperationsType
-            .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            .FirstOrDefault();
-        if (ctor is null) { return null; }
-
-        try
-        {
-            // Build parameter values: pipeline is required, everything else can be null/default.
-            // Constructor signature is typically:
-            //   (HttpPipeline pipeline, string applicationId, Uri endpoint = null, string apiVersion = default)
-            // or for older libraries:
-            //   (ClientDiagnostics diagnostics, HttpPipeline pipeline, Uri endpoint, string apiVersion = default)
-            ParameterInfo[] parameters = ctor.GetParameters();
-            object?[] args = new object?[parameters.Length];
-
-            ArmClientOptions options = new();
-            HttpPipeline pipeline = HttpPipelineBuilder.Build(options);
-
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                Type paramType = parameters[i].ParameterType;
-                if (paramType == typeof(HttpPipeline))
-                {
-                    args[i] = pipeline;
-                }
-                else if (paramType.Name == "ClientDiagnostics")
-                {
-                    // ClientDiagnostics is internal; create via reflection
-                    args[i] = Activator.CreateInstance(paramType,
-                        BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
-                        binder: null,
-                        args: [options],
-                        culture: null);
-                }
-                // Leave apiVersion, applicationId, endpoint, etc. as null
-                // so the constructor falls through to its hardcoded default
-            }
-
-            object? instance = ctor.Invoke(args);
-            if (instance is null) { return null; }
-
-            // Read the private _apiVersion field
-            FieldInfo? versionField = restOperationsType.GetField("_apiVersion",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            return versionField?.GetValue(instance) as string;
-        }
-        catch
-        {
-            return null;
-        }
+        // The version is the next token that looks like a date (YYYY-MM-DD with optional suffix)
+        Match match = Regex.Match(rest, @"(\d{4}-\d{2}-\d{2}[\w-]*)");
+        return match.Success ? match.Groups[1].Value.TrimEnd('.') : null;
     }
 
     /// <summary>

--- a/sdk/provisioning/Generator/src/Model/Specification.Customize.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.Customize.cs
@@ -118,10 +118,11 @@ public abstract partial class Specification : ModelBase
     public void IncludeVersions<T>(params string[] apiVersions)
     {
         Resource resource = GetResource<T>();
+        resource.ResourceVersions ??= [];
         for (int i = apiVersions.Length - 1; i >= 0; i--)
         {
-            if (resource.ResourceVersions!.Contains(apiVersions[i])) { continue; }
-            resource.ResourceVersions!.Insert(0, apiVersions[i]);
+            if (resource.ResourceVersions.Contains(apiVersions[i])) { continue; }
+            resource.ResourceVersions.Insert(0, apiVersions[i]);
         }
     }
 

--- a/sdk/provisioning/Generator/src/Model/Specification.cs
+++ b/sdk/provisioning/Generator/src/Model/Specification.cs
@@ -7,19 +7,11 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using Azure.Identity;
-using Azure.ResourceManager;
 
 namespace Azure.Provisioning.Generator.Model;
 
 public abstract partial class Specification : ModelBase
 {
-    /// <summary>
-    /// ArmClient used for talking to the service so it can fetch lists of
-    /// supported versions for resources.
-    /// </summary>
-    private static ArmClient Arm { get; } = new ArmClient(new DefaultAzureCredential());
-
     public Assembly ArmAssembly { get => ArmType!.Assembly; }
 
     // Flag indicating we don't need to clean the output directory
@@ -57,6 +49,7 @@ public abstract partial class Specification : ModelBase
     {
         Analyze();
         Customize();
+        ResolveVersions();
         Lint();
         ContextualException.WithContext(
             $"Generating all types for {Namespace}",


### PR DESCRIPTION
## Description

Fixes https://github.com/Azure/azure-sdk-for-net/issues/56466

Changes the provisioning generator to extract api-versions from the mgmt library's RestOperations classes instead of calling the ARM API at runtime.

### Problem

The generator previously used `ArmClient` with `DefaultAzureCredential` to call ARM API to get valid api-versions for resources. This had multiple downsides:
1. Required authentication to run (impossible in CI)
2. Some services deploy before updating swagger, so live versions may not match documentation
3. Caused api-version mismatches - the default version from ARM might not match the mgmt library's actual API shape

### Solution

Replace the ARM API call with a two-step approach:

1. **Extract api-version from mgmt library** - Parse RestOperations constructor IL to find the default api-version string literal (the `_apiVersion = apiVersion ?? ""YYYY-MM-DD""` pattern)
2. **Read existing versions from generated code** - Parse the ResourceVersions class in existing generated `.cs` files to preserve previously known versions

The default version is now set to match the mgmt library's api-version, ensuring consistency with the actual API shape.

### Key changes

- **`Generator.csproj`** - Removed `Azure.Identity` package reference
- **`Specification.cs`** - Removed `ArmClient` field and `Azure.Identity` dependency
- **`Specification.Analyze.cs`** - Replaced ARM API calls with:
  - `FindMgmtApiVersion()` - finds RestOperations type from resource's fields
  - `ExtractApiVersionFromRestOperations()` - IL parsing to extract version string
  - `ReadExistingResourceVersions()` - parses generated files for version declarations
  - `ResolveVersions()` - combines existing + mgmt versions (called after Customize)
  - `CacheGenerationDirectory()` - static file cache for shared output directories
- **`Specification.Customize.cs`** - Made `IncludeVersions` null-safe