### PR TITLE
Fix incorrect body type for CreateOrUpdate when @armResourceCreateOrUpdate is used with @patch

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -554,7 +554,14 @@ function parseResourceOperation(
         };
       case armResourceCreateOrUpdateName:
         return {
-          kind: ResourceOperationKind.Create,
+          // When the decorator is @armResourceCreateOrUpdate but the HTTP verb is PATCH,
+          // classify as Update. This handles cases like Legacy.CreateOrReplaceAsync used
+          // with @patch override, where the template still produces @armResourceCreateOrUpdate
+          // but the operation is semantically an update.
+          kind:
+            serviceMethod?.operation?.verb === "patch"
+              ? ResourceOperationKind.Update
+              : ResourceOperationKind.Create,
           modelId: getResourceModelId(sdkContext, decorator),
           explicitResourceName: undefined
         };


### PR DESCRIPTION
## Fix: Incorrect Body Type for CreateOrUpdate in DatadogMonitorCollection

Fixes #56503

### Problem

When migrating Datadog to the new mgmt generator, the `CreateOrUpdate` method in `DatadogMonitorCollection` was generated with `DatadogMonitorPatch` as the body parameter instead of `DatadogMonitorData`, causing a contract-implementation mismatch.

### Root Cause

The Datadog TypeSpec defines:
- `create` using `Legacy.CreateOrUpdateAsync` (PUT) with the resource type as body
- `update` using `Legacy.CreateOrReplaceAsync` + `@patch` override with `DatadogMonitorResourceUpdateParameters` as body

Both templates produce the `@armResourceCreateOrUpdate` decorator. The emitter classified **both** as `ResourceOperationKind.Create` without considering the HTTP verb, so the C# generator picked the wrong one (the PATCH update) for the collection's `CreateOrUpdate` method.

### Fix

In `resource-detection.ts`'s `parseResourceOperation()`: when `@armResourceCreateOrUpdate` is detected but the HTTP verb is `patch`, classify the operation as `Update` instead of `Create`. This ensures only the actual PUT create-or-update operation is used for the collection's `CreateOrUpdate` method.

### Testing

- Added a new test case in `resource-detection.test.ts` that reproduces the exact Datadog pattern (`CreateOrUpdateAsync` + `CreateOrReplaceAsync` with `@patch`)
- All 15 emitter tests pass
- All 114 C# generator tests pass
