### PR TITLE
Add ConfigurationClientSettings and experimental constructor to ConfigurationClient

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net10.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net10.0.cs
@@ -26,6 +26,8 @@ namespace Azure.Data.AppConfiguration
     public partial class ConfigurationClient
     {
         protected ConfigurationClient() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public ConfigurationClient(Azure.Data.AppConfiguration.ConfigurationClientSettings settings) { }
         public ConfigurationClient(string connectionString) { }
         public ConfigurationClient(string connectionString, Azure.Data.AppConfiguration.ConfigurationClientOptions options) { }
         public ConfigurationClient(System.Uri endpoint, Azure.Core.TokenCredential credential) { }
@@ -103,6 +105,14 @@ namespace Azure.Data.AppConfiguration
             V2023_10_01 = 1,
             V2023_11_01 = 2,
         }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+    public partial class ConfigurationClientSettings : System.ClientModel.Primitives.ClientSettings
+    {
+        public ConfigurationClientSettings() { }
+        public System.Uri? Endpoint { get { throw null; } set { } }
+        public Azure.Data.AppConfiguration.ConfigurationClientOptions? Options { get { throw null; } set { } }
+        protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
     }
     public static partial class ConfigurationModelFactory
     {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net8.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net8.0.cs
@@ -26,6 +26,8 @@ namespace Azure.Data.AppConfiguration
     public partial class ConfigurationClient
     {
         protected ConfigurationClient() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public ConfigurationClient(Azure.Data.AppConfiguration.ConfigurationClientSettings settings) { }
         public ConfigurationClient(string connectionString) { }
         public ConfigurationClient(string connectionString, Azure.Data.AppConfiguration.ConfigurationClientOptions options) { }
         public ConfigurationClient(System.Uri endpoint, Azure.Core.TokenCredential credential) { }
@@ -103,6 +105,14 @@ namespace Azure.Data.AppConfiguration
             V2023_10_01 = 1,
             V2023_11_01 = 2,
         }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+    public partial class ConfigurationClientSettings : System.ClientModel.Primitives.ClientSettings
+    {
+        public ConfigurationClientSettings() { }
+        public System.Uri? Endpoint { get { throw null; } set { } }
+        public Azure.Data.AppConfiguration.ConfigurationClientOptions? Options { get { throw null; } set { } }
+        protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
     }
     public static partial class ConfigurationModelFactory
     {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -26,6 +26,7 @@ namespace Azure.Data.AppConfiguration
     public partial class ConfigurationClient
     {
         protected ConfigurationClient() { }
+        public ConfigurationClient(Azure.Data.AppConfiguration.ConfigurationClientSettings settings) { }
         public ConfigurationClient(string connectionString) { }
         public ConfigurationClient(string connectionString, Azure.Data.AppConfiguration.ConfigurationClientOptions options) { }
         public ConfigurationClient(System.Uri endpoint, Azure.Core.TokenCredential credential) { }
@@ -103,6 +104,13 @@ namespace Azure.Data.AppConfiguration
             V2023_10_01 = 1,
             V2023_11_01 = 2,
         }
+    }
+    public partial class ConfigurationClientSettings : System.ClientModel.Primitives.ClientSettings
+    {
+        public ConfigurationClientSettings() { }
+        public System.Uri? Endpoint { get { throw null; } set { } }
+        public Azure.Data.AppConfiguration.ConfigurationClientOptions? Options { get { throw null; } set { } }
+        protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
     }
     public static partial class ConfigurationModelFactory
     {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(AzureCoreSharedSources)AzureResourceProviderNamespaceAttribute.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ConnectionString.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)ArrayBufferWriter.cs" LinkBase="Shared" />
+    <Compile Include="$(AzureCoreSharedSources)ExperimentalAttribute.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)HashCodeBuilder.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)NoBodyResponseOfT.cs" LinkBase="Shared" />
     <Compile Include="$(AzureCoreSharedSources)PageResponseEnumerator.cs" LinkBase="Shared" />

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using System.Threading;
@@ -149,6 +150,17 @@ namespace Azure.Data.AppConfiguration
             _apiVersion = options.Version;
 
             ClientDiagnostics = new ClientDiagnostics(options, true);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigurationClient"/> class using the provided settings.
+        /// </summary>
+        /// <param name="settings">The <see cref="ConfigurationClientSettings"/> used to configure the client.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="settings"/> is null, or the endpoint or credential in the settings is null.</exception>
+        [Experimental("SCME0002")]
+        public ConfigurationClient(ConfigurationClientSettings settings)
+            : this(settings?.Endpoint, settings?.CredentialProvider as TokenCredential, settings?.Options ?? new ConfigurationClientOptions())
+        {
         }
 
         /// <summary> Initializes a new instance of ConfigurationClient. </summary>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientSettings.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClientSettings.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Configuration;
+
+#nullable enable
+
+namespace Azure.Data.AppConfiguration
+{
+    /// <summary>
+    /// Represents the settings used to configure a <see cref="ConfigurationClient"/> that can be loaded from an <see cref="IConfigurationSection"/>.
+    /// </summary>
+    [Experimental("SCME0002")]
+    public class ConfigurationClientSettings : ClientSettings
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="Uri"/> referencing the app configuration storage.
+        /// </summary>
+        public Uri? Endpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ConfigurationClientOptions"/> used to configure requests sent to the App Configuration service.
+        /// </summary>
+        public ConfigurationClientOptions? Options { get; set; }
+
+        /// <inheritdoc/>
+        protected override void BindCore(IConfigurationSection section)
+        {
+            string? endpoint = section["Endpoint"];
+            if (!string.IsNullOrEmpty(endpoint))
+            {
+                Endpoint = new Uri(endpoint);
+            }
+
+            IConfigurationSection optionsSection = section.GetSection("Options");
+            if (optionsSection.Exists())
+            {
+                Options = new ConfigurationClientOptions(optionsSection);
+            }
+        }
+    }
+}

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/Azure.Data.AppConfiguration.Tests.csproj
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/Azure.Data.AppConfiguration.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Azure.Messaging.EventGrid" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
     
     <ExcludeFromProjectReferenceToConversion Include="Azure.Messaging.EventGrid" />
   </ItemGroup>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationClientSettingsTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationClientSettingsTests.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.ClientModel;
-using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationClientSettingsTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationClientSettingsTests.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma warning disable SCME0002 // Type is for evaluation purposes only
+
+using System;
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.Data.AppConfiguration.Tests
+{
+    public class ConfigurationClientSettingsTests
+    {
+        [Test]
+        public void BindLoadsEndpoint()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Endpoint"] = "https://myappconfig.azconfig.io"
+                })
+                .Build();
+
+            ConfigurationClientSettings settings = config.GetClientSettings<ConfigurationClientSettings>("Client");
+
+            Assert.That(settings.Endpoint, Is.EqualTo(new Uri("https://myappconfig.azconfig.io")));
+        }
+
+        [Test]
+        public void BindLoadsOptions()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Options:Audience"] = "https://azconfig.io"
+                })
+                .Build();
+
+            ConfigurationClientSettings settings = config.GetClientSettings<ConfigurationClientSettings>("Client");
+
+            Assert.That(settings.Options, Is.Not.Null);
+            Assert.That(settings.Options.Audience, Is.EqualTo(new AppConfigurationAudience("https://azconfig.io")));
+        }
+
+        [Test]
+        public void BindLoadsCredential()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Credential:CredentialSource"] = "ApiKey",
+                    ["Client:Credential:Key"] = "test-key-123"
+                })
+                .Build();
+
+            ConfigurationClientSettings settings = config.GetClientSettings<ConfigurationClientSettings>("Client");
+
+            Assert.That(settings.Credential, Is.Not.Null);
+            Assert.That(settings.Credential.CredentialSource, Is.EqualTo("ApiKey"));
+            Assert.That(settings.Credential.Key, Is.EqualTo("test-key-123"));
+        }
+
+        [Test]
+        public void BindLoadsAllPropertiesTogether()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Endpoint"] = "https://myappconfig.azconfig.io",
+                    ["Client:Options:Audience"] = "https://azconfig.io",
+                    ["Client:Credential:CredentialSource"] = "ApiKey",
+                    ["Client:Credential:Key"] = "my-key"
+                })
+                .Build();
+
+            ConfigurationClientSettings settings = config.GetClientSettings<ConfigurationClientSettings>("Client");
+
+            Assert.That(settings.Endpoint, Is.EqualTo(new Uri("https://myappconfig.azconfig.io")));
+            Assert.That(settings.Options, Is.Not.Null);
+            Assert.That(settings.Options.Audience, Is.EqualTo(new AppConfigurationAudience("https://azconfig.io")));
+            Assert.That(settings.Credential, Is.Not.Null);
+            Assert.That(settings.Credential.CredentialSource, Is.EqualTo("ApiKey"));
+            Assert.That(settings.Credential.Key, Is.EqualTo("my-key"));
+        }
+
+        [Test]
+        public void BindHandlesMissingOptionalProperties()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Endpoint"] = "https://myappconfig.azconfig.io"
+                })
+                .Build();
+
+            ConfigurationClientSettings settings = config.GetClientSettings<ConfigurationClientSettings>("Client");
+
+            Assert.That(settings.Endpoint, Is.EqualTo(new Uri("https://myappconfig.azconfig.io")));
+            Assert.That(settings.Options, Is.Null);
+        }
+
+        [Test]
+        public void BindHandlesMissingEndpoint()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Options:Audience"] = "https://azconfig.io"
+                })
+                .Build();
+
+            ConfigurationClientSettings settings = config.GetClientSettings<ConfigurationClientSettings>("Client");
+
+            Assert.That(settings.Endpoint, Is.Null);
+            Assert.That(settings.Options, Is.Not.Null);
+        }
+
+        [Test]
+        public void BindHandlesMissingSection()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>())
+                .Build();
+
+            ConfigurationClientSettings settings = config.GetClientSettings<ConfigurationClientSettings>("NonExistentSection");
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.Endpoint, Is.Null);
+            Assert.That(settings.Options, Is.Null);
+            Assert.That(settings.Credential, Is.Not.Null);
+        }
+
+        [Test]
+        public void OptionsAudienceNotSetWhenMissing()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Options:SomeOtherKey"] = "SomeValue"
+                })
+                .Build();
+
+            ConfigurationClientSettings settings = config.GetClientSettings<ConfigurationClientSettings>("Client");
+
+            Assert.That(settings.Options, Is.Not.Null);
+            Assert.That(settings.Options.Audience, Is.Null);
+        }
+
+        [Test]
+        public void EndpointCanBeSetDirectly()
+        {
+            var settings = new ConfigurationClientSettings
+            {
+                Endpoint = new Uri("https://direct.azconfig.io")
+            };
+
+            Assert.That(settings.Endpoint, Is.EqualTo(new Uri("https://direct.azconfig.io")));
+        }
+
+        [Test]
+        public void OptionsCanBeSetDirectly()
+        {
+            var options = new ConfigurationClientOptions();
+            var settings = new ConfigurationClientSettings
+            {
+                Options = options
+            };
+
+            Assert.That(settings.Options, Is.SameAs(options));
+        }
+
+        [Test]
+        public void CredentialProviderCanBeSetDirectly()
+        {
+            var settings = new ConfigurationClientSettings();
+
+            // CredentialProvider is settable (default is null)
+            Assert.That(settings.CredentialProvider, Is.Null);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds IConfiguration support to ConfigurationClient, following the same pattern used for SecretClient in #56402 / #56409.

### Changes
- **ConfigurationClientSettings.cs** (new): Settings class extending ClientSettings with Endpoint and Options properties, plus BindCore for configuration binding
- **ConfigurationClient.cs**: New experimental constructor ConfigurationClient(ConfigurationClientSettings settings) that delegates to existing (Uri, TokenCredential, ConfigurationClientOptions) constructor
- **ConfigurationClientOptions.cs**: Internal IConfigurationSection constructor for binding options from config (binds Audience); extracted GetVersionString helper to eliminate duplicated version switch
- **Azure.Data.AppConfiguration.csproj**: Added shared ExperimentalAttribute.cs for netstandard2.0 compatibility
- **API files**: Updated for all target frameworks
- **ConfigurationClientSettingsTests.cs** (new): Comprehensive unit tests for settings binding covering all publicly settable properties

Fixes #56535
