### PR TITLE
[ContentUnderstanding] Fix README: rename MediaContent to AnalysisContent

### DIFF
--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
@@ -143,7 +143,7 @@ For a complete list of available prebuilt analyzers and their capabilities, see 
 >
 ### Content types
 
-The API returns different content types based on the input. Both `DocumentContent` and `AudioVisualContent` classes derive from `MediaContent` class, which provides basic information and markdown representation. Each derived class provides additional properties to access detailed information:
+The API returns different content types based on the input. Both `DocumentContent` and `AudioVisualContent` classes derive from `AnalysisContent` class, which provides basic information and markdown representation. Each derived class provides additional properties to access detailed information:
 
 * **`DocumentContent`** - For document files (PDF, HTML, images, Office documents such as Word, Excel, PowerPoint, and more). Provides basic information such as page count and MIME type. Retrieve detailed information including pages, tables, figures, paragraphs, and many others.
 * **`AudioVisualContent`** - For audio and video files. Provides basic information such as timing information (start/end times) and frame dimensions (for video). Retrieve detailed information including transcript phrases, timing information, and for video, key frame references and more.


### PR DESCRIPTION
The base class was renamed from `MediaContent` to `AnalysisContent` in the GA TypeSpec update but the README was not updated.

### Changes
- `MediaContent` → `AnalysisContent` in the content types documentation section (line 146)