### PR TITLE
Fix Azure.GeneratorAgent.Tests target framework to match src project

### DIFF
--- a/sdk/tools/Azure.GeneratorAgent/tests/Azure.GeneratorAgent.Tests.csproj
+++ b/sdk/tools/Azure.GeneratorAgent/tests/Azure.GeneratorAgent.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <RequiredTargetFrameworks>$(LtsTargetFramework)</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Fix Azure.GeneratorAgent.Tests target framework mismatch

### Problem

The `Azure.GeneratorAgent.Tests` project was failing in CI with:

`
error NETSDK1005: Assets file doesn't have a target for 'net462'
`

**Root cause:** The test project used the default `RequiredTargetFrameworks` for test projects, which expands to `net10.0;net8.0;net9.0;net462` on Windows CI. However, its dependency `Azure.GeneratorAgent.csproj` only targets `net10.0` (LTS), so building for `net462` fails because there is no compatible target in the src project.

### Fix

Override `RequiredTargetFrameworks` in the test project to `` to match the src project's single-TFM constraint.

### Validation

- Build succeeds with 0 warnings and 0 errors
