### PR TITLE
Fix broken link in Azure.Identity CHANGELOG

### DIFF
--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features Added
 
-- Added experimental `Microsoft.Extensions.Configuration` and `Microsoft.Extensions.DependencyInjection` integration for Azure SDK clients. For details, see the [Configuration and Dependency Injection](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/docs/ConfigurationAndDependencyInjection.md) documentation.
+- Added experimental `Microsoft.Extensions.Configuration` and `Microsoft.Extensions.DependencyInjection` integration for Azure SDK clients. For details, see the [Configuration and Dependency Injection](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/System.ClientModel/src/docs/ConfigurationAndDependencyInjection.md) documentation.
 
 - The `WorkloadIdentityCredentialOptions.IsAzureProxyEnabled` property, which enables Azure Kubernetes token proxy mode, is only available in beta releases of this package.
 


### PR DESCRIPTION
The `ConfigurationAndDependencyInjection.md` documentation link in the Azure.Identity CHANGELOG was pointing to `sdk/core/Azure.Core/src/docs/`, but the file is actually located at `sdk/core/System.ClientModel/src/docs/`. This broken link was causing CI failures (e.g., [build 5935345](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5935345)) for any PR that modifies the Identity CHANGELOG.

### Fix
Updated the link path from `Azure.Core` to `System.ClientModel`.