### PR TITLE
[Release] Azure.Provisioning.AppConfiguration 1.2.0-beta.1

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -120,7 +120,7 @@
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
     <PackageVersion Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
     <PackageVersion Include="Azure.ResourceManager" Version="1.14.0" />
-    <PackageVersion Include="Azure.ResourceManager.AppConfiguration" Version="1.4.0" />
+    <PackageVersion Include="Azure.ResourceManager.AppConfiguration" Version="1.4.1" />
     <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.5.0" />
     <PackageVersion Include="Azure.ResourceManager.ApplicationInsights" Version="1.0.1" />
     <PackageVersion Include="Azure.ResourceManager.AppService" Version="1.4.1" />

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
+## 1.2.0-beta.1 (2026-02-27)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Regenerated from updated `Azure.ResourceManager.AppConfiguration` 1.4.1 package.
 
 ## 1.1.0 (2025-06-16)
 

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationKeyValue.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationKeyValue.cs
@@ -161,6 +161,7 @@ public partial class AppConfigurationKeyValue : ProvisionableResource
     /// </summary>
     protected override void DefineProvisionableProperties()
     {
+        base.DefineProvisionableProperties();
         _name = DefineProperty<string>("Name", ["name"], isRequired: true);
         _contentType = DefineProperty<string>("ContentType", ["properties", "contentType"]);
         _tags = DefineDictionaryProperty<string>("Tags", ["properties", "tags"]);

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationPrivateEndpointConnection.cs
@@ -107,6 +107,7 @@ public partial class AppConfigurationPrivateEndpointConnection : ProvisionableRe
     /// </summary>
     protected override void DefineProvisionableProperties()
     {
+        base.DefineProvisionableProperties();
         _name = DefineProperty<string>("Name", ["name"], isRequired: true);
         _connectionState = DefineModelProperty<AppConfigurationPrivateLinkServiceConnectionState>("ConnectionState", ["properties", "privateLinkServiceConnectionState"]);
         _privateEndpointId = DefineProperty<ResourceIdentifier>("PrivateEndpointId", ["properties", "privateEndpoint", "id"]);

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationReplica.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationReplica.cs
@@ -104,6 +104,7 @@ public partial class AppConfigurationReplica : ProvisionableResource
     /// </summary>
     protected override void DefineProvisionableProperties()
     {
+        base.DefineProvisionableProperties();
         _name = DefineProperty<string>("Name", ["name"], isRequired: true);
         _location = DefineProperty<AzureLocation>("Location", ["location"]);
         _endpoint = DefineProperty<string>("Endpoint", ["properties", "endpoint"], isOutput: true);

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationSnapshot.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationSnapshot.cs
@@ -198,6 +198,7 @@ public partial class AppConfigurationSnapshot : ProvisionableResource
     /// </summary>
     protected override void DefineProvisionableProperties()
     {
+        base.DefineProvisionableProperties();
         _name = DefineProperty<string>("Name", ["name"], isRequired: true);
         _compositionType = DefineProperty<SnapshotCompositionType>("CompositionType", ["properties", "compositionType"]);
         _filters = DefineListProperty<SnapshotKeyValueFilter>("Filters", ["properties", "filters"]);

--- a/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppConfiguration/src/Generated/AppConfigurationStore.cs
@@ -221,6 +221,7 @@ public partial class AppConfigurationStore : ProvisionableResource
     /// </summary>
     protected override void DefineProvisionableProperties()
     {
+        base.DefineProvisionableProperties();
         _name = DefineProperty<string>("Name", ["name"], isRequired: true);
         _location = DefineProperty<AzureLocation>("Location", ["location"], isRequired: true);
         _createMode = DefineProperty<AppConfigurationCreateMode>("CreateMode", ["properties", "createMode"]);


### PR DESCRIPTION
Prepare release for Azure.Provisioning.AppConfiguration 1.2.0-beta.1

### Changes
- Bumped `Azure.ResourceManager.AppConfiguration` from 1.4.0 to 1.4.1
- Regenerated provisioning library
- Set release date to 2026-02-27