### PR TITLE
Exclude generator library tests from dependency test batching

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -441,7 +441,7 @@
       <_ProjectName Condition="'$(TestDependsIncludePackageRootDirectoryOnly)' == 'true'">$(PackageRootDirectory)</_ProjectName>
     </PropertyGroup>
 
-    <ItemGroup Condition="'@(_DependsOnGiven)' != '@(_TestDependsOnDendencies)' and '$(IsClientLibrary)' == 'true'" >
+    <ItemGroup Condition="'@(_DependsOnGiven)' != '@(_TestDependsOnDendencies)' and '$(IsClientLibrary)' == 'true' and '$(IsGeneratorLibrary)' != 'true'" >
       <ProjectsToInclude Include="$(_ProjectName)" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-for-net/issues/56518

## Exclude generator library tests from dependency test batching

### Problem

`Azure.GeneratorAgent.Tests` fails in CI with:

```
error NETSDK1005: Assets file doesn't have a target for 'net462'
```

**Root cause chain:**
1. `Azure.GeneratorAgent.Tests` gets `IsClientLibrary=true` (name starts with `Azure.`)
2. `ProjectDependsOnInner` target includes it in the dependency test project list (condition checks `IsClientLibrary == true`)
3. The batching system puts it in a `ProjectListOverrideFile` batch
4. CI runs `dotnet test eng/service.proj --framework net462` on the batch
5. The project only targets `net10.0` (LTS) since `IsGeneratorLibrary=true` restricts its TFMs
6. Build fails because the assets file has no `net462` target

### Fix

Add `'$(IsGeneratorLibrary)' != 'true'` to the `ProjectDependsOnInner` target's ItemGroup condition in `eng/Directory.Build.Common.targets`. This prevents generator library test projects from being discovered as dependency test candidates.

This is consistent with the existing `IsGeneratorLibrary` exclusion in `Directory.Build.Common.props` (line 238) which already excludes generator libraries from the multi-TFM test framework override.

### Previous workaround

PR #56517 restricted the test project's `RequiredTargetFrameworks` to `$(LtsTargetFramework)`, which was necessary but insufficient — the CI batching still included the project in net462 test runs via `--framework` flag override.
