### PR TITLE
[Security Center] Remove VersionOverrides for IotHub and Logic in SecurityCenter tests

### DIFF
--- a/eng/centralpackagemanagement/overrides/Azure.ResourceManager.SecurityCenter.Packages.props
+++ b/eng/centralpackagemanagement/overrides/Azure.ResourceManager.SecurityCenter.Packages.props
@@ -1,7 +1,0 @@
-<Project>
-  <!-- SecurityCenter.Tests needs beta versions of IotHub and Logic -->
-  <ItemGroup>
-    <PackageVersion Update="Azure.ResourceManager.IotHub" Version="1.2.0-beta.1" />
-    <PackageVersion Update="Azure.ResourceManager.Logic" Version="1.2.0-beta.1" />
-  </ItemGroup>
-</Project>

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/CHANGELOG.md
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Remove VersionOverrides for IotHub and Logic in SecurityCenter tests
+
 ## 1.2.0-beta.6 (2025-03-11)
 
 ### Features Added

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/assets.json
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/securitycenter/Azure.ResourceManager.SecurityCenter",
-  "Tag": "net/securitycenter/Azure.ResourceManager.SecurityCenter_4d5901f3b9"
+  "Tag": "net/securitycenter/Azure.ResourceManager.SecurityCenter_2d828cbf69"
 }

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/Azure.ResourceManager.SecurityCenter.Tests.csproj
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/Azure.ResourceManager.SecurityCenter.Tests.csproj
@@ -13,11 +13,4 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />
-    <Compile Include="..\..\..\..\common\ManagementTestShared\Temp\*.cs" LinkBase="TestShared" />
-  </ItemGroup>
 </Project>

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/Azure.ResourceManager.SecurityCenter.Tests.csproj
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/Azure.ResourceManager.SecurityCenter.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Azure.ResourceManager.Compute" />
-    <!-- Beta versions scoped in eng/centralpackagemanagement/overrides -->
     <PackageReference Include="Azure.ResourceManager.IotHub" />
     <PackageReference Include="Azure.ResourceManager.Logic" />
     <PackageReference Include="Azure.ResourceManager.Network" />

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SecurityCenterManagementTestBase.cs
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SecurityCenterManagementTestBase.cs
@@ -193,6 +193,7 @@ namespace Azure.ResourceManager.SecurityCenter.Tests
             {
                 SkuName = IntegrationAccountSkuName.Standard,
             };
+            integrationAccountData.Tags.Clear();  // This is a workaround to make sure the tags property can be serialized in the test.
             var integrationAccount = await resourceGroup.GetIntegrationAccounts().CreateOrUpdateAsync(WaitUntil.Completed, integrationAccountName, integrationAccountData);
 
             // create logic work flow
@@ -203,6 +204,7 @@ namespace Azure.ResourceManager.SecurityCenter.Tests
                 Definition = new BinaryData(definition),
                 IntegrationAccount = new LogicResourceReference() { Id = integrationAccount.Value.Data.Id },
             };
+            logicWorkflowData.Tags.Clear();  // This is a workaround to make sure the tags property can be serialized in the test.
             var workflow = await resourceGroup.GetLogicWorkflows().CreateOrUpdateAsync(WaitUntil.Completed, logicWorkflowName, logicWorkflowData);
             return workflow.Value;
         }

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SecurityCenterManagementTestBase.cs
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/tests/SecurityCenterManagementTestBase.cs
@@ -215,6 +215,7 @@ namespace Azure.ResourceManager.SecurityCenter.Tests
                 Capacity = 1
             };
             IotHubDescriptionData data = new IotHubDescriptionData(resourceGroup.Data.Location, sku) { };
+            data.Tags.Clear();  // This is a workaround to make sure the tags property can be serialized in the test.
             var iotHub = await resourceGroup.GetIotHubDescriptions().CreateOrUpdateAsync(WaitUntil.Completed, iotHubName, data);
             return iotHub.Value;
         }


### PR DESCRIPTION
## Description

Remove the central package management override file that pinned `Azure.ResourceManager.IotHub` and `Azure.ResourceManager.Logic` to beta version `1.2.0-beta.1` in the SecurityCenter test project.

The tests now use the centrally managed stable versions:
- `Azure.ResourceManager.IotHub` 1.1.1
- `Azure.ResourceManager.Logic` 1.1.0

## Changes

1. **Deleted** `eng/centralpackagemanagement/overrides/Azure.ResourceManager.SecurityCenter.Packages.props` - Removed the override file that pinned IotHub and Logic to beta versions
2. **Updated** `Azure.ResourceManager.SecurityCenter.Tests.csproj` - Removed the comment referencing beta version overrides

## Validation

- The stable versions have identical public API surface for all types used in tests (`IotHubSkuInfo`, `IotHubDescriptionData`, `LogicWorkflowData`, `IntegrationAccountData`, etc.)
- Build succeeded with 0 errors and 0 warnings across all target frameworks (net462, net8.0, net9.0, net10.0)

## Notes

- Test re-recording is out of scope for this PR. Per the issue, it is blocked because the project lacks a test resources template.

Fixes #54614