### PR TITLE
Refresh Azure.Provisioning.Search

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -148,7 +148,7 @@
     <PackageVersion Include="Azure.ResourceManager.Redis" Version="1.5.1" />
     <PackageVersion Include="Azure.ResourceManager.RedisEnterprise" Version="1.3.0" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.11.2" />
-    <PackageVersion Include="Azure.ResourceManager.Search" Version="1.3.0-beta.5" />
+    <PackageVersion Include="Azure.ResourceManager.Search" Version="1.3.0" />
     <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="Azure.ResourceManager.SignalR" Version="1.1.4" />
     <PackageVersion Include="Azure.ResourceManager.Sql" Version="1.3.0" />

--- a/sdk/provisioning/Azure.Provisioning.Search/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.Search/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Release History
 
-## 1.1.0-beta.2 (Unreleased)
+## 1.1.0-beta.2 (2026-02-27)
 
 ### Features Added
+
+- Upgraded dependency on `Azure.ResourceManager.Search` to version 1.3.0.
 
 ### Breaking Changes
 

--- a/sdk/provisioning/Azure.Provisioning.Search/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.Search/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.1.0-beta.2 (2026-02-27)
+## 1.1.0-beta.2 (2026-03-03)
 
 ### Features Added
 
 - Upgraded dependency on `Azure.ResourceManager.Search` to version 1.3.0.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.1.0-beta.1 (2025-06-16)
 


### PR DESCRIPTION
Refresh Azure.Provisioning.Search provisioning library.

Release date: 2026-02-27
- Upgraded Azure.ResourceManager.Search from 1.3.0-beta.5 to 1.3.0