### PR TITLE
Remove duplicate ModelReaderWriterBuildable attribute for OperationStatusResult in Azure.ResourceManager

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/AzureResourceManagerContext.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/Common/Custom/Models/AzureResourceManagerContext.cs
@@ -35,7 +35,6 @@ namespace Azure.ResourceManager
     [ModelReaderWriterBuildable(typeof(ManagementGroupPathElement))]
     [ModelReaderWriterBuildable(typeof(ParentManagementGroupInfo))]
     [ModelReaderWriterBuildable(typeof(ManagedServiceIdentity))]
-    [ModelReaderWriterBuildable(typeof(OperationStatusResult))]
     [ModelReaderWriterBuildable(typeof(FeatureResource))]
     [ModelReaderWriterBuildable(typeof(GenericResourceData))]
     [ModelReaderWriterBuildable(typeof(PolicyAssignmentData))]


### PR DESCRIPTION
## Description

Removes a duplicate `[ModelReaderWriterBuildable(typeof(OperationStatusResult))]` attribute from the custom `AzureResourceManagerContext` partial class.

The `OperationStatusResult` type was declared in both:
- `src/Common/Generated/Models/AzureResourceManagerContext.cs` (generated)
- `src/Common/Custom/Models/AzureResourceManagerContext.cs` (custom)

This caused duplicate LineId values. The fix removes the entry from the custom file since the generated file already declares it.

## Validation

- Build succeeds with 0 warnings and 0 errors.