### PR TITLE
Fix smoke test restore failure for release builds with unreleased packages

### DIFF
--- a/eng/pipelines/templates/jobs/smoke.tests.template.yml
+++ b/eng/pipelines/templates/jobs/smoke.tests.template.yml
@@ -87,8 +87,12 @@ jobs:
 
       - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
-      - pwsh: dotnet restore ./common/SmokeTests/SmokeTest/SmokeTest.csproj
-        displayName: dotnet restore
+      - ${{ if eq(parameters.Daily, false) }}:
+        - pwsh: dotnet restore ./common/SmokeTests/SmokeTest/SmokeTest.csproj /p:RestoreAdditionalProjectSources=$(Pipeline.Workspace)/${{ parameters.ArtifactName }}
+          displayName: dotnet restore
+      - ${{ if eq(parameters.Daily, true) }}:
+        - pwsh: dotnet restore ./common/SmokeTests/SmokeTest/SmokeTest.csproj
+          displayName: dotnet restore
 
       - pwsh: dotnet run -p .\common\SmokeTests\SmokeTest\SmokeTest.csproj --framework $(TestTargetFramework)
         displayName: "Run Smoke Tests"

--- a/eng/scripts/InstallationCheck.ps1
+++ b/eng/scripts/InstallationCheck.ps1
@@ -14,6 +14,12 @@ cd "InstallationCheck"
 
 Write-Host "dotnet new console --no-restore"
 dotnet new console --no-restore
+
+# Opt out of Central Package Management so that the dynamically added
+# PackageReference with an explicit Version attribute is allowed.
+'<Project></Project>' | Set-Content "Directory.Build.props"
+'<Project></Project>' | Set-Content "Directory.Build.targets"
+
 $localFeed = "$ArtifactsDirectory/$Artifact"
 
 $version = (Get-Content "$ArtifactsDirectory/PackageInfo/$Artifact.json" | ConvertFrom-Json).Version


### PR DESCRIPTION
## Problem

The \
et - identity\ release build (build 5929066) has two failures in the release stage:

### 1. Smoke Test Restore Failure (NU1102)

Release (non-daily) smoke test builds fail with \NU1102: Unable to find package\ errors when the smoke test csproj references package versions that haven't been published to any NuGet feed yet.

\Update-Dependencies.ps1\ sets versions from the artifact's PackageInfo JSON (e.g. \Azure.Identity 1.18.0\, \Azure.Identity.Broker 1.4.0-beta.1\). These versions don't exist on any feed yet — the built \.nupkg\ files are in the downloaded pipeline artifact but were **never added as a NuGet source** for \dotnet restore\.

This is a latent bug that surfaced when Azure.Identity.Broker was bumped to unreleased \1.4.0-beta.1\ in Nov 2025.

### 2. Verify Package Installation Failure (NU1008 - CPM)

The \InstallationCheck.ps1\ script creates a temp project inside the repo tree and uses \dotnet add package --version\ which sets an inline Version on PackageReference. The recent CPM modernization (#55609, merged Feb 25) now makes this an error (NU1008) since CPM forbids inline version attributes.

## Fixes

### Commit 1: Smoke test restore
For release builds, add the downloaded artifact folder as \RestoreAdditionalProjectSources\ so \dotnet restore\ can find the just-built packages.

### Commit 2: InstallationCheck CPM isolation
Write empty \Directory.Build.props\ and \Directory.Build.targets\ files in the \InstallationCheck\ directory to isolate it from the repo's CPM configuration.

## Validation

Both issues were reproduced locally and confirmed fixed:
- Smoke test: simulated release build with mock PackageInfo JSONs, restore fails without fix, succeeds with \RestoreAdditionalProjectSources\
- InstallationCheck: \dotnet new console\ + \dotnet add package --version\ fails with NU1008, succeeds after isolating from repo build props