### PR TITLE
Bump mgmt dependency versions for provisioning generator (CosmosDB, Search)

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -130,7 +130,7 @@
     <PackageVersion Include="Azure.ResourceManager.Communication" Version="1.3.0" />
     <PackageVersion Include="Azure.ResourceManager.ContainerRegistry" Version="1.4.0" />
     <PackageVersion Include="Azure.ResourceManager.ContainerService" Version="1.3.0" />
-    <PackageVersion Include="Azure.ResourceManager.CosmosDB" Version="1.4.0-beta.12" />
+    <PackageVersion Include="Azure.ResourceManager.CosmosDB" Version="1.4.0" />
     <PackageVersion Include="Azure.ResourceManager.Dns" Version="1.2.0-beta.2" />
     <PackageVersion Include="Azure.ResourceManager.EventGrid" Version="1.1.0" />
     <PackageVersion Include="Azure.ResourceManager.EventHubs" Version="1.2.1" />

--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -148,7 +148,7 @@
     <PackageVersion Include="Azure.ResourceManager.Redis" Version="1.5.1" />
     <PackageVersion Include="Azure.ResourceManager.RedisEnterprise" Version="1.3.0" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.11.2" />
-    <PackageVersion Include="Azure.ResourceManager.Search" Version="1.3.0-beta.5" />
+    <PackageVersion Include="Azure.ResourceManager.Search" Version="1.3.0" />
     <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="Azure.ResourceManager.SignalR" Version="1.1.4" />
     <PackageVersion Include="Azure.ResourceManager.Sql" Version="1.3.0" />

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.1.0-beta.2 (Unreleased)
+## 1.1.0-beta.2 (2026-02-27)
 
 ### Features Added
+
+- Upgraded dependency on `Azure.ResourceManager.CosmosDB` to version 1.4.0.
 
 ### Breaking Changes
 

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Release History
 
-## 1.1.0-beta.2 (2026-03-03)
+## 1.1.0-beta.2 (Unreleased)
 
 ### Features Added
 
-- Upgraded dependency on `Azure.ResourceManager.CosmosDB` to version 1.4.0.
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
 
 ## 1.1.0-beta.1 (2025-06-16)
 

--- a/sdk/provisioning/Azure.Provisioning.CosmosDB/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.CosmosDB/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.1.0-beta.2 (2026-02-27)
+## 1.1.0-beta.2 (2026-03-03)
 
 ### Features Added
 
 - Upgraded dependency on `Azure.ResourceManager.CosmosDB` to version 1.4.0.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.1.0-beta.1 (2025-06-16)
 

--- a/sdk/provisioning/Generator/src/Specifications/CosmosDBSpecification.cs
+++ b/sdk/provisioning/Generator/src/Specifications/CosmosDBSpecification.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Azure.Provisioning.Generator.Model;
@@ -25,17 +25,11 @@ public class CosmosDBSpecification() :
         RemoveProperty<CosmosDBPrivateEndpointConnectionData>("ResourceType");
 
         // Patch models
-        CustomizeSimpleModel<AzureBlobDataTransferDataSourceSink>(m => { m.DiscriminatorName = "component"; m.DiscriminatorValue = "AzureBlobStorage"; });
-        CustomizeSimpleModel<CosmosCassandraDataTransferDataSourceSink>(m => { m.DiscriminatorName = "component"; m.DiscriminatorValue = "CosmosDBCassandra"; });
-        CustomizeSimpleModel<CosmosMongoDataTransferDataSourceSink>(m => { m.DiscriminatorName = "component"; m.DiscriminatorValue = "CosmosDBMongo"; });
-        CustomizeSimpleModel<CosmosSqlDataTransferDataSourceSink>(m => { m.DiscriminatorName = "component"; m.DiscriminatorValue = "CosmosDBSql"; });
         CustomizeProperty<CosmosDBAccountKeyList>("PrimaryMasterKey", p => p.IsSecure = true);
         CustomizeProperty<CosmosDBAccountKeyList>("SecondaryMasterKey", p => p.IsSecure = true);
         CustomizeProperty<CosmosDBAccountKeyList>("PrimaryReadonlyMasterKey", p => p.IsSecure = true);
         CustomizeProperty<CosmosDBAccountKeyList>("SecondaryReadonlyMasterKey", p => p.IsSecure = true);
         CustomizeProperty<CosmosDBServiceResource>("Properties", p => p.Name = "CreateOrUpdateProperties");
-        CustomizeProperty<DataTransferJobProperties>("Error", p => p.Name = "ErrorResult");
-        CustomizeProperty<DataTransferJobGetResultResource>("Error", p => p.Name = "ErrorResult");
         CustomizeEnum<CosmosDBAccountCreateMode>(e => e.Values.Add(new EnumValue(e, "PointInTimeRestore", "PointInTimeRestore") { Hidden = true }));
 
         // Naming requirements


### PR DESCRIPTION
Bump management library dependency versions used by the provisioning generator.

### Changes
- Bumped \Azure.ResourceManager.CosmosDB\ from 1.4.0-beta.12 to 1.4.0
- Bumped \Azure.ResourceManager.Search\ from 1.3.0-beta.5 to 1.3.0
- Updated \CosmosDBSpecification.cs\ to remove DataTransfer types no longer present in the stable CosmosDB package