### PR TITLE
[EngSys] Fix inappropriate beta version reference

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -165,7 +165,7 @@
 
     <!-- CDK -->
     <PackageVersion Include="Azure.Provisioning" Version="1.4.0" />
-    <PackageVersion Include="Azure.Provisioning.AppService" Version="1.4.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.AppService" Version="1.3.1" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="1.2.0" />
     <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="1.0.0" />
     <PackageVersion Include="Azure.Provisioning.EventGrid" Version="1.1.0" />


### PR DESCRIPTION
# Summary

The focus of these changes is to fix an automated bump to package versions where the latest beta was used rather than the latest stable, introduced by #56592.  This will be fixed by #56550.

