### PR TITLE
[Release] Azure.Provisioning.PostgreSql 1.2.0-beta.1

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Regenerated from updated `Azure.ResourceManager.PostgreSql` 1.4.1 package, adding PostgreSQL versions 17 and 18 to `PostgreSqlFlexibleServerVersion`.
 
-
 ## 1.1.1 (2025-06-25)
 
 ### Bugs Fixed

--- a/sdk/provisioning/Azure.Provisioning.PostgreSql/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.PostgreSql/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
+## 1.2.0-beta.1 (2026-02-27)
 
 ### Features Added
 
 - Regenerated from updated `Azure.ResourceManager.PostgreSql` 1.4.1 package, adding PostgreSQL versions 17 and 18 to `PostgreSqlFlexibleServerVersion`.
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.1.1 (2025-06-25)
 


### PR DESCRIPTION
Prepare release for Azure.Provisioning.PostgreSql 1.2.0-beta.1

### Changes
- Set release date to 2026-02-27
- Cleaned up empty changelog sections

### Changelog
- Regenerated from updated `Azure.ResourceManager.PostgreSql` 1.4.1 package, adding PostgreSQL versions 17 and 18 to `PostgreSqlFlexibleServerVersion`.