### PR TITLE
Document cancellation behavior of UpdateConcurrency when reducing concurrency

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/README.md
@@ -436,20 +436,20 @@ For applications that prefer using a shared `Azure.Identity` credential for thei
 
 ```C# Snippet:DependencyInjectionRegisterClientWithIdentity
 public void ConfigureServices(IServiceCollection services)
- {
-     services.AddAzureClients(builder =>
-     {
-         // This will register the ServiceBusClient using an Azure Identity credential.
-         builder.AddServiceBusClientWithNamespace("<< YOUR NAMESPACE >>.servicebus.windows.net");
+{
+    services.AddAzureClients(builder =>
+    {
+        // This will register the ServiceBusClient using an Azure Identity credential.
+        builder.AddServiceBusClientWithNamespace("<< YOUR NAMESPACE >>.servicebus.windows.net");
 
-         // By default, DefaultAzureCredential is used, which is likely desired for most
-         // scenarios. If you need to restrict to a specific credential instance, you could
-         // register that instance as the default credential instead.
-         builder.UseCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned));
-     });
+        // By default, DefaultAzureCredential is used, which is likely desired for most
+        // scenarios. If you need to restrict to a specific credential instance, you could
+        // register that instance as the default credential instead.
+        builder.UseCredential(new ManagedIdentityCredential(ManagedIdentityId.SystemAssigned));
+    });
 
-     // Register other services, controllers, and other infrastructure.
- }
+    // Register other services, controllers, and other infrastructure.
+}
 ```
 
 It is also possible to register sub-clients, such as `ServiceBusSender` and `ServiceBusReceiver` with DI using the registered `ServiceBusClient` instance.  For example, to register a sender for each queue that belongs to the namespace:

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample08_Interop.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample08_Interop.md
@@ -14,7 +14,7 @@ using var stream = new MemoryStream();
 XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream);
 
 // serialize an instance of our type into a JSON string
-string json = JsonSerializer.Serialize(new TestModel {A = "Hello world", B = 5, C = true});
+string json = JsonSerializer.Serialize(new TestModel { A = "Hello world", B = 5, C = true });
 
 // serialize our JSON string into the XML envelope using the DataContractSerializer
 serializer.WriteObject(writer, json);
@@ -39,7 +39,7 @@ XmlDictionaryReader reader =
     XmlDictionaryReader.CreateBinaryReader(received.Body.ToStream(), XmlDictionaryReaderQuotas.Max);
 
 // deserialize the XML envelope into a string
-string receivedJson = (string) deserializer.ReadObject(reader);
+string receivedJson = (string)deserializer.ReadObject(reader);
 
 // deserialize the JSON string into TestModel
 TestModel output = JsonSerializer.Deserialize<TestModel>(receivedJson);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample15_MockingClientTypes.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample15_MockingClientTypes.md
@@ -46,7 +46,7 @@ Mock<ServiceBusSender> mockSender = new();
 // This sets up the mock ServiceBusClient to return the mock of the ServiceBusSender.
 
 mockClient
-    .Setup(client =>client.CreateSender(It.IsAny<string>()))
+    .Setup(client => client.CreateSender(It.IsAny<string>()))
     .Returns(mockSender.Object);
 
 // This sets up the mock sender to successfully return a completed task when any message is passed to
@@ -101,7 +101,7 @@ int numMessagesToReturn = 10;
 // for a complete set of properties that can be populated using the ServiceBusModelFactory.ServiceBusReceivedMessage
 // method.
 
-for (int i=0; i < numMessagesToReturn; i++)
+for (int i = 0; i < numMessagesToReturn; i++)
 {
     // This mocks a ServiceBusReceivedMessage instance using the model factory. Different arguments can mock different
     // potential outputs from the broker.
@@ -197,7 +197,7 @@ ServiceBusMessageBatch mockBatch = ServiceBusModelFactory.ServiceBusMessageBatch
     batchOptions: new CreateMessageBatchOptions(),
     // The model factory allows a custom TryAddMessage callback, allowing control of
     // what messages the batch accepts.
-    tryAddCallback: _=> backingList.Count < batchCountThreshold);
+    tryAddCallback: _ => backingList.Count < batchCountThreshold);
 
 // This sets up a mock of the CreateMessageBatchAsync method, returning the batch that was previously
 // mocked.
@@ -311,10 +311,10 @@ mockSender
         It.IsAny<ServiceBusMessage>(),
         It.IsAny<CancellationToken>()))
     .Callback<ServiceBusMessage, CancellationToken>(
-    (m,ct) => messagesToReturn.Enqueue(ServiceBusModelFactory.ServiceBusReceivedMessage(
-        body:m.Body,
-        messageId:m.MessageId,
-        sessionId:m.SessionId)))
+    (m, ct) => messagesToReturn.Enqueue(ServiceBusModelFactory.ServiceBusReceivedMessage(
+        body: m.Body,
+        messageId: m.MessageId,
+        sessionId: m.SessionId)))
     .Returns(Task.CompletedTask);
 
 // This sets up the receiver to return a message off of the queue, or return null if there are no messages waiting to be received.
@@ -626,7 +626,7 @@ mockClient
 // complete set of properties that can be populated using the ServiceBusModelFactory.ServiceBusReceivedMessage method.
 
 List<ServiceBusReceivedMessage> messagesToReturn = new();
-int numMessages= 3;
+int numMessages = 3;
 
 for (int i = 0; i < numMessages; i++)
 {
@@ -870,7 +870,7 @@ mockReceiver
     .ReturnsAsync(() =>
     {
         ServiceBusReceivedMessage m = messagesToReturn.FirstOrDefault();
-        if (m!= null)
+        if (m != null)
         {
             messagesToReturn.RemoveAt(0);
         }
@@ -1445,7 +1445,7 @@ The key interactions with the `ServiceBusClient` when using topics and subscript
 ```C# Snippet:ServiceBus_MockingTopicSubscriptionCrud
 Mock<ServiceBusAdministrationClient> mockAdministrationClient = new();
 Mock<Response<TopicProperties>> mockTopicResponse = new();
-Mock<Response<SubscriptionProperties>> mockSubscriptionResponse= new();
+Mock<Response<SubscriptionProperties>> mockSubscriptionResponse = new();
 
 // This sets up the mock administration client to return a mocked topic properties using the
 // service bus model factory. It populates each of the arguments using the CreateTopicOptions instance
@@ -1522,7 +1522,7 @@ TopicProperties createdTopic = await adminClient.CreateTopicAsync(topicOptions);
 string subscriptionName = "subscription";
 var subscriptionOptions = new CreateSubscriptionOptions(topicName, subscriptionName)
 {
-    UserMetadata= "some metadata"
+    UserMetadata = "some metadata"
 };
 SubscriptionProperties createdSubscription = await adminClient.CreateSubscriptionAsync(subscriptionOptions);
 ```

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -1031,6 +1031,13 @@ namespace Azure.Messaging.ServiceBus
         /// </summary>
         /// <param name="maxConcurrentCalls">The new max concurrent calls value. This will be reflected in the <see cref="ServiceBusProcessor.MaxConcurrentCalls"/>
         /// property.</param>
+        /// <remarks>
+        /// When reducing concurrency, any in-progress message handlers that exceed the new concurrency limit will have their
+        /// <see cref="System.Threading.CancellationToken"/> signaled. Handlers should observe the cancellation token passed via
+        /// <see cref="ProcessMessageEventArgs.CancellationToken"/> and handle cancellation gracefully to avoid incomplete processing.
+        /// The cancellation is cooperative; handlers that do not observe the token will continue to run until they complete.
+        /// When increasing concurrency, the change takes effect immediately by allowing additional concurrent message handlers.
+        /// </remarks>
         public void UpdateConcurrency(int maxConcurrentCalls)
         {
             lock (_optionsLock)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusProcessor.cs
@@ -1032,8 +1032,8 @@ namespace Azure.Messaging.ServiceBus
         /// <param name="maxConcurrentCalls">The new max concurrent calls value. This will be reflected in the <see cref="ServiceBusProcessor.MaxConcurrentCalls"/>
         /// property.</param>
         /// <remarks>
-        /// When reducing concurrency, any in-progress message handlers that exceed the new concurrency limit will have their
-        /// <see cref="System.Threading.CancellationToken"/> signaled. Handlers should observe the cancellation token passed via
+        /// When reducing concurrency, cancellation will be requested for in-progress message handlers that exceed the new concurrency limit via their associated
+        /// <see cref="System.Threading.CancellationToken"/>. There is no guarantee as to which handlers will be cancelled. Handlers should observe the cancellation token passed via
         /// <see cref="ProcessMessageEventArgs.CancellationToken"/> and handle cancellation gracefully to avoid incomplete processing.
         /// The cancellation is cooperative; handlers that do not observe the token will continue to run until they complete.
         /// When increasing concurrency, the change takes effect immediately by allowing additional concurrent message handlers.

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -329,6 +329,13 @@ namespace Azure.Messaging.ServiceBus
         /// <see cref="ServiceBusSessionProcessor.MaxConcurrentSessions"/>property.</param>
         /// <param name="maxConcurrentCallsPerSession">The new max concurrent calls per session value. This will be reflect in the
         /// <see cref="ServiceBusSessionProcessor.MaxConcurrentCallsPerSession"/>.</param>
+        /// <remarks>
+        /// When reducing concurrency, any in-progress message handlers that exceed the new concurrency limit will have their
+        /// <see cref="System.Threading.CancellationToken"/> signaled. Handlers should observe the cancellation token passed via
+        /// <see cref="ProcessSessionMessageEventArgs.CancellationToken"/> and handle cancellation gracefully to avoid incomplete processing.
+        /// The cancellation is cooperative; handlers that do not observe the token will continue to run until they complete.
+        /// When increasing concurrency, the change takes effect immediately by allowing additional concurrent message handlers.
+        /// </remarks>
         public void UpdateConcurrency(int maxConcurrentSessions, int maxConcurrentCallsPerSession)
         {
             InnerProcessor.UpdateConcurrency(maxConcurrentSessions, maxConcurrentCallsPerSession);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Processor/ServiceBusSessionProcessor.cs
@@ -326,12 +326,12 @@ namespace Azure.Messaging.ServiceBus
         /// Updates the concurrency for the processor. This method can be used to dynamically change the concurrency of a running processor.
         /// </summary>
         /// <param name="maxConcurrentSessions">The new max concurrent sessions value. This will be reflected in the
-        /// <see cref="ServiceBusSessionProcessor.MaxConcurrentSessions"/>property.</param>
-        /// <param name="maxConcurrentCallsPerSession">The new max concurrent calls per session value. This will be reflect in the
+        /// <see cref="ServiceBusSessionProcessor.MaxConcurrentSessions"/> property.</param>
+        /// <param name="maxConcurrentCallsPerSession">The new max concurrent calls per session value. This will be reflected in the
         /// <see cref="ServiceBusSessionProcessor.MaxConcurrentCallsPerSession"/>.</param>
         /// <remarks>
-        /// When reducing concurrency, any in-progress message handlers that exceed the new concurrency limit will have their
-        /// <see cref="System.Threading.CancellationToken"/> signaled. Handlers should observe the cancellation token passed via
+        /// When reducing concurrency, cancellation will be requested for in-progress message handlers that exceed the new concurrency limit via their associated
+        /// <see cref="System.Threading.CancellationToken"/>. There is no guarantee as to which handlers will be cancelled. Handlers should observe the cancellation token passed via
         /// <see cref="ProcessSessionMessageEventArgs.CancellationToken"/> and handle cancellation gracefully to avoid incomplete processing.
         /// The cancellation is cooperative; handlers that do not observe the token will continue to run until they complete.
         /// When increasing concurrency, the change takes effect immediately by allowing additional concurrent message handlers.


### PR DESCRIPTION
## Description

Adds `<remarks>` XML documentation to `UpdateConcurrency` on both `ServiceBusProcessor` and `ServiceBusSessionProcessor` documenting that reducing concurrency cancels excess in-progress message handlers via their `CancellationToken`.

The current behavior in `ReconcileConcurrencyAsync` intentionally cancels excess tasks when concurrency is reduced, but this is not mentioned anywhere in the API documentation. This has caused confusion for users who expect in-progress handlers to complete naturally.

The new remarks clarify:
- Reducing concurrency signals the `CancellationToken` of excess in-progress handlers
- The cancellation is cooperative (handlers that don't observe the token continue running)
- Increasing concurrency takes effect immediately

Fixes #56447 (documentation portion)

**Note:** The reporter also requested an enhancement to optionally allow graceful draining instead of cancellation. That is tracked separately and not addressed by this PR.