### PR TITLE
Add Microsoft.Agents.AI.OpenAI and Workflows to Hosted Agents CPM overrides

### DIFF
--- a/eng/centralpackagemanagement/overrides/Azure.AI.AgentServer.AgentFramework.Packages.props
+++ b/eng/centralpackagemanagement/overrides/Azure.AI.AgentServer.AgentFramework.Packages.props
@@ -1,5 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Agents.AI" Version="1.0.0-rc1" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.0.0-rc1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Add Microsoft.Agents.AI.OpenAI and Workflows to Hosted Agents CPM overrides

### Why

The `Microsoft.Agents.AI.OpenAI` and `Microsoft.Agents.AI.Workflows` packages (at `1.0.0-rc1`) are used by the `Azure.AI.AgentServer.AgentFramework` project and its samples on the `agentserver/first-release` branch but were missing from the Central Package Management (CPM) overrides. Only `Microsoft.Agents.AI` was listed.

Adding these ensures consistent version resolution across the repo and prevents NuGet from pulling unintended transitive versions.

### Changes

- Added `Microsoft.Agents.AI.OpenAI` (`1.0.0-rc1`) to `eng/centralpackagemanagement/overrides/Azure.AI.AgentServer.AgentFramework.Packages.props`
- Added `Microsoft.Agents.AI.Workflows` (`1.0.0-rc1`) to the same file
