### PR TITLE
Override CopyMsalSettableProperties in Broker DevelopmentBrokerOptions

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/src/DevelopmentBrokerOptions.cs
+++ b/sdk/identity/Azure.Identity.Broker/src/DevelopmentBrokerOptions.cs
@@ -48,6 +48,23 @@ namespace Azure.Identity.Broker
 
         Action<PublicClientApplicationBuilder> IMsalPublicClientInitializerOptions.BeforeBuildClient => _beforeBuildClient;
 
+        internal override void CopyMsalSettableProperties(TokenCredentialOptions source)
+        {
+            base.CopyMsalSettableProperties(source);
+
+#pragma warning disable AZC0112 // Accessing internal property via InternalsVisibleTo
+            bool? value = source switch
+            {
+                DefaultAzureCredentialOptions dac => dac.IsLegacyMsaPassthroughEnabled,
+                DevelopmentBrokerOptions dbo => dbo.IsLegacyMsaPassthroughEnabled,
+                _ => null
+            };
+#pragma warning restore AZC0112
+
+            if (value.HasValue)
+                IsLegacyMsaPassthroughEnabled = value;
+        }
+
         private void AddBroker(PublicClientApplicationBuilder builder)
         {
             builder.WithParentActivityOrWindow(() => IntPtr.Zero);

--- a/sdk/identity/Azure.Identity.Broker/tests/DevelopmentBrokerOptionsTests.cs
+++ b/sdk/identity/Azure.Identity.Broker/tests/DevelopmentBrokerOptionsTests.cs
@@ -69,6 +69,19 @@ namespace Azure.Identity.Broker.Tests
             Assert.AreEqual(true, GetIsLegacyMsaPassthroughEnabled(target));
         }
 
+        [Test]
+        public void CopyMsalSettableProperties_CopiesFromDevelopmentBrokerOptions()
+        {
+            Assert.IsTrue(DefaultAzureCredentialFactory.TryCreateDevelopmentBrokerOptions(out var source));
+            Assert.IsTrue(DefaultAzureCredentialFactory.TryCreateDevelopmentBrokerOptions(out var target));
+
+            source.GetType().GetProperty("IsLegacyMsaPassthroughEnabled").SetValue(source, true);
+
+            target.CopyMsalSettableProperties(source);
+
+            Assert.AreEqual(true, GetIsLegacyMsaPassthroughEnabled(target));
+        }
+
         private static bool? GetIsLegacyMsaPassthroughEnabled(InteractiveBrowserCredentialOptions options)
         {
             return (bool?)options.GetType().GetProperty("IsLegacyMsaPassthroughEnabled")?.GetValue(options);

--- a/sdk/identity/Azure.Identity.Broker/tests/DevelopmentBrokerOptionsTests.cs
+++ b/sdk/identity/Azure.Identity.Broker/tests/DevelopmentBrokerOptionsTests.cs
@@ -30,5 +30,48 @@ namespace Azure.Identity.Broker.Tests
                 // This is expected, as the broker is not available in the test environment.
             }
         }
+
+        [Test]
+        public void CopyMsalSettableProperties_CopiesFromDefaultAzureCredentialOptions()
+        {
+            var source = new DefaultAzureCredentialOptions();
+            source.IsLegacyMsaPassthroughEnabled = true;
+
+            Assert.IsTrue(DefaultAzureCredentialFactory.TryCreateDevelopmentBrokerOptions(out var target));
+            target.CopyMsalSettableProperties(source);
+
+            Assert.AreEqual(true, GetIsLegacyMsaPassthroughEnabled(target));
+        }
+
+        [Test]
+        public void CopyMsalSettableProperties_CopiesFalseFromDefaultAzureCredentialOptions()
+        {
+            var source = new DefaultAzureCredentialOptions();
+            source.IsLegacyMsaPassthroughEnabled = false;
+
+            Assert.IsTrue(DefaultAzureCredentialFactory.TryCreateDevelopmentBrokerOptions(out var target));
+            target.CopyMsalSettableProperties(source);
+
+            Assert.AreEqual(false, GetIsLegacyMsaPassthroughEnabled(target));
+        }
+
+        [Test]
+        public void CopyMsalSettableProperties_DoesNotOverwriteWhenSourceHasNoValue()
+        {
+            var source = new InteractiveBrowserCredentialOptions();
+
+            Assert.IsTrue(DefaultAzureCredentialFactory.TryCreateDevelopmentBrokerOptions(out var target));
+            // Set a value on the target before copying
+            target.GetType().GetProperty("IsLegacyMsaPassthroughEnabled").SetValue(target, true);
+
+            target.CopyMsalSettableProperties(source);
+
+            Assert.AreEqual(true, GetIsLegacyMsaPassthroughEnabled(target));
+        }
+
+        private static bool? GetIsLegacyMsaPassthroughEnabled(InteractiveBrowserCredentialOptions options)
+        {
+            return (bool?)options.GetType().GetProperty("IsLegacyMsaPassthroughEnabled")?.GetValue(options);
+        }
     }
 }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/BrokerCredentialCreationTests.cs
@@ -680,7 +680,6 @@ namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.Broker
         // is published with the internal virtual method.
         [Test]
         [NonParallelizable]
-        [Ignore("Requires Broker DBO override of CopyMsalSettableProperties — see https://github.com/Azure/azure-sdk-for-net/issues/56384")]
         public void IsLegacyMsaPassthroughEnabled_ConfigSetsFalse()
         {
             using (new TestEnvVar(AllNulledEnvVars()))
@@ -696,7 +695,6 @@ namespace Azure.Identity.Broker.Tests.ConfigurableCredentials.Broker
 
         [Test]
         [NonParallelizable]
-        [Ignore("Requires Broker DBO override of CopyMsalSettableProperties — see https://github.com/Azure/azure-sdk-for-net/issues/56384")]
         public void IsLegacyMsaPassthroughEnabled_ConfigSetsTrue()
         {
             using (new TestEnvVar(AllNulledEnvVars()))


### PR DESCRIPTION
## Description

Override CopyMsalSettableProperties in Azure.Identity.Broker.DevelopmentBrokerOptions to copy IsLegacyMsaPassthroughEnabled from source options during credential creation.

## Changes

1. **DevelopmentBrokerOptions.cs** (Broker src) — Added CopyMsalSettableProperties override that copies IsLegacyMsaPassthroughEnabled from DefaultAzureCredentialOptions or DevelopmentBrokerOptions source
2. **DevelopmentBrokerOptionsTests.cs** — Added 3 unit tests verifying the property value flows through correctly
3. **BrokerCredentialCreationTests.cs** — Removed \[Ignore]\ from two \IsLegacyMsaPassthroughEnabled\ tests

Fixes #56384