### PR TITLE
[CU-SDK-UPDATE] default polling interval to 3 seconds

### DIFF
--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Set the default initial polling interval to 3 seconds for `Analyze`, `AnalyzeAsync`, `AnalyzeBinary`, and `AnalyzeBinaryAsync` to optimize polling efficiency.
 
-## 1.0.0 (2026-02-11)
+## 1.0.0 (2026-02-27)
 
 ### Features Added
 

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.1 (Unreleased)
 
 ### Other Changes
+
+- Extracted repeated `TimeSpan.FromSeconds(3)` into a shared `DefaultLroPollingInterval` constant for the LRO polling interval in Analyze/AnalyzeBinary protocol methods.
 
 ## 1.0.0 (2026-02-11)
 

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/CHANGELOG.md
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.0.1 (2026-03-06)
 
 ### Other Changes
 
-- Extracted repeated `TimeSpan.FromSeconds(3)` into a shared `DefaultLroPollingInterval` constant for the LRO polling interval in Analyze/AnalyzeBinary protocol methods.
+- Set the default initial polling interval to 3 seconds for `Analyze`, `AnalyzeAsync`, `AnalyzeBinary`, and `AnalyzeBinaryAsync` to optimize polling efficiency.
 
 ## 1.0.0 (2026-02-11)
 

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Azure.AI.ContentUnderstanding.csproj
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/Azure.AI.ContentUnderstanding.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the Azure.AI.ContentUnderstanding client library for Azure Content Understanding in Foundry Tools, a multimodal AI service that extracts semantic content from documents, audio, and video files.</Description>
     <AssemblyTitle>Microsoft Azure.AI.ContentUnderstanding client library</AssemblyTitle>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageTags>Azure.AI.ContentUnderstanding</PackageTags>

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/ContentUnderstandingClient.Customizations.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/ContentUnderstandingClient.Customizations.cs
@@ -42,6 +42,7 @@ namespace Azure.AI.ContentUnderstanding
         //     so that the operation ID is accessible via the Id property.
         private const string DefaultStringEncoding = "utf16";
         private const string DefaultContentType = "application/octet-stream";
+        private static readonly TimeSpan DefaultLroPollingInterval = TimeSpan.FromSeconds(3);
 
         #region Convenience Methods
 
@@ -184,9 +185,9 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // CUSTOMIZATION: SDK-CUSTOMIZATION: Default polling interval to 3 seconds for
-                    // Content Understanding operations (generated code defaults to 1 second).
-                    await operationWithId.WaitForCompletionAsync(TimeSpan.FromSeconds(3), context?.CancellationToken ?? default).ConfigureAwait(false);
+                    // CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
+                    // when waiting for completion in these protocol wrappers.
+                    await operationWithId.WaitForCompletionAsync(DefaultLroPollingInterval, context?.CancellationToken ?? default).ConfigureAwait(false);
                 }
 
                 return operationWithId;
@@ -233,9 +234,9 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // CUSTOMIZATION: SDK-CUSTOMIZATION: Default polling interval to 3 seconds for
-                    // Content Understanding operations (generated code defaults to 1 second).
-                    operationWithId.WaitForCompletion(TimeSpan.FromSeconds(3), context?.CancellationToken ?? default);
+                    // CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
+                    // when waiting for completion in these protocol wrappers.
+                    operationWithId.WaitForCompletion(DefaultLroPollingInterval, context?.CancellationToken ?? default);
                 }
 
                 return operationWithId;
@@ -284,9 +285,9 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // CUSTOMIZATION: SDK-CUSTOMIZATION: Default polling interval to 3 seconds for
-                    // Content Understanding operations (generated code defaults to 1 second).
-                    await operationWithId.WaitForCompletionAsync(TimeSpan.FromSeconds(3), context?.CancellationToken ?? default).ConfigureAwait(false);
+                    // CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
+                    // when waiting for completion in these protocol wrappers.
+                    await operationWithId.WaitForCompletionAsync(DefaultLroPollingInterval, context?.CancellationToken ?? default).ConfigureAwait(false);
                 }
 
                 return operationWithId;
@@ -335,9 +336,9 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // CUSTOMIZATION: SDK-CUSTOMIZATION: Default polling interval to 3 seconds for
-                    // Content Understanding operations (generated code defaults to 1 second).
-                    operationWithId.WaitForCompletion(TimeSpan.FromSeconds(3), context?.CancellationToken ?? default);
+                    // CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
+                    // when waiting for completion in these protocol wrappers.
+                    operationWithId.WaitForCompletion(DefaultLroPollingInterval, context?.CancellationToken ?? default);
                 }
 
                 return operationWithId;

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/ContentUnderstandingClient.Customizations.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/ContentUnderstandingClient.Customizations.cs
@@ -184,7 +184,9 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    await operationWithId.WaitForCompletionAsync(context?.CancellationToken ?? default).ConfigureAwait(false);
+                    // CUSTOMIZATION: SDK-CUSTOMIZATION: Default polling interval to 3 seconds for
+                    // Content Understanding operations (generated code defaults to 1 second).
+                    await operationWithId.WaitForCompletionAsync(TimeSpan.FromSeconds(3), context?.CancellationToken ?? default).ConfigureAwait(false);
                 }
 
                 return operationWithId;
@@ -231,7 +233,9 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    operationWithId.WaitForCompletion(context?.CancellationToken ?? default);
+                    // CUSTOMIZATION: SDK-CUSTOMIZATION: Default polling interval to 3 seconds for
+                    // Content Understanding operations (generated code defaults to 1 second).
+                    operationWithId.WaitForCompletion(TimeSpan.FromSeconds(3), context?.CancellationToken ?? default);
                 }
 
                 return operationWithId;
@@ -280,7 +284,9 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    await operationWithId.WaitForCompletionAsync(context?.CancellationToken ?? default).ConfigureAwait(false);
+                    // CUSTOMIZATION: SDK-CUSTOMIZATION: Default polling interval to 3 seconds for
+                    // Content Understanding operations (generated code defaults to 1 second).
+                    await operationWithId.WaitForCompletionAsync(TimeSpan.FromSeconds(3), context?.CancellationToken ?? default).ConfigureAwait(false);
                 }
 
                 return operationWithId;
@@ -329,7 +335,9 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    operationWithId.WaitForCompletion(context?.CancellationToken ?? default);
+                    // CUSTOMIZATION: SDK-CUSTOMIZATION: Default polling interval to 3 seconds for
+                    // Content Understanding operations (generated code defaults to 1 second).
+                    operationWithId.WaitForCompletion(TimeSpan.FromSeconds(3), context?.CancellationToken ?? default);
                 }
 
                 return operationWithId;

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/ContentUnderstandingClient.Customizations.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/ContentUnderstandingClient.Customizations.cs
@@ -185,7 +185,7 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
+                    // SDK-IMPROVEMENT: Use a longer polling interval than the generated default (1 second)
                     // when waiting for completion in these protocol wrappers.
                     await operationWithId.WaitForCompletionAsync(DefaultLroPollingInterval, context?.CancellationToken ?? default).ConfigureAwait(false);
                 }
@@ -234,7 +234,7 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
+                    // SDK-IMPROVEMENT: Use a longer polling interval than the generated default (1 second)
                     // when waiting for completion in these protocol wrappers.
                     operationWithId.WaitForCompletion(DefaultLroPollingInterval, context?.CancellationToken ?? default);
                 }
@@ -285,7 +285,7 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
+                    // SDK-IMPROVEMENT: Use a longer polling interval than the generated default (1 second)
                     // when waiting for completion in these protocol wrappers.
                     await operationWithId.WaitForCompletionAsync(DefaultLroPollingInterval, context?.CancellationToken ?? default).ConfigureAwait(false);
                 }
@@ -336,7 +336,7 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
+                    // SDK-IMPROVEMENT: Use a longer polling interval than the generated default (1 second)
                     // when waiting for completion in these protocol wrappers.
                     operationWithId.WaitForCompletion(DefaultLroPollingInterval, context?.CancellationToken ?? default);
                 }

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/ContentUnderstandingClient.Customizations.cs
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/src/ContentUnderstandingClient.Customizations.cs
@@ -185,7 +185,7 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // SDK-IMPROVEMENT: Use a longer polling interval than the generated default (1 second)
+                    // SDK-CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
                     // when waiting for completion in these protocol wrappers.
                     await operationWithId.WaitForCompletionAsync(DefaultLroPollingInterval, context?.CancellationToken ?? default).ConfigureAwait(false);
                 }
@@ -234,7 +234,7 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // SDK-IMPROVEMENT: Use a longer polling interval than the generated default (1 second)
+                    // SDK-CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
                     // when waiting for completion in these protocol wrappers.
                     operationWithId.WaitForCompletion(DefaultLroPollingInterval, context?.CancellationToken ?? default);
                 }
@@ -285,7 +285,7 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // SDK-IMPROVEMENT: Use a longer polling interval than the generated default (1 second)
+                    // SDK-CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
                     // when waiting for completion in these protocol wrappers.
                     await operationWithId.WaitForCompletionAsync(DefaultLroPollingInterval, context?.CancellationToken ?? default).ConfigureAwait(false);
                 }
@@ -336,7 +336,7 @@ namespace Azure.AI.ContentUnderstanding
                 // Now honor the caller's original waitUntil preference.
                 if (waitUntil == WaitUntil.Completed)
                 {
-                    // SDK-IMPROVEMENT: Use a longer polling interval than the generated default (1 second)
+                    // SDK-CUSTOMIZATION: Use a longer polling interval than the generated default (1 second)
                     // when waiting for completion in these protocol wrappers.
                     operationWithId.WaitForCompletion(DefaultLroPollingInterval, context?.CancellationToken ?? default);
                 }


### PR DESCRIPTION
PR Summary

- This PR updates Azure.AI.ContentUnderstanding default LRO polling interval from 1 second to 3 seconds for analyze convenience methods when WaitUntil.Completed is used.
- Scope: single file change in [ContentUnderstandingClient.Customizations.cs](vscode-file://vscode-app/c:/Users/v-cyuanchang/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

What Changed
- Replaced WaitForCompletion/WaitForCompletionAsync overloads that used default polling with overloads that explicitly pass TimeSpan.FromSeconds(3).
- Applied consistently in four paths:
  - AnalyzeAsync
  - Analyze
  - AnalyzeBinaryAsync
  - AnalyzeBinary
- Added customization comments to document intent and avoid future generator overwrite confusion.

Impact
Reduces polling frequency for completed-wait flows, which lowers request churn while preserving behavior and return types.
No API surface changes; only runtime polling cadence changes for these completion-wait code paths.