### PR TITLE
Restore PackAsTool for Azure.GeneratorAgent

### DIFF
--- a/sdk/tools/Azure.GeneratorAgent/src/Azure.GeneratorAgent.csproj
+++ b/sdk/tools/Azure.GeneratorAgent/src/Azure.GeneratorAgent.csproj
@@ -7,8 +7,10 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsToolProject>true</IsToolProject>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
     <Version>1.0.0-beta.1</Version>
+    <PackageDescription>Azure SDK Code Generation CLI tool for automated SDK workflows</PackageDescription>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
@@ -17,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitHub.Copilot.SDK" />
+    <PackageReference Include="GitHub.Copilot.SDK" ExcludeAssets="build" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/sdk/tools/Azure.GeneratorAgent/src/Azure.GeneratorAgent.csproj
+++ b/sdk/tools/Azure.GeneratorAgent/src/Azure.GeneratorAgent.csproj
@@ -9,6 +9,7 @@
     <IsToolProject>true</IsToolProject>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <ToolCommandName>azure-generator-agent</ToolCommandName>
     <Version>1.0.0-beta.1</Version>
     <PackageDescription>Azure SDK Code Generation CLI tool for automated SDK workflows</PackageDescription>
     <SignAssembly>false</SignAssembly>


### PR DESCRIPTION
…ownload

PR #56543 set IsPackable=false and removed PackAsTool=true to work around BinSkim BA2008 errors caused by copilot.exe — a native binary that GitHub.Copilot.SDK v0.1.24 downloads at build time via MSBuild targets. The binary lacks Control Flow Guard (CFG).

Instead of removing packaging, add ExcludeAssets="build" on the GitHub.Copilot.SDK PackageReference. This prevents the SDK's build targets from downloading copilot.exe into the output directory while preserving the compile-time reference to the managed DLL. The Copilot CLI must be installed separately at runtime, which is the documented usage pattern for the SDK.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
