### PR TITLE
Add tests for multi-scope extension resource detection (#56504)

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -354,9 +354,7 @@ function convertResolvedResourceToMetadata(
   }
 
   // Convert resource scope
-  const resourceScopeValue = convertScopeToResourceScope(
-    resolvedResource.scope
-  );
+  const resourceScopeValue = convertScopeToResourceScope(resolvedResource.scope);
 
   // Build resource type string
   const resourceType = formatResourceType(resolvedResource.resourceType);
@@ -441,7 +439,9 @@ function convertScopeToResourceScope(
 export function getOperationScopeFromPath(path: string): ResourceScope {
   if (path.startsWith("/{resourceUri}") || path.startsWith("/{scope}")) {
     return ResourceScope.Extension;
-  } else if (
+  }
+
+  if (
     /^\/subscriptions\/\{[^}]+\}\/resourceGroups\/\{[^}]+\}\//.test(path)
   ) {
     return ResourceScope.ResourceGroup;
@@ -458,6 +458,7 @@ export function getOperationScopeFromPath(path: string): ResourceScope {
     // e.g., /providers/Microsoft.Management/serviceGroups/{name}/providers/Microsoft.Edge/sites/{siteName}
     return ResourceScope.Extension;
   }
+
   return ResourceScope.Tenant; // all the templates work as if there is a tenant decorator when there is no such decorator
 }
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -1856,6 +1856,169 @@ interface SitesByServiceGroup extends SiteOps<ServiceGroup> {}
     );
   });
 
+  it("extension resource at multiple scopes with variable provider paths (Maintenance RP pattern)", async () => {
+    // This test validates the Maintenance RP ConfigurationAssignment pattern where
+    // the same extension resource is accessed through paths with variable provider names:
+    // - /subscriptions/{id}/resourcegroups/{rg}/providers/{providerName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{name}
+    // - /subscriptions/{id}/resourcegroups/{rg}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{name}
+    const program = await typeSpecCompile(
+      `
+using Azure.ResourceManager.Legacy;
+
+/** ConfigurationAssignment properties */
+model ConfigurationAssignmentProperties {
+  /** The maintenance configuration ID */
+  maintenanceConfigurationId?: string;
+}
+
+/** A configuration assignment resource */
+model ConfigurationAssignment is ProxyResource<ConfigurationAssignmentProperties> {
+  ...ResourceNameParameter<
+    Resource = ConfigurationAssignment,
+    KeyName = "configurationAssignmentName",
+    SegmentName = "configurationAssignments",
+    NamePattern = ""
+  >;
+}
+
+/** Operations for configuration assignments on a resource (flat path) */
+@armResourceOperations
+interface ConfigurationAssignmentOperationGroupOps
+  extends Azure.ResourceManager.Legacy.ExtensionOperations<
+      {
+        ...ApiVersionParameter,
+        ...SubscriptionIdParameter,
+        ...ResourceGroupParameter,
+        @path @key @segment("providers") providerName: string,
+        @path @key resourceType: string,
+        @path @key resourceName: string,
+      },
+      {
+        ...Azure.ResourceManager.Extension.ExtensionProviderNamespace<ConfigurationAssignment>,
+        ...ParentKeysOf<ConfigurationAssignment>,
+      },
+      {
+        ...Azure.ResourceManager.Extension.ExtensionProviderNamespace<ConfigurationAssignment>,
+        ...KeysOf<ResourceNameParameter<
+          Resource = ConfigurationAssignment,
+          KeyName = "configurationAssignmentName",
+          SegmentName = "configurationAssignments",
+          NamePattern = ""
+        >>,
+      }
+    > {}
+
+/** Operations for configuration assignments on a nested resource (parent path) */
+@armResourceOperations
+interface ConfigurationAssignmentOps
+  extends Azure.ResourceManager.Legacy.ExtensionOperations<
+      {
+        ...ApiVersionParameter,
+        ...SubscriptionIdParameter,
+        ...ResourceGroupParameter,
+        @path @key @segment("providers") providerName: string,
+        @path @key resourceParentType: string,
+        @path @key resourceParentName: string,
+        @path @key resourceType: string,
+        @path @key resourceName: string,
+      },
+      {
+        ...Azure.ResourceManager.Extension.ExtensionProviderNamespace<ConfigurationAssignment>,
+        ...ParentKeysOf<ConfigurationAssignment>,
+      },
+      {
+        ...Azure.ResourceManager.Extension.ExtensionProviderNamespace<ConfigurationAssignment>,
+        ...KeysOf<ResourceNameParameter<
+          Resource = ConfigurationAssignment,
+          KeyName = "configurationAssignmentName",
+          SegmentName = "configurationAssignments",
+          NamePattern = ""
+        >>,
+      }
+    > {}
+
+@armResourceOperations
+interface ConfigurationAssignmentOperationGroup {
+  get is ConfigurationAssignmentOperationGroupOps.Read<ConfigurationAssignment>;
+  createOrUpdate is ConfigurationAssignmentOperationGroupOps.CreateOrUpdateSync<ConfigurationAssignment>;
+  delete is ConfigurationAssignmentOperationGroupOps.DeleteSync<ConfigurationAssignment>;
+}
+
+@armResourceOperations
+interface ConfigurationAssignments {
+  getParent is ConfigurationAssignmentOps.Read<ConfigurationAssignment>;
+  createOrUpdateParent is ConfigurationAssignmentOps.CreateOrUpdateSync<ConfigurationAssignment>;
+  deleteParent is ConfigurationAssignmentOps.DeleteSync<ConfigurationAssignment>;
+  listParent is ConfigurationAssignmentOps.List<ConfigurationAssignment>;
+}
+`,
+      runner
+    );
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const root = createModel(sdkContext);
+
+    // Build ARM provider schema using legacy detection
+    const armProviderSchema = buildArmProviderSchema(sdkContext, root);
+    ok(armProviderSchema);
+    ok(armProviderSchema.resources);
+
+    // Find the ConfigurationAssignment model
+    const caModel = root.models.find(
+      (m) => m.name === "ConfigurationAssignment"
+    );
+    ok(caModel, "ConfigurationAssignment model should exist");
+    const caModelId = caModel.crossLanguageDefinitionId;
+
+    const caResources = armProviderSchema.resources.filter(
+      (r) => r.resourceModelId === caModelId
+    );
+
+    // Should have 2 resources: one for flat path, one for nested parent path
+    strictEqual(caResources.length, 2,
+      `Should have 2 ConfigurationAssignment resources, got ${caResources.length}`);
+
+    // Validate using resolveArmResources API - schemas should match
+    const resolvedSchema = resolveArmResources(program, sdkContext);
+    ok(resolvedSchema);
+
+    // The two APIs have known differences for multi-interface extension resources:
+    // 1. buildArmProviderSchema creates separate resources per interface/path,
+    //    resolveArmResources merges operations sharing the same model into one resource.
+    // 2. Scope detection may differ (path-based vs ARM library resolution).
+    // Normalize by merging resources and normalizing scope before comparing.
+    const mergeByModelId = (schema: typeof armProviderSchema) => {
+      const copy = JSON.parse(JSON.stringify(schema)) as typeof armProviderSchema;
+      const byModelId = new Map<string, (typeof copy.resources)[0]>();
+      for (const resource of copy.resources) {
+        const existing = byModelId.get(resource.resourceModelId);
+        if (existing) {
+          existing.metadata.methods.push(...resource.metadata.methods);
+          if (resource.metadata.resourceIdPattern.length < existing.metadata.resourceIdPattern.length) {
+            existing.metadata.resourceIdPattern = resource.metadata.resourceIdPattern;
+          }
+        } else {
+          byModelId.set(resource.resourceModelId, resource);
+        }
+      }
+      copy.resources = [...byModelId.values()];
+      return copy;
+    };
+    const normalizeScopesAndMethodResourceScope = (resource: ArmResourceSchema) => {
+      // Normalize resource-level scope (may differ between APIs)
+      (resource.metadata as { resourceScope: unknown }).resourceScope = "<normalized>";
+      for (const method of resource.metadata.methods) {
+        (method as { resourceScope: unknown }).resourceScope = "<normalized>";
+        (method as { operationScope: unknown }).operationScope = "<normalized>";
+      }
+    };
+
+    deepStrictEqual(
+      normalizeSchemaForComparison(mergeByModelId(resolvedSchema), normalizeScopesAndMethodResourceScope),
+      normalizeSchemaForComparison(mergeByModelId(armProviderSchema), normalizeScopesAndMethodResourceScope)
+    );
+  });
+
   it("custom Azure resource with @customAzureResource decorator (TrafficManager pattern)", async () => {
     const program = await typeSpecCompile(
       `

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-type.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-type.test.ts
@@ -110,8 +110,17 @@ describe("Operation Scope Detection", () => {
   });
 
   it("management group scope", async () => {
+    // ManagementGroup-scoped resources naturally have 2 /providers/ segments
+    // (one for MG scope, one for resource RP) — this is NOT an extension.
     const path =
       "/providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Edge/sites/{siteName}";
+    const scope = getOperationScopeFromPath(path);
+    strictEqual(scope, ResourceScope.ManagementGroup);
+  });
+
+  it("management group scope for single provider", async () => {
+    const path =
+      "/providers/Microsoft.Management/managementGroups/{groupId}/subscriptions/{subscriptionId}";
     const scope = getOperationScopeFromPath(path);
     strictEqual(scope, ResourceScope.ManagementGroup);
   });
@@ -123,16 +132,44 @@ describe("Operation Scope Detection", () => {
   });
 
   it("extension scope for multiple provider segments (serviceGroups)", async () => {
+    // Multi-provider path that doesn't match RG/Sub/MG → Extension
     const path =
       "/providers/Microsoft.Management/serviceGroups/{servicegroupName}/providers/Microsoft.Edge/sites/{siteName}";
     const scope = getOperationScopeFromPath(path);
     strictEqual(scope, ResourceScope.Extension);
   });
 
-  it("resource group scope takes priority over nested extension resources", async () => {
+  it("resource group scope for nested providers under resource group", async () => {
+    // Path starts with /subscriptions/.../resourceGroups/... → ResourceGroup
+    // (RG regex matches before multi-provider check)
     const path =
       "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Something/parentResource/{parentName}/providers/Microsoft.Edge/sites/{siteName}";
     const scope = getOperationScopeFromPath(path);
     strictEqual(scope, ResourceScope.ResourceGroup);
+  });
+
+  it("resource group scope for variable provider name with RG prefix (Maintenance pattern)", async () => {
+    // RG regex matches before multi-provider check. The actual Extension scope
+    // for Maintenance RP is determined by the ARM library, not path analysis.
+    const path =
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}";
+    const scope = getOperationScopeFromPath(path);
+    strictEqual(scope, ResourceScope.ResourceGroup);
+  });
+
+  it("resource group scope for variable provider name with RG prefix and parent resource", async () => {
+    const path =
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}";
+    const scope = getOperationScopeFromPath(path);
+    strictEqual(scope, ResourceScope.ResourceGroup);
+  });
+
+  it("subscription scope for variable provider without multiple providers", async () => {
+    // A single-provider path with a variable provider name still follows
+    // normal scope detection since it's not a multi-provider extension pattern.
+    const path =
+      "/subscriptions/{subscriptionId}/providers/{providerName}/{resourceType}/{resourceName}";
+    const scope = getOperationScopeFromPath(path);
+    strictEqual(scope, ResourceScope.Subscription);
   });
 });

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/MultiScopeExtensionResourceTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/MultiScopeExtensionResourceTests.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Management.Models;
+using Azure.Generator.Management.Providers;
+using Azure.Generator.Management.Tests.Common;
+using Azure.Generator.Management.Tests.TestHelpers;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Primitives;
+using NUnit.Framework;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Azure.Generator.Management.Tests.Providers
+{
+    internal class MultiScopeExtensionResourceTests
+    {
+        /// <summary>
+        /// Verifies that an extension resource with Extension scope (as emitted for multi-scope
+        /// resources like ConfigurationAssignment) is correctly modeled as an extension resource
+        /// with methods on MockableArmClient.
+        /// </summary>
+        [TestCase]
+        public void Verify_ExtensionScopeResource_IsModeledAsExtensionResource()
+        {
+            var (client, models) = BuildExtensionResourceClient(ResourceScope.Extension);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => models,
+                clients: () => [client]);
+
+            var outputLibrary = plugin.Object.OutputLibrary as ManagementOutputLibrary;
+            Assert.IsNotNull(outputLibrary);
+
+            // Verify a ResourceClientProvider is created and marked as extension
+            var resources = outputLibrary!.TypeProviders.OfType<ResourceClientProvider>().ToList();
+            Assert.AreEqual(1, resources.Count, "Should generate exactly one resource");
+            var resource = resources[0];
+            Assert.IsTrue(resource.IsExtensionResource, "Resource should be an extension resource");
+            Assert.AreEqual(ResourceScope.Extension, resource.ResourceScope);
+            Assert.AreEqual("ConfigurationAssignmentResource", resource.Name);
+
+            // Extension scope resources should produce a MockableArmClientProvider
+            var mockableArmClient = outputLibrary.TypeProviders
+                .OfType<MockableArmClientProvider>().FirstOrDefault();
+            Assert.IsNotNull(mockableArmClient, "Extension resource should produce a MockableArmClientProvider");
+
+            // The MockableArmClient should have methods for the extension resource
+            Assert.IsTrue(mockableArmClient!.Methods.Count > 0,
+                "MockableArmClientProvider should have methods for the extension resource");
+
+            // There should be NO MockableResourceProvider for ResourceGroup or Subscription scope
+            // because all operations are Extension-scoped
+            var mockableByScope = outputLibrary.TypeProviders
+                .OfType<MockableResourceProvider>()
+                .Where(m => m is not MockableArmClientProvider)
+                .ToList();
+            foreach (var mockable in mockableByScope)
+            {
+                // Mockable resources for RG/Sub/etc should have no methods since this resource is Extension-only
+                Assert.AreEqual(0, mockable.Methods.Count,
+                    $"MockableResourceProvider '{mockable.Name}' should have no methods for an Extension-only resource");
+            }
+        }
+
+        private static (InputClient Client, IReadOnlyList<InputModelType> Models) BuildExtensionResourceClient(ResourceScope scope)
+        {
+            const string resourceModelName = "ConfigurationAssignment";
+            var resourceModel = InputFactory.Model(resourceModelName,
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                ],
+                decorators: []);
+
+            var responseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: resourceModel);
+            var uuidType = new InputPrimitiveType(InputPrimitiveTypeKind.String, "uuid", "Azure.Core.uuid");
+
+            // Path parameters for the multi-scope extension pattern
+            var subsIdParam = InputFactory.PathParameter("subscriptionId", uuidType, isRequired: true);
+            var rgParam = InputFactory.PathParameter("resourceGroupName", InputPrimitiveType.String, isRequired: true);
+            var providerNameParam = InputFactory.PathParameter("providerName", InputPrimitiveType.String, isRequired: true);
+            var resourceTypeParam = InputFactory.PathParameter("resourceType", InputPrimitiveType.String, isRequired: true);
+            var resourceNameParam = InputFactory.PathParameter("resourceName", InputPrimitiveType.String, isRequired: true);
+            var configNameParam = InputFactory.PathParameter("configurationAssignmentName", InputPrimitiveType.String, isRequired: true);
+            var dataParam = InputFactory.BodyParameter("data", resourceModel, isRequired: true);
+
+            // The multi-provider path pattern: parent resource has a variable provider name
+            var extensionPath = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}";
+            var resourceIdPattern = extensionPath;
+
+            var getOperation = InputFactory.Operation(
+                name: "get",
+                responses: [responseType],
+                parameters: [subsIdParam, rgParam, providerNameParam, resourceTypeParam, resourceNameParam, configNameParam],
+                path: extensionPath);
+
+            var createOperation = InputFactory.Operation(
+                name: "createOrUpdate",
+                responses: [responseType],
+                parameters: [subsIdParam, rgParam, providerNameParam, resourceTypeParam, resourceNameParam, configNameParam, dataParam],
+                path: extensionPath);
+
+            var deleteOperation = InputFactory.Operation(
+                name: "delete",
+                responses: [InputFactory.OperationResponse(statusCodes: [200])],
+                parameters: [subsIdParam, rgParam, providerNameParam, resourceTypeParam, resourceNameParam, configNameParam],
+                path: extensionPath);
+
+            // Method parameters
+            var subsIdMethodParam = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
+            var rgMethodParam = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var providerNameMethodParam = InputFactory.MethodParameter("providerName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            var resourceTypeMethodParam = InputFactory.MethodParameter("resourceType", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            var resourceNameMethodParam = InputFactory.MethodParameter("resourceName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            var configNameMethodParam = InputFactory.MethodParameter("configurationAssignmentName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            var dataMethodParam = InputFactory.MethodParameter("data", resourceModel, location: InputRequestLocation.Body, isRequired: true);
+
+            var getMethod = InputFactory.BasicServiceMethod("get", getOperation,
+                parameters: [configNameMethodParam, providerNameMethodParam, resourceTypeMethodParam, resourceNameMethodParam, subsIdMethodParam, rgMethodParam],
+                crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var createMethod = InputFactory.BasicServiceMethod("createOrUpdate", createOperation,
+                parameters: [configNameMethodParam, providerNameMethodParam, resourceTypeMethodParam, resourceNameMethodParam, subsIdMethodParam, rgMethodParam, dataMethodParam],
+                crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var deleteMethod = InputFactory.BasicServiceMethod("delete", deleteOperation,
+                parameters: [configNameMethodParam, providerNameMethodParam, resourceTypeMethodParam, resourceNameMethodParam, subsIdMethodParam, rgMethodParam],
+                crossLanguageDefinitionId: Guid.NewGuid().ToString());
+
+            var armProviderDecorator = BuildArmProviderSchema(resourceModel, [
+                new ResourceMethod(ResourceOperationKind.Read, getMethod, getMethod.Operation.Path, scope, resourceIdPattern, null!),
+                new ResourceMethod(ResourceOperationKind.Create, createMethod, createMethod.Operation.Path, scope, resourceIdPattern, null!),
+                new ResourceMethod(ResourceOperationKind.Delete, deleteMethod, deleteMethod.Operation.Path, scope, resourceIdPattern, null!),
+            ], resourceIdPattern, "Microsoft.Maintenance/configurationAssignments", null, scope, "ConfigurationAssignment");
+
+            var client = InputFactory.Client(
+                "MaintenanceClient",
+                methods: [getMethod, createMethod, deleteMethod],
+                decorators: [armProviderDecorator],
+                crossLanguageDefinitionId: "Test.MaintenanceClient");
+
+            return (client, [resourceModel]);
+        }
+
+        private static InputDecoratorInfo BuildArmProviderSchema(InputModelType resourceModel, IReadOnlyList<ResourceMethod> methods, string resourceIdPattern, string resourceType, string? singletonResourceName, ResourceScope resourceScope, string? resourceName)
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+            };
+
+            var resourceSchema = new Dictionary<string, object?>
+            {
+                ["resourceModelId"] = resourceModel.CrossLanguageDefinitionId,
+                ["resourceIdPattern"] = resourceIdPattern,
+                ["resourceType"] = resourceType,
+                ["resourceScope"] = resourceScope.ToString(),
+                ["methods"] = methods.Select(SerializeResourceMethod).ToList(),
+                ["singletonResourceName"] = singletonResourceName,
+                ["resourceName"] = resourceName,
+            };
+
+            var arguments = new Dictionary<string, BinaryData>
+            {
+                ["resources"] = BinaryData.FromObjectAsJson(new[] { resourceSchema }, options),
+                ["nonResourceMethods"] = BinaryData.FromObjectAsJson(Array.Empty<object>(), options)
+            };
+
+            return new InputDecoratorInfo("Azure.ClientGenerator.Core.@armProviderSchema", arguments);
+
+            static Dictionary<string, string> SerializeResourceMethod(ResourceMethod m)
+            {
+                var result = new Dictionary<string, string>
+                {
+                    ["methodId"] = m.InputMethod.CrossLanguageDefinitionId,
+                    ["kind"] = m.Kind.ToString(),
+                    ["operationPath"] = m.OperationPath,
+                    ["operationScope"] = m.OperationScope.ToString()
+                };
+                if (m.ResourceScope != null)
+                {
+                    result["resourceScope"] = m.ResourceScope;
+                }
+                return result;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue
Fixes #56504

## Changes
Add tests for multi-scope extension resource detection patterns (e.g., Maintenance RP's ConfigurationAssignment).

### Emitter Tests
- Unit tests for getOperationScopeFromPath with multi-provider paths
- Integration test with Legacy.ExtensionOperations using Maintenance RP path patterns

### C# Generator Tests
- E2e test verifying Extension scope resources are modeled correctly

### Minor Cleanup
- Formatting cleanup in getOperationScopeFromPath
