### PR TITLE
Prepare Azure.Data.AppConfiguration 1.9.0 release and fix CPM update in prepare-release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -276,7 +276,7 @@ stages:
                       parameters:
                         EnableNuGetCache: false
                     - pwsh: |
-                        eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}'
+                        eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -SkipCpmUpdate $false
                       displayName: Increment package version
                     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                       parameters:

--- a/eng/scripts/Update-PkgVersion.ps1
+++ b/eng/scripts/Update-PkgVersion.ps1
@@ -40,7 +40,8 @@ Param (
   [string] $PackageName,
   [string] $NewVersionString,
   [string] $ReleaseDate,
-  [boolean] $ReplaceLatestEntryTitle=$true
+  [boolean] $ReplaceLatestEntryTitle=$true,
+  [boolean] $SkipCpmUpdate=$true
 )
 
 . (Join-Path $PSScriptRoot ".." common scripts common.ps1)
@@ -109,88 +110,93 @@ $csproj.Save($csprojPath)
 # Update Central Package Management files with the released version so
 # other packages that depend on this one pick up the latest release.
 # Wrapped in its own try/catch so a CPM failure never blocks the version bump PR.
-try {
-  $releasedVersion = $packageOldSemVer.ToString()
-  $escapedName = [regex]::Escape($PackageName)
-  # Match PackageVersion (Include|Update) and PackageReference (Update) entries with literal versions.
-  # The version must start with a digit to skip MSBuild property references like $(SomeVersion).
-  $versionPattern = '(<Package(?:Version|Reference)\s+(?:Include|Update)="' + $escapedName + '"\s+Version=")(\d[^"]*?)(")'
-  $totalUpdates = 0
+if ($SkipCpmUpdate) {
+  Write-Host "Skipping CPM update (SkipCpmUpdate flag is set)"
+}
+else {
+  try {
+    $releasedVersion = $packageOldSemVer.ToString()
+    $escapedName = [regex]::Escape($PackageName)
+    # Match PackageVersion (Include|Update) and PackageReference (Update) entries with literal versions.
+    # The version must start with a digit to skip MSBuild property references like $(SomeVersion).
+    $versionPattern = '(<Package(?:Version|Reference)\s+(?:Include|Update)="' + $escapedName + '"\s+Version=")(\d[^"]*?)(")'
+    $totalUpdates = 0
 
-  # New CPM structure (post CPM migration): eng/centralpackagemanagement/*.Packages.props
-  # Update all occurrences in files directly in this directory — NOT in overrides/ subdirectory.
-  $cpmDir = Join-Path $RepoRoot "eng" "centralpackagemanagement"
-  if (Test-Path -LiteralPath $cpmDir -PathType Container) {
-    $cpmFiles = Get-ChildItem -LiteralPath $cpmDir -File -Filter '*.Packages.props'
-    foreach ($file in $cpmFiles) {
-      $content = Get-Content -LiteralPath $file.FullName -Raw
-      if (-not $content) { continue }
-      $newContent = [regex]::Replace($content, $versionPattern, '${1}' + $releasedVersion + '${3}')
+    # New CPM structure (post CPM migration): eng/centralpackagemanagement/*.Packages.props
+    # Update all occurrences in files directly in this directory — NOT in overrides/ subdirectory.
+    $cpmDir = Join-Path $RepoRoot "eng" "centralpackagemanagement"
+    if (Test-Path -LiteralPath $cpmDir -PathType Container) {
+      $cpmFiles = Get-ChildItem -LiteralPath $cpmDir -File -Filter '*.Packages.props'
+      foreach ($file in $cpmFiles) {
+        $content = Get-Content -LiteralPath $file.FullName -Raw
+        if (-not $content) { continue }
+        $newContent = [regex]::Replace($content, $versionPattern, '${1}' + $releasedVersion + '${3}')
 
-      if ($newContent -ne $content) {
-        Set-Content -LiteralPath $file.FullName -Value $newContent -NoNewline
-        Write-Host "Updated package '$PackageName' version to '$releasedVersion' in '$($file.FullName)'"
+        if ($newContent -ne $content) {
+          Set-Content -LiteralPath $file.FullName -Value $newContent -NoNewline
+          Write-Host "Updated package '$PackageName' version to '$releasedVersion' in '$($file.FullName)'"
+          $totalUpdates++
+        }
+      }
+    }
+
+    # Old format (pre CPM migration): eng/Packages.Data.props
+    # Only update entries inside the three central ItemGroups (approved dependencies,
+    # build-time packages, and test/support packages). Per-package override ItemGroups
+    # that use MSBuildProjectName conditions must NOT be touched.
+    $oldFile = Join-Path $RepoRoot "eng" "Packages.Data.props"
+    if (Test-Path -LiteralPath $oldFile -PathType Leaf) {
+      $content = Get-Content -LiteralPath $oldFile -Raw
+
+      # Walk each ItemGroup block individually. Check the Condition attribute to decide
+      # whether this block is safe to update, then only replace within that block's body.
+      $itemGroupPattern = '<ItemGroup(?<attrs>[^>]*)>(?<body>.*?)</ItemGroup>'
+      $regexOptions = [System.Text.RegularExpressions.RegexOptions]::Singleline
+      $packagePattern = '(<Package(?:Version|Reference)\s+(?:Include|Update)="' + $escapedName + '"\s+Version=")(\d[^"]*?)(")'
+
+      $builder = New-Object System.Text.StringBuilder
+      $lastIndex = 0
+      $oldFileUpdated = $false
+
+      foreach ($match in [regex]::Matches($content, $itemGroupPattern, $regexOptions)) {
+        # Append content before this ItemGroup unchanged.
+        if ($match.Index -gt $lastIndex) {
+          [void]$builder.Append($content.Substring($lastIndex, $match.Index - $lastIndex))
+        }
+
+        $attrs = $match.Groups['attrs'].Value
+        $body = $match.Groups['body'].Value
+
+        # Determine if this ItemGroup is safe to update.
+        $isUnsafe = ($attrs -match 'MSBuildProjectName') -or
+                    ($attrs -match 'TargetFramework') -or
+                    ($attrs -match "IsClientLibrary\)'\s*!=\s*'true'")
+
+        $newBody = $body
+        if (-not $isUnsafe) {
+          $newBody = [regex]::Replace($body, $packagePattern, '${1}' + $releasedVersion + '${3}')
+          if ($newBody -ne $body) { $oldFileUpdated = $true }
+        }
+
+        [void]$builder.Append('<ItemGroup' + $attrs + '>' + $newBody + '</ItemGroup>')
+        $lastIndex = $match.Index + $match.Length
+      }
+
+      if ($lastIndex -lt $content.Length) {
+        [void]$builder.Append($content.Substring($lastIndex))
+      }
+
+      if ($oldFileUpdated) {
+        Set-Content -LiteralPath $oldFile -Value $builder.ToString() -NoNewline
+        Write-Host "Updated package '$PackageName' version to '$releasedVersion' in '$oldFile'"
         $totalUpdates++
       }
     }
+
+    Write-Host "Updated $totalUpdates central package management file(s)"
   }
-
-  # Old format (pre CPM migration): eng/Packages.Data.props
-  # Only update entries inside the three central ItemGroups (approved dependencies,
-  # build-time packages, and test/support packages). Per-package override ItemGroups
-  # that use MSBuildProjectName conditions must NOT be touched.
-  $oldFile = Join-Path $RepoRoot "eng" "Packages.Data.props"
-  if (Test-Path -LiteralPath $oldFile -PathType Leaf) {
-    $content = Get-Content -LiteralPath $oldFile -Raw
-
-    # Walk each ItemGroup block individually. Check the Condition attribute to decide
-    # whether this block is safe to update, then only replace within that block's body.
-    $itemGroupPattern = '<ItemGroup(?<attrs>[^>]*)>(?<body>.*?)</ItemGroup>'
-    $regexOptions = [System.Text.RegularExpressions.RegexOptions]::Singleline
-    $packagePattern = '(<Package(?:Version|Reference)\s+(?:Include|Update)="' + $escapedName + '"\s+Version=")(\d[^"]*?)(")'
-
-    $builder = New-Object System.Text.StringBuilder
-    $lastIndex = 0
-    $oldFileUpdated = $false
-
-    foreach ($match in [regex]::Matches($content, $itemGroupPattern, $regexOptions)) {
-      # Append content before this ItemGroup unchanged.
-      if ($match.Index -gt $lastIndex) {
-        [void]$builder.Append($content.Substring($lastIndex, $match.Index - $lastIndex))
-      }
-
-      $attrs = $match.Groups['attrs'].Value
-      $body = $match.Groups['body'].Value
-
-      # Determine if this ItemGroup is safe to update.
-      $isUnsafe = ($attrs -match 'MSBuildProjectName') -or
-                  ($attrs -match 'TargetFramework') -or
-                  ($attrs -match "IsClientLibrary\)'\s*!=\s*'true'")
-
-      $newBody = $body
-      if (-not $isUnsafe) {
-        $newBody = [regex]::Replace($body, $packagePattern, '${1}' + $releasedVersion + '${3}')
-        if ($newBody -ne $body) { $oldFileUpdated = $true }
-      }
-
-      [void]$builder.Append('<ItemGroup' + $attrs + '>' + $newBody + '</ItemGroup>')
-      $lastIndex = $match.Index + $match.Length
-    }
-
-    if ($lastIndex -lt $content.Length) {
-      [void]$builder.Append($content.Substring($lastIndex))
-    }
-
-    if ($oldFileUpdated) {
-      Set-Content -LiteralPath $oldFile -Value $builder.ToString() -NoNewline
-      Write-Host "Updated package '$PackageName' version to '$releasedVersion' in '$oldFile'"
-      $totalUpdates++
-    }
+  catch {
+    Write-Warning "CPM update failed — central package management will need to be updated manually: $($_.Exception.Message)"
+    Write-Host "##vso[task.logissue type=warning]CPM update failed for package version bump. Central package management files will need a manual update."
   }
-
-  Write-Host "Updated $totalUpdates central package management file(s)"
-}
-catch {
-  Write-Warning "CPM update failed — central package management will need to be updated manually: $($_.Exception.Message)"
-  Write-Host "##vso[task.logissue type=warning]CPM update failed for package version bump. Central package management files will need a manual update."
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.9.0-beta.1 (Unreleased)
+## 1.9.0 (2026-02-27)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Added `ConfigurationClientSettings` to support creating a `ConfigurationClient` from `IConfiguration`, including configuration-based credential resolution and dependency injection registration.
 
 ## 1.8.0 (2026-01-27)
 

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Azure.Data.AppConfiguration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Application Configuration Service client library</Description>
     <AssemblyTitle>Microsoft Azure.Data.AppConfiguration client library</AssemblyTitle>
-    <Version>1.9.0-beta.1</Version>
+    <Version>1.9.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.8.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Application Configuration;Data;AppConfig;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
## Changes

### Azure.Data.AppConfiguration 1.9.0 Release
- Updated version from 1.9.0-beta.1 to 1.9.0
- Added changelog entry for `ConfigurationClientSettings` configuration support

### Fix CPM update during prepare-release
When `Update-PkgVersion.ps1` was recently updated to auto-update Central Package Management files (#56470), it also ran during `Prepare-Release.ps1`, causing unintended changes to `Directory.Packages.props` before the package is actually published.

**Fix:** Added a `` parameter (default `True`) to `Update-PkgVersion.ps1` so CPM updates are skipped by default. The release pipeline in `archetype-net-release.yml` now explicitly passes `-SkipCpmUpdate False` to opt in to CPM updates during the post-release version bump.