### PR TITLE
[Azure.ResourceManager.ContainerService] Stable patch release to remove mgmt-debug flag

### DIFF
--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/CHANGELOG.md
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.1 (2026-02-28)
 
 ### Other Changes
+
+- Removed `mgmt-debug` flag that was accidentally left in the released library, which added unnecessary `Serialized Name:` comments to XML doc comments.
 
 ## 1.3.0 (2025-12-18)
 

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Azure.ResourceManager.ContainerService.csproj
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Azure.ResourceManager.ContainerService.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0-beta.1</Version>
+    <Version>1.3.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.ContainerService</PackageId>

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/AgentPoolSnapshotData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/AgentPoolSnapshotData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the AgentPoolSnapshot data model.
     /// A node pool snapshot resource.
-    /// Serialized Name: Snapshot
     /// </summary>
     public partial class AgentPoolSnapshotData : TrackedResourceData
     {
@@ -65,38 +64,14 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="creationData">
-        /// CreationData to be used to specify the source agent pool resource ID to create this snapshot.
-        /// Serialized Name: Snapshot.properties.creationData
-        /// </param>
-        /// <param name="snapshotType">
-        /// The type of a snapshot. The default is NodePool.
-        /// Serialized Name: Snapshot.properties.snapshotType
-        /// </param>
-        /// <param name="kubernetesVersion">
-        /// The version of Kubernetes.
-        /// Serialized Name: Snapshot.properties.kubernetesVersion
-        /// </param>
-        /// <param name="nodeImageVersion">
-        /// The version of node image.
-        /// Serialized Name: Snapshot.properties.nodeImageVersion
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: Snapshot.properties.osType
-        /// </param>
-        /// <param name="osSku">
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: Snapshot.properties.osSku
-        /// </param>
-        /// <param name="vmSize">
-        /// The size of the VM.
-        /// Serialized Name: Snapshot.properties.vmSize
-        /// </param>
-        /// <param name="enableFips">
-        /// Whether to use a FIPS-enabled OS.
-        /// Serialized Name: Snapshot.properties.enableFIPS
-        /// </param>
+        /// <param name="creationData"> CreationData to be used to specify the source agent pool resource ID to create this snapshot. </param>
+        /// <param name="snapshotType"> The type of a snapshot. The default is NodePool. </param>
+        /// <param name="kubernetesVersion"> The version of Kubernetes. </param>
+        /// <param name="nodeImageVersion"> The version of node image. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="osSku"> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </param>
+        /// <param name="vmSize"> The size of the VM. </param>
+        /// <param name="enableFips"> Whether to use a FIPS-enabled OS. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolSnapshotData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IDictionary<string, string> tags, AzureLocation location, ContainerServiceCreationData creationData, SnapshotType? snapshotType, string kubernetesVersion, string nodeImageVersion, ContainerServiceOSType? osType, ContainerServiceOSSku? osSku, string vmSize, bool? enableFips, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData, tags, location)
         {
@@ -116,15 +91,9 @@ namespace Azure.ResourceManager.ContainerService
         {
         }
 
-        /// <summary>
-        /// CreationData to be used to specify the source agent pool resource ID to create this snapshot.
-        /// Serialized Name: Snapshot.properties.creationData
-        /// </summary>
+        /// <summary> CreationData to be used to specify the source agent pool resource ID to create this snapshot. </summary>
         internal ContainerServiceCreationData CreationData { get; set; }
-        /// <summary>
-        /// This is the ARM ID of the source object to be used to create the target object.
-        /// Serialized Name: CreationData.sourceResourceId
-        /// </summary>
+        /// <summary> This is the ARM ID of the source object to be used to create the target object. </summary>
         [WirePath("properties.creationData.sourceResourceId")]
         public ResourceIdentifier CreationDataSourceResourceId
         {
@@ -137,46 +106,25 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// The type of a snapshot. The default is NodePool.
-        /// Serialized Name: Snapshot.properties.snapshotType
-        /// </summary>
+        /// <summary> The type of a snapshot. The default is NodePool. </summary>
         [WirePath("properties.snapshotType")]
         public SnapshotType? SnapshotType { get; set; }
-        /// <summary>
-        /// The version of Kubernetes.
-        /// Serialized Name: Snapshot.properties.kubernetesVersion
-        /// </summary>
+        /// <summary> The version of Kubernetes. </summary>
         [WirePath("properties.kubernetesVersion")]
         public string KubernetesVersion { get; }
-        /// <summary>
-        /// The version of node image.
-        /// Serialized Name: Snapshot.properties.nodeImageVersion
-        /// </summary>
+        /// <summary> The version of node image. </summary>
         [WirePath("properties.nodeImageVersion")]
         public string NodeImageVersion { get; }
-        /// <summary>
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: Snapshot.properties.osType
-        /// </summary>
+        /// <summary> The operating system type. The default is Linux. </summary>
         [WirePath("properties.osType")]
         public ContainerServiceOSType? OSType { get; }
-        /// <summary>
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: Snapshot.properties.osSku
-        /// </summary>
+        /// <summary> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </summary>
         [WirePath("properties.osSku")]
         public ContainerServiceOSSku? OSSku { get; }
-        /// <summary>
-        /// The size of the VM.
-        /// Serialized Name: Snapshot.properties.vmSize
-        /// </summary>
+        /// <summary> The size of the VM. </summary>
         [WirePath("properties.vmSize")]
         public string VmSize { get; }
-        /// <summary>
-        /// Whether to use a FIPS-enabled OS.
-        /// Serialized Name: Snapshot.properties.enableFIPS
-        /// </summary>
+        /// <summary> Whether to use a FIPS-enabled OS. </summary>
         [WirePath("properties.enableFIPS")]
         public bool? EnableFips { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/AgentPoolUpgradeProfileData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/AgentPoolUpgradeProfileData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the AgentPoolUpgradeProfile data model.
     /// The list of available upgrades for an agent pool.
-    /// Serialized Name: AgentPoolUpgradeProfile
     /// </summary>
     public partial class AgentPoolUpgradeProfileData : ResourceData
     {
@@ -53,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolUpgradeProfileData"/>. </summary>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.kubernetesVersion
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.osType
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="kubernetesVersion"/> is null. </exception>
         internal AgentPoolUpgradeProfileData(string kubernetesVersion, ContainerServiceOSType osType)
         {
@@ -76,22 +69,10 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.kubernetesVersion
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.osType
-        /// </param>
-        /// <param name="upgrades">
-        /// List of orchestrator types and versions available for upgrade.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.upgrades
-        /// </param>
-        /// <param name="latestNodeImageVersion">
-        /// The latest AKS supported node image version.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.latestNodeImageVersion
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="upgrades"> List of orchestrator types and versions available for upgrade. </param>
+        /// <param name="latestNodeImageVersion"> The latest AKS supported node image version. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolUpgradeProfileData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, string kubernetesVersion, ContainerServiceOSType osType, IReadOnlyList<AgentPoolUpgradeProfilePropertiesUpgradesItem> upgrades, string latestNodeImageVersion, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -107,28 +88,16 @@ namespace Azure.ResourceManager.ContainerService
         {
         }
 
-        /// <summary>
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.kubernetesVersion
-        /// </summary>
+        /// <summary> The Kubernetes version (major.minor.patch). </summary>
         [WirePath("properties.kubernetesVersion")]
         public string KubernetesVersion { get; }
-        /// <summary>
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.osType
-        /// </summary>
+        /// <summary> The operating system type. The default is Linux. </summary>
         [WirePath("properties.osType")]
         public ContainerServiceOSType OSType { get; }
-        /// <summary>
-        /// List of orchestrator types and versions available for upgrade.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.upgrades
-        /// </summary>
+        /// <summary> List of orchestrator types and versions available for upgrade. </summary>
         [WirePath("properties.upgrades")]
         public IReadOnlyList<AgentPoolUpgradeProfilePropertiesUpgradesItem> Upgrades { get; }
-        /// <summary>
-        /// The latest AKS supported node image version.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.latestNodeImageVersion
-        /// </summary>
+        /// <summary> The latest AKS supported node image version. </summary>
         [WirePath("properties.latestNodeImageVersion")]
         public string LatestNodeImageVersion { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ArmContainerServiceModelFactory.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ArmContainerServiceModelFactory.cs
@@ -20,10 +20,7 @@ namespace Azure.ResourceManager.ContainerService.Models
     public static partial class ArmContainerServiceModelFactory
     {
         /// <summary> Initializes a new instance of <see cref="Models.KubernetesVersionListResult"/>. </summary>
-        /// <param name="values">
-        /// Array of AKS supported Kubernetes versions.
-        /// Serialized Name: KubernetesVersionListResult.values
-        /// </param>
+        /// <param name="values"> Array of AKS supported Kubernetes versions. </param>
         /// <returns> A new <see cref="Models.KubernetesVersionListResult"/> instance for mocking. </returns>
         public static KubernetesVersionListResult KubernetesVersionListResult(IEnumerable<KubernetesVersion> values = null)
         {
@@ -33,26 +30,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.KubernetesVersion"/>. </summary>
-        /// <param name="version">
-        /// major.minor version of Kubernetes release
-        /// Serialized Name: KubernetesVersion.version
-        /// </param>
-        /// <param name="capabilitiesSupportPlan">
-        /// Capabilities on this Kubernetes version.
-        /// Serialized Name: KubernetesVersion.capabilities
-        /// </param>
-        /// <param name="isDefault">
-        /// Whether this version is default.
-        /// Serialized Name: KubernetesVersion.isDefault
-        /// </param>
-        /// <param name="isPreview">
-        /// Whether this version is in preview mode.
-        /// Serialized Name: KubernetesVersion.isPreview
-        /// </param>
-        /// <param name="patchVersions">
-        /// Patch versions of Kubernetes release
-        /// Serialized Name: KubernetesVersion.patchVersions
-        /// </param>
+        /// <param name="version"> major.minor version of Kubernetes release. </param>
+        /// <param name="capabilitiesSupportPlan"> Capabilities on this Kubernetes version. </param>
+        /// <param name="isDefault"> Whether this version is default. </param>
+        /// <param name="isPreview"> Whether this version is in preview mode. </param>
+        /// <param name="patchVersions"> Patch versions of Kubernetes release. </param>
         /// <returns> A new <see cref="Models.KubernetesVersion"/> instance for mocking. </returns>
         public static KubernetesVersion KubernetesVersion(string version = null, IEnumerable<KubernetesSupportPlan> capabilitiesSupportPlan = null, bool? isDefault = null, bool? isPreview = null, IReadOnlyDictionary<string, KubernetesPatchVersion> patchVersions = null)
         {
@@ -69,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.KubernetesPatchVersion"/>. </summary>
-        /// <param name="upgrades">
-        /// Possible upgrade path for given patch version
-        /// Serialized Name: KubernetesPatchVersion.upgrades
-        /// </param>
+        /// <param name="upgrades"> Possible upgrade path for given patch version. </param>
         /// <returns> A new <see cref="Models.KubernetesPatchVersion"/> instance for mocking. </returns>
         public static KubernetesPatchVersion KubernetesPatchVersion(IEnumerable<string> upgrades = null)
         {
@@ -88,206 +67,56 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedCluster.eTag
-        /// </param>
-        /// <param name="sku">
-        /// The managed cluster SKU.
-        /// Serialized Name: ManagedCluster.sku
-        /// </param>
-        /// <param name="extendedLocation">
-        /// The extended location of the Virtual Machine.
-        /// Serialized Name: ManagedCluster.extendedLocation
-        /// </param>
-        /// <param name="clusterIdentity">
-        /// The identity of the managed cluster, if configured.
-        /// Serialized Name: ManagedCluster.identity
-        /// </param>
-        /// <param name="kind">
-        /// This is primarily used to expose different UI experiences in the portal for different kinds
-        /// Serialized Name: ManagedCluster.kind
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current provisioning state.
-        /// Serialized Name: ManagedCluster.properties.provisioningState
-        /// </param>
-        /// <param name="powerStateCode">
-        /// The Power State of the cluster.
-        /// Serialized Name: ManagedCluster.properties.powerState
-        /// </param>
-        /// <param name="maxAgentPools">
-        /// The max number of agent pools for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.maxAgentPools
-        /// </param>
-        /// <param name="kubernetesVersion">
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -&gt; 1.15.x or 1.15.x -&gt; 1.16.x are allowed, however 1.14.x -&gt; 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details.
-        /// Serialized Name: ManagedCluster.properties.kubernetesVersion
-        /// </param>
-        /// <param name="currentKubernetesVersion">
-        /// The version of Kubernetes the Managed Cluster is running. If kubernetesVersion was a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If kubernetesVersion was &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: ManagedCluster.properties.currentKubernetesVersion
-        /// </param>
-        /// <param name="dnsPrefix">
-        /// The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created.
-        /// Serialized Name: ManagedCluster.properties.dnsPrefix
-        /// </param>
-        /// <param name="fqdnSubdomain">
-        /// The FQDN subdomain of the private cluster with custom private dns zone. This cannot be updated once the Managed Cluster has been created.
-        /// Serialized Name: ManagedCluster.properties.fqdnSubdomain
-        /// </param>
-        /// <param name="fqdn">
-        /// The FQDN of the master pool.
-        /// Serialized Name: ManagedCluster.properties.fqdn
-        /// </param>
-        /// <param name="privateFqdn">
-        /// The FQDN of private cluster.
-        /// Serialized Name: ManagedCluster.properties.privateFQDN
-        /// </param>
-        /// <param name="azurePortalFqdn">
-        /// The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly.
-        /// Serialized Name: ManagedCluster.properties.azurePortalFQDN
-        /// </param>
-        /// <param name="agentPoolProfiles">
-        /// The agent pool properties.
-        /// Serialized Name: ManagedCluster.properties.agentPoolProfiles
-        /// </param>
-        /// <param name="linuxProfile">
-        /// The profile for Linux VMs in the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.linuxProfile
-        /// </param>
-        /// <param name="windowsProfile">
-        /// The profile for Windows VMs in the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.windowsProfile
-        /// </param>
-        /// <param name="servicePrincipalProfile">
-        /// Information about a service principal identity for the cluster to use for manipulating Azure APIs.
-        /// Serialized Name: ManagedCluster.properties.servicePrincipalProfile
-        /// </param>
-        /// <param name="addonProfiles">
-        /// The profile of managed cluster add-on.
-        /// Serialized Name: ManagedCluster.properties.addonProfiles
-        /// </param>
-        /// <param name="podIdentityProfile">
-        /// The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on AAD pod identity integration.
-        /// Serialized Name: ManagedCluster.properties.podIdentityProfile
-        /// </param>
-        /// <param name="oidcIssuerProfile">
-        /// The OIDC issuer profile of the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.oidcIssuerProfile
-        /// </param>
-        /// <param name="nodeResourceGroup">
-        /// The name of the resource group containing agent pool nodes.
-        /// Serialized Name: ManagedCluster.properties.nodeResourceGroup
-        /// </param>
-        /// <param name="nodeResourceGroupRestrictionLevel">
-        /// Profile of the node resource group configuration.
-        /// Serialized Name: ManagedCluster.properties.nodeResourceGroupProfile
-        /// </param>
-        /// <param name="enableRbac">
-        /// Whether to enable Kubernetes Role-Based Access Control.
-        /// Serialized Name: ManagedCluster.properties.enableRBAC
-        /// </param>
-        /// <param name="supportPlan">
-        /// The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'.
-        /// Serialized Name: ManagedCluster.properties.supportPlan
-        /// </param>
-        /// <param name="networkProfile">
-        /// The network configuration profile.
-        /// Serialized Name: ManagedCluster.properties.networkProfile
-        /// </param>
-        /// <param name="aadProfile">
-        /// The Azure Active Directory configuration.
-        /// Serialized Name: ManagedCluster.properties.aadProfile
-        /// </param>
-        /// <param name="autoUpgradeProfile">
-        /// The auto upgrade configuration.
-        /// Serialized Name: ManagedCluster.properties.autoUpgradeProfile
-        /// </param>
-        /// <param name="upgradeOverrideSettings">
-        /// Settings for upgrading a cluster.
-        /// Serialized Name: ManagedCluster.properties.upgradeSettings
-        /// </param>
-        /// <param name="autoScalerProfile">
-        /// Parameters to be applied to the cluster-autoscaler when enabled
-        /// Serialized Name: ManagedCluster.properties.autoScalerProfile
-        /// </param>
-        /// <param name="apiServerAccessProfile">
-        /// The access profile for managed cluster API server.
-        /// Serialized Name: ManagedCluster.properties.apiServerAccessProfile
-        /// </param>
-        /// <param name="diskEncryptionSetId">
-        /// The Resource ID of the disk encryption set to use for enabling encryption at rest. This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'
-        /// Serialized Name: ManagedCluster.properties.diskEncryptionSetID
-        /// </param>
-        /// <param name="identityProfile">
-        /// The user identity associated with the managed cluster. This identity will be used by the kubelet. Only one user assigned identity is allowed. The only accepted key is "kubeletidentity", with value of "resourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}".
-        /// Serialized Name: ManagedCluster.properties.identityProfile
-        /// </param>
-        /// <param name="privateLinkResources">
-        /// Private link resources associated with the cluster.
-        /// Serialized Name: ManagedCluster.properties.privateLinkResources
-        /// </param>
-        /// <param name="disableLocalAccounts">
-        /// If local accounts should be disabled on the Managed Cluster. If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled. For more details see [disable local accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview).
-        /// Serialized Name: ManagedCluster.properties.disableLocalAccounts
-        /// </param>
-        /// <param name="httpProxyConfig">
-        /// Configurations for provisioning the cluster with HTTP proxy servers.
-        /// Serialized Name: ManagedCluster.properties.httpProxyConfig
-        /// </param>
-        /// <param name="securityProfile">
-        /// Security profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.securityProfile
-        /// </param>
-        /// <param name="storageProfile">
-        /// Storage profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.storageProfile
-        /// </param>
-        /// <param name="ingressWebAppRouting">
-        /// Ingress profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.ingressProfile
-        /// </param>
-        /// <param name="publicNetworkAccess">
-        /// PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS
-        /// Serialized Name: ManagedCluster.properties.publicNetworkAccess
-        /// </param>
-        /// <param name="workloadAutoScalerProfile">
-        /// Workload Auto-scaler profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.workloadAutoScalerProfile
-        /// </param>
-        /// <param name="azureMonitorMetrics">
-        /// Azure Monitor addon profiles for monitoring the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.azureMonitorProfile
-        /// </param>
-        /// <param name="serviceMeshProfile">
-        /// Service mesh profile for a managed cluster.
-        /// Serialized Name: ManagedCluster.properties.serviceMeshProfile
-        /// </param>
-        /// <param name="resourceId">
-        /// The resourceUID uniquely identifies ManagedClusters that reuse ARM ResourceIds (i.e: create, delete, create sequence)
-        /// Serialized Name: ManagedCluster.properties.resourceUID
-        /// </param>
-        /// <param name="isCostAnalysisEnabled">
-        /// Optional cluster metrics configuration.
-        /// Serialized Name: ManagedCluster.properties.metricsProfile
-        /// </param>
-        /// <param name="nodeProvisioningProfile">
-        /// Node provisioning settings that apply to the whole cluster.
-        /// Serialized Name: ManagedCluster.properties.nodeProvisioningProfile
-        /// </param>
-        /// <param name="bootstrapProfile">
-        /// Profile of the cluster bootstrap configuration.
-        /// Serialized Name: ManagedCluster.properties.bootstrapProfile
-        /// </param>
-        /// <param name="isAIToolchainOperatorEnabled">
-        /// AI toolchain operator settings that apply to the whole cluster.
-        /// Serialized Name: ManagedCluster.properties.aiToolchainOperatorProfile
-        /// </param>
-        /// <param name="statusProvisioningError">
-        /// Contains read-only information about the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.status
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="sku"> The managed cluster SKU. </param>
+        /// <param name="extendedLocation"> The extended location of the Virtual Machine. </param>
+        /// <param name="clusterIdentity"> The identity of the managed cluster, if configured. </param>
+        /// <param name="kind"> This is primarily used to expose different UI experiences in the portal for different kinds. </param>
+        /// <param name="provisioningState"> The current provisioning state. </param>
+        /// <param name="powerStateCode"> The Power State of the cluster. </param>
+        /// <param name="maxAgentPools"> The max number of agent pools for the managed cluster. </param>
+        /// <param name="kubernetesVersion"> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -&gt; 1.15.x or 1.15.x -&gt; 1.16.x are allowed, however 1.14.x -&gt; 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details. </param>
+        /// <param name="currentKubernetesVersion"> The version of Kubernetes the Managed Cluster is running. If kubernetesVersion was a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If kubernetesVersion was &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </param>
+        /// <param name="dnsPrefix"> The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created. </param>
+        /// <param name="fqdnSubdomain"> The FQDN subdomain of the private cluster with custom private dns zone. This cannot be updated once the Managed Cluster has been created. </param>
+        /// <param name="fqdn"> The FQDN of the master pool. </param>
+        /// <param name="privateFqdn"> The FQDN of private cluster. </param>
+        /// <param name="azurePortalFqdn"> The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly. </param>
+        /// <param name="agentPoolProfiles"> The agent pool properties. </param>
+        /// <param name="linuxProfile"> The profile for Linux VMs in the Managed Cluster. </param>
+        /// <param name="windowsProfile"> The profile for Windows VMs in the Managed Cluster. </param>
+        /// <param name="servicePrincipalProfile"> Information about a service principal identity for the cluster to use for manipulating Azure APIs. </param>
+        /// <param name="addonProfiles"> The profile of managed cluster add-on. </param>
+        /// <param name="podIdentityProfile"> The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on AAD pod identity integration. </param>
+        /// <param name="oidcIssuerProfile"> The OIDC issuer profile of the Managed Cluster. </param>
+        /// <param name="nodeResourceGroup"> The name of the resource group containing agent pool nodes. </param>
+        /// <param name="nodeResourceGroupRestrictionLevel"> Profile of the node resource group configuration. </param>
+        /// <param name="enableRbac"> Whether to enable Kubernetes Role-Based Access Control. </param>
+        /// <param name="supportPlan"> The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'. </param>
+        /// <param name="networkProfile"> The network configuration profile. </param>
+        /// <param name="aadProfile"> The Azure Active Directory configuration. </param>
+        /// <param name="autoUpgradeProfile"> The auto upgrade configuration. </param>
+        /// <param name="upgradeOverrideSettings"> Settings for upgrading a cluster. </param>
+        /// <param name="autoScalerProfile"> Parameters to be applied to the cluster-autoscaler when enabled. </param>
+        /// <param name="apiServerAccessProfile"> The access profile for managed cluster API server. </param>
+        /// <param name="diskEncryptionSetId"> The Resource ID of the disk encryption set to use for enabling encryption at rest. This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'. </param>
+        /// <param name="identityProfile"> The user identity associated with the managed cluster. This identity will be used by the kubelet. Only one user assigned identity is allowed. The only accepted key is "kubeletidentity", with value of "resourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}". </param>
+        /// <param name="privateLinkResources"> Private link resources associated with the cluster. </param>
+        /// <param name="disableLocalAccounts"> If local accounts should be disabled on the Managed Cluster. If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled. For more details see [disable local accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview). </param>
+        /// <param name="httpProxyConfig"> Configurations for provisioning the cluster with HTTP proxy servers. </param>
+        /// <param name="securityProfile"> Security profile for the managed cluster. </param>
+        /// <param name="storageProfile"> Storage profile for the managed cluster. </param>
+        /// <param name="ingressWebAppRouting"> Ingress profile for the managed cluster. </param>
+        /// <param name="publicNetworkAccess"> PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS. </param>
+        /// <param name="workloadAutoScalerProfile"> Workload Auto-scaler profile for the managed cluster. </param>
+        /// <param name="azureMonitorMetrics"> Azure Monitor addon profiles for monitoring the managed cluster. </param>
+        /// <param name="serviceMeshProfile"> Service mesh profile for a managed cluster. </param>
+        /// <param name="resourceId"> The resourceUID uniquely identifies ManagedClusters that reuse ARM ResourceIds (i.e: create, delete, create sequence). </param>
+        /// <param name="isCostAnalysisEnabled"> Optional cluster metrics configuration. </param>
+        /// <param name="nodeProvisioningProfile"> Node provisioning settings that apply to the whole cluster. </param>
+        /// <param name="bootstrapProfile"> Profile of the cluster bootstrap configuration. </param>
+        /// <param name="isAIToolchainOperatorEnabled"> AI toolchain operator settings that apply to the whole cluster. </param>
+        /// <param name="statusProvisioningError"> Contains read-only information about the Managed Cluster. </param>
         /// <returns> A new <see cref="ContainerService.ContainerServiceManagedClusterData"/> instance for mocking. </returns>
         public static ContainerServiceManagedClusterData ContainerServiceManagedClusterData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IDictionary<string, string> tags = null, AzureLocation location = default, ETag? etag = null, ManagedClusterSku sku = null, ExtendedLocation extendedLocation = null, ManagedClusterIdentity clusterIdentity = null, string kind = null, string provisioningState = null, ContainerServiceStateCode? powerStateCode = null, int? maxAgentPools = null, string kubernetesVersion = null, string currentKubernetesVersion = null, string dnsPrefix = null, string fqdnSubdomain = null, string fqdn = null, string privateFqdn = null, string azurePortalFqdn = null, IEnumerable<ManagedClusterAgentPoolProfile> agentPoolProfiles = null, ContainerServiceLinuxProfile linuxProfile = null, ManagedClusterWindowsProfile windowsProfile = null, ManagedClusterServicePrincipalProfile servicePrincipalProfile = null, IDictionary<string, ManagedClusterAddonProfile> addonProfiles = null, ManagedClusterPodIdentityProfile podIdentityProfile = null, ManagedClusterOidcIssuerProfile oidcIssuerProfile = null, string nodeResourceGroup = null, ManagedClusterNodeResourceGroupRestrictionLevel? nodeResourceGroupRestrictionLevel = null, bool? enableRbac = null, KubernetesSupportPlan? supportPlan = null, ContainerServiceNetworkProfile networkProfile = null, ManagedClusterAadProfile aadProfile = null, ManagedClusterAutoUpgradeProfile autoUpgradeProfile = null, UpgradeOverrideSettings upgradeOverrideSettings = null, ManagedClusterAutoScalerProfile autoScalerProfile = null, ManagedClusterApiServerAccessProfile apiServerAccessProfile = null, ResourceIdentifier diskEncryptionSetId = null, IDictionary<string, ContainerServiceUserAssignedIdentity> identityProfile = null, IEnumerable<ContainerServicePrivateLinkResourceData> privateLinkResources = null, bool? disableLocalAccounts = null, ManagedClusterHttpProxyConfig httpProxyConfig = null, ManagedClusterSecurityProfile securityProfile = null, ManagedClusterStorageProfile storageProfile = null, ManagedClusterIngressProfileWebAppRouting ingressWebAppRouting = null, ContainerServicePublicNetworkAccess? publicNetworkAccess = null, ManagedClusterWorkloadAutoScalerProfile workloadAutoScalerProfile = null, ManagedClusterMonitorProfileMetrics azureMonitorMetrics = null, ServiceMeshProfile serviceMeshProfile = null, ResourceIdentifier resourceId = null, bool? isCostAnalysisEnabled = null, ManagedClusterNodeProvisioningProfile nodeProvisioningProfile = null, ManagedClusterBootstrapProfile bootstrapProfile = null, bool? isAIToolchainOperatorEnabled = null, ResponseError statusProvisioningError = null)
         {
@@ -358,226 +187,61 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterAgentPoolProfile"/>. </summary>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.eTag
-        /// </param>
-        /// <param name="count">
-        /// Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.count
-        /// </param>
-        /// <param name="vmSize">
-        /// The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vmSize
-        /// </param>
-        /// <param name="osDiskSizeInGB">
-        /// OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskSizeGB
-        /// </param>
-        /// <param name="osDiskType">
-        /// The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskType
-        /// </param>
-        /// <param name="kubeletDiskType">
-        /// Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletDiskType
-        /// </param>
-        /// <param name="workloadRuntime">
-        /// Determines the type of workload a node can run.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.workloadRuntime
-        /// </param>
-        /// <param name="messageOfTheDay">
-        /// Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.messageOfTheDay
-        /// </param>
-        /// <param name="vnetSubnetId">
-        /// The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vnetSubnetID
-        /// </param>
-        /// <param name="podSubnetId">
-        /// The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podSubnetID
-        /// </param>
-        /// <param name="podIPAllocationMode">
-        /// Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podIPAllocationMode
-        /// </param>
-        /// <param name="maxPods">
-        /// The maximum number of pods that can run on a node.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxPods
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osType
-        /// </param>
-        /// <param name="osSku">
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osSKU
-        /// </param>
-        /// <param name="maxCount">
-        /// The maximum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxCount
-        /// </param>
-        /// <param name="minCount">
-        /// The minimum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.minCount
-        /// </param>
-        /// <param name="enableAutoScaling">
-        /// Whether to enable auto-scaler
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableAutoScaling
-        /// </param>
-        /// <param name="scaleDownMode">
-        /// The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleDownMode
-        /// </param>
-        /// <param name="agentPoolType">
-        /// The type of Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.type
-        /// </param>
-        /// <param name="mode">
-        /// The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.mode
-        /// </param>
-        /// <param name="orchestratorVersion">
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.orchestratorVersion
-        /// </param>
-        /// <param name="currentOrchestratorVersion">
-        /// The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.currentOrchestratorVersion
-        /// </param>
-        /// <param name="nodeImageVersion">
-        /// The version of node image
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeImageVersion
-        /// </param>
-        /// <param name="upgradeSettings">
-        /// Settings for upgrading the agentpool
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.upgradeSettings
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current deployment or provisioning state.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.provisioningState
-        /// </param>
-        /// <param name="powerStateCode">
-        /// Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.powerState
-        /// </param>
-        /// <param name="availabilityZones">
-        /// The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.availabilityZones
-        /// </param>
-        /// <param name="enableNodePublicIP">
-        /// Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableNodePublicIP
-        /// </param>
-        /// <param name="nodePublicIPPrefixId">
-        /// The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodePublicIPPrefixID
-        /// </param>
-        /// <param name="scaleSetPriority">
-        /// The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetPriority
-        /// </param>
-        /// <param name="scaleSetEvictionPolicy">
-        /// The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetEvictionPolicy
-        /// </param>
-        /// <param name="spotMaxPrice">
-        /// The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.spotMaxPrice
-        /// </param>
-        /// <param name="tags">
-        /// The tags to be persisted on the agent pool virtual machine scale set.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.tags
-        /// </param>
-        /// <param name="nodeLabels">
-        /// The node labels to be persisted across all nodes in agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeLabels
-        /// </param>
-        /// <param name="nodeTaints">
-        /// The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeTaints
-        /// </param>
-        /// <param name="proximityPlacementGroupId">
-        /// The ID for Proximity Placement Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.proximityPlacementGroupID
-        /// </param>
-        /// <param name="kubeletConfig">
-        /// The Kubelet configuration on the agent pool nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletConfig
-        /// </param>
-        /// <param name="linuxOSConfig">
-        /// The OS configuration of Linux agent nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.linuxOSConfig
-        /// </param>
-        /// <param name="enableEncryptionAtHost">
-        /// Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableEncryptionAtHost
-        /// </param>
-        /// <param name="enableUltraSsd">
-        /// Whether to enable UltraSSD
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableUltraSSD
-        /// </param>
-        /// <param name="enableFips">
-        /// Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableFIPS
-        /// </param>
-        /// <param name="gpuInstanceProfile">
-        /// GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuInstanceProfile
-        /// </param>
-        /// <param name="creationDataSourceResourceId">
-        /// CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.creationData
-        /// </param>
-        /// <param name="capacityReservationGroupId">
-        /// AKS will associate the specified agent pool with the Capacity Reservation Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.capacityReservationGroupID
-        /// </param>
-        /// <param name="hostGroupId">
-        /// The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.hostGroupID
-        /// </param>
-        /// <param name="networkProfile">
-        /// Network-related settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.networkProfile
-        /// </param>
-        /// <param name="isOutboundNatDisabled">
-        /// The Windows agent pool's specific profile.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.windowsProfile
-        /// </param>
-        /// <param name="securityProfile">
-        /// The security settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.securityProfile
-        /// </param>
-        /// <param name="gpuDriver">
-        /// GPU settings for the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuProfile
-        /// </param>
-        /// <param name="gatewayPublicIPPrefixSize">
-        /// Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gatewayProfile
-        /// </param>
-        /// <param name="scaleManual">
-        /// Specifications on VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachinesProfile
-        /// </param>
-        /// <param name="virtualMachineNodesStatus">
-        /// The status of nodes in a VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachineNodesStatus
-        /// </param>
-        /// <param name="statusProvisioningError">
-        /// Contains read-only information about the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.status
-        /// </param>
-        /// <param name="localDnsProfile">
-        /// Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.localDNSProfile
-        /// </param>
-        /// <param name="name">
-        /// Unique name of the agent pool profile in the context of the subscription and resource group. Windows agent pool names must be 6 characters or less.
-        /// Serialized Name: ManagedClusterAgentPoolProfile.name
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="count"> Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1. </param>
+        /// <param name="vmSize"> The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions. </param>
+        /// <param name="osDiskSizeInGB"> OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified. </param>
+        /// <param name="osDiskType"> The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os). </param>
+        /// <param name="kubeletDiskType"> Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. </param>
+        /// <param name="workloadRuntime"> Determines the type of workload a node can run. </param>
+        /// <param name="messageOfTheDay"> Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script). </param>
+        /// <param name="vnetSubnetId"> The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podSubnetId"> The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podIPAllocationMode"> Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'. </param>
+        /// <param name="maxPods"> The maximum number of pods that can run on a node. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="osSku"> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </param>
+        /// <param name="maxCount"> The maximum number of nodes for auto-scaling. </param>
+        /// <param name="minCount"> The minimum number of nodes for auto-scaling. </param>
+        /// <param name="enableAutoScaling"> Whether to enable auto-scaler. </param>
+        /// <param name="scaleDownMode"> The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete. </param>
+        /// <param name="agentPoolType"> The type of Agent Pool. </param>
+        /// <param name="mode"> The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools. </param>
+        /// <param name="orchestratorVersion"> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool). </param>
+        /// <param name="currentOrchestratorVersion"> The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </param>
+        /// <param name="nodeImageVersion"> The version of node image. </param>
+        /// <param name="upgradeSettings"> Settings for upgrading the agentpool. </param>
+        /// <param name="provisioningState"> The current deployment or provisioning state. </param>
+        /// <param name="powerStateCode"> Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded. </param>
+        /// <param name="availabilityZones"> The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'. </param>
+        /// <param name="enableNodePublicIP"> Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false. </param>
+        /// <param name="nodePublicIPPrefixId"> The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}. </param>
+        /// <param name="scaleSetPriority"> The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'. </param>
+        /// <param name="scaleSetEvictionPolicy"> The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'. </param>
+        /// <param name="spotMaxPrice"> The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing). </param>
+        /// <param name="tags"> The tags to be persisted on the agent pool virtual machine scale set. </param>
+        /// <param name="nodeLabels"> The node labels to be persisted across all nodes in agent pool. </param>
+        /// <param name="nodeTaints"> The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. </param>
+        /// <param name="proximityPlacementGroupId"> The ID for Proximity Placement Group. </param>
+        /// <param name="kubeletConfig"> The Kubelet configuration on the agent pool nodes. </param>
+        /// <param name="linuxOSConfig"> The OS configuration of Linux agent nodes. </param>
+        /// <param name="enableEncryptionAtHost"> Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption. </param>
+        /// <param name="enableUltraSsd"> Whether to enable UltraSSD. </param>
+        /// <param name="enableFips"> Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details. </param>
+        /// <param name="gpuInstanceProfile"> GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU. </param>
+        /// <param name="creationDataSourceResourceId"> CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot. </param>
+        /// <param name="capacityReservationGroupId"> AKS will associate the specified agent pool with the Capacity Reservation Group. </param>
+        /// <param name="hostGroupId"> The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts). </param>
+        /// <param name="networkProfile"> Network-related settings of an agent pool. </param>
+        /// <param name="isOutboundNatDisabled"> The Windows agent pool's specific profile. </param>
+        /// <param name="securityProfile"> The security settings of an agent pool. </param>
+        /// <param name="gpuDriver"> GPU settings for the Agent Pool. </param>
+        /// <param name="gatewayPublicIPPrefixSize"> Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway. </param>
+        /// <param name="scaleManual"> Specifications on VirtualMachines agent pool. </param>
+        /// <param name="virtualMachineNodesStatus"> The status of nodes in a VirtualMachines agent pool. </param>
+        /// <param name="statusProvisioningError"> Contains read-only information about the Agent Pool. </param>
+        /// <param name="localDnsProfile"> Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns. </param>
+        /// <param name="name"> Unique name of the agent pool profile in the context of the subscription and resource group. Windows agent pool names must be 6 characters or less. </param>
         /// <returns> A new <see cref="Models.ManagedClusterAgentPoolProfile"/> instance for mocking. </returns>
         public static ManagedClusterAgentPoolProfile ManagedClusterAgentPoolProfile(ETag? etag = null, int? count = null, string vmSize = null, int? osDiskSizeInGB = null, ContainerServiceOSDiskType? osDiskType = null, KubeletDiskType? kubeletDiskType = null, WorkloadRuntime? workloadRuntime = null, string messageOfTheDay = null, ResourceIdentifier vnetSubnetId = null, ResourceIdentifier podSubnetId = null, PodIPAllocationMode? podIPAllocationMode = null, int? maxPods = null, ContainerServiceOSType? osType = null, ContainerServiceOSSku? osSku = null, int? maxCount = null, int? minCount = null, bool? enableAutoScaling = null, ScaleDownMode? scaleDownMode = null, AgentPoolType? agentPoolType = null, AgentPoolMode? mode = null, string orchestratorVersion = null, string currentOrchestratorVersion = null, string nodeImageVersion = null, AgentPoolUpgradeSettings upgradeSettings = null, string provisioningState = null, ContainerServiceStateCode? powerStateCode = null, IEnumerable<string> availabilityZones = null, bool? enableNodePublicIP = null, ResourceIdentifier nodePublicIPPrefixId = null, ScaleSetPriority? scaleSetPriority = null, ScaleSetEvictionPolicy? scaleSetEvictionPolicy = null, float? spotMaxPrice = null, IDictionary<string, string> tags = null, IDictionary<string, string> nodeLabels = null, IEnumerable<string> nodeTaints = null, ResourceIdentifier proximityPlacementGroupId = null, KubeletConfig kubeletConfig = null, LinuxOSConfig linuxOSConfig = null, bool? enableEncryptionAtHost = null, bool? enableUltraSsd = null, bool? enableFips = null, GpuInstanceProfile? gpuInstanceProfile = null, ResourceIdentifier creationDataSourceResourceId = null, ResourceIdentifier capacityReservationGroupId = null, ResourceIdentifier hostGroupId = null, AgentPoolNetworkProfile networkProfile = null, bool? isOutboundNatDisabled = null, AgentPoolSecurityProfile securityProfile = null, AgentPoolGpuDriver? gpuDriver = null, int? gatewayPublicIPPrefixSize = null, IEnumerable<ManualScaleProfile> scaleManual = null, IEnumerable<AgentPoolVirtualMachineNodes> virtualMachineNodesStatus = null, ResponseError statusProvisioningError = null, LocalDnsProfile localDnsProfile = null, string name = null)
         {
@@ -648,222 +312,60 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterAgentPoolProfileProperties"/>. </summary>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.eTag
-        /// </param>
-        /// <param name="count">
-        /// Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.count
-        /// </param>
-        /// <param name="vmSize">
-        /// The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vmSize
-        /// </param>
-        /// <param name="osDiskSizeInGB">
-        /// OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskSizeGB
-        /// </param>
-        /// <param name="osDiskType">
-        /// The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskType
-        /// </param>
-        /// <param name="kubeletDiskType">
-        /// Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletDiskType
-        /// </param>
-        /// <param name="workloadRuntime">
-        /// Determines the type of workload a node can run.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.workloadRuntime
-        /// </param>
-        /// <param name="messageOfTheDay">
-        /// Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.messageOfTheDay
-        /// </param>
-        /// <param name="vnetSubnetId">
-        /// The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vnetSubnetID
-        /// </param>
-        /// <param name="podSubnetId">
-        /// The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podSubnetID
-        /// </param>
-        /// <param name="podIPAllocationMode">
-        /// Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podIPAllocationMode
-        /// </param>
-        /// <param name="maxPods">
-        /// The maximum number of pods that can run on a node.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxPods
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osType
-        /// </param>
-        /// <param name="osSku">
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osSKU
-        /// </param>
-        /// <param name="maxCount">
-        /// The maximum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxCount
-        /// </param>
-        /// <param name="minCount">
-        /// The minimum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.minCount
-        /// </param>
-        /// <param name="enableAutoScaling">
-        /// Whether to enable auto-scaler
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableAutoScaling
-        /// </param>
-        /// <param name="scaleDownMode">
-        /// The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleDownMode
-        /// </param>
-        /// <param name="agentPoolType">
-        /// The type of Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.type
-        /// </param>
-        /// <param name="mode">
-        /// The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.mode
-        /// </param>
-        /// <param name="orchestratorVersion">
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.orchestratorVersion
-        /// </param>
-        /// <param name="currentOrchestratorVersion">
-        /// The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.currentOrchestratorVersion
-        /// </param>
-        /// <param name="nodeImageVersion">
-        /// The version of node image
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeImageVersion
-        /// </param>
-        /// <param name="upgradeSettings">
-        /// Settings for upgrading the agentpool
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.upgradeSettings
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current deployment or provisioning state.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.provisioningState
-        /// </param>
-        /// <param name="powerStateCode">
-        /// Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.powerState
-        /// </param>
-        /// <param name="availabilityZones">
-        /// The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.availabilityZones
-        /// </param>
-        /// <param name="enableNodePublicIP">
-        /// Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableNodePublicIP
-        /// </param>
-        /// <param name="nodePublicIPPrefixId">
-        /// The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodePublicIPPrefixID
-        /// </param>
-        /// <param name="scaleSetPriority">
-        /// The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetPriority
-        /// </param>
-        /// <param name="scaleSetEvictionPolicy">
-        /// The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetEvictionPolicy
-        /// </param>
-        /// <param name="spotMaxPrice">
-        /// The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.spotMaxPrice
-        /// </param>
-        /// <param name="tags">
-        /// The tags to be persisted on the agent pool virtual machine scale set.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.tags
-        /// </param>
-        /// <param name="nodeLabels">
-        /// The node labels to be persisted across all nodes in agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeLabels
-        /// </param>
-        /// <param name="nodeTaints">
-        /// The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeTaints
-        /// </param>
-        /// <param name="proximityPlacementGroupId">
-        /// The ID for Proximity Placement Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.proximityPlacementGroupID
-        /// </param>
-        /// <param name="kubeletConfig">
-        /// The Kubelet configuration on the agent pool nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletConfig
-        /// </param>
-        /// <param name="linuxOSConfig">
-        /// The OS configuration of Linux agent nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.linuxOSConfig
-        /// </param>
-        /// <param name="enableEncryptionAtHost">
-        /// Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableEncryptionAtHost
-        /// </param>
-        /// <param name="enableUltraSsd">
-        /// Whether to enable UltraSSD
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableUltraSSD
-        /// </param>
-        /// <param name="enableFips">
-        /// Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableFIPS
-        /// </param>
-        /// <param name="gpuInstanceProfile">
-        /// GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuInstanceProfile
-        /// </param>
-        /// <param name="creationDataSourceResourceId">
-        /// CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.creationData
-        /// </param>
-        /// <param name="capacityReservationGroupId">
-        /// AKS will associate the specified agent pool with the Capacity Reservation Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.capacityReservationGroupID
-        /// </param>
-        /// <param name="hostGroupId">
-        /// The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.hostGroupID
-        /// </param>
-        /// <param name="networkProfile">
-        /// Network-related settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.networkProfile
-        /// </param>
-        /// <param name="isOutboundNatDisabled">
-        /// The Windows agent pool's specific profile.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.windowsProfile
-        /// </param>
-        /// <param name="securityProfile">
-        /// The security settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.securityProfile
-        /// </param>
-        /// <param name="gpuDriver">
-        /// GPU settings for the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuProfile
-        /// </param>
-        /// <param name="gatewayPublicIPPrefixSize">
-        /// Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gatewayProfile
-        /// </param>
-        /// <param name="scaleManual">
-        /// Specifications on VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachinesProfile
-        /// </param>
-        /// <param name="virtualMachineNodesStatus">
-        /// The status of nodes in a VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachineNodesStatus
-        /// </param>
-        /// <param name="statusProvisioningError">
-        /// Contains read-only information about the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.status
-        /// </param>
-        /// <param name="localDnsProfile">
-        /// Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.localDNSProfile
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="count"> Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1. </param>
+        /// <param name="vmSize"> The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions. </param>
+        /// <param name="osDiskSizeInGB"> OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified. </param>
+        /// <param name="osDiskType"> The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os). </param>
+        /// <param name="kubeletDiskType"> Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. </param>
+        /// <param name="workloadRuntime"> Determines the type of workload a node can run. </param>
+        /// <param name="messageOfTheDay"> Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script). </param>
+        /// <param name="vnetSubnetId"> The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podSubnetId"> The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podIPAllocationMode"> Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'. </param>
+        /// <param name="maxPods"> The maximum number of pods that can run on a node. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="osSku"> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </param>
+        /// <param name="maxCount"> The maximum number of nodes for auto-scaling. </param>
+        /// <param name="minCount"> The minimum number of nodes for auto-scaling. </param>
+        /// <param name="enableAutoScaling"> Whether to enable auto-scaler. </param>
+        /// <param name="scaleDownMode"> The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete. </param>
+        /// <param name="agentPoolType"> The type of Agent Pool. </param>
+        /// <param name="mode"> The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools. </param>
+        /// <param name="orchestratorVersion"> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool). </param>
+        /// <param name="currentOrchestratorVersion"> The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </param>
+        /// <param name="nodeImageVersion"> The version of node image. </param>
+        /// <param name="upgradeSettings"> Settings for upgrading the agentpool. </param>
+        /// <param name="provisioningState"> The current deployment or provisioning state. </param>
+        /// <param name="powerStateCode"> Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded. </param>
+        /// <param name="availabilityZones"> The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'. </param>
+        /// <param name="enableNodePublicIP"> Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false. </param>
+        /// <param name="nodePublicIPPrefixId"> The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}. </param>
+        /// <param name="scaleSetPriority"> The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'. </param>
+        /// <param name="scaleSetEvictionPolicy"> The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'. </param>
+        /// <param name="spotMaxPrice"> The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing). </param>
+        /// <param name="tags"> The tags to be persisted on the agent pool virtual machine scale set. </param>
+        /// <param name="nodeLabels"> The node labels to be persisted across all nodes in agent pool. </param>
+        /// <param name="nodeTaints"> The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. </param>
+        /// <param name="proximityPlacementGroupId"> The ID for Proximity Placement Group. </param>
+        /// <param name="kubeletConfig"> The Kubelet configuration on the agent pool nodes. </param>
+        /// <param name="linuxOSConfig"> The OS configuration of Linux agent nodes. </param>
+        /// <param name="enableEncryptionAtHost"> Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption. </param>
+        /// <param name="enableUltraSsd"> Whether to enable UltraSSD. </param>
+        /// <param name="enableFips"> Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details. </param>
+        /// <param name="gpuInstanceProfile"> GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU. </param>
+        /// <param name="creationDataSourceResourceId"> CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot. </param>
+        /// <param name="capacityReservationGroupId"> AKS will associate the specified agent pool with the Capacity Reservation Group. </param>
+        /// <param name="hostGroupId"> The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts). </param>
+        /// <param name="networkProfile"> Network-related settings of an agent pool. </param>
+        /// <param name="isOutboundNatDisabled"> The Windows agent pool's specific profile. </param>
+        /// <param name="securityProfile"> The security settings of an agent pool. </param>
+        /// <param name="gpuDriver"> GPU settings for the Agent Pool. </param>
+        /// <param name="gatewayPublicIPPrefixSize"> Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway. </param>
+        /// <param name="scaleManual"> Specifications on VirtualMachines agent pool. </param>
+        /// <param name="virtualMachineNodesStatus"> The status of nodes in a VirtualMachines agent pool. </param>
+        /// <param name="statusProvisioningError"> Contains read-only information about the Agent Pool. </param>
+        /// <param name="localDnsProfile"> Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns. </param>
         /// <returns> A new <see cref="Models.ManagedClusterAgentPoolProfileProperties"/> instance for mocking. </returns>
         public static ManagedClusterAgentPoolProfileProperties ManagedClusterAgentPoolProfileProperties(ETag? etag = null, int? count = null, string vmSize = null, int? osDiskSizeInGB = null, ContainerServiceOSDiskType? osDiskType = null, KubeletDiskType? kubeletDiskType = null, WorkloadRuntime? workloadRuntime = null, string messageOfTheDay = null, ResourceIdentifier vnetSubnetId = null, ResourceIdentifier podSubnetId = null, PodIPAllocationMode? podIPAllocationMode = null, int? maxPods = null, ContainerServiceOSType? osType = null, ContainerServiceOSSku? osSku = null, int? maxCount = null, int? minCount = null, bool? enableAutoScaling = null, ScaleDownMode? scaleDownMode = null, AgentPoolType? agentPoolType = null, AgentPoolMode? mode = null, string orchestratorVersion = null, string currentOrchestratorVersion = null, string nodeImageVersion = null, AgentPoolUpgradeSettings upgradeSettings = null, string provisioningState = null, ContainerServiceStateCode? powerStateCode = null, IEnumerable<string> availabilityZones = null, bool? enableNodePublicIP = null, ResourceIdentifier nodePublicIPPrefixId = null, ScaleSetPriority? scaleSetPriority = null, ScaleSetEvictionPolicy? scaleSetEvictionPolicy = null, float? spotMaxPrice = null, IDictionary<string, string> tags = null, IDictionary<string, string> nodeLabels = null, IEnumerable<string> nodeTaints = null, ResourceIdentifier proximityPlacementGroupId = null, KubeletConfig kubeletConfig = null, LinuxOSConfig linuxOSConfig = null, bool? enableEncryptionAtHost = null, bool? enableUltraSsd = null, bool? enableFips = null, GpuInstanceProfile? gpuInstanceProfile = null, ResourceIdentifier creationDataSourceResourceId = null, ResourceIdentifier capacityReservationGroupId = null, ResourceIdentifier hostGroupId = null, AgentPoolNetworkProfile networkProfile = null, bool? isOutboundNatDisabled = null, AgentPoolSecurityProfile securityProfile = null, AgentPoolGpuDriver? gpuDriver = null, int? gatewayPublicIPPrefixSize = null, IEnumerable<ManualScaleProfile> scaleManual = null, IEnumerable<AgentPoolVirtualMachineNodes> virtualMachineNodesStatus = null, ResponseError statusProvisioningError = null, LocalDnsProfile localDnsProfile = null)
         {
@@ -933,22 +435,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.LocalDnsProfile"/>. </summary>
-        /// <param name="mode">
-        /// Mode of enablement for localDNS.
-        /// Serialized Name: LocalDNSProfile.mode
-        /// </param>
-        /// <param name="state">
-        /// System-generated state of localDNS.
-        /// Serialized Name: LocalDNSProfile.state
-        /// </param>
-        /// <param name="vnetDnsOverrides">
-        /// VnetDNS overrides apply to DNS traffic from pods with dnsPolicy:default or kubelet (referred to as VnetDNS traffic).
-        /// Serialized Name: LocalDNSProfile.vnetDNSOverrides
-        /// </param>
-        /// <param name="kubeDnsOverrides">
-        /// KubeDNS overrides apply to DNS traffic from pods with dnsPolicy:ClusterFirst (referred to as KubeDNS traffic).
-        /// Serialized Name: LocalDNSProfile.kubeDNSOverrides
-        /// </param>
+        /// <param name="mode"> Mode of enablement for localDNS. </param>
+        /// <param name="state"> System-generated state of localDNS. </param>
+        /// <param name="vnetDnsOverrides"> VnetDNS overrides apply to DNS traffic from pods with dnsPolicy:default or kubelet (referred to as VnetDNS traffic). </param>
+        /// <param name="kubeDnsOverrides"> KubeDNS overrides apply to DNS traffic from pods with dnsPolicy:ClusterFirst (referred to as KubeDNS traffic). </param>
         /// <returns> A new <see cref="Models.LocalDnsProfile"/> instance for mocking. </returns>
         public static LocalDnsProfile LocalDnsProfile(LocalDnsMode? mode = null, LocalDnsState? state = null, IDictionary<string, LocalDnsOverride> vnetDnsOverrides = null, IDictionary<string, LocalDnsOverride> kubeDnsOverrides = null)
         {
@@ -959,18 +449,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterAddonProfile"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether the add-on is enabled or not.
-        /// Serialized Name: ManagedClusterAddonProfile.enabled
-        /// </param>
-        /// <param name="config">
-        /// Key-value pairs for configuring an add-on.
-        /// Serialized Name: ManagedClusterAddonProfile.config
-        /// </param>
-        /// <param name="identity">
-        /// Information of user assigned identity used by this add-on.
-        /// Serialized Name: ManagedClusterAddonProfile.identity
-        /// </param>
+        /// <param name="isEnabled"> Whether the add-on is enabled or not. </param>
+        /// <param name="config"> Key-value pairs for configuring an add-on. </param>
+        /// <param name="identity"> Information of user assigned identity used by this add-on. </param>
         /// <returns> A new <see cref="Models.ManagedClusterAddonProfile"/> instance for mocking. </returns>
         public static ManagedClusterAddonProfile ManagedClusterAddonProfile(bool isEnabled = default, IDictionary<string, string> config = null, ManagedClusterAddonProfileIdentity identity = null)
         {
@@ -980,27 +461,12 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterPodIdentity"/>. </summary>
-        /// <param name="name">
-        /// The name of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.name
-        /// </param>
-        /// <param name="namespace">
-        /// The namespace of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.namespace
-        /// </param>
-        /// <param name="bindingSelector">
-        /// The binding selector to use for the AzureIdentityBinding resource.
-        /// Serialized Name: ManagedClusterPodIdentity.bindingSelector
-        /// </param>
-        /// <param name="identity">
-        /// The user assigned identity details.
-        /// Serialized Name: ManagedClusterPodIdentity.identity
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current provisioning state of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.provisioningState
-        /// </param>
-        /// <param name="errorDetail"> Serialized Name: ManagedClusterPodIdentity.provisioningInfo. </param>
+        /// <param name="name"> The name of the pod identity. </param>
+        /// <param name="namespace"> The namespace of the pod identity. </param>
+        /// <param name="bindingSelector"> The binding selector to use for the AzureIdentityBinding resource. </param>
+        /// <param name="identity"> The user assigned identity details. </param>
+        /// <param name="provisioningState"> The current provisioning state of the pod identity. </param>
+        /// <param name="errorDetail"></param>
         /// <returns> A new <see cref="Models.ManagedClusterPodIdentity"/> instance for mocking. </returns>
         public static ManagedClusterPodIdentity ManagedClusterPodIdentity(string name = null, string @namespace = null, string bindingSelector = null, ContainerServiceUserAssignedIdentity identity = null, ManagedClusterPodIdentityProvisioningState? provisioningState = null, ResponseError errorDetail = null)
         {
@@ -1015,14 +481,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterOidcIssuerProfile"/>. </summary>
-        /// <param name="issuerUriInfo">
-        /// The OIDC issuer url of the Managed Cluster.
-        /// Serialized Name: ManagedClusterOidcIssuerProfile.issuerURL
-        /// </param>
-        /// <param name="isEnabled">
-        /// Whether the OIDC issuer is enabled.
-        /// Serialized Name: ManagedClusterOidcIssuerProfile.enabled
-        /// </param>
+        /// <param name="issuerUriInfo"> The OIDC issuer url of the Managed Cluster. </param>
+        /// <param name="isEnabled"> Whether the OIDC issuer is enabled. </param>
         /// <returns> A new <see cref="Models.ManagedClusterOidcIssuerProfile"/> instance for mocking. </returns>
         public static ManagedClusterOidcIssuerProfile ManagedClusterOidcIssuerProfile(string issuerUriInfo = null, bool? isEnabled = null)
         {
@@ -1030,30 +490,12 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ContainerServicePrivateLinkResourceData"/>. </summary>
-        /// <param name="id">
-        /// The ID of the private link resource.
-        /// Serialized Name: PrivateLinkResource.id
-        /// </param>
-        /// <param name="name">
-        /// The name of the private link resource.
-        /// Serialized Name: PrivateLinkResource.name
-        /// </param>
-        /// <param name="resourceType">
-        /// The resource type.
-        /// Serialized Name: PrivateLinkResource.type
-        /// </param>
-        /// <param name="groupId">
-        /// The group ID of the resource.
-        /// Serialized Name: PrivateLinkResource.groupId
-        /// </param>
-        /// <param name="requiredMembers">
-        /// The RequiredMembers of the resource
-        /// Serialized Name: PrivateLinkResource.requiredMembers
-        /// </param>
-        /// <param name="privateLinkServiceId">
-        /// The private link service ID of the resource, this field is exposed only to NRP internally.
-        /// Serialized Name: PrivateLinkResource.privateLinkServiceID
-        /// </param>
+        /// <param name="id"> The ID of the private link resource. </param>
+        /// <param name="name"> The name of the private link resource. </param>
+        /// <param name="resourceType"> The resource type. </param>
+        /// <param name="groupId"> The group ID of the resource. </param>
+        /// <param name="requiredMembers"> The RequiredMembers of the resource. </param>
+        /// <param name="privateLinkServiceId"> The private link service ID of the resource, this field is exposed only to NRP internally. </param>
         /// <returns> A new <see cref="Models.ContainerServicePrivateLinkResourceData"/> instance for mocking. </returns>
         public static ContainerServicePrivateLinkResourceData ContainerServicePrivateLinkResourceData(ResourceIdentifier id = null, string name = null, ResourceType? resourceType = null, string groupId = null, IEnumerable<string> requiredMembers = null, ResourceIdentifier privateLinkServiceId = null)
         {
@@ -1070,22 +512,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterIngressProfileWebAppRouting"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable the Application Routing add-on.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.enabled
-        /// </param>
-        /// <param name="dnsZoneResourceIds">
-        /// Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.dnsZoneResourceIds
-        /// </param>
-        /// <param name="nginxDefaultIngressControllerType">
-        /// Configuration for the default NginxIngressController. See more at https://learn.microsoft.com/en-us/azure/aks/app-routing-nginx-configuration#the-default-nginx-ingress-controller.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.nginx
-        /// </param>
-        /// <param name="identity">
-        /// Managed identity of the Application Routing add-on. This is the identity that should be granted permissions, for example, to manage the associated Azure DNS resource and get certificates from Azure Key Vault. See [this overview of the add-on](https://learn.microsoft.com/en-us/azure/aks/web-app-routing?tabs=with-osm) for more instructions.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.identity
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable the Application Routing add-on. </param>
+        /// <param name="dnsZoneResourceIds"> Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group. </param>
+        /// <param name="nginxDefaultIngressControllerType"> Configuration for the default NginxIngressController. See more at https://learn.microsoft.com/en-us/azure/aks/app-routing-nginx-configuration#the-default-nginx-ingress-controller. </param>
+        /// <param name="identity"> Managed identity of the Application Routing add-on. This is the identity that should be granted permissions, for example, to manage the associated Azure DNS resource and get certificates from Azure Key Vault. See [this overview of the add-on](https://learn.microsoft.com/en-us/azure/aks/web-app-routing?tabs=with-osm) for more instructions. </param>
         /// <returns> A new <see cref="Models.ManagedClusterIngressProfileWebAppRouting"/> instance for mocking. </returns>
         public static ManagedClusterIngressProfileWebAppRouting ManagedClusterIngressProfileWebAppRouting(bool? isEnabled = null, IEnumerable<ResourceIdentifier> dnsZoneResourceIds = null, NginxIngressControllerType? nginxDefaultIngressControllerType = null, ContainerServiceUserAssignedIdentity identity = null)
         {
@@ -1099,14 +529,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="controlPlaneProfile">
-        /// The list of available upgrade versions for the control plane.
-        /// Serialized Name: ManagedClusterUpgradeProfile.properties.controlPlaneProfile
-        /// </param>
-        /// <param name="agentPoolProfiles">
-        /// The list of available upgrade versions for agent pools.
-        /// Serialized Name: ManagedClusterUpgradeProfile.properties.agentPoolProfiles
-        /// </param>
+        /// <param name="controlPlaneProfile"> The list of available upgrade versions for the control plane. </param>
+        /// <param name="agentPoolProfiles"> The list of available upgrade versions for agent pools. </param>
         /// <returns> A new <see cref="ContainerService.ManagedClusterUpgradeProfileData"/> instance for mocking. </returns>
         public static ManagedClusterUpgradeProfileData ManagedClusterUpgradeProfileData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, ManagedClusterPoolUpgradeProfile controlPlaneProfile = null, IEnumerable<ManagedClusterPoolUpgradeProfile> agentPoolProfiles = null)
         {
@@ -1123,22 +547,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterPoolUpgradeProfile"/>. </summary>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.kubernetesVersion
-        /// </param>
-        /// <param name="name">
-        /// The Agent Pool name.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.name
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.osType
-        /// </param>
-        /// <param name="upgrades">
-        /// List of orchestrator types and versions available for upgrade.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.upgrades
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="name"> The Agent Pool name. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="upgrades"> List of orchestrator types and versions available for upgrade. </param>
         /// <returns> A new <see cref="Models.ManagedClusterPoolUpgradeProfile"/> instance for mocking. </returns>
         public static ManagedClusterPoolUpgradeProfile ManagedClusterPoolUpgradeProfile(string kubernetesVersion = null, string name = null, ContainerServiceOSType osType = default, IEnumerable<ManagedClusterPoolUpgradeProfileUpgradesItem> upgrades = null)
         {
@@ -1148,14 +560,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterPoolUpgradeProfileUpgradesItem"/>. </summary>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: ManagedClusterPoolUpgradeProfileUpgradesItem.kubernetesVersion
-        /// </param>
-        /// <param name="isPreview">
-        /// Whether the Kubernetes version is currently in preview.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfileUpgradesItem.isPreview
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="isPreview"> Whether the Kubernetes version is currently in preview. </param>
         /// <returns> A new <see cref="Models.ManagedClusterPoolUpgradeProfileUpgradesItem"/> instance for mocking. </returns>
         public static ManagedClusterPoolUpgradeProfileUpgradesItem ManagedClusterPoolUpgradeProfileUpgradesItem(string kubernetesVersion = null, bool? isPreview = null)
         {
@@ -1169,10 +575,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="kubeConfig">
-        /// Base64-encoded Kubernetes configuration file.
-        /// Serialized Name: ManagedClusterAccessProfile.properties.kubeConfig
-        /// </param>
+        /// <param name="kubeConfig"> Base64-encoded Kubernetes configuration file. </param>
         /// <returns> A new <see cref="Models.ManagedClusterAccessProfile"/> instance for mocking. </returns>
         public static ManagedClusterAccessProfile ManagedClusterAccessProfile(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IDictionary<string, string> tags = null, AzureLocation location = default, byte[] kubeConfig = null)
         {
@@ -1190,10 +593,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterCredentials"/>. </summary>
-        /// <param name="kubeconfigs">
-        /// Base64-encoded Kubernetes configuration file.
-        /// Serialized Name: CredentialResults.kubeconfigs
-        /// </param>
+        /// <param name="kubeconfigs"> Base64-encoded Kubernetes configuration file. </param>
         /// <returns> A new <see cref="Models.ManagedClusterCredentials"/> instance for mocking. </returns>
         public static ManagedClusterCredentials ManagedClusterCredentials(IEnumerable<ManagedClusterCredential> kubeconfigs = null)
         {
@@ -1203,14 +603,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterCredential"/>. </summary>
-        /// <param name="name">
-        /// The name of the credential.
-        /// Serialized Name: CredentialResult.name
-        /// </param>
-        /// <param name="value">
-        /// Base64-encoded Kubernetes configuration file.
-        /// Serialized Name: CredentialResult.value
-        /// </param>
+        /// <param name="name"> The name of the credential. </param>
+        /// <param name="value"> Base64-encoded Kubernetes configuration file. </param>
         /// <returns> A new <see cref="Models.ManagedClusterCredential"/> instance for mocking. </returns>
         public static ManagedClusterCredential ManagedClusterCredential(string name = null, byte[] value = null)
         {
@@ -1222,18 +616,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="timesInWeek">
-        /// Time slots during the week when planned maintenance is allowed to proceed. If two array entries specify the same day of the week, the applied configuration is the union of times in both entries.
-        /// Serialized Name: MaintenanceConfiguration.properties.timeInWeek
-        /// </param>
-        /// <param name="notAllowedTimes">
-        /// Time slots on which upgrade is not allowed.
-        /// Serialized Name: MaintenanceConfiguration.properties.notAllowedTime
-        /// </param>
-        /// <param name="maintenanceWindow">
-        /// Maintenance window for the maintenance configuration.
-        /// Serialized Name: MaintenanceConfiguration.properties.maintenanceWindow
-        /// </param>
+        /// <param name="timesInWeek"> Time slots during the week when planned maintenance is allowed to proceed. If two array entries specify the same day of the week, the applied configuration is the union of times in both entries. </param>
+        /// <param name="notAllowedTimes"> Time slots on which upgrade is not allowed. </param>
+        /// <param name="maintenanceWindow"> Maintenance window for the maintenance configuration. </param>
         /// <returns> A new <see cref="ContainerService.ContainerServiceMaintenanceConfigurationData"/> instance for mocking. </returns>
         public static ContainerServiceMaintenanceConfigurationData ContainerServiceMaintenanceConfigurationData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IEnumerable<ContainerServiceTimeInWeek> timesInWeek = null, IEnumerable<ContainerServiceTimeSpan> notAllowedTimes = null, ContainerServiceMaintenanceWindow maintenanceWindow = null)
         {
@@ -1258,14 +643,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedNamespace.eTag
-        /// </param>
-        /// <param name="properties">
-        /// Properties of a namespace.
-        /// Serialized Name: ManagedNamespace.properties
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="properties"> Properties of a namespace. </param>
         /// <returns> A new <see cref="ContainerService.ManagedClusterNamespaceData"/> instance for mocking. </returns>
         public static ManagedClusterNamespaceData ManagedClusterNamespaceData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IDictionary<string, string> tags = null, AzureLocation location = default, ETag? etag = null, ManagedClusterNamespaceProperties properties = null)
         {
@@ -1284,38 +663,14 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterNamespaceProperties"/>. </summary>
-        /// <param name="provisioningState">
-        /// The current provisioning state of the namespace.
-        /// Serialized Name: NamespaceProperties.provisioningState
-        /// </param>
-        /// <param name="labels">
-        /// The labels of managed namespace.
-        /// Serialized Name: NamespaceProperties.labels
-        /// </param>
-        /// <param name="annotations">
-        /// The annotations of managed namespace.
-        /// Serialized Name: NamespaceProperties.annotations
-        /// </param>
-        /// <param name="portalFqdn">
-        /// The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly.
-        /// Serialized Name: NamespaceProperties.portalFqdn
-        /// </param>
-        /// <param name="defaultResourceQuota">
-        /// The default resource quota enforced upon the namespace. Customers can have other Kubernetes resource quota objects under the namespace. Resource quotas are additive; if multiple resource quotas are applied to a given namespace, then the effective limit will be one such that all quotas on the namespace can be satisfied.
-        /// Serialized Name: NamespaceProperties.defaultResourceQuota
-        /// </param>
-        /// <param name="defaultNetworkPolicy">
-        /// The default network policy enforced upon the namespace. Customers can have other Kubernetes network policy objects under the namespace. Network policies are additive; if a policy or policies apply to a given pod for a given direction, the connections allowed in that direction for the pod is the union of what all applicable policies allow.
-        /// Serialized Name: NamespaceProperties.defaultNetworkPolicy
-        /// </param>
-        /// <param name="adoptionPolicy">
-        /// Action if Kubernetes namespace with same name already exists.
-        /// Serialized Name: NamespaceProperties.adoptionPolicy
-        /// </param>
-        /// <param name="deletePolicy">
-        /// Delete options of a namespace.
-        /// Serialized Name: NamespaceProperties.deletePolicy
-        /// </param>
+        /// <param name="provisioningState"> The current provisioning state of the namespace. </param>
+        /// <param name="labels"> The labels of managed namespace. </param>
+        /// <param name="annotations"> The annotations of managed namespace. </param>
+        /// <param name="portalFqdn"> The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly. </param>
+        /// <param name="defaultResourceQuota"> The default resource quota enforced upon the namespace. Customers can have other Kubernetes resource quota objects under the namespace. Resource quotas are additive; if multiple resource quotas are applied to a given namespace, then the effective limit will be one such that all quotas on the namespace can be satisfied. </param>
+        /// <param name="defaultNetworkPolicy"> The default network policy enforced upon the namespace. Customers can have other Kubernetes network policy objects under the namespace. Network policies are additive; if a policy or policies apply to a given pod for a given direction, the connections allowed in that direction for the pod is the union of what all applicable policies allow. </param>
+        /// <param name="adoptionPolicy"> Action if Kubernetes namespace with same name already exists. </param>
+        /// <param name="deletePolicy"> Delete options of a namespace. </param>
         /// <returns> A new <see cref="Models.ManagedClusterNamespaceProperties"/> instance for mocking. </returns>
         public static ManagedClusterNamespaceProperties ManagedClusterNamespaceProperties(ManagedClusterNamespaceProvisioningState? provisioningState = null, IDictionary<string, string> labels = null, IDictionary<string, string> annotations = null, string portalFqdn = null, NamespaceResourceQuota defaultResourceQuota = null, NamespaceNetworkPolicies defaultNetworkPolicy = null, NamespaceAdoptionPolicy? adoptionPolicy = null, NamespaceDeletePolicy? deletePolicy = null)
         {
@@ -1339,222 +694,60 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: AgentPool.properties.eTag
-        /// </param>
-        /// <param name="count">
-        /// Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
-        /// Serialized Name: AgentPool.properties.count
-        /// </param>
-        /// <param name="vmSize">
-        /// The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions
-        /// Serialized Name: AgentPool.properties.vmSize
-        /// </param>
-        /// <param name="osDiskSizeInGB">
-        /// OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-        /// Serialized Name: AgentPool.properties.osDiskSizeGB
-        /// </param>
-        /// <param name="osDiskType">
-        /// The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-        /// Serialized Name: AgentPool.properties.osDiskType
-        /// </param>
-        /// <param name="kubeletDiskType">
-        /// Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
-        /// Serialized Name: AgentPool.properties.kubeletDiskType
-        /// </param>
-        /// <param name="workloadRuntime">
-        /// Determines the type of workload a node can run.
-        /// Serialized Name: AgentPool.properties.workloadRuntime
-        /// </param>
-        /// <param name="messageOfTheDay">
-        /// Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script).
-        /// Serialized Name: AgentPool.properties.messageOfTheDay
-        /// </param>
-        /// <param name="vnetSubnetId">
-        /// The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: AgentPool.properties.vnetSubnetID
-        /// </param>
-        /// <param name="podSubnetId">
-        /// The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: AgentPool.properties.podSubnetID
-        /// </param>
-        /// <param name="podIPAllocationMode">
-        /// Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
-        /// Serialized Name: AgentPool.properties.podIPAllocationMode
-        /// </param>
-        /// <param name="maxPods">
-        /// The maximum number of pods that can run on a node.
-        /// Serialized Name: AgentPool.properties.maxPods
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: AgentPool.properties.osType
-        /// </param>
-        /// <param name="osSku">
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: AgentPool.properties.osSKU
-        /// </param>
-        /// <param name="maxCount">
-        /// The maximum number of nodes for auto-scaling
-        /// Serialized Name: AgentPool.properties.maxCount
-        /// </param>
-        /// <param name="minCount">
-        /// The minimum number of nodes for auto-scaling
-        /// Serialized Name: AgentPool.properties.minCount
-        /// </param>
-        /// <param name="enableAutoScaling">
-        /// Whether to enable auto-scaler
-        /// Serialized Name: AgentPool.properties.enableAutoScaling
-        /// </param>
-        /// <param name="scaleDownMode">
-        /// The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
-        /// Serialized Name: AgentPool.properties.scaleDownMode
-        /// </param>
-        /// <param name="typePropertiesType">
-        /// The type of Agent Pool.
-        /// Serialized Name: AgentPool.properties.type
-        /// </param>
-        /// <param name="mode">
-        /// The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
-        /// Serialized Name: AgentPool.properties.mode
-        /// </param>
-        /// <param name="orchestratorVersion">
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-        /// Serialized Name: AgentPool.properties.orchestratorVersion
-        /// </param>
-        /// <param name="currentOrchestratorVersion">
-        /// The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: AgentPool.properties.currentOrchestratorVersion
-        /// </param>
-        /// <param name="nodeImageVersion">
-        /// The version of node image
-        /// Serialized Name: AgentPool.properties.nodeImageVersion
-        /// </param>
-        /// <param name="upgradeSettings">
-        /// Settings for upgrading the agentpool
-        /// Serialized Name: AgentPool.properties.upgradeSettings
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current deployment or provisioning state.
-        /// Serialized Name: AgentPool.properties.provisioningState
-        /// </param>
-        /// <param name="powerStateCode">
-        /// Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded
-        /// Serialized Name: AgentPool.properties.powerState
-        /// </param>
-        /// <param name="availabilityZones">
-        /// The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
-        /// Serialized Name: AgentPool.properties.availabilityZones
-        /// </param>
-        /// <param name="enableNodePublicIP">
-        /// Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false.
-        /// Serialized Name: AgentPool.properties.enableNodePublicIP
-        /// </param>
-        /// <param name="nodePublicIPPrefixId">
-        /// The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
-        /// Serialized Name: AgentPool.properties.nodePublicIPPrefixID
-        /// </param>
-        /// <param name="scaleSetPriority">
-        /// The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'.
-        /// Serialized Name: AgentPool.properties.scaleSetPriority
-        /// </param>
-        /// <param name="scaleSetEvictionPolicy">
-        /// The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'.
-        /// Serialized Name: AgentPool.properties.scaleSetEvictionPolicy
-        /// </param>
-        /// <param name="spotMaxPrice">
-        /// The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)
-        /// Serialized Name: AgentPool.properties.spotMaxPrice
-        /// </param>
-        /// <param name="tags">
-        /// The tags to be persisted on the agent pool virtual machine scale set.
-        /// Serialized Name: AgentPool.properties.tags
-        /// </param>
-        /// <param name="nodeLabels">
-        /// The node labels to be persisted across all nodes in agent pool.
-        /// Serialized Name: AgentPool.properties.nodeLabels
-        /// </param>
-        /// <param name="nodeTaints">
-        /// The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
-        /// Serialized Name: AgentPool.properties.nodeTaints
-        /// </param>
-        /// <param name="proximityPlacementGroupId">
-        /// The ID for Proximity Placement Group.
-        /// Serialized Name: AgentPool.properties.proximityPlacementGroupID
-        /// </param>
-        /// <param name="kubeletConfig">
-        /// The Kubelet configuration on the agent pool nodes.
-        /// Serialized Name: AgentPool.properties.kubeletConfig
-        /// </param>
-        /// <param name="linuxOSConfig">
-        /// The OS configuration of Linux agent nodes.
-        /// Serialized Name: AgentPool.properties.linuxOSConfig
-        /// </param>
-        /// <param name="enableEncryptionAtHost">
-        /// Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption
-        /// Serialized Name: AgentPool.properties.enableEncryptionAtHost
-        /// </param>
-        /// <param name="enableUltraSsd">
-        /// Whether to enable UltraSSD
-        /// Serialized Name: AgentPool.properties.enableUltraSSD
-        /// </param>
-        /// <param name="enableFips">
-        /// Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details.
-        /// Serialized Name: AgentPool.properties.enableFIPS
-        /// </param>
-        /// <param name="gpuInstanceProfile">
-        /// GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-        /// Serialized Name: AgentPool.properties.gpuInstanceProfile
-        /// </param>
-        /// <param name="creationDataSourceResourceId">
-        /// CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot.
-        /// Serialized Name: AgentPool.properties.creationData
-        /// </param>
-        /// <param name="capacityReservationGroupId">
-        /// AKS will associate the specified agent pool with the Capacity Reservation Group.
-        /// Serialized Name: AgentPool.properties.capacityReservationGroupID
-        /// </param>
-        /// <param name="hostGroupId">
-        /// The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
-        /// Serialized Name: AgentPool.properties.hostGroupID
-        /// </param>
-        /// <param name="networkProfile">
-        /// Network-related settings of an agent pool.
-        /// Serialized Name: AgentPool.properties.networkProfile
-        /// </param>
-        /// <param name="isOutboundNatDisabled">
-        /// The Windows agent pool's specific profile.
-        /// Serialized Name: AgentPool.properties.windowsProfile
-        /// </param>
-        /// <param name="securityProfile">
-        /// The security settings of an agent pool.
-        /// Serialized Name: AgentPool.properties.securityProfile
-        /// </param>
-        /// <param name="gpuDriver">
-        /// GPU settings for the Agent Pool.
-        /// Serialized Name: AgentPool.properties.gpuProfile
-        /// </param>
-        /// <param name="gatewayPublicIPPrefixSize">
-        /// Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway.
-        /// Serialized Name: AgentPool.properties.gatewayProfile
-        /// </param>
-        /// <param name="scaleManual">
-        /// Specifications on VirtualMachines agent pool.
-        /// Serialized Name: AgentPool.properties.virtualMachinesProfile
-        /// </param>
-        /// <param name="virtualMachineNodesStatus">
-        /// The status of nodes in a VirtualMachines agent pool.
-        /// Serialized Name: AgentPool.properties.virtualMachineNodesStatus
-        /// </param>
-        /// <param name="statusProvisioningError">
-        /// Contains read-only information about the Agent Pool.
-        /// Serialized Name: AgentPool.properties.status
-        /// </param>
-        /// <param name="localDnsProfile">
-        /// Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
-        /// Serialized Name: AgentPool.properties.localDNSProfile
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="count"> Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1. </param>
+        /// <param name="vmSize"> The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions. </param>
+        /// <param name="osDiskSizeInGB"> OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified. </param>
+        /// <param name="osDiskType"> The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os). </param>
+        /// <param name="kubeletDiskType"> Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. </param>
+        /// <param name="workloadRuntime"> Determines the type of workload a node can run. </param>
+        /// <param name="messageOfTheDay"> Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script). </param>
+        /// <param name="vnetSubnetId"> The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podSubnetId"> The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podIPAllocationMode"> Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'. </param>
+        /// <param name="maxPods"> The maximum number of pods that can run on a node. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="osSku"> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </param>
+        /// <param name="maxCount"> The maximum number of nodes for auto-scaling. </param>
+        /// <param name="minCount"> The minimum number of nodes for auto-scaling. </param>
+        /// <param name="enableAutoScaling"> Whether to enable auto-scaler. </param>
+        /// <param name="scaleDownMode"> The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete. </param>
+        /// <param name="typePropertiesType"> The type of Agent Pool. </param>
+        /// <param name="mode"> The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools. </param>
+        /// <param name="orchestratorVersion"> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool). </param>
+        /// <param name="currentOrchestratorVersion"> The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </param>
+        /// <param name="nodeImageVersion"> The version of node image. </param>
+        /// <param name="upgradeSettings"> Settings for upgrading the agentpool. </param>
+        /// <param name="provisioningState"> The current deployment or provisioning state. </param>
+        /// <param name="powerStateCode"> Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded. </param>
+        /// <param name="availabilityZones"> The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'. </param>
+        /// <param name="enableNodePublicIP"> Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false. </param>
+        /// <param name="nodePublicIPPrefixId"> The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}. </param>
+        /// <param name="scaleSetPriority"> The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'. </param>
+        /// <param name="scaleSetEvictionPolicy"> The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'. </param>
+        /// <param name="spotMaxPrice"> The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing). </param>
+        /// <param name="tags"> The tags to be persisted on the agent pool virtual machine scale set. </param>
+        /// <param name="nodeLabels"> The node labels to be persisted across all nodes in agent pool. </param>
+        /// <param name="nodeTaints"> The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. </param>
+        /// <param name="proximityPlacementGroupId"> The ID for Proximity Placement Group. </param>
+        /// <param name="kubeletConfig"> The Kubelet configuration on the agent pool nodes. </param>
+        /// <param name="linuxOSConfig"> The OS configuration of Linux agent nodes. </param>
+        /// <param name="enableEncryptionAtHost"> Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption. </param>
+        /// <param name="enableUltraSsd"> Whether to enable UltraSSD. </param>
+        /// <param name="enableFips"> Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details. </param>
+        /// <param name="gpuInstanceProfile"> GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU. </param>
+        /// <param name="creationDataSourceResourceId"> CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot. </param>
+        /// <param name="capacityReservationGroupId"> AKS will associate the specified agent pool with the Capacity Reservation Group. </param>
+        /// <param name="hostGroupId"> The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts). </param>
+        /// <param name="networkProfile"> Network-related settings of an agent pool. </param>
+        /// <param name="isOutboundNatDisabled"> The Windows agent pool's specific profile. </param>
+        /// <param name="securityProfile"> The security settings of an agent pool. </param>
+        /// <param name="gpuDriver"> GPU settings for the Agent Pool. </param>
+        /// <param name="gatewayPublicIPPrefixSize"> Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway. </param>
+        /// <param name="scaleManual"> Specifications on VirtualMachines agent pool. </param>
+        /// <param name="virtualMachineNodesStatus"> The status of nodes in a VirtualMachines agent pool. </param>
+        /// <param name="statusProvisioningError"> Contains read-only information about the Agent Pool. </param>
+        /// <param name="localDnsProfile"> Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns. </param>
         /// <returns> A new <see cref="ContainerService.ContainerServiceAgentPoolData"/> instance for mocking. </returns>
         public static ContainerServiceAgentPoolData ContainerServiceAgentPoolData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, ETag? etag = null, int? count = null, string vmSize = null, int? osDiskSizeInGB = null, ContainerServiceOSDiskType? osDiskType = null, KubeletDiskType? kubeletDiskType = null, WorkloadRuntime? workloadRuntime = null, string messageOfTheDay = null, ResourceIdentifier vnetSubnetId = null, ResourceIdentifier podSubnetId = null, PodIPAllocationMode? podIPAllocationMode = null, int? maxPods = null, ContainerServiceOSType? osType = null, ContainerServiceOSSku? osSku = null, int? maxCount = null, int? minCount = null, bool? enableAutoScaling = null, ScaleDownMode? scaleDownMode = null, AgentPoolType? typePropertiesType = null, AgentPoolMode? mode = null, string orchestratorVersion = null, string currentOrchestratorVersion = null, string nodeImageVersion = null, AgentPoolUpgradeSettings upgradeSettings = null, string provisioningState = null, ContainerServiceStateCode? powerStateCode = null, IEnumerable<string> availabilityZones = null, bool? enableNodePublicIP = null, ResourceIdentifier nodePublicIPPrefixId = null, ScaleSetPriority? scaleSetPriority = null, ScaleSetEvictionPolicy? scaleSetEvictionPolicy = null, float? spotMaxPrice = null, IDictionary<string, string> tags = null, IDictionary<string, string> nodeLabels = null, IEnumerable<string> nodeTaints = null, ResourceIdentifier proximityPlacementGroupId = null, KubeletConfig kubeletConfig = null, LinuxOSConfig linuxOSConfig = null, bool? enableEncryptionAtHost = null, bool? enableUltraSsd = null, bool? enableFips = null, GpuInstanceProfile? gpuInstanceProfile = null, ResourceIdentifier creationDataSourceResourceId = null, ResourceIdentifier capacityReservationGroupId = null, ResourceIdentifier hostGroupId = null, AgentPoolNetworkProfile networkProfile = null, bool? isOutboundNatDisabled = null, AgentPoolSecurityProfile securityProfile = null, AgentPoolGpuDriver? gpuDriver = null, int? gatewayPublicIPPrefixSize = null, IEnumerable<ManualScaleProfile> scaleManual = null, IEnumerable<AgentPoolVirtualMachineNodes> virtualMachineNodesStatus = null, ResponseError statusProvisioningError = null, LocalDnsProfile localDnsProfile = null)
         {
@@ -1632,22 +825,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.kubernetesVersion
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.osType
-        /// </param>
-        /// <param name="upgrades">
-        /// List of orchestrator types and versions available for upgrade.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.upgrades
-        /// </param>
-        /// <param name="latestNodeImageVersion">
-        /// The latest AKS supported node image version.
-        /// Serialized Name: AgentPoolUpgradeProfile.properties.latestNodeImageVersion
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="upgrades"> List of orchestrator types and versions available for upgrade. </param>
+        /// <param name="latestNodeImageVersion"> The latest AKS supported node image version. </param>
         /// <returns> A new <see cref="ContainerService.AgentPoolUpgradeProfileData"/> instance for mocking. </returns>
         public static AgentPoolUpgradeProfileData AgentPoolUpgradeProfileData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, string kubernetesVersion = null, ContainerServiceOSType osType = default, IEnumerable<AgentPoolUpgradeProfilePropertiesUpgradesItem> upgrades = null, string latestNodeImageVersion = null)
         {
@@ -1666,14 +847,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.AgentPoolUpgradeProfilePropertiesUpgradesItem"/>. </summary>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolUpgradeProfilePropertiesUpgradesItem.kubernetesVersion
-        /// </param>
-        /// <param name="isPreview">
-        /// Whether the Kubernetes version is currently in preview.
-        /// Serialized Name: AgentPoolUpgradeProfilePropertiesUpgradesItem.isPreview
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="isPreview"> Whether the Kubernetes version is currently in preview. </param>
         /// <returns> A new <see cref="Models.AgentPoolUpgradeProfilePropertiesUpgradesItem"/> instance for mocking. </returns>
         public static AgentPoolUpgradeProfilePropertiesUpgradesItem AgentPoolUpgradeProfilePropertiesUpgradesItem(string kubernetesVersion = null, bool? isPreview = null)
         {
@@ -1685,10 +860,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="agentPoolVersions">
-        /// List of versions available for agent pool.
-        /// Serialized Name: AgentPoolAvailableVersions.properties.agentPoolVersions
-        /// </param>
+        /// <param name="agentPoolVersions"> List of versions available for agent pool. </param>
         /// <returns> A new <see cref="Models.AgentPoolAvailableVersions"/> instance for mocking. </returns>
         public static AgentPoolAvailableVersions AgentPoolAvailableVersions(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IEnumerable<AgentPoolAvailableVersion> agentPoolVersions = null)
         {
@@ -1704,18 +876,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.AgentPoolAvailableVersion"/>. </summary>
-        /// <param name="isDefault">
-        /// Whether this version is the default agent pool version.
-        /// Serialized Name: AgentPoolAvailableVersion.default
-        /// </param>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolAvailableVersion.kubernetesVersion
-        /// </param>
-        /// <param name="isPreview">
-        /// Whether Kubernetes version is currently in preview.
-        /// Serialized Name: AgentPoolAvailableVersion.isPreview
-        /// </param>
+        /// <param name="isDefault"> Whether this version is the default agent pool version. </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="isPreview"> Whether Kubernetes version is currently in preview. </param>
         /// <returns> A new <see cref="Models.AgentPoolAvailableVersion"/> instance for mocking. </returns>
         public static AgentPoolAvailableVersion AgentPoolAvailableVersion(bool? isDefault = null, string kubernetesVersion = null, bool? isPreview = null)
         {
@@ -1727,18 +890,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="provisioningState">
-        /// The current provisioning state.
-        /// Serialized Name: PrivateEndpointConnection.properties.provisioningState
-        /// </param>
-        /// <param name="privateEndpointId">
-        /// The resource of private endpoint.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateEndpoint
-        /// </param>
-        /// <param name="connectionState">
-        /// A collection of information about the state of the connection between service consumer and provider.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateLinkServiceConnectionState
-        /// </param>
+        /// <param name="provisioningState"> The current provisioning state. </param>
+        /// <param name="privateEndpointId"> The resource of private endpoint. </param>
+        /// <param name="connectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
         /// <returns> A new <see cref="ContainerService.ContainerServicePrivateEndpointConnectionData"/> instance for mocking. </returns>
         public static ContainerServicePrivateEndpointConnectionData ContainerServicePrivateEndpointConnectionData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, ContainerServicePrivateEndpointConnectionProvisioningState? provisioningState = null, ResourceIdentifier privateEndpointId = null, ContainerServicePrivateLinkServiceConnectionState connectionState = null)
         {
@@ -1754,18 +908,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterRunCommandContent"/>. </summary>
-        /// <param name="command">
-        /// The command to run.
-        /// Serialized Name: RunCommandRequest.command
-        /// </param>
-        /// <param name="context">
-        /// A base64 encoded zip file containing the files required by the command.
-        /// Serialized Name: RunCommandRequest.context
-        /// </param>
-        /// <param name="clusterToken">
-        /// AuthToken issued for AKS AAD Server App.
-        /// Serialized Name: RunCommandRequest.clusterToken
-        /// </param>
+        /// <param name="command"> The command to run. </param>
+        /// <param name="context"> A base64 encoded zip file containing the files required by the command. </param>
+        /// <param name="clusterToken"> AuthToken issued for AKS AAD Server App. </param>
         /// <returns> A new <see cref="Models.ManagedClusterRunCommandContent"/> instance for mocking. </returns>
         public static ManagedClusterRunCommandContent ManagedClusterRunCommandContent(string command = null, string context = null, string clusterToken = null)
         {
@@ -1773,34 +918,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ManagedClusterRunCommandResult"/>. </summary>
-        /// <param name="id">
-        /// The command id.
-        /// Serialized Name: RunCommandResult.id
-        /// </param>
-        /// <param name="provisioningState">
-        /// provisioning State
-        /// Serialized Name: RunCommandResult.properties.provisioningState
-        /// </param>
-        /// <param name="exitCode">
-        /// The exit code of the command
-        /// Serialized Name: RunCommandResult.properties.exitCode
-        /// </param>
-        /// <param name="startedOn">
-        /// The time when the command started.
-        /// Serialized Name: RunCommandResult.properties.startedAt
-        /// </param>
-        /// <param name="finishedOn">
-        /// The time when the command finished.
-        /// Serialized Name: RunCommandResult.properties.finishedAt
-        /// </param>
-        /// <param name="logs">
-        /// The command output.
-        /// Serialized Name: RunCommandResult.properties.logs
-        /// </param>
-        /// <param name="reason">
-        /// An explanation of why provisioningState is set to failed (if so).
-        /// Serialized Name: RunCommandResult.properties.reason
-        /// </param>
+        /// <param name="id"> The command id. </param>
+        /// <param name="provisioningState"> provisioning State. </param>
+        /// <param name="exitCode"> The exit code of the command. </param>
+        /// <param name="startedOn"> The time when the command started. </param>
+        /// <param name="finishedOn"> The time when the command finished. </param>
+        /// <param name="logs"> The command output. </param>
+        /// <param name="reason"> An explanation of why provisioningState is set to failed (if so). </param>
         /// <returns> A new <see cref="Models.ManagedClusterRunCommandResult"/> instance for mocking. </returns>
         public static ManagedClusterRunCommandResult ManagedClusterRunCommandResult(string id = null, string provisioningState = null, int? exitCode = null, DateTimeOffset? startedOn = null, DateTimeOffset? finishedOn = null, string logs = null, string reason = null)
         {
@@ -1816,14 +940,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ContainerServiceOutboundEnvironmentEndpoint"/>. </summary>
-        /// <param name="category">
-        /// The category of endpoints accessed by the AKS agent node, e.g. azure-resource-management, apiserver, etc.
-        /// Serialized Name: OutboundEnvironmentEndpoint.category
-        /// </param>
-        /// <param name="endpoints">
-        /// The endpoints that AKS agent nodes connect to
-        /// Serialized Name: OutboundEnvironmentEndpoint.endpoints
-        /// </param>
+        /// <param name="category"> The category of endpoints accessed by the AKS agent node, e.g. azure-resource-management, apiserver, etc. </param>
+        /// <param name="endpoints"> The endpoints that AKS agent nodes connect to. </param>
         /// <returns> A new <see cref="Models.ContainerServiceOutboundEnvironmentEndpoint"/> instance for mocking. </returns>
         public static ContainerServiceOutboundEnvironmentEndpoint ContainerServiceOutboundEnvironmentEndpoint(string category = null, IEnumerable<ContainerServiceEndpointDependency> endpoints = null)
         {
@@ -1833,14 +951,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ContainerServiceEndpointDependency"/>. </summary>
-        /// <param name="domainName">
-        /// The domain name of the dependency.
-        /// Serialized Name: EndpointDependency.domainName
-        /// </param>
-        /// <param name="endpointDetails">
-        /// The Ports and Protocols used when connecting to domainName.
-        /// Serialized Name: EndpointDependency.endpointDetails
-        /// </param>
+        /// <param name="domainName"> The domain name of the dependency. </param>
+        /// <param name="endpointDetails"> The Ports and Protocols used when connecting to domainName. </param>
         /// <returns> A new <see cref="Models.ContainerServiceEndpointDependency"/> instance for mocking. </returns>
         public static ContainerServiceEndpointDependency ContainerServiceEndpointDependency(string domainName = null, IEnumerable<ContainerServiceEndpointDetail> endpointDetails = null)
         {
@@ -1850,22 +962,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ContainerServiceEndpointDetail"/>. </summary>
-        /// <param name="ipAddress">
-        /// An IP Address that Domain Name currently resolves to.
-        /// Serialized Name: EndpointDetail.ipAddress
-        /// </param>
-        /// <param name="port">
-        /// The port an endpoint is connected to.
-        /// Serialized Name: EndpointDetail.port
-        /// </param>
-        /// <param name="protocol">
-        /// The protocol used for connection
-        /// Serialized Name: EndpointDetail.protocol
-        /// </param>
-        /// <param name="description">
-        /// Description of the detail
-        /// Serialized Name: EndpointDetail.description
-        /// </param>
+        /// <param name="ipAddress"> An IP Address that Domain Name currently resolves to. </param>
+        /// <param name="port"> The port an endpoint is connected to. </param>
+        /// <param name="protocol"> The protocol used for connection. </param>
+        /// <param name="description"> Description of the detail. </param>
         /// <returns> A new <see cref="Models.ContainerServiceEndpointDetail"/> instance for mocking. </returns>
         public static ContainerServiceEndpointDetail ContainerServiceEndpointDetail(IPAddress ipAddress = null, int? port = null, string protocol = null, string description = null)
         {
@@ -1879,38 +979,14 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="creationDataSourceResourceId">
-        /// CreationData to be used to specify the source agent pool resource ID to create this snapshot.
-        /// Serialized Name: Snapshot.properties.creationData
-        /// </param>
-        /// <param name="snapshotType">
-        /// The type of a snapshot. The default is NodePool.
-        /// Serialized Name: Snapshot.properties.snapshotType
-        /// </param>
-        /// <param name="kubernetesVersion">
-        /// The version of Kubernetes.
-        /// Serialized Name: Snapshot.properties.kubernetesVersion
-        /// </param>
-        /// <param name="nodeImageVersion">
-        /// The version of node image.
-        /// Serialized Name: Snapshot.properties.nodeImageVersion
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: Snapshot.properties.osType
-        /// </param>
-        /// <param name="osSku">
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: Snapshot.properties.osSku
-        /// </param>
-        /// <param name="vmSize">
-        /// The size of the VM.
-        /// Serialized Name: Snapshot.properties.vmSize
-        /// </param>
-        /// <param name="enableFips">
-        /// Whether to use a FIPS-enabled OS.
-        /// Serialized Name: Snapshot.properties.enableFIPS
-        /// </param>
+        /// <param name="creationDataSourceResourceId"> CreationData to be used to specify the source agent pool resource ID to create this snapshot. </param>
+        /// <param name="snapshotType"> The type of a snapshot. The default is NodePool. </param>
+        /// <param name="kubernetesVersion"> The version of Kubernetes. </param>
+        /// <param name="nodeImageVersion"> The version of node image. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="osSku"> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </param>
+        /// <param name="vmSize"> The size of the VM. </param>
+        /// <param name="enableFips"> Whether to use a FIPS-enabled OS. </param>
         /// <returns> A new <see cref="ContainerService.AgentPoolSnapshotData"/> instance for mocking. </returns>
         public static AgentPoolSnapshotData AgentPoolSnapshotData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IDictionary<string, string> tags = null, AzureLocation location = default, ResourceIdentifier creationDataSourceResourceId = null, SnapshotType? snapshotType = null, string kubernetesVersion = null, string nodeImageVersion = null, ContainerServiceOSType? osType = null, ContainerServiceOSSku? osSku = null, string vmSize = null, bool? enableFips = null)
         {
@@ -1939,10 +1015,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="meshRevisions">
-        /// Mesh revision profile properties for a mesh
-        /// Serialized Name: MeshRevisionProfile.properties
-        /// </param>
+        /// <param name="meshRevisions"> Mesh revision profile properties for a mesh. </param>
         /// <returns> A new <see cref="ContainerService.MeshRevisionProfileData"/> instance for mocking. </returns>
         public static MeshRevisionProfileData MeshRevisionProfileData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IEnumerable<MeshRevision> meshRevisions = null)
         {
@@ -1962,10 +1035,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="properties">
-        /// Mesh upgrade profile properties for a major.minor release.
-        /// Serialized Name: MeshUpgradeProfile.properties
-        /// </param>
+        /// <param name="properties"> Mesh upgrade profile properties for a major.minor release. </param>
         /// <returns> A new <see cref="ContainerService.MeshUpgradeProfileData"/> instance for mocking. </returns>
         public static MeshUpgradeProfileData MeshUpgradeProfileData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, MeshUpgradeProfileProperties properties = null)
         {
@@ -1983,18 +1053,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="provisioningState">
-        /// The current provisioning state of trusted access role binding.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.provisioningState
-        /// </param>
-        /// <param name="sourceResourceId">
-        /// The ARM resource ID of source resource that trusted access is configured for.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.sourceResourceId
-        /// </param>
-        /// <param name="roles">
-        /// A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.roles
-        /// </param>
+        /// <param name="provisioningState"> The current provisioning state of trusted access role binding. </param>
+        /// <param name="sourceResourceId"> The ARM resource ID of source resource that trusted access is configured for. </param>
+        /// <param name="roles"> A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'. </param>
         /// <returns> A new <see cref="ContainerService.ContainerServiceTrustedAccessRoleBindingData"/> instance for mocking. </returns>
         public static ContainerServiceTrustedAccessRoleBindingData ContainerServiceTrustedAccessRoleBindingData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, ContainerServiceTrustedAccessRoleBindingProvisioningState? provisioningState = null, ResourceIdentifier sourceResourceId = null, IEnumerable<string> roles = null)
         {
@@ -2012,18 +1073,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ContainerServiceTrustedAccessRole"/>. </summary>
-        /// <param name="sourceResourceType">
-        /// Resource type of Azure resource
-        /// Serialized Name: TrustedAccessRole.sourceResourceType
-        /// </param>
-        /// <param name="name">
-        /// Name of role, name is unique under a source resource type
-        /// Serialized Name: TrustedAccessRole.name
-        /// </param>
-        /// <param name="rules">
-        /// List of rules for the role. This maps to 'rules' property of [Kubernetes Cluster Role](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/#ClusterRole).
-        /// Serialized Name: TrustedAccessRole.rules
-        /// </param>
+        /// <param name="sourceResourceType"> Resource type of Azure resource. </param>
+        /// <param name="name"> Name of role, name is unique under a source resource type. </param>
+        /// <param name="rules"> List of rules for the role. This maps to 'rules' property of [Kubernetes Cluster Role](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/#ClusterRole). </param>
         /// <returns> A new <see cref="Models.ContainerServiceTrustedAccessRole"/> instance for mocking. </returns>
         public static ContainerServiceTrustedAccessRole ContainerServiceTrustedAccessRole(string sourceResourceType = null, string name = null, IEnumerable<ContainerServiceTrustedAccessRoleRule> rules = null)
         {
@@ -2033,26 +1085,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ContainerServiceTrustedAccessRoleRule"/>. </summary>
-        /// <param name="verbs">
-        /// List of allowed verbs
-        /// Serialized Name: TrustedAccessRoleRule.verbs
-        /// </param>
-        /// <param name="apiGroups">
-        /// List of allowed apiGroups
-        /// Serialized Name: TrustedAccessRoleRule.apiGroups
-        /// </param>
-        /// <param name="resources">
-        /// List of allowed resources
-        /// Serialized Name: TrustedAccessRoleRule.resources
-        /// </param>
-        /// <param name="resourceNames">
-        /// List of allowed names
-        /// Serialized Name: TrustedAccessRoleRule.resourceNames
-        /// </param>
-        /// <param name="nonResourceUrls">
-        /// List of allowed nonResourceURLs
-        /// Serialized Name: TrustedAccessRoleRule.nonResourceURLs
-        /// </param>
+        /// <param name="verbs"> List of allowed verbs. </param>
+        /// <param name="apiGroups"> List of allowed apiGroups. </param>
+        /// <param name="resources"> List of allowed resources. </param>
+        /// <param name="resourceNames"> List of allowed names. </param>
+        /// <param name="nonResourceUrls"> List of allowed nonResourceURLs. </param>
         /// <returns> A new <see cref="Models.ContainerServiceTrustedAccessRoleRule"/> instance for mocking. </returns>
         public static ContainerServiceTrustedAccessRoleRule ContainerServiceTrustedAccessRoleRule(IEnumerable<string> verbs = null, IEnumerable<string> apiGroups = null, IEnumerable<string> resources = null, IEnumerable<string> resourceNames = null, IEnumerable<string> nonResourceUrls = null)
         {
@@ -2076,14 +1113,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="zones">
-        /// The Availability zone in which machine is located.
-        /// Serialized Name: Machine.zones
-        /// </param>
-        /// <param name="properties">
-        /// The properties of the machine
-        /// Serialized Name: Machine.properties
-        /// </param>
+        /// <param name="zones"> The Availability zone in which machine is located. </param>
+        /// <param name="properties"> The properties of the machine. </param>
         /// <returns> A new <see cref="ContainerService.ContainerServiceMachineData"/> instance for mocking. </returns>
         public static ContainerServiceMachineData ContainerServiceMachineData(ResourceIdentifier id = null, string name = null, ResourceType resourceType = default, SystemData systemData = null, IEnumerable<string> zones = null, ContainerServiceMachineProperties properties = null)
         {
@@ -2100,14 +1131,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ContainerServiceMachineProperties"/>. </summary>
-        /// <param name="networkIPAddresses">
-        /// network properties of the machine
-        /// Serialized Name: MachineProperties.network
-        /// </param>
-        /// <param name="resourceId">
-        /// Azure resource id of the machine. It can be used to GET underlying VM Instance
-        /// Serialized Name: MachineProperties.resourceId
-        /// </param>
+        /// <param name="networkIPAddresses"> network properties of the machine. </param>
+        /// <param name="resourceId"> Azure resource id of the machine. It can be used to GET underlying VM Instance. </param>
         /// <returns> A new <see cref="Models.ContainerServiceMachineProperties"/> instance for mocking. </returns>
         public static ContainerServiceMachineProperties ContainerServiceMachineProperties(IEnumerable<ContainerServiceMachineIPAddress> networkIPAddresses = null, ResourceIdentifier resourceId = null)
         {
@@ -2117,14 +1142,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="Models.ContainerServiceMachineIPAddress"/>. </summary>
-        /// <param name="family">
-        /// To determine if address belongs IPv4 or IPv6 family
-        /// Serialized Name: MachineIpAddress.family
-        /// </param>
-        /// <param name="ip">
-        /// IPv4 or IPv6 address of the machine
-        /// Serialized Name: MachineIpAddress.ip
-        /// </param>
+        /// <param name="family"> To determine if address belongs IPv4 or IPv6 family. </param>
+        /// <param name="ip"> IPv4 or IPv6 address of the machine. </param>
         /// <returns> A new <see cref="Models.ContainerServiceMachineIPAddress"/> instance for mocking. </returns>
         public static ContainerServiceMachineIPAddress ContainerServiceMachineIPAddress(ContainerServiceIPFamily? family = null, string ip = null)
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceAgentPoolData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceAgentPoolData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the ContainerServiceAgentPool data model.
     /// Agent Pool.
-    /// Serialized Name: AgentPool
     /// </summary>
     public partial class ContainerServiceAgentPoolData : ResourceData
     {
@@ -67,222 +66,60 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: AgentPool.properties.eTag
-        /// </param>
-        /// <param name="count">
-        /// Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
-        /// Serialized Name: AgentPool.properties.count
-        /// </param>
-        /// <param name="vmSize">
-        /// The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions
-        /// Serialized Name: AgentPool.properties.vmSize
-        /// </param>
-        /// <param name="osDiskSizeInGB">
-        /// OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-        /// Serialized Name: AgentPool.properties.osDiskSizeGB
-        /// </param>
-        /// <param name="osDiskType">
-        /// The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-        /// Serialized Name: AgentPool.properties.osDiskType
-        /// </param>
-        /// <param name="kubeletDiskType">
-        /// Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
-        /// Serialized Name: AgentPool.properties.kubeletDiskType
-        /// </param>
-        /// <param name="workloadRuntime">
-        /// Determines the type of workload a node can run.
-        /// Serialized Name: AgentPool.properties.workloadRuntime
-        /// </param>
-        /// <param name="messageOfTheDay">
-        /// Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script).
-        /// Serialized Name: AgentPool.properties.messageOfTheDay
-        /// </param>
-        /// <param name="vnetSubnetId">
-        /// The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: AgentPool.properties.vnetSubnetID
-        /// </param>
-        /// <param name="podSubnetId">
-        /// The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: AgentPool.properties.podSubnetID
-        /// </param>
-        /// <param name="podIPAllocationMode">
-        /// Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
-        /// Serialized Name: AgentPool.properties.podIPAllocationMode
-        /// </param>
-        /// <param name="maxPods">
-        /// The maximum number of pods that can run on a node.
-        /// Serialized Name: AgentPool.properties.maxPods
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: AgentPool.properties.osType
-        /// </param>
-        /// <param name="osSku">
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: AgentPool.properties.osSKU
-        /// </param>
-        /// <param name="maxCount">
-        /// The maximum number of nodes for auto-scaling
-        /// Serialized Name: AgentPool.properties.maxCount
-        /// </param>
-        /// <param name="minCount">
-        /// The minimum number of nodes for auto-scaling
-        /// Serialized Name: AgentPool.properties.minCount
-        /// </param>
-        /// <param name="enableAutoScaling">
-        /// Whether to enable auto-scaler
-        /// Serialized Name: AgentPool.properties.enableAutoScaling
-        /// </param>
-        /// <param name="scaleDownMode">
-        /// The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
-        /// Serialized Name: AgentPool.properties.scaleDownMode
-        /// </param>
-        /// <param name="typePropertiesType">
-        /// The type of Agent Pool.
-        /// Serialized Name: AgentPool.properties.type
-        /// </param>
-        /// <param name="mode">
-        /// The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
-        /// Serialized Name: AgentPool.properties.mode
-        /// </param>
-        /// <param name="orchestratorVersion">
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-        /// Serialized Name: AgentPool.properties.orchestratorVersion
-        /// </param>
-        /// <param name="currentOrchestratorVersion">
-        /// The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: AgentPool.properties.currentOrchestratorVersion
-        /// </param>
-        /// <param name="nodeImageVersion">
-        /// The version of node image
-        /// Serialized Name: AgentPool.properties.nodeImageVersion
-        /// </param>
-        /// <param name="upgradeSettings">
-        /// Settings for upgrading the agentpool
-        /// Serialized Name: AgentPool.properties.upgradeSettings
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current deployment or provisioning state.
-        /// Serialized Name: AgentPool.properties.provisioningState
-        /// </param>
-        /// <param name="powerState">
-        /// Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded
-        /// Serialized Name: AgentPool.properties.powerState
-        /// </param>
-        /// <param name="availabilityZones">
-        /// The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
-        /// Serialized Name: AgentPool.properties.availabilityZones
-        /// </param>
-        /// <param name="enableNodePublicIP">
-        /// Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false.
-        /// Serialized Name: AgentPool.properties.enableNodePublicIP
-        /// </param>
-        /// <param name="nodePublicIPPrefixId">
-        /// The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
-        /// Serialized Name: AgentPool.properties.nodePublicIPPrefixID
-        /// </param>
-        /// <param name="scaleSetPriority">
-        /// The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'.
-        /// Serialized Name: AgentPool.properties.scaleSetPriority
-        /// </param>
-        /// <param name="scaleSetEvictionPolicy">
-        /// The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'.
-        /// Serialized Name: AgentPool.properties.scaleSetEvictionPolicy
-        /// </param>
-        /// <param name="spotMaxPrice">
-        /// The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)
-        /// Serialized Name: AgentPool.properties.spotMaxPrice
-        /// </param>
-        /// <param name="tags">
-        /// The tags to be persisted on the agent pool virtual machine scale set.
-        /// Serialized Name: AgentPool.properties.tags
-        /// </param>
-        /// <param name="nodeLabels">
-        /// The node labels to be persisted across all nodes in agent pool.
-        /// Serialized Name: AgentPool.properties.nodeLabels
-        /// </param>
-        /// <param name="nodeTaints">
-        /// The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
-        /// Serialized Name: AgentPool.properties.nodeTaints
-        /// </param>
-        /// <param name="proximityPlacementGroupId">
-        /// The ID for Proximity Placement Group.
-        /// Serialized Name: AgentPool.properties.proximityPlacementGroupID
-        /// </param>
-        /// <param name="kubeletConfig">
-        /// The Kubelet configuration on the agent pool nodes.
-        /// Serialized Name: AgentPool.properties.kubeletConfig
-        /// </param>
-        /// <param name="linuxOSConfig">
-        /// The OS configuration of Linux agent nodes.
-        /// Serialized Name: AgentPool.properties.linuxOSConfig
-        /// </param>
-        /// <param name="enableEncryptionAtHost">
-        /// Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption
-        /// Serialized Name: AgentPool.properties.enableEncryptionAtHost
-        /// </param>
-        /// <param name="enableUltraSsd">
-        /// Whether to enable UltraSSD
-        /// Serialized Name: AgentPool.properties.enableUltraSSD
-        /// </param>
-        /// <param name="enableFips">
-        /// Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details.
-        /// Serialized Name: AgentPool.properties.enableFIPS
-        /// </param>
-        /// <param name="gpuInstanceProfile">
-        /// GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-        /// Serialized Name: AgentPool.properties.gpuInstanceProfile
-        /// </param>
-        /// <param name="creationData">
-        /// CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot.
-        /// Serialized Name: AgentPool.properties.creationData
-        /// </param>
-        /// <param name="capacityReservationGroupId">
-        /// AKS will associate the specified agent pool with the Capacity Reservation Group.
-        /// Serialized Name: AgentPool.properties.capacityReservationGroupID
-        /// </param>
-        /// <param name="hostGroupId">
-        /// The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
-        /// Serialized Name: AgentPool.properties.hostGroupID
-        /// </param>
-        /// <param name="networkProfile">
-        /// Network-related settings of an agent pool.
-        /// Serialized Name: AgentPool.properties.networkProfile
-        /// </param>
-        /// <param name="windowsProfile">
-        /// The Windows agent pool's specific profile.
-        /// Serialized Name: AgentPool.properties.windowsProfile
-        /// </param>
-        /// <param name="securityProfile">
-        /// The security settings of an agent pool.
-        /// Serialized Name: AgentPool.properties.securityProfile
-        /// </param>
-        /// <param name="gpuProfile">
-        /// GPU settings for the Agent Pool.
-        /// Serialized Name: AgentPool.properties.gpuProfile
-        /// </param>
-        /// <param name="gatewayProfile">
-        /// Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway.
-        /// Serialized Name: AgentPool.properties.gatewayProfile
-        /// </param>
-        /// <param name="virtualMachinesProfile">
-        /// Specifications on VirtualMachines agent pool.
-        /// Serialized Name: AgentPool.properties.virtualMachinesProfile
-        /// </param>
-        /// <param name="virtualMachineNodesStatus">
-        /// The status of nodes in a VirtualMachines agent pool.
-        /// Serialized Name: AgentPool.properties.virtualMachineNodesStatus
-        /// </param>
-        /// <param name="status">
-        /// Contains read-only information about the Agent Pool.
-        /// Serialized Name: AgentPool.properties.status
-        /// </param>
-        /// <param name="localDnsProfile">
-        /// Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
-        /// Serialized Name: AgentPool.properties.localDNSProfile
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="count"> Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1. </param>
+        /// <param name="vmSize"> The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions. </param>
+        /// <param name="osDiskSizeInGB"> OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified. </param>
+        /// <param name="osDiskType"> The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os). </param>
+        /// <param name="kubeletDiskType"> Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. </param>
+        /// <param name="workloadRuntime"> Determines the type of workload a node can run. </param>
+        /// <param name="messageOfTheDay"> Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script). </param>
+        /// <param name="vnetSubnetId"> The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podSubnetId"> The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podIPAllocationMode"> Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'. </param>
+        /// <param name="maxPods"> The maximum number of pods that can run on a node. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="osSku"> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </param>
+        /// <param name="maxCount"> The maximum number of nodes for auto-scaling. </param>
+        /// <param name="minCount"> The minimum number of nodes for auto-scaling. </param>
+        /// <param name="enableAutoScaling"> Whether to enable auto-scaler. </param>
+        /// <param name="scaleDownMode"> The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete. </param>
+        /// <param name="typePropertiesType"> The type of Agent Pool. </param>
+        /// <param name="mode"> The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools. </param>
+        /// <param name="orchestratorVersion"> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool). </param>
+        /// <param name="currentOrchestratorVersion"> The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </param>
+        /// <param name="nodeImageVersion"> The version of node image. </param>
+        /// <param name="upgradeSettings"> Settings for upgrading the agentpool. </param>
+        /// <param name="provisioningState"> The current deployment or provisioning state. </param>
+        /// <param name="powerState"> Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded. </param>
+        /// <param name="availabilityZones"> The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'. </param>
+        /// <param name="enableNodePublicIP"> Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false. </param>
+        /// <param name="nodePublicIPPrefixId"> The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}. </param>
+        /// <param name="scaleSetPriority"> The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'. </param>
+        /// <param name="scaleSetEvictionPolicy"> The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'. </param>
+        /// <param name="spotMaxPrice"> The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing). </param>
+        /// <param name="tags"> The tags to be persisted on the agent pool virtual machine scale set. </param>
+        /// <param name="nodeLabels"> The node labels to be persisted across all nodes in agent pool. </param>
+        /// <param name="nodeTaints"> The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. </param>
+        /// <param name="proximityPlacementGroupId"> The ID for Proximity Placement Group. </param>
+        /// <param name="kubeletConfig"> The Kubelet configuration on the agent pool nodes. </param>
+        /// <param name="linuxOSConfig"> The OS configuration of Linux agent nodes. </param>
+        /// <param name="enableEncryptionAtHost"> Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption. </param>
+        /// <param name="enableUltraSsd"> Whether to enable UltraSSD. </param>
+        /// <param name="enableFips"> Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details. </param>
+        /// <param name="gpuInstanceProfile"> GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU. </param>
+        /// <param name="creationData"> CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot. </param>
+        /// <param name="capacityReservationGroupId"> AKS will associate the specified agent pool with the Capacity Reservation Group. </param>
+        /// <param name="hostGroupId"> The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts). </param>
+        /// <param name="networkProfile"> Network-related settings of an agent pool. </param>
+        /// <param name="windowsProfile"> The Windows agent pool's specific profile. </param>
+        /// <param name="securityProfile"> The security settings of an agent pool. </param>
+        /// <param name="gpuProfile"> GPU settings for the Agent Pool. </param>
+        /// <param name="gatewayProfile"> Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway. </param>
+        /// <param name="virtualMachinesProfile"> Specifications on VirtualMachines agent pool. </param>
+        /// <param name="virtualMachineNodesStatus"> The status of nodes in a VirtualMachines agent pool. </param>
+        /// <param name="status"> Contains read-only information about the Agent Pool. </param>
+        /// <param name="localDnsProfile"> Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceAgentPoolData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, ETag? etag, int? count, string vmSize, int? osDiskSizeInGB, ContainerServiceOSDiskType? osDiskType, KubeletDiskType? kubeletDiskType, WorkloadRuntime? workloadRuntime, string messageOfTheDay, ResourceIdentifier vnetSubnetId, ResourceIdentifier podSubnetId, PodIPAllocationMode? podIPAllocationMode, int? maxPods, ContainerServiceOSType? osType, ContainerServiceOSSku? osSku, int? maxCount, int? minCount, bool? enableAutoScaling, ScaleDownMode? scaleDownMode, AgentPoolType? typePropertiesType, AgentPoolMode? mode, string orchestratorVersion, string currentOrchestratorVersion, string nodeImageVersion, AgentPoolUpgradeSettings upgradeSettings, string provisioningState, ContainerServicePowerState powerState, IList<string> availabilityZones, bool? enableNodePublicIP, ResourceIdentifier nodePublicIPPrefixId, ScaleSetPriority? scaleSetPriority, ScaleSetEvictionPolicy? scaleSetEvictionPolicy, float? spotMaxPrice, IDictionary<string, string> tags, IDictionary<string, string> nodeLabels, IList<string> nodeTaints, ResourceIdentifier proximityPlacementGroupId, KubeletConfig kubeletConfig, LinuxOSConfig linuxOSConfig, bool? enableEncryptionAtHost, bool? enableUltraSsd, bool? enableFips, GpuInstanceProfile? gpuInstanceProfile, ContainerServiceCreationData creationData, ResourceIdentifier capacityReservationGroupId, ResourceIdentifier hostGroupId, AgentPoolNetworkProfile networkProfile, AgentPoolWindowsProfile windowsProfile, AgentPoolSecurityProfile securityProfile, AgentPoolGpuProfile gpuProfile, AgentPoolGatewayProfile gatewayProfile, VirtualMachinesProfile virtualMachinesProfile, IList<AgentPoolVirtualMachineNodes> virtualMachineNodesStatus, AgentPoolStatus status, LocalDnsProfile localDnsProfile, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -343,165 +180,84 @@ namespace Azure.ResourceManager.ContainerService
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: AgentPool.properties.eTag
-        /// </summary>
+        /// <summary> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </summary>
         [WirePath("properties.eTag")]
         public ETag? ETag { get; }
-        /// <summary>
-        /// Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
-        /// Serialized Name: AgentPool.properties.count
-        /// </summary>
+        /// <summary> Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1. </summary>
         [WirePath("properties.count")]
         public int? Count { get; set; }
-        /// <summary>
-        /// The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions
-        /// Serialized Name: AgentPool.properties.vmSize
-        /// </summary>
+        /// <summary> The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions. </summary>
         [WirePath("properties.vmSize")]
         public string VmSize { get; set; }
-        /// <summary>
-        /// OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-        /// Serialized Name: AgentPool.properties.osDiskSizeGB
-        /// </summary>
+        /// <summary> OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified. </summary>
         [WirePath("properties.osDiskSizeGB")]
         public int? OSDiskSizeInGB { get; set; }
-        /// <summary>
-        /// The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-        /// Serialized Name: AgentPool.properties.osDiskType
-        /// </summary>
+        /// <summary> The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os). </summary>
         [WirePath("properties.osDiskType")]
         public ContainerServiceOSDiskType? OSDiskType { get; set; }
-        /// <summary>
-        /// Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
-        /// Serialized Name: AgentPool.properties.kubeletDiskType
-        /// </summary>
+        /// <summary> Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. </summary>
         [WirePath("properties.kubeletDiskType")]
         public KubeletDiskType? KubeletDiskType { get; set; }
-        /// <summary>
-        /// Determines the type of workload a node can run.
-        /// Serialized Name: AgentPool.properties.workloadRuntime
-        /// </summary>
+        /// <summary> Determines the type of workload a node can run. </summary>
         [WirePath("properties.workloadRuntime")]
         public WorkloadRuntime? WorkloadRuntime { get; set; }
-        /// <summary>
-        /// Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script).
-        /// Serialized Name: AgentPool.properties.messageOfTheDay
-        /// </summary>
+        /// <summary> Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script). </summary>
         [WirePath("properties.messageOfTheDay")]
         public string MessageOfTheDay { get; set; }
-        /// <summary>
-        /// The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: AgentPool.properties.vnetSubnetID
-        /// </summary>
+        /// <summary> The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </summary>
         [WirePath("properties.vnetSubnetID")]
         public ResourceIdentifier VnetSubnetId { get; set; }
-        /// <summary>
-        /// The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: AgentPool.properties.podSubnetID
-        /// </summary>
+        /// <summary> The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </summary>
         [WirePath("properties.podSubnetID")]
         public ResourceIdentifier PodSubnetId { get; set; }
-        /// <summary>
-        /// Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
-        /// Serialized Name: AgentPool.properties.podIPAllocationMode
-        /// </summary>
+        /// <summary> Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'. </summary>
         [WirePath("properties.podIPAllocationMode")]
         public PodIPAllocationMode? PodIPAllocationMode { get; set; }
-        /// <summary>
-        /// The maximum number of pods that can run on a node.
-        /// Serialized Name: AgentPool.properties.maxPods
-        /// </summary>
+        /// <summary> The maximum number of pods that can run on a node. </summary>
         [WirePath("properties.maxPods")]
         public int? MaxPods { get; set; }
-        /// <summary>
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: AgentPool.properties.osType
-        /// </summary>
+        /// <summary> The operating system type. The default is Linux. </summary>
         [WirePath("properties.osType")]
         public ContainerServiceOSType? OSType { get; set; }
-        /// <summary>
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: AgentPool.properties.osSKU
-        /// </summary>
+        /// <summary> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </summary>
         [WirePath("properties.osSKU")]
         public ContainerServiceOSSku? OSSku { get; set; }
-        /// <summary>
-        /// The maximum number of nodes for auto-scaling
-        /// Serialized Name: AgentPool.properties.maxCount
-        /// </summary>
+        /// <summary> The maximum number of nodes for auto-scaling. </summary>
         [WirePath("properties.maxCount")]
         public int? MaxCount { get; set; }
-        /// <summary>
-        /// The minimum number of nodes for auto-scaling
-        /// Serialized Name: AgentPool.properties.minCount
-        /// </summary>
+        /// <summary> The minimum number of nodes for auto-scaling. </summary>
         [WirePath("properties.minCount")]
         public int? MinCount { get; set; }
-        /// <summary>
-        /// Whether to enable auto-scaler
-        /// Serialized Name: AgentPool.properties.enableAutoScaling
-        /// </summary>
+        /// <summary> Whether to enable auto-scaler. </summary>
         [WirePath("properties.enableAutoScaling")]
         public bool? EnableAutoScaling { get; set; }
-        /// <summary>
-        /// The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
-        /// Serialized Name: AgentPool.properties.scaleDownMode
-        /// </summary>
+        /// <summary> The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete. </summary>
         [WirePath("properties.scaleDownMode")]
         public ScaleDownMode? ScaleDownMode { get; set; }
-        /// <summary>
-        /// The type of Agent Pool.
-        /// Serialized Name: AgentPool.properties.type
-        /// </summary>
+        /// <summary> The type of Agent Pool. </summary>
         [WirePath("properties.type")]
         public AgentPoolType? TypePropertiesType { get; set; }
-        /// <summary>
-        /// The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
-        /// Serialized Name: AgentPool.properties.mode
-        /// </summary>
+        /// <summary> The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools. </summary>
         [WirePath("properties.mode")]
         public AgentPoolMode? Mode { get; set; }
-        /// <summary>
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-        /// Serialized Name: AgentPool.properties.orchestratorVersion
-        /// </summary>
+        /// <summary> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool). </summary>
         [WirePath("properties.orchestratorVersion")]
         public string OrchestratorVersion { get; set; }
-        /// <summary>
-        /// The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: AgentPool.properties.currentOrchestratorVersion
-        /// </summary>
+        /// <summary> The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </summary>
         [WirePath("properties.currentOrchestratorVersion")]
         public string CurrentOrchestratorVersion { get; }
-        /// <summary>
-        /// The version of node image
-        /// Serialized Name: AgentPool.properties.nodeImageVersion
-        /// </summary>
+        /// <summary> The version of node image. </summary>
         [WirePath("properties.nodeImageVersion")]
         public string NodeImageVersion { get; }
-        /// <summary>
-        /// Settings for upgrading the agentpool
-        /// Serialized Name: AgentPool.properties.upgradeSettings
-        /// </summary>
+        /// <summary> Settings for upgrading the agentpool. </summary>
         [WirePath("properties.upgradeSettings")]
         public AgentPoolUpgradeSettings UpgradeSettings { get; set; }
-        /// <summary>
-        /// The current deployment or provisioning state.
-        /// Serialized Name: AgentPool.properties.provisioningState
-        /// </summary>
+        /// <summary> The current deployment or provisioning state. </summary>
         [WirePath("properties.provisioningState")]
         public string ProvisioningState { get; }
-        /// <summary>
-        /// Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded
-        /// Serialized Name: AgentPool.properties.powerState
-        /// </summary>
+        /// <summary> Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded. </summary>
         internal ContainerServicePowerState PowerState { get; set; }
-        /// <summary>
-        /// Tells whether the cluster is Running or Stopped
-        /// Serialized Name: PowerState.code
-        /// </summary>
+        /// <summary> Tells whether the cluster is Running or Stopped. </summary>
         [WirePath("properties.powerState.code")]
         public ContainerServiceStateCode? PowerStateCode
         {
@@ -514,111 +270,57 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
-        /// Serialized Name: AgentPool.properties.availabilityZones
-        /// </summary>
+        /// <summary> The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'. </summary>
         [WirePath("properties.availabilityZones")]
         public IList<string> AvailabilityZones { get; }
-        /// <summary>
-        /// Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false.
-        /// Serialized Name: AgentPool.properties.enableNodePublicIP
-        /// </summary>
+        /// <summary> Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false. </summary>
         [WirePath("properties.enableNodePublicIP")]
         public bool? EnableNodePublicIP { get; set; }
-        /// <summary>
-        /// The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
-        /// Serialized Name: AgentPool.properties.nodePublicIPPrefixID
-        /// </summary>
+        /// <summary> The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}. </summary>
         [WirePath("properties.nodePublicIPPrefixID")]
         public ResourceIdentifier NodePublicIPPrefixId { get; set; }
-        /// <summary>
-        /// The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'.
-        /// Serialized Name: AgentPool.properties.scaleSetPriority
-        /// </summary>
+        /// <summary> The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'. </summary>
         [WirePath("properties.scaleSetPriority")]
         public ScaleSetPriority? ScaleSetPriority { get; set; }
-        /// <summary>
-        /// The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'.
-        /// Serialized Name: AgentPool.properties.scaleSetEvictionPolicy
-        /// </summary>
+        /// <summary> The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'. </summary>
         [WirePath("properties.scaleSetEvictionPolicy")]
         public ScaleSetEvictionPolicy? ScaleSetEvictionPolicy { get; set; }
-        /// <summary>
-        /// The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)
-        /// Serialized Name: AgentPool.properties.spotMaxPrice
-        /// </summary>
+        /// <summary> The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing). </summary>
         [WirePath("properties.spotMaxPrice")]
         public float? SpotMaxPrice { get; set; }
-        /// <summary>
-        /// The tags to be persisted on the agent pool virtual machine scale set.
-        /// Serialized Name: AgentPool.properties.tags
-        /// </summary>
+        /// <summary> The tags to be persisted on the agent pool virtual machine scale set. </summary>
         [WirePath("properties.tags")]
         public IDictionary<string, string> Tags { get; }
-        /// <summary>
-        /// The node labels to be persisted across all nodes in agent pool.
-        /// Serialized Name: AgentPool.properties.nodeLabels
-        /// </summary>
+        /// <summary> The node labels to be persisted across all nodes in agent pool. </summary>
         [WirePath("properties.nodeLabels")]
         public IDictionary<string, string> NodeLabels { get; }
-        /// <summary>
-        /// The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
-        /// Serialized Name: AgentPool.properties.nodeTaints
-        /// </summary>
+        /// <summary> The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. </summary>
         [WirePath("properties.nodeTaints")]
         public IList<string> NodeTaints { get; }
-        /// <summary>
-        /// The ID for Proximity Placement Group.
-        /// Serialized Name: AgentPool.properties.proximityPlacementGroupID
-        /// </summary>
+        /// <summary> The ID for Proximity Placement Group. </summary>
         [WirePath("properties.proximityPlacementGroupID")]
         public ResourceIdentifier ProximityPlacementGroupId { get; set; }
-        /// <summary>
-        /// The Kubelet configuration on the agent pool nodes.
-        /// Serialized Name: AgentPool.properties.kubeletConfig
-        /// </summary>
+        /// <summary> The Kubelet configuration on the agent pool nodes. </summary>
         [WirePath("properties.kubeletConfig")]
         public KubeletConfig KubeletConfig { get; set; }
-        /// <summary>
-        /// The OS configuration of Linux agent nodes.
-        /// Serialized Name: AgentPool.properties.linuxOSConfig
-        /// </summary>
+        /// <summary> The OS configuration of Linux agent nodes. </summary>
         [WirePath("properties.linuxOSConfig")]
         public LinuxOSConfig LinuxOSConfig { get; set; }
-        /// <summary>
-        /// Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption
-        /// Serialized Name: AgentPool.properties.enableEncryptionAtHost
-        /// </summary>
+        /// <summary> Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption. </summary>
         [WirePath("properties.enableEncryptionAtHost")]
         public bool? EnableEncryptionAtHost { get; set; }
-        /// <summary>
-        /// Whether to enable UltraSSD
-        /// Serialized Name: AgentPool.properties.enableUltraSSD
-        /// </summary>
+        /// <summary> Whether to enable UltraSSD. </summary>
         [WirePath("properties.enableUltraSSD")]
         public bool? EnableUltraSsd { get; set; }
-        /// <summary>
-        /// Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details.
-        /// Serialized Name: AgentPool.properties.enableFIPS
-        /// </summary>
+        /// <summary> Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details. </summary>
         [WirePath("properties.enableFIPS")]
         public bool? EnableFips { get; set; }
-        /// <summary>
-        /// GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-        /// Serialized Name: AgentPool.properties.gpuInstanceProfile
-        /// </summary>
+        /// <summary> GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU. </summary>
         [WirePath("properties.gpuInstanceProfile")]
         public GpuInstanceProfile? GpuInstanceProfile { get; set; }
-        /// <summary>
-        /// CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot.
-        /// Serialized Name: AgentPool.properties.creationData
-        /// </summary>
+        /// <summary> CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot. </summary>
         internal ContainerServiceCreationData CreationData { get; set; }
-        /// <summary>
-        /// This is the ARM ID of the source object to be used to create the target object.
-        /// Serialized Name: CreationData.sourceResourceId
-        /// </summary>
+        /// <summary> This is the ARM ID of the source object to be used to create the target object. </summary>
         [WirePath("properties.creationData.sourceResourceId")]
         public ResourceIdentifier CreationDataSourceResourceId
         {
@@ -631,33 +333,18 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// AKS will associate the specified agent pool with the Capacity Reservation Group.
-        /// Serialized Name: AgentPool.properties.capacityReservationGroupID
-        /// </summary>
+        /// <summary> AKS will associate the specified agent pool with the Capacity Reservation Group. </summary>
         [WirePath("properties.capacityReservationGroupID")]
         public ResourceIdentifier CapacityReservationGroupId { get; set; }
-        /// <summary>
-        /// The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
-        /// Serialized Name: AgentPool.properties.hostGroupID
-        /// </summary>
+        /// <summary> The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts). </summary>
         [WirePath("properties.hostGroupID")]
         public ResourceIdentifier HostGroupId { get; set; }
-        /// <summary>
-        /// Network-related settings of an agent pool.
-        /// Serialized Name: AgentPool.properties.networkProfile
-        /// </summary>
+        /// <summary> Network-related settings of an agent pool. </summary>
         [WirePath("properties.networkProfile")]
         public AgentPoolNetworkProfile NetworkProfile { get; set; }
-        /// <summary>
-        /// The Windows agent pool's specific profile.
-        /// Serialized Name: AgentPool.properties.windowsProfile
-        /// </summary>
+        /// <summary> The Windows agent pool's specific profile. </summary>
         internal AgentPoolWindowsProfile WindowsProfile { get; set; }
-        /// <summary>
-        /// Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled.
-        /// Serialized Name: AgentPoolWindowsProfile.disableOutboundNat
-        /// </summary>
+        /// <summary> Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled. </summary>
         [WirePath("properties.windowsProfile.disableOutboundNat")]
         public bool? IsOutboundNatDisabled
         {
@@ -670,21 +357,12 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// The security settings of an agent pool.
-        /// Serialized Name: AgentPool.properties.securityProfile
-        /// </summary>
+        /// <summary> The security settings of an agent pool. </summary>
         [WirePath("properties.securityProfile")]
         public AgentPoolSecurityProfile SecurityProfile { get; set; }
-        /// <summary>
-        /// GPU settings for the Agent Pool.
-        /// Serialized Name: AgentPool.properties.gpuProfile
-        /// </summary>
+        /// <summary> GPU settings for the Agent Pool. </summary>
         internal AgentPoolGpuProfile GpuProfile { get; set; }
-        /// <summary>
-        /// Whether to install GPU drivers. When it's not specified, default is Install.
-        /// Serialized Name: GPUProfile.driver
-        /// </summary>
+        /// <summary> Whether to install GPU drivers. When it's not specified, default is Install. </summary>
         [WirePath("properties.gpuProfile.driver")]
         public AgentPoolGpuDriver? GpuDriver
         {
@@ -697,15 +375,9 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway.
-        /// Serialized Name: AgentPool.properties.gatewayProfile
-        /// </summary>
+        /// <summary> Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway. </summary>
         internal AgentPoolGatewayProfile GatewayProfile { get; set; }
-        /// <summary>
-        /// The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31] (/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31.
-        /// Serialized Name: AgentPoolGatewayProfile.publicIPPrefixSize
-        /// </summary>
+        /// <summary> The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31] (/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31. </summary>
         [WirePath("properties.gatewayProfile.publicIPPrefixSize")]
         public int? GatewayPublicIPPrefixSize
         {
@@ -718,15 +390,9 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// Specifications on VirtualMachines agent pool.
-        /// Serialized Name: AgentPool.properties.virtualMachinesProfile
-        /// </summary>
+        /// <summary> Specifications on VirtualMachines agent pool. </summary>
         internal VirtualMachinesProfile VirtualMachinesProfile { get; set; }
-        /// <summary>
-        /// Specifications on how to scale the VirtualMachines agent pool to a fixed size.
-        /// Serialized Name: ScaleProfile.manual
-        /// </summary>
+        /// <summary> Specifications on how to scale the VirtualMachines agent pool to a fixed size. </summary>
         [WirePath("properties.virtualMachinesProfile.scale.manual")]
         public IList<ManualScaleProfile> ScaleManual
         {
@@ -738,31 +404,19 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// The status of nodes in a VirtualMachines agent pool.
-        /// Serialized Name: AgentPool.properties.virtualMachineNodesStatus
-        /// </summary>
+        /// <summary> The status of nodes in a VirtualMachines agent pool. </summary>
         [WirePath("properties.virtualMachineNodesStatus")]
         public IList<AgentPoolVirtualMachineNodes> VirtualMachineNodesStatus { get; }
-        /// <summary>
-        /// Contains read-only information about the Agent Pool.
-        /// Serialized Name: AgentPool.properties.status
-        /// </summary>
+        /// <summary> Contains read-only information about the Agent Pool. </summary>
         internal AgentPoolStatus Status { get; set; }
-        /// <summary>
-        /// The error detail information of the agent pool. Preserves the detailed info of failure. If there was no error, this field is omitted.
-        /// Serialized Name: AgentPoolStatus.provisioningError
-        /// </summary>
+        /// <summary> The error detail information of the agent pool. Preserves the detailed info of failure. If there was no error, this field is omitted. </summary>
         [WirePath("properties.status.provisioningError")]
         public ResponseError StatusProvisioningError
         {
             get => Status is null ? default : Status.ProvisioningError;
         }
 
-        /// <summary>
-        /// Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
-        /// Serialized Name: AgentPool.properties.localDNSProfile
-        /// </summary>
+        /// <summary> Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns. </summary>
         [WirePath("properties.localDNSProfile")]
         public LocalDnsProfile LocalDnsProfile { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceMachineData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceMachineData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the ContainerServiceMachine data model.
     /// A machine. Contains details about the underlying virtual machine. A machine may be visible here but not in kubectl get nodes; if so it may be because the machine has not been registered with the Kubernetes API Server yet.
-    /// Serialized Name: Machine
     /// </summary>
     public partial class ContainerServiceMachineData : ResourceData
     {
@@ -63,14 +62,8 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="zones">
-        /// The Availability zone in which machine is located.
-        /// Serialized Name: Machine.zones
-        /// </param>
-        /// <param name="properties">
-        /// The properties of the machine
-        /// Serialized Name: Machine.properties
-        /// </param>
+        /// <param name="zones"> The Availability zone in which machine is located. </param>
+        /// <param name="properties"> The properties of the machine. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMachineData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IReadOnlyList<string> zones, ContainerServiceMachineProperties properties, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -79,16 +72,10 @@ namespace Azure.ResourceManager.ContainerService
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The Availability zone in which machine is located.
-        /// Serialized Name: Machine.zones
-        /// </summary>
+        /// <summary> The Availability zone in which machine is located. </summary>
         [WirePath("zones")]
         public IReadOnlyList<string> Zones { get; }
-        /// <summary>
-        /// The properties of the machine
-        /// Serialized Name: Machine.properties
-        /// </summary>
+        /// <summary> The properties of the machine. </summary>
         [WirePath("properties")]
         public ContainerServiceMachineProperties Properties { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceMaintenanceConfigurationData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceMaintenanceConfigurationData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the ContainerServiceMaintenanceConfiguration data model.
     /// Planned maintenance configuration, used to configure when updates can be deployed to a Managed Cluster. See [planned maintenance](https://docs.microsoft.com/azure/aks/planned-maintenance) for more information about planned maintenance.
-    /// Serialized Name: MaintenanceConfiguration
     /// </summary>
     public partial class ContainerServiceMaintenanceConfigurationData : ResourceData
     {
@@ -64,18 +63,9 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="timesInWeek">
-        /// Time slots during the week when planned maintenance is allowed to proceed. If two array entries specify the same day of the week, the applied configuration is the union of times in both entries.
-        /// Serialized Name: MaintenanceConfiguration.properties.timeInWeek
-        /// </param>
-        /// <param name="notAllowedTimes">
-        /// Time slots on which upgrade is not allowed.
-        /// Serialized Name: MaintenanceConfiguration.properties.notAllowedTime
-        /// </param>
-        /// <param name="maintenanceWindow">
-        /// Maintenance window for the maintenance configuration.
-        /// Serialized Name: MaintenanceConfiguration.properties.maintenanceWindow
-        /// </param>
+        /// <param name="timesInWeek"> Time slots during the week when planned maintenance is allowed to proceed. If two array entries specify the same day of the week, the applied configuration is the union of times in both entries. </param>
+        /// <param name="notAllowedTimes"> Time slots on which upgrade is not allowed. </param>
+        /// <param name="maintenanceWindow"> Maintenance window for the maintenance configuration. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMaintenanceConfigurationData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IList<ContainerServiceTimeInWeek> timesInWeek, IList<ContainerServiceTimeSpan> notAllowedTimes, ContainerServiceMaintenanceWindow maintenanceWindow, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -85,22 +75,13 @@ namespace Azure.ResourceManager.ContainerService
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Time slots during the week when planned maintenance is allowed to proceed. If two array entries specify the same day of the week, the applied configuration is the union of times in both entries.
-        /// Serialized Name: MaintenanceConfiguration.properties.timeInWeek
-        /// </summary>
+        /// <summary> Time slots during the week when planned maintenance is allowed to proceed. If two array entries specify the same day of the week, the applied configuration is the union of times in both entries. </summary>
         [WirePath("properties.timeInWeek")]
         public IList<ContainerServiceTimeInWeek> TimesInWeek { get; }
-        /// <summary>
-        /// Time slots on which upgrade is not allowed.
-        /// Serialized Name: MaintenanceConfiguration.properties.notAllowedTime
-        /// </summary>
+        /// <summary> Time slots on which upgrade is not allowed. </summary>
         [WirePath("properties.notAllowedTime")]
         public IList<ContainerServiceTimeSpan> NotAllowedTimes { get; }
-        /// <summary>
-        /// Maintenance window for the maintenance configuration.
-        /// Serialized Name: MaintenanceConfiguration.properties.maintenanceWindow
-        /// </summary>
+        /// <summary> Maintenance window for the maintenance configuration. </summary>
         [WirePath("properties.maintenanceWindow")]
         public ContainerServiceMaintenanceWindow MaintenanceWindow { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceManagedClusterData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceManagedClusterData.cs
@@ -17,7 +17,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the ContainerServiceManagedCluster data model.
     /// Managed cluster.
-    /// Serialized Name: ManagedCluster
     /// </summary>
     public partial class ContainerServiceManagedClusterData : TrackedResourceData
     {
@@ -70,206 +69,56 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedCluster.eTag
-        /// </param>
-        /// <param name="sku">
-        /// The managed cluster SKU.
-        /// Serialized Name: ManagedCluster.sku
-        /// </param>
-        /// <param name="extendedLocation">
-        /// The extended location of the Virtual Machine.
-        /// Serialized Name: ManagedCluster.extendedLocation
-        /// </param>
-        /// <param name="clusterIdentity">
-        /// The identity of the managed cluster, if configured.
-        /// Serialized Name: ManagedCluster.identity
-        /// </param>
-        /// <param name="kind">
-        /// This is primarily used to expose different UI experiences in the portal for different kinds
-        /// Serialized Name: ManagedCluster.kind
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current provisioning state.
-        /// Serialized Name: ManagedCluster.properties.provisioningState
-        /// </param>
-        /// <param name="powerState">
-        /// The Power State of the cluster.
-        /// Serialized Name: ManagedCluster.properties.powerState
-        /// </param>
-        /// <param name="maxAgentPools">
-        /// The max number of agent pools for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.maxAgentPools
-        /// </param>
-        /// <param name="kubernetesVersion">
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -&gt; 1.15.x or 1.15.x -&gt; 1.16.x are allowed, however 1.14.x -&gt; 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details.
-        /// Serialized Name: ManagedCluster.properties.kubernetesVersion
-        /// </param>
-        /// <param name="currentKubernetesVersion">
-        /// The version of Kubernetes the Managed Cluster is running. If kubernetesVersion was a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If kubernetesVersion was &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: ManagedCluster.properties.currentKubernetesVersion
-        /// </param>
-        /// <param name="dnsPrefix">
-        /// The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created.
-        /// Serialized Name: ManagedCluster.properties.dnsPrefix
-        /// </param>
-        /// <param name="fqdnSubdomain">
-        /// The FQDN subdomain of the private cluster with custom private dns zone. This cannot be updated once the Managed Cluster has been created.
-        /// Serialized Name: ManagedCluster.properties.fqdnSubdomain
-        /// </param>
-        /// <param name="fqdn">
-        /// The FQDN of the master pool.
-        /// Serialized Name: ManagedCluster.properties.fqdn
-        /// </param>
-        /// <param name="privateFqdn">
-        /// The FQDN of private cluster.
-        /// Serialized Name: ManagedCluster.properties.privateFQDN
-        /// </param>
-        /// <param name="azurePortalFqdn">
-        /// The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly.
-        /// Serialized Name: ManagedCluster.properties.azurePortalFQDN
-        /// </param>
-        /// <param name="agentPoolProfiles">
-        /// The agent pool properties.
-        /// Serialized Name: ManagedCluster.properties.agentPoolProfiles
-        /// </param>
-        /// <param name="linuxProfile">
-        /// The profile for Linux VMs in the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.linuxProfile
-        /// </param>
-        /// <param name="windowsProfile">
-        /// The profile for Windows VMs in the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.windowsProfile
-        /// </param>
-        /// <param name="servicePrincipalProfile">
-        /// Information about a service principal identity for the cluster to use for manipulating Azure APIs.
-        /// Serialized Name: ManagedCluster.properties.servicePrincipalProfile
-        /// </param>
-        /// <param name="addonProfiles">
-        /// The profile of managed cluster add-on.
-        /// Serialized Name: ManagedCluster.properties.addonProfiles
-        /// </param>
-        /// <param name="podIdentityProfile">
-        /// The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on AAD pod identity integration.
-        /// Serialized Name: ManagedCluster.properties.podIdentityProfile
-        /// </param>
-        /// <param name="oidcIssuerProfile">
-        /// The OIDC issuer profile of the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.oidcIssuerProfile
-        /// </param>
-        /// <param name="nodeResourceGroup">
-        /// The name of the resource group containing agent pool nodes.
-        /// Serialized Name: ManagedCluster.properties.nodeResourceGroup
-        /// </param>
-        /// <param name="nodeResourceGroupProfile">
-        /// Profile of the node resource group configuration.
-        /// Serialized Name: ManagedCluster.properties.nodeResourceGroupProfile
-        /// </param>
-        /// <param name="enableRbac">
-        /// Whether to enable Kubernetes Role-Based Access Control.
-        /// Serialized Name: ManagedCluster.properties.enableRBAC
-        /// </param>
-        /// <param name="supportPlan">
-        /// The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'.
-        /// Serialized Name: ManagedCluster.properties.supportPlan
-        /// </param>
-        /// <param name="networkProfile">
-        /// The network configuration profile.
-        /// Serialized Name: ManagedCluster.properties.networkProfile
-        /// </param>
-        /// <param name="aadProfile">
-        /// The Azure Active Directory configuration.
-        /// Serialized Name: ManagedCluster.properties.aadProfile
-        /// </param>
-        /// <param name="autoUpgradeProfile">
-        /// The auto upgrade configuration.
-        /// Serialized Name: ManagedCluster.properties.autoUpgradeProfile
-        /// </param>
-        /// <param name="upgradeSettings">
-        /// Settings for upgrading a cluster.
-        /// Serialized Name: ManagedCluster.properties.upgradeSettings
-        /// </param>
-        /// <param name="autoScalerProfile">
-        /// Parameters to be applied to the cluster-autoscaler when enabled
-        /// Serialized Name: ManagedCluster.properties.autoScalerProfile
-        /// </param>
-        /// <param name="apiServerAccessProfile">
-        /// The access profile for managed cluster API server.
-        /// Serialized Name: ManagedCluster.properties.apiServerAccessProfile
-        /// </param>
-        /// <param name="diskEncryptionSetId">
-        /// The Resource ID of the disk encryption set to use for enabling encryption at rest. This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'
-        /// Serialized Name: ManagedCluster.properties.diskEncryptionSetID
-        /// </param>
-        /// <param name="identityProfile">
-        /// The user identity associated with the managed cluster. This identity will be used by the kubelet. Only one user assigned identity is allowed. The only accepted key is "kubeletidentity", with value of "resourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}".
-        /// Serialized Name: ManagedCluster.properties.identityProfile
-        /// </param>
-        /// <param name="privateLinkResources">
-        /// Private link resources associated with the cluster.
-        /// Serialized Name: ManagedCluster.properties.privateLinkResources
-        /// </param>
-        /// <param name="disableLocalAccounts">
-        /// If local accounts should be disabled on the Managed Cluster. If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled. For more details see [disable local accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview).
-        /// Serialized Name: ManagedCluster.properties.disableLocalAccounts
-        /// </param>
-        /// <param name="httpProxyConfig">
-        /// Configurations for provisioning the cluster with HTTP proxy servers.
-        /// Serialized Name: ManagedCluster.properties.httpProxyConfig
-        /// </param>
-        /// <param name="securityProfile">
-        /// Security profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.securityProfile
-        /// </param>
-        /// <param name="storageProfile">
-        /// Storage profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.storageProfile
-        /// </param>
-        /// <param name="ingressProfile">
-        /// Ingress profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.ingressProfile
-        /// </param>
-        /// <param name="publicNetworkAccess">
-        /// PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS
-        /// Serialized Name: ManagedCluster.properties.publicNetworkAccess
-        /// </param>
-        /// <param name="workloadAutoScalerProfile">
-        /// Workload Auto-scaler profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.workloadAutoScalerProfile
-        /// </param>
-        /// <param name="azureMonitorProfile">
-        /// Azure Monitor addon profiles for monitoring the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.azureMonitorProfile
-        /// </param>
-        /// <param name="serviceMeshProfile">
-        /// Service mesh profile for a managed cluster.
-        /// Serialized Name: ManagedCluster.properties.serviceMeshProfile
-        /// </param>
-        /// <param name="resourceId">
-        /// The resourceUID uniquely identifies ManagedClusters that reuse ARM ResourceIds (i.e: create, delete, create sequence)
-        /// Serialized Name: ManagedCluster.properties.resourceUID
-        /// </param>
-        /// <param name="metricsProfile">
-        /// Optional cluster metrics configuration.
-        /// Serialized Name: ManagedCluster.properties.metricsProfile
-        /// </param>
-        /// <param name="nodeProvisioningProfile">
-        /// Node provisioning settings that apply to the whole cluster.
-        /// Serialized Name: ManagedCluster.properties.nodeProvisioningProfile
-        /// </param>
-        /// <param name="bootstrapProfile">
-        /// Profile of the cluster bootstrap configuration.
-        /// Serialized Name: ManagedCluster.properties.bootstrapProfile
-        /// </param>
-        /// <param name="aiToolchainOperatorProfile">
-        /// AI toolchain operator settings that apply to the whole cluster.
-        /// Serialized Name: ManagedCluster.properties.aiToolchainOperatorProfile
-        /// </param>
-        /// <param name="status">
-        /// Contains read-only information about the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.status
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="sku"> The managed cluster SKU. </param>
+        /// <param name="extendedLocation"> The extended location of the Virtual Machine. </param>
+        /// <param name="clusterIdentity"> The identity of the managed cluster, if configured. </param>
+        /// <param name="kind"> This is primarily used to expose different UI experiences in the portal for different kinds. </param>
+        /// <param name="provisioningState"> The current provisioning state. </param>
+        /// <param name="powerState"> The Power State of the cluster. </param>
+        /// <param name="maxAgentPools"> The max number of agent pools for the managed cluster. </param>
+        /// <param name="kubernetesVersion"> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -&gt; 1.15.x or 1.15.x -&gt; 1.16.x are allowed, however 1.14.x -&gt; 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details. </param>
+        /// <param name="currentKubernetesVersion"> The version of Kubernetes the Managed Cluster is running. If kubernetesVersion was a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If kubernetesVersion was &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </param>
+        /// <param name="dnsPrefix"> The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created. </param>
+        /// <param name="fqdnSubdomain"> The FQDN subdomain of the private cluster with custom private dns zone. This cannot be updated once the Managed Cluster has been created. </param>
+        /// <param name="fqdn"> The FQDN of the master pool. </param>
+        /// <param name="privateFqdn"> The FQDN of private cluster. </param>
+        /// <param name="azurePortalFqdn"> The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly. </param>
+        /// <param name="agentPoolProfiles"> The agent pool properties. </param>
+        /// <param name="linuxProfile"> The profile for Linux VMs in the Managed Cluster. </param>
+        /// <param name="windowsProfile"> The profile for Windows VMs in the Managed Cluster. </param>
+        /// <param name="servicePrincipalProfile"> Information about a service principal identity for the cluster to use for manipulating Azure APIs. </param>
+        /// <param name="addonProfiles"> The profile of managed cluster add-on. </param>
+        /// <param name="podIdentityProfile"> The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on AAD pod identity integration. </param>
+        /// <param name="oidcIssuerProfile"> The OIDC issuer profile of the Managed Cluster. </param>
+        /// <param name="nodeResourceGroup"> The name of the resource group containing agent pool nodes. </param>
+        /// <param name="nodeResourceGroupProfile"> Profile of the node resource group configuration. </param>
+        /// <param name="enableRbac"> Whether to enable Kubernetes Role-Based Access Control. </param>
+        /// <param name="supportPlan"> The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'. </param>
+        /// <param name="networkProfile"> The network configuration profile. </param>
+        /// <param name="aadProfile"> The Azure Active Directory configuration. </param>
+        /// <param name="autoUpgradeProfile"> The auto upgrade configuration. </param>
+        /// <param name="upgradeSettings"> Settings for upgrading a cluster. </param>
+        /// <param name="autoScalerProfile"> Parameters to be applied to the cluster-autoscaler when enabled. </param>
+        /// <param name="apiServerAccessProfile"> The access profile for managed cluster API server. </param>
+        /// <param name="diskEncryptionSetId"> The Resource ID of the disk encryption set to use for enabling encryption at rest. This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'. </param>
+        /// <param name="identityProfile"> The user identity associated with the managed cluster. This identity will be used by the kubelet. Only one user assigned identity is allowed. The only accepted key is "kubeletidentity", with value of "resourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}". </param>
+        /// <param name="privateLinkResources"> Private link resources associated with the cluster. </param>
+        /// <param name="disableLocalAccounts"> If local accounts should be disabled on the Managed Cluster. If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled. For more details see [disable local accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview). </param>
+        /// <param name="httpProxyConfig"> Configurations for provisioning the cluster with HTTP proxy servers. </param>
+        /// <param name="securityProfile"> Security profile for the managed cluster. </param>
+        /// <param name="storageProfile"> Storage profile for the managed cluster. </param>
+        /// <param name="ingressProfile"> Ingress profile for the managed cluster. </param>
+        /// <param name="publicNetworkAccess"> PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS. </param>
+        /// <param name="workloadAutoScalerProfile"> Workload Auto-scaler profile for the managed cluster. </param>
+        /// <param name="azureMonitorProfile"> Azure Monitor addon profiles for monitoring the managed cluster. </param>
+        /// <param name="serviceMeshProfile"> Service mesh profile for a managed cluster. </param>
+        /// <param name="resourceId"> The resourceUID uniquely identifies ManagedClusters that reuse ARM ResourceIds (i.e: create, delete, create sequence). </param>
+        /// <param name="metricsProfile"> Optional cluster metrics configuration. </param>
+        /// <param name="nodeProvisioningProfile"> Node provisioning settings that apply to the whole cluster. </param>
+        /// <param name="bootstrapProfile"> Profile of the cluster bootstrap configuration. </param>
+        /// <param name="aiToolchainOperatorProfile"> AI toolchain operator settings that apply to the whole cluster. </param>
+        /// <param name="status"> Contains read-only information about the Managed Cluster. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceManagedClusterData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IDictionary<string, string> tags, AzureLocation location, ETag? etag, ManagedClusterSku sku, ExtendedLocation extendedLocation, ManagedClusterIdentity clusterIdentity, string kind, string provisioningState, ContainerServicePowerState powerState, int? maxAgentPools, string kubernetesVersion, string currentKubernetesVersion, string dnsPrefix, string fqdnSubdomain, string fqdn, string privateFqdn, string azurePortalFqdn, IList<ManagedClusterAgentPoolProfile> agentPoolProfiles, ContainerServiceLinuxProfile linuxProfile, ManagedClusterWindowsProfile windowsProfile, ManagedClusterServicePrincipalProfile servicePrincipalProfile, IDictionary<string, ManagedClusterAddonProfile> addonProfiles, ManagedClusterPodIdentityProfile podIdentityProfile, ManagedClusterOidcIssuerProfile oidcIssuerProfile, string nodeResourceGroup, ManagedClusterNodeResourceGroupProfile nodeResourceGroupProfile, bool? enableRbac, KubernetesSupportPlan? supportPlan, ContainerServiceNetworkProfile networkProfile, ManagedClusterAadProfile aadProfile, ManagedClusterAutoUpgradeProfile autoUpgradeProfile, ClusterUpgradeSettings upgradeSettings, ManagedClusterAutoScalerProfile autoScalerProfile, ManagedClusterApiServerAccessProfile apiServerAccessProfile, ResourceIdentifier diskEncryptionSetId, IDictionary<string, ContainerServiceUserAssignedIdentity> identityProfile, IList<ContainerServicePrivateLinkResourceData> privateLinkResources, bool? disableLocalAccounts, ManagedClusterHttpProxyConfig httpProxyConfig, ManagedClusterSecurityProfile securityProfile, ManagedClusterStorageProfile storageProfile, ManagedClusterIngressProfile ingressProfile, ContainerServicePublicNetworkAccess? publicNetworkAccess, ManagedClusterWorkloadAutoScalerProfile workloadAutoScalerProfile, ManagedClusterAzureMonitorProfile azureMonitorProfile, ServiceMeshProfile serviceMeshProfile, ResourceIdentifier resourceId, ManagedClusterMetricsProfile metricsProfile, ManagedClusterNodeProvisioningProfile nodeProvisioningProfile, ManagedClusterBootstrapProfile bootstrapProfile, ManagedClusterAIToolchainOperatorProfile aiToolchainOperatorProfile, ManagedClusterStatus status, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData, tags, location)
         {
@@ -331,162 +180,84 @@ namespace Azure.ResourceManager.ContainerService
         {
         }
 
-        /// <summary>
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedCluster.eTag
-        /// </summary>
+        /// <summary> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </summary>
         [WirePath("eTag")]
         public ETag? ETag { get; }
-        /// <summary>
-        /// The managed cluster SKU.
-        /// Serialized Name: ManagedCluster.sku
-        /// </summary>
+        /// <summary> The managed cluster SKU. </summary>
         [WirePath("sku")]
         public ManagedClusterSku Sku { get; set; }
-        /// <summary>
-        /// The extended location of the Virtual Machine.
-        /// Serialized Name: ManagedCluster.extendedLocation
-        /// </summary>
+        /// <summary> The extended location of the Virtual Machine. </summary>
         [WirePath("extendedLocation")]
         public ExtendedLocation ExtendedLocation { get; set; }
-        /// <summary>
-        /// The identity of the managed cluster, if configured.
-        /// Serialized Name: ManagedCluster.identity
-        /// </summary>
+        /// <summary> The identity of the managed cluster, if configured. </summary>
         [WirePath("identity")]
         public ManagedClusterIdentity ClusterIdentity { get; set; }
-        /// <summary>
-        /// This is primarily used to expose different UI experiences in the portal for different kinds
-        /// Serialized Name: ManagedCluster.kind
-        /// </summary>
+        /// <summary> This is primarily used to expose different UI experiences in the portal for different kinds. </summary>
         [WirePath("kind")]
         public string Kind { get; set; }
-        /// <summary>
-        /// The current provisioning state.
-        /// Serialized Name: ManagedCluster.properties.provisioningState
-        /// </summary>
+        /// <summary> The current provisioning state. </summary>
         [WirePath("properties.provisioningState")]
         public string ProvisioningState { get; }
-        /// <summary>
-        /// The Power State of the cluster.
-        /// Serialized Name: ManagedCluster.properties.powerState
-        /// </summary>
+        /// <summary> The Power State of the cluster. </summary>
         internal ContainerServicePowerState PowerState { get; }
-        /// <summary>
-        /// Tells whether the cluster is Running or Stopped
-        /// Serialized Name: PowerState.code
-        /// </summary>
+        /// <summary> Tells whether the cluster is Running or Stopped. </summary>
         [WirePath("properties.powerState.code")]
         public ContainerServiceStateCode? PowerStateCode
         {
             get => PowerState?.Code;
         }
 
-        /// <summary>
-        /// The max number of agent pools for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.maxAgentPools
-        /// </summary>
+        /// <summary> The max number of agent pools for the managed cluster. </summary>
         [WirePath("properties.maxAgentPools")]
         public int? MaxAgentPools { get; }
-        /// <summary>
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -&gt; 1.15.x or 1.15.x -&gt; 1.16.x are allowed, however 1.14.x -&gt; 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details.
-        /// Serialized Name: ManagedCluster.properties.kubernetesVersion
-        /// </summary>
+        /// <summary> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. When you upgrade a supported AKS cluster, Kubernetes minor versions cannot be skipped. All upgrades must be performed sequentially by major version number. For example, upgrades between 1.14.x -&gt; 1.15.x or 1.15.x -&gt; 1.16.x are allowed, however 1.14.x -&gt; 1.16.x is not allowed. See [upgrading an AKS cluster](https://docs.microsoft.com/azure/aks/upgrade-cluster) for more details. </summary>
         [WirePath("properties.kubernetesVersion")]
         public string KubernetesVersion { get; set; }
-        /// <summary>
-        /// The version of Kubernetes the Managed Cluster is running. If kubernetesVersion was a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If kubernetesVersion was &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: ManagedCluster.properties.currentKubernetesVersion
-        /// </summary>
+        /// <summary> The version of Kubernetes the Managed Cluster is running. If kubernetesVersion was a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If kubernetesVersion was &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </summary>
         [WirePath("properties.currentKubernetesVersion")]
         public string CurrentKubernetesVersion { get; }
-        /// <summary>
-        /// The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created.
-        /// Serialized Name: ManagedCluster.properties.dnsPrefix
-        /// </summary>
+        /// <summary> The DNS prefix of the Managed Cluster. This cannot be updated once the Managed Cluster has been created. </summary>
         [WirePath("properties.dnsPrefix")]
         public string DnsPrefix { get; set; }
-        /// <summary>
-        /// The FQDN subdomain of the private cluster with custom private dns zone. This cannot be updated once the Managed Cluster has been created.
-        /// Serialized Name: ManagedCluster.properties.fqdnSubdomain
-        /// </summary>
+        /// <summary> The FQDN subdomain of the private cluster with custom private dns zone. This cannot be updated once the Managed Cluster has been created. </summary>
         [WirePath("properties.fqdnSubdomain")]
         public string FqdnSubdomain { get; set; }
-        /// <summary>
-        /// The FQDN of the master pool.
-        /// Serialized Name: ManagedCluster.properties.fqdn
-        /// </summary>
+        /// <summary> The FQDN of the master pool. </summary>
         [WirePath("properties.fqdn")]
         public string Fqdn { get; }
-        /// <summary>
-        /// The FQDN of private cluster.
-        /// Serialized Name: ManagedCluster.properties.privateFQDN
-        /// </summary>
+        /// <summary> The FQDN of private cluster. </summary>
         [WirePath("properties.privateFQDN")]
         public string PrivateFqdn { get; }
-        /// <summary>
-        /// The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly.
-        /// Serialized Name: ManagedCluster.properties.azurePortalFQDN
-        /// </summary>
+        /// <summary> The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly. </summary>
         [WirePath("properties.azurePortalFQDN")]
         public string AzurePortalFqdn { get; }
-        /// <summary>
-        /// The agent pool properties.
-        /// Serialized Name: ManagedCluster.properties.agentPoolProfiles
-        /// </summary>
+        /// <summary> The agent pool properties. </summary>
         [WirePath("properties.agentPoolProfiles")]
         public IList<ManagedClusterAgentPoolProfile> AgentPoolProfiles { get; }
-        /// <summary>
-        /// The profile for Linux VMs in the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.linuxProfile
-        /// </summary>
+        /// <summary> The profile for Linux VMs in the Managed Cluster. </summary>
         [WirePath("properties.linuxProfile")]
         public ContainerServiceLinuxProfile LinuxProfile { get; set; }
-        /// <summary>
-        /// The profile for Windows VMs in the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.windowsProfile
-        /// </summary>
+        /// <summary> The profile for Windows VMs in the Managed Cluster. </summary>
         [WirePath("properties.windowsProfile")]
         public ManagedClusterWindowsProfile WindowsProfile { get; set; }
-        /// <summary>
-        /// Information about a service principal identity for the cluster to use for manipulating Azure APIs.
-        /// Serialized Name: ManagedCluster.properties.servicePrincipalProfile
-        /// </summary>
+        /// <summary> Information about a service principal identity for the cluster to use for manipulating Azure APIs. </summary>
         [WirePath("properties.servicePrincipalProfile")]
         public ManagedClusterServicePrincipalProfile ServicePrincipalProfile { get; set; }
-        /// <summary>
-        /// The profile of managed cluster add-on.
-        /// Serialized Name: ManagedCluster.properties.addonProfiles
-        /// </summary>
+        /// <summary> The profile of managed cluster add-on. </summary>
         [WirePath("properties.addonProfiles")]
         public IDictionary<string, ManagedClusterAddonProfile> AddonProfiles { get; }
-        /// <summary>
-        /// The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on AAD pod identity integration.
-        /// Serialized Name: ManagedCluster.properties.podIdentityProfile
-        /// </summary>
+        /// <summary> The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on AAD pod identity integration. </summary>
         [WirePath("properties.podIdentityProfile")]
         public ManagedClusterPodIdentityProfile PodIdentityProfile { get; set; }
-        /// <summary>
-        /// The OIDC issuer profile of the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.oidcIssuerProfile
-        /// </summary>
+        /// <summary> The OIDC issuer profile of the Managed Cluster. </summary>
         [WirePath("properties.oidcIssuerProfile")]
         public ManagedClusterOidcIssuerProfile OidcIssuerProfile { get; set; }
-        /// <summary>
-        /// The name of the resource group containing agent pool nodes.
-        /// Serialized Name: ManagedCluster.properties.nodeResourceGroup
-        /// </summary>
+        /// <summary> The name of the resource group containing agent pool nodes. </summary>
         [WirePath("properties.nodeResourceGroup")]
         public string NodeResourceGroup { get; set; }
-        /// <summary>
-        /// Profile of the node resource group configuration.
-        /// Serialized Name: ManagedCluster.properties.nodeResourceGroupProfile
-        /// </summary>
+        /// <summary> Profile of the node resource group configuration. </summary>
         internal ManagedClusterNodeResourceGroupProfile NodeResourceGroupProfile { get; set; }
-        /// <summary>
-        /// The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'
-        /// Serialized Name: ManagedClusterNodeResourceGroupProfile.restrictionLevel
-        /// </summary>
+        /// <summary> The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'. </summary>
         [WirePath("properties.nodeResourceGroupProfile.restrictionLevel")]
         public ManagedClusterNodeResourceGroupRestrictionLevel? NodeResourceGroupRestrictionLevel
         {
@@ -499,45 +270,24 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// Whether to enable Kubernetes Role-Based Access Control.
-        /// Serialized Name: ManagedCluster.properties.enableRBAC
-        /// </summary>
+        /// <summary> Whether to enable Kubernetes Role-Based Access Control. </summary>
         [WirePath("properties.enableRBAC")]
         public bool? EnableRbac { get; set; }
-        /// <summary>
-        /// The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'.
-        /// Serialized Name: ManagedCluster.properties.supportPlan
-        /// </summary>
+        /// <summary> The support plan for the Managed Cluster. If unspecified, the default is 'KubernetesOfficial'. </summary>
         [WirePath("properties.supportPlan")]
         public KubernetesSupportPlan? SupportPlan { get; set; }
-        /// <summary>
-        /// The network configuration profile.
-        /// Serialized Name: ManagedCluster.properties.networkProfile
-        /// </summary>
+        /// <summary> The network configuration profile. </summary>
         [WirePath("properties.networkProfile")]
         public ContainerServiceNetworkProfile NetworkProfile { get; set; }
-        /// <summary>
-        /// The Azure Active Directory configuration.
-        /// Serialized Name: ManagedCluster.properties.aadProfile
-        /// </summary>
+        /// <summary> The Azure Active Directory configuration. </summary>
         [WirePath("properties.aadProfile")]
         public ManagedClusterAadProfile AadProfile { get; set; }
-        /// <summary>
-        /// The auto upgrade configuration.
-        /// Serialized Name: ManagedCluster.properties.autoUpgradeProfile
-        /// </summary>
+        /// <summary> The auto upgrade configuration. </summary>
         [WirePath("properties.autoUpgradeProfile")]
         public ManagedClusterAutoUpgradeProfile AutoUpgradeProfile { get; set; }
-        /// <summary>
-        /// Settings for upgrading a cluster.
-        /// Serialized Name: ManagedCluster.properties.upgradeSettings
-        /// </summary>
+        /// <summary> Settings for upgrading a cluster. </summary>
         internal ClusterUpgradeSettings UpgradeSettings { get; set; }
-        /// <summary>
-        /// Settings for overrides.
-        /// Serialized Name: ClusterUpgradeSettings.overrideSettings
-        /// </summary>
+        /// <summary> Settings for overrides. </summary>
         [WirePath("properties.upgradeSettings.overrideSettings")]
         public UpgradeOverrideSettings UpgradeOverrideSettings
         {
@@ -550,69 +300,36 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// Parameters to be applied to the cluster-autoscaler when enabled
-        /// Serialized Name: ManagedCluster.properties.autoScalerProfile
-        /// </summary>
+        /// <summary> Parameters to be applied to the cluster-autoscaler when enabled. </summary>
         [WirePath("properties.autoScalerProfile")]
         public ManagedClusterAutoScalerProfile AutoScalerProfile { get; set; }
-        /// <summary>
-        /// The access profile for managed cluster API server.
-        /// Serialized Name: ManagedCluster.properties.apiServerAccessProfile
-        /// </summary>
+        /// <summary> The access profile for managed cluster API server. </summary>
         [WirePath("properties.apiServerAccessProfile")]
         public ManagedClusterApiServerAccessProfile ApiServerAccessProfile { get; set; }
-        /// <summary>
-        /// The Resource ID of the disk encryption set to use for enabling encryption at rest. This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'
-        /// Serialized Name: ManagedCluster.properties.diskEncryptionSetID
-        /// </summary>
+        /// <summary> The Resource ID of the disk encryption set to use for enabling encryption at rest. This is of the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{encryptionSetName}'. </summary>
         [WirePath("properties.diskEncryptionSetID")]
         public ResourceIdentifier DiskEncryptionSetId { get; set; }
-        /// <summary>
-        /// The user identity associated with the managed cluster. This identity will be used by the kubelet. Only one user assigned identity is allowed. The only accepted key is "kubeletidentity", with value of "resourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}".
-        /// Serialized Name: ManagedCluster.properties.identityProfile
-        /// </summary>
+        /// <summary> The user identity associated with the managed cluster. This identity will be used by the kubelet. Only one user assigned identity is allowed. The only accepted key is "kubeletidentity", with value of "resourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}". </summary>
         [WirePath("properties.identityProfile")]
         public IDictionary<string, ContainerServiceUserAssignedIdentity> IdentityProfile { get; }
-        /// <summary>
-        /// Private link resources associated with the cluster.
-        /// Serialized Name: ManagedCluster.properties.privateLinkResources
-        /// </summary>
+        /// <summary> Private link resources associated with the cluster. </summary>
         [WirePath("properties.privateLinkResources")]
         public IList<ContainerServicePrivateLinkResourceData> PrivateLinkResources { get; }
-        /// <summary>
-        /// If local accounts should be disabled on the Managed Cluster. If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled. For more details see [disable local accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview).
-        /// Serialized Name: ManagedCluster.properties.disableLocalAccounts
-        /// </summary>
+        /// <summary> If local accounts should be disabled on the Managed Cluster. If set to true, getting static credentials will be disabled for this cluster. This must only be used on Managed Clusters that are AAD enabled. For more details see [disable local accounts](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts-preview). </summary>
         [WirePath("properties.disableLocalAccounts")]
         public bool? DisableLocalAccounts { get; set; }
-        /// <summary>
-        /// Configurations for provisioning the cluster with HTTP proxy servers.
-        /// Serialized Name: ManagedCluster.properties.httpProxyConfig
-        /// </summary>
+        /// <summary> Configurations for provisioning the cluster with HTTP proxy servers. </summary>
         [WirePath("properties.httpProxyConfig")]
         public ManagedClusterHttpProxyConfig HttpProxyConfig { get; set; }
-        /// <summary>
-        /// Security profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.securityProfile
-        /// </summary>
+        /// <summary> Security profile for the managed cluster. </summary>
         [WirePath("properties.securityProfile")]
         public ManagedClusterSecurityProfile SecurityProfile { get; set; }
-        /// <summary>
-        /// Storage profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.storageProfile
-        /// </summary>
+        /// <summary> Storage profile for the managed cluster. </summary>
         [WirePath("properties.storageProfile")]
         public ManagedClusterStorageProfile StorageProfile { get; set; }
-        /// <summary>
-        /// Ingress profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.ingressProfile
-        /// </summary>
+        /// <summary> Ingress profile for the managed cluster. </summary>
         internal ManagedClusterIngressProfile IngressProfile { get; set; }
-        /// <summary>
-        /// App Routing settings for the ingress profile. You can find an overview and onboarding guide for this feature at https://learn.microsoft.com/en-us/azure/aks/app-routing?tabs=default%2Cdeploy-app-default.
-        /// Serialized Name: ManagedClusterIngressProfile.webAppRouting
-        /// </summary>
+        /// <summary> App Routing settings for the ingress profile. You can find an overview and onboarding guide for this feature at https://learn.microsoft.com/en-us/azure/aks/app-routing?tabs=default%2Cdeploy-app-default. </summary>
         [WirePath("properties.ingressProfile.webAppRouting")]
         public ManagedClusterIngressProfileWebAppRouting IngressWebAppRouting
         {
@@ -625,27 +342,15 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS
-        /// Serialized Name: ManagedCluster.properties.publicNetworkAccess
-        /// </summary>
+        /// <summary> PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS. </summary>
         [WirePath("properties.publicNetworkAccess")]
         public ContainerServicePublicNetworkAccess? PublicNetworkAccess { get; set; }
-        /// <summary>
-        /// Workload Auto-scaler profile for the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.workloadAutoScalerProfile
-        /// </summary>
+        /// <summary> Workload Auto-scaler profile for the managed cluster. </summary>
         [WirePath("properties.workloadAutoScalerProfile")]
         public ManagedClusterWorkloadAutoScalerProfile WorkloadAutoScalerProfile { get; set; }
-        /// <summary>
-        /// Azure Monitor addon profiles for monitoring the managed cluster.
-        /// Serialized Name: ManagedCluster.properties.azureMonitorProfile
-        /// </summary>
+        /// <summary> Azure Monitor addon profiles for monitoring the managed cluster. </summary>
         internal ManagedClusterAzureMonitorProfile AzureMonitorProfile { get; set; }
-        /// <summary>
-        /// Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview.
-        /// Serialized Name: ManagedClusterAzureMonitorProfile.metrics
-        /// </summary>
+        /// <summary> Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview. </summary>
         [WirePath("properties.azureMonitorProfile.metrics")]
         public ManagedClusterMonitorProfileMetrics AzureMonitorMetrics
         {
@@ -658,27 +363,15 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// Service mesh profile for a managed cluster.
-        /// Serialized Name: ManagedCluster.properties.serviceMeshProfile
-        /// </summary>
+        /// <summary> Service mesh profile for a managed cluster. </summary>
         [WirePath("properties.serviceMeshProfile")]
         public ServiceMeshProfile ServiceMeshProfile { get; set; }
-        /// <summary>
-        /// The resourceUID uniquely identifies ManagedClusters that reuse ARM ResourceIds (i.e: create, delete, create sequence)
-        /// Serialized Name: ManagedCluster.properties.resourceUID
-        /// </summary>
+        /// <summary> The resourceUID uniquely identifies ManagedClusters that reuse ARM ResourceIds (i.e: create, delete, create sequence). </summary>
         [WirePath("properties.resourceUID")]
         public ResourceIdentifier ResourceId { get; }
-        /// <summary>
-        /// Optional cluster metrics configuration.
-        /// Serialized Name: ManagedCluster.properties.metricsProfile
-        /// </summary>
+        /// <summary> Optional cluster metrics configuration. </summary>
         internal ManagedClusterMetricsProfile MetricsProfile { get; set; }
-        /// <summary>
-        /// Whether to enable cost analysis. The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis.
-        /// Serialized Name: ManagedClusterCostAnalysis.enabled
-        /// </summary>
+        /// <summary> Whether to enable cost analysis. The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis. </summary>
         [WirePath("properties.metricsProfile.costAnalysis.enabled")]
         public bool? IsCostAnalysisEnabled
         {
@@ -691,27 +384,15 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// Node provisioning settings that apply to the whole cluster.
-        /// Serialized Name: ManagedCluster.properties.nodeProvisioningProfile
-        /// </summary>
+        /// <summary> Node provisioning settings that apply to the whole cluster. </summary>
         [WirePath("properties.nodeProvisioningProfile")]
         public ManagedClusterNodeProvisioningProfile NodeProvisioningProfile { get; set; }
-        /// <summary>
-        /// Profile of the cluster bootstrap configuration.
-        /// Serialized Name: ManagedCluster.properties.bootstrapProfile
-        /// </summary>
+        /// <summary> Profile of the cluster bootstrap configuration. </summary>
         [WirePath("properties.bootstrapProfile")]
         public ManagedClusterBootstrapProfile BootstrapProfile { get; set; }
-        /// <summary>
-        /// AI toolchain operator settings that apply to the whole cluster.
-        /// Serialized Name: ManagedCluster.properties.aiToolchainOperatorProfile
-        /// </summary>
+        /// <summary> AI toolchain operator settings that apply to the whole cluster. </summary>
         internal ManagedClusterAIToolchainOperatorProfile AiToolchainOperatorProfile { get; set; }
-        /// <summary>
-        /// Whether to enable AI toolchain operator to the cluster. Indicates if AI toolchain operator  enabled or not.
-        /// Serialized Name: ManagedClusterAIToolchainOperatorProfile.enabled
-        /// </summary>
+        /// <summary> Whether to enable AI toolchain operator to the cluster. Indicates if AI toolchain operator  enabled or not. </summary>
         [WirePath("properties.aiToolchainOperatorProfile.enabled")]
         public bool? IsAIToolchainOperatorEnabled
         {
@@ -724,15 +405,9 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// Contains read-only information about the Managed Cluster.
-        /// Serialized Name: ManagedCluster.properties.status
-        /// </summary>
+        /// <summary> Contains read-only information about the Managed Cluster. </summary>
         internal ManagedClusterStatus Status { get; set; }
-        /// <summary>
-        /// The error details information of the managed cluster. Preserves the detailed info of failure. If there was no error, this field is omitted.
-        /// Serialized Name: ManagedClusterStatus.provisioningError
-        /// </summary>
+        /// <summary> The error details information of the managed cluster. Preserves the detailed info of failure. If there was no error, this field is omitted. </summary>
         [WirePath("properties.status.provisioningError")]
         public ResponseError StatusProvisioningError
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServicePrivateEndpointConnectionData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServicePrivateEndpointConnectionData.cs
@@ -17,7 +17,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the ContainerServicePrivateEndpointConnection data model.
     /// A private endpoint connection
-    /// Serialized Name: PrivateEndpointConnection
     /// </summary>
     public partial class ContainerServicePrivateEndpointConnectionData : ResourceData
     {
@@ -63,18 +62,9 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="provisioningState">
-        /// The current provisioning state.
-        /// Serialized Name: PrivateEndpointConnection.properties.provisioningState
-        /// </param>
-        /// <param name="privateEndpoint">
-        /// The resource of private endpoint.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateEndpoint
-        /// </param>
-        /// <param name="connectionState">
-        /// A collection of information about the state of the connection between service consumer and provider.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateLinkServiceConnectionState
-        /// </param>
+        /// <param name="provisioningState"> The current provisioning state. </param>
+        /// <param name="privateEndpoint"> The resource of private endpoint. </param>
+        /// <param name="connectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServicePrivateEndpointConnectionData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, ContainerServicePrivateEndpointConnectionProvisioningState? provisioningState, WritableSubResource privateEndpoint, ContainerServicePrivateLinkServiceConnectionState connectionState, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -84,16 +74,10 @@ namespace Azure.ResourceManager.ContainerService
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The current provisioning state.
-        /// Serialized Name: PrivateEndpointConnection.properties.provisioningState
-        /// </summary>
+        /// <summary> The current provisioning state. </summary>
         [WirePath("properties.provisioningState")]
         public ContainerServicePrivateEndpointConnectionProvisioningState? ProvisioningState { get; }
-        /// <summary>
-        /// The resource of private endpoint.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateEndpoint
-        /// </summary>
+        /// <summary> The resource of private endpoint. </summary>
         internal WritableSubResource PrivateEndpoint { get; set; }
         /// <summary> Gets or sets Id. </summary>
         [WirePath("properties.privateEndpoint.id")]
@@ -108,10 +92,7 @@ namespace Azure.ResourceManager.ContainerService
             }
         }
 
-        /// <summary>
-        /// A collection of information about the state of the connection between service consumer and provider.
-        /// Serialized Name: PrivateEndpointConnection.properties.privateLinkServiceConnectionState
-        /// </summary>
+        /// <summary> A collection of information about the state of the connection between service consumer and provider. </summary>
         [WirePath("properties.privateLinkServiceConnectionState")]
         public ContainerServicePrivateLinkServiceConnectionState ConnectionState { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceTrustedAccessRoleBindingData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ContainerServiceTrustedAccessRoleBindingData.cs
@@ -17,7 +17,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the ContainerServiceTrustedAccessRoleBinding data model.
     /// Defines binding between a resource and role
-    /// Serialized Name: TrustedAccessRoleBinding
     /// </summary>
     public partial class ContainerServiceTrustedAccessRoleBindingData : ResourceData
     {
@@ -54,14 +53,8 @@ namespace Azure.ResourceManager.ContainerService
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceTrustedAccessRoleBindingData"/>. </summary>
-        /// <param name="sourceResourceId">
-        /// The ARM resource ID of source resource that trusted access is configured for.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.sourceResourceId
-        /// </param>
-        /// <param name="roles">
-        /// A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.roles
-        /// </param>
+        /// <param name="sourceResourceId"> The ARM resource ID of source resource that trusted access is configured for. </param>
+        /// <param name="roles"> A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="sourceResourceId"/> or <paramref name="roles"/> is null. </exception>
         public ContainerServiceTrustedAccessRoleBindingData(ResourceIdentifier sourceResourceId, IEnumerable<string> roles)
         {
@@ -77,18 +70,9 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="provisioningState">
-        /// The current provisioning state of trusted access role binding.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.provisioningState
-        /// </param>
-        /// <param name="sourceResourceId">
-        /// The ARM resource ID of source resource that trusted access is configured for.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.sourceResourceId
-        /// </param>
-        /// <param name="roles">
-        /// A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.roles
-        /// </param>
+        /// <param name="provisioningState"> The current provisioning state of trusted access role binding. </param>
+        /// <param name="sourceResourceId"> The ARM resource ID of source resource that trusted access is configured for. </param>
+        /// <param name="roles"> A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceTrustedAccessRoleBindingData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, ContainerServiceTrustedAccessRoleBindingProvisioningState? provisioningState, ResourceIdentifier sourceResourceId, IList<string> roles, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -103,22 +87,13 @@ namespace Azure.ResourceManager.ContainerService
         {
         }
 
-        /// <summary>
-        /// The current provisioning state of trusted access role binding.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.provisioningState
-        /// </summary>
+        /// <summary> The current provisioning state of trusted access role binding. </summary>
         [WirePath("properties.provisioningState")]
         public ContainerServiceTrustedAccessRoleBindingProvisioningState? ProvisioningState { get; }
-        /// <summary>
-        /// The ARM resource ID of source resource that trusted access is configured for.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.sourceResourceId
-        /// </summary>
+        /// <summary> The ARM resource ID of source resource that trusted access is configured for. </summary>
         [WirePath("properties.sourceResourceId")]
         public ResourceIdentifier SourceResourceId { get; set; }
-        /// <summary>
-        /// A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'.
-        /// Serialized Name: TrustedAccessRoleBinding.properties.roles
-        /// </summary>
+        /// <summary> A list of roles to bind, each item is a resource type qualified role name. For example: 'Microsoft.MachineLearningServices/workspaces/reader'. </summary>
         [WirePath("properties.roles")]
         public IList<string> Roles { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ManagedClusterNamespaceData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ManagedClusterNamespaceData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the ManagedClusterNamespace data model.
     /// Namespace managed by ARM.
-    /// Serialized Name: ManagedNamespace
     /// </summary>
     public partial class ManagedClusterNamespaceData : TrackedResourceData
     {
@@ -65,14 +64,8 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedNamespace.eTag
-        /// </param>
-        /// <param name="properties">
-        /// Properties of a namespace.
-        /// Serialized Name: ManagedNamespace.properties
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="properties"> Properties of a namespace. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterNamespaceData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IDictionary<string, string> tags, AzureLocation location, ETag? etag, ManagedClusterNamespaceProperties properties, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData, tags, location)
         {
@@ -86,16 +79,10 @@ namespace Azure.ResourceManager.ContainerService
         {
         }
 
-        /// <summary>
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedNamespace.eTag
-        /// </summary>
+        /// <summary> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </summary>
         [WirePath("eTag")]
         public ETag? ETag { get; }
-        /// <summary>
-        /// Properties of a namespace.
-        /// Serialized Name: ManagedNamespace.properties
-        /// </summary>
+        /// <summary> Properties of a namespace. </summary>
         [WirePath("properties")]
         public ManagedClusterNamespaceProperties Properties { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ManagedClusterUpgradeProfileData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/ManagedClusterUpgradeProfileData.cs
@@ -17,7 +17,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the ManagedClusterUpgradeProfile data model.
     /// The list of available upgrades for compute pools.
-    /// Serialized Name: ManagedClusterUpgradeProfile
     /// </summary>
     public partial class ManagedClusterUpgradeProfileData : ResourceData
     {
@@ -54,14 +53,8 @@ namespace Azure.ResourceManager.ContainerService
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterUpgradeProfileData"/>. </summary>
-        /// <param name="controlPlaneProfile">
-        /// The list of available upgrade versions for the control plane.
-        /// Serialized Name: ManagedClusterUpgradeProfile.properties.controlPlaneProfile
-        /// </param>
-        /// <param name="agentPoolProfiles">
-        /// The list of available upgrade versions for agent pools.
-        /// Serialized Name: ManagedClusterUpgradeProfile.properties.agentPoolProfiles
-        /// </param>
+        /// <param name="controlPlaneProfile"> The list of available upgrade versions for the control plane. </param>
+        /// <param name="agentPoolProfiles"> The list of available upgrade versions for agent pools. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="controlPlaneProfile"/> or <paramref name="agentPoolProfiles"/> is null. </exception>
         internal ManagedClusterUpgradeProfileData(ManagedClusterPoolUpgradeProfile controlPlaneProfile, IEnumerable<ManagedClusterPoolUpgradeProfile> agentPoolProfiles)
         {
@@ -77,14 +70,8 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="controlPlaneProfile">
-        /// The list of available upgrade versions for the control plane.
-        /// Serialized Name: ManagedClusterUpgradeProfile.properties.controlPlaneProfile
-        /// </param>
-        /// <param name="agentPoolProfiles">
-        /// The list of available upgrade versions for agent pools.
-        /// Serialized Name: ManagedClusterUpgradeProfile.properties.agentPoolProfiles
-        /// </param>
+        /// <param name="controlPlaneProfile"> The list of available upgrade versions for the control plane. </param>
+        /// <param name="agentPoolProfiles"> The list of available upgrade versions for agent pools. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterUpgradeProfileData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, ManagedClusterPoolUpgradeProfile controlPlaneProfile, IReadOnlyList<ManagedClusterPoolUpgradeProfile> agentPoolProfiles, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -98,16 +85,10 @@ namespace Azure.ResourceManager.ContainerService
         {
         }
 
-        /// <summary>
-        /// The list of available upgrade versions for the control plane.
-        /// Serialized Name: ManagedClusterUpgradeProfile.properties.controlPlaneProfile
-        /// </summary>
+        /// <summary> The list of available upgrade versions for the control plane. </summary>
         [WirePath("properties.controlPlaneProfile")]
         public ManagedClusterPoolUpgradeProfile ControlPlaneProfile { get; }
-        /// <summary>
-        /// The list of available upgrade versions for agent pools.
-        /// Serialized Name: ManagedClusterUpgradeProfile.properties.agentPoolProfiles
-        /// </summary>
+        /// <summary> The list of available upgrade versions for agent pools. </summary>
         [WirePath("properties.agentPoolProfiles")]
         public IReadOnlyList<ManagedClusterPoolUpgradeProfile> AgentPoolProfiles { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/MeshRevisionProfileData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/MeshRevisionProfileData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the MeshRevisionProfile data model.
     /// Mesh revision profile for a mesh.
-    /// Serialized Name: MeshRevisionProfile
     /// </summary>
     public partial class MeshRevisionProfileData : ResourceData
     {
@@ -62,10 +61,7 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="properties">
-        /// Mesh revision profile properties for a mesh
-        /// Serialized Name: MeshRevisionProfile.properties
-        /// </param>
+        /// <param name="properties"> Mesh revision profile properties for a mesh. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MeshRevisionProfileData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, MeshRevisionProfileProperties properties, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -73,12 +69,9 @@ namespace Azure.ResourceManager.ContainerService
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Mesh revision profile properties for a mesh
-        /// Serialized Name: MeshRevisionProfile.properties
-        /// </summary>
+        /// <summary> Mesh revision profile properties for a mesh. </summary>
         internal MeshRevisionProfileProperties Properties { get; set; }
-        /// <summary> Serialized Name: MeshRevisionProfileProperties.meshRevisions. </summary>
+        /// <summary> Gets the mesh revisions. </summary>
         [WirePath("properties.meshRevisions")]
         public IList<MeshRevision> MeshRevisions
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/MeshUpgradeProfileData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/MeshUpgradeProfileData.cs
@@ -16,7 +16,6 @@ namespace Azure.ResourceManager.ContainerService
     /// <summary>
     /// A class representing the MeshUpgradeProfile data model.
     /// Upgrade profile for given mesh.
-    /// Serialized Name: MeshUpgradeProfile
     /// </summary>
     public partial class MeshUpgradeProfileData : ResourceData
     {
@@ -62,10 +61,7 @@ namespace Azure.ResourceManager.ContainerService
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="properties">
-        /// Mesh upgrade profile properties for a major.minor release.
-        /// Serialized Name: MeshUpgradeProfile.properties
-        /// </param>
+        /// <param name="properties"> Mesh upgrade profile properties for a major.minor release. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MeshUpgradeProfileData(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, MeshUpgradeProfileProperties properties, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -73,10 +69,7 @@ namespace Azure.ResourceManager.ContainerService
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Mesh upgrade profile properties for a major.minor release.
-        /// Serialized Name: MeshUpgradeProfile.properties
-        /// </summary>
+        /// <summary> Mesh upgrade profile properties for a major.minor release. </summary>
         [WirePath("properties")]
         public MeshUpgradeProfileProperties Properties { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AdvancedNetworkingObservability.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AdvancedNetworkingObservability.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Observability profile to enable advanced network metrics and flow logs with historical contexts.
-    /// Serialized Name: AdvancedNetworkingObservability
-    /// </summary>
+    /// <summary> Observability profile to enable advanced network metrics and flow logs with historical contexts. </summary>
     internal partial class AdvancedNetworkingObservability
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AdvancedNetworkingObservability"/>. </summary>
-        /// <param name="isObservabilityEnabled">
-        /// Indicates the enablement of Advanced Networking observability functionalities on clusters.
-        /// Serialized Name: AdvancedNetworkingObservability.enabled
-        /// </param>
+        /// <param name="isObservabilityEnabled"> Indicates the enablement of Advanced Networking observability functionalities on clusters. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AdvancedNetworkingObservability(bool? isObservabilityEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Indicates the enablement of Advanced Networking observability functionalities on clusters.
-        /// Serialized Name: AdvancedNetworkingObservability.enabled
-        /// </summary>
+        /// <summary> Indicates the enablement of Advanced Networking observability functionalities on clusters. </summary>
         [WirePath("enabled")]
         public bool? IsObservabilityEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolAvailableVersion.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolAvailableVersion.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The AgentPoolAvailableVersion.
-    /// Serialized Name: AgentPoolAvailableVersion
-    /// </summary>
+    /// <summary> The AgentPoolAvailableVersion. </summary>
     public partial class AgentPoolAvailableVersion
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolAvailableVersion"/>. </summary>
-        /// <param name="isDefault">
-        /// Whether this version is the default agent pool version.
-        /// Serialized Name: AgentPoolAvailableVersion.default
-        /// </param>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolAvailableVersion.kubernetesVersion
-        /// </param>
-        /// <param name="isPreview">
-        /// Whether Kubernetes version is currently in preview.
-        /// Serialized Name: AgentPoolAvailableVersion.isPreview
-        /// </param>
+        /// <param name="isDefault"> Whether this version is the default agent pool version. </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="isPreview"> Whether Kubernetes version is currently in preview. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolAvailableVersion(bool? isDefault, string kubernetesVersion, bool? isPreview, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether this version is the default agent pool version.
-        /// Serialized Name: AgentPoolAvailableVersion.default
-        /// </summary>
+        /// <summary> Whether this version is the default agent pool version. </summary>
         [WirePath("default")]
         public bool? IsDefault { get; }
-        /// <summary>
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolAvailableVersion.kubernetesVersion
-        /// </summary>
+        /// <summary> The Kubernetes version (major.minor.patch). </summary>
         [WirePath("kubernetesVersion")]
         public string KubernetesVersion { get; }
-        /// <summary>
-        /// Whether Kubernetes version is currently in preview.
-        /// Serialized Name: AgentPoolAvailableVersion.isPreview
-        /// </summary>
+        /// <summary> Whether Kubernetes version is currently in preview. </summary>
         [WirePath("isPreview")]
         public bool? IsPreview { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolAvailableVersions.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolAvailableVersions.cs
@@ -12,10 +12,7 @@ using Azure.ResourceManager.Models;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The list of available versions for an agent pool.
-    /// Serialized Name: AgentPoolAvailableVersions
-    /// </summary>
+    /// <summary> The list of available versions for an agent pool. </summary>
     public partial class AgentPoolAvailableVersions : ResourceData
     {
         /// <summary>
@@ -61,10 +58,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="name"> The name. </param>
         /// <param name="resourceType"> The resourceType. </param>
         /// <param name="systemData"> The systemData. </param>
-        /// <param name="agentPoolVersions">
-        /// List of versions available for agent pool.
-        /// Serialized Name: AgentPoolAvailableVersions.properties.agentPoolVersions
-        /// </param>
+        /// <param name="agentPoolVersions"> List of versions available for agent pool. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolAvailableVersions(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IReadOnlyList<AgentPoolAvailableVersion> agentPoolVersions, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData)
         {
@@ -72,10 +66,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// List of versions available for agent pool.
-        /// Serialized Name: AgentPoolAvailableVersions.properties.agentPoolVersions
-        /// </summary>
+        /// <summary> List of versions available for agent pool. </summary>
         [WirePath("properties.agentPoolVersions")]
         public IReadOnlyList<AgentPoolAvailableVersion> AgentPoolVersions { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolDeleteMachinesContent.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolDeleteMachinesContent.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Specifies a list of machine names from the agent pool to be deleted.
-    /// Serialized Name: AgentPoolDeleteMachinesParameter
-    /// </summary>
+    /// <summary> Specifies a list of machine names from the agent pool to be deleted. </summary>
     public partial class AgentPoolDeleteMachinesContent
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolDeleteMachinesContent"/>. </summary>
-        /// <param name="machineNames">
-        /// The agent pool machine names.
-        /// Serialized Name: AgentPoolDeleteMachinesParameter.machineNames
-        /// </param>
+        /// <param name="machineNames"> The agent pool machine names. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="machineNames"/> is null. </exception>
         public AgentPoolDeleteMachinesContent(IEnumerable<string> machineNames)
         {
@@ -63,10 +57,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolDeleteMachinesContent"/>. </summary>
-        /// <param name="machineNames">
-        /// The agent pool machine names.
-        /// Serialized Name: AgentPoolDeleteMachinesParameter.machineNames
-        /// </param>
+        /// <param name="machineNames"> The agent pool machine names. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolDeleteMachinesContent(IList<string> machineNames, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -79,10 +70,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// The agent pool machine names.
-        /// Serialized Name: AgentPoolDeleteMachinesParameter.machineNames
-        /// </summary>
+        /// <summary> The agent pool machine names. </summary>
         [WirePath("machineNames")]
         public IList<string> MachineNames { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolGatewayProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolGatewayProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Profile of the managed cluster gateway agent pool.
-    /// Serialized Name: AgentPoolGatewayProfile
-    /// </summary>
+    /// <summary> Profile of the managed cluster gateway agent pool. </summary>
     internal partial class AgentPoolGatewayProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolGatewayProfile"/>. </summary>
-        /// <param name="publicIPPrefixSize">
-        /// The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31] (/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31.
-        /// Serialized Name: AgentPoolGatewayProfile.publicIPPrefixSize
-        /// </param>
+        /// <param name="publicIPPrefixSize"> The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31] (/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolGatewayProfile(int? publicIPPrefixSize, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31] (/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31.
-        /// Serialized Name: AgentPoolGatewayProfile.publicIPPrefixSize
-        /// </summary>
+        /// <summary> The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31] (/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31. </summary>
         [WirePath("publicIPPrefixSize")]
         public int? PublicIPPrefixSize { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolGpuDriver.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolGpuDriver.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Whether to install GPU drivers. When it's not specified, default is Install.
-    /// Serialized Name: GPUDriver
-    /// </summary>
+    /// <summary> Whether to install GPU drivers. When it's not specified, default is Install. </summary>
     public readonly partial struct AgentPoolGpuDriver : IEquatable<AgentPoolGpuDriver>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string InstallValue = "Install";
         private const string NoneValue = "None";
 
-        /// <summary>
-        /// Install driver.
-        /// Serialized Name: GPUDriver.Install
-        /// </summary>
+        /// <summary> Install driver. </summary>
         public static AgentPoolGpuDriver Install { get; } = new AgentPoolGpuDriver(InstallValue);
-        /// <summary>
-        /// Skip driver install.
-        /// Serialized Name: GPUDriver.None
-        /// </summary>
+        /// <summary> Skip driver install. </summary>
         public static AgentPoolGpuDriver None { get; } = new AgentPoolGpuDriver(NoneValue);
         /// <summary> Determines if two <see cref="AgentPoolGpuDriver"/> values are the same. </summary>
         public static bool operator ==(AgentPoolGpuDriver left, AgentPoolGpuDriver right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolGpuProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolGpuProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// GPU settings for the Agent Pool.
-    /// Serialized Name: GPUProfile
-    /// </summary>
+    /// <summary> GPU settings for the Agent Pool. </summary>
     internal partial class AgentPoolGpuProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolGpuProfile"/>. </summary>
-        /// <param name="driver">
-        /// Whether to install GPU drivers. When it's not specified, default is Install.
-        /// Serialized Name: GPUProfile.driver
-        /// </param>
+        /// <param name="driver"> Whether to install GPU drivers. When it's not specified, default is Install. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolGpuProfile(AgentPoolGpuDriver? driver, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to install GPU drivers. When it's not specified, default is Install.
-        /// Serialized Name: GPUProfile.driver
-        /// </summary>
+        /// <summary> Whether to install GPU drivers. When it's not specified, default is Install. </summary>
         [WirePath("driver")]
         public AgentPoolGpuDriver? Driver { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolMode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
-    /// Serialized Name: AgentPoolMode
-    /// </summary>
+    /// <summary> The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools. </summary>
     public readonly partial struct AgentPoolMode : IEquatable<AgentPoolMode>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string UserValue = "User";
         private const string GatewayValue = "Gateway";
 
-        /// <summary>
-        /// System agent pools are primarily for hosting critical system pods such as CoreDNS and metrics-server. System agent pools osType must be Linux. System agent pools VM SKU must have at least 2vCPUs and 4GB of memory.
-        /// Serialized Name: AgentPoolMode.System
-        /// </summary>
+        /// <summary> System agent pools are primarily for hosting critical system pods such as CoreDNS and metrics-server. System agent pools osType must be Linux. System agent pools VM SKU must have at least 2vCPUs and 4GB of memory. </summary>
         public static AgentPoolMode System { get; } = new AgentPoolMode(SystemValue);
-        /// <summary>
-        /// User agent pools are primarily for hosting your application pods.
-        /// Serialized Name: AgentPoolMode.User
-        /// </summary>
+        /// <summary> User agent pools are primarily for hosting your application pods. </summary>
         public static AgentPoolMode User { get; } = new AgentPoolMode(UserValue);
-        /// <summary>
-        /// Gateway agent pools are dedicated to providing static egress IPs to pods. For more details, see https://aka.ms/aks/static-egress-gateway.
-        /// Serialized Name: AgentPoolMode.Gateway
-        /// </summary>
+        /// <summary> Gateway agent pools are dedicated to providing static egress IPs to pods. For more details, see https://aka.ms/aks/static-egress-gateway. </summary>
         public static AgentPoolMode Gateway { get; } = new AgentPoolMode(GatewayValue);
         /// <summary> Determines if two <see cref="AgentPoolMode"/> values are the same. </summary>
         public static bool operator ==(AgentPoolMode left, AgentPoolMode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolNetworkPortProtocol.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolNetworkPortProtocol.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The network protocol of the port.
-    /// Serialized Name: Protocol
-    /// </summary>
+    /// <summary> The network protocol of the port. </summary>
     public readonly partial struct AgentPoolNetworkPortProtocol : IEquatable<AgentPoolNetworkPortProtocol>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string TcpValue = "TCP";
         private const string UdpValue = "UDP";
 
-        /// <summary>
-        /// TCP protocol.
-        /// Serialized Name: Protocol.TCP
-        /// </summary>
+        /// <summary> TCP protocol. </summary>
         public static AgentPoolNetworkPortProtocol Tcp { get; } = new AgentPoolNetworkPortProtocol(TcpValue);
-        /// <summary>
-        /// UDP protocol.
-        /// Serialized Name: Protocol.UDP
-        /// </summary>
+        /// <summary> UDP protocol. </summary>
         public static AgentPoolNetworkPortProtocol Udp { get; } = new AgentPoolNetworkPortProtocol(UdpValue);
         /// <summary> Determines if two <see cref="AgentPoolNetworkPortProtocol"/> values are the same. </summary>
         public static bool operator ==(AgentPoolNetworkPortProtocol left, AgentPoolNetworkPortProtocol right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolNetworkPortRange.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolNetworkPortRange.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The port range.
-    /// Serialized Name: PortRange
-    /// </summary>
+    /// <summary> The port range. </summary>
     public partial class AgentPoolNetworkPortRange
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolNetworkPortRange"/>. </summary>
-        /// <param name="portStart">
-        /// The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd.
-        /// Serialized Name: PortRange.portStart
-        /// </param>
-        /// <param name="portEnd">
-        /// The maximum port that is included in the range. It should be ranged from 1 to 65535, and be greater than or equal to portStart.
-        /// Serialized Name: PortRange.portEnd
-        /// </param>
-        /// <param name="protocol">
-        /// The network protocol of the port.
-        /// Serialized Name: PortRange.protocol
-        /// </param>
+        /// <param name="portStart"> The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd. </param>
+        /// <param name="portEnd"> The maximum port that is included in the range. It should be ranged from 1 to 65535, and be greater than or equal to portStart. </param>
+        /// <param name="protocol"> The network protocol of the port. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolNetworkPortRange(int? portStart, int? portEnd, AgentPoolNetworkPortProtocol? protocol, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd.
-        /// Serialized Name: PortRange.portStart
-        /// </summary>
+        /// <summary> The minimum port that is included in the range. It should be ranged from 1 to 65535, and be less than or equal to portEnd. </summary>
         [WirePath("portStart")]
         public int? PortStart { get; set; }
-        /// <summary>
-        /// The maximum port that is included in the range. It should be ranged from 1 to 65535, and be greater than or equal to portStart.
-        /// Serialized Name: PortRange.portEnd
-        /// </summary>
+        /// <summary> The maximum port that is included in the range. It should be ranged from 1 to 65535, and be greater than or equal to portStart. </summary>
         [WirePath("portEnd")]
         public int? PortEnd { get; set; }
-        /// <summary>
-        /// The network protocol of the port.
-        /// Serialized Name: PortRange.protocol
-        /// </summary>
+        /// <summary> The network protocol of the port. </summary>
         [WirePath("protocol")]
         public AgentPoolNetworkPortProtocol? Protocol { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolNetworkProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolNetworkProfile.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Network settings of an agent pool.
-    /// Serialized Name: AgentPoolNetworkProfile
-    /// </summary>
+    /// <summary> Network settings of an agent pool. </summary>
     public partial class AgentPoolNetworkProfile
     {
         /// <summary>
@@ -58,18 +55,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolNetworkProfile"/>. </summary>
-        /// <param name="nodePublicIPTags">
-        /// IPTags of instance-level public IPs.
-        /// Serialized Name: AgentPoolNetworkProfile.nodePublicIPTags
-        /// </param>
-        /// <param name="allowedHostPorts">
-        /// The port ranges that are allowed to access. The specified ranges are allowed to overlap.
-        /// Serialized Name: AgentPoolNetworkProfile.allowedHostPorts
-        /// </param>
-        /// <param name="applicationSecurityGroups">
-        /// The IDs of the application security groups which agent pool will associate when created.
-        /// Serialized Name: AgentPoolNetworkProfile.applicationSecurityGroups
-        /// </param>
+        /// <param name="nodePublicIPTags"> IPTags of instance-level public IPs. </param>
+        /// <param name="allowedHostPorts"> The port ranges that are allowed to access. The specified ranges are allowed to overlap. </param>
+        /// <param name="applicationSecurityGroups"> The IDs of the application security groups which agent pool will associate when created. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolNetworkProfile(IList<ContainerServiceIPTag> nodePublicIPTags, IList<AgentPoolNetworkPortRange> allowedHostPorts, IList<ResourceIdentifier> applicationSecurityGroups, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -79,22 +67,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// IPTags of instance-level public IPs.
-        /// Serialized Name: AgentPoolNetworkProfile.nodePublicIPTags
-        /// </summary>
+        /// <summary> IPTags of instance-level public IPs. </summary>
         [WirePath("nodePublicIPTags")]
         public IList<ContainerServiceIPTag> NodePublicIPTags { get; }
-        /// <summary>
-        /// The port ranges that are allowed to access. The specified ranges are allowed to overlap.
-        /// Serialized Name: AgentPoolNetworkProfile.allowedHostPorts
-        /// </summary>
+        /// <summary> The port ranges that are allowed to access. The specified ranges are allowed to overlap. </summary>
         [WirePath("allowedHostPorts")]
         public IList<AgentPoolNetworkPortRange> AllowedHostPorts { get; }
-        /// <summary>
-        /// The IDs of the application security groups which agent pool will associate when created.
-        /// Serialized Name: AgentPoolNetworkProfile.applicationSecurityGroups
-        /// </summary>
+        /// <summary> The IDs of the application security groups which agent pool will associate when created. </summary>
         [WirePath("applicationSecurityGroups")]
         public IList<ResourceIdentifier> ApplicationSecurityGroups { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolSecurityProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolSecurityProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The security settings of an agent pool.
-    /// Serialized Name: AgentPoolSecurityProfile
-    /// </summary>
+    /// <summary> The security settings of an agent pool. </summary>
     public partial class AgentPoolSecurityProfile
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolSecurityProfile"/>. </summary>
-        /// <param name="isVtpmEnabled">
-        /// vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false.
-        /// Serialized Name: AgentPoolSecurityProfile.enableVTPM
-        /// </param>
-        /// <param name="isSecureBootEnabled">
-        /// Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.  If not specified, the default is false.
-        /// Serialized Name: AgentPoolSecurityProfile.enableSecureBoot
-        /// </param>
-        /// <param name="sshAccess">
-        /// SSH access method of an agent pool.
-        /// Serialized Name: AgentPoolSecurityProfile.sshAccess
-        /// </param>
+        /// <param name="isVtpmEnabled"> vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false. </param>
+        /// <param name="isSecureBootEnabled"> Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.  If not specified, the default is false. </param>
+        /// <param name="sshAccess"> SSH access method of an agent pool. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolSecurityProfile(bool? isVtpmEnabled, bool? isSecureBootEnabled, AgentPoolSshAccess? sshAccess, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false.
-        /// Serialized Name: AgentPoolSecurityProfile.enableVTPM
-        /// </summary>
+        /// <summary> vTPM is a Trusted Launch feature for configuring a dedicated secure vault for keys and measurements held locally on the node. For more details, see aka.ms/aks/trustedlaunch. If not specified, the default is false. </summary>
         [WirePath("enableVTPM")]
         public bool? IsVtpmEnabled { get; set; }
-        /// <summary>
-        /// Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.  If not specified, the default is false.
-        /// Serialized Name: AgentPoolSecurityProfile.enableSecureBoot
-        /// </summary>
+        /// <summary> Secure Boot is a feature of Trusted Launch which ensures that only signed operating systems and drivers can boot. For more details, see aka.ms/aks/trustedlaunch.  If not specified, the default is false. </summary>
         [WirePath("enableSecureBoot")]
         public bool? IsSecureBootEnabled { get; set; }
-        /// <summary>
-        /// SSH access method of an agent pool.
-        /// Serialized Name: AgentPoolSecurityProfile.sshAccess
-        /// </summary>
+        /// <summary> SSH access method of an agent pool. </summary>
         [WirePath("sshAccess")]
         public AgentPoolSshAccess? SshAccess { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolSnapshotListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolSnapshotListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The response from the List Snapshots operation.
-    /// Serialized Name: SnapshotListResult
-    /// </summary>
+    /// <summary> The response from the List Snapshots operation. </summary>
     internal partial class AgentPoolSnapshotListResult
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolSnapshotListResult"/>. </summary>
-        /// <param name="value">
-        /// The list of snapshots.
-        /// Serialized Name: SnapshotListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The URL to get the next set of snapshot results.
-        /// Serialized Name: SnapshotListResult.nextLink
-        /// </param>
+        /// <param name="value"> The list of snapshots. </param>
+        /// <param name="nextLink"> The URL to get the next set of snapshot results. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolSnapshotListResult(IReadOnlyList<AgentPoolSnapshotData> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The list of snapshots.
-        /// Serialized Name: SnapshotListResult.value
-        /// </summary>
+        /// <summary> The list of snapshots. </summary>
         public IReadOnlyList<AgentPoolSnapshotData> Value { get; }
-        /// <summary>
-        /// The URL to get the next set of snapshot results.
-        /// Serialized Name: SnapshotListResult.nextLink
-        /// </summary>
+        /// <summary> The URL to get the next set of snapshot results. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolSshAccess.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolSshAccess.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// SSH access method of an agent pool.
-    /// Serialized Name: AgentPoolSSHAccess
-    /// </summary>
+    /// <summary> SSH access method of an agent pool. </summary>
     public readonly partial struct AgentPoolSshAccess : IEquatable<AgentPoolSshAccess>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string LocalUserValue = "LocalUser";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Can SSH onto the node as a local user using private key.
-        /// Serialized Name: AgentPoolSSHAccess.LocalUser
-        /// </summary>
+        /// <summary> Can SSH onto the node as a local user using private key. </summary>
         public static AgentPoolSshAccess LocalUser { get; } = new AgentPoolSshAccess(LocalUserValue);
-        /// <summary>
-        /// SSH service will be turned off on the node.
-        /// Serialized Name: AgentPoolSSHAccess.Disabled
-        /// </summary>
+        /// <summary> SSH service will be turned off on the node. </summary>
         public static AgentPoolSshAccess Disabled { get; } = new AgentPoolSshAccess(DisabledValue);
         /// <summary> Determines if two <see cref="AgentPoolSshAccess"/> values are the same. </summary>
         public static bool operator ==(AgentPoolSshAccess left, AgentPoolSshAccess right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolStatus.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolStatus.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Contains read-only information about the Agent Pool.
-    /// Serialized Name: AgentPoolStatus
-    /// </summary>
+    /// <summary> Contains read-only information about the Agent Pool. </summary>
     internal partial class AgentPoolStatus
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolStatus"/>. </summary>
-        /// <param name="provisioningError">
-        /// The error detail information of the agent pool. Preserves the detailed info of failure. If there was no error, this field is omitted.
-        /// Serialized Name: AgentPoolStatus.provisioningError
-        /// </param>
+        /// <param name="provisioningError"> The error detail information of the agent pool. Preserves the detailed info of failure. If there was no error, this field is omitted. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolStatus(ResponseError provisioningError, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The error detail information of the agent pool. Preserves the detailed info of failure. If there was no error, this field is omitted.
-        /// Serialized Name: AgentPoolStatus.provisioningError
-        /// </summary>
+        /// <summary> The error detail information of the agent pool. Preserves the detailed info of failure. If there was no error, this field is omitted. </summary>
         [WirePath("provisioningError")]
         public ResponseError ProvisioningError { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The type of Agent Pool.
-    /// Serialized Name: AgentPoolType
-    /// </summary>
+    /// <summary> The type of Agent Pool. </summary>
     public readonly partial struct AgentPoolType : IEquatable<AgentPoolType>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string AvailabilitySetValue = "AvailabilitySet";
         private const string VirtualMachinesValue = "VirtualMachines";
 
-        /// <summary>
-        /// Create an Agent Pool backed by a Virtual Machine Scale Set.
-        /// Serialized Name: AgentPoolType.VirtualMachineScaleSets
-        /// </summary>
+        /// <summary> Create an Agent Pool backed by a Virtual Machine Scale Set. </summary>
         public static AgentPoolType VirtualMachineScaleSets { get; } = new AgentPoolType(VirtualMachineScaleSetsValue);
-        /// <summary>
-        /// Use of this is strongly discouraged.
-        /// Serialized Name: AgentPoolType.AvailabilitySet
-        /// </summary>
+        /// <summary> Use of this is strongly discouraged. </summary>
         public static AgentPoolType AvailabilitySet { get; } = new AgentPoolType(AvailabilitySetValue);
-        /// <summary>
-        /// Create an Agent Pool backed by a Single Instance VM orchestration mode.
-        /// Serialized Name: AgentPoolType.VirtualMachines
-        /// </summary>
+        /// <summary> Create an Agent Pool backed by a Single Instance VM orchestration mode. </summary>
         public static AgentPoolType VirtualMachines { get; } = new AgentPoolType(VirtualMachinesValue);
         /// <summary> Determines if two <see cref="AgentPoolType"/> values are the same. </summary>
         public static bool operator ==(AgentPoolType left, AgentPoolType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolUpgradeProfilePropertiesUpgradesItem.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolUpgradeProfilePropertiesUpgradesItem.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The AgentPoolUpgradeProfilePropertiesUpgradesItem.
-    /// Serialized Name: AgentPoolUpgradeProfilePropertiesUpgradesItem
-    /// </summary>
+    /// <summary> The AgentPoolUpgradeProfilePropertiesUpgradesItem. </summary>
     public partial class AgentPoolUpgradeProfilePropertiesUpgradesItem
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolUpgradeProfilePropertiesUpgradesItem"/>. </summary>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolUpgradeProfilePropertiesUpgradesItem.kubernetesVersion
-        /// </param>
-        /// <param name="isPreview">
-        /// Whether the Kubernetes version is currently in preview.
-        /// Serialized Name: AgentPoolUpgradeProfilePropertiesUpgradesItem.isPreview
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="isPreview"> Whether the Kubernetes version is currently in preview. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolUpgradeProfilePropertiesUpgradesItem(string kubernetesVersion, bool? isPreview, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: AgentPoolUpgradeProfilePropertiesUpgradesItem.kubernetesVersion
-        /// </summary>
+        /// <summary> The Kubernetes version (major.minor.patch). </summary>
         [WirePath("kubernetesVersion")]
         public string KubernetesVersion { get; }
-        /// <summary>
-        /// Whether the Kubernetes version is currently in preview.
-        /// Serialized Name: AgentPoolUpgradeProfilePropertiesUpgradesItem.isPreview
-        /// </summary>
+        /// <summary> Whether the Kubernetes version is currently in preview. </summary>
         [WirePath("isPreview")]
         public bool? IsPreview { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolUpgradeSettings.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolUpgradeSettings.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Settings for upgrading an agentpool
-    /// Serialized Name: AgentPoolUpgradeSettings
-    /// </summary>
+    /// <summary> Settings for upgrading an agentpool. </summary>
     public partial class AgentPoolUpgradeSettings
     {
         /// <summary>
@@ -54,26 +51,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolUpgradeSettings"/>. </summary>
-        /// <param name="maxSurge">
-        /// The maximum number or percentage of nodes that are surged during upgrade. This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 10%. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster
-        /// Serialized Name: AgentPoolUpgradeSettings.maxSurge
-        /// </param>
-        /// <param name="maxUnavailable">
-        /// The maximum number or percentage of nodes that can be simultaneously unavailable during upgrade. This can either be set to an integer (e.g. '1') or a percentage (e.g. '5%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 0. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster
-        /// Serialized Name: AgentPoolUpgradeSettings.maxUnavailable
-        /// </param>
-        /// <param name="drainTimeoutInMinutes">
-        /// The drain timeout for a node. The amount of time (in minutes) to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails. If not specified, the default is 30 minutes.
-        /// Serialized Name: AgentPoolUpgradeSettings.drainTimeoutInMinutes
-        /// </param>
-        /// <param name="nodeSoakDurationInMinutes">
-        /// The soak duration for a node. The amount of time (in minutes) to wait after draining a node and before reimaging it and moving on to next node. If not specified, the default is 0 minutes.
-        /// Serialized Name: AgentPoolUpgradeSettings.nodeSoakDurationInMinutes
-        /// </param>
-        /// <param name="undrainableNodeBehavior">
-        /// Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes.
-        /// Serialized Name: AgentPoolUpgradeSettings.undrainableNodeBehavior
-        /// </param>
+        /// <param name="maxSurge"> The maximum number or percentage of nodes that are surged during upgrade. This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 10%. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster. </param>
+        /// <param name="maxUnavailable"> The maximum number or percentage of nodes that can be simultaneously unavailable during upgrade. This can either be set to an integer (e.g. '1') or a percentage (e.g. '5%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 0. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster. </param>
+        /// <param name="drainTimeoutInMinutes"> The drain timeout for a node. The amount of time (in minutes) to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails. If not specified, the default is 30 minutes. </param>
+        /// <param name="nodeSoakDurationInMinutes"> The soak duration for a node. The amount of time (in minutes) to wait after draining a node and before reimaging it and moving on to next node. If not specified, the default is 0 minutes. </param>
+        /// <param name="undrainableNodeBehavior"> Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolUpgradeSettings(string maxSurge, string maxUnavailable, int? drainTimeoutInMinutes, int? nodeSoakDurationInMinutes, UndrainableNodeBehavior? undrainableNodeBehavior, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -85,34 +67,19 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The maximum number or percentage of nodes that are surged during upgrade. This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 10%. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster
-        /// Serialized Name: AgentPoolUpgradeSettings.maxSurge
-        /// </summary>
+        /// <summary> The maximum number or percentage of nodes that are surged during upgrade. This can either be set to an integer (e.g. '5') or a percentage (e.g. '50%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 10%. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster. </summary>
         [WirePath("maxSurge")]
         public string MaxSurge { get; set; }
-        /// <summary>
-        /// The maximum number or percentage of nodes that can be simultaneously unavailable during upgrade. This can either be set to an integer (e.g. '1') or a percentage (e.g. '5%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 0. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster
-        /// Serialized Name: AgentPoolUpgradeSettings.maxUnavailable
-        /// </summary>
+        /// <summary> The maximum number or percentage of nodes that can be simultaneously unavailable during upgrade. This can either be set to an integer (e.g. '1') or a percentage (e.g. '5%'). If a percentage is specified, it is the percentage of the total agent pool size at the time of the upgrade. For percentages, fractional nodes are rounded up. If not specified, the default is 0. For more information, including best practices, see: https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster. </summary>
         [WirePath("maxUnavailable")]
         public string MaxUnavailable { get; set; }
-        /// <summary>
-        /// The drain timeout for a node. The amount of time (in minutes) to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails. If not specified, the default is 30 minutes.
-        /// Serialized Name: AgentPoolUpgradeSettings.drainTimeoutInMinutes
-        /// </summary>
+        /// <summary> The drain timeout for a node. The amount of time (in minutes) to wait on eviction of pods and graceful termination per node. This eviction wait time honors waiting on pod disruption budgets. If this time is exceeded, the upgrade fails. If not specified, the default is 30 minutes. </summary>
         [WirePath("drainTimeoutInMinutes")]
         public int? DrainTimeoutInMinutes { get; set; }
-        /// <summary>
-        /// The soak duration for a node. The amount of time (in minutes) to wait after draining a node and before reimaging it and moving on to next node. If not specified, the default is 0 minutes.
-        /// Serialized Name: AgentPoolUpgradeSettings.nodeSoakDurationInMinutes
-        /// </summary>
+        /// <summary> The soak duration for a node. The amount of time (in minutes) to wait after draining a node and before reimaging it and moving on to next node. If not specified, the default is 0 minutes. </summary>
         [WirePath("nodeSoakDurationInMinutes")]
         public int? NodeSoakDurationInMinutes { get; set; }
-        /// <summary>
-        /// Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes.
-        /// Serialized Name: AgentPoolUpgradeSettings.undrainableNodeBehavior
-        /// </summary>
+        /// <summary> Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes. </summary>
         [WirePath("undrainableNodeBehavior")]
         public UndrainableNodeBehavior? UndrainableNodeBehavior { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolVirtualMachineNodes.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolVirtualMachineNodes.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Current status on a group of nodes of the same vm size.
-    /// Serialized Name: VirtualMachineNodes
-    /// </summary>
+    /// <summary> Current status on a group of nodes of the same vm size. </summary>
     public partial class AgentPoolVirtualMachineNodes
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolVirtualMachineNodes"/>. </summary>
-        /// <param name="size">
-        /// The VM size of the agents used to host this group of nodes.
-        /// Serialized Name: VirtualMachineNodes.size
-        /// </param>
-        /// <param name="count">
-        /// Number of nodes.
-        /// Serialized Name: VirtualMachineNodes.count
-        /// </param>
+        /// <param name="size"> The VM size of the agents used to host this group of nodes. </param>
+        /// <param name="count"> Number of nodes. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolVirtualMachineNodes(string size, int? count, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The VM size of the agents used to host this group of nodes.
-        /// Serialized Name: VirtualMachineNodes.size
-        /// </summary>
+        /// <summary> The VM size of the agents used to host this group of nodes. </summary>
         [WirePath("size")]
         public string Size { get; set; }
-        /// <summary>
-        /// Number of nodes.
-        /// Serialized Name: VirtualMachineNodes.count
-        /// </summary>
+        /// <summary> Number of nodes. </summary>
         [WirePath("count")]
         public int? Count { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolWindowsProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AgentPoolWindowsProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The Windows agent pool's specific profile.
-    /// Serialized Name: AgentPoolWindowsProfile
-    /// </summary>
+    /// <summary> The Windows agent pool's specific profile. </summary>
     internal partial class AgentPoolWindowsProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="AgentPoolWindowsProfile"/>. </summary>
-        /// <param name="isOutboundNatDisabled">
-        /// Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled.
-        /// Serialized Name: AgentPoolWindowsProfile.disableOutboundNat
-        /// </param>
+        /// <param name="isOutboundNatDisabled"> Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal AgentPoolWindowsProfile(bool? isOutboundNatDisabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled.
-        /// Serialized Name: AgentPoolWindowsProfile.disableOutboundNat
-        /// </summary>
+        /// <summary> Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled. </summary>
         [WirePath("disableOutboundNat")]
         public bool? IsOutboundNatDisabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AutoScaleExpander.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/AutoScaleExpander.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The expander to use when scaling up. If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information.
-    /// Serialized Name: Expander
-    /// </summary>
+    /// <summary> The expander to use when scaling up. If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information. </summary>
     public readonly partial struct AutoScaleExpander : IEquatable<AutoScaleExpander>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string PriorityValue = "priority";
         private const string RandomValue = "random";
 
-        /// <summary>
-        /// Selects the node group that will have the least idle CPU (if tied, unused memory) after scale-up. This is useful when you have different classes of nodes, for example, high CPU or high memory nodes, and only want to expand those when there are pending pods that need a lot of those resources.
-        /// Serialized Name: Expander.least-waste
-        /// </summary>
+        /// <summary> Selects the node group that will have the least idle CPU (if tied, unused memory) after scale-up. This is useful when you have different classes of nodes, for example, high CPU or high memory nodes, and only want to expand those when there are pending pods that need a lot of those resources. </summary>
         public static AutoScaleExpander LeastWaste { get; } = new AutoScaleExpander(LeastWasteValue);
-        /// <summary>
-        /// Selects the node group that would be able to schedule the most pods when scaling up. This is useful when you are using nodeSelector to make sure certain pods land on certain nodes. Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can add multiple smaller nodes at once.
-        /// Serialized Name: Expander.most-pods
-        /// </summary>
+        /// <summary> Selects the node group that would be able to schedule the most pods when scaling up. This is useful when you are using nodeSelector to make sure certain pods land on certain nodes. Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can add multiple smaller nodes at once. </summary>
         public static AutoScaleExpander MostPods { get; } = new AutoScaleExpander(MostPodsValue);
-        /// <summary>
-        /// Selects the node group that has the highest priority assigned by the user. It's configuration is described in more details [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md).
-        /// Serialized Name: Expander.priority
-        /// </summary>
+        /// <summary> Selects the node group that has the highest priority assigned by the user. It's configuration is described in more details [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md). </summary>
         public static AutoScaleExpander Priority { get; } = new AutoScaleExpander(PriorityValue);
-        /// <summary>
-        /// Used when you don't have a particular need for the node groups to scale differently.
-        /// Serialized Name: Expander.random
-        /// </summary>
+        /// <summary> Used when you don't have a particular need for the node groups to scale differently. </summary>
         public static AutoScaleExpander Random { get; } = new AutoScaleExpander(RandomValue);
         /// <summary> Determines if two <see cref="AutoScaleExpander"/> values are the same. </summary>
         public static bool operator ==(AutoScaleExpander left, AutoScaleExpander right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ClusterUpgradeSettings.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ClusterUpgradeSettings.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Settings for upgrading a cluster.
-    /// Serialized Name: ClusterUpgradeSettings
-    /// </summary>
+    /// <summary> Settings for upgrading a cluster. </summary>
     internal partial class ClusterUpgradeSettings
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ClusterUpgradeSettings"/>. </summary>
-        /// <param name="overrideSettings">
-        /// Settings for overrides.
-        /// Serialized Name: ClusterUpgradeSettings.overrideSettings
-        /// </param>
+        /// <param name="overrideSettings"> Settings for overrides. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ClusterUpgradeSettings(UpgradeOverrideSettings overrideSettings, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Settings for overrides.
-        /// Serialized Name: ClusterUpgradeSettings.overrideSettings
-        /// </summary>
+        /// <summary> Settings for overrides. </summary>
         [WirePath("overrideSettings")]
         public UpgradeOverrideSettings OverrideSettings { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/CompatibleVersions.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/CompatibleVersions.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Version information about a product/service that is compatible with a service mesh revision.
-    /// Serialized Name: CompatibleVersions
-    /// </summary>
+    /// <summary> Version information about a product/service that is compatible with a service mesh revision. </summary>
     public partial class CompatibleVersions
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="CompatibleVersions"/>. </summary>
-        /// <param name="name">
-        /// The product/service name.
-        /// Serialized Name: CompatibleVersions.name
-        /// </param>
-        /// <param name="versions">
-        /// Product/service versions compatible with a service mesh add-on revision.
-        /// Serialized Name: CompatibleVersions.versions
-        /// </param>
+        /// <param name="name"> The product/service name. </param>
+        /// <param name="versions"> Product/service versions compatible with a service mesh add-on revision. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal CompatibleVersions(string name, IList<string> versions, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,16 +62,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The product/service name.
-        /// Serialized Name: CompatibleVersions.name
-        /// </summary>
+        /// <summary> The product/service name. </summary>
         [WirePath("name")]
         public string Name { get; set; }
-        /// <summary>
-        /// Product/service versions compatible with a service mesh add-on revision.
-        /// Serialized Name: CompatibleVersions.versions
-        /// </summary>
+        /// <summary> Product/service versions compatible with a service mesh add-on revision. </summary>
         [WirePath("versions")]
         public IList<string> Versions { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceAgentPoolListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceAgentPoolListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The response from the List Agent Pools operation.
-    /// Serialized Name: AgentPoolListResult
-    /// </summary>
+    /// <summary> The response from the List Agent Pools operation. </summary>
     internal partial class ContainerServiceAgentPoolListResult
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceAgentPoolListResult"/>. </summary>
-        /// <param name="value">
-        /// The list of agent pools.
-        /// Serialized Name: AgentPoolListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The URL to get the next set of agent pool results.
-        /// Serialized Name: AgentPoolListResult.nextLink
-        /// </param>
+        /// <param name="value"> The list of agent pools. </param>
+        /// <param name="nextLink"> The URL to get the next set of agent pool results. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceAgentPoolListResult(IReadOnlyList<ContainerServiceAgentPoolData> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The list of agent pools.
-        /// Serialized Name: AgentPoolListResult.value
-        /// </summary>
+        /// <summary> The list of agent pools. </summary>
         public IReadOnlyList<ContainerServiceAgentPoolData> Value { get; }
-        /// <summary>
-        /// The URL to get the next set of agent pool results.
-        /// Serialized Name: AgentPoolListResult.nextLink
-        /// </summary>
+        /// <summary> The URL to get the next set of agent pool results. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceArtifactSource.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceArtifactSource.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The artifact source. The source where the artifacts are downloaded from.
-    /// Serialized Name: ArtifactSource
-    /// </summary>
+    /// <summary> The artifact source. The source where the artifacts are downloaded from. </summary>
     public readonly partial struct ContainerServiceArtifactSource : IEquatable<ContainerServiceArtifactSource>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string CacheValue = "Cache";
         private const string DirectValue = "Direct";
 
-        /// <summary>
-        /// pull images from Azure Container Registry with cache
-        /// Serialized Name: ArtifactSource.Cache
-        /// </summary>
+        /// <summary> pull images from Azure Container Registry with cache. </summary>
         public static ContainerServiceArtifactSource Cache { get; } = new ContainerServiceArtifactSource(CacheValue);
-        /// <summary>
-        /// pull images from Microsoft Artifact Registry
-        /// Serialized Name: ArtifactSource.Direct
-        /// </summary>
+        /// <summary> pull images from Microsoft Artifact Registry. </summary>
         public static ContainerServiceArtifactSource Direct { get; } = new ContainerServiceArtifactSource(DirectValue);
         /// <summary> Determines if two <see cref="ContainerServiceArtifactSource"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceArtifactSource left, ContainerServiceArtifactSource right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceCreationData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceCreationData.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Data used when creating a target resource from a source resource.
-    /// Serialized Name: CreationData
-    /// </summary>
+    /// <summary> Data used when creating a target resource from a source resource. </summary>
     internal partial class ContainerServiceCreationData
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceCreationData"/>. </summary>
-        /// <param name="sourceResourceId">
-        /// This is the ARM ID of the source object to be used to create the target object.
-        /// Serialized Name: CreationData.sourceResourceId
-        /// </param>
+        /// <param name="sourceResourceId"> This is the ARM ID of the source object to be used to create the target object. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceCreationData(ResourceIdentifier sourceResourceId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// This is the ARM ID of the source object to be used to create the target object.
-        /// Serialized Name: CreationData.sourceResourceId
-        /// </summary>
+        /// <summary> This is the ARM ID of the source object to be used to create the target object. </summary>
         [WirePath("sourceResourceId")]
         public ResourceIdentifier SourceResourceId { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceDateSpan.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceDateSpan.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// A date range. For example, between '2022-12-23' and '2023-01-05'.
-    /// Serialized Name: DateSpan
-    /// </summary>
+    /// <summary> A date range. For example, between '2022-12-23' and '2023-01-05'. </summary>
     public partial class ContainerServiceDateSpan
     {
         /// <summary>
@@ -49,14 +46,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceDateSpan"/>. </summary>
-        /// <param name="start">
-        /// The start date of the date span.
-        /// Serialized Name: DateSpan.start
-        /// </param>
-        /// <param name="end">
-        /// The end date of the date span.
-        /// Serialized Name: DateSpan.end
-        /// </param>
+        /// <param name="start"> The start date of the date span. </param>
+        /// <param name="end"> The end date of the date span. </param>
         public ContainerServiceDateSpan(DateTimeOffset start, DateTimeOffset end)
         {
             Start = start;
@@ -64,14 +55,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceDateSpan"/>. </summary>
-        /// <param name="start">
-        /// The start date of the date span.
-        /// Serialized Name: DateSpan.start
-        /// </param>
-        /// <param name="end">
-        /// The end date of the date span.
-        /// Serialized Name: DateSpan.end
-        /// </param>
+        /// <param name="start"> The start date of the date span. </param>
+        /// <param name="end"> The end date of the date span. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceDateSpan(DateTimeOffset start, DateTimeOffset end, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -85,16 +70,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// The start date of the date span.
-        /// Serialized Name: DateSpan.start
-        /// </summary>
+        /// <summary> The start date of the date span. </summary>
         [WirePath("start")]
         public DateTimeOffset Start { get; set; }
-        /// <summary>
-        /// The end date of the date span.
-        /// Serialized Name: DateSpan.end
-        /// </summary>
+        /// <summary> The end date of the date span. </summary>
         [WirePath("end")]
         public DateTimeOffset End { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceEndpointDependency.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceEndpointDependency.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// A domain name that AKS agent nodes are reaching at.
-    /// Serialized Name: EndpointDependency
-    /// </summary>
+    /// <summary> A domain name that AKS agent nodes are reaching at. </summary>
     public partial class ContainerServiceEndpointDependency
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceEndpointDependency"/>. </summary>
-        /// <param name="domainName">
-        /// The domain name of the dependency.
-        /// Serialized Name: EndpointDependency.domainName
-        /// </param>
-        /// <param name="endpointDetails">
-        /// The Ports and Protocols used when connecting to domainName.
-        /// Serialized Name: EndpointDependency.endpointDetails
-        /// </param>
+        /// <param name="domainName"> The domain name of the dependency. </param>
+        /// <param name="endpointDetails"> The Ports and Protocols used when connecting to domainName. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceEndpointDependency(string domainName, IReadOnlyList<ContainerServiceEndpointDetail> endpointDetails, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,16 +62,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The domain name of the dependency.
-        /// Serialized Name: EndpointDependency.domainName
-        /// </summary>
+        /// <summary> The domain name of the dependency. </summary>
         [WirePath("domainName")]
         public string DomainName { get; }
-        /// <summary>
-        /// The Ports and Protocols used when connecting to domainName.
-        /// Serialized Name: EndpointDependency.endpointDetails
-        /// </summary>
+        /// <summary> The Ports and Protocols used when connecting to domainName. </summary>
         [WirePath("endpointDetails")]
         public IReadOnlyList<ContainerServiceEndpointDetail> EndpointDetails { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceEndpointDetail.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceEndpointDetail.cs
@@ -11,10 +11,7 @@ using System.Net;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// connect information from the AKS agent nodes to a single endpoint.
-    /// Serialized Name: EndpointDetail
-    /// </summary>
+    /// <summary> connect information from the AKS agent nodes to a single endpoint. </summary>
     public partial class ContainerServiceEndpointDetail
     {
         /// <summary>
@@ -55,22 +52,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceEndpointDetail"/>. </summary>
-        /// <param name="ipAddress">
-        /// An IP Address that Domain Name currently resolves to.
-        /// Serialized Name: EndpointDetail.ipAddress
-        /// </param>
-        /// <param name="port">
-        /// The port an endpoint is connected to.
-        /// Serialized Name: EndpointDetail.port
-        /// </param>
-        /// <param name="protocol">
-        /// The protocol used for connection
-        /// Serialized Name: EndpointDetail.protocol
-        /// </param>
-        /// <param name="description">
-        /// Description of the detail
-        /// Serialized Name: EndpointDetail.description
-        /// </param>
+        /// <param name="ipAddress"> An IP Address that Domain Name currently resolves to. </param>
+        /// <param name="port"> The port an endpoint is connected to. </param>
+        /// <param name="protocol"> The protocol used for connection. </param>
+        /// <param name="description"> Description of the detail. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceEndpointDetail(IPAddress ipAddress, int? port, string protocol, string description, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,28 +66,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// An IP Address that Domain Name currently resolves to.
-        /// Serialized Name: EndpointDetail.ipAddress
-        /// </summary>
+        /// <summary> An IP Address that Domain Name currently resolves to. </summary>
         [WirePath("ipAddress")]
         public IPAddress IPAddress { get; }
-        /// <summary>
-        /// The port an endpoint is connected to.
-        /// Serialized Name: EndpointDetail.port
-        /// </summary>
+        /// <summary> The port an endpoint is connected to. </summary>
         [WirePath("port")]
         public int? Port { get; }
-        /// <summary>
-        /// The protocol used for connection
-        /// Serialized Name: EndpointDetail.protocol
-        /// </summary>
+        /// <summary> The protocol used for connection. </summary>
         [WirePath("protocol")]
         public string Protocol { get; }
-        /// <summary>
-        /// Description of the detail
-        /// Serialized Name: EndpointDetail.description
-        /// </summary>
+        /// <summary> Description of the detail. </summary>
         [WirePath("description")]
         public string Description { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceIPFamily.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceIPFamily.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The IP version to use for cluster networking and IP assignment.
-    /// Serialized Name: IpFamily
-    /// </summary>
+    /// <summary> The IP version to use for cluster networking and IP assignment. </summary>
     public readonly partial struct ContainerServiceIPFamily : IEquatable<ContainerServiceIPFamily>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string IPv4Value = "IPv4";
         private const string IPv6Value = "IPv6";
 
-        /// <summary>
-        /// IPv4
-        /// Serialized Name: IpFamily.IPv4
-        /// </summary>
+        /// <summary> IPv4. </summary>
         public static ContainerServiceIPFamily IPv4 { get; } = new ContainerServiceIPFamily(IPv4Value);
-        /// <summary>
-        /// IPv6
-        /// Serialized Name: IpFamily.IPv6
-        /// </summary>
+        /// <summary> IPv6. </summary>
         public static ContainerServiceIPFamily IPv6 { get; } = new ContainerServiceIPFamily(IPv6Value);
         /// <summary> Determines if two <see cref="ContainerServiceIPFamily"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceIPFamily left, ContainerServiceIPFamily right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceIPTag.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceIPTag.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Contains the IPTag associated with the object.
-    /// Serialized Name: IPTag
-    /// </summary>
+    /// <summary> Contains the IPTag associated with the object. </summary>
     public partial class ContainerServiceIPTag
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceIPTag"/>. </summary>
-        /// <param name="ipTagType">
-        /// The IP tag type. Example: RoutingPreference.
-        /// Serialized Name: IPTag.ipTagType
-        /// </param>
-        /// <param name="tag">
-        /// The value of the IP tag associated with the public IP. Example: Internet.
-        /// Serialized Name: IPTag.tag
-        /// </param>
+        /// <param name="ipTagType"> The IP tag type. Example: RoutingPreference. </param>
+        /// <param name="tag"> The value of the IP tag associated with the public IP. Example: Internet. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceIPTag(string ipTagType, string tag, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The IP tag type. Example: RoutingPreference.
-        /// Serialized Name: IPTag.ipTagType
-        /// </summary>
+        /// <summary> The IP tag type. Example: RoutingPreference. </summary>
         [WirePath("ipTagType")]
         public string IPTagType { get; set; }
-        /// <summary>
-        /// The value of the IP tag associated with the public IP. Example: Internet.
-        /// Serialized Name: IPTag.tag
-        /// </summary>
+        /// <summary> The value of the IP tag associated with the public IP. Example: Internet. </summary>
         [WirePath("tag")]
         public string Tag { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceLinuxProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceLinuxProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Profile for Linux VMs in the container service cluster.
-    /// Serialized Name: ContainerServiceLinuxProfile
-    /// </summary>
+    /// <summary> Profile for Linux VMs in the container service cluster. </summary>
     public partial class ContainerServiceLinuxProfile
     {
         /// <summary>
@@ -49,14 +46,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceLinuxProfile"/>. </summary>
-        /// <param name="adminUsername">
-        /// The administrator username to use for Linux VMs.
-        /// Serialized Name: ContainerServiceLinuxProfile.adminUsername
-        /// </param>
-        /// <param name="ssh">
-        /// The SSH configuration for Linux-based VMs running on Azure.
-        /// Serialized Name: ContainerServiceLinuxProfile.ssh
-        /// </param>
+        /// <param name="adminUsername"> The administrator username to use for Linux VMs. </param>
+        /// <param name="ssh"> The SSH configuration for Linux-based VMs running on Azure. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="adminUsername"/> or <paramref name="ssh"/> is null. </exception>
         public ContainerServiceLinuxProfile(string adminUsername, ContainerServiceSshConfiguration ssh)
         {
@@ -68,14 +59,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceLinuxProfile"/>. </summary>
-        /// <param name="adminUsername">
-        /// The administrator username to use for Linux VMs.
-        /// Serialized Name: ContainerServiceLinuxProfile.adminUsername
-        /// </param>
-        /// <param name="ssh">
-        /// The SSH configuration for Linux-based VMs running on Azure.
-        /// Serialized Name: ContainerServiceLinuxProfile.ssh
-        /// </param>
+        /// <param name="adminUsername"> The administrator username to use for Linux VMs. </param>
+        /// <param name="ssh"> The SSH configuration for Linux-based VMs running on Azure. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceLinuxProfile(string adminUsername, ContainerServiceSshConfiguration ssh, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -89,21 +74,12 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// The administrator username to use for Linux VMs.
-        /// Serialized Name: ContainerServiceLinuxProfile.adminUsername
-        /// </summary>
+        /// <summary> The administrator username to use for Linux VMs. </summary>
         [WirePath("adminUsername")]
         public string AdminUsername { get; set; }
-        /// <summary>
-        /// The SSH configuration for Linux-based VMs running on Azure.
-        /// Serialized Name: ContainerServiceLinuxProfile.ssh
-        /// </summary>
+        /// <summary> The SSH configuration for Linux-based VMs running on Azure. </summary>
         internal ContainerServiceSshConfiguration Ssh { get; set; }
-        /// <summary>
-        /// The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified.
-        /// Serialized Name: ContainerServiceSshConfiguration.publicKeys
-        /// </summary>
+        /// <summary> The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. </summary>
         [WirePath("ssh.publicKeys")]
         public IList<ContainerServiceSshPublicKey> SshPublicKeys
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceLoadBalancerSku.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceLoadBalancerSku.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The load balancer sku for the managed cluster. The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs.
-    /// Serialized Name: LoadBalancerSku
-    /// </summary>
+    /// <summary> The load balancer sku for the managed cluster. The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs. </summary>
     public readonly partial struct ContainerServiceLoadBalancerSku : IEquatable<ContainerServiceLoadBalancerSku>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string StandardValue = "standard";
         private const string BasicValue = "basic";
 
-        /// <summary>
-        /// Use a a standard Load Balancer. This is the recommended Load Balancer SKU. For more information about on working with the load balancer in the managed cluster, see the [standard Load Balancer](https://docs.microsoft.com/azure/aks/load-balancer-standard) article.
-        /// Serialized Name: LoadBalancerSku.standard
-        /// </summary>
+        /// <summary> Use a a standard Load Balancer. This is the recommended Load Balancer SKU. For more information about on working with the load balancer in the managed cluster, see the [standard Load Balancer](https://docs.microsoft.com/azure/aks/load-balancer-standard) article. </summary>
         public static ContainerServiceLoadBalancerSku Standard { get; } = new ContainerServiceLoadBalancerSku(StandardValue);
-        /// <summary>
-        /// Use a basic Load Balancer with limited functionality.
-        /// Serialized Name: LoadBalancerSku.basic
-        /// </summary>
+        /// <summary> Use a basic Load Balancer with limited functionality. </summary>
         public static ContainerServiceLoadBalancerSku Basic { get; } = new ContainerServiceLoadBalancerSku(BasicValue);
         /// <summary> Determines if two <see cref="ContainerServiceLoadBalancerSku"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceLoadBalancerSku left, ContainerServiceLoadBalancerSku right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMachineIPAddress.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMachineIPAddress.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The machine IP address details.
-    /// Serialized Name: MachineIpAddress
-    /// </summary>
+    /// <summary> The machine IP address details. </summary>
     public partial class ContainerServiceMachineIPAddress
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMachineIPAddress"/>. </summary>
-        /// <param name="family">
-        /// To determine if address belongs IPv4 or IPv6 family
-        /// Serialized Name: MachineIpAddress.family
-        /// </param>
-        /// <param name="ip">
-        /// IPv4 or IPv6 address of the machine
-        /// Serialized Name: MachineIpAddress.ip
-        /// </param>
+        /// <param name="family"> To determine if address belongs IPv4 or IPv6 family. </param>
+        /// <param name="ip"> IPv4 or IPv6 address of the machine. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMachineIPAddress(ContainerServiceIPFamily? family, string ip, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// To determine if address belongs IPv4 or IPv6 family
-        /// Serialized Name: MachineIpAddress.family
-        /// </summary>
+        /// <summary> To determine if address belongs IPv4 or IPv6 family. </summary>
         [WirePath("family")]
         public ContainerServiceIPFamily? Family { get; }
-        /// <summary>
-        /// IPv4 or IPv6 address of the machine
-        /// Serialized Name: MachineIpAddress.ip
-        /// </summary>
+        /// <summary> IPv4 or IPv6 address of the machine. </summary>
         [WirePath("ip")]
         public string IP { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMachineProperties.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMachineProperties.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The properties of the machine
-    /// Serialized Name: MachineProperties
-    /// </summary>
+    /// <summary> The properties of the machine. </summary>
     public partial class ContainerServiceMachineProperties
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMachineProperties"/>. </summary>
-        /// <param name="network">
-        /// network properties of the machine
-        /// Serialized Name: MachineProperties.network
-        /// </param>
-        /// <param name="resourceId">
-        /// Azure resource id of the machine. It can be used to GET underlying VM Instance
-        /// Serialized Name: MachineProperties.resourceId
-        /// </param>
+        /// <param name="network"> network properties of the machine. </param>
+        /// <param name="resourceId"> Azure resource id of the machine. It can be used to GET underlying VM Instance. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMachineProperties(MachineNetworkProperties network, ResourceIdentifier resourceId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,25 +62,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// network properties of the machine
-        /// Serialized Name: MachineProperties.network
-        /// </summary>
+        /// <summary> network properties of the machine. </summary>
         internal MachineNetworkProperties Network { get; }
-        /// <summary>
-        /// IPv4, IPv6 addresses of the machine
-        /// Serialized Name: MachineNetworkProperties.ipAddresses
-        /// </summary>
+        /// <summary> IPv4, IPv6 addresses of the machine. </summary>
         [WirePath("network.ipAddresses")]
         public IReadOnlyList<ContainerServiceMachineIPAddress> NetworkIPAddresses
         {
             get => Network?.IPAddresses;
         }
 
-        /// <summary>
-        /// Azure resource id of the machine. It can be used to GET underlying VM Instance
-        /// Serialized Name: MachineProperties.resourceId
-        /// </summary>
+        /// <summary> Azure resource id of the machine. It can be used to GET underlying VM Instance. </summary>
         [WirePath("resourceId")]
         public ResourceIdentifier ResourceId { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceAbsoluteMonthlySchedule.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceAbsoluteMonthlySchedule.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'.
-    /// Serialized Name: AbsoluteMonthlySchedule
-    /// </summary>
+    /// <summary> For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'. </summary>
     public partial class ContainerServiceMaintenanceAbsoluteMonthlySchedule
     {
         /// <summary>
@@ -49,14 +46,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceAbsoluteMonthlySchedule"/>. </summary>
-        /// <param name="intervalMonths">
-        /// Specifies the number of months between each set of occurrences.
-        /// Serialized Name: AbsoluteMonthlySchedule.intervalMonths
-        /// </param>
-        /// <param name="dayOfMonth">
-        /// The date of the month.
-        /// Serialized Name: AbsoluteMonthlySchedule.dayOfMonth
-        /// </param>
+        /// <param name="intervalMonths"> Specifies the number of months between each set of occurrences. </param>
+        /// <param name="dayOfMonth"> The date of the month. </param>
         public ContainerServiceMaintenanceAbsoluteMonthlySchedule(int intervalMonths, int dayOfMonth)
         {
             IntervalMonths = intervalMonths;
@@ -64,14 +55,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceAbsoluteMonthlySchedule"/>. </summary>
-        /// <param name="intervalMonths">
-        /// Specifies the number of months between each set of occurrences.
-        /// Serialized Name: AbsoluteMonthlySchedule.intervalMonths
-        /// </param>
-        /// <param name="dayOfMonth">
-        /// The date of the month.
-        /// Serialized Name: AbsoluteMonthlySchedule.dayOfMonth
-        /// </param>
+        /// <param name="intervalMonths"> Specifies the number of months between each set of occurrences. </param>
+        /// <param name="dayOfMonth"> The date of the month. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMaintenanceAbsoluteMonthlySchedule(int intervalMonths, int dayOfMonth, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -85,16 +70,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Specifies the number of months between each set of occurrences.
-        /// Serialized Name: AbsoluteMonthlySchedule.intervalMonths
-        /// </summary>
+        /// <summary> Specifies the number of months between each set of occurrences. </summary>
         [WirePath("intervalMonths")]
         public int IntervalMonths { get; set; }
-        /// <summary>
-        /// The date of the month.
-        /// Serialized Name: AbsoluteMonthlySchedule.dayOfMonth
-        /// </summary>
+        /// <summary> The date of the month. </summary>
         [WirePath("dayOfMonth")]
         public int DayOfMonth { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceConfigurationListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceConfigurationListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The response from the List maintenance configurations operation.
-    /// Serialized Name: MaintenanceConfigurationListResult
-    /// </summary>
+    /// <summary> The response from the List maintenance configurations operation. </summary>
     internal partial class ContainerServiceMaintenanceConfigurationListResult
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceConfigurationListResult"/>. </summary>
-        /// <param name="value">
-        /// The list of maintenance configurations.
-        /// Serialized Name: MaintenanceConfigurationListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The URL to get the next set of maintenance configuration results.
-        /// Serialized Name: MaintenanceConfigurationListResult.nextLink
-        /// </param>
+        /// <param name="value"> The list of maintenance configurations. </param>
+        /// <param name="nextLink"> The URL to get the next set of maintenance configuration results. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMaintenanceConfigurationListResult(IReadOnlyList<ContainerServiceMaintenanceConfigurationData> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The list of maintenance configurations.
-        /// Serialized Name: MaintenanceConfigurationListResult.value
-        /// </summary>
+        /// <summary> The list of maintenance configurations. </summary>
         public IReadOnlyList<ContainerServiceMaintenanceConfigurationData> Value { get; }
-        /// <summary>
-        /// The URL to get the next set of maintenance configuration results.
-        /// Serialized Name: MaintenanceConfigurationListResult.nextLink
-        /// </summary>
+        /// <summary> The URL to get the next set of maintenance configuration results. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceRelativeMonthlySchedule.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceRelativeMonthlySchedule.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'.
-    /// Serialized Name: RelativeMonthlySchedule
-    /// </summary>
+    /// <summary> For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'. </summary>
     public partial class ContainerServiceMaintenanceRelativeMonthlySchedule
     {
         /// <summary>
@@ -49,18 +46,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceRelativeMonthlySchedule"/>. </summary>
-        /// <param name="intervalMonths">
-        /// Specifies the number of months between each set of occurrences.
-        /// Serialized Name: RelativeMonthlySchedule.intervalMonths
-        /// </param>
-        /// <param name="weekIndex">
-        /// The week index. Specifies on which week of the month the dayOfWeek applies.
-        /// Serialized Name: RelativeMonthlySchedule.weekIndex
-        /// </param>
-        /// <param name="dayOfWeek">
-        /// Specifies on which day of the week the maintenance occurs.
-        /// Serialized Name: RelativeMonthlySchedule.dayOfWeek
-        /// </param>
+        /// <param name="intervalMonths"> Specifies the number of months between each set of occurrences. </param>
+        /// <param name="weekIndex"> The week index. Specifies on which week of the month the dayOfWeek applies. </param>
+        /// <param name="dayOfWeek"> Specifies on which day of the week the maintenance occurs. </param>
         public ContainerServiceMaintenanceRelativeMonthlySchedule(int intervalMonths, ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex weekIndex, ContainerServiceWeekDay dayOfWeek)
         {
             IntervalMonths = intervalMonths;
@@ -69,18 +57,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceRelativeMonthlySchedule"/>. </summary>
-        /// <param name="intervalMonths">
-        /// Specifies the number of months between each set of occurrences.
-        /// Serialized Name: RelativeMonthlySchedule.intervalMonths
-        /// </param>
-        /// <param name="weekIndex">
-        /// The week index. Specifies on which week of the month the dayOfWeek applies.
-        /// Serialized Name: RelativeMonthlySchedule.weekIndex
-        /// </param>
-        /// <param name="dayOfWeek">
-        /// Specifies on which day of the week the maintenance occurs.
-        /// Serialized Name: RelativeMonthlySchedule.dayOfWeek
-        /// </param>
+        /// <param name="intervalMonths"> Specifies the number of months between each set of occurrences. </param>
+        /// <param name="weekIndex"> The week index. Specifies on which week of the month the dayOfWeek applies. </param>
+        /// <param name="dayOfWeek"> Specifies on which day of the week the maintenance occurs. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMaintenanceRelativeMonthlySchedule(int intervalMonths, ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex weekIndex, ContainerServiceWeekDay dayOfWeek, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -95,22 +74,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Specifies the number of months between each set of occurrences.
-        /// Serialized Name: RelativeMonthlySchedule.intervalMonths
-        /// </summary>
+        /// <summary> Specifies the number of months between each set of occurrences. </summary>
         [WirePath("intervalMonths")]
         public int IntervalMonths { get; set; }
-        /// <summary>
-        /// The week index. Specifies on which week of the month the dayOfWeek applies.
-        /// Serialized Name: RelativeMonthlySchedule.weekIndex
-        /// </summary>
+        /// <summary> The week index. Specifies on which week of the month the dayOfWeek applies. </summary>
         [WirePath("weekIndex")]
         public ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex WeekIndex { get; set; }
-        /// <summary>
-        /// Specifies on which day of the week the maintenance occurs.
-        /// Serialized Name: RelativeMonthlySchedule.dayOfWeek
-        /// </summary>
+        /// <summary> Specifies on which day of the week the maintenance occurs. </summary>
         [WirePath("dayOfWeek")]
         public ContainerServiceWeekDay DayOfWeek { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The week index. Specifies on which week of the month the dayOfWeek applies.
-    /// Serialized Name: Type
-    /// </summary>
+    /// <summary> The week index. Specifies on which week of the month the dayOfWeek applies. </summary>
     public readonly partial struct ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex : IEquatable<ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex>
     {
         private readonly string _value;
@@ -31,30 +28,15 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string FourthValue = "Fourth";
         private const string LastValue = "Last";
 
-        /// <summary>
-        /// First week of the month.
-        /// Serialized Name: Type.First
-        /// </summary>
+        /// <summary> First week of the month. </summary>
         public static ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex First { get; } = new ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex(FirstValue);
-        /// <summary>
-        /// Second week of the month.
-        /// Serialized Name: Type.Second
-        /// </summary>
+        /// <summary> Second week of the month. </summary>
         public static ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex Second { get; } = new ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex(SecondValue);
-        /// <summary>
-        /// Third week of the month.
-        /// Serialized Name: Type.Third
-        /// </summary>
+        /// <summary> Third week of the month. </summary>
         public static ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex Third { get; } = new ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex(ThirdValue);
-        /// <summary>
-        /// Fourth week of the month.
-        /// Serialized Name: Type.Fourth
-        /// </summary>
+        /// <summary> Fourth week of the month. </summary>
         public static ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex Fourth { get; } = new ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex(FourthValue);
-        /// <summary>
-        /// Last week of the month.
-        /// Serialized Name: Type.Last
-        /// </summary>
+        /// <summary> Last week of the month. </summary>
         public static ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex Last { get; } = new ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex(LastValue);
         /// <summary> Determines if two <see cref="ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex left, ContainerServiceMaintenanceRelativeMonthlyScheduleWeekIndex right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceSchedule.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceSchedule.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// One and only one of the schedule types should be specified. Choose either 'daily', 'weekly', 'absoluteMonthly' or 'relativeMonthly' for your maintenance schedule.
-    /// Serialized Name: Schedule
-    /// </summary>
+    /// <summary> One and only one of the schedule types should be specified. Choose either 'daily', 'weekly', 'absoluteMonthly' or 'relativeMonthly' for your maintenance schedule. </summary>
     public partial class ContainerServiceMaintenanceSchedule
     {
         /// <summary>
@@ -54,22 +51,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceSchedule"/>. </summary>
-        /// <param name="daily">
-        /// For schedules like: 'recur every day' or 'recur every 3 days'.
-        /// Serialized Name: Schedule.daily
-        /// </param>
-        /// <param name="weekly">
-        /// For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'.
-        /// Serialized Name: Schedule.weekly
-        /// </param>
-        /// <param name="absoluteMonthly">
-        /// For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'.
-        /// Serialized Name: Schedule.absoluteMonthly
-        /// </param>
-        /// <param name="relativeMonthly">
-        /// For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'.
-        /// Serialized Name: Schedule.relativeMonthly
-        /// </param>
+        /// <param name="daily"> For schedules like: 'recur every day' or 'recur every 3 days'. </param>
+        /// <param name="weekly"> For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'. </param>
+        /// <param name="absoluteMonthly"> For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'. </param>
+        /// <param name="relativeMonthly"> For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMaintenanceSchedule(DailySchedule daily, ContainerServiceMaintenanceWeeklySchedule weekly, ContainerServiceMaintenanceAbsoluteMonthlySchedule absoluteMonthly, ContainerServiceMaintenanceRelativeMonthlySchedule relativeMonthly, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -80,15 +65,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// For schedules like: 'recur every day' or 'recur every 3 days'.
-        /// Serialized Name: Schedule.daily
-        /// </summary>
+        /// <summary> For schedules like: 'recur every day' or 'recur every 3 days'. </summary>
         internal DailySchedule Daily { get; set; }
-        /// <summary>
-        /// Specifies the number of days between each set of occurrences.
-        /// Serialized Name: DailySchedule.intervalDays
-        /// </summary>
+        /// <summary> Specifies the number of days between each set of occurrences. </summary>
         [WirePath("daily.intervalDays")]
         public int? DailyIntervalDays
         {
@@ -99,22 +78,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'.
-        /// Serialized Name: Schedule.weekly
-        /// </summary>
+        /// <summary> For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'. </summary>
         [WirePath("weekly")]
         public ContainerServiceMaintenanceWeeklySchedule Weekly { get; set; }
-        /// <summary>
-        /// For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'.
-        /// Serialized Name: Schedule.absoluteMonthly
-        /// </summary>
+        /// <summary> For schedules like: 'recur every month on the 15th' or 'recur every 3 months on the 20th'. </summary>
         [WirePath("absoluteMonthly")]
         public ContainerServiceMaintenanceAbsoluteMonthlySchedule AbsoluteMonthly { get; set; }
-        /// <summary>
-        /// For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'.
-        /// Serialized Name: Schedule.relativeMonthly
-        /// </summary>
+        /// <summary> For schedules like: 'recur every month on the first Monday' or 'recur every 3 months on last Friday'. </summary>
         [WirePath("relativeMonthly")]
         public ContainerServiceMaintenanceRelativeMonthlySchedule RelativeMonthly { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceWeeklySchedule.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceWeeklySchedule.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'.
-    /// Serialized Name: WeeklySchedule
-    /// </summary>
+    /// <summary> For schedules like: 'recur every Monday' or 'recur every 3 weeks on Wednesday'. </summary>
     public partial class ContainerServiceMaintenanceWeeklySchedule
     {
         /// <summary>
@@ -49,14 +46,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceWeeklySchedule"/>. </summary>
-        /// <param name="intervalWeeks">
-        /// Specifies the number of weeks between each set of occurrences.
-        /// Serialized Name: WeeklySchedule.intervalWeeks
-        /// </param>
-        /// <param name="dayOfWeek">
-        /// Specifies on which day of the week the maintenance occurs.
-        /// Serialized Name: WeeklySchedule.dayOfWeek
-        /// </param>
+        /// <param name="intervalWeeks"> Specifies the number of weeks between each set of occurrences. </param>
+        /// <param name="dayOfWeek"> Specifies on which day of the week the maintenance occurs. </param>
         public ContainerServiceMaintenanceWeeklySchedule(int intervalWeeks, ContainerServiceWeekDay dayOfWeek)
         {
             IntervalWeeks = intervalWeeks;
@@ -64,14 +55,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceWeeklySchedule"/>. </summary>
-        /// <param name="intervalWeeks">
-        /// Specifies the number of weeks between each set of occurrences.
-        /// Serialized Name: WeeklySchedule.intervalWeeks
-        /// </param>
-        /// <param name="dayOfWeek">
-        /// Specifies on which day of the week the maintenance occurs.
-        /// Serialized Name: WeeklySchedule.dayOfWeek
-        /// </param>
+        /// <param name="intervalWeeks"> Specifies the number of weeks between each set of occurrences. </param>
+        /// <param name="dayOfWeek"> Specifies on which day of the week the maintenance occurs. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMaintenanceWeeklySchedule(int intervalWeeks, ContainerServiceWeekDay dayOfWeek, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -85,16 +70,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Specifies the number of weeks between each set of occurrences.
-        /// Serialized Name: WeeklySchedule.intervalWeeks
-        /// </summary>
+        /// <summary> Specifies the number of weeks between each set of occurrences. </summary>
         [WirePath("intervalWeeks")]
         public int IntervalWeeks { get; set; }
-        /// <summary>
-        /// Specifies on which day of the week the maintenance occurs.
-        /// Serialized Name: WeeklySchedule.dayOfWeek
-        /// </summary>
+        /// <summary> Specifies on which day of the week the maintenance occurs. </summary>
         [WirePath("dayOfWeek")]
         public ContainerServiceWeekDay DayOfWeek { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceWindow.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceMaintenanceWindow.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Maintenance window used to configure scheduled auto-upgrade for a Managed Cluster.
-    /// Serialized Name: MaintenanceWindow
-    /// </summary>
+    /// <summary> Maintenance window used to configure scheduled auto-upgrade for a Managed Cluster. </summary>
     public partial class ContainerServiceMaintenanceWindow
     {
         /// <summary>
@@ -49,18 +46,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceWindow"/>. </summary>
-        /// <param name="schedule">
-        /// Recurrence schedule for the maintenance window.
-        /// Serialized Name: MaintenanceWindow.schedule
-        /// </param>
-        /// <param name="durationHours">
-        /// Length of maintenance window range from 4 to 24 hours.
-        /// Serialized Name: MaintenanceWindow.durationHours
-        /// </param>
-        /// <param name="startTime">
-        /// The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'.
-        /// Serialized Name: MaintenanceWindow.startTime
-        /// </param>
+        /// <param name="schedule"> Recurrence schedule for the maintenance window. </param>
+        /// <param name="durationHours"> Length of maintenance window range from 4 to 24 hours. </param>
+        /// <param name="startTime"> The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="schedule"/> or <paramref name="startTime"/> is null. </exception>
         public ContainerServiceMaintenanceWindow(ContainerServiceMaintenanceSchedule schedule, int durationHours, string startTime)
         {
@@ -74,30 +62,12 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceMaintenanceWindow"/>. </summary>
-        /// <param name="schedule">
-        /// Recurrence schedule for the maintenance window.
-        /// Serialized Name: MaintenanceWindow.schedule
-        /// </param>
-        /// <param name="durationHours">
-        /// Length of maintenance window range from 4 to 24 hours.
-        /// Serialized Name: MaintenanceWindow.durationHours
-        /// </param>
-        /// <param name="utcOffset">
-        /// The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00' for PST. If not specified, the default is '+00:00'.
-        /// Serialized Name: MaintenanceWindow.utcOffset
-        /// </param>
-        /// <param name="startDate">
-        /// The date the maintenance window activates. If the current date is before this date, the maintenance window is inactive and will not be used for upgrades. If not specified, the maintenance window will be active right away.
-        /// Serialized Name: MaintenanceWindow.startDate
-        /// </param>
-        /// <param name="startTime">
-        /// The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'.
-        /// Serialized Name: MaintenanceWindow.startTime
-        /// </param>
-        /// <param name="notAllowedDates">
-        /// Date ranges on which upgrade is not allowed. 'utcOffset' applies to this field. For example, with 'utcOffset: +02:00' and 'dateSpan' being '2022-12-23' to '2023-01-03', maintenance will be blocked from '2022-12-22 22:00' to '2023-01-03 22:00' in UTC time.
-        /// Serialized Name: MaintenanceWindow.notAllowedDates
-        /// </param>
+        /// <param name="schedule"> Recurrence schedule for the maintenance window. </param>
+        /// <param name="durationHours"> Length of maintenance window range from 4 to 24 hours. </param>
+        /// <param name="utcOffset"> The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00' for PST. If not specified, the default is '+00:00'. </param>
+        /// <param name="startDate"> The date the maintenance window activates. If the current date is before this date, the maintenance window is inactive and will not be used for upgrades. If not specified, the maintenance window will be active right away. </param>
+        /// <param name="startTime"> The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'. </param>
+        /// <param name="notAllowedDates"> Date ranges on which upgrade is not allowed. 'utcOffset' applies to this field. For example, with 'utcOffset: +02:00' and 'dateSpan' being '2022-12-23' to '2023-01-03', maintenance will be blocked from '2022-12-22 22:00' to '2023-01-03 22:00' in UTC time. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceMaintenanceWindow(ContainerServiceMaintenanceSchedule schedule, int durationHours, string utcOffset, string startDate, string startTime, IList<ContainerServiceDateSpan> notAllowedDates, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -115,40 +85,22 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Recurrence schedule for the maintenance window.
-        /// Serialized Name: MaintenanceWindow.schedule
-        /// </summary>
+        /// <summary> Recurrence schedule for the maintenance window. </summary>
         [WirePath("schedule")]
         public ContainerServiceMaintenanceSchedule Schedule { get; set; }
-        /// <summary>
-        /// Length of maintenance window range from 4 to 24 hours.
-        /// Serialized Name: MaintenanceWindow.durationHours
-        /// </summary>
+        /// <summary> Length of maintenance window range from 4 to 24 hours. </summary>
         [WirePath("durationHours")]
         public int DurationHours { get; set; }
-        /// <summary>
-        /// The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00' for PST. If not specified, the default is '+00:00'.
-        /// Serialized Name: MaintenanceWindow.utcOffset
-        /// </summary>
+        /// <summary> The UTC offset in format +/-HH:mm. For example, '+05:30' for IST and '-07:00' for PST. If not specified, the default is '+00:00'. </summary>
         [WirePath("utcOffset")]
         public string UtcOffset { get; set; }
-        /// <summary>
-        /// The date the maintenance window activates. If the current date is before this date, the maintenance window is inactive and will not be used for upgrades. If not specified, the maintenance window will be active right away.
-        /// Serialized Name: MaintenanceWindow.startDate
-        /// </summary>
+        /// <summary> The date the maintenance window activates. If the current date is before this date, the maintenance window is inactive and will not be used for upgrades. If not specified, the maintenance window will be active right away. </summary>
         [WirePath("startDate")]
         public string StartDate { get; set; }
-        /// <summary>
-        /// The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'.
-        /// Serialized Name: MaintenanceWindow.startTime
-        /// </summary>
+        /// <summary> The start time of the maintenance window. Accepted values are from '00:00' to '23:59'. 'utcOffset' applies to this field. For example: '02:00' with 'utcOffset: +02:00' means UTC time '00:00'. </summary>
         [WirePath("startTime")]
         public string StartTime { get; set; }
-        /// <summary>
-        /// Date ranges on which upgrade is not allowed. 'utcOffset' applies to this field. For example, with 'utcOffset: +02:00' and 'dateSpan' being '2022-12-23' to '2023-01-03', maintenance will be blocked from '2022-12-22 22:00' to '2023-01-03 22:00' in UTC time.
-        /// Serialized Name: MaintenanceWindow.notAllowedDates
-        /// </summary>
+        /// <summary> Date ranges on which upgrade is not allowed. 'utcOffset' applies to this field. For example, with 'utcOffset: +02:00' and 'dateSpan' being '2022-12-23' to '2023-01-03', maintenance will be blocked from '2022-12-22 22:00' to '2023-01-03 22:00' in UTC time. </summary>
         [WirePath("notAllowedDates")]
         public IList<ContainerServiceDateSpan> NotAllowedDates { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkMode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The network mode Azure CNI is configured with. This cannot be specified if networkPlugin is anything other than 'azure'.
-    /// Serialized Name: NetworkMode
-    /// </summary>
+    /// <summary> The network mode Azure CNI is configured with. This cannot be specified if networkPlugin is anything other than 'azure'. </summary>
     public readonly partial struct ContainerServiceNetworkMode : IEquatable<ContainerServiceNetworkMode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string TransparentValue = "transparent";
         private const string BridgeValue = "bridge";
 
-        /// <summary>
-        /// No bridge is created. Intra-VM Pod to Pod communication is through IP routes created by Azure CNI. See [Transparent Mode](https://docs.microsoft.com/azure/aks/faq#transparent-mode) for more information.
-        /// Serialized Name: NetworkMode.transparent
-        /// </summary>
+        /// <summary> No bridge is created. Intra-VM Pod to Pod communication is through IP routes created by Azure CNI. See [Transparent Mode](https://docs.microsoft.com/azure/aks/faq#transparent-mode) for more information. </summary>
         public static ContainerServiceNetworkMode Transparent { get; } = new ContainerServiceNetworkMode(TransparentValue);
-        /// <summary>
-        /// This is no longer supported
-        /// Serialized Name: NetworkMode.bridge
-        /// </summary>
+        /// <summary> This is no longer supported. </summary>
         public static ContainerServiceNetworkMode Bridge { get; } = new ContainerServiceNetworkMode(BridgeValue);
         /// <summary> Determines if two <see cref="ContainerServiceNetworkMode"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceNetworkMode left, ContainerServiceNetworkMode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkPlugin.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkPlugin.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Network plugin used for building the Kubernetes network.
-    /// Serialized Name: NetworkPlugin
-    /// </summary>
+    /// <summary> Network plugin used for building the Kubernetes network. </summary>
     public readonly partial struct ContainerServiceNetworkPlugin : IEquatable<ContainerServiceNetworkPlugin>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string KubenetValue = "kubenet";
         private const string NoneValue = "none";
 
-        /// <summary>
-        /// Use the Azure CNI network plugin. See [Azure CNI (advanced) networking](https://docs.microsoft.com/azure/aks/concepts-network#azure-cni-advanced-networking) for more information.
-        /// Serialized Name: NetworkPlugin.azure
-        /// </summary>
+        /// <summary> Use the Azure CNI network plugin. See [Azure CNI (advanced) networking](https://docs.microsoft.com/azure/aks/concepts-network#azure-cni-advanced-networking) for more information. </summary>
         public static ContainerServiceNetworkPlugin Azure { get; } = new ContainerServiceNetworkPlugin(AzureValue);
-        /// <summary>
-        /// Use the Kubenet network plugin. See [Kubenet (basic) networking](https://docs.microsoft.com/azure/aks/concepts-network#kubenet-basic-networking) for more information.
-        /// Serialized Name: NetworkPlugin.kubenet
-        /// </summary>
+        /// <summary> Use the Kubenet network plugin. See [Kubenet (basic) networking](https://docs.microsoft.com/azure/aks/concepts-network#kubenet-basic-networking) for more information. </summary>
         public static ContainerServiceNetworkPlugin Kubenet { get; } = new ContainerServiceNetworkPlugin(KubenetValue);
-        /// <summary>
-        /// No CNI plugin is pre-installed. See [BYO CNI](https://docs.microsoft.com/en-us/azure/aks/use-byo-cni) for more information.
-        /// Serialized Name: NetworkPlugin.none
-        /// </summary>
+        /// <summary> No CNI plugin is pre-installed. See [BYO CNI](https://docs.microsoft.com/en-us/azure/aks/use-byo-cni) for more information. </summary>
         public static ContainerServiceNetworkPlugin None { get; } = new ContainerServiceNetworkPlugin(NoneValue);
         /// <summary> Determines if two <see cref="ContainerServiceNetworkPlugin"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceNetworkPlugin left, ContainerServiceNetworkPlugin right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkPluginMode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkPluginMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The mode the network plugin should use.
-    /// Serialized Name: NetworkPluginMode
-    /// </summary>
+    /// <summary> The mode the network plugin should use. </summary>
     public readonly partial struct ContainerServiceNetworkPluginMode : IEquatable<ContainerServiceNetworkPluginMode>
     {
         private readonly string _value;
@@ -27,10 +24,7 @@ namespace Azure.ResourceManager.ContainerService.Models
 
         private const string OverlayValue = "overlay";
 
-        /// <summary>
-        /// Used with networkPlugin=azure, pods are given IPs from the PodCIDR address space but use Azure Routing Domains rather than Kubenet's method of route tables. For more information visit https://aka.ms/aks/azure-cni-overlay.
-        /// Serialized Name: NetworkPluginMode.overlay
-        /// </summary>
+        /// <summary> Used with networkPlugin=azure, pods are given IPs from the PodCIDR address space but use Azure Routing Domains rather than Kubenet's method of route tables. For more information visit https://aka.ms/aks/azure-cni-overlay. </summary>
         public static ContainerServiceNetworkPluginMode Overlay { get; } = new ContainerServiceNetworkPluginMode(OverlayValue);
         /// <summary> Determines if two <see cref="ContainerServiceNetworkPluginMode"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceNetworkPluginMode left, ContainerServiceNetworkPluginMode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkPolicy.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkPolicy.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Network policy used for building the Kubernetes network.
-    /// Serialized Name: NetworkPolicy
-    /// </summary>
+    /// <summary> Network policy used for building the Kubernetes network. </summary>
     public readonly partial struct ContainerServiceNetworkPolicy : IEquatable<ContainerServiceNetworkPolicy>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string AzureValue = "azure";
         private const string CiliumValue = "cilium";
 
-        /// <summary>
-        /// Network policies will not be enforced. This is the default value when NetworkPolicy is not specified.
-        /// Serialized Name: NetworkPolicy.none
-        /// </summary>
+        /// <summary> Network policies will not be enforced. This is the default value when NetworkPolicy is not specified. </summary>
         public static ContainerServiceNetworkPolicy None { get; } = new ContainerServiceNetworkPolicy(NoneValue);
-        /// <summary>
-        /// Use Calico network policies. See [differences between Azure and Calico policies](https://docs.microsoft.com/azure/aks/use-network-policies#differences-between-azure-and-calico-policies-and-their-capabilities) for more information.
-        /// Serialized Name: NetworkPolicy.calico
-        /// </summary>
+        /// <summary> Use Calico network policies. See [differences between Azure and Calico policies](https://docs.microsoft.com/azure/aks/use-network-policies#differences-between-azure-and-calico-policies-and-their-capabilities) for more information. </summary>
         public static ContainerServiceNetworkPolicy Calico { get; } = new ContainerServiceNetworkPolicy(CalicoValue);
-        /// <summary>
-        /// Use Azure network policies. See [differences between Azure and Calico policies](https://docs.microsoft.com/azure/aks/use-network-policies#differences-between-azure-and-calico-policies-and-their-capabilities) for more information.
-        /// Serialized Name: NetworkPolicy.azure
-        /// </summary>
+        /// <summary> Use Azure network policies. See [differences between Azure and Calico policies](https://docs.microsoft.com/azure/aks/use-network-policies#differences-between-azure-and-calico-policies-and-their-capabilities) for more information. </summary>
         public static ContainerServiceNetworkPolicy Azure { get; } = new ContainerServiceNetworkPolicy(AzureValue);
-        /// <summary>
-        /// Use Cilium to enforce network policies. This requires networkDataplane to be 'cilium'.
-        /// Serialized Name: NetworkPolicy.cilium
-        /// </summary>
+        /// <summary> Use Cilium to enforce network policies. This requires networkDataplane to be 'cilium'. </summary>
         public static ContainerServiceNetworkPolicy Cilium { get; } = new ContainerServiceNetworkPolicy(CiliumValue);
         /// <summary> Determines if two <see cref="ContainerServiceNetworkPolicy"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceNetworkPolicy left, ContainerServiceNetworkPolicy right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceNetworkProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Profile of network configuration.
-    /// Serialized Name: ContainerServiceNetworkProfile
-    /// </summary>
+    /// <summary> Profile of network configuration. </summary>
     public partial class ContainerServiceNetworkProfile
     {
         /// <summary>
@@ -57,74 +54,23 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceNetworkProfile"/>. </summary>
-        /// <param name="networkPlugin">
-        /// Network plugin used for building the Kubernetes network.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkPlugin
-        /// </param>
-        /// <param name="networkPluginMode">
-        /// The mode the network plugin should use.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkPluginMode
-        /// </param>
-        /// <param name="networkPolicy">
-        /// Network policy used for building the Kubernetes network.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkPolicy
-        /// </param>
-        /// <param name="networkMode">
-        /// The network mode Azure CNI is configured with. This cannot be specified if networkPlugin is anything other than 'azure'.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkMode
-        /// </param>
-        /// <param name="networkDataplane">
-        /// Network dataplane used in the Kubernetes cluster.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkDataplane
-        /// </param>
-        /// <param name="advancedNetworking">
-        /// Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking.
-        /// Serialized Name: ContainerServiceNetworkProfile.advancedNetworking
-        /// </param>
-        /// <param name="podCidr">
-        /// A CIDR notation IP range from which to assign pod IPs when kubenet is used.
-        /// Serialized Name: ContainerServiceNetworkProfile.podCidr
-        /// </param>
-        /// <param name="serviceCidr">
-        /// A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.
-        /// Serialized Name: ContainerServiceNetworkProfile.serviceCidr
-        /// </param>
-        /// <param name="dnsServiceIP">
-        /// An IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.
-        /// Serialized Name: ContainerServiceNetworkProfile.dnsServiceIP
-        /// </param>
-        /// <param name="outboundType">
-        /// The outbound (egress) routing method. This can only be set at cluster creation time and cannot be changed later. For more information see [egress outbound type](https://docs.microsoft.com/azure/aks/egress-outboundtype).
-        /// Serialized Name: ContainerServiceNetworkProfile.outboundType
-        /// </param>
-        /// <param name="loadBalancerSku">
-        /// The load balancer sku for the managed cluster. The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs.
-        /// Serialized Name: ContainerServiceNetworkProfile.loadBalancerSku
-        /// </param>
-        /// <param name="loadBalancerProfile">
-        /// Profile of the cluster load balancer.
-        /// Serialized Name: ContainerServiceNetworkProfile.loadBalancerProfile
-        /// </param>
-        /// <param name="natGatewayProfile">
-        /// Profile of the cluster NAT gateway.
-        /// Serialized Name: ContainerServiceNetworkProfile.natGatewayProfile
-        /// </param>
-        /// <param name="staticEgressGatewayProfile">
-        /// The profile for Static Egress Gateway addon. For more details about Static Egress Gateway, see https://aka.ms/aks/static-egress-gateway.
-        /// Serialized Name: ContainerServiceNetworkProfile.staticEgressGatewayProfile
-        /// </param>
-        /// <param name="podCidrs">
-        /// The CIDR notation IP ranges from which to assign pod IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking.
-        /// Serialized Name: ContainerServiceNetworkProfile.podCidrs
-        /// </param>
-        /// <param name="serviceCidrs">
-        /// The CIDR notation IP ranges from which to assign service cluster IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges.
-        /// Serialized Name: ContainerServiceNetworkProfile.serviceCidrs
-        /// </param>
-        /// <param name="networkIPFamilies">
-        /// The IP families used to specify IP versions available to the cluster. IP families are used to determine single-stack or dual-stack clusters. For single-stack, the expected value is IPv4. For dual-stack, the expected values are IPv4 and IPv6.
-        /// Serialized Name: ContainerServiceNetworkProfile.ipFamilies
-        /// </param>
+        /// <param name="networkPlugin"> Network plugin used for building the Kubernetes network. </param>
+        /// <param name="networkPluginMode"> The mode the network plugin should use. </param>
+        /// <param name="networkPolicy"> Network policy used for building the Kubernetes network. </param>
+        /// <param name="networkMode"> The network mode Azure CNI is configured with. This cannot be specified if networkPlugin is anything other than 'azure'. </param>
+        /// <param name="networkDataplane"> Network dataplane used in the Kubernetes cluster. </param>
+        /// <param name="advancedNetworking"> Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking. </param>
+        /// <param name="podCidr"> A CIDR notation IP range from which to assign pod IPs when kubenet is used. </param>
+        /// <param name="serviceCidr"> A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges. </param>
+        /// <param name="dnsServiceIP"> An IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr. </param>
+        /// <param name="outboundType"> The outbound (egress) routing method. This can only be set at cluster creation time and cannot be changed later. For more information see [egress outbound type](https://docs.microsoft.com/azure/aks/egress-outboundtype). </param>
+        /// <param name="loadBalancerSku"> The load balancer sku for the managed cluster. The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs. </param>
+        /// <param name="loadBalancerProfile"> Profile of the cluster load balancer. </param>
+        /// <param name="natGatewayProfile"> Profile of the cluster NAT gateway. </param>
+        /// <param name="staticEgressGatewayProfile"> The profile for Static Egress Gateway addon. For more details about Static Egress Gateway, see https://aka.ms/aks/static-egress-gateway. </param>
+        /// <param name="podCidrs"> The CIDR notation IP ranges from which to assign pod IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. </param>
+        /// <param name="serviceCidrs"> The CIDR notation IP ranges from which to assign service cluster IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges. </param>
+        /// <param name="networkIPFamilies"> The IP families used to specify IP versions available to the cluster. IP families are used to determine single-stack or dual-stack clusters. For single-stack, the expected value is IPv4. For dual-stack, the expected values are IPv4 and IPv6. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceNetworkProfile(ContainerServiceNetworkPlugin? networkPlugin, ContainerServiceNetworkPluginMode? networkPluginMode, ContainerServiceNetworkPolicy? networkPolicy, ContainerServiceNetworkMode? networkMode, NetworkDataplane? networkDataplane, ManagedClusterAdvancedNetworking advancedNetworking, string podCidr, string serviceCidr, string dnsServiceIP, ContainerServiceOutboundType? outboundType, ContainerServiceLoadBalancerSku? loadBalancerSku, ManagedClusterLoadBalancerProfile loadBalancerProfile, ManagedClusterNatGatewayProfile natGatewayProfile, ManagedClusterStaticEgressGatewayProfile staticEgressGatewayProfile, IList<string> podCidrs, IList<string> serviceCidrs, IList<ContainerServiceIPFamily> networkIPFamilies, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -148,93 +94,48 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Network plugin used for building the Kubernetes network.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkPlugin
-        /// </summary>
+        /// <summary> Network plugin used for building the Kubernetes network. </summary>
         [WirePath("networkPlugin")]
         public ContainerServiceNetworkPlugin? NetworkPlugin { get; set; }
-        /// <summary>
-        /// The mode the network plugin should use.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkPluginMode
-        /// </summary>
+        /// <summary> The mode the network plugin should use. </summary>
         [WirePath("networkPluginMode")]
         public ContainerServiceNetworkPluginMode? NetworkPluginMode { get; set; }
-        /// <summary>
-        /// Network policy used for building the Kubernetes network.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkPolicy
-        /// </summary>
+        /// <summary> Network policy used for building the Kubernetes network. </summary>
         [WirePath("networkPolicy")]
         public ContainerServiceNetworkPolicy? NetworkPolicy { get; set; }
-        /// <summary>
-        /// The network mode Azure CNI is configured with. This cannot be specified if networkPlugin is anything other than 'azure'.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkMode
-        /// </summary>
+        /// <summary> The network mode Azure CNI is configured with. This cannot be specified if networkPlugin is anything other than 'azure'. </summary>
         [WirePath("networkMode")]
         public ContainerServiceNetworkMode? NetworkMode { get; set; }
-        /// <summary>
-        /// Network dataplane used in the Kubernetes cluster.
-        /// Serialized Name: ContainerServiceNetworkProfile.networkDataplane
-        /// </summary>
+        /// <summary> Network dataplane used in the Kubernetes cluster. </summary>
         [WirePath("networkDataplane")]
         public NetworkDataplane? NetworkDataplane { get; set; }
-        /// <summary>
-        /// Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking.
-        /// Serialized Name: ContainerServiceNetworkProfile.advancedNetworking
-        /// </summary>
+        /// <summary> Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking. </summary>
         [WirePath("advancedNetworking")]
         public ManagedClusterAdvancedNetworking AdvancedNetworking { get; set; }
-        /// <summary>
-        /// A CIDR notation IP range from which to assign pod IPs when kubenet is used.
-        /// Serialized Name: ContainerServiceNetworkProfile.podCidr
-        /// </summary>
+        /// <summary> A CIDR notation IP range from which to assign pod IPs when kubenet is used. </summary>
         [WirePath("podCidr")]
         public string PodCidr { get; set; }
-        /// <summary>
-        /// A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.
-        /// Serialized Name: ContainerServiceNetworkProfile.serviceCidr
-        /// </summary>
+        /// <summary> A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges. </summary>
         [WirePath("serviceCidr")]
         public string ServiceCidr { get; set; }
-        /// <summary>
-        /// An IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.
-        /// Serialized Name: ContainerServiceNetworkProfile.dnsServiceIP
-        /// </summary>
+        /// <summary> An IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr. </summary>
         [WirePath("dnsServiceIP")]
         public string DnsServiceIP { get; set; }
-        /// <summary>
-        /// The outbound (egress) routing method. This can only be set at cluster creation time and cannot be changed later. For more information see [egress outbound type](https://docs.microsoft.com/azure/aks/egress-outboundtype).
-        /// Serialized Name: ContainerServiceNetworkProfile.outboundType
-        /// </summary>
+        /// <summary> The outbound (egress) routing method. This can only be set at cluster creation time and cannot be changed later. For more information see [egress outbound type](https://docs.microsoft.com/azure/aks/egress-outboundtype). </summary>
         [WirePath("outboundType")]
         public ContainerServiceOutboundType? OutboundType { get; set; }
-        /// <summary>
-        /// The load balancer sku for the managed cluster. The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs.
-        /// Serialized Name: ContainerServiceNetworkProfile.loadBalancerSku
-        /// </summary>
+        /// <summary> The load balancer sku for the managed cluster. The default is 'standard'. See [Azure Load Balancer SKUs](https://docs.microsoft.com/azure/load-balancer/skus) for more information about the differences between load balancer SKUs. </summary>
         [WirePath("loadBalancerSku")]
         public ContainerServiceLoadBalancerSku? LoadBalancerSku { get; set; }
-        /// <summary>
-        /// Profile of the cluster load balancer.
-        /// Serialized Name: ContainerServiceNetworkProfile.loadBalancerProfile
-        /// </summary>
+        /// <summary> Profile of the cluster load balancer. </summary>
         [WirePath("loadBalancerProfile")]
         public ManagedClusterLoadBalancerProfile LoadBalancerProfile { get; set; }
-        /// <summary>
-        /// Profile of the cluster NAT gateway.
-        /// Serialized Name: ContainerServiceNetworkProfile.natGatewayProfile
-        /// </summary>
+        /// <summary> Profile of the cluster NAT gateway. </summary>
         [WirePath("natGatewayProfile")]
         public ManagedClusterNatGatewayProfile NatGatewayProfile { get; set; }
-        /// <summary>
-        /// The profile for Static Egress Gateway addon. For more details about Static Egress Gateway, see https://aka.ms/aks/static-egress-gateway.
-        /// Serialized Name: ContainerServiceNetworkProfile.staticEgressGatewayProfile
-        /// </summary>
+        /// <summary> The profile for Static Egress Gateway addon. For more details about Static Egress Gateway, see https://aka.ms/aks/static-egress-gateway. </summary>
         internal ManagedClusterStaticEgressGatewayProfile StaticEgressGatewayProfile { get; set; }
-        /// <summary>
-        /// Enable Static Egress Gateway addon. Indicates if Static Egress Gateway addon is enabled or not.
-        /// Serialized Name: ManagedClusterStaticEgressGatewayProfile.enabled
-        /// </summary>
+        /// <summary> Enable Static Egress Gateway addon. Indicates if Static Egress Gateway addon is enabled or not. </summary>
         [WirePath("staticEgressGatewayProfile.enabled")]
         public bool? IsStaticEgressGatewayAddonEnabled
         {
@@ -247,22 +148,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// The CIDR notation IP ranges from which to assign pod IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking.
-        /// Serialized Name: ContainerServiceNetworkProfile.podCidrs
-        /// </summary>
+        /// <summary> The CIDR notation IP ranges from which to assign pod IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. </summary>
         [WirePath("podCidrs")]
         public IList<string> PodCidrs { get; }
-        /// <summary>
-        /// The CIDR notation IP ranges from which to assign service cluster IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges.
-        /// Serialized Name: ContainerServiceNetworkProfile.serviceCidrs
-        /// </summary>
+        /// <summary> The CIDR notation IP ranges from which to assign service cluster IPs. One IPv4 CIDR is expected for single-stack networking. Two CIDRs, one for each IP family (IPv4/IPv6), is expected for dual-stack networking. They must not overlap with any Subnet IP ranges. </summary>
         [WirePath("serviceCidrs")]
         public IList<string> ServiceCidrs { get; }
-        /// <summary>
-        /// The IP families used to specify IP versions available to the cluster. IP families are used to determine single-stack or dual-stack clusters. For single-stack, the expected value is IPv4. For dual-stack, the expected values are IPv4 and IPv6.
-        /// Serialized Name: ContainerServiceNetworkProfile.ipFamilies
-        /// </summary>
+        /// <summary> The IP families used to specify IP versions available to the cluster. IP families are used to determine single-stack or dual-stack clusters. For single-stack, the expected value is IPv4. For dual-stack, the expected values are IPv4 and IPv6. </summary>
         [WirePath("ipFamilies")]
         public IList<ContainerServiceIPFamily> NetworkIPFamilies { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOSDiskType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOSDiskType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-    /// Serialized Name: OSDiskType
-    /// </summary>
+    /// <summary> The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os). </summary>
     public readonly partial struct ContainerServiceOSDiskType : IEquatable<ContainerServiceOSDiskType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string ManagedValue = "Managed";
         private const string EphemeralValue = "Ephemeral";
 
-        /// <summary>
-        /// Azure replicates the operating system disk for a virtual machine to Azure storage to avoid data loss should the VM need to be relocated to another host. Since containers aren't designed to have local state persisted, this behavior offers limited value while providing some drawbacks, including slower node provisioning and higher read/write latency.
-        /// Serialized Name: OSDiskType.Managed
-        /// </summary>
+        /// <summary> Azure replicates the operating system disk for a virtual machine to Azure storage to avoid data loss should the VM need to be relocated to another host. Since containers aren't designed to have local state persisted, this behavior offers limited value while providing some drawbacks, including slower node provisioning and higher read/write latency. </summary>
         public static ContainerServiceOSDiskType Managed { get; } = new ContainerServiceOSDiskType(ManagedValue);
-        /// <summary>
-        /// Ephemeral OS disks are stored only on the host machine, just like a temporary disk. This provides lower read/write latency, along with faster node scaling and cluster upgrades.
-        /// Serialized Name: OSDiskType.Ephemeral
-        /// </summary>
+        /// <summary> Ephemeral OS disks are stored only on the host machine, just like a temporary disk. This provides lower read/write latency, along with faster node scaling and cluster upgrades. </summary>
         public static ContainerServiceOSDiskType Ephemeral { get; } = new ContainerServiceOSDiskType(EphemeralValue);
         /// <summary> Determines if two <see cref="ContainerServiceOSDiskType"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceOSDiskType left, ContainerServiceOSDiskType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOSSku.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOSSku.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-    /// Serialized Name: OSSku
-    /// </summary>
+    /// <summary> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </summary>
     public readonly partial struct ContainerServiceOSSku : IEquatable<ContainerServiceOSSku>
     {
         private readonly string _value;
@@ -34,45 +31,21 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string Ubuntu2204Value = "Ubuntu2204";
         private const string Ubuntu2404Value = "Ubuntu2404";
 
-        /// <summary>
-        /// Use Ubuntu as the OS for node images.
-        /// Serialized Name: OSSku.Ubuntu
-        /// </summary>
+        /// <summary> Use Ubuntu as the OS for node images. </summary>
         public static ContainerServiceOSSku Ubuntu { get; } = new ContainerServiceOSSku(UbuntuValue);
-        /// <summary>
-        /// Use AzureLinux as the OS for node images. Azure Linux is a container-optimized Linux distro built by Microsoft, visit https://aka.ms/azurelinux for more information.
-        /// Serialized Name: OSSku.AzureLinux
-        /// </summary>
+        /// <summary> Use AzureLinux as the OS for node images. Azure Linux is a container-optimized Linux distro built by Microsoft, visit https://aka.ms/azurelinux for more information. </summary>
         public static ContainerServiceOSSku AzureLinux { get; } = new ContainerServiceOSSku(AzureLinuxValue);
-        /// <summary>
-        /// Use AzureLinux3 as the OS for node images. Azure Linux is a container-optimized Linux distro built by Microsoft, visit https://aka.ms/azurelinux for more information. For limitations, visit https://aka.ms/aks/node-images. For OS migration guidance, see https://aka.ms/aks/upgrade-os-version.
-        /// Serialized Name: OSSku.AzureLinux3
-        /// </summary>
+        /// <summary> Use AzureLinux3 as the OS for node images. Azure Linux is a container-optimized Linux distro built by Microsoft, visit https://aka.ms/azurelinux for more information. For limitations, visit https://aka.ms/aks/node-images. For OS migration guidance, see https://aka.ms/aks/upgrade-os-version. </summary>
         public static ContainerServiceOSSku AzureLinux3 { get; } = new ContainerServiceOSSku(AzureLinux3Value);
-        /// <summary>
-        /// Deprecated OSSKU. Microsoft recommends that new deployments choose 'AzureLinux' instead.
-        /// Serialized Name: OSSku.CBLMariner
-        /// </summary>
+        /// <summary> Deprecated OSSKU. Microsoft recommends that new deployments choose 'AzureLinux' instead. </summary>
         public static ContainerServiceOSSku CblMariner { get; } = new ContainerServiceOSSku(CblMarinerValue);
-        /// <summary>
-        /// Use Windows2019 as the OS for node images. Unsupported for system node pools. Windows2019 only supports Windows2019 containers; it cannot run Windows2022 containers and vice versa.
-        /// Serialized Name: OSSku.Windows2019
-        /// </summary>
+        /// <summary> Use Windows2019 as the OS for node images. Unsupported for system node pools. Windows2019 only supports Windows2019 containers; it cannot run Windows2022 containers and vice versa. </summary>
         public static ContainerServiceOSSku Windows2019 { get; } = new ContainerServiceOSSku(Windows2019Value);
-        /// <summary>
-        /// Use Windows2022 as the OS for node images. Unsupported for system node pools. Windows2022 only supports Windows2022 containers; it cannot run Windows2019 containers and vice versa.
-        /// Serialized Name: OSSku.Windows2022
-        /// </summary>
+        /// <summary> Use Windows2022 as the OS for node images. Unsupported for system node pools. Windows2022 only supports Windows2022 containers; it cannot run Windows2019 containers and vice versa. </summary>
         public static ContainerServiceOSSku Windows2022 { get; } = new ContainerServiceOSSku(Windows2022Value);
-        /// <summary>
-        /// Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see https://aka.ms/aks/supported-ubuntu-versions
-        /// Serialized Name: OSSku.Ubuntu2204
-        /// </summary>
+        /// <summary> Use Ubuntu2204 as the OS for node images, however, Ubuntu 22.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see https://aka.ms/aks/supported-ubuntu-versions. </summary>
         public static ContainerServiceOSSku Ubuntu2204 { get; } = new ContainerServiceOSSku(Ubuntu2204Value);
-        /// <summary>
-        /// Use Ubuntu2404 as the OS for node images, however, Ubuntu 24.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see https://aka.ms/aks/supported-ubuntu-versions
-        /// Serialized Name: OSSku.Ubuntu2404
-        /// </summary>
+        /// <summary> Use Ubuntu2404 as the OS for node images, however, Ubuntu 24.04 may not be supported for all nodepools. For limitations and supported kubernetes versions, see https://aka.ms/aks/supported-ubuntu-versions. </summary>
         public static ContainerServiceOSSku Ubuntu2404 { get; } = new ContainerServiceOSSku(Ubuntu2404Value);
         /// <summary> Determines if two <see cref="ContainerServiceOSSku"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceOSSku left, ContainerServiceOSSku right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOSType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOSType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The operating system type. The default is Linux.
-    /// Serialized Name: OSType
-    /// </summary>
+    /// <summary> The operating system type. The default is Linux. </summary>
     public readonly partial struct ContainerServiceOSType : IEquatable<ContainerServiceOSType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string LinuxValue = "Linux";
         private const string WindowsValue = "Windows";
 
-        /// <summary>
-        /// Use Linux.
-        /// Serialized Name: OSType.Linux
-        /// </summary>
+        /// <summary> Use Linux. </summary>
         public static ContainerServiceOSType Linux { get; } = new ContainerServiceOSType(LinuxValue);
-        /// <summary>
-        /// Use Windows.
-        /// Serialized Name: OSType.Windows
-        /// </summary>
+        /// <summary> Use Windows. </summary>
         public static ContainerServiceOSType Windows { get; } = new ContainerServiceOSType(WindowsValue);
         /// <summary> Determines if two <see cref="ContainerServiceOSType"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceOSType left, ContainerServiceOSType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOutboundEnvironmentEndpoint.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOutboundEnvironmentEndpoint.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Egress endpoints which AKS agent nodes connect to for common purpose.
-    /// Serialized Name: OutboundEnvironmentEndpoint
-    /// </summary>
+    /// <summary> Egress endpoints which AKS agent nodes connect to for common purpose. </summary>
     public partial class ContainerServiceOutboundEnvironmentEndpoint
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceOutboundEnvironmentEndpoint"/>. </summary>
-        /// <param name="category">
-        /// The category of endpoints accessed by the AKS agent node, e.g. azure-resource-management, apiserver, etc.
-        /// Serialized Name: OutboundEnvironmentEndpoint.category
-        /// </param>
-        /// <param name="endpoints">
-        /// The endpoints that AKS agent nodes connect to
-        /// Serialized Name: OutboundEnvironmentEndpoint.endpoints
-        /// </param>
+        /// <param name="category"> The category of endpoints accessed by the AKS agent node, e.g. azure-resource-management, apiserver, etc. </param>
+        /// <param name="endpoints"> The endpoints that AKS agent nodes connect to. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceOutboundEnvironmentEndpoint(string category, IReadOnlyList<ContainerServiceEndpointDependency> endpoints, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,16 +62,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The category of endpoints accessed by the AKS agent node, e.g. azure-resource-management, apiserver, etc.
-        /// Serialized Name: OutboundEnvironmentEndpoint.category
-        /// </summary>
+        /// <summary> The category of endpoints accessed by the AKS agent node, e.g. azure-resource-management, apiserver, etc. </summary>
         [WirePath("category")]
         public string Category { get; }
-        /// <summary>
-        /// The endpoints that AKS agent nodes connect to
-        /// Serialized Name: OutboundEnvironmentEndpoint.endpoints
-        /// </summary>
+        /// <summary> The endpoints that AKS agent nodes connect to. </summary>
         [WirePath("endpoints")]
         public IReadOnlyList<ContainerServiceEndpointDependency> Endpoints { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOutboundType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceOutboundType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The outbound (egress) routing method. This can only be set at cluster creation time and cannot be changed later. For more information see [egress outbound type](https://docs.microsoft.com/azure/aks/egress-outboundtype).
-    /// Serialized Name: OutboundType
-    /// </summary>
+    /// <summary> The outbound (egress) routing method. This can only be set at cluster creation time and cannot be changed later. For more information see [egress outbound type](https://docs.microsoft.com/azure/aks/egress-outboundtype). </summary>
     public readonly partial struct ContainerServiceOutboundType : IEquatable<ContainerServiceOutboundType>
     {
         private readonly string _value;
@@ -31,30 +28,15 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string UserAssignedNatGatewayValue = "userAssignedNATGateway";
         private const string NoneValue = "none";
 
-        /// <summary>
-        /// The load balancer is used for egress through an AKS assigned public IP. This supports Kubernetes services of type 'loadBalancer'. For more information see [outbound type loadbalancer](https://docs.microsoft.com/azure/aks/egress-outboundtype#outbound-type-of-loadbalancer).
-        /// Serialized Name: OutboundType.loadBalancer
-        /// </summary>
+        /// <summary> The load balancer is used for egress through an AKS assigned public IP. This supports Kubernetes services of type 'loadBalancer'. For more information see [outbound type loadbalancer](https://docs.microsoft.com/azure/aks/egress-outboundtype#outbound-type-of-loadbalancer). </summary>
         public static ContainerServiceOutboundType LoadBalancer { get; } = new ContainerServiceOutboundType(LoadBalancerValue);
-        /// <summary>
-        /// Egress paths must be defined by the user. This is an advanced scenario and requires proper network configuration. For more information see [outbound type userDefinedRouting](https://docs.microsoft.com/azure/aks/egress-outboundtype#outbound-type-of-userdefinedrouting).
-        /// Serialized Name: OutboundType.userDefinedRouting
-        /// </summary>
+        /// <summary> Egress paths must be defined by the user. This is an advanced scenario and requires proper network configuration. For more information see [outbound type userDefinedRouting](https://docs.microsoft.com/azure/aks/egress-outboundtype#outbound-type-of-userdefinedrouting). </summary>
         public static ContainerServiceOutboundType UserDefinedRouting { get; } = new ContainerServiceOutboundType(UserDefinedRoutingValue);
-        /// <summary>
-        /// The AKS-managed NAT gateway is used for egress.
-        /// Serialized Name: OutboundType.managedNATGateway
-        /// </summary>
+        /// <summary> The AKS-managed NAT gateway is used for egress. </summary>
         public static ContainerServiceOutboundType ManagedNatGateway { get; } = new ContainerServiceOutboundType(ManagedNatGatewayValue);
-        /// <summary>
-        /// The user-assigned NAT gateway associated to the cluster subnet is used for egress. This is an advanced scenario and requires proper network configuration.
-        /// Serialized Name: OutboundType.userAssignedNATGateway
-        /// </summary>
+        /// <summary> The user-assigned NAT gateway associated to the cluster subnet is used for egress. This is an advanced scenario and requires proper network configuration. </summary>
         public static ContainerServiceOutboundType UserAssignedNatGateway { get; } = new ContainerServiceOutboundType(UserAssignedNatGatewayValue);
-        /// <summary>
-        /// The AKS cluster is not set with any outbound-type. All AKS nodes follows Azure VM default outbound behavior. Please refer to https://azure.microsoft.com/en-us/updates/default-outbound-access-for-vms-in-azure-will-be-retired-transition-to-a-new-method-of-internet-access/
-        /// Serialized Name: OutboundType.none
-        /// </summary>
+        /// <summary> The AKS cluster is not set with any outbound-type. All AKS nodes follows Azure VM default outbound behavior. Please refer to https://azure.microsoft.com/en-us/updates/default-outbound-access-for-vms-in-azure-will-be-retired-transition-to-a-new-method-of-internet-access/. </summary>
         public static ContainerServiceOutboundType None { get; } = new ContainerServiceOutboundType(NoneValue);
         /// <summary> Determines if two <see cref="ContainerServiceOutboundType"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceOutboundType left, ContainerServiceOutboundType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePowerState.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePowerState.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Describes the Power State of the cluster
-    /// Serialized Name: PowerState
-    /// </summary>
+    /// <summary> Describes the Power State of the cluster. </summary>
     internal partial class ContainerServicePowerState
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServicePowerState"/>. </summary>
-        /// <param name="code">
-        /// Tells whether the cluster is Running or Stopped
-        /// Serialized Name: PowerState.code
-        /// </param>
+        /// <param name="code"> Tells whether the cluster is Running or Stopped. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServicePowerState(ContainerServiceStateCode? code, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Tells whether the cluster is Running or Stopped
-        /// Serialized Name: PowerState.code
-        /// </summary>
+        /// <summary> Tells whether the cluster is Running or Stopped. </summary>
         [WirePath("code")]
         public ContainerServiceStateCode? Code { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateEndpointConnectionListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateEndpointConnectionListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// A list of private endpoint connections
-    /// Serialized Name: PrivateEndpointConnectionListResult
-    /// </summary>
+    /// <summary> A list of private endpoint connections. </summary>
     internal partial class ContainerServicePrivateEndpointConnectionListResult
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServicePrivateEndpointConnectionListResult"/>. </summary>
-        /// <param name="value">
-        /// The collection value.
-        /// Serialized Name: PrivateEndpointConnectionListResult.value
-        /// </param>
+        /// <param name="value"> The collection value. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServicePrivateEndpointConnectionListResult(IReadOnlyList<ContainerServicePrivateEndpointConnectionData> value, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The collection value.
-        /// Serialized Name: PrivateEndpointConnectionListResult.value
-        /// </summary>
+        /// <summary> The collection value. </summary>
         [WirePath("value")]
         public IReadOnlyList<ContainerServicePrivateEndpointConnectionData> Value { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateEndpointConnectionProvisioningState.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateEndpointConnectionProvisioningState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The current provisioning state.
-    /// Serialized Name: PrivateEndpointConnectionProvisioningState
-    /// </summary>
+    /// <summary> The current provisioning state. </summary>
     public readonly partial struct ContainerServicePrivateEndpointConnectionProvisioningState : IEquatable<ContainerServicePrivateEndpointConnectionProvisioningState>
     {
         private readonly string _value;
@@ -31,30 +28,15 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string FailedValue = "Failed";
         private const string SucceededValue = "Succeeded";
 
-        /// <summary>
-        /// Canceled
-        /// Serialized Name: PrivateEndpointConnectionProvisioningState.Canceled
-        /// </summary>
+        /// <summary> Canceled. </summary>
         public static ContainerServicePrivateEndpointConnectionProvisioningState Canceled { get; } = new ContainerServicePrivateEndpointConnectionProvisioningState(CanceledValue);
-        /// <summary>
-        /// Creating
-        /// Serialized Name: PrivateEndpointConnectionProvisioningState.Creating
-        /// </summary>
+        /// <summary> Creating. </summary>
         public static ContainerServicePrivateEndpointConnectionProvisioningState Creating { get; } = new ContainerServicePrivateEndpointConnectionProvisioningState(CreatingValue);
-        /// <summary>
-        /// Deleting
-        /// Serialized Name: PrivateEndpointConnectionProvisioningState.Deleting
-        /// </summary>
+        /// <summary> Deleting. </summary>
         public static ContainerServicePrivateEndpointConnectionProvisioningState Deleting { get; } = new ContainerServicePrivateEndpointConnectionProvisioningState(DeletingValue);
-        /// <summary>
-        /// Failed
-        /// Serialized Name: PrivateEndpointConnectionProvisioningState.Failed
-        /// </summary>
+        /// <summary> Failed. </summary>
         public static ContainerServicePrivateEndpointConnectionProvisioningState Failed { get; } = new ContainerServicePrivateEndpointConnectionProvisioningState(FailedValue);
-        /// <summary>
-        /// Succeeded
-        /// Serialized Name: PrivateEndpointConnectionProvisioningState.Succeeded
-        /// </summary>
+        /// <summary> Succeeded. </summary>
         public static ContainerServicePrivateEndpointConnectionProvisioningState Succeeded { get; } = new ContainerServicePrivateEndpointConnectionProvisioningState(SucceededValue);
         /// <summary> Determines if two <see cref="ContainerServicePrivateEndpointConnectionProvisioningState"/> values are the same. </summary>
         public static bool operator ==(ContainerServicePrivateEndpointConnectionProvisioningState left, ContainerServicePrivateEndpointConnectionProvisioningState right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateLinkResourceData.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateLinkResourceData.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// A private link resource
-    /// Serialized Name: PrivateLinkResource
-    /// </summary>
+    /// <summary> A private link resource. </summary>
     public partial class ContainerServicePrivateLinkResourceData
     {
         /// <summary>
@@ -56,30 +53,12 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServicePrivateLinkResourceData"/>. </summary>
-        /// <param name="id">
-        /// The ID of the private link resource.
-        /// Serialized Name: PrivateLinkResource.id
-        /// </param>
-        /// <param name="name">
-        /// The name of the private link resource.
-        /// Serialized Name: PrivateLinkResource.name
-        /// </param>
-        /// <param name="resourceType">
-        /// The resource type.
-        /// Serialized Name: PrivateLinkResource.type
-        /// </param>
-        /// <param name="groupId">
-        /// The group ID of the resource.
-        /// Serialized Name: PrivateLinkResource.groupId
-        /// </param>
-        /// <param name="requiredMembers">
-        /// The RequiredMembers of the resource
-        /// Serialized Name: PrivateLinkResource.requiredMembers
-        /// </param>
-        /// <param name="privateLinkServiceId">
-        /// The private link service ID of the resource, this field is exposed only to NRP internally.
-        /// Serialized Name: PrivateLinkResource.privateLinkServiceID
-        /// </param>
+        /// <param name="id"> The ID of the private link resource. </param>
+        /// <param name="name"> The name of the private link resource. </param>
+        /// <param name="resourceType"> The resource type. </param>
+        /// <param name="groupId"> The group ID of the resource. </param>
+        /// <param name="requiredMembers"> The RequiredMembers of the resource. </param>
+        /// <param name="privateLinkServiceId"> The private link service ID of the resource, this field is exposed only to NRP internally. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServicePrivateLinkResourceData(ResourceIdentifier id, string name, ResourceType? resourceType, string groupId, IList<string> requiredMembers, ResourceIdentifier privateLinkServiceId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -92,40 +71,22 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The ID of the private link resource.
-        /// Serialized Name: PrivateLinkResource.id
-        /// </summary>
+        /// <summary> The ID of the private link resource. </summary>
         [WirePath("id")]
         public ResourceIdentifier Id { get; set; }
-        /// <summary>
-        /// The name of the private link resource.
-        /// Serialized Name: PrivateLinkResource.name
-        /// </summary>
+        /// <summary> The name of the private link resource. </summary>
         [WirePath("name")]
         public string Name { get; set; }
-        /// <summary>
-        /// The resource type.
-        /// Serialized Name: PrivateLinkResource.type
-        /// </summary>
+        /// <summary> The resource type. </summary>
         [WirePath("type")]
         public ResourceType? ResourceType { get; set; }
-        /// <summary>
-        /// The group ID of the resource.
-        /// Serialized Name: PrivateLinkResource.groupId
-        /// </summary>
+        /// <summary> The group ID of the resource. </summary>
         [WirePath("groupId")]
         public string GroupId { get; set; }
-        /// <summary>
-        /// The RequiredMembers of the resource
-        /// Serialized Name: PrivateLinkResource.requiredMembers
-        /// </summary>
+        /// <summary> The RequiredMembers of the resource. </summary>
         [WirePath("requiredMembers")]
         public IList<string> RequiredMembers { get; }
-        /// <summary>
-        /// The private link service ID of the resource, this field is exposed only to NRP internally.
-        /// Serialized Name: PrivateLinkResource.privateLinkServiceID
-        /// </summary>
+        /// <summary> The private link service ID of the resource, this field is exposed only to NRP internally. </summary>
         [WirePath("privateLinkServiceID")]
         public ResourceIdentifier PrivateLinkServiceId { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateLinkResourcesListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateLinkResourcesListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// A list of private link resources
-    /// Serialized Name: PrivateLinkResourcesListResult
-    /// </summary>
+    /// <summary> A list of private link resources. </summary>
     internal partial class ContainerServicePrivateLinkResourcesListResult
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServicePrivateLinkResourcesListResult"/>. </summary>
-        /// <param name="value">
-        /// The collection value.
-        /// Serialized Name: PrivateLinkResourcesListResult.value
-        /// </param>
+        /// <param name="value"> The collection value. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServicePrivateLinkResourcesListResult(IReadOnlyList<ContainerServicePrivateLinkResourceData> value, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The collection value.
-        /// Serialized Name: PrivateLinkResourcesListResult.value
-        /// </summary>
+        /// <summary> The collection value. </summary>
         [WirePath("value")]
         public IReadOnlyList<ContainerServicePrivateLinkResourceData> Value { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateLinkServiceConnectionState.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateLinkServiceConnectionState.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The state of a private link service connection.
-    /// Serialized Name: PrivateLinkServiceConnectionState
-    /// </summary>
+    /// <summary> The state of a private link service connection. </summary>
     public partial class ContainerServicePrivateLinkServiceConnectionState
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServicePrivateLinkServiceConnectionState"/>. </summary>
-        /// <param name="status">
-        /// The private link service connection status.
-        /// Serialized Name: PrivateLinkServiceConnectionState.status
-        /// </param>
-        /// <param name="description">
-        /// The private link service connection description.
-        /// Serialized Name: PrivateLinkServiceConnectionState.description
-        /// </param>
+        /// <param name="status"> The private link service connection status. </param>
+        /// <param name="description"> The private link service connection description. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServicePrivateLinkServiceConnectionState(ContainerServicePrivateLinkServiceConnectionStatus? status, string description, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The private link service connection status.
-        /// Serialized Name: PrivateLinkServiceConnectionState.status
-        /// </summary>
+        /// <summary> The private link service connection status. </summary>
         [WirePath("status")]
         public ContainerServicePrivateLinkServiceConnectionStatus? Status { get; set; }
-        /// <summary>
-        /// The private link service connection description.
-        /// Serialized Name: PrivateLinkServiceConnectionState.description
-        /// </summary>
+        /// <summary> The private link service connection description. </summary>
         [WirePath("description")]
         public string Description { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateLinkServiceConnectionStatus.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePrivateLinkServiceConnectionStatus.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The private link service connection status.
-    /// Serialized Name: ConnectionStatus
-    /// </summary>
+    /// <summary> The private link service connection status. </summary>
     public readonly partial struct ContainerServicePrivateLinkServiceConnectionStatus : IEquatable<ContainerServicePrivateLinkServiceConnectionStatus>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string RejectedValue = "Rejected";
         private const string DisconnectedValue = "Disconnected";
 
-        /// <summary>
-        /// Pending
-        /// Serialized Name: ConnectionStatus.Pending
-        /// </summary>
+        /// <summary> Pending. </summary>
         public static ContainerServicePrivateLinkServiceConnectionStatus Pending { get; } = new ContainerServicePrivateLinkServiceConnectionStatus(PendingValue);
-        /// <summary>
-        /// Approved
-        /// Serialized Name: ConnectionStatus.Approved
-        /// </summary>
+        /// <summary> Approved. </summary>
         public static ContainerServicePrivateLinkServiceConnectionStatus Approved { get; } = new ContainerServicePrivateLinkServiceConnectionStatus(ApprovedValue);
-        /// <summary>
-        /// Rejected
-        /// Serialized Name: ConnectionStatus.Rejected
-        /// </summary>
+        /// <summary> Rejected. </summary>
         public static ContainerServicePrivateLinkServiceConnectionStatus Rejected { get; } = new ContainerServicePrivateLinkServiceConnectionStatus(RejectedValue);
-        /// <summary>
-        /// Disconnected
-        /// Serialized Name: ConnectionStatus.Disconnected
-        /// </summary>
+        /// <summary> Disconnected. </summary>
         public static ContainerServicePrivateLinkServiceConnectionStatus Disconnected { get; } = new ContainerServicePrivateLinkServiceConnectionStatus(DisconnectedValue);
         /// <summary> Determines if two <see cref="ContainerServicePrivateLinkServiceConnectionStatus"/> values are the same. </summary>
         public static bool operator ==(ContainerServicePrivateLinkServiceConnectionStatus left, ContainerServicePrivateLinkServiceConnectionStatus right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePublicNetworkAccess.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServicePublicNetworkAccess.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS
-    /// Serialized Name: PublicNetworkAccess
-    /// </summary>
+    /// <summary> PublicNetworkAccess of the managedCluster. Allow or deny public network access for AKS. </summary>
     public readonly partial struct ContainerServicePublicNetworkAccess : IEquatable<ContainerServicePublicNetworkAccess>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Enabled
-        /// Serialized Name: PublicNetworkAccess.Enabled
-        /// </summary>
+        /// <summary> Enabled. </summary>
         public static ContainerServicePublicNetworkAccess Enabled { get; } = new ContainerServicePublicNetworkAccess(EnabledValue);
-        /// <summary>
-        /// Disabled
-        /// Serialized Name: PublicNetworkAccess.Disabled
-        /// </summary>
+        /// <summary> Disabled. </summary>
         public static ContainerServicePublicNetworkAccess Disabled { get; } = new ContainerServicePublicNetworkAccess(DisabledValue);
         /// <summary> Determines if two <see cref="ContainerServicePublicNetworkAccess"/> values are the same. </summary>
         public static bool operator ==(ContainerServicePublicNetworkAccess left, ContainerServicePublicNetworkAccess right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceSshConfiguration.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceSshConfiguration.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// SSH configuration for Linux-based VMs running on Azure.
-    /// Serialized Name: ContainerServiceSshConfiguration
-    /// </summary>
+    /// <summary> SSH configuration for Linux-based VMs running on Azure. </summary>
     public partial class ContainerServiceSshConfiguration
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceSshConfiguration"/>. </summary>
-        /// <param name="publicKeys">
-        /// The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified.
-        /// Serialized Name: ContainerServiceSshConfiguration.publicKeys
-        /// </param>
+        /// <param name="publicKeys"> The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="publicKeys"/> is null. </exception>
         public ContainerServiceSshConfiguration(IEnumerable<ContainerServiceSshPublicKey> publicKeys)
         {
@@ -63,10 +57,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceSshConfiguration"/>. </summary>
-        /// <param name="publicKeys">
-        /// The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified.
-        /// Serialized Name: ContainerServiceSshConfiguration.publicKeys
-        /// </param>
+        /// <param name="publicKeys"> The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceSshConfiguration(IList<ContainerServiceSshPublicKey> publicKeys, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -79,10 +70,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified.
-        /// Serialized Name: ContainerServiceSshConfiguration.publicKeys
-        /// </summary>
+        /// <summary> The list of SSH public keys used to authenticate with Linux-based VMs. A maximum of 1 key may be specified. </summary>
         [WirePath("publicKeys")]
         public IList<ContainerServiceSshPublicKey> PublicKeys { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceSshPublicKey.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceSshPublicKey.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Contains information about SSH certificate public key data.
-    /// Serialized Name: ContainerServiceSshPublicKey
-    /// </summary>
+    /// <summary> Contains information about SSH certificate public key data. </summary>
     public partial class ContainerServiceSshPublicKey
     {
         /// <summary>
@@ -49,10 +46,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceSshPublicKey"/>. </summary>
-        /// <param name="keyData">
-        /// Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers.
-        /// Serialized Name: ContainerServiceSshPublicKey.keyData
-        /// </param>
+        /// <param name="keyData"> Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="keyData"/> is null. </exception>
         public ContainerServiceSshPublicKey(string keyData)
         {
@@ -62,10 +56,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceSshPublicKey"/>. </summary>
-        /// <param name="keyData">
-        /// Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers.
-        /// Serialized Name: ContainerServiceSshPublicKey.keyData
-        /// </param>
+        /// <param name="keyData"> Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceSshPublicKey(string keyData, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -78,10 +69,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers.
-        /// Serialized Name: ContainerServiceSshPublicKey.keyData
-        /// </summary>
+        /// <summary> Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers. </summary>
         [WirePath("keyData")]
         public string KeyData { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceStateCode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceStateCode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Tells whether the cluster is Running or Stopped
-    /// Serialized Name: Code
-    /// </summary>
+    /// <summary> Tells whether the cluster is Running or Stopped. </summary>
     public readonly partial struct ContainerServiceStateCode : IEquatable<ContainerServiceStateCode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string RunningValue = "Running";
         private const string StoppedValue = "Stopped";
 
-        /// <summary>
-        /// The cluster is running.
-        /// Serialized Name: Code.Running
-        /// </summary>
+        /// <summary> The cluster is running. </summary>
         public static ContainerServiceStateCode Running { get; } = new ContainerServiceStateCode(RunningValue);
-        /// <summary>
-        /// The cluster is stopped.
-        /// Serialized Name: Code.Stopped
-        /// </summary>
+        /// <summary> The cluster is stopped. </summary>
         public static ContainerServiceStateCode Stopped { get; } = new ContainerServiceStateCode(StoppedValue);
         /// <summary> Determines if two <see cref="ContainerServiceStateCode"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceStateCode left, ContainerServiceStateCode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTagsObject.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTagsObject.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Tags object for patch operations.
-    /// Serialized Name: TagsObject
-    /// </summary>
+    /// <summary> Tags object for patch operations. </summary>
     public partial class ContainerServiceTagsObject
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceTagsObject"/>. </summary>
-        /// <param name="tags">
-        /// Resource tags.
-        /// Serialized Name: TagsObject.tags
-        /// </param>
+        /// <param name="tags"> Resource tags. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceTagsObject(IDictionary<string, string> tags, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Resource tags.
-        /// Serialized Name: TagsObject.tags
-        /// </summary>
+        /// <summary> Resource tags. </summary>
         [WirePath("tags")]
         public IDictionary<string, string> Tags { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTimeInWeek.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTimeInWeek.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Time in a week.
-    /// Serialized Name: TimeInWeek
-    /// </summary>
+    /// <summary> Time in a week. </summary>
     public partial class ContainerServiceTimeInWeek
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceTimeInWeek"/>. </summary>
-        /// <param name="day">
-        /// The day of the week.
-        /// Serialized Name: TimeInWeek.day
-        /// </param>
-        /// <param name="hourSlots">
-        /// A list of hours in the day used to identify a time range. Each integer hour represents a time range beginning at 0m after the hour ending at the next hour (non-inclusive). 0 corresponds to 00:00 UTC, 23 corresponds to 23:00 UTC. Specifying [0, 1] means the 00:00 - 02:00 UTC time range.
-        /// Serialized Name: TimeInWeek.hourSlots
-        /// </param>
+        /// <param name="day"> The day of the week. </param>
+        /// <param name="hourSlots"> A list of hours in the day used to identify a time range. Each integer hour represents a time range beginning at 0m after the hour ending at the next hour (non-inclusive). 0 corresponds to 00:00 UTC, 23 corresponds to 23:00 UTC. Specifying [0, 1] means the 00:00 - 02:00 UTC time range. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceTimeInWeek(ContainerServiceWeekDay? day, IList<int> hourSlots, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,16 +62,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The day of the week.
-        /// Serialized Name: TimeInWeek.day
-        /// </summary>
+        /// <summary> The day of the week. </summary>
         [WirePath("day")]
         public ContainerServiceWeekDay? Day { get; set; }
-        /// <summary>
-        /// A list of hours in the day used to identify a time range. Each integer hour represents a time range beginning at 0m after the hour ending at the next hour (non-inclusive). 0 corresponds to 00:00 UTC, 23 corresponds to 23:00 UTC. Specifying [0, 1] means the 00:00 - 02:00 UTC time range.
-        /// Serialized Name: TimeInWeek.hourSlots
-        /// </summary>
+        /// <summary> A list of hours in the day used to identify a time range. Each integer hour represents a time range beginning at 0m after the hour ending at the next hour (non-inclusive). 0 corresponds to 00:00 UTC, 23 corresponds to 23:00 UTC. Specifying [0, 1] means the 00:00 - 02:00 UTC time range. </summary>
         [WirePath("hourSlots")]
         public IList<int> HourSlots { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTimeSpan.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTimeSpan.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// A time range. For example, between 2021-05-25T13:00:00Z and 2021-05-25T14:00:00Z.
-    /// Serialized Name: TimeSpan
-    /// </summary>
+    /// <summary> A time range. For example, between 2021-05-25T13:00:00Z and 2021-05-25T14:00:00Z. </summary>
     public partial class ContainerServiceTimeSpan
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceTimeSpan"/>. </summary>
-        /// <param name="startOn">
-        /// The start of a time span
-        /// Serialized Name: TimeSpan.start
-        /// </param>
-        /// <param name="endOn">
-        /// The end of a time span
-        /// Serialized Name: TimeSpan.end
-        /// </param>
+        /// <param name="startOn"> The start of a time span. </param>
+        /// <param name="endOn"> The end of a time span. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceTimeSpan(DateTimeOffset? startOn, DateTimeOffset? endOn, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The start of a time span
-        /// Serialized Name: TimeSpan.start
-        /// </summary>
+        /// <summary> The start of a time span. </summary>
         [WirePath("start")]
         public DateTimeOffset? StartOn { get; set; }
-        /// <summary>
-        /// The end of a time span
-        /// Serialized Name: TimeSpan.end
-        /// </summary>
+        /// <summary> The end of a time span. </summary>
         [WirePath("end")]
         public DateTimeOffset? EndOn { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTrustedAccessRole.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTrustedAccessRole.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Trusted access role definition.
-    /// Serialized Name: TrustedAccessRole
-    /// </summary>
+    /// <summary> Trusted access role definition. </summary>
     public partial class ContainerServiceTrustedAccessRole
     {
         /// <summary>
@@ -55,18 +52,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceTrustedAccessRole"/>. </summary>
-        /// <param name="sourceResourceType">
-        /// Resource type of Azure resource
-        /// Serialized Name: TrustedAccessRole.sourceResourceType
-        /// </param>
-        /// <param name="name">
-        /// Name of role, name is unique under a source resource type
-        /// Serialized Name: TrustedAccessRole.name
-        /// </param>
-        /// <param name="rules">
-        /// List of rules for the role. This maps to 'rules' property of [Kubernetes Cluster Role](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/#ClusterRole).
-        /// Serialized Name: TrustedAccessRole.rules
-        /// </param>
+        /// <param name="sourceResourceType"> Resource type of Azure resource. </param>
+        /// <param name="name"> Name of role, name is unique under a source resource type. </param>
+        /// <param name="rules"> List of rules for the role. This maps to 'rules' property of [Kubernetes Cluster Role](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/#ClusterRole). </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceTrustedAccessRole(string sourceResourceType, string name, IReadOnlyList<ContainerServiceTrustedAccessRoleRule> rules, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -76,22 +64,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Resource type of Azure resource
-        /// Serialized Name: TrustedAccessRole.sourceResourceType
-        /// </summary>
+        /// <summary> Resource type of Azure resource. </summary>
         [WirePath("sourceResourceType")]
         public string SourceResourceType { get; }
-        /// <summary>
-        /// Name of role, name is unique under a source resource type
-        /// Serialized Name: TrustedAccessRole.name
-        /// </summary>
+        /// <summary> Name of role, name is unique under a source resource type. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// List of rules for the role. This maps to 'rules' property of [Kubernetes Cluster Role](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/#ClusterRole).
-        /// Serialized Name: TrustedAccessRole.rules
-        /// </summary>
+        /// <summary> List of rules for the role. This maps to 'rules' property of [Kubernetes Cluster Role](https://kubernetes.io/docs/reference/kubernetes-api/authorization-resources/cluster-role-v1/#ClusterRole). </summary>
         [WirePath("rules")]
         public IReadOnlyList<ContainerServiceTrustedAccessRoleRule> Rules { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTrustedAccessRoleBindingProvisioningState.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTrustedAccessRoleBindingProvisioningState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The current provisioning state of trusted access role binding.
-    /// Serialized Name: TrustedAccessRoleBindingProvisioningState
-    /// </summary>
+    /// <summary> The current provisioning state of trusted access role binding. </summary>
     public readonly partial struct ContainerServiceTrustedAccessRoleBindingProvisioningState : IEquatable<ContainerServiceTrustedAccessRoleBindingProvisioningState>
     {
         private readonly string _value;
@@ -31,30 +28,15 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string SucceededValue = "Succeeded";
         private const string UpdatingValue = "Updating";
 
-        /// <summary>
-        /// Canceled
-        /// Serialized Name: TrustedAccessRoleBindingProvisioningState.Canceled
-        /// </summary>
+        /// <summary> Canceled. </summary>
         public static ContainerServiceTrustedAccessRoleBindingProvisioningState Canceled { get; } = new ContainerServiceTrustedAccessRoleBindingProvisioningState(CanceledValue);
-        /// <summary>
-        /// Deleting
-        /// Serialized Name: TrustedAccessRoleBindingProvisioningState.Deleting
-        /// </summary>
+        /// <summary> Deleting. </summary>
         public static ContainerServiceTrustedAccessRoleBindingProvisioningState Deleting { get; } = new ContainerServiceTrustedAccessRoleBindingProvisioningState(DeletingValue);
-        /// <summary>
-        /// Failed
-        /// Serialized Name: TrustedAccessRoleBindingProvisioningState.Failed
-        /// </summary>
+        /// <summary> Failed. </summary>
         public static ContainerServiceTrustedAccessRoleBindingProvisioningState Failed { get; } = new ContainerServiceTrustedAccessRoleBindingProvisioningState(FailedValue);
-        /// <summary>
-        /// Succeeded
-        /// Serialized Name: TrustedAccessRoleBindingProvisioningState.Succeeded
-        /// </summary>
+        /// <summary> Succeeded. </summary>
         public static ContainerServiceTrustedAccessRoleBindingProvisioningState Succeeded { get; } = new ContainerServiceTrustedAccessRoleBindingProvisioningState(SucceededValue);
-        /// <summary>
-        /// Updating
-        /// Serialized Name: TrustedAccessRoleBindingProvisioningState.Updating
-        /// </summary>
+        /// <summary> Updating. </summary>
         public static ContainerServiceTrustedAccessRoleBindingProvisioningState Updating { get; } = new ContainerServiceTrustedAccessRoleBindingProvisioningState(UpdatingValue);
         /// <summary> Determines if two <see cref="ContainerServiceTrustedAccessRoleBindingProvisioningState"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceTrustedAccessRoleBindingProvisioningState left, ContainerServiceTrustedAccessRoleBindingProvisioningState right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTrustedAccessRoleRule.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceTrustedAccessRoleRule.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Rule for trusted access role
-    /// Serialized Name: TrustedAccessRoleRule
-    /// </summary>
+    /// <summary> Rule for trusted access role. </summary>
     public partial class ContainerServiceTrustedAccessRoleRule
     {
         /// <summary>
@@ -59,26 +56,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceTrustedAccessRoleRule"/>. </summary>
-        /// <param name="verbs">
-        /// List of allowed verbs
-        /// Serialized Name: TrustedAccessRoleRule.verbs
-        /// </param>
-        /// <param name="apiGroups">
-        /// List of allowed apiGroups
-        /// Serialized Name: TrustedAccessRoleRule.apiGroups
-        /// </param>
-        /// <param name="resources">
-        /// List of allowed resources
-        /// Serialized Name: TrustedAccessRoleRule.resources
-        /// </param>
-        /// <param name="resourceNames">
-        /// List of allowed names
-        /// Serialized Name: TrustedAccessRoleRule.resourceNames
-        /// </param>
-        /// <param name="nonResourceUrls">
-        /// List of allowed nonResourceURLs
-        /// Serialized Name: TrustedAccessRoleRule.nonResourceURLs
-        /// </param>
+        /// <param name="verbs"> List of allowed verbs. </param>
+        /// <param name="apiGroups"> List of allowed apiGroups. </param>
+        /// <param name="resources"> List of allowed resources. </param>
+        /// <param name="resourceNames"> List of allowed names. </param>
+        /// <param name="nonResourceUrls"> List of allowed nonResourceURLs. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceTrustedAccessRoleRule(IReadOnlyList<string> verbs, IReadOnlyList<string> apiGroups, IReadOnlyList<string> resources, IReadOnlyList<string> resourceNames, IReadOnlyList<string> nonResourceUrls, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -90,34 +72,19 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// List of allowed verbs
-        /// Serialized Name: TrustedAccessRoleRule.verbs
-        /// </summary>
+        /// <summary> List of allowed verbs. </summary>
         [WirePath("verbs")]
         public IReadOnlyList<string> Verbs { get; }
-        /// <summary>
-        /// List of allowed apiGroups
-        /// Serialized Name: TrustedAccessRoleRule.apiGroups
-        /// </summary>
+        /// <summary> List of allowed apiGroups. </summary>
         [WirePath("apiGroups")]
         public IReadOnlyList<string> ApiGroups { get; }
-        /// <summary>
-        /// List of allowed resources
-        /// Serialized Name: TrustedAccessRoleRule.resources
-        /// </summary>
+        /// <summary> List of allowed resources. </summary>
         [WirePath("resources")]
         public IReadOnlyList<string> Resources { get; }
-        /// <summary>
-        /// List of allowed names
-        /// Serialized Name: TrustedAccessRoleRule.resourceNames
-        /// </summary>
+        /// <summary> List of allowed names. </summary>
         [WirePath("resourceNames")]
         public IReadOnlyList<string> ResourceNames { get; }
-        /// <summary>
-        /// List of allowed nonResourceURLs
-        /// Serialized Name: TrustedAccessRoleRule.nonResourceURLs
-        /// </summary>
+        /// <summary> List of allowed nonResourceURLs. </summary>
         [WirePath("nonResourceURLs")]
         public IReadOnlyList<string> NonResourceUrls { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceUserAssignedIdentity.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceUserAssignedIdentity.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Details about a user assigned identity.
-    /// Serialized Name: UserAssignedIdentity
-    /// </summary>
+    /// <summary> Details about a user assigned identity. </summary>
     public partial class ContainerServiceUserAssignedIdentity
     {
         /// <summary>
@@ -55,18 +52,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ContainerServiceUserAssignedIdentity"/>. </summary>
-        /// <param name="resourceId">
-        /// The resource ID of the user assigned identity.
-        /// Serialized Name: UserAssignedIdentity.resourceId
-        /// </param>
-        /// <param name="clientId">
-        /// The client ID of the user assigned identity.
-        /// Serialized Name: UserAssignedIdentity.clientId
-        /// </param>
-        /// <param name="objectId">
-        /// The object ID of the user assigned identity.
-        /// Serialized Name: UserAssignedIdentity.objectId
-        /// </param>
+        /// <param name="resourceId"> The resource ID of the user assigned identity. </param>
+        /// <param name="clientId"> The client ID of the user assigned identity. </param>
+        /// <param name="objectId"> The object ID of the user assigned identity. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ContainerServiceUserAssignedIdentity(ResourceIdentifier resourceId, Guid? clientId, Guid? objectId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -76,22 +64,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The resource ID of the user assigned identity.
-        /// Serialized Name: UserAssignedIdentity.resourceId
-        /// </summary>
+        /// <summary> The resource ID of the user assigned identity. </summary>
         [WirePath("resourceId")]
         public ResourceIdentifier ResourceId { get; set; }
-        /// <summary>
-        /// The client ID of the user assigned identity.
-        /// Serialized Name: UserAssignedIdentity.clientId
-        /// </summary>
+        /// <summary> The client ID of the user assigned identity. </summary>
         [WirePath("clientId")]
         public Guid? ClientId { get; set; }
-        /// <summary>
-        /// The object ID of the user assigned identity.
-        /// Serialized Name: UserAssignedIdentity.objectId
-        /// </summary>
+        /// <summary> The object ID of the user assigned identity. </summary>
         [WirePath("objectId")]
         public Guid? ObjectId { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceWeekDay.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ContainerServiceWeekDay.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The weekday enum.
-    /// Serialized Name: WeekDay
-    /// </summary>
+    /// <summary> The weekday enum. </summary>
     public readonly partial struct ContainerServiceWeekDay : IEquatable<ContainerServiceWeekDay>
     {
         private readonly string _value;
@@ -33,40 +30,19 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string FridayValue = "Friday";
         private const string SaturdayValue = "Saturday";
 
-        /// <summary>
-        /// Sunday
-        /// Serialized Name: WeekDay.Sunday
-        /// </summary>
+        /// <summary> Sunday. </summary>
         public static ContainerServiceWeekDay Sunday { get; } = new ContainerServiceWeekDay(SundayValue);
-        /// <summary>
-        /// Monday
-        /// Serialized Name: WeekDay.Monday
-        /// </summary>
+        /// <summary> Monday. </summary>
         public static ContainerServiceWeekDay Monday { get; } = new ContainerServiceWeekDay(MondayValue);
-        /// <summary>
-        /// Tuesday
-        /// Serialized Name: WeekDay.Tuesday
-        /// </summary>
+        /// <summary> Tuesday. </summary>
         public static ContainerServiceWeekDay Tuesday { get; } = new ContainerServiceWeekDay(TuesdayValue);
-        /// <summary>
-        /// Wednesday
-        /// Serialized Name: WeekDay.Wednesday
-        /// </summary>
+        /// <summary> Wednesday. </summary>
         public static ContainerServiceWeekDay Wednesday { get; } = new ContainerServiceWeekDay(WednesdayValue);
-        /// <summary>
-        /// Thursday
-        /// Serialized Name: WeekDay.Thursday
-        /// </summary>
+        /// <summary> Thursday. </summary>
         public static ContainerServiceWeekDay Thursday { get; } = new ContainerServiceWeekDay(ThursdayValue);
-        /// <summary>
-        /// Friday
-        /// Serialized Name: WeekDay.Friday
-        /// </summary>
+        /// <summary> Friday. </summary>
         public static ContainerServiceWeekDay Friday { get; } = new ContainerServiceWeekDay(FridayValue);
-        /// <summary>
-        /// Saturday
-        /// Serialized Name: WeekDay.Saturday
-        /// </summary>
+        /// <summary> Saturday. </summary>
         public static ContainerServiceWeekDay Saturday { get; } = new ContainerServiceWeekDay(SaturdayValue);
         /// <summary> Determines if two <see cref="ContainerServiceWeekDay"/> values are the same. </summary>
         public static bool operator ==(ContainerServiceWeekDay left, ContainerServiceWeekDay right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/DailySchedule.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/DailySchedule.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// For schedules like: 'recur every day' or 'recur every 3 days'.
-    /// Serialized Name: DailySchedule
-    /// </summary>
+    /// <summary> For schedules like: 'recur every day' or 'recur every 3 days'. </summary>
     internal partial class DailySchedule
     {
         /// <summary>
@@ -49,20 +46,14 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="DailySchedule"/>. </summary>
-        /// <param name="intervalDays">
-        /// Specifies the number of days between each set of occurrences.
-        /// Serialized Name: DailySchedule.intervalDays
-        /// </param>
+        /// <param name="intervalDays"> Specifies the number of days between each set of occurrences. </param>
         public DailySchedule(int intervalDays)
         {
             IntervalDays = intervalDays;
         }
 
         /// <summary> Initializes a new instance of <see cref="DailySchedule"/>. </summary>
-        /// <param name="intervalDays">
-        /// Specifies the number of days between each set of occurrences.
-        /// Serialized Name: DailySchedule.intervalDays
-        /// </param>
+        /// <param name="intervalDays"> Specifies the number of days between each set of occurrences. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal DailySchedule(int intervalDays, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,10 +66,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Specifies the number of days between each set of occurrences.
-        /// Serialized Name: DailySchedule.intervalDays
-        /// </summary>
+        /// <summary> Specifies the number of days between each set of occurrences. </summary>
         [WirePath("intervalDays")]
         public int IntervalDays { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/GpuInstanceProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/GpuInstanceProfile.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-    /// Serialized Name: GPUInstanceProfile
-    /// </summary>
+    /// <summary> GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU. </summary>
     public readonly partial struct GpuInstanceProfile : IEquatable<GpuInstanceProfile>
     {
         private readonly string _value;
@@ -31,30 +28,15 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string Mig4GValue = "MIG4g";
         private const string Mig7GValue = "MIG7g";
 
-        /// <summary>
-        /// MIG1g
-        /// Serialized Name: GPUInstanceProfile.MIG1g
-        /// </summary>
+        /// <summary> MIG1g. </summary>
         public static GpuInstanceProfile Mig1G { get; } = new GpuInstanceProfile(Mig1GValue);
-        /// <summary>
-        /// MIG2g
-        /// Serialized Name: GPUInstanceProfile.MIG2g
-        /// </summary>
+        /// <summary> MIG2g. </summary>
         public static GpuInstanceProfile Mig2G { get; } = new GpuInstanceProfile(Mig2GValue);
-        /// <summary>
-        /// MIG3g
-        /// Serialized Name: GPUInstanceProfile.MIG3g
-        /// </summary>
+        /// <summary> MIG3g. </summary>
         public static GpuInstanceProfile Mig3G { get; } = new GpuInstanceProfile(Mig3GValue);
-        /// <summary>
-        /// MIG4g
-        /// Serialized Name: GPUInstanceProfile.MIG4g
-        /// </summary>
+        /// <summary> MIG4g. </summary>
         public static GpuInstanceProfile Mig4G { get; } = new GpuInstanceProfile(Mig4GValue);
-        /// <summary>
-        /// MIG7g
-        /// Serialized Name: GPUInstanceProfile.MIG7g
-        /// </summary>
+        /// <summary> MIG7g. </summary>
         public static GpuInstanceProfile Mig7G { get; } = new GpuInstanceProfile(Mig7GValue);
         /// <summary> Determines if two <see cref="GpuInstanceProfile"/> values are the same. </summary>
         public static bool operator ==(GpuInstanceProfile left, GpuInstanceProfile right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioCertificateAuthority.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioCertificateAuthority.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca
-    /// Serialized Name: IstioCertificateAuthority
-    /// </summary>
+    /// <summary> Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca. </summary>
     internal partial class IstioCertificateAuthority
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="IstioCertificateAuthority"/>. </summary>
-        /// <param name="plugin">
-        /// Plugin certificates information for Service Mesh.
-        /// Serialized Name: IstioCertificateAuthority.plugin
-        /// </param>
+        /// <param name="plugin"> Plugin certificates information for Service Mesh. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal IstioCertificateAuthority(IstioPluginCertificateAuthority plugin, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Plugin certificates information for Service Mesh.
-        /// Serialized Name: IstioCertificateAuthority.plugin
-        /// </summary>
+        /// <summary> Plugin certificates information for Service Mesh. </summary>
         [WirePath("plugin")]
         public IstioPluginCertificateAuthority Plugin { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioComponents.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioComponents.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Istio components configuration.
-    /// Serialized Name: IstioComponents
-    /// </summary>
+    /// <summary> Istio components configuration. </summary>
     public partial class IstioComponents
     {
         /// <summary>
@@ -56,14 +53,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="IstioComponents"/>. </summary>
-        /// <param name="ingressGateways">
-        /// Istio ingress gateways.
-        /// Serialized Name: IstioComponents.ingressGateways
-        /// </param>
-        /// <param name="egressGateways">
-        /// Istio egress gateways.
-        /// Serialized Name: IstioComponents.egressGateways
-        /// </param>
+        /// <param name="ingressGateways"> Istio ingress gateways. </param>
+        /// <param name="egressGateways"> Istio egress gateways. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal IstioComponents(IList<IstioIngressGateway> ingressGateways, IList<IstioEgressGateway> egressGateways, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -72,16 +63,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Istio ingress gateways.
-        /// Serialized Name: IstioComponents.ingressGateways
-        /// </summary>
+        /// <summary> Istio ingress gateways. </summary>
         [WirePath("ingressGateways")]
         public IList<IstioIngressGateway> IngressGateways { get; }
-        /// <summary>
-        /// Istio egress gateways.
-        /// Serialized Name: IstioComponents.egressGateways
-        /// </summary>
+        /// <summary> Istio egress gateways. </summary>
         [WirePath("egressGateways")]
         public IList<IstioEgressGateway> EgressGateways { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioEgressGateway.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioEgressGateway.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Istio egress gateway configuration.
-    /// Serialized Name: IstioEgressGateway
-    /// </summary>
+    /// <summary> Istio egress gateway configuration. </summary>
     public partial class IstioEgressGateway
     {
         /// <summary>
@@ -49,14 +46,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="IstioEgressGateway"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable the egress gateway.
-        /// Serialized Name: IstioEgressGateway.enabled
-        /// </param>
-        /// <param name="name">
-        /// Name of the Istio add-on egress gateway.
-        /// Serialized Name: IstioEgressGateway.name
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable the egress gateway. </param>
+        /// <param name="name"> Name of the Istio add-on egress gateway. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
         public IstioEgressGateway(bool isEnabled, string name)
         {
@@ -67,22 +58,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="IstioEgressGateway"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable the egress gateway.
-        /// Serialized Name: IstioEgressGateway.enabled
-        /// </param>
-        /// <param name="name">
-        /// Name of the Istio add-on egress gateway.
-        /// Serialized Name: IstioEgressGateway.name
-        /// </param>
-        /// <param name="namespace">
-        /// Namespace that the Istio add-on egress gateway should be deployed in. If unspecified, the default is aks-istio-egress.
-        /// Serialized Name: IstioEgressGateway.namespace
-        /// </param>
-        /// <param name="gatewayConfigurationName">
-        /// Name of the gateway configuration custom resource for the Istio add-on egress gateway. Must be specified when enabling the Istio egress gateway. Must be deployed in the same namespace that the Istio egress gateway will be deployed in.
-        /// Serialized Name: IstioEgressGateway.gatewayConfigurationName
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable the egress gateway. </param>
+        /// <param name="name"> Name of the Istio add-on egress gateway. </param>
+        /// <param name="namespace"> Namespace that the Istio add-on egress gateway should be deployed in. If unspecified, the default is aks-istio-egress. </param>
+        /// <param name="gatewayConfigurationName"> Name of the gateway configuration custom resource for the Istio add-on egress gateway. Must be specified when enabling the Istio egress gateway. Must be deployed in the same namespace that the Istio egress gateway will be deployed in. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal IstioEgressGateway(bool isEnabled, string name, string @namespace, string gatewayConfigurationName, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -98,28 +77,16 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Whether to enable the egress gateway.
-        /// Serialized Name: IstioEgressGateway.enabled
-        /// </summary>
+        /// <summary> Whether to enable the egress gateway. </summary>
         [WirePath("enabled")]
         public bool IsEnabled { get; set; }
-        /// <summary>
-        /// Name of the Istio add-on egress gateway.
-        /// Serialized Name: IstioEgressGateway.name
-        /// </summary>
+        /// <summary> Name of the Istio add-on egress gateway. </summary>
         [WirePath("name")]
         public string Name { get; set; }
-        /// <summary>
-        /// Namespace that the Istio add-on egress gateway should be deployed in. If unspecified, the default is aks-istio-egress.
-        /// Serialized Name: IstioEgressGateway.namespace
-        /// </summary>
+        /// <summary> Namespace that the Istio add-on egress gateway should be deployed in. If unspecified, the default is aks-istio-egress. </summary>
         [WirePath("namespace")]
         public string Namespace { get; set; }
-        /// <summary>
-        /// Name of the gateway configuration custom resource for the Istio add-on egress gateway. Must be specified when enabling the Istio egress gateway. Must be deployed in the same namespace that the Istio egress gateway will be deployed in.
-        /// Serialized Name: IstioEgressGateway.gatewayConfigurationName
-        /// </summary>
+        /// <summary> Name of the gateway configuration custom resource for the Istio add-on egress gateway. Must be specified when enabling the Istio egress gateway. Must be deployed in the same namespace that the Istio egress gateway will be deployed in. </summary>
         [WirePath("gatewayConfigurationName")]
         public string GatewayConfigurationName { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioIngressGateway.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioIngressGateway.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`.
-    /// Serialized Name: IstioIngressGateway
-    /// </summary>
+    /// <summary> Istio ingress gateway configuration. For now, we support up to one external ingress gateway named `aks-istio-ingressgateway-external` and one internal ingress gateway named `aks-istio-ingressgateway-internal`. </summary>
     public partial class IstioIngressGateway
     {
         /// <summary>
@@ -49,14 +46,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="IstioIngressGateway"/>. </summary>
-        /// <param name="mode">
-        /// Mode of an ingress gateway.
-        /// Serialized Name: IstioIngressGateway.mode
-        /// </param>
-        /// <param name="isEnabled">
-        /// Whether to enable the ingress gateway.
-        /// Serialized Name: IstioIngressGateway.enabled
-        /// </param>
+        /// <param name="mode"> Mode of an ingress gateway. </param>
+        /// <param name="isEnabled"> Whether to enable the ingress gateway. </param>
         public IstioIngressGateway(IstioIngressGatewayMode mode, bool isEnabled)
         {
             Mode = mode;
@@ -64,14 +55,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="IstioIngressGateway"/>. </summary>
-        /// <param name="mode">
-        /// Mode of an ingress gateway.
-        /// Serialized Name: IstioIngressGateway.mode
-        /// </param>
-        /// <param name="isEnabled">
-        /// Whether to enable the ingress gateway.
-        /// Serialized Name: IstioIngressGateway.enabled
-        /// </param>
+        /// <param name="mode"> Mode of an ingress gateway. </param>
+        /// <param name="isEnabled"> Whether to enable the ingress gateway. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal IstioIngressGateway(IstioIngressGatewayMode mode, bool isEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -85,16 +70,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Mode of an ingress gateway.
-        /// Serialized Name: IstioIngressGateway.mode
-        /// </summary>
+        /// <summary> Mode of an ingress gateway. </summary>
         [WirePath("mode")]
         public IstioIngressGatewayMode Mode { get; set; }
-        /// <summary>
-        /// Whether to enable the ingress gateway.
-        /// Serialized Name: IstioIngressGateway.enabled
-        /// </summary>
+        /// <summary> Whether to enable the ingress gateway. </summary>
         [WirePath("enabled")]
         public bool IsEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioIngressGatewayMode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioIngressGatewayMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Mode of an ingress gateway.
-    /// Serialized Name: IstioIngressGatewayMode
-    /// </summary>
+    /// <summary> Mode of an ingress gateway. </summary>
     public readonly partial struct IstioIngressGatewayMode : IEquatable<IstioIngressGatewayMode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string ExternalValue = "External";
         private const string InternalValue = "Internal";
 
-        /// <summary>
-        /// The ingress gateway is assigned a public IP address and is publicly accessible.
-        /// Serialized Name: IstioIngressGatewayMode.External
-        /// </summary>
+        /// <summary> The ingress gateway is assigned a public IP address and is publicly accessible. </summary>
         public static IstioIngressGatewayMode External { get; } = new IstioIngressGatewayMode(ExternalValue);
-        /// <summary>
-        /// The ingress gateway is assigned an internal IP address and cannot is accessed publicly.
-        /// Serialized Name: IstioIngressGatewayMode.Internal
-        /// </summary>
+        /// <summary> The ingress gateway is assigned an internal IP address and cannot is accessed publicly. </summary>
         public static IstioIngressGatewayMode Internal { get; } = new IstioIngressGatewayMode(InternalValue);
         /// <summary> Determines if two <see cref="IstioIngressGatewayMode"/> values are the same. </summary>
         public static bool operator ==(IstioIngressGatewayMode left, IstioIngressGatewayMode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioPluginCertificateAuthority.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioPluginCertificateAuthority.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Plugin certificates information for Service Mesh.
-    /// Serialized Name: IstioPluginCertificateAuthority
-    /// </summary>
+    /// <summary> Plugin certificates information for Service Mesh. </summary>
     public partial class IstioPluginCertificateAuthority
     {
         /// <summary>
@@ -55,26 +52,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="IstioPluginCertificateAuthority"/>. </summary>
-        /// <param name="keyVaultId">
-        /// The resource ID of the Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.keyVaultId
-        /// </param>
-        /// <param name="certObjectName">
-        /// Intermediate certificate object name in Azure Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.certObjectName
-        /// </param>
-        /// <param name="keyObjectName">
-        /// Intermediate certificate private key object name in Azure Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.keyObjectName
-        /// </param>
-        /// <param name="rootCertObjectName">
-        /// Root certificate object name in Azure Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.rootCertObjectName
-        /// </param>
-        /// <param name="certChainObjectName">
-        /// Certificate chain object name in Azure Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.certChainObjectName
-        /// </param>
+        /// <param name="keyVaultId"> The resource ID of the Key Vault. </param>
+        /// <param name="certObjectName"> Intermediate certificate object name in Azure Key Vault. </param>
+        /// <param name="keyObjectName"> Intermediate certificate private key object name in Azure Key Vault. </param>
+        /// <param name="rootCertObjectName"> Root certificate object name in Azure Key Vault. </param>
+        /// <param name="certChainObjectName"> Certificate chain object name in Azure Key Vault. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal IstioPluginCertificateAuthority(ResourceIdentifier keyVaultId, string certObjectName, string keyObjectName, string rootCertObjectName, string certChainObjectName, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -86,34 +68,19 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The resource ID of the Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.keyVaultId
-        /// </summary>
+        /// <summary> The resource ID of the Key Vault. </summary>
         [WirePath("keyVaultId")]
         public ResourceIdentifier KeyVaultId { get; set; }
-        /// <summary>
-        /// Intermediate certificate object name in Azure Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.certObjectName
-        /// </summary>
+        /// <summary> Intermediate certificate object name in Azure Key Vault. </summary>
         [WirePath("certObjectName")]
         public string CertObjectName { get; set; }
-        /// <summary>
-        /// Intermediate certificate private key object name in Azure Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.keyObjectName
-        /// </summary>
+        /// <summary> Intermediate certificate private key object name in Azure Key Vault. </summary>
         [WirePath("keyObjectName")]
         public string KeyObjectName { get; set; }
-        /// <summary>
-        /// Root certificate object name in Azure Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.rootCertObjectName
-        /// </summary>
+        /// <summary> Root certificate object name in Azure Key Vault. </summary>
         [WirePath("rootCertObjectName")]
         public string RootCertObjectName { get; set; }
-        /// <summary>
-        /// Certificate chain object name in Azure Key Vault.
-        /// Serialized Name: IstioPluginCertificateAuthority.certChainObjectName
-        /// </summary>
+        /// <summary> Certificate chain object name in Azure Key Vault. </summary>
         [WirePath("certChainObjectName")]
         public string CertChainObjectName { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioServiceMesh.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/IstioServiceMesh.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Istio service mesh configuration.
-    /// Serialized Name: IstioServiceMesh
-    /// </summary>
+    /// <summary> Istio service mesh configuration. </summary>
     public partial class IstioServiceMesh
     {
         /// <summary>
@@ -55,18 +52,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="IstioServiceMesh"/>. </summary>
-        /// <param name="components">
-        /// Istio components configuration.
-        /// Serialized Name: IstioServiceMesh.components
-        /// </param>
-        /// <param name="certificateAuthority">
-        /// Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca
-        /// Serialized Name: IstioServiceMesh.certificateAuthority
-        /// </param>
-        /// <param name="revisions">
-        /// The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade
-        /// Serialized Name: IstioServiceMesh.revisions
-        /// </param>
+        /// <param name="components"> Istio components configuration. </param>
+        /// <param name="certificateAuthority"> Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca. </param>
+        /// <param name="revisions"> The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal IstioServiceMesh(IstioComponents components, IstioCertificateAuthority certificateAuthority, IList<string> revisions, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -76,21 +64,12 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Istio components configuration.
-        /// Serialized Name: IstioServiceMesh.components
-        /// </summary>
+        /// <summary> Istio components configuration. </summary>
         [WirePath("components")]
         public IstioComponents Components { get; set; }
-        /// <summary>
-        /// Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca
-        /// Serialized Name: IstioServiceMesh.certificateAuthority
-        /// </summary>
+        /// <summary> Istio Service Mesh Certificate Authority (CA) configuration. For now, we only support plugin certificates as described here https://aka.ms/asm-plugin-ca. </summary>
         internal IstioCertificateAuthority CertificateAuthority { get; set; }
-        /// <summary>
-        /// Plugin certificates information for Service Mesh.
-        /// Serialized Name: IstioCertificateAuthority.plugin
-        /// </summary>
+        /// <summary> Plugin certificates information for Service Mesh. </summary>
         [WirePath("certificateAuthority.plugin")]
         public IstioPluginCertificateAuthority CertificateAuthorityPlugin
         {
@@ -103,10 +82,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade
-        /// Serialized Name: IstioServiceMesh.revisions
-        /// </summary>
+        /// <summary> The list of revisions of the Istio control plane. When an upgrade is not in progress, this holds one value. When canary upgrade is in progress, this can only hold two consecutive values. For more information, see: https://learn.microsoft.com/en-us/azure/aks/istio-upgrade. </summary>
         [WirePath("revisions")]
         public IList<string> Revisions { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubeConfigFormat.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubeConfigFormat.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The KubeConfigFormat.
-    /// Serialized Name: Format
-    /// </summary>
+    /// <summary> The KubeConfigFormat. </summary>
     public readonly partial struct KubeConfigFormat : IEquatable<KubeConfigFormat>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string AzureValue = "azure";
         private const string ExecValue = "exec";
 
-        /// <summary>
-        /// Return azure auth-provider kubeconfig. This format is deprecated in v1.22 and will be fully removed in v1.26. See: https://aka.ms/k8s/changes-1-26.
-        /// Serialized Name: Format.azure
-        /// </summary>
+        /// <summary> Return azure auth-provider kubeconfig. This format is deprecated in v1.22 and will be fully removed in v1.26. See: https://aka.ms/k8s/changes-1-26. </summary>
         public static KubeConfigFormat Azure { get; } = new KubeConfigFormat(AzureValue);
-        /// <summary>
-        /// Return exec format kubeconfig. This format requires kubelogin binary in the path.
-        /// Serialized Name: Format.exec
-        /// </summary>
+        /// <summary> Return exec format kubeconfig. This format requires kubelogin binary in the path. </summary>
         public static KubeConfigFormat Exec { get; } = new KubeConfigFormat(ExecValue);
         /// <summary> Determines if two <see cref="KubeConfigFormat"/> values are the same. </summary>
         public static bool operator ==(KubeConfigFormat left, KubeConfigFormat right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubeletConfig.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubeletConfig.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Kubelet configurations of agent nodes. See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
-    /// Serialized Name: KubeletConfig
-    /// </summary>
+    /// <summary> Kubelet configurations of agent nodes. See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details. </summary>
     public partial class KubeletConfig
     {
         /// <summary>
@@ -55,50 +52,17 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="KubeletConfig"/>. </summary>
-        /// <param name="cpuManagerPolicy">
-        /// The CPU Manager policy to use. The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'.
-        /// Serialized Name: KubeletConfig.cpuManagerPolicy
-        /// </param>
-        /// <param name="isCpuCfsQuotaEnabled">
-        /// If CPU CFS quota enforcement is enabled for containers that specify CPU limits. The default is true.
-        /// Serialized Name: KubeletConfig.cpuCfsQuota
-        /// </param>
-        /// <param name="cpuCfsQuotaPeriod">
-        /// The CPU CFS quota period value. The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'.
-        /// Serialized Name: KubeletConfig.cpuCfsQuotaPeriod
-        /// </param>
-        /// <param name="imageGcHighThreshold">
-        /// The percent of disk usage after which image garbage collection is always run. To disable image garbage collection, set to 100. The default is 85%
-        /// Serialized Name: KubeletConfig.imageGcHighThreshold
-        /// </param>
-        /// <param name="imageGcLowThreshold">
-        /// The percent of disk usage before which image garbage collection is never run. This cannot be set higher than imageGcHighThreshold. The default is 80%
-        /// Serialized Name: KubeletConfig.imageGcLowThreshold
-        /// </param>
-        /// <param name="topologyManagerPolicy">
-        /// The Topology Manager policy to use. For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'.
-        /// Serialized Name: KubeletConfig.topologyManagerPolicy
-        /// </param>
-        /// <param name="allowedUnsafeSysctls">
-        /// Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`).
-        /// Serialized Name: KubeletConfig.allowedUnsafeSysctls
-        /// </param>
-        /// <param name="failStartWithSwapOn">
-        /// If set to true it will make the Kubelet fail to start if swap is enabled on the node.
-        /// Serialized Name: KubeletConfig.failSwapOn
-        /// </param>
-        /// <param name="containerLogMaxSizeInMB">
-        /// The maximum size (e.g. 10Mi) of container log file before it is rotated.
-        /// Serialized Name: KubeletConfig.containerLogMaxSizeMB
-        /// </param>
-        /// <param name="containerLogMaxFiles">
-        /// The maximum number of container log files that can be present for a container. The number must be ≥ 2.
-        /// Serialized Name: KubeletConfig.containerLogMaxFiles
-        /// </param>
-        /// <param name="podMaxPids">
-        /// The maximum number of processes per pod.
-        /// Serialized Name: KubeletConfig.podMaxPids
-        /// </param>
+        /// <param name="cpuManagerPolicy"> The CPU Manager policy to use. The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'. </param>
+        /// <param name="isCpuCfsQuotaEnabled"> If CPU CFS quota enforcement is enabled for containers that specify CPU limits. The default is true. </param>
+        /// <param name="cpuCfsQuotaPeriod"> The CPU CFS quota period value. The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'. </param>
+        /// <param name="imageGcHighThreshold"> The percent of disk usage after which image garbage collection is always run. To disable image garbage collection, set to 100. The default is 85%. </param>
+        /// <param name="imageGcLowThreshold"> The percent of disk usage before which image garbage collection is never run. This cannot be set higher than imageGcHighThreshold. The default is 80%. </param>
+        /// <param name="topologyManagerPolicy"> The Topology Manager policy to use. For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. </param>
+        /// <param name="allowedUnsafeSysctls"> Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`). </param>
+        /// <param name="failStartWithSwapOn"> If set to true it will make the Kubelet fail to start if swap is enabled on the node. </param>
+        /// <param name="containerLogMaxSizeInMB"> The maximum size (e.g. 10Mi) of container log file before it is rotated. </param>
+        /// <param name="containerLogMaxFiles"> The maximum number of container log files that can be present for a container. The number must be ≥ 2. </param>
+        /// <param name="podMaxPids"> The maximum number of processes per pod. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal KubeletConfig(string cpuManagerPolicy, bool? isCpuCfsQuotaEnabled, string cpuCfsQuotaPeriod, int? imageGcHighThreshold, int? imageGcLowThreshold, string topologyManagerPolicy, IList<string> allowedUnsafeSysctls, bool? failStartWithSwapOn, int? containerLogMaxSizeInMB, int? containerLogMaxFiles, int? podMaxPids, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -116,70 +80,37 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The CPU Manager policy to use. The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'.
-        /// Serialized Name: KubeletConfig.cpuManagerPolicy
-        /// </summary>
+        /// <summary> The CPU Manager policy to use. The default is 'none'. See [Kubernetes CPU management policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#cpu-management-policies) for more information. Allowed values are 'none' and 'static'. </summary>
         [WirePath("cpuManagerPolicy")]
         public string CpuManagerPolicy { get; set; }
-        /// <summary>
-        /// If CPU CFS quota enforcement is enabled for containers that specify CPU limits. The default is true.
-        /// Serialized Name: KubeletConfig.cpuCfsQuota
-        /// </summary>
+        /// <summary> If CPU CFS quota enforcement is enabled for containers that specify CPU limits. The default is true. </summary>
         [WirePath("cpuCfsQuota")]
         public bool? IsCpuCfsQuotaEnabled { get; set; }
-        /// <summary>
-        /// The CPU CFS quota period value. The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'.
-        /// Serialized Name: KubeletConfig.cpuCfsQuotaPeriod
-        /// </summary>
+        /// <summary> The CPU CFS quota period value. The default is '100ms.' Valid values are a sequence of decimal numbers with an optional fraction and a unit suffix. For example: '300ms', '2h45m'. Supported units are 'ns', 'us', 'ms', 's', 'm', and 'h'. </summary>
         [WirePath("cpuCfsQuotaPeriod")]
         public string CpuCfsQuotaPeriod { get; set; }
-        /// <summary>
-        /// The percent of disk usage after which image garbage collection is always run. To disable image garbage collection, set to 100. The default is 85%
-        /// Serialized Name: KubeletConfig.imageGcHighThreshold
-        /// </summary>
+        /// <summary> The percent of disk usage after which image garbage collection is always run. To disable image garbage collection, set to 100. The default is 85%. </summary>
         [WirePath("imageGcHighThreshold")]
         public int? ImageGcHighThreshold { get; set; }
-        /// <summary>
-        /// The percent of disk usage before which image garbage collection is never run. This cannot be set higher than imageGcHighThreshold. The default is 80%
-        /// Serialized Name: KubeletConfig.imageGcLowThreshold
-        /// </summary>
+        /// <summary> The percent of disk usage before which image garbage collection is never run. This cannot be set higher than imageGcHighThreshold. The default is 80%. </summary>
         [WirePath("imageGcLowThreshold")]
         public int? ImageGcLowThreshold { get; set; }
-        /// <summary>
-        /// The Topology Manager policy to use. For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'.
-        /// Serialized Name: KubeletConfig.topologyManagerPolicy
-        /// </summary>
+        /// <summary> The Topology Manager policy to use. For more information see [Kubernetes Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager). The default is 'none'. Allowed values are 'none', 'best-effort', 'restricted', and 'single-numa-node'. </summary>
         [WirePath("topologyManagerPolicy")]
         public string TopologyManagerPolicy { get; set; }
-        /// <summary>
-        /// Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`).
-        /// Serialized Name: KubeletConfig.allowedUnsafeSysctls
-        /// </summary>
+        /// <summary> Allowed list of unsafe sysctls or unsafe sysctl patterns (ending in `*`). </summary>
         [WirePath("allowedUnsafeSysctls")]
         public IList<string> AllowedUnsafeSysctls { get; }
-        /// <summary>
-        /// If set to true it will make the Kubelet fail to start if swap is enabled on the node.
-        /// Serialized Name: KubeletConfig.failSwapOn
-        /// </summary>
+        /// <summary> If set to true it will make the Kubelet fail to start if swap is enabled on the node. </summary>
         [WirePath("failSwapOn")]
         public bool? FailStartWithSwapOn { get; set; }
-        /// <summary>
-        /// The maximum size (e.g. 10Mi) of container log file before it is rotated.
-        /// Serialized Name: KubeletConfig.containerLogMaxSizeMB
-        /// </summary>
+        /// <summary> The maximum size (e.g. 10Mi) of container log file before it is rotated. </summary>
         [WirePath("containerLogMaxSizeMB")]
         public int? ContainerLogMaxSizeInMB { get; set; }
-        /// <summary>
-        /// The maximum number of container log files that can be present for a container. The number must be ≥ 2.
-        /// Serialized Name: KubeletConfig.containerLogMaxFiles
-        /// </summary>
+        /// <summary> The maximum number of container log files that can be present for a container. The number must be ≥ 2. </summary>
         [WirePath("containerLogMaxFiles")]
         public int? ContainerLogMaxFiles { get; set; }
-        /// <summary>
-        /// The maximum number of processes per pod.
-        /// Serialized Name: KubeletConfig.podMaxPids
-        /// </summary>
+        /// <summary> The maximum number of processes per pod. </summary>
         [WirePath("podMaxPids")]
         public int? PodMaxPids { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubeletDiskType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubeletDiskType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
-    /// Serialized Name: KubeletDiskType
-    /// </summary>
+    /// <summary> Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. </summary>
     public readonly partial struct KubeletDiskType : IEquatable<KubeletDiskType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string OSValue = "OS";
         private const string TemporaryValue = "Temporary";
 
-        /// <summary>
-        /// Kubelet will use the OS disk for its data.
-        /// Serialized Name: KubeletDiskType.OS
-        /// </summary>
+        /// <summary> Kubelet will use the OS disk for its data. </summary>
         public static KubeletDiskType OS { get; } = new KubeletDiskType(OSValue);
-        /// <summary>
-        /// Kubelet will use the temporary disk for its data.
-        /// Serialized Name: KubeletDiskType.Temporary
-        /// </summary>
+        /// <summary> Kubelet will use the temporary disk for its data. </summary>
         public static KubeletDiskType Temporary { get; } = new KubeletDiskType(TemporaryValue);
         /// <summary> Determines if two <see cref="KubeletDiskType"/> values are the same. </summary>
         public static bool operator ==(KubeletDiskType left, KubeletDiskType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesPatchVersion.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesPatchVersion.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Kubernetes patch version profile
-    /// Serialized Name: KubernetesPatchVersion
-    /// </summary>
+    /// <summary> Kubernetes patch version profile. </summary>
     public partial class KubernetesPatchVersion
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="KubernetesPatchVersion"/>. </summary>
-        /// <param name="upgrades">
-        /// Possible upgrade path for given patch version
-        /// Serialized Name: KubernetesPatchVersion.upgrades
-        /// </param>
+        /// <param name="upgrades"> Possible upgrade path for given patch version. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal KubernetesPatchVersion(IReadOnlyList<string> upgrades, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Possible upgrade path for given patch version
-        /// Serialized Name: KubernetesPatchVersion.upgrades
-        /// </summary>
+        /// <summary> Possible upgrade path for given patch version. </summary>
         [WirePath("upgrades")]
         public IReadOnlyList<string> Upgrades { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesSupportPlan.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesSupportPlan.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Different support tiers for AKS managed clusters
-    /// Serialized Name: KubernetesSupportPlan
-    /// </summary>
+    /// <summary> Different support tiers for AKS managed clusters. </summary>
     public readonly partial struct KubernetesSupportPlan : IEquatable<KubernetesSupportPlan>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string KubernetesOfficialValue = "KubernetesOfficial";
         private const string AKSLongTermSupportValue = "AKSLongTermSupport";
 
-        /// <summary>
-        /// Support for the version is the same as for the open source Kubernetes offering. Official Kubernetes open source community support versions for 1 year after release.
-        /// Serialized Name: KubernetesSupportPlan.KubernetesOfficial
-        /// </summary>
+        /// <summary> Support for the version is the same as for the open source Kubernetes offering. Official Kubernetes open source community support versions for 1 year after release. </summary>
         public static KubernetesSupportPlan KubernetesOfficial { get; } = new KubernetesSupportPlan(KubernetesOfficialValue);
-        /// <summary>
-        /// Support for the version extended past the KubernetesOfficial support of 1 year. AKS continues to patch CVEs for another 1 year, for a total of 2 years of support.
-        /// Serialized Name: KubernetesSupportPlan.AKSLongTermSupport
-        /// </summary>
+        /// <summary> Support for the version extended past the KubernetesOfficial support of 1 year. AKS continues to patch CVEs for another 1 year, for a total of 2 years of support. </summary>
         public static KubernetesSupportPlan AKSLongTermSupport { get; } = new KubernetesSupportPlan(AKSLongTermSupportValue);
         /// <summary> Determines if two <see cref="KubernetesSupportPlan"/> values are the same. </summary>
         public static bool operator ==(KubernetesSupportPlan left, KubernetesSupportPlan right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesVersion.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesVersion.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Kubernetes version profile for given major.minor release.
-    /// Serialized Name: KubernetesVersion
-    /// </summary>
+    /// <summary> Kubernetes version profile for given major.minor release. </summary>
     public partial class KubernetesVersion
     {
         /// <summary>
@@ -55,26 +52,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="KubernetesVersion"/>. </summary>
-        /// <param name="version">
-        /// major.minor version of Kubernetes release
-        /// Serialized Name: KubernetesVersion.version
-        /// </param>
-        /// <param name="capabilities">
-        /// Capabilities on this Kubernetes version.
-        /// Serialized Name: KubernetesVersion.capabilities
-        /// </param>
-        /// <param name="isDefault">
-        /// Whether this version is default.
-        /// Serialized Name: KubernetesVersion.isDefault
-        /// </param>
-        /// <param name="isPreview">
-        /// Whether this version is in preview mode.
-        /// Serialized Name: KubernetesVersion.isPreview
-        /// </param>
-        /// <param name="patchVersions">
-        /// Patch versions of Kubernetes release
-        /// Serialized Name: KubernetesVersion.patchVersions
-        /// </param>
+        /// <param name="version"> major.minor version of Kubernetes release. </param>
+        /// <param name="capabilities"> Capabilities on this Kubernetes version. </param>
+        /// <param name="isDefault"> Whether this version is default. </param>
+        /// <param name="isPreview"> Whether this version is in preview mode. </param>
+        /// <param name="patchVersions"> Patch versions of Kubernetes release. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal KubernetesVersion(string version, KubernetesVersionCapabilities capabilities, bool? isDefault, bool? isPreview, IReadOnlyDictionary<string, KubernetesPatchVersion> patchVersions, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -86,40 +68,25 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// major.minor version of Kubernetes release
-        /// Serialized Name: KubernetesVersion.version
-        /// </summary>
+        /// <summary> major.minor version of Kubernetes release. </summary>
         [WirePath("version")]
         public string Version { get; }
-        /// <summary>
-        /// Capabilities on this Kubernetes version.
-        /// Serialized Name: KubernetesVersion.capabilities
-        /// </summary>
+        /// <summary> Capabilities on this Kubernetes version. </summary>
         internal KubernetesVersionCapabilities Capabilities { get; }
-        /// <summary> Serialized Name: KubernetesVersionCapabilities.supportPlan. </summary>
+        /// <summary> Gets the capabilities support plan. </summary>
         [WirePath("capabilities.supportPlan")]
         public IReadOnlyList<KubernetesSupportPlan> CapabilitiesSupportPlan
         {
             get => Capabilities?.SupportPlan;
         }
 
-        /// <summary>
-        /// Whether this version is default.
-        /// Serialized Name: KubernetesVersion.isDefault
-        /// </summary>
+        /// <summary> Whether this version is default. </summary>
         [WirePath("isDefault")]
         public bool? IsDefault { get; }
-        /// <summary>
-        /// Whether this version is in preview mode.
-        /// Serialized Name: KubernetesVersion.isPreview
-        /// </summary>
+        /// <summary> Whether this version is in preview mode. </summary>
         [WirePath("isPreview")]
         public bool? IsPreview { get; }
-        /// <summary>
-        /// Patch versions of Kubernetes release
-        /// Serialized Name: KubernetesVersion.patchVersions
-        /// </summary>
+        /// <summary> Patch versions of Kubernetes release. </summary>
         [WirePath("patchVersions")]
         public IReadOnlyDictionary<string, KubernetesPatchVersion> PatchVersions { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesVersionCapabilities.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesVersionCapabilities.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Capabilities on this Kubernetes version.
-    /// Serialized Name: KubernetesVersionCapabilities
-    /// </summary>
+    /// <summary> Capabilities on this Kubernetes version. </summary>
     internal partial class KubernetesVersionCapabilities
     {
         /// <summary>
@@ -55,7 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="KubernetesVersionCapabilities"/>. </summary>
-        /// <param name="supportPlan"> Serialized Name: KubernetesVersionCapabilities.supportPlan. </param>
+        /// <param name="supportPlan"></param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal KubernetesVersionCapabilities(IReadOnlyList<KubernetesSupportPlan> supportPlan, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -63,7 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary> Serialized Name: KubernetesVersionCapabilities.supportPlan. </summary>
+        /// <summary> Gets the support plan. </summary>
         [WirePath("supportPlan")]
         public IReadOnlyList<KubernetesSupportPlan> SupportPlan { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesVersionListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/KubernetesVersionListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Hold values properties, which is array of KubernetesVersion
-    /// Serialized Name: KubernetesVersionListResult
-    /// </summary>
+    /// <summary> Hold values properties, which is array of KubernetesVersion. </summary>
     public partial class KubernetesVersionListResult
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="KubernetesVersionListResult"/>. </summary>
-        /// <param name="values">
-        /// Array of AKS supported Kubernetes versions.
-        /// Serialized Name: KubernetesVersionListResult.values
-        /// </param>
+        /// <param name="values"> Array of AKS supported Kubernetes versions. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal KubernetesVersionListResult(IReadOnlyList<KubernetesVersion> values, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Array of AKS supported Kubernetes versions.
-        /// Serialized Name: KubernetesVersionListResult.values
-        /// </summary>
+        /// <summary> Array of AKS supported Kubernetes versions. </summary>
         [WirePath("values")]
         public IReadOnlyList<KubernetesVersion> Values { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LinuxOSConfig.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LinuxOSConfig.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// OS configurations of Linux agent nodes. See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details.
-    /// Serialized Name: LinuxOSConfig
-    /// </summary>
+    /// <summary> OS configurations of Linux agent nodes. See [AKS custom node configuration](https://docs.microsoft.com/azure/aks/custom-node-configuration) for more details. </summary>
     public partial class LinuxOSConfig
     {
         /// <summary>
@@ -54,22 +51,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="LinuxOSConfig"/>. </summary>
-        /// <param name="sysctls">
-        /// Sysctl settings for Linux agent nodes.
-        /// Serialized Name: LinuxOSConfig.sysctls
-        /// </param>
-        /// <param name="transparentHugePageEnabled">
-        /// Whether transparent hugepages are enabled. Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).
-        /// Serialized Name: LinuxOSConfig.transparentHugePageEnabled
-        /// </param>
-        /// <param name="transparentHugePageDefrag">
-        /// Whether the kernel should make aggressive use of memory compaction to make more hugepages available. Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).
-        /// Serialized Name: LinuxOSConfig.transparentHugePageDefrag
-        /// </param>
-        /// <param name="swapFileSizeInMB">
-        /// The size in MB of a swap file that will be created on each node.
-        /// Serialized Name: LinuxOSConfig.swapFileSizeMB
-        /// </param>
+        /// <param name="sysctls"> Sysctl settings for Linux agent nodes. </param>
+        /// <param name="transparentHugePageEnabled"> Whether transparent hugepages are enabled. Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). </param>
+        /// <param name="transparentHugePageDefrag"> Whether the kernel should make aggressive use of memory compaction to make more hugepages available. Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). </param>
+        /// <param name="swapFileSizeInMB"> The size in MB of a swap file that will be created on each node. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal LinuxOSConfig(SysctlConfig sysctls, string transparentHugePageEnabled, string transparentHugePageDefrag, int? swapFileSizeInMB, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -80,28 +65,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Sysctl settings for Linux agent nodes.
-        /// Serialized Name: LinuxOSConfig.sysctls
-        /// </summary>
+        /// <summary> Sysctl settings for Linux agent nodes. </summary>
         [WirePath("sysctls")]
         public SysctlConfig Sysctls { get; set; }
-        /// <summary>
-        /// Whether transparent hugepages are enabled. Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).
-        /// Serialized Name: LinuxOSConfig.transparentHugePageEnabled
-        /// </summary>
+        /// <summary> Whether transparent hugepages are enabled. Valid values are 'always', 'madvise', and 'never'. The default is 'always'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). </summary>
         [WirePath("transparentHugePageEnabled")]
         public string TransparentHugePageEnabled { get; set; }
-        /// <summary>
-        /// Whether the kernel should make aggressive use of memory compaction to make more hugepages available. Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge).
-        /// Serialized Name: LinuxOSConfig.transparentHugePageDefrag
-        /// </summary>
+        /// <summary> Whether the kernel should make aggressive use of memory compaction to make more hugepages available. Valid values are 'always', 'defer', 'defer+madvise', 'madvise' and 'never'. The default is 'madvise'. For more information see [Transparent Hugepages](https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html#admin-guide-transhuge). </summary>
         [WirePath("transparentHugePageDefrag")]
         public string TransparentHugePageDefrag { get; set; }
-        /// <summary>
-        /// The size in MB of a swap file that will be created on each node.
-        /// Serialized Name: LinuxOSConfig.swapFileSizeMB
-        /// </summary>
+        /// <summary> The size in MB of a swap file that will be created on each node. </summary>
         [WirePath("swapFileSizeMB")]
         public int? SwapFileSizeInMB { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsForwardDestination.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsForwardDestination.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Destination server for DNS queries to be forwarded from localDNS.
-    /// Serialized Name: LocalDNSForwardDestination
-    /// </summary>
+    /// <summary> Destination server for DNS queries to be forwarded from localDNS. </summary>
     public readonly partial struct LocalDnsForwardDestination : IEquatable<LocalDnsForwardDestination>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string ClusterCoreDnsValue = "ClusterCoreDNS";
         private const string VnetDnsValue = "VnetDNS";
 
-        /// <summary>
-        /// Forward DNS queries from localDNS to cluster CoreDNS.
-        /// Serialized Name: LocalDNSForwardDestination.ClusterCoreDNS
-        /// </summary>
+        /// <summary> Forward DNS queries from localDNS to cluster CoreDNS. </summary>
         public static LocalDnsForwardDestination ClusterCoreDns { get; } = new LocalDnsForwardDestination(ClusterCoreDnsValue);
-        /// <summary>
-        /// Forward DNS queries from localDNS to DNS server configured in the VNET. A VNET can have multiple DNS servers configured.
-        /// Serialized Name: LocalDNSForwardDestination.VnetDNS
-        /// </summary>
+        /// <summary> Forward DNS queries from localDNS to DNS server configured in the VNET. A VNET can have multiple DNS servers configured. </summary>
         public static LocalDnsForwardDestination VnetDns { get; } = new LocalDnsForwardDestination(VnetDnsValue);
         /// <summary> Determines if two <see cref="LocalDnsForwardDestination"/> values are the same. </summary>
         public static bool operator ==(LocalDnsForwardDestination left, LocalDnsForwardDestination right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsForwardPolicy.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsForwardPolicy.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Forward policy for selecting upstream DNS server. See [forward plugin](https://coredns.io/plugins/forward) for more information.
-    /// Serialized Name: LocalDNSForwardPolicy
-    /// </summary>
+    /// <summary> Forward policy for selecting upstream DNS server. See [forward plugin](https://coredns.io/plugins/forward) for more information. </summary>
     public readonly partial struct LocalDnsForwardPolicy : IEquatable<LocalDnsForwardPolicy>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string RoundRobinValue = "RoundRobin";
         private const string RandomValue = "Random";
 
-        /// <summary>
-        /// Implements sequential upstream DNS server selection. See [forward plugin](https://coredns.io/plugins/forward) for more information.
-        /// Serialized Name: LocalDNSForwardPolicy.Sequential
-        /// </summary>
+        /// <summary> Implements sequential upstream DNS server selection. See [forward plugin](https://coredns.io/plugins/forward) for more information. </summary>
         public static LocalDnsForwardPolicy Sequential { get; } = new LocalDnsForwardPolicy(SequentialValue);
-        /// <summary>
-        /// Implements round robin upstream DNS server selection. See [forward plugin](https://coredns.io/plugins/forward) for more information.
-        /// Serialized Name: LocalDNSForwardPolicy.RoundRobin
-        /// </summary>
+        /// <summary> Implements round robin upstream DNS server selection. See [forward plugin](https://coredns.io/plugins/forward) for more information. </summary>
         public static LocalDnsForwardPolicy RoundRobin { get; } = new LocalDnsForwardPolicy(RoundRobinValue);
-        /// <summary>
-        /// Implements random upstream DNS server selection. See [forward plugin](https://coredns.io/plugins/forward) for more information.
-        /// Serialized Name: LocalDNSForwardPolicy.Random
-        /// </summary>
+        /// <summary> Implements random upstream DNS server selection. See [forward plugin](https://coredns.io/plugins/forward) for more information. </summary>
         public static LocalDnsForwardPolicy Random { get; } = new LocalDnsForwardPolicy(RandomValue);
         /// <summary> Determines if two <see cref="LocalDnsForwardPolicy"/> values are the same. </summary>
         public static bool operator ==(LocalDnsForwardPolicy left, LocalDnsForwardPolicy right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsMode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Mode of enablement for localDNS.
-    /// Serialized Name: LocalDNSMode
-    /// </summary>
+    /// <summary> Mode of enablement for localDNS. </summary>
     public readonly partial struct LocalDnsMode : IEquatable<LocalDnsMode>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string RequiredValue = "Required";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// If the current orchestrator version supports this feature, prefer enabling localDNS.
-        /// Serialized Name: LocalDNSMode.Preferred
-        /// </summary>
+        /// <summary> If the current orchestrator version supports this feature, prefer enabling localDNS. </summary>
         public static LocalDnsMode Preferred { get; } = new LocalDnsMode(PreferredValue);
-        /// <summary>
-        /// Enable localDNS.
-        /// Serialized Name: LocalDNSMode.Required
-        /// </summary>
+        /// <summary> Enable localDNS. </summary>
         public static LocalDnsMode Required { get; } = new LocalDnsMode(RequiredValue);
-        /// <summary>
-        /// Disable localDNS.
-        /// Serialized Name: LocalDNSMode.Disabled
-        /// </summary>
+        /// <summary> Disable localDNS. </summary>
         public static LocalDnsMode Disabled { get; } = new LocalDnsMode(DisabledValue);
         /// <summary> Determines if two <see cref="LocalDnsMode"/> values are the same. </summary>
         public static bool operator ==(LocalDnsMode left, LocalDnsMode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsOverride.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsOverride.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Overrides for localDNS profile.
-    /// Serialized Name: LocalDNSOverride
-    /// </summary>
+    /// <summary> Overrides for localDNS profile. </summary>
     public partial class LocalDnsOverride
     {
         /// <summary>
@@ -54,38 +51,14 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="LocalDnsOverride"/>. </summary>
-        /// <param name="queryLogging">
-        /// Log level for DNS queries in localDNS.
-        /// Serialized Name: LocalDNSOverride.queryLogging
-        /// </param>
-        /// <param name="protocol">
-        /// Enforce TCP or prefer UDP protocol for connections from localDNS to upstream DNS server.
-        /// Serialized Name: LocalDNSOverride.protocol
-        /// </param>
-        /// <param name="forwardDestination">
-        /// Destination server for DNS queries to be forwarded from localDNS.
-        /// Serialized Name: LocalDNSOverride.forwardDestination
-        /// </param>
-        /// <param name="forwardPolicy">
-        /// Forward policy for selecting upstream DNS server. See [forward plugin](https://coredns.io/plugins/forward) for more information.
-        /// Serialized Name: LocalDNSOverride.forwardPolicy
-        /// </param>
-        /// <param name="maxConcurrent">
-        /// Maximum number of concurrent queries. See [forward plugin](https://coredns.io/plugins/forward) for more information.
-        /// Serialized Name: LocalDNSOverride.maxConcurrent
-        /// </param>
-        /// <param name="cacheDurationInSeconds">
-        /// Cache max TTL in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information.
-        /// Serialized Name: LocalDNSOverride.cacheDurationInSeconds
-        /// </param>
-        /// <param name="serveStaleDurationInSeconds">
-        /// Serve stale duration in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information.
-        /// Serialized Name: LocalDNSOverride.serveStaleDurationInSeconds
-        /// </param>
-        /// <param name="serveStale">
-        /// Policy for serving stale data. See [cache plugin](https://coredns.io/plugins/cache) for more information.
-        /// Serialized Name: LocalDNSOverride.serveStale
-        /// </param>
+        /// <param name="queryLogging"> Log level for DNS queries in localDNS. </param>
+        /// <param name="protocol"> Enforce TCP or prefer UDP protocol for connections from localDNS to upstream DNS server. </param>
+        /// <param name="forwardDestination"> Destination server for DNS queries to be forwarded from localDNS. </param>
+        /// <param name="forwardPolicy"> Forward policy for selecting upstream DNS server. See [forward plugin](https://coredns.io/plugins/forward) for more information. </param>
+        /// <param name="maxConcurrent"> Maximum number of concurrent queries. See [forward plugin](https://coredns.io/plugins/forward) for more information. </param>
+        /// <param name="cacheDurationInSeconds"> Cache max TTL in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information. </param>
+        /// <param name="serveStaleDurationInSeconds"> Serve stale duration in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information. </param>
+        /// <param name="serveStale"> Policy for serving stale data. See [cache plugin](https://coredns.io/plugins/cache) for more information. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal LocalDnsOverride(LocalDnsQueryLogging? queryLogging, LocalDnsProtocol? protocol, LocalDnsForwardDestination? forwardDestination, LocalDnsForwardPolicy? forwardPolicy, int? maxConcurrent, int? cacheDurationInSeconds, int? serveStaleDurationInSeconds, LocalDnsServeStale? serveStale, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -100,52 +73,28 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Log level for DNS queries in localDNS.
-        /// Serialized Name: LocalDNSOverride.queryLogging
-        /// </summary>
+        /// <summary> Log level for DNS queries in localDNS. </summary>
         [WirePath("queryLogging")]
         public LocalDnsQueryLogging? QueryLogging { get; set; }
-        /// <summary>
-        /// Enforce TCP or prefer UDP protocol for connections from localDNS to upstream DNS server.
-        /// Serialized Name: LocalDNSOverride.protocol
-        /// </summary>
+        /// <summary> Enforce TCP or prefer UDP protocol for connections from localDNS to upstream DNS server. </summary>
         [WirePath("protocol")]
         public LocalDnsProtocol? Protocol { get; set; }
-        /// <summary>
-        /// Destination server for DNS queries to be forwarded from localDNS.
-        /// Serialized Name: LocalDNSOverride.forwardDestination
-        /// </summary>
+        /// <summary> Destination server for DNS queries to be forwarded from localDNS. </summary>
         [WirePath("forwardDestination")]
         public LocalDnsForwardDestination? ForwardDestination { get; set; }
-        /// <summary>
-        /// Forward policy for selecting upstream DNS server. See [forward plugin](https://coredns.io/plugins/forward) for more information.
-        /// Serialized Name: LocalDNSOverride.forwardPolicy
-        /// </summary>
+        /// <summary> Forward policy for selecting upstream DNS server. See [forward plugin](https://coredns.io/plugins/forward) for more information. </summary>
         [WirePath("forwardPolicy")]
         public LocalDnsForwardPolicy? ForwardPolicy { get; set; }
-        /// <summary>
-        /// Maximum number of concurrent queries. See [forward plugin](https://coredns.io/plugins/forward) for more information.
-        /// Serialized Name: LocalDNSOverride.maxConcurrent
-        /// </summary>
+        /// <summary> Maximum number of concurrent queries. See [forward plugin](https://coredns.io/plugins/forward) for more information. </summary>
         [WirePath("maxConcurrent")]
         public int? MaxConcurrent { get; set; }
-        /// <summary>
-        /// Cache max TTL in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information.
-        /// Serialized Name: LocalDNSOverride.cacheDurationInSeconds
-        /// </summary>
+        /// <summary> Cache max TTL in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information. </summary>
         [WirePath("cacheDurationInSeconds")]
         public int? CacheDurationInSeconds { get; set; }
-        /// <summary>
-        /// Serve stale duration in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information.
-        /// Serialized Name: LocalDNSOverride.serveStaleDurationInSeconds
-        /// </summary>
+        /// <summary> Serve stale duration in seconds. See [cache plugin](https://coredns.io/plugins/cache) for more information. </summary>
         [WirePath("serveStaleDurationInSeconds")]
         public int? ServeStaleDurationInSeconds { get; set; }
-        /// <summary>
-        /// Policy for serving stale data. See [cache plugin](https://coredns.io/plugins/cache) for more information.
-        /// Serialized Name: LocalDNSOverride.serveStale
-        /// </summary>
+        /// <summary> Policy for serving stale data. See [cache plugin](https://coredns.io/plugins/cache) for more information. </summary>
         [WirePath("serveStale")]
         public LocalDnsServeStale? ServeStale { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
-    /// Serialized Name: LocalDNSProfile
-    /// </summary>
+    /// <summary> Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns. </summary>
     public partial class LocalDnsProfile
     {
         /// <summary>
@@ -56,22 +53,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="LocalDnsProfile"/>. </summary>
-        /// <param name="mode">
-        /// Mode of enablement for localDNS.
-        /// Serialized Name: LocalDNSProfile.mode
-        /// </param>
-        /// <param name="state">
-        /// System-generated state of localDNS.
-        /// Serialized Name: LocalDNSProfile.state
-        /// </param>
-        /// <param name="vnetDnsOverrides">
-        /// VnetDNS overrides apply to DNS traffic from pods with dnsPolicy:default or kubelet (referred to as VnetDNS traffic).
-        /// Serialized Name: LocalDNSProfile.vnetDNSOverrides
-        /// </param>
-        /// <param name="kubeDnsOverrides">
-        /// KubeDNS overrides apply to DNS traffic from pods with dnsPolicy:ClusterFirst (referred to as KubeDNS traffic).
-        /// Serialized Name: LocalDNSProfile.kubeDNSOverrides
-        /// </param>
+        /// <param name="mode"> Mode of enablement for localDNS. </param>
+        /// <param name="state"> System-generated state of localDNS. </param>
+        /// <param name="vnetDnsOverrides"> VnetDNS overrides apply to DNS traffic from pods with dnsPolicy:default or kubelet (referred to as VnetDNS traffic). </param>
+        /// <param name="kubeDnsOverrides"> KubeDNS overrides apply to DNS traffic from pods with dnsPolicy:ClusterFirst (referred to as KubeDNS traffic). </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal LocalDnsProfile(LocalDnsMode? mode, LocalDnsState? state, IDictionary<string, LocalDnsOverride> vnetDnsOverrides, IDictionary<string, LocalDnsOverride> kubeDnsOverrides, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -82,28 +67,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Mode of enablement for localDNS.
-        /// Serialized Name: LocalDNSProfile.mode
-        /// </summary>
+        /// <summary> Mode of enablement for localDNS. </summary>
         [WirePath("mode")]
         public LocalDnsMode? Mode { get; set; }
-        /// <summary>
-        /// System-generated state of localDNS.
-        /// Serialized Name: LocalDNSProfile.state
-        /// </summary>
+        /// <summary> System-generated state of localDNS. </summary>
         [WirePath("state")]
         public LocalDnsState? State { get; }
-        /// <summary>
-        /// VnetDNS overrides apply to DNS traffic from pods with dnsPolicy:default or kubelet (referred to as VnetDNS traffic).
-        /// Serialized Name: LocalDNSProfile.vnetDNSOverrides
-        /// </summary>
+        /// <summary> VnetDNS overrides apply to DNS traffic from pods with dnsPolicy:default or kubelet (referred to as VnetDNS traffic). </summary>
         [WirePath("vnetDNSOverrides")]
         public IDictionary<string, LocalDnsOverride> VnetDnsOverrides { get; }
-        /// <summary>
-        /// KubeDNS overrides apply to DNS traffic from pods with dnsPolicy:ClusterFirst (referred to as KubeDNS traffic).
-        /// Serialized Name: LocalDNSProfile.kubeDNSOverrides
-        /// </summary>
+        /// <summary> KubeDNS overrides apply to DNS traffic from pods with dnsPolicy:ClusterFirst (referred to as KubeDNS traffic). </summary>
         [WirePath("kubeDNSOverrides")]
         public IDictionary<string, LocalDnsOverride> KubeDnsOverrides { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsProtocol.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsProtocol.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Enforce TCP or prefer UDP protocol for connections from localDNS to upstream DNS server.
-    /// Serialized Name: LocalDNSProtocol
-    /// </summary>
+    /// <summary> Enforce TCP or prefer UDP protocol for connections from localDNS to upstream DNS server. </summary>
     public readonly partial struct LocalDnsProtocol : IEquatable<LocalDnsProtocol>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string PreferUdpValue = "PreferUDP";
         private const string ForceTcpValue = "ForceTCP";
 
-        /// <summary>
-        /// Prefer UDP protocol for connections from localDNS to upstream DNS server.
-        /// Serialized Name: LocalDNSProtocol.PreferUDP
-        /// </summary>
+        /// <summary> Prefer UDP protocol for connections from localDNS to upstream DNS server. </summary>
         public static LocalDnsProtocol PreferUdp { get; } = new LocalDnsProtocol(PreferUdpValue);
-        /// <summary>
-        /// Enforce TCP protocol for connections from localDNS to upstream DNS server.
-        /// Serialized Name: LocalDNSProtocol.ForceTCP
-        /// </summary>
+        /// <summary> Enforce TCP protocol for connections from localDNS to upstream DNS server. </summary>
         public static LocalDnsProtocol ForceTcp { get; } = new LocalDnsProtocol(ForceTcpValue);
         /// <summary> Determines if two <see cref="LocalDnsProtocol"/> values are the same. </summary>
         public static bool operator ==(LocalDnsProtocol left, LocalDnsProtocol right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsQueryLogging.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsQueryLogging.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Log level for DNS queries in localDNS.
-    /// Serialized Name: LocalDNSQueryLogging
-    /// </summary>
+    /// <summary> Log level for DNS queries in localDNS. </summary>
     public readonly partial struct LocalDnsQueryLogging : IEquatable<LocalDnsQueryLogging>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string ErrorValue = "Error";
         private const string LogValue = "Log";
 
-        /// <summary>
-        /// Enables error logging in localDNS. See [errors plugin](https://coredns.io/plugins/errors) for more information.
-        /// Serialized Name: LocalDNSQueryLogging.Error
-        /// </summary>
+        /// <summary> Enables error logging in localDNS. See [errors plugin](https://coredns.io/plugins/errors) for more information. </summary>
         public static LocalDnsQueryLogging Error { get; } = new LocalDnsQueryLogging(ErrorValue);
-        /// <summary>
-        /// Enables query logging in localDNS. See [log plugin](https://coredns.io/plugins/log) for more information.
-        /// Serialized Name: LocalDNSQueryLogging.Log
-        /// </summary>
+        /// <summary> Enables query logging in localDNS. See [log plugin](https://coredns.io/plugins/log) for more information. </summary>
         public static LocalDnsQueryLogging Log { get; } = new LocalDnsQueryLogging(LogValue);
         /// <summary> Determines if two <see cref="LocalDnsQueryLogging"/> values are the same. </summary>
         public static bool operator ==(LocalDnsQueryLogging left, LocalDnsQueryLogging right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsServeStale.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsServeStale.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Policy for serving stale data. See [cache plugin](https://coredns.io/plugins/cache) for more information.
-    /// Serialized Name: LocalDNSServeStale
-    /// </summary>
+    /// <summary> Policy for serving stale data. See [cache plugin](https://coredns.io/plugins/cache) for more information. </summary>
     public readonly partial struct LocalDnsServeStale : IEquatable<LocalDnsServeStale>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string ImmediateValue = "Immediate";
         private const string DisableValue = "Disable";
 
-        /// <summary>
-        /// Serve stale data with verification. First verify that an entry is still unavailable from the source before sending the expired entry to the client. See [cache plugin](https://coredns.io/plugins/cache) for more information.
-        /// Serialized Name: LocalDNSServeStale.Verify
-        /// </summary>
+        /// <summary> Serve stale data with verification. First verify that an entry is still unavailable from the source before sending the expired entry to the client. See [cache plugin](https://coredns.io/plugins/cache) for more information. </summary>
         public static LocalDnsServeStale Verify { get; } = new LocalDnsServeStale(VerifyValue);
-        /// <summary>
-        /// Serve stale data immediately. Send the expired entry to the client before checking to see if the entry is available from the source. See [cache plugin](https://coredns.io/plugins/cache) for more information.
-        /// Serialized Name: LocalDNSServeStale.Immediate
-        /// </summary>
+        /// <summary> Serve stale data immediately. Send the expired entry to the client before checking to see if the entry is available from the source. See [cache plugin](https://coredns.io/plugins/cache) for more information. </summary>
         public static LocalDnsServeStale Immediate { get; } = new LocalDnsServeStale(ImmediateValue);
-        /// <summary>
-        /// Disable serving stale data.
-        /// Serialized Name: LocalDNSServeStale.Disable
-        /// </summary>
+        /// <summary> Disable serving stale data. </summary>
         public static LocalDnsServeStale Disable { get; } = new LocalDnsServeStale(DisableValue);
         /// <summary> Determines if two <see cref="LocalDnsServeStale"/> values are the same. </summary>
         public static bool operator ==(LocalDnsServeStale left, LocalDnsServeStale right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsState.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/LocalDnsState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// System-generated state of localDNS.
-    /// Serialized Name: LocalDNSState
-    /// </summary>
+    /// <summary> System-generated state of localDNS. </summary>
     public readonly partial struct LocalDnsState : IEquatable<LocalDnsState>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string EnabledValue = "Enabled";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// localDNS is enabled.
-        /// Serialized Name: LocalDNSState.Enabled
-        /// </summary>
+        /// <summary> localDNS is enabled. </summary>
         public static LocalDnsState Enabled { get; } = new LocalDnsState(EnabledValue);
-        /// <summary>
-        /// localDNS is disabled.
-        /// Serialized Name: LocalDNSState.Disabled
-        /// </summary>
+        /// <summary> localDNS is disabled. </summary>
         public static LocalDnsState Disabled { get; } = new LocalDnsState(DisabledValue);
         /// <summary> Determines if two <see cref="LocalDnsState"/> values are the same. </summary>
         public static bool operator ==(LocalDnsState left, LocalDnsState right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MachineListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MachineListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The response from the List Machines operation.
-    /// Serialized Name: MachineListResult
-    /// </summary>
+    /// <summary> The response from the List Machines operation. </summary>
     internal partial class MachineListResult
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="MachineListResult"/>. </summary>
-        /// <param name="nextLink">
-        /// The URL to get the next set of machine results.
-        /// Serialized Name: MachineListResult.nextLink
-        /// </param>
-        /// <param name="value">
-        /// The list of Machines in cluster.
-        /// Serialized Name: MachineListResult.value
-        /// </param>
+        /// <param name="nextLink"> The URL to get the next set of machine results. </param>
+        /// <param name="value"> The list of Machines in cluster. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MachineListResult(Uri nextLink, IReadOnlyList<ContainerServiceMachineData> value, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The URL to get the next set of machine results.
-        /// Serialized Name: MachineListResult.nextLink
-        /// </summary>
+        /// <summary> The URL to get the next set of machine results. </summary>
         public Uri NextLink { get; }
-        /// <summary>
-        /// The list of Machines in cluster.
-        /// Serialized Name: MachineListResult.value
-        /// </summary>
+        /// <summary> The list of Machines in cluster. </summary>
         public IReadOnlyList<ContainerServiceMachineData> Value { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MachineNetworkProperties.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MachineNetworkProperties.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// network properties of the machine
-    /// Serialized Name: MachineNetworkProperties
-    /// </summary>
+    /// <summary> network properties of the machine. </summary>
     internal partial class MachineNetworkProperties
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="MachineNetworkProperties"/>. </summary>
-        /// <param name="ipAddresses">
-        /// IPv4, IPv6 addresses of the machine
-        /// Serialized Name: MachineNetworkProperties.ipAddresses
-        /// </param>
+        /// <param name="ipAddresses"> IPv4, IPv6 addresses of the machine. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MachineNetworkProperties(IReadOnlyList<ContainerServiceMachineIPAddress> ipAddresses, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// IPv4, IPv6 addresses of the machine
-        /// Serialized Name: MachineNetworkProperties.ipAddresses
-        /// </summary>
+        /// <summary> IPv4, IPv6 addresses of the machine. </summary>
         [WirePath("ipAddresses")]
         public IReadOnlyList<ContainerServiceMachineIPAddress> IPAddresses { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAIToolchainOperatorProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAIToolchainOperatorProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// When enabling the operator, a set of AKS managed CRDs and controllers will be installed in the cluster. The operator automates the deployment of OSS models for inference and/or training purposes. It provides a set of preset models and enables distributed inference against them.
-    /// Serialized Name: ManagedClusterAIToolchainOperatorProfile
-    /// </summary>
+    /// <summary> When enabling the operator, a set of AKS managed CRDs and controllers will be installed in the cluster. The operator automates the deployment of OSS models for inference and/or training purposes. It provides a set of preset models and enables distributed inference against them. </summary>
     internal partial class ManagedClusterAIToolchainOperatorProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAIToolchainOperatorProfile"/>. </summary>
-        /// <param name="isAIToolchainOperatorEnabled">
-        /// Whether to enable AI toolchain operator to the cluster. Indicates if AI toolchain operator  enabled or not.
-        /// Serialized Name: ManagedClusterAIToolchainOperatorProfile.enabled
-        /// </param>
+        /// <param name="isAIToolchainOperatorEnabled"> Whether to enable AI toolchain operator to the cluster. Indicates if AI toolchain operator  enabled or not. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAIToolchainOperatorProfile(bool? isAIToolchainOperatorEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable AI toolchain operator to the cluster. Indicates if AI toolchain operator  enabled or not.
-        /// Serialized Name: ManagedClusterAIToolchainOperatorProfile.enabled
-        /// </summary>
+        /// <summary> Whether to enable AI toolchain operator to the cluster. Indicates if AI toolchain operator  enabled or not. </summary>
         [WirePath("enabled")]
         public bool? IsAIToolchainOperatorEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAadProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAadProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// AADProfile specifies attributes for Azure Active Directory integration. For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad).
-    /// Serialized Name: ManagedClusterAADProfile
-    /// </summary>
+    /// <summary> AADProfile specifies attributes for Azure Active Directory integration. For more details see [managed AAD on AKS](https://docs.microsoft.com/azure/aks/managed-aad). </summary>
     public partial class ManagedClusterAadProfile
     {
         /// <summary>
@@ -55,34 +52,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAadProfile"/>. </summary>
-        /// <param name="isManagedAadEnabled">
-        /// Whether to enable managed AAD.
-        /// Serialized Name: ManagedClusterAADProfile.managed
-        /// </param>
-        /// <param name="isAzureRbacEnabled">
-        /// Whether to enable Azure RBAC for Kubernetes authorization.
-        /// Serialized Name: ManagedClusterAADProfile.enableAzureRBAC
-        /// </param>
-        /// <param name="adminGroupObjectIds">
-        /// The list of AAD group object IDs that will have admin role of the cluster.
-        /// Serialized Name: ManagedClusterAADProfile.adminGroupObjectIDs
-        /// </param>
-        /// <param name="clientAppId">
-        /// (DEPRECATED) The client AAD application ID. Learn more at https://aka.ms/aks/aad-legacy.
-        /// Serialized Name: ManagedClusterAADProfile.clientAppID
-        /// </param>
-        /// <param name="serverAppId">
-        /// (DEPRECATED) The server AAD application ID. Learn more at https://aka.ms/aks/aad-legacy.
-        /// Serialized Name: ManagedClusterAADProfile.serverAppID
-        /// </param>
-        /// <param name="serverAppSecret">
-        /// (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.
-        /// Serialized Name: ManagedClusterAADProfile.serverAppSecret
-        /// </param>
-        /// <param name="tenantId">
-        /// The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription.
-        /// Serialized Name: ManagedClusterAADProfile.tenantID
-        /// </param>
+        /// <param name="isManagedAadEnabled"> Whether to enable managed AAD. </param>
+        /// <param name="isAzureRbacEnabled"> Whether to enable Azure RBAC for Kubernetes authorization. </param>
+        /// <param name="adminGroupObjectIds"> The list of AAD group object IDs that will have admin role of the cluster. </param>
+        /// <param name="clientAppId"> (DEPRECATED) The client AAD application ID. Learn more at https://aka.ms/aks/aad-legacy. </param>
+        /// <param name="serverAppId"> (DEPRECATED) The server AAD application ID. Learn more at https://aka.ms/aks/aad-legacy. </param>
+        /// <param name="serverAppSecret"> (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy. </param>
+        /// <param name="tenantId"> The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAadProfile(bool? isManagedAadEnabled, bool? isAzureRbacEnabled, IList<Guid> adminGroupObjectIds, Guid? clientAppId, Guid? serverAppId, string serverAppSecret, Guid? tenantId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -96,46 +72,25 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable managed AAD.
-        /// Serialized Name: ManagedClusterAADProfile.managed
-        /// </summary>
+        /// <summary> Whether to enable managed AAD. </summary>
         [WirePath("managed")]
         public bool? IsManagedAadEnabled { get; set; }
-        /// <summary>
-        /// Whether to enable Azure RBAC for Kubernetes authorization.
-        /// Serialized Name: ManagedClusterAADProfile.enableAzureRBAC
-        /// </summary>
+        /// <summary> Whether to enable Azure RBAC for Kubernetes authorization. </summary>
         [WirePath("enableAzureRBAC")]
         public bool? IsAzureRbacEnabled { get; set; }
-        /// <summary>
-        /// The list of AAD group object IDs that will have admin role of the cluster.
-        /// Serialized Name: ManagedClusterAADProfile.adminGroupObjectIDs
-        /// </summary>
+        /// <summary> The list of AAD group object IDs that will have admin role of the cluster. </summary>
         [WirePath("adminGroupObjectIDs")]
         public IList<Guid> AdminGroupObjectIds { get; }
-        /// <summary>
-        /// (DEPRECATED) The client AAD application ID. Learn more at https://aka.ms/aks/aad-legacy.
-        /// Serialized Name: ManagedClusterAADProfile.clientAppID
-        /// </summary>
+        /// <summary> (DEPRECATED) The client AAD application ID. Learn more at https://aka.ms/aks/aad-legacy. </summary>
         [WirePath("clientAppID")]
         public Guid? ClientAppId { get; set; }
-        /// <summary>
-        /// (DEPRECATED) The server AAD application ID. Learn more at https://aka.ms/aks/aad-legacy.
-        /// Serialized Name: ManagedClusterAADProfile.serverAppID
-        /// </summary>
+        /// <summary> (DEPRECATED) The server AAD application ID. Learn more at https://aka.ms/aks/aad-legacy. </summary>
         [WirePath("serverAppID")]
         public Guid? ServerAppId { get; set; }
-        /// <summary>
-        /// (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy.
-        /// Serialized Name: ManagedClusterAADProfile.serverAppSecret
-        /// </summary>
+        /// <summary> (DEPRECATED) The server AAD application secret. Learn more at https://aka.ms/aks/aad-legacy. </summary>
         [WirePath("serverAppSecret")]
         public string ServerAppSecret { get; set; }
-        /// <summary>
-        /// The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription.
-        /// Serialized Name: ManagedClusterAADProfile.tenantID
-        /// </summary>
+        /// <summary> The AAD tenant ID to use for authentication. If not specified, will use the tenant of the deployment subscription. </summary>
         [WirePath("tenantID")]
         public Guid? TenantId { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAccessProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAccessProfile.cs
@@ -12,10 +12,7 @@ using Azure.ResourceManager.Models;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Managed cluster Access Profile.
-    /// Serialized Name: ManagedClusterAccessProfile
-    /// </summary>
+    /// <summary> Managed cluster Access Profile. </summary>
     public partial class ManagedClusterAccessProfile : TrackedResourceData
     {
         /// <summary>
@@ -63,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         /// <param name="systemData"> The systemData. </param>
         /// <param name="tags"> The tags. </param>
         /// <param name="location"> The location. </param>
-        /// <param name="kubeConfig">
-        /// Base64-encoded Kubernetes configuration file.
-        /// Serialized Name: ManagedClusterAccessProfile.properties.kubeConfig
-        /// </param>
+        /// <param name="kubeConfig"> Base64-encoded Kubernetes configuration file. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAccessProfile(ResourceIdentifier id, string name, ResourceType resourceType, SystemData systemData, IDictionary<string, string> tags, AzureLocation location, byte[] kubeConfig, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(id, name, resourceType, systemData, tags, location)
         {
@@ -79,10 +73,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Base64-encoded Kubernetes configuration file.
-        /// Serialized Name: ManagedClusterAccessProfile.properties.kubeConfig
-        /// </summary>
+        /// <summary> Base64-encoded Kubernetes configuration file. </summary>
         [WirePath("properties.kubeConfig")]
         public byte[] KubeConfig { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAddonProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAddonProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// A Kubernetes add-on profile for a managed cluster.
-    /// Serialized Name: ManagedClusterAddonProfile
-    /// </summary>
+    /// <summary> A Kubernetes add-on profile for a managed cluster. </summary>
     public partial class ManagedClusterAddonProfile
     {
         /// <summary>
@@ -49,10 +46,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAddonProfile"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether the add-on is enabled or not.
-        /// Serialized Name: ManagedClusterAddonProfile.enabled
-        /// </param>
+        /// <param name="isEnabled"> Whether the add-on is enabled or not. </param>
         public ManagedClusterAddonProfile(bool isEnabled)
         {
             IsEnabled = isEnabled;
@@ -60,18 +54,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAddonProfile"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether the add-on is enabled or not.
-        /// Serialized Name: ManagedClusterAddonProfile.enabled
-        /// </param>
-        /// <param name="config">
-        /// Key-value pairs for configuring an add-on.
-        /// Serialized Name: ManagedClusterAddonProfile.config
-        /// </param>
-        /// <param name="identity">
-        /// Information of user assigned identity used by this add-on.
-        /// Serialized Name: ManagedClusterAddonProfile.identity
-        /// </param>
+        /// <param name="isEnabled"> Whether the add-on is enabled or not. </param>
+        /// <param name="config"> Key-value pairs for configuring an add-on. </param>
+        /// <param name="identity"> Information of user assigned identity used by this add-on. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAddonProfile(bool isEnabled, IDictionary<string, string> config, ManagedClusterAddonProfileIdentity identity, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -86,22 +71,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Whether the add-on is enabled or not.
-        /// Serialized Name: ManagedClusterAddonProfile.enabled
-        /// </summary>
+        /// <summary> Whether the add-on is enabled or not. </summary>
         [WirePath("enabled")]
         public bool IsEnabled { get; set; }
-        /// <summary>
-        /// Key-value pairs for configuring an add-on.
-        /// Serialized Name: ManagedClusterAddonProfile.config
-        /// </summary>
+        /// <summary> Key-value pairs for configuring an add-on. </summary>
         [WirePath("config")]
         public IDictionary<string, string> Config { get; }
-        /// <summary>
-        /// Information of user assigned identity used by this add-on.
-        /// Serialized Name: ManagedClusterAddonProfile.identity
-        /// </summary>
+        /// <summary> Information of user assigned identity used by this add-on. </summary>
         [WirePath("identity")]
         public ManagedClusterAddonProfileIdentity Identity { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAddonProfileIdentity.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAddonProfileIdentity.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Information of user assigned identity used by this add-on.
-    /// Serialized Name: ManagedClusterAddonProfileIdentity
-    /// </summary>
+    /// <summary> Information of user assigned identity used by this add-on. </summary>
     public partial class ManagedClusterAddonProfileIdentity : ContainerServiceUserAssignedIdentity
     {
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAddonProfileIdentity"/>. </summary>
@@ -23,18 +20,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAddonProfileIdentity"/>. </summary>
-        /// <param name="resourceId">
-        /// The resource ID of the user assigned identity.
-        /// Serialized Name: UserAssignedIdentity.resourceId
-        /// </param>
-        /// <param name="clientId">
-        /// The client ID of the user assigned identity.
-        /// Serialized Name: UserAssignedIdentity.clientId
-        /// </param>
-        /// <param name="objectId">
-        /// The object ID of the user assigned identity.
-        /// Serialized Name: UserAssignedIdentity.objectId
-        /// </param>
+        /// <param name="resourceId"> The resource ID of the user assigned identity. </param>
+        /// <param name="clientId"> The client ID of the user assigned identity. </param>
+        /// <param name="objectId"> The object ID of the user assigned identity. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAddonProfileIdentity(ResourceIdentifier resourceId, Guid? clientId, Guid? objectId, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(resourceId, clientId, objectId, serializedAdditionalRawData)
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAdvancedNetworkPolicy.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAdvancedNetworkPolicy.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Enable advanced network policies. This allows users to configure Layer 7 network policies (FQDN, HTTP, Kafka). Policies themselves must be configured via the Cilium Network Policy resources, see https://docs.cilium.io/en/latest/security/policy/index.html. This can be enabled only on cilium-based clusters. If not specified, the default value is FQDN if security.enabled is set to true.
-    /// Serialized Name: AdvancedNetworkPolicies
-    /// </summary>
+    /// <summary> Enable advanced network policies. This allows users to configure Layer 7 network policies (FQDN, HTTP, Kafka). Policies themselves must be configured via the Cilium Network Policy resources, see https://docs.cilium.io/en/latest/security/policy/index.html. This can be enabled only on cilium-based clusters. If not specified, the default value is FQDN if security.enabled is set to true. </summary>
     public readonly partial struct ManagedClusterAdvancedNetworkPolicy : IEquatable<ManagedClusterAdvancedNetworkPolicy>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string FqdnValue = "FQDN";
         private const string NoneValue = "None";
 
-        /// <summary>
-        /// Enable Layer7 network policies (FQDN, HTTP/S, Kafka). This option is a superset of the FQDN option.
-        /// Serialized Name: AdvancedNetworkPolicies.L7
-        /// </summary>
+        /// <summary> Enable Layer7 network policies (FQDN, HTTP/S, Kafka). This option is a superset of the FQDN option. </summary>
         public static ManagedClusterAdvancedNetworkPolicy L7 { get; } = new ManagedClusterAdvancedNetworkPolicy(L7Value);
-        /// <summary>
-        /// Enable FQDN based network policies
-        /// Serialized Name: AdvancedNetworkPolicies.FQDN
-        /// </summary>
+        /// <summary> Enable FQDN based network policies. </summary>
         public static ManagedClusterAdvancedNetworkPolicy Fqdn { get; } = new ManagedClusterAdvancedNetworkPolicy(FqdnValue);
-        /// <summary>
-        /// Disable Layer 7 network policies (FQDN, HTTP/S, Kafka)
-        /// Serialized Name: AdvancedNetworkPolicies.None
-        /// </summary>
+        /// <summary> Disable Layer 7 network policies (FQDN, HTTP/S, Kafka). </summary>
         public static ManagedClusterAdvancedNetworkPolicy None { get; } = new ManagedClusterAdvancedNetworkPolicy(NoneValue);
         /// <summary> Determines if two <see cref="ManagedClusterAdvancedNetworkPolicy"/> values are the same. </summary>
         public static bool operator ==(ManagedClusterAdvancedNetworkPolicy left, ManagedClusterAdvancedNetworkPolicy right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAdvancedNetworking.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAdvancedNetworking.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking.
-    /// Serialized Name: AdvancedNetworking
-    /// </summary>
+    /// <summary> Advanced Networking profile for enabling observability and security feature suite on a cluster. For more information see aka.ms/aksadvancednetworking. </summary>
     public partial class ManagedClusterAdvancedNetworking
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAdvancedNetworking"/>. </summary>
-        /// <param name="isEnabled">
-        /// Indicates the enablement of Advanced Networking functionalities of observability and security on AKS clusters. When this is set to true, all observability and security features will be set to enabled unless explicitly disabled. If not specified, the default is false.
-        /// Serialized Name: AdvancedNetworking.enabled
-        /// </param>
-        /// <param name="observability">
-        /// Observability profile to enable advanced network metrics and flow logs with historical contexts.
-        /// Serialized Name: AdvancedNetworking.observability
-        /// </param>
-        /// <param name="security">
-        /// Security profile to enable security features on cilium based cluster.
-        /// Serialized Name: AdvancedNetworking.security
-        /// </param>
+        /// <param name="isEnabled"> Indicates the enablement of Advanced Networking functionalities of observability and security on AKS clusters. When this is set to true, all observability and security features will be set to enabled unless explicitly disabled. If not specified, the default is false. </param>
+        /// <param name="observability"> Observability profile to enable advanced network metrics and flow logs with historical contexts. </param>
+        /// <param name="security"> Security profile to enable security features on cilium based cluster. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAdvancedNetworking(bool? isEnabled, AdvancedNetworkingObservability observability, ManagedClusterAdvancedNetworkingSecurity security, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,21 +63,12 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Indicates the enablement of Advanced Networking functionalities of observability and security on AKS clusters. When this is set to true, all observability and security features will be set to enabled unless explicitly disabled. If not specified, the default is false.
-        /// Serialized Name: AdvancedNetworking.enabled
-        /// </summary>
+        /// <summary> Indicates the enablement of Advanced Networking functionalities of observability and security on AKS clusters. When this is set to true, all observability and security features will be set to enabled unless explicitly disabled. If not specified, the default is false. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
-        /// <summary>
-        /// Observability profile to enable advanced network metrics and flow logs with historical contexts.
-        /// Serialized Name: AdvancedNetworking.observability
-        /// </summary>
+        /// <summary> Observability profile to enable advanced network metrics and flow logs with historical contexts. </summary>
         internal AdvancedNetworkingObservability Observability { get; set; }
-        /// <summary>
-        /// Indicates the enablement of Advanced Networking observability functionalities on clusters.
-        /// Serialized Name: AdvancedNetworkingObservability.enabled
-        /// </summary>
+        /// <summary> Indicates the enablement of Advanced Networking observability functionalities on clusters. </summary>
         [WirePath("observability.enabled")]
         public bool? IsObservabilityEnabled
         {
@@ -102,10 +81,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// Security profile to enable security features on cilium based cluster.
-        /// Serialized Name: AdvancedNetworking.security
-        /// </summary>
+        /// <summary> Security profile to enable security features on cilium based cluster. </summary>
         [WirePath("security")]
         public ManagedClusterAdvancedNetworkingSecurity Security { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAdvancedNetworkingSecurity.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAdvancedNetworkingSecurity.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Security profile to enable security features on cilium based cluster.
-    /// Serialized Name: AdvancedNetworkingSecurity
-    /// </summary>
+    /// <summary> Security profile to enable security features on cilium based cluster. </summary>
     public partial class ManagedClusterAdvancedNetworkingSecurity
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAdvancedNetworkingSecurity"/>. </summary>
-        /// <param name="isEnabled">
-        /// This feature allows user to configure network policy based on DNS (FQDN) names. It can be enabled only on cilium based clusters. If not specified, the default is false.
-        /// Serialized Name: AdvancedNetworkingSecurity.enabled
-        /// </param>
-        /// <param name="advancedNetworkPolicies">
-        /// Enable advanced network policies. This allows users to configure Layer 7 network policies (FQDN, HTTP, Kafka). Policies themselves must be configured via the Cilium Network Policy resources, see https://docs.cilium.io/en/latest/security/policy/index.html. This can be enabled only on cilium-based clusters. If not specified, the default value is FQDN if security.enabled is set to true.
-        /// Serialized Name: AdvancedNetworkingSecurity.advancedNetworkPolicies
-        /// </param>
+        /// <param name="isEnabled"> This feature allows user to configure network policy based on DNS (FQDN) names. It can be enabled only on cilium based clusters. If not specified, the default is false. </param>
+        /// <param name="advancedNetworkPolicies"> Enable advanced network policies. This allows users to configure Layer 7 network policies (FQDN, HTTP, Kafka). Policies themselves must be configured via the Cilium Network Policy resources, see https://docs.cilium.io/en/latest/security/policy/index.html. This can be enabled only on cilium-based clusters. If not specified, the default value is FQDN if security.enabled is set to true. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAdvancedNetworkingSecurity(bool? isEnabled, ManagedClusterAdvancedNetworkPolicy? advancedNetworkPolicies, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// This feature allows user to configure network policy based on DNS (FQDN) names. It can be enabled only on cilium based clusters. If not specified, the default is false.
-        /// Serialized Name: AdvancedNetworkingSecurity.enabled
-        /// </summary>
+        /// <summary> This feature allows user to configure network policy based on DNS (FQDN) names. It can be enabled only on cilium based clusters. If not specified, the default is false. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
-        /// <summary>
-        /// Enable advanced network policies. This allows users to configure Layer 7 network policies (FQDN, HTTP, Kafka). Policies themselves must be configured via the Cilium Network Policy resources, see https://docs.cilium.io/en/latest/security/policy/index.html. This can be enabled only on cilium-based clusters. If not specified, the default value is FQDN if security.enabled is set to true.
-        /// Serialized Name: AdvancedNetworkingSecurity.advancedNetworkPolicies
-        /// </summary>
+        /// <summary> Enable advanced network policies. This allows users to configure Layer 7 network policies (FQDN, HTTP, Kafka). Policies themselves must be configured via the Cilium Network Policy resources, see https://docs.cilium.io/en/latest/security/policy/index.html. This can be enabled only on cilium-based clusters. If not specified, the default value is FQDN if security.enabled is set to true. </summary>
         [WirePath("advancedNetworkPolicies")]
         public ManagedClusterAdvancedNetworkPolicy? AdvancedNetworkPolicies { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAgentPoolProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAgentPoolProfile.cs
@@ -11,17 +11,11 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Profile for the container service agent pool.
-    /// Serialized Name: ManagedClusterAgentPoolProfile
-    /// </summary>
+    /// <summary> Profile for the container service agent pool. </summary>
     public partial class ManagedClusterAgentPoolProfile : ManagedClusterAgentPoolProfileProperties
     {
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAgentPoolProfile"/>. </summary>
-        /// <param name="name">
-        /// Unique name of the agent pool profile in the context of the subscription and resource group. Windows agent pool names must be 6 characters or less.
-        /// Serialized Name: ManagedClusterAgentPoolProfile.name
-        /// </param>
+        /// <param name="name"> Unique name of the agent pool profile in the context of the subscription and resource group. Windows agent pool names must be 6 characters or less. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/> is null. </exception>
         public ManagedClusterAgentPoolProfile(string name)
         {
@@ -31,227 +25,62 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAgentPoolProfile"/>. </summary>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.eTag
-        /// </param>
-        /// <param name="count">
-        /// Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.count
-        /// </param>
-        /// <param name="vmSize">
-        /// The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vmSize
-        /// </param>
-        /// <param name="osDiskSizeInGB">
-        /// OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskSizeGB
-        /// </param>
-        /// <param name="osDiskType">
-        /// The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskType
-        /// </param>
-        /// <param name="kubeletDiskType">
-        /// Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletDiskType
-        /// </param>
-        /// <param name="workloadRuntime">
-        /// Determines the type of workload a node can run.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.workloadRuntime
-        /// </param>
-        /// <param name="messageOfTheDay">
-        /// Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.messageOfTheDay
-        /// </param>
-        /// <param name="vnetSubnetId">
-        /// The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vnetSubnetID
-        /// </param>
-        /// <param name="podSubnetId">
-        /// The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podSubnetID
-        /// </param>
-        /// <param name="podIPAllocationMode">
-        /// Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podIPAllocationMode
-        /// </param>
-        /// <param name="maxPods">
-        /// The maximum number of pods that can run on a node.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxPods
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osType
-        /// </param>
-        /// <param name="osSku">
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osSKU
-        /// </param>
-        /// <param name="maxCount">
-        /// The maximum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxCount
-        /// </param>
-        /// <param name="minCount">
-        /// The minimum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.minCount
-        /// </param>
-        /// <param name="enableAutoScaling">
-        /// Whether to enable auto-scaler
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableAutoScaling
-        /// </param>
-        /// <param name="scaleDownMode">
-        /// The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleDownMode
-        /// </param>
-        /// <param name="agentPoolType">
-        /// The type of Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.type
-        /// </param>
-        /// <param name="mode">
-        /// The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.mode
-        /// </param>
-        /// <param name="orchestratorVersion">
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.orchestratorVersion
-        /// </param>
-        /// <param name="currentOrchestratorVersion">
-        /// The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.currentOrchestratorVersion
-        /// </param>
-        /// <param name="nodeImageVersion">
-        /// The version of node image
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeImageVersion
-        /// </param>
-        /// <param name="upgradeSettings">
-        /// Settings for upgrading the agentpool
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.upgradeSettings
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current deployment or provisioning state.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.provisioningState
-        /// </param>
-        /// <param name="powerState">
-        /// Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.powerState
-        /// </param>
-        /// <param name="availabilityZones">
-        /// The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.availabilityZones
-        /// </param>
-        /// <param name="enableNodePublicIP">
-        /// Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableNodePublicIP
-        /// </param>
-        /// <param name="nodePublicIPPrefixId">
-        /// The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodePublicIPPrefixID
-        /// </param>
-        /// <param name="scaleSetPriority">
-        /// The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetPriority
-        /// </param>
-        /// <param name="scaleSetEvictionPolicy">
-        /// The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetEvictionPolicy
-        /// </param>
-        /// <param name="spotMaxPrice">
-        /// The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.spotMaxPrice
-        /// </param>
-        /// <param name="tags">
-        /// The tags to be persisted on the agent pool virtual machine scale set.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.tags
-        /// </param>
-        /// <param name="nodeLabels">
-        /// The node labels to be persisted across all nodes in agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeLabels
-        /// </param>
-        /// <param name="nodeTaints">
-        /// The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeTaints
-        /// </param>
-        /// <param name="proximityPlacementGroupId">
-        /// The ID for Proximity Placement Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.proximityPlacementGroupID
-        /// </param>
-        /// <param name="kubeletConfig">
-        /// The Kubelet configuration on the agent pool nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletConfig
-        /// </param>
-        /// <param name="linuxOSConfig">
-        /// The OS configuration of Linux agent nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.linuxOSConfig
-        /// </param>
-        /// <param name="enableEncryptionAtHost">
-        /// Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableEncryptionAtHost
-        /// </param>
-        /// <param name="enableUltraSsd">
-        /// Whether to enable UltraSSD
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableUltraSSD
-        /// </param>
-        /// <param name="enableFips">
-        /// Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableFIPS
-        /// </param>
-        /// <param name="gpuInstanceProfile">
-        /// GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuInstanceProfile
-        /// </param>
-        /// <param name="creationData">
-        /// CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.creationData
-        /// </param>
-        /// <param name="capacityReservationGroupId">
-        /// AKS will associate the specified agent pool with the Capacity Reservation Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.capacityReservationGroupID
-        /// </param>
-        /// <param name="hostGroupId">
-        /// The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.hostGroupID
-        /// </param>
-        /// <param name="networkProfile">
-        /// Network-related settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.networkProfile
-        /// </param>
-        /// <param name="windowsProfile">
-        /// The Windows agent pool's specific profile.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.windowsProfile
-        /// </param>
-        /// <param name="securityProfile">
-        /// The security settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.securityProfile
-        /// </param>
-        /// <param name="gpuProfile">
-        /// GPU settings for the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuProfile
-        /// </param>
-        /// <param name="gatewayProfile">
-        /// Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gatewayProfile
-        /// </param>
-        /// <param name="virtualMachinesProfile">
-        /// Specifications on VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachinesProfile
-        /// </param>
-        /// <param name="virtualMachineNodesStatus">
-        /// The status of nodes in a VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachineNodesStatus
-        /// </param>
-        /// <param name="status">
-        /// Contains read-only information about the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.status
-        /// </param>
-        /// <param name="localDnsProfile">
-        /// Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.localDNSProfile
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="count"> Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1. </param>
+        /// <param name="vmSize"> The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions. </param>
+        /// <param name="osDiskSizeInGB"> OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified. </param>
+        /// <param name="osDiskType"> The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os). </param>
+        /// <param name="kubeletDiskType"> Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. </param>
+        /// <param name="workloadRuntime"> Determines the type of workload a node can run. </param>
+        /// <param name="messageOfTheDay"> Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script). </param>
+        /// <param name="vnetSubnetId"> The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podSubnetId"> The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podIPAllocationMode"> Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'. </param>
+        /// <param name="maxPods"> The maximum number of pods that can run on a node. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="osSku"> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </param>
+        /// <param name="maxCount"> The maximum number of nodes for auto-scaling. </param>
+        /// <param name="minCount"> The minimum number of nodes for auto-scaling. </param>
+        /// <param name="enableAutoScaling"> Whether to enable auto-scaler. </param>
+        /// <param name="scaleDownMode"> The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete. </param>
+        /// <param name="agentPoolType"> The type of Agent Pool. </param>
+        /// <param name="mode"> The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools. </param>
+        /// <param name="orchestratorVersion"> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool). </param>
+        /// <param name="currentOrchestratorVersion"> The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </param>
+        /// <param name="nodeImageVersion"> The version of node image. </param>
+        /// <param name="upgradeSettings"> Settings for upgrading the agentpool. </param>
+        /// <param name="provisioningState"> The current deployment or provisioning state. </param>
+        /// <param name="powerState"> Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded. </param>
+        /// <param name="availabilityZones"> The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'. </param>
+        /// <param name="enableNodePublicIP"> Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false. </param>
+        /// <param name="nodePublicIPPrefixId"> The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}. </param>
+        /// <param name="scaleSetPriority"> The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'. </param>
+        /// <param name="scaleSetEvictionPolicy"> The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'. </param>
+        /// <param name="spotMaxPrice"> The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing). </param>
+        /// <param name="tags"> The tags to be persisted on the agent pool virtual machine scale set. </param>
+        /// <param name="nodeLabels"> The node labels to be persisted across all nodes in agent pool. </param>
+        /// <param name="nodeTaints"> The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. </param>
+        /// <param name="proximityPlacementGroupId"> The ID for Proximity Placement Group. </param>
+        /// <param name="kubeletConfig"> The Kubelet configuration on the agent pool nodes. </param>
+        /// <param name="linuxOSConfig"> The OS configuration of Linux agent nodes. </param>
+        /// <param name="enableEncryptionAtHost"> Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption. </param>
+        /// <param name="enableUltraSsd"> Whether to enable UltraSSD. </param>
+        /// <param name="enableFips"> Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details. </param>
+        /// <param name="gpuInstanceProfile"> GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU. </param>
+        /// <param name="creationData"> CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot. </param>
+        /// <param name="capacityReservationGroupId"> AKS will associate the specified agent pool with the Capacity Reservation Group. </param>
+        /// <param name="hostGroupId"> The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts). </param>
+        /// <param name="networkProfile"> Network-related settings of an agent pool. </param>
+        /// <param name="windowsProfile"> The Windows agent pool's specific profile. </param>
+        /// <param name="securityProfile"> The security settings of an agent pool. </param>
+        /// <param name="gpuProfile"> GPU settings for the Agent Pool. </param>
+        /// <param name="gatewayProfile"> Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway. </param>
+        /// <param name="virtualMachinesProfile"> Specifications on VirtualMachines agent pool. </param>
+        /// <param name="virtualMachineNodesStatus"> The status of nodes in a VirtualMachines agent pool. </param>
+        /// <param name="status"> Contains read-only information about the Agent Pool. </param>
+        /// <param name="localDnsProfile"> Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
-        /// <param name="name">
-        /// Unique name of the agent pool profile in the context of the subscription and resource group. Windows agent pool names must be 6 characters or less.
-        /// Serialized Name: ManagedClusterAgentPoolProfile.name
-        /// </param>
+        /// <param name="name"> Unique name of the agent pool profile in the context of the subscription and resource group. Windows agent pool names must be 6 characters or less. </param>
         internal ManagedClusterAgentPoolProfile(ETag? etag, int? count, string vmSize, int? osDiskSizeInGB, ContainerServiceOSDiskType? osDiskType, KubeletDiskType? kubeletDiskType, WorkloadRuntime? workloadRuntime, string messageOfTheDay, ResourceIdentifier vnetSubnetId, ResourceIdentifier podSubnetId, PodIPAllocationMode? podIPAllocationMode, int? maxPods, ContainerServiceOSType? osType, ContainerServiceOSSku? osSku, int? maxCount, int? minCount, bool? enableAutoScaling, ScaleDownMode? scaleDownMode, AgentPoolType? agentPoolType, AgentPoolMode? mode, string orchestratorVersion, string currentOrchestratorVersion, string nodeImageVersion, AgentPoolUpgradeSettings upgradeSettings, string provisioningState, ContainerServicePowerState powerState, IList<string> availabilityZones, bool? enableNodePublicIP, ResourceIdentifier nodePublicIPPrefixId, ScaleSetPriority? scaleSetPriority, ScaleSetEvictionPolicy? scaleSetEvictionPolicy, float? spotMaxPrice, IDictionary<string, string> tags, IDictionary<string, string> nodeLabels, IList<string> nodeTaints, ResourceIdentifier proximityPlacementGroupId, KubeletConfig kubeletConfig, LinuxOSConfig linuxOSConfig, bool? enableEncryptionAtHost, bool? enableUltraSsd, bool? enableFips, GpuInstanceProfile? gpuInstanceProfile, ContainerServiceCreationData creationData, ResourceIdentifier capacityReservationGroupId, ResourceIdentifier hostGroupId, AgentPoolNetworkProfile networkProfile, AgentPoolWindowsProfile windowsProfile, AgentPoolSecurityProfile securityProfile, AgentPoolGpuProfile gpuProfile, AgentPoolGatewayProfile gatewayProfile, VirtualMachinesProfile virtualMachinesProfile, IList<AgentPoolVirtualMachineNodes> virtualMachineNodesStatus, AgentPoolStatus status, LocalDnsProfile localDnsProfile, IDictionary<string, BinaryData> serializedAdditionalRawData, string name) : base(etag, count, vmSize, osDiskSizeInGB, osDiskType, kubeletDiskType, workloadRuntime, messageOfTheDay, vnetSubnetId, podSubnetId, podIPAllocationMode, maxPods, osType, osSku, maxCount, minCount, enableAutoScaling, scaleDownMode, agentPoolType, mode, orchestratorVersion, currentOrchestratorVersion, nodeImageVersion, upgradeSettings, provisioningState, powerState, availabilityZones, enableNodePublicIP, nodePublicIPPrefixId, scaleSetPriority, scaleSetEvictionPolicy, spotMaxPrice, tags, nodeLabels, nodeTaints, proximityPlacementGroupId, kubeletConfig, linuxOSConfig, enableEncryptionAtHost, enableUltraSsd, enableFips, gpuInstanceProfile, creationData, capacityReservationGroupId, hostGroupId, networkProfile, windowsProfile, securityProfile, gpuProfile, gatewayProfile, virtualMachinesProfile, virtualMachineNodesStatus, status, localDnsProfile, serializedAdditionalRawData)
         {
             Name = name;
@@ -262,10 +91,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Unique name of the agent pool profile in the context of the subscription and resource group. Windows agent pool names must be 6 characters or less.
-        /// Serialized Name: ManagedClusterAgentPoolProfile.name
-        /// </summary>
+        /// <summary> Unique name of the agent pool profile in the context of the subscription and resource group. Windows agent pool names must be 6 characters or less. </summary>
         [WirePath("name")]
         public string Name { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAgentPoolProfileProperties.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAgentPoolProfileProperties.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Properties for the container service agent pool profile.
-    /// Serialized Name: ManagedClusterAgentPoolProfileProperties
-    /// </summary>
+    /// <summary> Properties for the container service agent pool profile. </summary>
     public partial class ManagedClusterAgentPoolProfileProperties
     {
         /// <summary>
@@ -60,222 +57,60 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAgentPoolProfileProperties"/>. </summary>
-        /// <param name="etag">
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.eTag
-        /// </param>
-        /// <param name="count">
-        /// Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.count
-        /// </param>
-        /// <param name="vmSize">
-        /// The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vmSize
-        /// </param>
-        /// <param name="osDiskSizeInGB">
-        /// OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskSizeGB
-        /// </param>
-        /// <param name="osDiskType">
-        /// The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskType
-        /// </param>
-        /// <param name="kubeletDiskType">
-        /// Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletDiskType
-        /// </param>
-        /// <param name="workloadRuntime">
-        /// Determines the type of workload a node can run.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.workloadRuntime
-        /// </param>
-        /// <param name="messageOfTheDay">
-        /// Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.messageOfTheDay
-        /// </param>
-        /// <param name="vnetSubnetId">
-        /// The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vnetSubnetID
-        /// </param>
-        /// <param name="podSubnetId">
-        /// The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podSubnetID
-        /// </param>
-        /// <param name="podIPAllocationMode">
-        /// Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podIPAllocationMode
-        /// </param>
-        /// <param name="maxPods">
-        /// The maximum number of pods that can run on a node.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxPods
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osType
-        /// </param>
-        /// <param name="osSku">
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osSKU
-        /// </param>
-        /// <param name="maxCount">
-        /// The maximum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxCount
-        /// </param>
-        /// <param name="minCount">
-        /// The minimum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.minCount
-        /// </param>
-        /// <param name="enableAutoScaling">
-        /// Whether to enable auto-scaler
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableAutoScaling
-        /// </param>
-        /// <param name="scaleDownMode">
-        /// The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleDownMode
-        /// </param>
-        /// <param name="agentPoolType">
-        /// The type of Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.type
-        /// </param>
-        /// <param name="mode">
-        /// The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.mode
-        /// </param>
-        /// <param name="orchestratorVersion">
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.orchestratorVersion
-        /// </param>
-        /// <param name="currentOrchestratorVersion">
-        /// The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.currentOrchestratorVersion
-        /// </param>
-        /// <param name="nodeImageVersion">
-        /// The version of node image
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeImageVersion
-        /// </param>
-        /// <param name="upgradeSettings">
-        /// Settings for upgrading the agentpool
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.upgradeSettings
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current deployment or provisioning state.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.provisioningState
-        /// </param>
-        /// <param name="powerState">
-        /// Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.powerState
-        /// </param>
-        /// <param name="availabilityZones">
-        /// The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.availabilityZones
-        /// </param>
-        /// <param name="enableNodePublicIP">
-        /// Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableNodePublicIP
-        /// </param>
-        /// <param name="nodePublicIPPrefixId">
-        /// The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodePublicIPPrefixID
-        /// </param>
-        /// <param name="scaleSetPriority">
-        /// The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetPriority
-        /// </param>
-        /// <param name="scaleSetEvictionPolicy">
-        /// The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetEvictionPolicy
-        /// </param>
-        /// <param name="spotMaxPrice">
-        /// The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.spotMaxPrice
-        /// </param>
-        /// <param name="tags">
-        /// The tags to be persisted on the agent pool virtual machine scale set.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.tags
-        /// </param>
-        /// <param name="nodeLabels">
-        /// The node labels to be persisted across all nodes in agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeLabels
-        /// </param>
-        /// <param name="nodeTaints">
-        /// The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeTaints
-        /// </param>
-        /// <param name="proximityPlacementGroupId">
-        /// The ID for Proximity Placement Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.proximityPlacementGroupID
-        /// </param>
-        /// <param name="kubeletConfig">
-        /// The Kubelet configuration on the agent pool nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletConfig
-        /// </param>
-        /// <param name="linuxOSConfig">
-        /// The OS configuration of Linux agent nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.linuxOSConfig
-        /// </param>
-        /// <param name="enableEncryptionAtHost">
-        /// Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableEncryptionAtHost
-        /// </param>
-        /// <param name="enableUltraSsd">
-        /// Whether to enable UltraSSD
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableUltraSSD
-        /// </param>
-        /// <param name="enableFips">
-        /// Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableFIPS
-        /// </param>
-        /// <param name="gpuInstanceProfile">
-        /// GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuInstanceProfile
-        /// </param>
-        /// <param name="creationData">
-        /// CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.creationData
-        /// </param>
-        /// <param name="capacityReservationGroupId">
-        /// AKS will associate the specified agent pool with the Capacity Reservation Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.capacityReservationGroupID
-        /// </param>
-        /// <param name="hostGroupId">
-        /// The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.hostGroupID
-        /// </param>
-        /// <param name="networkProfile">
-        /// Network-related settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.networkProfile
-        /// </param>
-        /// <param name="windowsProfile">
-        /// The Windows agent pool's specific profile.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.windowsProfile
-        /// </param>
-        /// <param name="securityProfile">
-        /// The security settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.securityProfile
-        /// </param>
-        /// <param name="gpuProfile">
-        /// GPU settings for the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuProfile
-        /// </param>
-        /// <param name="gatewayProfile">
-        /// Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gatewayProfile
-        /// </param>
-        /// <param name="virtualMachinesProfile">
-        /// Specifications on VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachinesProfile
-        /// </param>
-        /// <param name="virtualMachineNodesStatus">
-        /// The status of nodes in a VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachineNodesStatus
-        /// </param>
-        /// <param name="status">
-        /// Contains read-only information about the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.status
-        /// </param>
-        /// <param name="localDnsProfile">
-        /// Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.localDNSProfile
-        /// </param>
+        /// <param name="etag"> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </param>
+        /// <param name="count"> Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1. </param>
+        /// <param name="vmSize"> The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions. </param>
+        /// <param name="osDiskSizeInGB"> OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified. </param>
+        /// <param name="osDiskType"> The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os). </param>
+        /// <param name="kubeletDiskType"> Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. </param>
+        /// <param name="workloadRuntime"> Determines the type of workload a node can run. </param>
+        /// <param name="messageOfTheDay"> Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script). </param>
+        /// <param name="vnetSubnetId"> The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podSubnetId"> The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </param>
+        /// <param name="podIPAllocationMode"> Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'. </param>
+        /// <param name="maxPods"> The maximum number of pods that can run on a node. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="osSku"> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </param>
+        /// <param name="maxCount"> The maximum number of nodes for auto-scaling. </param>
+        /// <param name="minCount"> The minimum number of nodes for auto-scaling. </param>
+        /// <param name="enableAutoScaling"> Whether to enable auto-scaler. </param>
+        /// <param name="scaleDownMode"> The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete. </param>
+        /// <param name="agentPoolType"> The type of Agent Pool. </param>
+        /// <param name="mode"> The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools. </param>
+        /// <param name="orchestratorVersion"> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool). </param>
+        /// <param name="currentOrchestratorVersion"> The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </param>
+        /// <param name="nodeImageVersion"> The version of node image. </param>
+        /// <param name="upgradeSettings"> Settings for upgrading the agentpool. </param>
+        /// <param name="provisioningState"> The current deployment or provisioning state. </param>
+        /// <param name="powerState"> Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded. </param>
+        /// <param name="availabilityZones"> The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'. </param>
+        /// <param name="enableNodePublicIP"> Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false. </param>
+        /// <param name="nodePublicIPPrefixId"> The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}. </param>
+        /// <param name="scaleSetPriority"> The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'. </param>
+        /// <param name="scaleSetEvictionPolicy"> The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'. </param>
+        /// <param name="spotMaxPrice"> The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing). </param>
+        /// <param name="tags"> The tags to be persisted on the agent pool virtual machine scale set. </param>
+        /// <param name="nodeLabels"> The node labels to be persisted across all nodes in agent pool. </param>
+        /// <param name="nodeTaints"> The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. </param>
+        /// <param name="proximityPlacementGroupId"> The ID for Proximity Placement Group. </param>
+        /// <param name="kubeletConfig"> The Kubelet configuration on the agent pool nodes. </param>
+        /// <param name="linuxOSConfig"> The OS configuration of Linux agent nodes. </param>
+        /// <param name="enableEncryptionAtHost"> Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption. </param>
+        /// <param name="enableUltraSsd"> Whether to enable UltraSSD. </param>
+        /// <param name="enableFips"> Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details. </param>
+        /// <param name="gpuInstanceProfile"> GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU. </param>
+        /// <param name="creationData"> CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot. </param>
+        /// <param name="capacityReservationGroupId"> AKS will associate the specified agent pool with the Capacity Reservation Group. </param>
+        /// <param name="hostGroupId"> The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts). </param>
+        /// <param name="networkProfile"> Network-related settings of an agent pool. </param>
+        /// <param name="windowsProfile"> The Windows agent pool's specific profile. </param>
+        /// <param name="securityProfile"> The security settings of an agent pool. </param>
+        /// <param name="gpuProfile"> GPU settings for the Agent Pool. </param>
+        /// <param name="gatewayProfile"> Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway. </param>
+        /// <param name="virtualMachinesProfile"> Specifications on VirtualMachines agent pool. </param>
+        /// <param name="virtualMachineNodesStatus"> The status of nodes in a VirtualMachines agent pool. </param>
+        /// <param name="status"> Contains read-only information about the Agent Pool. </param>
+        /// <param name="localDnsProfile"> Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAgentPoolProfileProperties(ETag? etag, int? count, string vmSize, int? osDiskSizeInGB, ContainerServiceOSDiskType? osDiskType, KubeletDiskType? kubeletDiskType, WorkloadRuntime? workloadRuntime, string messageOfTheDay, ResourceIdentifier vnetSubnetId, ResourceIdentifier podSubnetId, PodIPAllocationMode? podIPAllocationMode, int? maxPods, ContainerServiceOSType? osType, ContainerServiceOSSku? osSku, int? maxCount, int? minCount, bool? enableAutoScaling, ScaleDownMode? scaleDownMode, AgentPoolType? agentPoolType, AgentPoolMode? mode, string orchestratorVersion, string currentOrchestratorVersion, string nodeImageVersion, AgentPoolUpgradeSettings upgradeSettings, string provisioningState, ContainerServicePowerState powerState, IList<string> availabilityZones, bool? enableNodePublicIP, ResourceIdentifier nodePublicIPPrefixId, ScaleSetPriority? scaleSetPriority, ScaleSetEvictionPolicy? scaleSetEvictionPolicy, float? spotMaxPrice, IDictionary<string, string> tags, IDictionary<string, string> nodeLabels, IList<string> nodeTaints, ResourceIdentifier proximityPlacementGroupId, KubeletConfig kubeletConfig, LinuxOSConfig linuxOSConfig, bool? enableEncryptionAtHost, bool? enableUltraSsd, bool? enableFips, GpuInstanceProfile? gpuInstanceProfile, ContainerServiceCreationData creationData, ResourceIdentifier capacityReservationGroupId, ResourceIdentifier hostGroupId, AgentPoolNetworkProfile networkProfile, AgentPoolWindowsProfile windowsProfile, AgentPoolSecurityProfile securityProfile, AgentPoolGpuProfile gpuProfile, AgentPoolGatewayProfile gatewayProfile, VirtualMachinesProfile virtualMachinesProfile, IList<AgentPoolVirtualMachineNodes> virtualMachineNodesStatus, AgentPoolStatus status, LocalDnsProfile localDnsProfile, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -336,165 +171,84 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.eTag
-        /// </summary>
+        /// <summary> Unique read-only string used to implement optimistic concurrency. The eTag value will change when the resource is updated. Specify an if-match or if-none-match header with the eTag value for a subsequent request to enable optimistic concurrency per the normal eTag convention. </summary>
         [WirePath("eTag")]
         public ETag? ETag { get; }
-        /// <summary>
-        /// Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.count
-        /// </summary>
+        /// <summary> Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1. </summary>
         [WirePath("count")]
         public int? Count { get; set; }
-        /// <summary>
-        /// The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vmSize
-        /// </summary>
+        /// <summary> The size of the agent pool VMs. VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions. </summary>
         [WirePath("vmSize")]
         public string VmSize { get; set; }
-        /// <summary>
-        /// OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskSizeGB
-        /// </summary>
+        /// <summary> OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified. </summary>
         [WirePath("osDiskSizeGB")]
         public int? OSDiskSizeInGB { get; set; }
-        /// <summary>
-        /// The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osDiskType
-        /// </summary>
+        /// <summary> The OS disk type to be used for machines in the agent pool. The default is 'Ephemeral' if the VM supports it and has a cache disk larger than the requested OSDiskSizeGB. Otherwise, defaults to 'Managed'. May not be changed after creation. For more information see [Ephemeral OS](https://docs.microsoft.com/azure/aks/cluster-configuration#ephemeral-os). </summary>
         [WirePath("osDiskType")]
         public ContainerServiceOSDiskType? OSDiskType { get; set; }
-        /// <summary>
-        /// Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletDiskType
-        /// </summary>
+        /// <summary> Determines the placement of emptyDir volumes, container runtime data root, and Kubelet ephemeral storage. </summary>
         [WirePath("kubeletDiskType")]
         public KubeletDiskType? KubeletDiskType { get; set; }
-        /// <summary>
-        /// Determines the type of workload a node can run.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.workloadRuntime
-        /// </summary>
+        /// <summary> Determines the type of workload a node can run. </summary>
         [WirePath("workloadRuntime")]
         public WorkloadRuntime? WorkloadRuntime { get; set; }
-        /// <summary>
-        /// Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.messageOfTheDay
-        /// </summary>
+        /// <summary> Message of the day for Linux nodes, base64-encoded. A base64-encoded string which will be written to /etc/motd after decoding. This allows customization of the message of the day for Linux nodes. It must not be specified for Windows nodes. It must be a static string (i.e., will be printed raw and not be executed as a script). </summary>
         [WirePath("messageOfTheDay")]
         public string MessageOfTheDay { get; set; }
-        /// <summary>
-        /// The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.vnetSubnetID
-        /// </summary>
+        /// <summary> The ID of the subnet which agent pool nodes and optionally pods will join on startup. If this is not specified, a VNET and subnet will be generated and used. If no podSubnetID is specified, this applies to nodes and pods, otherwise it applies to just nodes. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </summary>
         [WirePath("vnetSubnetID")]
         public ResourceIdentifier VnetSubnetId { get; set; }
-        /// <summary>
-        /// The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podSubnetID
-        /// </summary>
+        /// <summary> The ID of the subnet which pods will join when launched. If omitted, pod IPs are statically assigned on the node subnet (see vnetSubnetID for more details). This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}. </summary>
         [WirePath("podSubnetID")]
         public ResourceIdentifier PodSubnetId { get; set; }
-        /// <summary>
-        /// Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.podIPAllocationMode
-        /// </summary>
+        /// <summary> Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'. </summary>
         [WirePath("podIPAllocationMode")]
         public PodIPAllocationMode? PodIPAllocationMode { get; set; }
-        /// <summary>
-        /// The maximum number of pods that can run on a node.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxPods
-        /// </summary>
+        /// <summary> The maximum number of pods that can run on a node. </summary>
         [WirePath("maxPods")]
         public int? MaxPods { get; set; }
-        /// <summary>
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osType
-        /// </summary>
+        /// <summary> The operating system type. The default is Linux. </summary>
         [WirePath("osType")]
         public ContainerServiceOSType? OSType { get; set; }
-        /// <summary>
-        /// Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.osSKU
-        /// </summary>
+        /// <summary> Specifies the OS SKU used by the agent pool. The default is Ubuntu if OSType is Linux. The default is Windows2019 when Kubernetes &lt;= 1.24 or Windows2022 when Kubernetes &gt;= 1.25 if OSType is Windows. </summary>
         [WirePath("osSKU")]
         public ContainerServiceOSSku? OSSku { get; set; }
-        /// <summary>
-        /// The maximum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.maxCount
-        /// </summary>
+        /// <summary> The maximum number of nodes for auto-scaling. </summary>
         [WirePath("maxCount")]
         public int? MaxCount { get; set; }
-        /// <summary>
-        /// The minimum number of nodes for auto-scaling
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.minCount
-        /// </summary>
+        /// <summary> The minimum number of nodes for auto-scaling. </summary>
         [WirePath("minCount")]
         public int? MinCount { get; set; }
-        /// <summary>
-        /// Whether to enable auto-scaler
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableAutoScaling
-        /// </summary>
+        /// <summary> Whether to enable auto-scaler. </summary>
         [WirePath("enableAutoScaling")]
         public bool? EnableAutoScaling { get; set; }
-        /// <summary>
-        /// The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleDownMode
-        /// </summary>
+        /// <summary> The scale down mode to use when scaling the Agent Pool. This also effects the cluster autoscaler behavior. If not specified, it defaults to Delete. </summary>
         [WirePath("scaleDownMode")]
         public ScaleDownMode? ScaleDownMode { get; set; }
-        /// <summary>
-        /// The type of Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.type
-        /// </summary>
+        /// <summary> The type of Agent Pool. </summary>
         [WirePath("type")]
         public AgentPoolType? AgentPoolType { get; set; }
-        /// <summary>
-        /// The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.mode
-        /// </summary>
+        /// <summary> The mode of an agent pool. A cluster must have at least one 'System' Agent Pool at all times. For additional information on agent pool restrictions and best practices, see: https://docs.microsoft.com/azure/aks/use-system-pools. </summary>
         [WirePath("mode")]
         public AgentPoolMode? Mode { get; set; }
-        /// <summary>
-        /// The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.orchestratorVersion
-        /// </summary>
+        /// <summary> The version of Kubernetes specified by the user. Both patch version &lt;major.minor.patch&gt; (e.g. 1.20.13) and &lt;major.minor&gt; (e.g. 1.20) are supported. When &lt;major.minor&gt; is specified, the latest supported GA patch version is chosen automatically. Updating the cluster with the same &lt;major.minor&gt; once it has been created (e.g. 1.14.x -&gt; 1.14) will not trigger an upgrade, even if a newer patch version is available. As a best practice, you should upgrade all node pools in an AKS cluster to the same Kubernetes version. The node pool version must have the same major version as the control plane. The node pool minor version must be within two minor versions of the control plane version. The node pool version cannot be greater than the control plane version. For more information see [upgrading a node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#upgrade-a-node-pool). </summary>
         [WirePath("orchestratorVersion")]
         public string OrchestratorVersion { get; set; }
-        /// <summary>
-        /// The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.currentOrchestratorVersion
-        /// </summary>
+        /// <summary> The version of Kubernetes the Agent Pool is running. If orchestratorVersion is a fully specified version &lt;major.minor.patch&gt;, this field will be exactly equal to it. If orchestratorVersion is &lt;major.minor&gt;, this field will contain the full &lt;major.minor.patch&gt; version being used. </summary>
         [WirePath("currentOrchestratorVersion")]
         public string CurrentOrchestratorVersion { get; }
-        /// <summary>
-        /// The version of node image
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeImageVersion
-        /// </summary>
+        /// <summary> The version of node image. </summary>
         [WirePath("nodeImageVersion")]
         public string NodeImageVersion { get; }
-        /// <summary>
-        /// Settings for upgrading the agentpool
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.upgradeSettings
-        /// </summary>
+        /// <summary> Settings for upgrading the agentpool. </summary>
         [WirePath("upgradeSettings")]
         public AgentPoolUpgradeSettings UpgradeSettings { get; set; }
-        /// <summary>
-        /// The current deployment or provisioning state.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.provisioningState
-        /// </summary>
+        /// <summary> The current deployment or provisioning state. </summary>
         [WirePath("provisioningState")]
         public string ProvisioningState { get; }
-        /// <summary>
-        /// Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.powerState
-        /// </summary>
+        /// <summary> Whether the Agent Pool is running or stopped. When an Agent Pool is first created it is initially Running. The Agent Pool can be stopped by setting this field to Stopped. A stopped Agent Pool stops all of its VMs and does not accrue billing charges. An Agent Pool can only be stopped if it is Running and provisioning state is Succeeded. </summary>
         internal ContainerServicePowerState PowerState { get; set; }
-        /// <summary>
-        /// Tells whether the cluster is Running or Stopped
-        /// Serialized Name: PowerState.code
-        /// </summary>
+        /// <summary> Tells whether the cluster is Running or Stopped. </summary>
         [WirePath("powerState.code")]
         public ContainerServiceStateCode? PowerStateCode
         {
@@ -507,111 +261,57 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.availabilityZones
-        /// </summary>
+        /// <summary> The list of Availability zones to use for nodes. This can only be specified if the AgentPoolType property is 'VirtualMachineScaleSets'. </summary>
         [WirePath("availabilityZones")]
         public IList<string> AvailabilityZones { get; }
-        /// <summary>
-        /// Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableNodePublicIP
-        /// </summary>
+        /// <summary> Whether each node is allocated its own public IP. Some scenarios may require nodes in a node pool to receive their own dedicated public IP addresses. A common scenario is for gaming workloads, where a console needs to make a direct connection to a cloud virtual machine to minimize hops. For more information see [assigning a public IP per node](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#assign-a-public-ip-per-node-for-your-node-pools). The default is false. </summary>
         [WirePath("enableNodePublicIP")]
         public bool? EnableNodePublicIP { get; set; }
-        /// <summary>
-        /// The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodePublicIPPrefixID
-        /// </summary>
+        /// <summary> The public IP prefix ID which VM nodes should use IPs from. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIPPrefixName}. </summary>
         [WirePath("nodePublicIPPrefixID")]
         public ResourceIdentifier NodePublicIPPrefixId { get; set; }
-        /// <summary>
-        /// The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetPriority
-        /// </summary>
+        /// <summary> The Virtual Machine Scale Set priority. If not specified, the default is 'Regular'. </summary>
         [WirePath("scaleSetPriority")]
         public ScaleSetPriority? ScaleSetPriority { get; set; }
-        /// <summary>
-        /// The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.scaleSetEvictionPolicy
-        /// </summary>
+        /// <summary> The Virtual Machine Scale Set eviction policy to use. This cannot be specified unless the scaleSetPriority is 'Spot'. If not specified, the default is 'Delete'. </summary>
         [WirePath("scaleSetEvictionPolicy")]
         public ScaleSetEvictionPolicy? ScaleSetEvictionPolicy { get; set; }
-        /// <summary>
-        /// The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing)
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.spotMaxPrice
-        /// </summary>
+        /// <summary> The max price (in US Dollars) you are willing to pay for spot instances. Possible values are any decimal value greater than zero or -1 which indicates default price to be up-to on-demand. Possible values are any decimal value greater than zero or -1 which indicates the willingness to pay any on-demand price. For more details on spot pricing, see [spot VMs pricing](https://docs.microsoft.com/azure/virtual-machines/spot-vms#pricing). </summary>
         [WirePath("spotMaxPrice")]
         public float? SpotMaxPrice { get; set; }
-        /// <summary>
-        /// The tags to be persisted on the agent pool virtual machine scale set.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.tags
-        /// </summary>
+        /// <summary> The tags to be persisted on the agent pool virtual machine scale set. </summary>
         [WirePath("tags")]
         public IDictionary<string, string> Tags { get; }
-        /// <summary>
-        /// The node labels to be persisted across all nodes in agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeLabels
-        /// </summary>
+        /// <summary> The node labels to be persisted across all nodes in agent pool. </summary>
         [WirePath("nodeLabels")]
         public IDictionary<string, string> NodeLabels { get; }
-        /// <summary>
-        /// The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.nodeTaints
-        /// </summary>
+        /// <summary> The taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. </summary>
         [WirePath("nodeTaints")]
         public IList<string> NodeTaints { get; }
-        /// <summary>
-        /// The ID for Proximity Placement Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.proximityPlacementGroupID
-        /// </summary>
+        /// <summary> The ID for Proximity Placement Group. </summary>
         [WirePath("proximityPlacementGroupID")]
         public ResourceIdentifier ProximityPlacementGroupId { get; set; }
-        /// <summary>
-        /// The Kubelet configuration on the agent pool nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.kubeletConfig
-        /// </summary>
+        /// <summary> The Kubelet configuration on the agent pool nodes. </summary>
         [WirePath("kubeletConfig")]
         public KubeletConfig KubeletConfig { get; set; }
-        /// <summary>
-        /// The OS configuration of Linux agent nodes.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.linuxOSConfig
-        /// </summary>
+        /// <summary> The OS configuration of Linux agent nodes. </summary>
         [WirePath("linuxOSConfig")]
         public LinuxOSConfig LinuxOSConfig { get; set; }
-        /// <summary>
-        /// Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableEncryptionAtHost
-        /// </summary>
+        /// <summary> Whether to enable host based OS and data drive encryption. This is only supported on certain VM sizes and in certain Azure regions. For more information, see: https://docs.microsoft.com/azure/aks/enable-host-encryption. </summary>
         [WirePath("enableEncryptionAtHost")]
         public bool? EnableEncryptionAtHost { get; set; }
-        /// <summary>
-        /// Whether to enable UltraSSD
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableUltraSSD
-        /// </summary>
+        /// <summary> Whether to enable UltraSSD. </summary>
         [WirePath("enableUltraSSD")]
         public bool? EnableUltraSsd { get; set; }
-        /// <summary>
-        /// Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.enableFIPS
-        /// </summary>
+        /// <summary> Whether to use a FIPS-enabled OS. See [Add a FIPS-enabled node pool](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview) for more details. </summary>
         [WirePath("enableFIPS")]
         public bool? EnableFips { get; set; }
-        /// <summary>
-        /// GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuInstanceProfile
-        /// </summary>
+        /// <summary> GPUInstanceProfile to be used to specify GPU MIG instance profile for supported GPU VM SKU. </summary>
         [WirePath("gpuInstanceProfile")]
         public GpuInstanceProfile? GpuInstanceProfile { get; set; }
-        /// <summary>
-        /// CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.creationData
-        /// </summary>
+        /// <summary> CreationData to be used to specify the source Snapshot ID if the node pool will be created/upgraded using a snapshot. </summary>
         internal ContainerServiceCreationData CreationData { get; set; }
-        /// <summary>
-        /// This is the ARM ID of the source object to be used to create the target object.
-        /// Serialized Name: CreationData.sourceResourceId
-        /// </summary>
+        /// <summary> This is the ARM ID of the source object to be used to create the target object. </summary>
         [WirePath("creationData.sourceResourceId")]
         public ResourceIdentifier CreationDataSourceResourceId
         {
@@ -624,33 +324,18 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// AKS will associate the specified agent pool with the Capacity Reservation Group.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.capacityReservationGroupID
-        /// </summary>
+        /// <summary> AKS will associate the specified agent pool with the Capacity Reservation Group. </summary>
         [WirePath("capacityReservationGroupID")]
         public ResourceIdentifier CapacityReservationGroupId { get; set; }
-        /// <summary>
-        /// The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts).
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.hostGroupID
-        /// </summary>
+        /// <summary> The fully qualified resource ID of the Dedicated Host Group to provision virtual machines from, used only in creation scenario and not allowed to changed once set. This is of the form: /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}. For more information see [Azure dedicated hosts](https://docs.microsoft.com/azure/virtual-machines/dedicated-hosts). </summary>
         [WirePath("hostGroupID")]
         public ResourceIdentifier HostGroupId { get; set; }
-        /// <summary>
-        /// Network-related settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.networkProfile
-        /// </summary>
+        /// <summary> Network-related settings of an agent pool. </summary>
         [WirePath("networkProfile")]
         public AgentPoolNetworkProfile NetworkProfile { get; set; }
-        /// <summary>
-        /// The Windows agent pool's specific profile.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.windowsProfile
-        /// </summary>
+        /// <summary> The Windows agent pool's specific profile. </summary>
         internal AgentPoolWindowsProfile WindowsProfile { get; set; }
-        /// <summary>
-        /// Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled.
-        /// Serialized Name: AgentPoolWindowsProfile.disableOutboundNat
-        /// </summary>
+        /// <summary> Whether to disable OutboundNAT in windows nodes. The default value is false. Outbound NAT can only be disabled if the cluster outboundType is NAT Gateway and the Windows agent pool does not have node public IP enabled. </summary>
         [WirePath("windowsProfile.disableOutboundNat")]
         public bool? IsOutboundNatDisabled
         {
@@ -663,21 +348,12 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// The security settings of an agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.securityProfile
-        /// </summary>
+        /// <summary> The security settings of an agent pool. </summary>
         [WirePath("securityProfile")]
         public AgentPoolSecurityProfile SecurityProfile { get; set; }
-        /// <summary>
-        /// GPU settings for the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gpuProfile
-        /// </summary>
+        /// <summary> GPU settings for the Agent Pool. </summary>
         internal AgentPoolGpuProfile GpuProfile { get; set; }
-        /// <summary>
-        /// Whether to install GPU drivers. When it's not specified, default is Install.
-        /// Serialized Name: GPUProfile.driver
-        /// </summary>
+        /// <summary> Whether to install GPU drivers. When it's not specified, default is Install. </summary>
         [WirePath("gpuProfile.driver")]
         public AgentPoolGpuDriver? GpuDriver
         {
@@ -690,15 +366,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.gatewayProfile
-        /// </summary>
+        /// <summary> Profile specific to a managed agent pool in Gateway mode. This field cannot be set if agent pool mode is not Gateway. </summary>
         internal AgentPoolGatewayProfile GatewayProfile { get; set; }
-        /// <summary>
-        /// The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31] (/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31.
-        /// Serialized Name: AgentPoolGatewayProfile.publicIPPrefixSize
-        /// </summary>
+        /// <summary> The Gateway agent pool associates one public IPPrefix for each static egress gateway to provide public egress. The size of Public IPPrefix should be selected by the user. Each node in the agent pool is assigned with one IP from the IPPrefix. The IPPrefix size thus serves as a cap on the size of the Gateway agent pool. Due to Azure public IPPrefix size limitation, the valid value range is [28, 31] (/31 = 2 nodes/IPs, /30 = 4 nodes/IPs, /29 = 8 nodes/IPs, /28 = 16 nodes/IPs). The default value is 31. </summary>
         [WirePath("gatewayProfile.publicIPPrefixSize")]
         public int? GatewayPublicIPPrefixSize
         {
@@ -711,15 +381,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// Specifications on VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachinesProfile
-        /// </summary>
+        /// <summary> Specifications on VirtualMachines agent pool. </summary>
         internal VirtualMachinesProfile VirtualMachinesProfile { get; set; }
-        /// <summary>
-        /// Specifications on how to scale the VirtualMachines agent pool to a fixed size.
-        /// Serialized Name: ScaleProfile.manual
-        /// </summary>
+        /// <summary> Specifications on how to scale the VirtualMachines agent pool to a fixed size. </summary>
         [WirePath("virtualMachinesProfile.scale.manual")]
         public IList<ManualScaleProfile> ScaleManual
         {
@@ -731,31 +395,19 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// The status of nodes in a VirtualMachines agent pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.virtualMachineNodesStatus
-        /// </summary>
+        /// <summary> The status of nodes in a VirtualMachines agent pool. </summary>
         [WirePath("virtualMachineNodesStatus")]
         public IList<AgentPoolVirtualMachineNodes> VirtualMachineNodesStatus { get; }
-        /// <summary>
-        /// Contains read-only information about the Agent Pool.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.status
-        /// </summary>
+        /// <summary> Contains read-only information about the Agent Pool. </summary>
         internal AgentPoolStatus Status { get; set; }
-        /// <summary>
-        /// The error detail information of the agent pool. Preserves the detailed info of failure. If there was no error, this field is omitted.
-        /// Serialized Name: AgentPoolStatus.provisioningError
-        /// </summary>
+        /// <summary> The error detail information of the agent pool. Preserves the detailed info of failure. If there was no error, this field is omitted. </summary>
         [WirePath("status.provisioningError")]
         public ResponseError StatusProvisioningError
         {
             get => Status is null ? default : Status.ProvisioningError;
         }
 
-        /// <summary>
-        /// Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns.
-        /// Serialized Name: ManagedClusterAgentPoolProfileProperties.localDNSProfile
-        /// </summary>
+        /// <summary> Configures the per-node local DNS, with VnetDNS and KubeDNS overrides. LocalDNS helps improve performance and reliability of DNS resolution in an AKS cluster. For more details see aka.ms/aks/localdns. </summary>
         [WirePath("localDNSProfile")]
         public LocalDnsProfile LocalDnsProfile { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterApiServerAccessProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterApiServerAccessProfile.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Access profile for managed cluster API server.
-    /// Serialized Name: ManagedClusterAPIServerAccessProfile
-    /// </summary>
+    /// <summary> Access profile for managed cluster API server. </summary>
     public partial class ManagedClusterApiServerAccessProfile
     {
         /// <summary>
@@ -56,34 +53,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterApiServerAccessProfile"/>. </summary>
-        /// <param name="authorizedIPRanges">
-        /// The IP ranges authorized to access the Kubernetes API server. IP ranges are specified in CIDR format, e.g. 137.117.106.88/29. This feature is not compatible with clusters that use Public IP Per Node, or clusters that are using a Basic Load Balancer. For more information see [API server authorized IP ranges](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges).
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.authorizedIPRanges
-        /// </param>
-        /// <param name="enablePrivateCluster">
-        /// Whether to create the cluster as a private cluster or not. For more details, see [Creating a private AKS cluster](https://docs.microsoft.com/azure/aks/private-clusters).
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.enablePrivateCluster
-        /// </param>
-        /// <param name="privateDnsZone">
-        /// The private DNS zone mode for the cluster. The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.privateDNSZone
-        /// </param>
-        /// <param name="enablePrivateClusterPublicFqdn">
-        /// Whether to create additional public FQDN for private cluster or not.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.enablePrivateClusterPublicFQDN
-        /// </param>
-        /// <param name="disableRunCommand">
-        /// Whether to disable run command for the cluster or not.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.disableRunCommand
-        /// </param>
-        /// <param name="enableVnetIntegration">
-        /// Whether to enable apiserver vnet integration for the cluster or not. See aka.ms/AksVnetIntegration for more details.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.enableVnetIntegration
-        /// </param>
-        /// <param name="subnetId">
-        /// The subnet to be used when apiserver vnet integration is enabled. It is required when creating a new cluster with BYO Vnet, or when updating an existing cluster to enable apiserver vnet integration.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.subnetId
-        /// </param>
+        /// <param name="authorizedIPRanges"> The IP ranges authorized to access the Kubernetes API server. IP ranges are specified in CIDR format, e.g. 137.117.106.88/29. This feature is not compatible with clusters that use Public IP Per Node, or clusters that are using a Basic Load Balancer. For more information see [API server authorized IP ranges](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges). </param>
+        /// <param name="enablePrivateCluster"> Whether to create the cluster as a private cluster or not. For more details, see [Creating a private AKS cluster](https://docs.microsoft.com/azure/aks/private-clusters). </param>
+        /// <param name="privateDnsZone"> The private DNS zone mode for the cluster. The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'. </param>
+        /// <param name="enablePrivateClusterPublicFqdn"> Whether to create additional public FQDN for private cluster or not. </param>
+        /// <param name="disableRunCommand"> Whether to disable run command for the cluster or not. </param>
+        /// <param name="enableVnetIntegration"> Whether to enable apiserver vnet integration for the cluster or not. See aka.ms/AksVnetIntegration for more details. </param>
+        /// <param name="subnetId"> The subnet to be used when apiserver vnet integration is enabled. It is required when creating a new cluster with BYO Vnet, or when updating an existing cluster to enable apiserver vnet integration. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterApiServerAccessProfile(IList<string> authorizedIPRanges, bool? enablePrivateCluster, string privateDnsZone, bool? enablePrivateClusterPublicFqdn, bool? disableRunCommand, bool? enableVnetIntegration, ResourceIdentifier subnetId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -97,46 +73,25 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The IP ranges authorized to access the Kubernetes API server. IP ranges are specified in CIDR format, e.g. 137.117.106.88/29. This feature is not compatible with clusters that use Public IP Per Node, or clusters that are using a Basic Load Balancer. For more information see [API server authorized IP ranges](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges).
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.authorizedIPRanges
-        /// </summary>
+        /// <summary> The IP ranges authorized to access the Kubernetes API server. IP ranges are specified in CIDR format, e.g. 137.117.106.88/29. This feature is not compatible with clusters that use Public IP Per Node, or clusters that are using a Basic Load Balancer. For more information see [API server authorized IP ranges](https://docs.microsoft.com/azure/aks/api-server-authorized-ip-ranges). </summary>
         [WirePath("authorizedIPRanges")]
         public IList<string> AuthorizedIPRanges { get; }
-        /// <summary>
-        /// Whether to create the cluster as a private cluster or not. For more details, see [Creating a private AKS cluster](https://docs.microsoft.com/azure/aks/private-clusters).
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.enablePrivateCluster
-        /// </summary>
+        /// <summary> Whether to create the cluster as a private cluster or not. For more details, see [Creating a private AKS cluster](https://docs.microsoft.com/azure/aks/private-clusters). </summary>
         [WirePath("enablePrivateCluster")]
         public bool? EnablePrivateCluster { get; set; }
-        /// <summary>
-        /// The private DNS zone mode for the cluster. The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.privateDNSZone
-        /// </summary>
+        /// <summary> The private DNS zone mode for the cluster. The default is System. For more details see [configure private DNS zone](https://docs.microsoft.com/azure/aks/private-clusters#configure-private-dns-zone). Allowed values are 'system' and 'none'. </summary>
         [WirePath("privateDNSZone")]
         public string PrivateDnsZone { get; set; }
-        /// <summary>
-        /// Whether to create additional public FQDN for private cluster or not.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.enablePrivateClusterPublicFQDN
-        /// </summary>
+        /// <summary> Whether to create additional public FQDN for private cluster or not. </summary>
         [WirePath("enablePrivateClusterPublicFQDN")]
         public bool? EnablePrivateClusterPublicFqdn { get; set; }
-        /// <summary>
-        /// Whether to disable run command for the cluster or not.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.disableRunCommand
-        /// </summary>
+        /// <summary> Whether to disable run command for the cluster or not. </summary>
         [WirePath("disableRunCommand")]
         public bool? DisableRunCommand { get; set; }
-        /// <summary>
-        /// Whether to enable apiserver vnet integration for the cluster or not. See aka.ms/AksVnetIntegration for more details.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.enableVnetIntegration
-        /// </summary>
+        /// <summary> Whether to enable apiserver vnet integration for the cluster or not. See aka.ms/AksVnetIntegration for more details. </summary>
         [WirePath("enableVnetIntegration")]
         public bool? EnableVnetIntegration { get; set; }
-        /// <summary>
-        /// The subnet to be used when apiserver vnet integration is enabled. It is required when creating a new cluster with BYO Vnet, or when updating an existing cluster to enable apiserver vnet integration.
-        /// Serialized Name: ManagedClusterAPIServerAccessProfile.subnetId
-        /// </summary>
+        /// <summary> The subnet to be used when apiserver vnet integration is enabled. It is required when creating a new cluster with BYO Vnet, or when updating an existing cluster to enable apiserver vnet integration. </summary>
         [WirePath("subnetId")]
         public ResourceIdentifier SubnetId { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAutoScalerProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAutoScalerProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Parameters to be applied to the cluster-autoscaler when enabled
-    /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile
-    /// </summary>
+    /// <summary> Parameters to be applied to the cluster-autoscaler when enabled. </summary>
     public partial class ManagedClusterAutoScalerProfile
     {
         /// <summary>
@@ -54,86 +51,26 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAutoScalerProfile"/>. </summary>
-        /// <param name="balanceSimilarNodeGroups">
-        /// Detects similar node pools and balances the number of nodes between them. Valid values are 'true' and 'false'
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.balance-similar-node-groups
-        /// </param>
-        /// <param name="daemonsetEvictionForEmptyNodes">
-        /// DaemonSet pods will be gracefully terminated from empty nodes. If set to true, all daemonset pods on empty nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.daemonset-eviction-for-empty-nodes
-        /// </param>
-        /// <param name="daemonsetEvictionForOccupiedNodes">
-        /// DaemonSet pods will be gracefully terminated from non-empty nodes. If set to true, all daemonset pods on occupied nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.daemonset-eviction-for-occupied-nodes
-        /// </param>
-        /// <param name="ignoreDaemonsetsUtilization">
-        /// Should CA ignore DaemonSet pods when calculating resource utilization for scaling down. If set to true, the resources used by daemonset will be taken into account when making scaling down decisions.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.ignore-daemonsets-utilization
-        /// </param>
-        /// <param name="expander">
-        /// The expander to use when scaling up. If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.expander
-        /// </param>
-        /// <param name="maxEmptyBulkDelete">
-        /// The maximum number of empty nodes that can be deleted at the same time. This must be a positive integer. The default is 10.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.max-empty-bulk-delete
-        /// </param>
-        /// <param name="maxGracefulTerminationSec">
-        /// The maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. The default is 600.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.max-graceful-termination-sec
-        /// </param>
-        /// <param name="maxNodeProvisionTime">
-        /// The maximum time the autoscaler waits for a node to be provisioned. The default is '15m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.max-node-provision-time
-        /// </param>
-        /// <param name="maxTotalUnreadyPercentage">
-        /// The maximum percentage of unready nodes in the cluster. After this percentage is exceeded, cluster autoscaler halts operations. The default is 45. The maximum is 100 and the minimum is 0.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.max-total-unready-percentage
-        /// </param>
-        /// <param name="newPodScaleUpDelay">
-        /// Ignore unscheduled pods before they're a certain age. For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. The default is '0s'. Values must be an integer followed by a unit ('s' for seconds, 'm' for minutes, 'h' for hours, etc).
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.new-pod-scale-up-delay
-        /// </param>
-        /// <param name="okTotalUnreadyCount">
-        /// The number of allowed unready nodes, irrespective of max-total-unready-percentage. This must be an integer. The default is 3.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.ok-total-unready-count
-        /// </param>
-        /// <param name="scanIntervalInSeconds">
-        /// How often cluster is reevaluated for scale up or down. The default is '10'. Values must be an integer number of seconds.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scan-interval
-        /// </param>
-        /// <param name="scaleDownDelayAfterAdd">
-        /// How long after scale up that scale down evaluation resumes. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-delay-after-add
-        /// </param>
-        /// <param name="scaleDownDelayAfterDelete">
-        /// How long after node deletion that scale down evaluation resumes. The default is the scan-interval. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-delay-after-delete
-        /// </param>
-        /// <param name="scaleDownDelayAfterFailure">
-        /// How long after scale down failure that scale down evaluation resumes. The default is '3m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-delay-after-failure
-        /// </param>
-        /// <param name="scaleDownUnneededTime">
-        /// How long a node should be unneeded before it is eligible for scale down. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-unneeded-time
-        /// </param>
-        /// <param name="scaleDownUnreadyTime">
-        /// How long an unready node should be unneeded before it is eligible for scale down. The default is '20m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-unready-time
-        /// </param>
-        /// <param name="scaleDownUtilizationThreshold">
-        /// Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. The default is '0.5'.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-utilization-threshold
-        /// </param>
-        /// <param name="skipNodesWithLocalStorage">
-        /// If cluster autoscaler will skip deleting nodes with pods with local storage, for example, EmptyDir or HostPath. The default is true.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.skip-nodes-with-local-storage
-        /// </param>
-        /// <param name="skipNodesWithSystemPods">
-        /// If cluster autoscaler will skip deleting nodes with pods from kube-system (except for DaemonSet or mirror pods). The default is true.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.skip-nodes-with-system-pods
-        /// </param>
+        /// <param name="balanceSimilarNodeGroups"> Detects similar node pools and balances the number of nodes between them. Valid values are 'true' and 'false'. </param>
+        /// <param name="daemonsetEvictionForEmptyNodes"> DaemonSet pods will be gracefully terminated from empty nodes. If set to true, all daemonset pods on empty nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted. </param>
+        /// <param name="daemonsetEvictionForOccupiedNodes"> DaemonSet pods will be gracefully terminated from non-empty nodes. If set to true, all daemonset pods on occupied nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted. </param>
+        /// <param name="ignoreDaemonsetsUtilization"> Should CA ignore DaemonSet pods when calculating resource utilization for scaling down. If set to true, the resources used by daemonset will be taken into account when making scaling down decisions. </param>
+        /// <param name="expander"> The expander to use when scaling up. If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information. </param>
+        /// <param name="maxEmptyBulkDelete"> The maximum number of empty nodes that can be deleted at the same time. This must be a positive integer. The default is 10. </param>
+        /// <param name="maxGracefulTerminationSec"> The maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. The default is 600. </param>
+        /// <param name="maxNodeProvisionTime"> The maximum time the autoscaler waits for a node to be provisioned. The default is '15m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </param>
+        /// <param name="maxTotalUnreadyPercentage"> The maximum percentage of unready nodes in the cluster. After this percentage is exceeded, cluster autoscaler halts operations. The default is 45. The maximum is 100 and the minimum is 0. </param>
+        /// <param name="newPodScaleUpDelay"> Ignore unscheduled pods before they're a certain age. For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. The default is '0s'. Values must be an integer followed by a unit ('s' for seconds, 'm' for minutes, 'h' for hours, etc). </param>
+        /// <param name="okTotalUnreadyCount"> The number of allowed unready nodes, irrespective of max-total-unready-percentage. This must be an integer. The default is 3. </param>
+        /// <param name="scanIntervalInSeconds"> How often cluster is reevaluated for scale up or down. The default is '10'. Values must be an integer number of seconds. </param>
+        /// <param name="scaleDownDelayAfterAdd"> How long after scale up that scale down evaluation resumes. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </param>
+        /// <param name="scaleDownDelayAfterDelete"> How long after node deletion that scale down evaluation resumes. The default is the scan-interval. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </param>
+        /// <param name="scaleDownDelayAfterFailure"> How long after scale down failure that scale down evaluation resumes. The default is '3m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </param>
+        /// <param name="scaleDownUnneededTime"> How long a node should be unneeded before it is eligible for scale down. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </param>
+        /// <param name="scaleDownUnreadyTime"> How long an unready node should be unneeded before it is eligible for scale down. The default is '20m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </param>
+        /// <param name="scaleDownUtilizationThreshold"> Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. The default is '0.5'. </param>
+        /// <param name="skipNodesWithLocalStorage"> If cluster autoscaler will skip deleting nodes with pods with local storage, for example, EmptyDir or HostPath. The default is true. </param>
+        /// <param name="skipNodesWithSystemPods"> If cluster autoscaler will skip deleting nodes with pods from kube-system (except for DaemonSet or mirror pods). The default is true. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAutoScalerProfile(string balanceSimilarNodeGroups, bool? daemonsetEvictionForEmptyNodes, bool? daemonsetEvictionForOccupiedNodes, bool? ignoreDaemonsetsUtilization, AutoScaleExpander? expander, string maxEmptyBulkDelete, string maxGracefulTerminationSec, string maxNodeProvisionTime, string maxTotalUnreadyPercentage, string newPodScaleUpDelay, string okTotalUnreadyCount, string scanIntervalInSeconds, string scaleDownDelayAfterAdd, string scaleDownDelayAfterDelete, string scaleDownDelayAfterFailure, string scaleDownUnneededTime, string scaleDownUnreadyTime, string scaleDownUtilizationThreshold, string skipNodesWithLocalStorage, string skipNodesWithSystemPods, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -160,124 +97,64 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Detects similar node pools and balances the number of nodes between them. Valid values are 'true' and 'false'
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.balance-similar-node-groups
-        /// </summary>
+        /// <summary> Detects similar node pools and balances the number of nodes between them. Valid values are 'true' and 'false'. </summary>
         [WirePath("balance-similar-node-groups")]
         public string BalanceSimilarNodeGroups { get; set; }
-        /// <summary>
-        /// DaemonSet pods will be gracefully terminated from empty nodes. If set to true, all daemonset pods on empty nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.daemonset-eviction-for-empty-nodes
-        /// </summary>
+        /// <summary> DaemonSet pods will be gracefully terminated from empty nodes. If set to true, all daemonset pods on empty nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted. </summary>
         [WirePath("daemonset-eviction-for-empty-nodes")]
         public bool? DaemonsetEvictionForEmptyNodes { get; set; }
-        /// <summary>
-        /// DaemonSet pods will be gracefully terminated from non-empty nodes. If set to true, all daemonset pods on occupied nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.daemonset-eviction-for-occupied-nodes
-        /// </summary>
+        /// <summary> DaemonSet pods will be gracefully terminated from non-empty nodes. If set to true, all daemonset pods on occupied nodes will be evicted before deletion of the node. If the daemonset pod cannot be evicted another node will be chosen for scaling. If set to false, the node will be deleted without ensuring that daemonset pods are deleted or evicted. </summary>
         [WirePath("daemonset-eviction-for-occupied-nodes")]
         public bool? DaemonsetEvictionForOccupiedNodes { get; set; }
-        /// <summary>
-        /// Should CA ignore DaemonSet pods when calculating resource utilization for scaling down. If set to true, the resources used by daemonset will be taken into account when making scaling down decisions.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.ignore-daemonsets-utilization
-        /// </summary>
+        /// <summary> Should CA ignore DaemonSet pods when calculating resource utilization for scaling down. If set to true, the resources used by daemonset will be taken into account when making scaling down decisions. </summary>
         [WirePath("ignore-daemonsets-utilization")]
         public bool? IgnoreDaemonsetsUtilization { get; set; }
-        /// <summary>
-        /// The expander to use when scaling up. If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.expander
-        /// </summary>
+        /// <summary> The expander to use when scaling up. If not specified, the default is 'random'. See [expanders](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) for more information. </summary>
         [WirePath("expander")]
         public AutoScaleExpander? Expander { get; set; }
-        /// <summary>
-        /// The maximum number of empty nodes that can be deleted at the same time. This must be a positive integer. The default is 10.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.max-empty-bulk-delete
-        /// </summary>
+        /// <summary> The maximum number of empty nodes that can be deleted at the same time. This must be a positive integer. The default is 10. </summary>
         [WirePath("max-empty-bulk-delete")]
         public string MaxEmptyBulkDelete { get; set; }
-        /// <summary>
-        /// The maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. The default is 600.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.max-graceful-termination-sec
-        /// </summary>
+        /// <summary> The maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. The default is 600. </summary>
         [WirePath("max-graceful-termination-sec")]
         public string MaxGracefulTerminationSec { get; set; }
-        /// <summary>
-        /// The maximum time the autoscaler waits for a node to be provisioned. The default is '15m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.max-node-provision-time
-        /// </summary>
+        /// <summary> The maximum time the autoscaler waits for a node to be provisioned. The default is '15m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </summary>
         [WirePath("max-node-provision-time")]
         public string MaxNodeProvisionTime { get; set; }
-        /// <summary>
-        /// The maximum percentage of unready nodes in the cluster. After this percentage is exceeded, cluster autoscaler halts operations. The default is 45. The maximum is 100 and the minimum is 0.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.max-total-unready-percentage
-        /// </summary>
+        /// <summary> The maximum percentage of unready nodes in the cluster. After this percentage is exceeded, cluster autoscaler halts operations. The default is 45. The maximum is 100 and the minimum is 0. </summary>
         [WirePath("max-total-unready-percentage")]
         public string MaxTotalUnreadyPercentage { get; set; }
-        /// <summary>
-        /// Ignore unscheduled pods before they're a certain age. For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. The default is '0s'. Values must be an integer followed by a unit ('s' for seconds, 'm' for minutes, 'h' for hours, etc).
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.new-pod-scale-up-delay
-        /// </summary>
+        /// <summary> Ignore unscheduled pods before they're a certain age. For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. The default is '0s'. Values must be an integer followed by a unit ('s' for seconds, 'm' for minutes, 'h' for hours, etc). </summary>
         [WirePath("new-pod-scale-up-delay")]
         public string NewPodScaleUpDelay { get; set; }
-        /// <summary>
-        /// The number of allowed unready nodes, irrespective of max-total-unready-percentage. This must be an integer. The default is 3.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.ok-total-unready-count
-        /// </summary>
+        /// <summary> The number of allowed unready nodes, irrespective of max-total-unready-percentage. This must be an integer. The default is 3. </summary>
         [WirePath("ok-total-unready-count")]
         public string OkTotalUnreadyCount { get; set; }
-        /// <summary>
-        /// How often cluster is reevaluated for scale up or down. The default is '10'. Values must be an integer number of seconds.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scan-interval
-        /// </summary>
+        /// <summary> How often cluster is reevaluated for scale up or down. The default is '10'. Values must be an integer number of seconds. </summary>
         [WirePath("scan-interval")]
         public string ScanIntervalInSeconds { get; set; }
-        /// <summary>
-        /// How long after scale up that scale down evaluation resumes. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-delay-after-add
-        /// </summary>
+        /// <summary> How long after scale up that scale down evaluation resumes. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </summary>
         [WirePath("scale-down-delay-after-add")]
         public string ScaleDownDelayAfterAdd { get; set; }
-        /// <summary>
-        /// How long after node deletion that scale down evaluation resumes. The default is the scan-interval. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-delay-after-delete
-        /// </summary>
+        /// <summary> How long after node deletion that scale down evaluation resumes. The default is the scan-interval. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </summary>
         [WirePath("scale-down-delay-after-delete")]
         public string ScaleDownDelayAfterDelete { get; set; }
-        /// <summary>
-        /// How long after scale down failure that scale down evaluation resumes. The default is '3m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-delay-after-failure
-        /// </summary>
+        /// <summary> How long after scale down failure that scale down evaluation resumes. The default is '3m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </summary>
         [WirePath("scale-down-delay-after-failure")]
         public string ScaleDownDelayAfterFailure { get; set; }
-        /// <summary>
-        /// How long a node should be unneeded before it is eligible for scale down. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-unneeded-time
-        /// </summary>
+        /// <summary> How long a node should be unneeded before it is eligible for scale down. The default is '10m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </summary>
         [WirePath("scale-down-unneeded-time")]
         public string ScaleDownUnneededTime { get; set; }
-        /// <summary>
-        /// How long an unready node should be unneeded before it is eligible for scale down. The default is '20m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-unready-time
-        /// </summary>
+        /// <summary> How long an unready node should be unneeded before it is eligible for scale down. The default is '20m'. Values must be an integer followed by an 'm'. No unit of time other than minutes (m) is supported. </summary>
         [WirePath("scale-down-unready-time")]
         public string ScaleDownUnreadyTime { get; set; }
-        /// <summary>
-        /// Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. The default is '0.5'.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.scale-down-utilization-threshold
-        /// </summary>
+        /// <summary> Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. The default is '0.5'. </summary>
         [WirePath("scale-down-utilization-threshold")]
         public string ScaleDownUtilizationThreshold { get; set; }
-        /// <summary>
-        /// If cluster autoscaler will skip deleting nodes with pods with local storage, for example, EmptyDir or HostPath. The default is true.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.skip-nodes-with-local-storage
-        /// </summary>
+        /// <summary> If cluster autoscaler will skip deleting nodes with pods with local storage, for example, EmptyDir or HostPath. The default is true. </summary>
         [WirePath("skip-nodes-with-local-storage")]
         public string SkipNodesWithLocalStorage { get; set; }
-        /// <summary>
-        /// If cluster autoscaler will skip deleting nodes with pods from kube-system (except for DaemonSet or mirror pods). The default is true.
-        /// Serialized Name: ManagedClusterPropertiesAutoScalerProfile.skip-nodes-with-system-pods
-        /// </summary>
+        /// <summary> If cluster autoscaler will skip deleting nodes with pods from kube-system (except for DaemonSet or mirror pods). The default is true. </summary>
         [WirePath("skip-nodes-with-system-pods")]
         public string SkipNodesWithSystemPods { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAutoUpgradeProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAutoUpgradeProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Auto upgrade profile for a managed cluster.
-    /// Serialized Name: ManagedClusterAutoUpgradeProfile
-    /// </summary>
+    /// <summary> Auto upgrade profile for a managed cluster. </summary>
     public partial class ManagedClusterAutoUpgradeProfile
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAutoUpgradeProfile"/>. </summary>
-        /// <param name="upgradeChannel">
-        /// The upgrade channel for auto upgrade. The default is 'none'. For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel).
-        /// Serialized Name: ManagedClusterAutoUpgradeProfile.upgradeChannel
-        /// </param>
-        /// <param name="nodeOSUpgradeChannel">
-        /// Node OS Upgrade Channel. Manner in which the OS on your nodes is updated. The default is NodeImage.
-        /// Serialized Name: ManagedClusterAutoUpgradeProfile.nodeOSUpgradeChannel
-        /// </param>
+        /// <param name="upgradeChannel"> The upgrade channel for auto upgrade. The default is 'none'. For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel). </param>
+        /// <param name="nodeOSUpgradeChannel"> Node OS Upgrade Channel. Manner in which the OS on your nodes is updated. The default is NodeImage. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAutoUpgradeProfile(UpgradeChannel? upgradeChannel, ManagedClusterNodeOSUpgradeChannel? nodeOSUpgradeChannel, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The upgrade channel for auto upgrade. The default is 'none'. For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel).
-        /// Serialized Name: ManagedClusterAutoUpgradeProfile.upgradeChannel
-        /// </summary>
+        /// <summary> The upgrade channel for auto upgrade. The default is 'none'. For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel). </summary>
         [WirePath("upgradeChannel")]
         public UpgradeChannel? UpgradeChannel { get; set; }
-        /// <summary>
-        /// Node OS Upgrade Channel. Manner in which the OS on your nodes is updated. The default is NodeImage.
-        /// Serialized Name: ManagedClusterAutoUpgradeProfile.nodeOSUpgradeChannel
-        /// </summary>
+        /// <summary> Node OS Upgrade Channel. Manner in which the OS on your nodes is updated. The default is NodeImage. </summary>
         [WirePath("nodeOSUpgradeChannel")]
         public ManagedClusterNodeOSUpgradeChannel? NodeOSUpgradeChannel { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAzureMonitorProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterAzureMonitorProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Azure Monitor addon profiles for monitoring the managed cluster.
-    /// Serialized Name: ManagedClusterAzureMonitorProfile
-    /// </summary>
+    /// <summary> Azure Monitor addon profiles for monitoring the managed cluster. </summary>
     internal partial class ManagedClusterAzureMonitorProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterAzureMonitorProfile"/>. </summary>
-        /// <param name="metrics">
-        /// Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview.
-        /// Serialized Name: ManagedClusterAzureMonitorProfile.metrics
-        /// </param>
+        /// <param name="metrics"> Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterAzureMonitorProfile(ManagedClusterMonitorProfileMetrics metrics, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview.
-        /// Serialized Name: ManagedClusterAzureMonitorProfile.metrics
-        /// </summary>
+        /// <summary> Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview. </summary>
         [WirePath("metrics")]
         public ManagedClusterMonitorProfileMetrics Metrics { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterBootstrapProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterBootstrapProfile.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The bootstrap profile.
-    /// Serialized Name: ManagedClusterBootstrapProfile
-    /// </summary>
+    /// <summary> The bootstrap profile. </summary>
     public partial class ManagedClusterBootstrapProfile
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterBootstrapProfile"/>. </summary>
-        /// <param name="artifactSource">
-        /// The artifact source. The source where the artifacts are downloaded from.
-        /// Serialized Name: ManagedClusterBootstrapProfile.artifactSource
-        /// </param>
-        /// <param name="containerRegistryId">
-        /// The resource Id of Azure Container Registry. The registry must have private network access, premium SKU and zone redundancy.
-        /// Serialized Name: ManagedClusterBootstrapProfile.containerRegistryId
-        /// </param>
+        /// <param name="artifactSource"> The artifact source. The source where the artifacts are downloaded from. </param>
+        /// <param name="containerRegistryId"> The resource Id of Azure Container Registry. The registry must have private network access, premium SKU and zone redundancy. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterBootstrapProfile(ContainerServiceArtifactSource? artifactSource, ResourceIdentifier containerRegistryId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,16 +62,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The artifact source. The source where the artifacts are downloaded from.
-        /// Serialized Name: ManagedClusterBootstrapProfile.artifactSource
-        /// </summary>
+        /// <summary> The artifact source. The source where the artifacts are downloaded from. </summary>
         [WirePath("artifactSource")]
         public ContainerServiceArtifactSource? ArtifactSource { get; set; }
-        /// <summary>
-        /// The resource Id of Azure Container Registry. The registry must have private network access, premium SKU and zone redundancy.
-        /// Serialized Name: ManagedClusterBootstrapProfile.containerRegistryId
-        /// </summary>
+        /// <summary> The resource Id of Azure Container Registry. The registry must have private network access, premium SKU and zone redundancy. </summary>
         [WirePath("containerRegistryId")]
         public ResourceIdentifier ContainerRegistryId { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterCostAnalysis.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterCostAnalysis.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The cost analysis configuration for the cluster
-    /// Serialized Name: ManagedClusterCostAnalysis
-    /// </summary>
+    /// <summary> The cost analysis configuration for the cluster. </summary>
     internal partial class ManagedClusterCostAnalysis
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterCostAnalysis"/>. </summary>
-        /// <param name="isCostAnalysisEnabled">
-        /// Whether to enable cost analysis. The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis.
-        /// Serialized Name: ManagedClusterCostAnalysis.enabled
-        /// </param>
+        /// <param name="isCostAnalysisEnabled"> Whether to enable cost analysis. The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterCostAnalysis(bool? isCostAnalysisEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable cost analysis. The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis.
-        /// Serialized Name: ManagedClusterCostAnalysis.enabled
-        /// </summary>
+        /// <summary> Whether to enable cost analysis. The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis. </summary>
         [WirePath("enabled")]
         public bool? IsCostAnalysisEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterCredential.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterCredential.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The credential result response.
-    /// Serialized Name: CredentialResult
-    /// </summary>
+    /// <summary> The credential result response. </summary>
     public partial class ManagedClusterCredential
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterCredential"/>. </summary>
-        /// <param name="name">
-        /// The name of the credential.
-        /// Serialized Name: CredentialResult.name
-        /// </param>
-        /// <param name="value">
-        /// Base64-encoded Kubernetes configuration file.
-        /// Serialized Name: CredentialResult.value
-        /// </param>
+        /// <param name="name"> The name of the credential. </param>
+        /// <param name="value"> Base64-encoded Kubernetes configuration file. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterCredential(string name, byte[] value, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The name of the credential.
-        /// Serialized Name: CredentialResult.name
-        /// </summary>
+        /// <summary> The name of the credential. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// Base64-encoded Kubernetes configuration file.
-        /// Serialized Name: CredentialResult.value
-        /// </summary>
+        /// <summary> Base64-encoded Kubernetes configuration file. </summary>
         [WirePath("value")]
         public byte[] Value { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterCredentials.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterCredentials.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The list credential result response.
-    /// Serialized Name: CredentialResults
-    /// </summary>
+    /// <summary> The list credential result response. </summary>
     public partial class ManagedClusterCredentials
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterCredentials"/>. </summary>
-        /// <param name="kubeconfigs">
-        /// Base64-encoded Kubernetes configuration file.
-        /// Serialized Name: CredentialResults.kubeconfigs
-        /// </param>
+        /// <param name="kubeconfigs"> Base64-encoded Kubernetes configuration file. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterCredentials(IReadOnlyList<ManagedClusterCredential> kubeconfigs, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Base64-encoded Kubernetes configuration file.
-        /// Serialized Name: CredentialResults.kubeconfigs
-        /// </summary>
+        /// <summary> Base64-encoded Kubernetes configuration file. </summary>
         [WirePath("kubeconfigs")]
         public IReadOnlyList<ManagedClusterCredential> Kubeconfigs { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterDelegatedIdentity.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterDelegatedIdentity.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Delegated resource properties - internal use only.
-    /// Serialized Name: DelegatedResource
-    /// </summary>
+    /// <summary> Delegated resource properties - internal use only. </summary>
     public partial class ManagedClusterDelegatedIdentity
     {
         /// <summary>
@@ -55,22 +52,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterDelegatedIdentity"/>. </summary>
-        /// <param name="resourceId">
-        /// The ARM resource id of the delegated resource - internal use only.
-        /// Serialized Name: DelegatedResource.resourceId
-        /// </param>
-        /// <param name="tenantId">
-        /// The tenant id of the delegated resource - internal use only.
-        /// Serialized Name: DelegatedResource.tenantId
-        /// </param>
-        /// <param name="referralResource">
-        /// The delegation id of the referral delegation (optional) - internal use only.
-        /// Serialized Name: DelegatedResource.referralResource
-        /// </param>
-        /// <param name="location">
-        /// The source resource location - internal use only.
-        /// Serialized Name: DelegatedResource.location
-        /// </param>
+        /// <param name="resourceId"> The ARM resource id of the delegated resource - internal use only. </param>
+        /// <param name="tenantId"> The tenant id of the delegated resource - internal use only. </param>
+        /// <param name="referralResource"> The delegation id of the referral delegation (optional) - internal use only. </param>
+        /// <param name="location"> The source resource location - internal use only. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterDelegatedIdentity(ResourceIdentifier resourceId, Guid? tenantId, string referralResource, AzureLocation? location, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,28 +66,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The ARM resource id of the delegated resource - internal use only.
-        /// Serialized Name: DelegatedResource.resourceId
-        /// </summary>
+        /// <summary> The ARM resource id of the delegated resource - internal use only. </summary>
         [WirePath("resourceId")]
         public ResourceIdentifier ResourceId { get; set; }
-        /// <summary>
-        /// The tenant id of the delegated resource - internal use only.
-        /// Serialized Name: DelegatedResource.tenantId
-        /// </summary>
+        /// <summary> The tenant id of the delegated resource - internal use only. </summary>
         [WirePath("tenantId")]
         public Guid? TenantId { get; set; }
-        /// <summary>
-        /// The delegation id of the referral delegation (optional) - internal use only.
-        /// Serialized Name: DelegatedResource.referralResource
-        /// </summary>
+        /// <summary> The delegation id of the referral delegation (optional) - internal use only. </summary>
         [WirePath("referralResource")]
         public string ReferralResource { get; set; }
-        /// <summary>
-        /// The source resource location - internal use only.
-        /// Serialized Name: DelegatedResource.location
-        /// </summary>
+        /// <summary> The source resource location - internal use only. </summary>
         [WirePath("location")]
         public AzureLocation? Location { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterHttpProxyConfig.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterHttpProxyConfig.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Cluster HTTP proxy configuration.
-    /// Serialized Name: ManagedClusterHttpProxyConfig
-    /// </summary>
+    /// <summary> Cluster HTTP proxy configuration. </summary>
     public partial class ManagedClusterHttpProxyConfig
     {
         /// <summary>
@@ -55,22 +52,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterHttpProxyConfig"/>. </summary>
-        /// <param name="httpProxy">
-        /// The HTTP proxy server endpoint to use.
-        /// Serialized Name: ManagedClusterHttpProxyConfig.httpProxy
-        /// </param>
-        /// <param name="httpsProxy">
-        /// The HTTPS proxy server endpoint to use.
-        /// Serialized Name: ManagedClusterHttpProxyConfig.httpsProxy
-        /// </param>
-        /// <param name="noProxy">
-        /// The endpoints that should not go through proxy.
-        /// Serialized Name: ManagedClusterHttpProxyConfig.noProxy
-        /// </param>
-        /// <param name="trustedCA">
-        /// Alternative CA cert to use for connecting to proxy servers.
-        /// Serialized Name: ManagedClusterHttpProxyConfig.trustedCa
-        /// </param>
+        /// <param name="httpProxy"> The HTTP proxy server endpoint to use. </param>
+        /// <param name="httpsProxy"> The HTTPS proxy server endpoint to use. </param>
+        /// <param name="noProxy"> The endpoints that should not go through proxy. </param>
+        /// <param name="trustedCA"> Alternative CA cert to use for connecting to proxy servers. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterHttpProxyConfig(string httpProxy, string httpsProxy, IList<string> noProxy, string trustedCA, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,28 +66,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The HTTP proxy server endpoint to use.
-        /// Serialized Name: ManagedClusterHttpProxyConfig.httpProxy
-        /// </summary>
+        /// <summary> The HTTP proxy server endpoint to use. </summary>
         [WirePath("httpProxy")]
         public string HttpProxy { get; set; }
-        /// <summary>
-        /// The HTTPS proxy server endpoint to use.
-        /// Serialized Name: ManagedClusterHttpProxyConfig.httpsProxy
-        /// </summary>
+        /// <summary> The HTTPS proxy server endpoint to use. </summary>
         [WirePath("httpsProxy")]
         public string HttpsProxy { get; set; }
-        /// <summary>
-        /// The endpoints that should not go through proxy.
-        /// Serialized Name: ManagedClusterHttpProxyConfig.noProxy
-        /// </summary>
+        /// <summary> The endpoints that should not go through proxy. </summary>
         [WirePath("noProxy")]
         public IList<string> NoProxy { get; }
-        /// <summary>
-        /// Alternative CA cert to use for connecting to proxy servers.
-        /// Serialized Name: ManagedClusterHttpProxyConfig.trustedCa
-        /// </summary>
+        /// <summary> Alternative CA cert to use for connecting to proxy servers. </summary>
         [WirePath("trustedCa")]
         public string TrustedCA { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterIngressProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterIngressProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Ingress profile for the container service cluster.
-    /// Serialized Name: ManagedClusterIngressProfile
-    /// </summary>
+    /// <summary> Ingress profile for the container service cluster. </summary>
     internal partial class ManagedClusterIngressProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterIngressProfile"/>. </summary>
-        /// <param name="webAppRouting">
-        /// App Routing settings for the ingress profile. You can find an overview and onboarding guide for this feature at https://learn.microsoft.com/en-us/azure/aks/app-routing?tabs=default%2Cdeploy-app-default.
-        /// Serialized Name: ManagedClusterIngressProfile.webAppRouting
-        /// </param>
+        /// <param name="webAppRouting"> App Routing settings for the ingress profile. You can find an overview and onboarding guide for this feature at https://learn.microsoft.com/en-us/azure/aks/app-routing?tabs=default%2Cdeploy-app-default. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterIngressProfile(ManagedClusterIngressProfileWebAppRouting webAppRouting, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// App Routing settings for the ingress profile. You can find an overview and onboarding guide for this feature at https://learn.microsoft.com/en-us/azure/aks/app-routing?tabs=default%2Cdeploy-app-default.
-        /// Serialized Name: ManagedClusterIngressProfile.webAppRouting
-        /// </summary>
+        /// <summary> App Routing settings for the ingress profile. You can find an overview and onboarding guide for this feature at https://learn.microsoft.com/en-us/azure/aks/app-routing?tabs=default%2Cdeploy-app-default. </summary>
         [WirePath("webAppRouting")]
         public ManagedClusterIngressProfileWebAppRouting WebAppRouting { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterIngressProfileNginx.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterIngressProfileNginx.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The ManagedClusterIngressProfileNginx.
-    /// Serialized Name: ManagedClusterIngressProfileNginx
-    /// </summary>
+    /// <summary> The ManagedClusterIngressProfileNginx. </summary>
     internal partial class ManagedClusterIngressProfileNginx
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterIngressProfileNginx"/>. </summary>
-        /// <param name="defaultIngressControllerType">
-        /// Ingress type for the default NginxIngressController custom resource
-        /// Serialized Name: ManagedClusterIngressProfileNginx.defaultIngressControllerType
-        /// </param>
+        /// <param name="defaultIngressControllerType"> Ingress type for the default NginxIngressController custom resource. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterIngressProfileNginx(NginxIngressControllerType? defaultIngressControllerType, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Ingress type for the default NginxIngressController custom resource
-        /// Serialized Name: ManagedClusterIngressProfileNginx.defaultIngressControllerType
-        /// </summary>
+        /// <summary> Ingress type for the default NginxIngressController custom resource. </summary>
         [WirePath("defaultIngressControllerType")]
         public NginxIngressControllerType? DefaultIngressControllerType { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterIngressProfileWebAppRouting.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterIngressProfileWebAppRouting.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Application Routing add-on settings for the ingress profile.
-    /// Serialized Name: ManagedClusterIngressProfileWebAppRouting
-    /// </summary>
+    /// <summary> Application Routing add-on settings for the ingress profile. </summary>
     public partial class ManagedClusterIngressProfileWebAppRouting
     {
         /// <summary>
@@ -56,22 +53,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterIngressProfileWebAppRouting"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable the Application Routing add-on.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.enabled
-        /// </param>
-        /// <param name="dnsZoneResourceIds">
-        /// Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.dnsZoneResourceIds
-        /// </param>
-        /// <param name="nginx">
-        /// Configuration for the default NginxIngressController. See more at https://learn.microsoft.com/en-us/azure/aks/app-routing-nginx-configuration#the-default-nginx-ingress-controller.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.nginx
-        /// </param>
-        /// <param name="identity">
-        /// Managed identity of the Application Routing add-on. This is the identity that should be granted permissions, for example, to manage the associated Azure DNS resource and get certificates from Azure Key Vault. See [this overview of the add-on](https://learn.microsoft.com/en-us/azure/aks/web-app-routing?tabs=with-osm) for more instructions.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.identity
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable the Application Routing add-on. </param>
+        /// <param name="dnsZoneResourceIds"> Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group. </param>
+        /// <param name="nginx"> Configuration for the default NginxIngressController. See more at https://learn.microsoft.com/en-us/azure/aks/app-routing-nginx-configuration#the-default-nginx-ingress-controller. </param>
+        /// <param name="identity"> Managed identity of the Application Routing add-on. This is the identity that should be granted permissions, for example, to manage the associated Azure DNS resource and get certificates from Azure Key Vault. See [this overview of the add-on](https://learn.microsoft.com/en-us/azure/aks/web-app-routing?tabs=with-osm) for more instructions. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterIngressProfileWebAppRouting(bool? isEnabled, IList<ResourceIdentifier> dnsZoneResourceIds, ManagedClusterIngressProfileNginx nginx, ContainerServiceUserAssignedIdentity identity, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -82,27 +67,15 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable the Application Routing add-on.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.enabled
-        /// </summary>
+        /// <summary> Whether to enable the Application Routing add-on. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
-        /// <summary>
-        /// Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.dnsZoneResourceIds
-        /// </summary>
+        /// <summary> Resource IDs of the DNS zones to be associated with the Application Routing add-on. Used only when Application Routing add-on is enabled. Public and private DNS zones can be in different resource groups, but all public DNS zones must be in the same resource group and all private DNS zones must be in the same resource group. </summary>
         [WirePath("dnsZoneResourceIds")]
         public IList<ResourceIdentifier> DnsZoneResourceIds { get; }
-        /// <summary>
-        /// Configuration for the default NginxIngressController. See more at https://learn.microsoft.com/en-us/azure/aks/app-routing-nginx-configuration#the-default-nginx-ingress-controller.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.nginx
-        /// </summary>
+        /// <summary> Configuration for the default NginxIngressController. See more at https://learn.microsoft.com/en-us/azure/aks/app-routing-nginx-configuration#the-default-nginx-ingress-controller. </summary>
         internal ManagedClusterIngressProfileNginx Nginx { get; set; }
-        /// <summary>
-        /// Ingress type for the default NginxIngressController custom resource
-        /// Serialized Name: ManagedClusterIngressProfileNginx.defaultIngressControllerType
-        /// </summary>
+        /// <summary> Ingress type for the default NginxIngressController custom resource. </summary>
         [WirePath("nginx.defaultIngressControllerType")]
         public NginxIngressControllerType? NginxDefaultIngressControllerType
         {
@@ -115,10 +88,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// Managed identity of the Application Routing add-on. This is the identity that should be granted permissions, for example, to manage the associated Azure DNS resource and get certificates from Azure Key Vault. See [this overview of the add-on](https://learn.microsoft.com/en-us/azure/aks/web-app-routing?tabs=with-osm) for more instructions.
-        /// Serialized Name: ManagedClusterIngressProfileWebAppRouting.identity
-        /// </summary>
+        /// <summary> Managed identity of the Application Routing add-on. This is the identity that should be granted permissions, for example, to manage the associated Azure DNS resource and get certificates from Azure Key Vault. See [this overview of the add-on](https://learn.microsoft.com/en-us/azure/aks/web-app-routing?tabs=with-osm) for more instructions. </summary>
         [WirePath("identity")]
         public ContainerServiceUserAssignedIdentity Identity { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterKeyVaultNetworkAccessType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterKeyVaultNetworkAccessType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Network access of the key vault. Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.
-    /// Serialized Name: KeyVaultNetworkAccessTypes
-    /// </summary>
+    /// <summary> Network access of the key vault. Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`. </summary>
     public readonly partial struct ManagedClusterKeyVaultNetworkAccessType : IEquatable<ManagedClusterKeyVaultNetworkAccessType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string PublicValue = "Public";
         private const string PrivateValue = "Private";
 
-        /// <summary>
-        /// Public
-        /// Serialized Name: KeyVaultNetworkAccessTypes.Public
-        /// </summary>
+        /// <summary> Public. </summary>
         public static ManagedClusterKeyVaultNetworkAccessType Public { get; } = new ManagedClusterKeyVaultNetworkAccessType(PublicValue);
-        /// <summary>
-        /// Private
-        /// Serialized Name: KeyVaultNetworkAccessTypes.Private
-        /// </summary>
+        /// <summary> Private. </summary>
         public static ManagedClusterKeyVaultNetworkAccessType Private { get; } = new ManagedClusterKeyVaultNetworkAccessType(PrivateValue);
         /// <summary> Determines if two <see cref="ManagedClusterKeyVaultNetworkAccessType"/> values are the same. </summary>
         public static bool operator ==(ManagedClusterKeyVaultNetworkAccessType left, ManagedClusterKeyVaultNetworkAccessType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The response from the List Managed Clusters operation.
-    /// Serialized Name: ManagedClusterListResult
-    /// </summary>
+    /// <summary> The response from the List Managed Clusters operation. </summary>
     internal partial class ManagedClusterListResult
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterListResult"/>. </summary>
-        /// <param name="value">
-        /// The list of managed clusters.
-        /// Serialized Name: ManagedClusterListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The URL to get the next set of managed cluster results.
-        /// Serialized Name: ManagedClusterListResult.nextLink
-        /// </param>
+        /// <param name="value"> The list of managed clusters. </param>
+        /// <param name="nextLink"> The URL to get the next set of managed cluster results. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterListResult(IReadOnlyList<ContainerServiceManagedClusterData> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The list of managed clusters.
-        /// Serialized Name: ManagedClusterListResult.value
-        /// </summary>
+        /// <summary> The list of managed clusters. </summary>
         public IReadOnlyList<ContainerServiceManagedClusterData> Value { get; }
-        /// <summary>
-        /// The URL to get the next set of managed cluster results.
-        /// Serialized Name: ManagedClusterListResult.nextLink
-        /// </summary>
+        /// <summary> The URL to get the next set of managed cluster results. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerBackendPoolType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerBackendPoolType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The type of the managed inbound Load Balancer BackendPool.
-    /// Serialized Name: BackendPoolType
-    /// </summary>
+    /// <summary> The type of the managed inbound Load Balancer BackendPool. </summary>
     public readonly partial struct ManagedClusterLoadBalancerBackendPoolType : IEquatable<ManagedClusterLoadBalancerBackendPoolType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string NodeIPConfigurationValue = "NodeIPConfiguration";
         private const string NodeIPValue = "NodeIP";
 
-        /// <summary>
-        /// The type of the managed inbound Load Balancer BackendPool. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend.
-        /// Serialized Name: BackendPoolType.NodeIPConfiguration
-        /// </summary>
+        /// <summary> The type of the managed inbound Load Balancer BackendPool. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend. </summary>
         public static ManagedClusterLoadBalancerBackendPoolType NodeIPConfiguration { get; } = new ManagedClusterLoadBalancerBackendPoolType(NodeIPConfigurationValue);
-        /// <summary>
-        /// The type of the managed inbound Load Balancer BackendPool. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend.
-        /// Serialized Name: BackendPoolType.NodeIP
-        /// </summary>
+        /// <summary> The type of the managed inbound Load Balancer BackendPool. https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#configure-load-balancer-backend. </summary>
         public static ManagedClusterLoadBalancerBackendPoolType NodeIP { get; } = new ManagedClusterLoadBalancerBackendPoolType(NodeIPValue);
         /// <summary> Determines if two <see cref="ManagedClusterLoadBalancerBackendPoolType"/> values are the same. </summary>
         public static bool operator ==(ManagedClusterLoadBalancerBackendPoolType left, ManagedClusterLoadBalancerBackendPoolType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerProfile.cs
@@ -11,10 +11,7 @@ using Azure.ResourceManager.Resources.Models;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Profile of the managed cluster load balancer.
-    /// Serialized Name: ManagedClusterLoadBalancerProfile
-    /// </summary>
+    /// <summary> Profile of the managed cluster load balancer. </summary>
     public partial class ManagedClusterLoadBalancerProfile
     {
         /// <summary>
@@ -56,38 +53,14 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterLoadBalancerProfile"/>. </summary>
-        /// <param name="managedOutboundIPs">
-        /// Desired managed outbound IPs for the cluster load balancer.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.managedOutboundIPs
-        /// </param>
-        /// <param name="outboundIPPrefixes">
-        /// Desired outbound IP Prefix resources for the cluster load balancer.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.outboundIPPrefixes
-        /// </param>
-        /// <param name="outboundIPs">
-        /// Desired outbound IP resources for the cluster load balancer.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.outboundIPs
-        /// </param>
-        /// <param name="effectiveOutboundIPs">
-        /// The effective outbound IP resources of the cluster load balancer.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.effectiveOutboundIPs
-        /// </param>
-        /// <param name="allocatedOutboundPorts">
-        /// The desired number of allocated SNAT ports per VM. Allowed values are in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.allocatedOutboundPorts
-        /// </param>
-        /// <param name="idleTimeoutInMinutes">
-        /// Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 30 minutes.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.idleTimeoutInMinutes
-        /// </param>
-        /// <param name="enableMultipleStandardLoadBalancers">
-        /// Enable multiple standard load balancers per AKS cluster or not.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.enableMultipleStandardLoadBalancers
-        /// </param>
-        /// <param name="backendPoolType">
-        /// The type of the managed inbound Load Balancer BackendPool.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.backendPoolType
-        /// </param>
+        /// <param name="managedOutboundIPs"> Desired managed outbound IPs for the cluster load balancer. </param>
+        /// <param name="outboundIPPrefixes"> Desired outbound IP Prefix resources for the cluster load balancer. </param>
+        /// <param name="outboundIPs"> Desired outbound IP resources for the cluster load balancer. </param>
+        /// <param name="effectiveOutboundIPs"> The effective outbound IP resources of the cluster load balancer. </param>
+        /// <param name="allocatedOutboundPorts"> The desired number of allocated SNAT ports per VM. Allowed values are in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports. </param>
+        /// <param name="idleTimeoutInMinutes"> Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 30 minutes. </param>
+        /// <param name="enableMultipleStandardLoadBalancers"> Enable multiple standard load balancers per AKS cluster or not. </param>
+        /// <param name="backendPoolType"> The type of the managed inbound Load Balancer BackendPool. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterLoadBalancerProfile(ManagedClusterLoadBalancerProfileManagedOutboundIPs managedOutboundIPs, ManagedClusterLoadBalancerProfileOutboundIPPrefixes outboundIPPrefixes, ManagedClusterLoadBalancerProfileOutboundIPs outboundIPs, IList<WritableSubResource> effectiveOutboundIPs, int? allocatedOutboundPorts, int? idleTimeoutInMinutes, bool? enableMultipleStandardLoadBalancers, ManagedClusterLoadBalancerBackendPoolType? backendPoolType, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -102,21 +75,12 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Desired managed outbound IPs for the cluster load balancer.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.managedOutboundIPs
-        /// </summary>
+        /// <summary> Desired managed outbound IPs for the cluster load balancer. </summary>
         [WirePath("managedOutboundIPs")]
         public ManagedClusterLoadBalancerProfileManagedOutboundIPs ManagedOutboundIPs { get; set; }
-        /// <summary>
-        /// Desired outbound IP Prefix resources for the cluster load balancer.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.outboundIPPrefixes
-        /// </summary>
+        /// <summary> Desired outbound IP Prefix resources for the cluster load balancer. </summary>
         internal ManagedClusterLoadBalancerProfileOutboundIPPrefixes OutboundIPPrefixes { get; set; }
-        /// <summary>
-        /// A list of public IP prefix resources.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileOutboundIPPrefixes.publicIPPrefixes
-        /// </summary>
+        /// <summary> A list of public IP prefix resources. </summary>
         [WirePath("outboundIPPrefixes.publicIPPrefixes")]
         public IList<WritableSubResource> OutboundPublicIPPrefixes
         {
@@ -128,15 +92,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// Desired outbound IP resources for the cluster load balancer.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.outboundIPs
-        /// </summary>
+        /// <summary> Desired outbound IP resources for the cluster load balancer. </summary>
         internal ManagedClusterLoadBalancerProfileOutboundIPs OutboundIPs { get; set; }
-        /// <summary>
-        /// A list of public IP resources.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileOutboundIPs.publicIPs
-        /// </summary>
+        /// <summary> A list of public IP resources. </summary>
         [WirePath("outboundIPs.publicIPs")]
         public IList<WritableSubResource> OutboundPublicIPs
         {
@@ -147,28 +105,16 @@ namespace Azure.ResourceManager.ContainerService.Models
                 return OutboundIPs.PublicIPs;
             }
         }
-        /// <summary>
-        /// The desired number of allocated SNAT ports per VM. Allowed values are in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.allocatedOutboundPorts
-        /// </summary>
+        /// <summary> The desired number of allocated SNAT ports per VM. Allowed values are in the range of 0 to 64000 (inclusive). The default value is 0 which results in Azure dynamically allocating ports. </summary>
         [WirePath("allocatedOutboundPorts")]
         public int? AllocatedOutboundPorts { get; set; }
-        /// <summary>
-        /// Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 30 minutes.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.idleTimeoutInMinutes
-        /// </summary>
+        /// <summary> Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 30 minutes. </summary>
         [WirePath("idleTimeoutInMinutes")]
         public int? IdleTimeoutInMinutes { get; set; }
-        /// <summary>
-        /// Enable multiple standard load balancers per AKS cluster or not.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.enableMultipleStandardLoadBalancers
-        /// </summary>
+        /// <summary> Enable multiple standard load balancers per AKS cluster or not. </summary>
         [WirePath("enableMultipleStandardLoadBalancers")]
         public bool? EnableMultipleStandardLoadBalancers { get; set; }
-        /// <summary>
-        /// The type of the managed inbound Load Balancer BackendPool.
-        /// Serialized Name: ManagedClusterLoadBalancerProfile.backendPoolType
-        /// </summary>
+        /// <summary> The type of the managed inbound Load Balancer BackendPool. </summary>
         [WirePath("backendPoolType")]
         public ManagedClusterLoadBalancerBackendPoolType? BackendPoolType { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerProfileManagedOutboundIPs.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerProfileManagedOutboundIPs.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Desired managed outbound IPs for the cluster load balancer.
-    /// Serialized Name: ManagedClusterLoadBalancerProfileManagedOutboundIPs
-    /// </summary>
+    /// <summary> Desired managed outbound IPs for the cluster load balancer. </summary>
     public partial class ManagedClusterLoadBalancerProfileManagedOutboundIPs
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterLoadBalancerProfileManagedOutboundIPs"/>. </summary>
-        /// <param name="count">
-        /// The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileManagedOutboundIPs.count
-        /// </param>
-        /// <param name="countIPv6">
-        /// The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileManagedOutboundIPs.countIPv6
-        /// </param>
+        /// <param name="count"> The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. </param>
+        /// <param name="countIPv6"> The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterLoadBalancerProfileManagedOutboundIPs(int? count, int? countIPv6, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileManagedOutboundIPs.count
-        /// </summary>
+        /// <summary> The desired number of IPv4 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1. </summary>
         [WirePath("count")]
         public int? Count { get; set; }
-        /// <summary>
-        /// The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileManagedOutboundIPs.countIPv6
-        /// </summary>
+        /// <summary> The desired number of IPv6 outbound IPs created/managed by Azure for the cluster load balancer. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 0 for single-stack and 1 for dual-stack. </summary>
         [WirePath("countIPv6")]
         public int? CountIPv6 { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerProfileOutboundIPPrefixes.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerProfileOutboundIPPrefixes.cs
@@ -11,10 +11,7 @@ using Azure.ResourceManager.Resources.Models;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Desired outbound IP Prefix resources for the cluster load balancer.
-    /// Serialized Name: ManagedClusterLoadBalancerProfileOutboundIPPrefixes
-    /// </summary>
+    /// <summary> Desired outbound IP Prefix resources for the cluster load balancer. </summary>
     internal partial class ManagedClusterLoadBalancerProfileOutboundIPPrefixes
     {
         /// <summary>
@@ -56,10 +53,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterLoadBalancerProfileOutboundIPPrefixes"/>. </summary>
-        /// <param name="publicIPPrefixes">
-        /// A list of public IP prefix resources.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileOutboundIPPrefixes.publicIPPrefixes
-        /// </param>
+        /// <param name="publicIPPrefixes"> A list of public IP prefix resources. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterLoadBalancerProfileOutboundIPPrefixes(IList<WritableSubResource> publicIPPrefixes, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -67,10 +61,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// A list of public IP prefix resources.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileOutboundIPPrefixes.publicIPPrefixes
-        /// </summary>
+        /// <summary> A list of public IP prefix resources. </summary>
         [WirePath("publicIPPrefixes")]
         public IList<WritableSubResource> PublicIPPrefixes { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerProfileOutboundIPs.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterLoadBalancerProfileOutboundIPs.cs
@@ -11,10 +11,7 @@ using Azure.ResourceManager.Resources.Models;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Desired outbound IP resources for the cluster load balancer.
-    /// Serialized Name: ManagedClusterLoadBalancerProfileOutboundIPs
-    /// </summary>
+    /// <summary> Desired outbound IP resources for the cluster load balancer. </summary>
     internal partial class ManagedClusterLoadBalancerProfileOutboundIPs
     {
         /// <summary>
@@ -56,10 +53,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterLoadBalancerProfileOutboundIPs"/>. </summary>
-        /// <param name="publicIPs">
-        /// A list of public IP resources.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileOutboundIPs.publicIPs
-        /// </param>
+        /// <param name="publicIPs"> A list of public IP resources. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterLoadBalancerProfileOutboundIPs(IList<WritableSubResource> publicIPs, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -67,10 +61,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// A list of public IP resources.
-        /// Serialized Name: ManagedClusterLoadBalancerProfileOutboundIPs.publicIPs
-        /// </summary>
+        /// <summary> A list of public IP resources. </summary>
         [WirePath("publicIPs")]
         public IList<WritableSubResource> PublicIPs { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterManagedOutboundIPProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterManagedOutboundIPProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Profile of the managed outbound IP resources of the managed cluster.
-    /// Serialized Name: ManagedClusterManagedOutboundIPProfile
-    /// </summary>
+    /// <summary> Profile of the managed outbound IP resources of the managed cluster. </summary>
     internal partial class ManagedClusterManagedOutboundIPProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterManagedOutboundIPProfile"/>. </summary>
-        /// <param name="count">
-        /// The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1.
-        /// Serialized Name: ManagedClusterManagedOutboundIPProfile.count
-        /// </param>
+        /// <param name="count"> The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterManagedOutboundIPProfile(int? count, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1.
-        /// Serialized Name: ManagedClusterManagedOutboundIPProfile.count
-        /// </summary>
+        /// <summary> The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. </summary>
         [WirePath("count")]
         public int? Count { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterMetricsProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterMetricsProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The metrics profile for the ManagedCluster.
-    /// Serialized Name: ManagedClusterMetricsProfile
-    /// </summary>
+    /// <summary> The metrics profile for the ManagedCluster. </summary>
     internal partial class ManagedClusterMetricsProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterMetricsProfile"/>. </summary>
-        /// <param name="costAnalysis">
-        /// The configuration for detailed per-Kubernetes resource cost analysis.
-        /// Serialized Name: ManagedClusterMetricsProfile.costAnalysis
-        /// </param>
+        /// <param name="costAnalysis"> The configuration for detailed per-Kubernetes resource cost analysis. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterMetricsProfile(ManagedClusterCostAnalysis costAnalysis, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,15 +59,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The configuration for detailed per-Kubernetes resource cost analysis.
-        /// Serialized Name: ManagedClusterMetricsProfile.costAnalysis
-        /// </summary>
+        /// <summary> The configuration for detailed per-Kubernetes resource cost analysis. </summary>
         internal ManagedClusterCostAnalysis CostAnalysis { get; set; }
-        /// <summary>
-        /// Whether to enable cost analysis. The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis.
-        /// Serialized Name: ManagedClusterCostAnalysis.enabled
-        /// </summary>
+        /// <summary> Whether to enable cost analysis. The Managed Cluster sku.tier must be set to 'Standard' or 'Premium' to enable this feature. Enabling this will add Kubernetes Namespace and Deployment details to the Cost Analysis views in the Azure portal. If not specified, the default is false. For more information see aka.ms/aks/docs/cost-analysis. </summary>
         [WirePath("costAnalysis.enabled")]
         public bool? IsCostAnalysisEnabled
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterMonitorProfileKubeStateMetrics.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterMonitorProfileKubeStateMetrics.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details.
-    /// Serialized Name: ManagedClusterAzureMonitorProfileKubeStateMetrics
-    /// </summary>
+    /// <summary> Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details. </summary>
     public partial class ManagedClusterMonitorProfileKubeStateMetrics
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterMonitorProfileKubeStateMetrics"/>. </summary>
-        /// <param name="metricLabelsAllowlist">
-        /// Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels.
-        /// Serialized Name: ManagedClusterAzureMonitorProfileKubeStateMetrics.metricLabelsAllowlist
-        /// </param>
-        /// <param name="metricAnnotationsAllowList">
-        /// Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels.
-        /// Serialized Name: ManagedClusterAzureMonitorProfileKubeStateMetrics.metricAnnotationsAllowList
-        /// </param>
+        /// <param name="metricLabelsAllowlist"> Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels. </param>
+        /// <param name="metricAnnotationsAllowList"> Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterMonitorProfileKubeStateMetrics(string metricLabelsAllowlist, string metricAnnotationsAllowList, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels.
-        /// Serialized Name: ManagedClusterAzureMonitorProfileKubeStateMetrics.metricLabelsAllowlist
-        /// </summary>
+        /// <summary> Comma-separated list of additional Kubernetes label keys that will be used in the resource's labels metric (Example: 'namespaces=[k8s-label-1,k8s-label-n,...],pods=[app],...'). By default the metric contains only resource name and namespace labels. </summary>
         [WirePath("metricLabelsAllowlist")]
         public string MetricLabelsAllowlist { get; set; }
-        /// <summary>
-        /// Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels.
-        /// Serialized Name: ManagedClusterAzureMonitorProfileKubeStateMetrics.metricAnnotationsAllowList
-        /// </summary>
+        /// <summary> Comma-separated list of Kubernetes annotation keys that will be used in the resource's labels metric (Example: 'namespaces=[kubernetes.io/team,...],pods=[kubernetes.io/team],...'). By default the metric contains only resource name and namespace labels. </summary>
         [WirePath("metricAnnotationsAllowList")]
         public string MetricAnnotationsAllowList { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterMonitorProfileMetrics.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterMonitorProfileMetrics.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview.
-    /// Serialized Name: ManagedClusterAzureMonitorProfileMetrics
-    /// </summary>
+    /// <summary> Metrics profile for the Azure Monitor managed service for Prometheus addon. Collect out-of-the-box Kubernetes infrastructure metrics to send to an Azure Monitor Workspace and configure additional scraping for custom targets. See aka.ms/AzureManagedPrometheus for an overview. </summary>
     public partial class ManagedClusterMonitorProfileMetrics
     {
         /// <summary>
@@ -49,24 +46,15 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterMonitorProfileMetrics"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling.
-        /// Serialized Name: ManagedClusterAzureMonitorProfileMetrics.enabled
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling. </param>
         public ManagedClusterMonitorProfileMetrics(bool isEnabled)
         {
             IsEnabled = isEnabled;
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterMonitorProfileMetrics"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling.
-        /// Serialized Name: ManagedClusterAzureMonitorProfileMetrics.enabled
-        /// </param>
-        /// <param name="kubeStateMetrics">
-        /// Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details.
-        /// Serialized Name: ManagedClusterAzureMonitorProfileMetrics.kubeStateMetrics
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling. </param>
+        /// <param name="kubeStateMetrics"> Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterMonitorProfileMetrics(bool isEnabled, ManagedClusterMonitorProfileKubeStateMetrics kubeStateMetrics, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -80,16 +68,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling.
-        /// Serialized Name: ManagedClusterAzureMonitorProfileMetrics.enabled
-        /// </summary>
+        /// <summary> Whether to enable or disable the Azure Managed Prometheus addon for Prometheus monitoring. See aka.ms/AzureManagedPrometheus-aks-enable for details on enabling and disabling. </summary>
         [WirePath("enabled")]
         public bool IsEnabled { get; set; }
-        /// <summary>
-        /// Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details.
-        /// Serialized Name: ManagedClusterAzureMonitorProfileMetrics.kubeStateMetrics
-        /// </summary>
+        /// <summary> Kube State Metrics profile for the Azure Managed Prometheus addon. These optional settings are for the kube-state-metrics pod that is deployed with the addon. See aka.ms/AzureManagedPrometheus-optional-parameters for details. </summary>
         [WirePath("kubeStateMetrics")]
         public ManagedClusterMonitorProfileKubeStateMetrics KubeStateMetrics { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNamespaceProperties.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNamespaceProperties.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Properties of a namespace managed by ARM
-    /// Serialized Name: NamespaceProperties
-    /// </summary>
+    /// <summary> Properties of a namespace managed by ARM. </summary>
     public partial class ManagedClusterNamespaceProperties
     {
         /// <summary>
@@ -56,38 +53,14 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterNamespaceProperties"/>. </summary>
-        /// <param name="provisioningState">
-        /// The current provisioning state of the namespace.
-        /// Serialized Name: NamespaceProperties.provisioningState
-        /// </param>
-        /// <param name="labels">
-        /// The labels of managed namespace.
-        /// Serialized Name: NamespaceProperties.labels
-        /// </param>
-        /// <param name="annotations">
-        /// The annotations of managed namespace.
-        /// Serialized Name: NamespaceProperties.annotations
-        /// </param>
-        /// <param name="portalFqdn">
-        /// The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly.
-        /// Serialized Name: NamespaceProperties.portalFqdn
-        /// </param>
-        /// <param name="defaultResourceQuota">
-        /// The default resource quota enforced upon the namespace. Customers can have other Kubernetes resource quota objects under the namespace. Resource quotas are additive; if multiple resource quotas are applied to a given namespace, then the effective limit will be one such that all quotas on the namespace can be satisfied.
-        /// Serialized Name: NamespaceProperties.defaultResourceQuota
-        /// </param>
-        /// <param name="defaultNetworkPolicy">
-        /// The default network policy enforced upon the namespace. Customers can have other Kubernetes network policy objects under the namespace. Network policies are additive; if a policy or policies apply to a given pod for a given direction, the connections allowed in that direction for the pod is the union of what all applicable policies allow.
-        /// Serialized Name: NamespaceProperties.defaultNetworkPolicy
-        /// </param>
-        /// <param name="adoptionPolicy">
-        /// Action if Kubernetes namespace with same name already exists.
-        /// Serialized Name: NamespaceProperties.adoptionPolicy
-        /// </param>
-        /// <param name="deletePolicy">
-        /// Delete options of a namespace.
-        /// Serialized Name: NamespaceProperties.deletePolicy
-        /// </param>
+        /// <param name="provisioningState"> The current provisioning state of the namespace. </param>
+        /// <param name="labels"> The labels of managed namespace. </param>
+        /// <param name="annotations"> The annotations of managed namespace. </param>
+        /// <param name="portalFqdn"> The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly. </param>
+        /// <param name="defaultResourceQuota"> The default resource quota enforced upon the namespace. Customers can have other Kubernetes resource quota objects under the namespace. Resource quotas are additive; if multiple resource quotas are applied to a given namespace, then the effective limit will be one such that all quotas on the namespace can be satisfied. </param>
+        /// <param name="defaultNetworkPolicy"> The default network policy enforced upon the namespace. Customers can have other Kubernetes network policy objects under the namespace. Network policies are additive; if a policy or policies apply to a given pod for a given direction, the connections allowed in that direction for the pod is the union of what all applicable policies allow. </param>
+        /// <param name="adoptionPolicy"> Action if Kubernetes namespace with same name already exists. </param>
+        /// <param name="deletePolicy"> Delete options of a namespace. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterNamespaceProperties(ManagedClusterNamespaceProvisioningState? provisioningState, IDictionary<string, string> labels, IDictionary<string, string> annotations, string portalFqdn, NamespaceResourceQuota defaultResourceQuota, NamespaceNetworkPolicies defaultNetworkPolicy, NamespaceAdoptionPolicy? adoptionPolicy, NamespaceDeletePolicy? deletePolicy, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -102,52 +75,28 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The current provisioning state of the namespace.
-        /// Serialized Name: NamespaceProperties.provisioningState
-        /// </summary>
+        /// <summary> The current provisioning state of the namespace. </summary>
         [WirePath("provisioningState")]
         public ManagedClusterNamespaceProvisioningState? ProvisioningState { get; }
-        /// <summary>
-        /// The labels of managed namespace.
-        /// Serialized Name: NamespaceProperties.labels
-        /// </summary>
+        /// <summary> The labels of managed namespace. </summary>
         [WirePath("labels")]
         public IDictionary<string, string> Labels { get; }
-        /// <summary>
-        /// The annotations of managed namespace.
-        /// Serialized Name: NamespaceProperties.annotations
-        /// </summary>
+        /// <summary> The annotations of managed namespace. </summary>
         [WirePath("annotations")]
         public IDictionary<string, string> Annotations { get; }
-        /// <summary>
-        /// The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly.
-        /// Serialized Name: NamespaceProperties.portalFqdn
-        /// </summary>
+        /// <summary> The special FQDN used by the Azure Portal to access the Managed Cluster. This FQDN is for use only by the Azure Portal and should not be used by other clients. The Azure Portal requires certain Cross-Origin Resource Sharing (CORS) headers to be sent in some responses, which Kubernetes APIServer doesn't handle by default. This special FQDN supports CORS, allowing the Azure Portal to function properly. </summary>
         [WirePath("portalFqdn")]
         public string PortalFqdn { get; }
-        /// <summary>
-        /// The default resource quota enforced upon the namespace. Customers can have other Kubernetes resource quota objects under the namespace. Resource quotas are additive; if multiple resource quotas are applied to a given namespace, then the effective limit will be one such that all quotas on the namespace can be satisfied.
-        /// Serialized Name: NamespaceProperties.defaultResourceQuota
-        /// </summary>
+        /// <summary> The default resource quota enforced upon the namespace. Customers can have other Kubernetes resource quota objects under the namespace. Resource quotas are additive; if multiple resource quotas are applied to a given namespace, then the effective limit will be one such that all quotas on the namespace can be satisfied. </summary>
         [WirePath("defaultResourceQuota")]
         public NamespaceResourceQuota DefaultResourceQuota { get; set; }
-        /// <summary>
-        /// The default network policy enforced upon the namespace. Customers can have other Kubernetes network policy objects under the namespace. Network policies are additive; if a policy or policies apply to a given pod for a given direction, the connections allowed in that direction for the pod is the union of what all applicable policies allow.
-        /// Serialized Name: NamespaceProperties.defaultNetworkPolicy
-        /// </summary>
+        /// <summary> The default network policy enforced upon the namespace. Customers can have other Kubernetes network policy objects under the namespace. Network policies are additive; if a policy or policies apply to a given pod for a given direction, the connections allowed in that direction for the pod is the union of what all applicable policies allow. </summary>
         [WirePath("defaultNetworkPolicy")]
         public NamespaceNetworkPolicies DefaultNetworkPolicy { get; set; }
-        /// <summary>
-        /// Action if Kubernetes namespace with same name already exists.
-        /// Serialized Name: NamespaceProperties.adoptionPolicy
-        /// </summary>
+        /// <summary> Action if Kubernetes namespace with same name already exists. </summary>
         [WirePath("adoptionPolicy")]
         public NamespaceAdoptionPolicy? AdoptionPolicy { get; set; }
-        /// <summary>
-        /// Delete options of a namespace.
-        /// Serialized Name: NamespaceProperties.deletePolicy
-        /// </summary>
+        /// <summary> Delete options of a namespace. </summary>
         [WirePath("deletePolicy")]
         public NamespaceDeletePolicy? DeletePolicy { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNamespaceProvisioningState.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNamespaceProvisioningState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The current provisioning state of the namespace.
-    /// Serialized Name: NamespaceProvisioningState
-    /// </summary>
+    /// <summary> The current provisioning state of the namespace. </summary>
     public readonly partial struct ManagedClusterNamespaceProvisioningState : IEquatable<ManagedClusterNamespaceProvisioningState>
     {
         private readonly string _value;
@@ -32,35 +29,17 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string FailedValue = "Failed";
         private const string CanceledValue = "Canceled";
 
-        /// <summary>
-        /// Updating
-        /// Serialized Name: NamespaceProvisioningState.Updating
-        /// </summary>
+        /// <summary> Updating. </summary>
         public static ManagedClusterNamespaceProvisioningState Updating { get; } = new ManagedClusterNamespaceProvisioningState(UpdatingValue);
-        /// <summary>
-        /// Deleting
-        /// Serialized Name: NamespaceProvisioningState.Deleting
-        /// </summary>
+        /// <summary> Deleting. </summary>
         public static ManagedClusterNamespaceProvisioningState Deleting { get; } = new ManagedClusterNamespaceProvisioningState(DeletingValue);
-        /// <summary>
-        /// Creating
-        /// Serialized Name: NamespaceProvisioningState.Creating
-        /// </summary>
+        /// <summary> Creating. </summary>
         public static ManagedClusterNamespaceProvisioningState Creating { get; } = new ManagedClusterNamespaceProvisioningState(CreatingValue);
-        /// <summary>
-        /// Succeeded
-        /// Serialized Name: NamespaceProvisioningState.Succeeded
-        /// </summary>
+        /// <summary> Succeeded. </summary>
         public static ManagedClusterNamespaceProvisioningState Succeeded { get; } = new ManagedClusterNamespaceProvisioningState(SucceededValue);
-        /// <summary>
-        /// Failed
-        /// Serialized Name: NamespaceProvisioningState.Failed
-        /// </summary>
+        /// <summary> Failed. </summary>
         public static ManagedClusterNamespaceProvisioningState Failed { get; } = new ManagedClusterNamespaceProvisioningState(FailedValue);
-        /// <summary>
-        /// Canceled
-        /// Serialized Name: NamespaceProvisioningState.Canceled
-        /// </summary>
+        /// <summary> Canceled. </summary>
         public static ManagedClusterNamespaceProvisioningState Canceled { get; } = new ManagedClusterNamespaceProvisioningState(CanceledValue);
         /// <summary> Determines if two <see cref="ManagedClusterNamespaceProvisioningState"/> values are the same. </summary>
         public static bool operator ==(ManagedClusterNamespaceProvisioningState left, ManagedClusterNamespaceProvisioningState right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNatGatewayProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNatGatewayProfile.cs
@@ -11,10 +11,7 @@ using Azure.ResourceManager.Resources.Models;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Profile of the managed cluster NAT gateway.
-    /// Serialized Name: ManagedClusterNATGatewayProfile
-    /// </summary>
+    /// <summary> Profile of the managed cluster NAT gateway. </summary>
     public partial class ManagedClusterNatGatewayProfile
     {
         /// <summary>
@@ -56,18 +53,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterNatGatewayProfile"/>. </summary>
-        /// <param name="managedOutboundIPProfile">
-        /// Profile of the managed outbound IP resources of the cluster NAT gateway.
-        /// Serialized Name: ManagedClusterNATGatewayProfile.managedOutboundIPProfile
-        /// </param>
-        /// <param name="effectiveOutboundIPs">
-        /// The effective outbound IP resources of the cluster NAT gateway.
-        /// Serialized Name: ManagedClusterNATGatewayProfile.effectiveOutboundIPs
-        /// </param>
-        /// <param name="idleTimeoutInMinutes">
-        /// Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes.
-        /// Serialized Name: ManagedClusterNATGatewayProfile.idleTimeoutInMinutes
-        /// </param>
+        /// <param name="managedOutboundIPProfile"> Profile of the managed outbound IP resources of the cluster NAT gateway. </param>
+        /// <param name="effectiveOutboundIPs"> The effective outbound IP resources of the cluster NAT gateway. </param>
+        /// <param name="idleTimeoutInMinutes"> Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterNatGatewayProfile(ManagedClusterManagedOutboundIPProfile managedOutboundIPProfile, IList<WritableSubResource> effectiveOutboundIPs, int? idleTimeoutInMinutes, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -77,15 +65,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Profile of the managed outbound IP resources of the cluster NAT gateway.
-        /// Serialized Name: ManagedClusterNATGatewayProfile.managedOutboundIPProfile
-        /// </summary>
+        /// <summary> Profile of the managed outbound IP resources of the cluster NAT gateway. </summary>
         internal ManagedClusterManagedOutboundIPProfile ManagedOutboundIPProfile { get; set; }
-        /// <summary>
-        /// The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1.
-        /// Serialized Name: ManagedClusterManagedOutboundIPProfile.count
-        /// </summary>
+        /// <summary> The desired number of outbound IPs created/managed by Azure. Allowed values must be in the range of 1 to 16 (inclusive). The default value is 1. </summary>
         [WirePath("managedOutboundIPProfile.count")]
         public int? ManagedOutboundIPCount
         {
@@ -97,10 +79,7 @@ namespace Azure.ResourceManager.ContainerService.Models
                 ManagedOutboundIPProfile.Count = value;
             }
         }
-        /// <summary>
-        /// Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes.
-        /// Serialized Name: ManagedClusterNATGatewayProfile.idleTimeoutInMinutes
-        /// </summary>
+        /// <summary> Desired outbound flow idle timeout in minutes. Allowed values are in the range of 4 to 120 (inclusive). The default value is 4 minutes. </summary>
         [WirePath("idleTimeoutInMinutes")]
         public int? IdleTimeoutInMinutes { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNodeOSUpgradeChannel.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNodeOSUpgradeChannel.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Node OS Upgrade Channel. Manner in which the OS on your nodes is updated. The default is NodeImage.
-    /// Serialized Name: NodeOSUpgradeChannel
-    /// </summary>
+    /// <summary> Node OS Upgrade Channel. Manner in which the OS on your nodes is updated. The default is NodeImage. </summary>
     public readonly partial struct ManagedClusterNodeOSUpgradeChannel : IEquatable<ManagedClusterNodeOSUpgradeChannel>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string NodeImageValue = "NodeImage";
         private const string SecurityPatchValue = "SecurityPatch";
 
-        /// <summary>
-        /// No attempt to update your machines OS will be made either by OS or by rolling VHDs. This means you are responsible for your security updates
-        /// Serialized Name: NodeOSUpgradeChannel.None
-        /// </summary>
+        /// <summary> No attempt to update your machines OS will be made either by OS or by rolling VHDs. This means you are responsible for your security updates. </summary>
         public static ManagedClusterNodeOSUpgradeChannel None { get; } = new ManagedClusterNodeOSUpgradeChannel(NoneValue);
-        /// <summary>
-        /// OS updates will be applied automatically through the OS built-in patching infrastructure. Newly scaled in machines will be unpatched initially and will be patched at some point by the OS's infrastructure. Behavior of this option depends on the OS in question. Ubuntu and Mariner apply security patches through unattended upgrade roughly once a day around 06:00 UTC. Windows does not apply security patches automatically and so for them this option is equivalent to None till further notice
-        /// Serialized Name: NodeOSUpgradeChannel.Unmanaged
-        /// </summary>
+        /// <summary> OS updates will be applied automatically through the OS built-in patching infrastructure. Newly scaled in machines will be unpatched initially and will be patched at some point by the OS's infrastructure. Behavior of this option depends on the OS in question. Ubuntu and Mariner apply security patches through unattended upgrade roughly once a day around 06:00 UTC. Windows does not apply security patches automatically and so for them this option is equivalent to None till further notice. </summary>
         public static ManagedClusterNodeOSUpgradeChannel Unmanaged { get; } = new ManagedClusterNodeOSUpgradeChannel(UnmanagedValue);
-        /// <summary>
-        /// AKS will update the nodes with a newly patched VHD containing security fixes and bugfixes on a weekly cadence. With the VHD update machines will be rolling reimaged to that VHD following maintenance windows and surge settings. No extra VHD cost is incurred when choosing this option as AKS hosts the images.
-        /// Serialized Name: NodeOSUpgradeChannel.NodeImage
-        /// </summary>
+        /// <summary> AKS will update the nodes with a newly patched VHD containing security fixes and bugfixes on a weekly cadence. With the VHD update machines will be rolling reimaged to that VHD following maintenance windows and surge settings. No extra VHD cost is incurred when choosing this option as AKS hosts the images. </summary>
         public static ManagedClusterNodeOSUpgradeChannel NodeImage { get; } = new ManagedClusterNodeOSUpgradeChannel(NodeImageValue);
-        /// <summary>
-        /// AKS downloads and updates the nodes with tested security updates. These updates honor the maintenance window settings and produce a new VHD that is used on new nodes. On some occasions it's not possible to apply the updates in place, in such cases the existing nodes will also be re-imaged to the newly produced VHD in order to apply the changes. This option incurs an extra cost of hosting the new Security Patch VHDs in your resource group for just in time consumption.
-        /// Serialized Name: NodeOSUpgradeChannel.SecurityPatch
-        /// </summary>
+        /// <summary> AKS downloads and updates the nodes with tested security updates. These updates honor the maintenance window settings and produce a new VHD that is used on new nodes. On some occasions it's not possible to apply the updates in place, in such cases the existing nodes will also be re-imaged to the newly produced VHD in order to apply the changes. This option incurs an extra cost of hosting the new Security Patch VHDs in your resource group for just in time consumption. </summary>
         public static ManagedClusterNodeOSUpgradeChannel SecurityPatch { get; } = new ManagedClusterNodeOSUpgradeChannel(SecurityPatchValue);
         /// <summary> Determines if two <see cref="ManagedClusterNodeOSUpgradeChannel"/> values are the same. </summary>
         public static bool operator ==(ManagedClusterNodeOSUpgradeChannel left, ManagedClusterNodeOSUpgradeChannel right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNodeProvisioningProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNodeProvisioningProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The ManagedClusterNodeProvisioningProfile.
-    /// Serialized Name: ManagedClusterNodeProvisioningProfile
-    /// </summary>
+    /// <summary> The ManagedClusterNodeProvisioningProfile. </summary>
     public partial class ManagedClusterNodeProvisioningProfile
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterNodeProvisioningProfile"/>. </summary>
-        /// <param name="mode">
-        /// The node provisioning mode. If not specified, the default is Manual.
-        /// Serialized Name: ManagedClusterNodeProvisioningProfile.mode
-        /// </param>
-        /// <param name="defaultNodePools">
-        /// The set of default Karpenter NodePools (CRDs) configured for node provisioning. This field has no effect unless mode is 'Auto'. Warning: Changing this from Auto to None on an existing cluster will cause the default Karpenter NodePools to be deleted, which will drain and delete the nodes associated with those pools. It is strongly recommended to not do this unless there are idle nodes ready to take the pods evicted by that action. If not specified, the default is Auto. For more information see aka.ms/aks/nap#node-pools.
-        /// Serialized Name: ManagedClusterNodeProvisioningProfile.defaultNodePools
-        /// </param>
+        /// <param name="mode"> The node provisioning mode. If not specified, the default is Manual. </param>
+        /// <param name="defaultNodePools"> The set of default Karpenter NodePools (CRDs) configured for node provisioning. This field has no effect unless mode is 'Auto'. Warning: Changing this from Auto to None on an existing cluster will cause the default Karpenter NodePools to be deleted, which will drain and delete the nodes associated with those pools. It is strongly recommended to not do this unless there are idle nodes ready to take the pods evicted by that action. If not specified, the default is Auto. For more information see aka.ms/aks/nap#node-pools. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterNodeProvisioningProfile(NodeProvisioningMode? mode, NodeProvisioningDefaultNodePool? defaultNodePools, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The node provisioning mode. If not specified, the default is Manual.
-        /// Serialized Name: ManagedClusterNodeProvisioningProfile.mode
-        /// </summary>
+        /// <summary> The node provisioning mode. If not specified, the default is Manual. </summary>
         [WirePath("mode")]
         public NodeProvisioningMode? Mode { get; set; }
-        /// <summary>
-        /// The set of default Karpenter NodePools (CRDs) configured for node provisioning. This field has no effect unless mode is 'Auto'. Warning: Changing this from Auto to None on an existing cluster will cause the default Karpenter NodePools to be deleted, which will drain and delete the nodes associated with those pools. It is strongly recommended to not do this unless there are idle nodes ready to take the pods evicted by that action. If not specified, the default is Auto. For more information see aka.ms/aks/nap#node-pools.
-        /// Serialized Name: ManagedClusterNodeProvisioningProfile.defaultNodePools
-        /// </summary>
+        /// <summary> The set of default Karpenter NodePools (CRDs) configured for node provisioning. This field has no effect unless mode is 'Auto'. Warning: Changing this from Auto to None on an existing cluster will cause the default Karpenter NodePools to be deleted, which will drain and delete the nodes associated with those pools. It is strongly recommended to not do this unless there are idle nodes ready to take the pods evicted by that action. If not specified, the default is Auto. For more information see aka.ms/aks/nap#node-pools. </summary>
         [WirePath("defaultNodePools")]
         public NodeProvisioningDefaultNodePool? DefaultNodePools { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNodeResourceGroupProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNodeResourceGroupProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Node resource group lockdown profile for a managed cluster.
-    /// Serialized Name: ManagedClusterNodeResourceGroupProfile
-    /// </summary>
+    /// <summary> Node resource group lockdown profile for a managed cluster. </summary>
     internal partial class ManagedClusterNodeResourceGroupProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterNodeResourceGroupProfile"/>. </summary>
-        /// <param name="restrictionLevel">
-        /// The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'
-        /// Serialized Name: ManagedClusterNodeResourceGroupProfile.restrictionLevel
-        /// </param>
+        /// <param name="restrictionLevel"> The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterNodeResourceGroupProfile(ManagedClusterNodeResourceGroupRestrictionLevel? restrictionLevel, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'
-        /// Serialized Name: ManagedClusterNodeResourceGroupProfile.restrictionLevel
-        /// </summary>
+        /// <summary> The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'. </summary>
         [WirePath("restrictionLevel")]
         public ManagedClusterNodeResourceGroupRestrictionLevel? RestrictionLevel { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNodeResourceGroupRestrictionLevel.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterNodeResourceGroupRestrictionLevel.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'
-    /// Serialized Name: RestrictionLevel
-    /// </summary>
+    /// <summary> The restriction level applied to the cluster's node resource group. If not specified, the default is 'Unrestricted'. </summary>
     public readonly partial struct ManagedClusterNodeResourceGroupRestrictionLevel : IEquatable<ManagedClusterNodeResourceGroupRestrictionLevel>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string UnrestrictedValue = "Unrestricted";
         private const string ReadOnlyValue = "ReadOnly";
 
-        /// <summary>
-        /// All RBAC permissions are allowed on the managed node resource group
-        /// Serialized Name: RestrictionLevel.Unrestricted
-        /// </summary>
+        /// <summary> All RBAC permissions are allowed on the managed node resource group. </summary>
         public static ManagedClusterNodeResourceGroupRestrictionLevel Unrestricted { get; } = new ManagedClusterNodeResourceGroupRestrictionLevel(UnrestrictedValue);
-        /// <summary>
-        /// Only */read RBAC permissions allowed on the managed node resource group
-        /// Serialized Name: RestrictionLevel.ReadOnly
-        /// </summary>
+        /// <summary> Only */read RBAC permissions allowed on the managed node resource group. </summary>
         public static ManagedClusterNodeResourceGroupRestrictionLevel ReadOnly { get; } = new ManagedClusterNodeResourceGroupRestrictionLevel(ReadOnlyValue);
         /// <summary> Determines if two <see cref="ManagedClusterNodeResourceGroupRestrictionLevel"/> values are the same. </summary>
         public static bool operator ==(ManagedClusterNodeResourceGroupRestrictionLevel left, ManagedClusterNodeResourceGroupRestrictionLevel right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterOidcIssuerProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterOidcIssuerProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The OIDC issuer profile of the Managed Cluster.
-    /// Serialized Name: ManagedClusterOidcIssuerProfile
-    /// </summary>
+    /// <summary> The OIDC issuer profile of the Managed Cluster. </summary>
     public partial class ManagedClusterOidcIssuerProfile
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterOidcIssuerProfile"/>. </summary>
-        /// <param name="issuerUriInfo">
-        /// The OIDC issuer url of the Managed Cluster.
-        /// Serialized Name: ManagedClusterOidcIssuerProfile.issuerURL
-        /// </param>
-        /// <param name="isEnabled">
-        /// Whether the OIDC issuer is enabled.
-        /// Serialized Name: ManagedClusterOidcIssuerProfile.enabled
-        /// </param>
+        /// <param name="issuerUriInfo"> The OIDC issuer url of the Managed Cluster. </param>
+        /// <param name="isEnabled"> Whether the OIDC issuer is enabled. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterOidcIssuerProfile(string issuerUriInfo, bool? isEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The OIDC issuer url of the Managed Cluster.
-        /// Serialized Name: ManagedClusterOidcIssuerProfile.issuerURL
-        /// </summary>
+        /// <summary> The OIDC issuer url of the Managed Cluster. </summary>
         [WirePath("issuerURL")]
         public string IssuerUriInfo { get; }
-        /// <summary>
-        /// Whether the OIDC issuer is enabled.
-        /// Serialized Name: ManagedClusterOidcIssuerProfile.enabled
-        /// </summary>
+        /// <summary> Whether the OIDC issuer is enabled. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentity.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentity.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Details about the pod identity assigned to the Managed Cluster.
-    /// Serialized Name: ManagedClusterPodIdentity
-    /// </summary>
+    /// <summary> Details about the pod identity assigned to the Managed Cluster. </summary>
     public partial class ManagedClusterPodIdentity
     {
         /// <summary>
@@ -49,18 +46,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPodIdentity"/>. </summary>
-        /// <param name="name">
-        /// The name of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.name
-        /// </param>
-        /// <param name="namespace">
-        /// The namespace of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.namespace
-        /// </param>
-        /// <param name="identity">
-        /// The user assigned identity details.
-        /// Serialized Name: ManagedClusterPodIdentity.identity
-        /// </param>
+        /// <param name="name"> The name of the pod identity. </param>
+        /// <param name="namespace"> The namespace of the pod identity. </param>
+        /// <param name="identity"> The user assigned identity details. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/>, <paramref name="namespace"/> or <paramref name="identity"/> is null. </exception>
         public ManagedClusterPodIdentity(string name, string @namespace, ContainerServiceUserAssignedIdentity identity)
         {
@@ -74,27 +62,12 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPodIdentity"/>. </summary>
-        /// <param name="name">
-        /// The name of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.name
-        /// </param>
-        /// <param name="namespace">
-        /// The namespace of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.namespace
-        /// </param>
-        /// <param name="bindingSelector">
-        /// The binding selector to use for the AzureIdentityBinding resource.
-        /// Serialized Name: ManagedClusterPodIdentity.bindingSelector
-        /// </param>
-        /// <param name="identity">
-        /// The user assigned identity details.
-        /// Serialized Name: ManagedClusterPodIdentity.identity
-        /// </param>
-        /// <param name="provisioningState">
-        /// The current provisioning state of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.provisioningState
-        /// </param>
-        /// <param name="provisioningInfo"> Serialized Name: ManagedClusterPodIdentity.provisioningInfo. </param>
+        /// <param name="name"> The name of the pod identity. </param>
+        /// <param name="namespace"> The namespace of the pod identity. </param>
+        /// <param name="bindingSelector"> The binding selector to use for the AzureIdentityBinding resource. </param>
+        /// <param name="identity"> The user assigned identity details. </param>
+        /// <param name="provisioningState"> The current provisioning state of the pod identity. </param>
+        /// <param name="provisioningInfo"></param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterPodIdentity(string name, string @namespace, string bindingSelector, ContainerServiceUserAssignedIdentity identity, ManagedClusterPodIdentityProvisioningState? provisioningState, ManagedClusterPodIdentityProvisioningInfo provisioningInfo, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -112,42 +85,24 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// The name of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.name
-        /// </summary>
+        /// <summary> The name of the pod identity. </summary>
         [WirePath("name")]
         public string Name { get; set; }
-        /// <summary>
-        /// The namespace of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.namespace
-        /// </summary>
+        /// <summary> The namespace of the pod identity. </summary>
         [WirePath("namespace")]
         public string Namespace { get; set; }
-        /// <summary>
-        /// The binding selector to use for the AzureIdentityBinding resource.
-        /// Serialized Name: ManagedClusterPodIdentity.bindingSelector
-        /// </summary>
+        /// <summary> The binding selector to use for the AzureIdentityBinding resource. </summary>
         [WirePath("bindingSelector")]
         public string BindingSelector { get; set; }
-        /// <summary>
-        /// The user assigned identity details.
-        /// Serialized Name: ManagedClusterPodIdentity.identity
-        /// </summary>
+        /// <summary> The user assigned identity details. </summary>
         [WirePath("identity")]
         public ContainerServiceUserAssignedIdentity Identity { get; set; }
-        /// <summary>
-        /// The current provisioning state of the pod identity.
-        /// Serialized Name: ManagedClusterPodIdentity.provisioningState
-        /// </summary>
+        /// <summary> The current provisioning state of the pod identity. </summary>
         [WirePath("provisioningState")]
         public ManagedClusterPodIdentityProvisioningState? ProvisioningState { get; }
-        /// <summary> Serialized Name: ManagedClusterPodIdentity.provisioningInfo. </summary>
+        /// <summary> Gets the provisioning info. </summary>
         internal ManagedClusterPodIdentityProvisioningInfo ProvisioningInfo { get; }
-        /// <summary>
-        /// Details about the error.
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningError.error
-        /// </summary>
+        /// <summary> Details about the error. </summary>
         [WirePath("provisioningInfo.error.error")]
         public ResponseError ErrorDetail
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityException.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityException.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// A pod identity exception, which allows pods with certain labels to access the Azure Instance Metadata Service (IMDS) endpoint without being intercepted by the node-managed identity (NMI) server. See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details.
-    /// Serialized Name: ManagedClusterPodIdentityException
-    /// </summary>
+    /// <summary> A pod identity exception, which allows pods with certain labels to access the Azure Instance Metadata Service (IMDS) endpoint without being intercepted by the node-managed identity (NMI) server. See [disable AAD Pod Identity for a specific Pod/Application](https://azure.github.io/aad-pod-identity/docs/configure/application_exception/) for more details. </summary>
     public partial class ManagedClusterPodIdentityException
     {
         /// <summary>
@@ -49,18 +46,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPodIdentityException"/>. </summary>
-        /// <param name="name">
-        /// The name of the pod identity exception.
-        /// Serialized Name: ManagedClusterPodIdentityException.name
-        /// </param>
-        /// <param name="namespace">
-        /// The namespace of the pod identity exception.
-        /// Serialized Name: ManagedClusterPodIdentityException.namespace
-        /// </param>
-        /// <param name="podLabels">
-        /// The pod labels to match.
-        /// Serialized Name: ManagedClusterPodIdentityException.podLabels
-        /// </param>
+        /// <param name="name"> The name of the pod identity exception. </param>
+        /// <param name="namespace"> The namespace of the pod identity exception. </param>
+        /// <param name="podLabels"> The pod labels to match. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="name"/>, <paramref name="namespace"/> or <paramref name="podLabels"/> is null. </exception>
         public ManagedClusterPodIdentityException(string name, string @namespace, IDictionary<string, string> podLabels)
         {
@@ -74,18 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPodIdentityException"/>. </summary>
-        /// <param name="name">
-        /// The name of the pod identity exception.
-        /// Serialized Name: ManagedClusterPodIdentityException.name
-        /// </param>
-        /// <param name="namespace">
-        /// The namespace of the pod identity exception.
-        /// Serialized Name: ManagedClusterPodIdentityException.namespace
-        /// </param>
-        /// <param name="podLabels">
-        /// The pod labels to match.
-        /// Serialized Name: ManagedClusterPodIdentityException.podLabels
-        /// </param>
+        /// <param name="name"> The name of the pod identity exception. </param>
+        /// <param name="namespace"> The namespace of the pod identity exception. </param>
+        /// <param name="podLabels"> The pod labels to match. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterPodIdentityException(string name, string @namespace, IDictionary<string, string> podLabels, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -100,22 +79,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// The name of the pod identity exception.
-        /// Serialized Name: ManagedClusterPodIdentityException.name
-        /// </summary>
+        /// <summary> The name of the pod identity exception. </summary>
         [WirePath("name")]
         public string Name { get; set; }
-        /// <summary>
-        /// The namespace of the pod identity exception.
-        /// Serialized Name: ManagedClusterPodIdentityException.namespace
-        /// </summary>
+        /// <summary> The namespace of the pod identity exception. </summary>
         [WirePath("namespace")]
         public string Namespace { get; set; }
-        /// <summary>
-        /// The pod labels to match.
-        /// Serialized Name: ManagedClusterPodIdentityException.podLabels
-        /// </summary>
+        /// <summary> The pod labels to match. </summary>
         [WirePath("podLabels")]
         public IDictionary<string, string> PodLabels { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration.
-    /// Serialized Name: ManagedClusterPodIdentityProfile
-    /// </summary>
+    /// <summary> The pod identity profile of the Managed Cluster. See [use AAD pod identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity) for more details on pod identity integration. </summary>
     public partial class ManagedClusterPodIdentityProfile
     {
         /// <summary>
@@ -56,22 +53,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPodIdentityProfile"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether the pod identity addon is enabled.
-        /// Serialized Name: ManagedClusterPodIdentityProfile.enabled
-        /// </param>
-        /// <param name="allowNetworkPluginKubenet">
-        /// Whether pod identity is allowed to run on clusters with Kubenet networking. Running in Kubenet is disabled by default due to the security related nature of AAD Pod Identity and the risks of IP spoofing. See [using Kubenet network plugin with AAD Pod Identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity#using-kubenet-network-plugin-with-azure-active-directory-pod-managed-identities) for more information.
-        /// Serialized Name: ManagedClusterPodIdentityProfile.allowNetworkPluginKubenet
-        /// </param>
-        /// <param name="userAssignedIdentities">
-        /// The pod identities to use in the cluster.
-        /// Serialized Name: ManagedClusterPodIdentityProfile.userAssignedIdentities
-        /// </param>
-        /// <param name="userAssignedIdentityExceptions">
-        /// The pod identity exceptions to allow.
-        /// Serialized Name: ManagedClusterPodIdentityProfile.userAssignedIdentityExceptions
-        /// </param>
+        /// <param name="isEnabled"> Whether the pod identity addon is enabled. </param>
+        /// <param name="allowNetworkPluginKubenet"> Whether pod identity is allowed to run on clusters with Kubenet networking. Running in Kubenet is disabled by default due to the security related nature of AAD Pod Identity and the risks of IP spoofing. See [using Kubenet network plugin with AAD Pod Identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity#using-kubenet-network-plugin-with-azure-active-directory-pod-managed-identities) for more information. </param>
+        /// <param name="userAssignedIdentities"> The pod identities to use in the cluster. </param>
+        /// <param name="userAssignedIdentityExceptions"> The pod identity exceptions to allow. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterPodIdentityProfile(bool? isEnabled, bool? allowNetworkPluginKubenet, IList<ManagedClusterPodIdentity> userAssignedIdentities, IList<ManagedClusterPodIdentityException> userAssignedIdentityExceptions, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -82,28 +67,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether the pod identity addon is enabled.
-        /// Serialized Name: ManagedClusterPodIdentityProfile.enabled
-        /// </summary>
+        /// <summary> Whether the pod identity addon is enabled. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
-        /// <summary>
-        /// Whether pod identity is allowed to run on clusters with Kubenet networking. Running in Kubenet is disabled by default due to the security related nature of AAD Pod Identity and the risks of IP spoofing. See [using Kubenet network plugin with AAD Pod Identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity#using-kubenet-network-plugin-with-azure-active-directory-pod-managed-identities) for more information.
-        /// Serialized Name: ManagedClusterPodIdentityProfile.allowNetworkPluginKubenet
-        /// </summary>
+        /// <summary> Whether pod identity is allowed to run on clusters with Kubenet networking. Running in Kubenet is disabled by default due to the security related nature of AAD Pod Identity and the risks of IP spoofing. See [using Kubenet network plugin with AAD Pod Identity](https://docs.microsoft.com/azure/aks/use-azure-ad-pod-identity#using-kubenet-network-plugin-with-azure-active-directory-pod-managed-identities) for more information. </summary>
         [WirePath("allowNetworkPluginKubenet")]
         public bool? AllowNetworkPluginKubenet { get; set; }
-        /// <summary>
-        /// The pod identities to use in the cluster.
-        /// Serialized Name: ManagedClusterPodIdentityProfile.userAssignedIdentities
-        /// </summary>
+        /// <summary> The pod identities to use in the cluster. </summary>
         [WirePath("userAssignedIdentities")]
         public IList<ManagedClusterPodIdentity> UserAssignedIdentities { get; }
-        /// <summary>
-        /// The pod identity exceptions to allow.
-        /// Serialized Name: ManagedClusterPodIdentityProfile.userAssignedIdentityExceptions
-        /// </summary>
+        /// <summary> The pod identity exceptions to allow. </summary>
         [WirePath("userAssignedIdentityExceptions")]
         public IList<ManagedClusterPodIdentityException> UserAssignedIdentityExceptions { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityProvisioningError.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityProvisioningError.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// An error response from the pod identity provisioning.
-    /// Serialized Name: ManagedClusterPodIdentityProvisioningError
-    /// </summary>
+    /// <summary> An error response from the pod identity provisioning. </summary>
     internal partial class ManagedClusterPodIdentityProvisioningError
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPodIdentityProvisioningError"/>. </summary>
-        /// <param name="errorDetail">
-        /// Details about the error.
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningError.error
-        /// </param>
+        /// <param name="errorDetail"> Details about the error. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterPodIdentityProvisioningError(ResponseError errorDetail, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Details about the error.
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningError.error
-        /// </summary>
+        /// <summary> Details about the error. </summary>
         [WirePath("error")]
         public ResponseError ErrorDetail { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityProvisioningInfo.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityProvisioningInfo.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The ManagedClusterPodIdentityProvisioningInfo.
-    /// Serialized Name: ManagedClusterPodIdentityProvisioningInfo
-    /// </summary>
+    /// <summary> The ManagedClusterPodIdentityProvisioningInfo. </summary>
     internal partial class ManagedClusterPodIdentityProvisioningInfo
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPodIdentityProvisioningInfo"/>. </summary>
-        /// <param name="error">
-        /// Pod identity assignment error (if any).
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningInfo.error
-        /// </param>
+        /// <param name="error"> Pod identity assignment error (if any). </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterPodIdentityProvisioningInfo(ManagedClusterPodIdentityProvisioningError error, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,15 +59,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Pod identity assignment error (if any).
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningInfo.error
-        /// </summary>
+        /// <summary> Pod identity assignment error (if any). </summary>
         internal ManagedClusterPodIdentityProvisioningError Error { get; }
-        /// <summary>
-        /// Details about the error.
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningError.error
-        /// </summary>
+        /// <summary> Details about the error. </summary>
         [WirePath("error.error")]
         public ResponseError ErrorDetail
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityProvisioningState.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPodIdentityProvisioningState.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The current provisioning state of the pod identity.
-    /// Serialized Name: ManagedClusterPodIdentityProvisioningState
-    /// </summary>
+    /// <summary> The current provisioning state of the pod identity. </summary>
     public readonly partial struct ManagedClusterPodIdentityProvisioningState : IEquatable<ManagedClusterPodIdentityProvisioningState>
     {
         private readonly string _value;
@@ -32,35 +29,17 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string SucceededValue = "Succeeded";
         private const string UpdatingValue = "Updating";
 
-        /// <summary>
-        /// Assigned
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningState.Assigned
-        /// </summary>
+        /// <summary> Assigned. </summary>
         public static ManagedClusterPodIdentityProvisioningState Assigned { get; } = new ManagedClusterPodIdentityProvisioningState(AssignedValue);
-        /// <summary>
-        /// Canceled
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningState.Canceled
-        /// </summary>
+        /// <summary> Canceled. </summary>
         public static ManagedClusterPodIdentityProvisioningState Canceled { get; } = new ManagedClusterPodIdentityProvisioningState(CanceledValue);
-        /// <summary>
-        /// Deleting
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningState.Deleting
-        /// </summary>
+        /// <summary> Deleting. </summary>
         public static ManagedClusterPodIdentityProvisioningState Deleting { get; } = new ManagedClusterPodIdentityProvisioningState(DeletingValue);
-        /// <summary>
-        /// Failed
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningState.Failed
-        /// </summary>
+        /// <summary> Failed. </summary>
         public static ManagedClusterPodIdentityProvisioningState Failed { get; } = new ManagedClusterPodIdentityProvisioningState(FailedValue);
-        /// <summary>
-        /// Succeeded
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningState.Succeeded
-        /// </summary>
+        /// <summary> Succeeded. </summary>
         public static ManagedClusterPodIdentityProvisioningState Succeeded { get; } = new ManagedClusterPodIdentityProvisioningState(SucceededValue);
-        /// <summary>
-        /// Updating
-        /// Serialized Name: ManagedClusterPodIdentityProvisioningState.Updating
-        /// </summary>
+        /// <summary> Updating. </summary>
         public static ManagedClusterPodIdentityProvisioningState Updating { get; } = new ManagedClusterPodIdentityProvisioningState(UpdatingValue);
         /// <summary> Determines if two <see cref="ManagedClusterPodIdentityProvisioningState"/> values are the same. </summary>
         public static bool operator ==(ManagedClusterPodIdentityProvisioningState left, ManagedClusterPodIdentityProvisioningState right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPoolUpgradeProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPoolUpgradeProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The list of available upgrade versions.
-    /// Serialized Name: ManagedClusterPoolUpgradeProfile
-    /// </summary>
+    /// <summary> The list of available upgrade versions. </summary>
     public partial class ManagedClusterPoolUpgradeProfile
     {
         /// <summary>
@@ -49,14 +46,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPoolUpgradeProfile"/>. </summary>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.kubernetesVersion
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.osType
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="kubernetesVersion"/> is null. </exception>
         internal ManagedClusterPoolUpgradeProfile(string kubernetesVersion, ContainerServiceOSType osType)
         {
@@ -68,22 +59,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPoolUpgradeProfile"/>. </summary>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.kubernetesVersion
-        /// </param>
-        /// <param name="name">
-        /// The Agent Pool name.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.name
-        /// </param>
-        /// <param name="osType">
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.osType
-        /// </param>
-        /// <param name="upgrades">
-        /// List of orchestrator types and versions available for upgrade.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.upgrades
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="name"> The Agent Pool name. </param>
+        /// <param name="osType"> The operating system type. The default is Linux. </param>
+        /// <param name="upgrades"> List of orchestrator types and versions available for upgrade. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterPoolUpgradeProfile(string kubernetesVersion, string name, ContainerServiceOSType osType, IReadOnlyList<ManagedClusterPoolUpgradeProfileUpgradesItem> upgrades, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -99,28 +78,16 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.kubernetesVersion
-        /// </summary>
+        /// <summary> The Kubernetes version (major.minor.patch). </summary>
         [WirePath("kubernetesVersion")]
         public string KubernetesVersion { get; }
-        /// <summary>
-        /// The Agent Pool name.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.name
-        /// </summary>
+        /// <summary> The Agent Pool name. </summary>
         [WirePath("name")]
         public string Name { get; }
-        /// <summary>
-        /// The operating system type. The default is Linux.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.osType
-        /// </summary>
+        /// <summary> The operating system type. The default is Linux. </summary>
         [WirePath("osType")]
         public ContainerServiceOSType OSType { get; }
-        /// <summary>
-        /// List of orchestrator types and versions available for upgrade.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfile.upgrades
-        /// </summary>
+        /// <summary> List of orchestrator types and versions available for upgrade. </summary>
         [WirePath("upgrades")]
         public IReadOnlyList<ManagedClusterPoolUpgradeProfileUpgradesItem> Upgrades { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPoolUpgradeProfileUpgradesItem.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterPoolUpgradeProfileUpgradesItem.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The ManagedClusterPoolUpgradeProfileUpgradesItem.
-    /// Serialized Name: ManagedClusterPoolUpgradeProfileUpgradesItem
-    /// </summary>
+    /// <summary> The ManagedClusterPoolUpgradeProfileUpgradesItem. </summary>
     public partial class ManagedClusterPoolUpgradeProfileUpgradesItem
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterPoolUpgradeProfileUpgradesItem"/>. </summary>
-        /// <param name="kubernetesVersion">
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: ManagedClusterPoolUpgradeProfileUpgradesItem.kubernetesVersion
-        /// </param>
-        /// <param name="isPreview">
-        /// Whether the Kubernetes version is currently in preview.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfileUpgradesItem.isPreview
-        /// </param>
+        /// <param name="kubernetesVersion"> The Kubernetes version (major.minor.patch). </param>
+        /// <param name="isPreview"> Whether the Kubernetes version is currently in preview. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterPoolUpgradeProfileUpgradesItem(string kubernetesVersion, bool? isPreview, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The Kubernetes version (major.minor.patch).
-        /// Serialized Name: ManagedClusterPoolUpgradeProfileUpgradesItem.kubernetesVersion
-        /// </summary>
+        /// <summary> The Kubernetes version (major.minor.patch). </summary>
         [WirePath("kubernetesVersion")]
         public string KubernetesVersion { get; }
-        /// <summary>
-        /// Whether the Kubernetes version is currently in preview.
-        /// Serialized Name: ManagedClusterPoolUpgradeProfileUpgradesItem.isPreview
-        /// </summary>
+        /// <summary> Whether the Kubernetes version is currently in preview. </summary>
         [WirePath("isPreview")]
         public bool? IsPreview { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterRunCommandContent.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterRunCommandContent.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// A run command request
-    /// Serialized Name: RunCommandRequest
-    /// </summary>
+    /// <summary> A run command request. </summary>
     public partial class ManagedClusterRunCommandContent
     {
         /// <summary>
@@ -49,10 +46,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterRunCommandContent"/>. </summary>
-        /// <param name="command">
-        /// The command to run.
-        /// Serialized Name: RunCommandRequest.command
-        /// </param>
+        /// <param name="command"> The command to run. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="command"/> is null. </exception>
         public ManagedClusterRunCommandContent(string command)
         {
@@ -62,18 +56,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterRunCommandContent"/>. </summary>
-        /// <param name="command">
-        /// The command to run.
-        /// Serialized Name: RunCommandRequest.command
-        /// </param>
-        /// <param name="context">
-        /// A base64 encoded zip file containing the files required by the command.
-        /// Serialized Name: RunCommandRequest.context
-        /// </param>
-        /// <param name="clusterToken">
-        /// AuthToken issued for AKS AAD Server App.
-        /// Serialized Name: RunCommandRequest.clusterToken
-        /// </param>
+        /// <param name="command"> The command to run. </param>
+        /// <param name="context"> A base64 encoded zip file containing the files required by the command. </param>
+        /// <param name="clusterToken"> AuthToken issued for AKS AAD Server App. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterRunCommandContent(string command, string context, string clusterToken, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -88,22 +73,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// The command to run.
-        /// Serialized Name: RunCommandRequest.command
-        /// </summary>
+        /// <summary> The command to run. </summary>
         [WirePath("command")]
         public string Command { get; }
-        /// <summary>
-        /// A base64 encoded zip file containing the files required by the command.
-        /// Serialized Name: RunCommandRequest.context
-        /// </summary>
+        /// <summary> A base64 encoded zip file containing the files required by the command. </summary>
         [WirePath("context")]
         public string Context { get; set; }
-        /// <summary>
-        /// AuthToken issued for AKS AAD Server App.
-        /// Serialized Name: RunCommandRequest.clusterToken
-        /// </summary>
+        /// <summary> AuthToken issued for AKS AAD Server App. </summary>
         [WirePath("clusterToken")]
         public string ClusterToken { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterRunCommandResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterRunCommandResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// run command result.
-    /// Serialized Name: RunCommandResult
-    /// </summary>
+    /// <summary> run command result. </summary>
     public partial class ManagedClusterRunCommandResult
     {
         /// <summary>
@@ -54,34 +51,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterRunCommandResult"/>. </summary>
-        /// <param name="id">
-        /// The command id.
-        /// Serialized Name: RunCommandResult.id
-        /// </param>
-        /// <param name="provisioningState">
-        /// provisioning State
-        /// Serialized Name: RunCommandResult.properties.provisioningState
-        /// </param>
-        /// <param name="exitCode">
-        /// The exit code of the command
-        /// Serialized Name: RunCommandResult.properties.exitCode
-        /// </param>
-        /// <param name="startedOn">
-        /// The time when the command started.
-        /// Serialized Name: RunCommandResult.properties.startedAt
-        /// </param>
-        /// <param name="finishedOn">
-        /// The time when the command finished.
-        /// Serialized Name: RunCommandResult.properties.finishedAt
-        /// </param>
-        /// <param name="logs">
-        /// The command output.
-        /// Serialized Name: RunCommandResult.properties.logs
-        /// </param>
-        /// <param name="reason">
-        /// An explanation of why provisioningState is set to failed (if so).
-        /// Serialized Name: RunCommandResult.properties.reason
-        /// </param>
+        /// <param name="id"> The command id. </param>
+        /// <param name="provisioningState"> provisioning State. </param>
+        /// <param name="exitCode"> The exit code of the command. </param>
+        /// <param name="startedOn"> The time when the command started. </param>
+        /// <param name="finishedOn"> The time when the command finished. </param>
+        /// <param name="logs"> The command output. </param>
+        /// <param name="reason"> An explanation of why provisioningState is set to failed (if so). </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterRunCommandResult(string id, string provisioningState, int? exitCode, DateTimeOffset? startedOn, DateTimeOffset? finishedOn, string logs, string reason, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -95,46 +71,25 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The command id.
-        /// Serialized Name: RunCommandResult.id
-        /// </summary>
+        /// <summary> The command id. </summary>
         [WirePath("id")]
         public string Id { get; }
-        /// <summary>
-        /// provisioning State
-        /// Serialized Name: RunCommandResult.properties.provisioningState
-        /// </summary>
+        /// <summary> provisioning State. </summary>
         [WirePath("properties.provisioningState")]
         public string ProvisioningState { get; }
-        /// <summary>
-        /// The exit code of the command
-        /// Serialized Name: RunCommandResult.properties.exitCode
-        /// </summary>
+        /// <summary> The exit code of the command. </summary>
         [WirePath("properties.exitCode")]
         public int? ExitCode { get; }
-        /// <summary>
-        /// The time when the command started.
-        /// Serialized Name: RunCommandResult.properties.startedAt
-        /// </summary>
+        /// <summary> The time when the command started. </summary>
         [WirePath("properties.startedAt")]
         public DateTimeOffset? StartedOn { get; }
-        /// <summary>
-        /// The time when the command finished.
-        /// Serialized Name: RunCommandResult.properties.finishedAt
-        /// </summary>
+        /// <summary> The time when the command finished. </summary>
         [WirePath("properties.finishedAt")]
         public DateTimeOffset? FinishedOn { get; }
-        /// <summary>
-        /// The command output.
-        /// Serialized Name: RunCommandResult.properties.logs
-        /// </summary>
+        /// <summary> The command output. </summary>
         [WirePath("properties.logs")]
         public string Logs { get; }
-        /// <summary>
-        /// An explanation of why provisioningState is set to failed (if so).
-        /// Serialized Name: RunCommandResult.properties.reason
-        /// </summary>
+        /// <summary> An explanation of why provisioningState is set to failed (if so). </summary>
         [WirePath("properties.reason")]
         public string Reason { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Security profile for the container service cluster.
-    /// Serialized Name: ManagedClusterSecurityProfile
-    /// </summary>
+    /// <summary> Security profile for the container service cluster. </summary>
     public partial class ManagedClusterSecurityProfile
     {
         /// <summary>
@@ -55,26 +52,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterSecurityProfile"/>. </summary>
-        /// <param name="defender">
-        /// Microsoft Defender settings for the security profile.
-        /// Serialized Name: ManagedClusterSecurityProfile.defender
-        /// </param>
-        /// <param name="azureKeyVaultKms">
-        /// Azure Key Vault [key management service](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/) settings for the security profile.
-        /// Serialized Name: ManagedClusterSecurityProfile.azureKeyVaultKms
-        /// </param>
-        /// <param name="workloadIdentity">
-        /// Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details.
-        /// Serialized Name: ManagedClusterSecurityProfile.workloadIdentity
-        /// </param>
-        /// <param name="imageCleaner">
-        /// Image Cleaner settings for the security profile.
-        /// Serialized Name: ManagedClusterSecurityProfile.imageCleaner
-        /// </param>
-        /// <param name="customCATrustCertificates">
-        /// A list of up to 10 base64 encoded CAs that will be added to the trust store on all nodes in the cluster. For more information see [Custom CA Trust Certificates](https://learn.microsoft.com/en-us/azure/aks/custom-certificate-authority).
-        /// Serialized Name: ManagedClusterSecurityProfile.customCATrustCertificates
-        /// </param>
+        /// <param name="defender"> Microsoft Defender settings for the security profile. </param>
+        /// <param name="azureKeyVaultKms"> Azure Key Vault [key management service](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/) settings for the security profile. </param>
+        /// <param name="workloadIdentity"> Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details. </param>
+        /// <param name="imageCleaner"> Image Cleaner settings for the security profile. </param>
+        /// <param name="customCATrustCertificates"> A list of up to 10 base64 encoded CAs that will be added to the trust store on all nodes in the cluster. For more information see [Custom CA Trust Certificates](https://learn.microsoft.com/en-us/azure/aks/custom-certificate-authority). </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterSecurityProfile(ManagedClusterSecurityProfileDefender defender, ManagedClusterSecurityProfileKeyVaultKms azureKeyVaultKms, ManagedClusterSecurityProfileWorkloadIdentity workloadIdentity, ManagedClusterSecurityProfileImageCleaner imageCleaner, IList<byte[]> customCATrustCertificates, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -86,27 +68,15 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Microsoft Defender settings for the security profile.
-        /// Serialized Name: ManagedClusterSecurityProfile.defender
-        /// </summary>
+        /// <summary> Microsoft Defender settings for the security profile. </summary>
         [WirePath("defender")]
         public ManagedClusterSecurityProfileDefender Defender { get; set; }
-        /// <summary>
-        /// Azure Key Vault [key management service](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/) settings for the security profile.
-        /// Serialized Name: ManagedClusterSecurityProfile.azureKeyVaultKms
-        /// </summary>
+        /// <summary> Azure Key Vault [key management service](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/) settings for the security profile. </summary>
         [WirePath("azureKeyVaultKms")]
         public ManagedClusterSecurityProfileKeyVaultKms AzureKeyVaultKms { get; set; }
-        /// <summary>
-        /// Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details.
-        /// Serialized Name: ManagedClusterSecurityProfile.workloadIdentity
-        /// </summary>
+        /// <summary> Workload identity settings for the security profile. Workload identity enables Kubernetes applications to access Azure cloud resources securely with Azure AD. See https://aka.ms/aks/wi for more details. </summary>
         internal ManagedClusterSecurityProfileWorkloadIdentity WorkloadIdentity { get; set; }
-        /// <summary>
-        /// Whether to enable workload identity.
-        /// Serialized Name: ManagedClusterSecurityProfileWorkloadIdentity.enabled
-        /// </summary>
+        /// <summary> Whether to enable workload identity. </summary>
         [WirePath("workloadIdentity.enabled")]
         public bool? IsWorkloadIdentityEnabled
         {
@@ -119,16 +89,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// Image Cleaner settings for the security profile.
-        /// Serialized Name: ManagedClusterSecurityProfile.imageCleaner
-        /// </summary>
+        /// <summary> Image Cleaner settings for the security profile. </summary>
         [WirePath("imageCleaner")]
         public ManagedClusterSecurityProfileImageCleaner ImageCleaner { get; set; }
-        /// <summary>
-        /// A list of up to 10 base64 encoded CAs that will be added to the trust store on all nodes in the cluster. For more information see [Custom CA Trust Certificates](https://learn.microsoft.com/en-us/azure/aks/custom-certificate-authority).
-        /// Serialized Name: ManagedClusterSecurityProfile.customCATrustCertificates
-        /// </summary>
+        /// <summary> A list of up to 10 base64 encoded CAs that will be added to the trust store on all nodes in the cluster. For more information see [Custom CA Trust Certificates](https://learn.microsoft.com/en-us/azure/aks/custom-certificate-authority). </summary>
         [WirePath("customCATrustCertificates")]
         public IList<byte[]> CustomCATrustCertificates { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileDefender.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileDefender.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Microsoft Defender settings for the security profile.
-    /// Serialized Name: ManagedClusterSecurityProfileDefender
-    /// </summary>
+    /// <summary> Microsoft Defender settings for the security profile. </summary>
     public partial class ManagedClusterSecurityProfileDefender
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterSecurityProfileDefender"/>. </summary>
-        /// <param name="logAnalyticsWorkspaceResourceId">
-        /// Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty.
-        /// Serialized Name: ManagedClusterSecurityProfileDefender.logAnalyticsWorkspaceResourceId
-        /// </param>
-        /// <param name="securityMonitoring">
-        /// Microsoft Defender threat detection for Cloud settings for the security profile.
-        /// Serialized Name: ManagedClusterSecurityProfileDefender.securityMonitoring
-        /// </param>
+        /// <param name="logAnalyticsWorkspaceResourceId"> Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty. </param>
+        /// <param name="securityMonitoring"> Microsoft Defender threat detection for Cloud settings for the security profile. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterSecurityProfileDefender(ResourceIdentifier logAnalyticsWorkspaceResourceId, ManagedClusterSecurityProfileDefenderSecurityMonitoring securityMonitoring, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,21 +62,12 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty.
-        /// Serialized Name: ManagedClusterSecurityProfileDefender.logAnalyticsWorkspaceResourceId
-        /// </summary>
+        /// <summary> Resource ID of the Log Analytics workspace to be associated with Microsoft Defender. When Microsoft Defender is enabled, this field is required and must be a valid workspace resource ID. When Microsoft Defender is disabled, leave the field empty. </summary>
         [WirePath("logAnalyticsWorkspaceResourceId")]
         public ResourceIdentifier LogAnalyticsWorkspaceResourceId { get; set; }
-        /// <summary>
-        /// Microsoft Defender threat detection for Cloud settings for the security profile.
-        /// Serialized Name: ManagedClusterSecurityProfileDefender.securityMonitoring
-        /// </summary>
+        /// <summary> Microsoft Defender threat detection for Cloud settings for the security profile. </summary>
         internal ManagedClusterSecurityProfileDefenderSecurityMonitoring SecurityMonitoring { get; set; }
-        /// <summary>
-        /// Whether to enable Defender threat detection
-        /// Serialized Name: ManagedClusterSecurityProfileDefenderSecurityMonitoring.enabled
-        /// </summary>
+        /// <summary> Whether to enable Defender threat detection. </summary>
         [WirePath("securityMonitoring.enabled")]
         public bool? IsSecurityMonitoringEnabled
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileDefenderSecurityMonitoring.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileDefenderSecurityMonitoring.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Microsoft Defender settings for the security profile threat detection.
-    /// Serialized Name: ManagedClusterSecurityProfileDefenderSecurityMonitoring
-    /// </summary>
+    /// <summary> Microsoft Defender settings for the security profile threat detection. </summary>
     internal partial class ManagedClusterSecurityProfileDefenderSecurityMonitoring
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterSecurityProfileDefenderSecurityMonitoring"/>. </summary>
-        /// <param name="isSecurityMonitoringEnabled">
-        /// Whether to enable Defender threat detection
-        /// Serialized Name: ManagedClusterSecurityProfileDefenderSecurityMonitoring.enabled
-        /// </param>
+        /// <param name="isSecurityMonitoringEnabled"> Whether to enable Defender threat detection. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterSecurityProfileDefenderSecurityMonitoring(bool? isSecurityMonitoringEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable Defender threat detection
-        /// Serialized Name: ManagedClusterSecurityProfileDefenderSecurityMonitoring.enabled
-        /// </summary>
+        /// <summary> Whether to enable Defender threat detection. </summary>
         [WirePath("enabled")]
         public bool? IsSecurityMonitoringEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileImageCleaner.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileImageCleaner.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile.
-    /// Serialized Name: ManagedClusterSecurityProfileImageCleaner
-    /// </summary>
+    /// <summary> Image Cleaner removes unused images from nodes, freeing up disk space and helping to reduce attack surface area. Here are settings for the security profile. </summary>
     public partial class ManagedClusterSecurityProfileImageCleaner
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterSecurityProfileImageCleaner"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable Image Cleaner on AKS cluster.
-        /// Serialized Name: ManagedClusterSecurityProfileImageCleaner.enabled
-        /// </param>
-        /// <param name="intervalHours">
-        /// Image Cleaner scanning interval in hours.
-        /// Serialized Name: ManagedClusterSecurityProfileImageCleaner.intervalHours
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable Image Cleaner on AKS cluster. </param>
+        /// <param name="intervalHours"> Image Cleaner scanning interval in hours. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterSecurityProfileImageCleaner(bool? isEnabled, int? intervalHours, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable Image Cleaner on AKS cluster.
-        /// Serialized Name: ManagedClusterSecurityProfileImageCleaner.enabled
-        /// </summary>
+        /// <summary> Whether to enable Image Cleaner on AKS cluster. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
-        /// <summary>
-        /// Image Cleaner scanning interval in hours.
-        /// Serialized Name: ManagedClusterSecurityProfileImageCleaner.intervalHours
-        /// </summary>
+        /// <summary> Image Cleaner scanning interval in hours. </summary>
         [WirePath("intervalHours")]
         public int? IntervalHours { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileKeyVaultKms.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileKeyVaultKms.cs
@@ -11,10 +11,7 @@ using Azure.Core;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Azure Key Vault key management service settings for the security profile.
-    /// Serialized Name: AzureKeyVaultKms
-    /// </summary>
+    /// <summary> Azure Key Vault key management service settings for the security profile. </summary>
     public partial class ManagedClusterSecurityProfileKeyVaultKms
     {
         /// <summary>
@@ -55,22 +52,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterSecurityProfileKeyVaultKms"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable Azure Key Vault key management service. The default is false.
-        /// Serialized Name: AzureKeyVaultKms.enabled
-        /// </param>
-        /// <param name="keyId">
-        /// Identifier of Azure Key Vault key. See [key identifier format](https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When Azure Key Vault key management service is disabled, leave the field empty.
-        /// Serialized Name: AzureKeyVaultKms.keyId
-        /// </param>
-        /// <param name="keyVaultNetworkAccess">
-        /// Network access of the key vault. Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.
-        /// Serialized Name: AzureKeyVaultKms.keyVaultNetworkAccess
-        /// </param>
-        /// <param name="keyVaultResourceId">
-        /// Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.
-        /// Serialized Name: AzureKeyVaultKms.keyVaultResourceId
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable Azure Key Vault key management service. The default is false. </param>
+        /// <param name="keyId"> Identifier of Azure Key Vault key. See [key identifier format](https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When Azure Key Vault key management service is disabled, leave the field empty. </param>
+        /// <param name="keyVaultNetworkAccess"> Network access of the key vault. Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`. </param>
+        /// <param name="keyVaultResourceId"> Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterSecurityProfileKeyVaultKms(bool? isEnabled, string keyId, ManagedClusterKeyVaultNetworkAccessType? keyVaultNetworkAccess, ResourceIdentifier keyVaultResourceId, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -81,28 +66,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable Azure Key Vault key management service. The default is false.
-        /// Serialized Name: AzureKeyVaultKms.enabled
-        /// </summary>
+        /// <summary> Whether to enable Azure Key Vault key management service. The default is false. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
-        /// <summary>
-        /// Identifier of Azure Key Vault key. See [key identifier format](https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When Azure Key Vault key management service is disabled, leave the field empty.
-        /// Serialized Name: AzureKeyVaultKms.keyId
-        /// </summary>
+        /// <summary> Identifier of Azure Key Vault key. See [key identifier format](https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When Azure Key Vault key management service is disabled, leave the field empty. </summary>
         [WirePath("keyId")]
         public string KeyId { get; set; }
-        /// <summary>
-        /// Network access of the key vault. Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.
-        /// Serialized Name: AzureKeyVaultKms.keyVaultNetworkAccess
-        /// </summary>
+        /// <summary> Network access of the key vault. Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`. </summary>
         [WirePath("keyVaultNetworkAccess")]
         public ManagedClusterKeyVaultNetworkAccessType? KeyVaultNetworkAccess { get; set; }
-        /// <summary>
-        /// Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty.
-        /// Serialized Name: AzureKeyVaultKms.keyVaultResourceId
-        /// </summary>
+        /// <summary> Resource ID of key vault. When keyVaultNetworkAccess is `Private`, this field is required and must be a valid resource ID. When keyVaultNetworkAccess is `Public`, leave the field empty. </summary>
         [WirePath("keyVaultResourceId")]
         public ResourceIdentifier KeyVaultResourceId { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileWorkloadIdentity.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSecurityProfileWorkloadIdentity.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Workload identity settings for the security profile.
-    /// Serialized Name: ManagedClusterSecurityProfileWorkloadIdentity
-    /// </summary>
+    /// <summary> Workload identity settings for the security profile. </summary>
     internal partial class ManagedClusterSecurityProfileWorkloadIdentity
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterSecurityProfileWorkloadIdentity"/>. </summary>
-        /// <param name="isWorkloadIdentityEnabled">
-        /// Whether to enable workload identity.
-        /// Serialized Name: ManagedClusterSecurityProfileWorkloadIdentity.enabled
-        /// </param>
+        /// <param name="isWorkloadIdentityEnabled"> Whether to enable workload identity. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterSecurityProfileWorkloadIdentity(bool? isWorkloadIdentityEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable workload identity.
-        /// Serialized Name: ManagedClusterSecurityProfileWorkloadIdentity.enabled
-        /// </summary>
+        /// <summary> Whether to enable workload identity. </summary>
         [WirePath("enabled")]
         public bool? IsWorkloadIdentityEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterServicePrincipalProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterServicePrincipalProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Information about a service principal identity for the cluster to use for manipulating Azure APIs.
-    /// Serialized Name: ManagedClusterServicePrincipalProfile
-    /// </summary>
+    /// <summary> Information about a service principal identity for the cluster to use for manipulating Azure APIs. </summary>
     public partial class ManagedClusterServicePrincipalProfile
     {
         /// <summary>
@@ -49,10 +46,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterServicePrincipalProfile"/>. </summary>
-        /// <param name="clientId">
-        /// The ID for the service principal.
-        /// Serialized Name: ManagedClusterServicePrincipalProfile.clientId
-        /// </param>
+        /// <param name="clientId"> The ID for the service principal. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="clientId"/> is null. </exception>
         public ManagedClusterServicePrincipalProfile(string clientId)
         {
@@ -62,14 +56,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterServicePrincipalProfile"/>. </summary>
-        /// <param name="clientId">
-        /// The ID for the service principal.
-        /// Serialized Name: ManagedClusterServicePrincipalProfile.clientId
-        /// </param>
-        /// <param name="secret">
-        /// The secret password associated with the service principal in plain text.
-        /// Serialized Name: ManagedClusterServicePrincipalProfile.secret
-        /// </param>
+        /// <param name="clientId"> The ID for the service principal. </param>
+        /// <param name="secret"> The secret password associated with the service principal in plain text. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterServicePrincipalProfile(string clientId, string secret, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -83,16 +71,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// The ID for the service principal.
-        /// Serialized Name: ManagedClusterServicePrincipalProfile.clientId
-        /// </summary>
+        /// <summary> The ID for the service principal. </summary>
         [WirePath("clientId")]
         public string ClientId { get; set; }
-        /// <summary>
-        /// The secret password associated with the service principal in plain text.
-        /// Serialized Name: ManagedClusterServicePrincipalProfile.secret
-        /// </summary>
+        /// <summary> The secret password associated with the service principal in plain text. </summary>
         [WirePath("secret")]
         public string Secret { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSku.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSku.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The SKU of a Managed Cluster.
-    /// Serialized Name: ManagedClusterSKU
-    /// </summary>
+    /// <summary> The SKU of a Managed Cluster. </summary>
     public partial class ManagedClusterSku
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterSku"/>. </summary>
-        /// <param name="name">
-        /// The name of a managed cluster SKU.
-        /// Serialized Name: ManagedClusterSKU.name
-        /// </param>
-        /// <param name="tier">
-        /// The tier of a managed cluster SKU. If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details.
-        /// Serialized Name: ManagedClusterSKU.tier
-        /// </param>
+        /// <param name="name"> The name of a managed cluster SKU. </param>
+        /// <param name="tier"> The tier of a managed cluster SKU. If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterSku(ManagedClusterSkuName? name, ManagedClusterSkuTier? tier, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The name of a managed cluster SKU.
-        /// Serialized Name: ManagedClusterSKU.name
-        /// </summary>
+        /// <summary> The name of a managed cluster SKU. </summary>
         [WirePath("name")]
         public ManagedClusterSkuName? Name { get; set; }
-        /// <summary>
-        /// The tier of a managed cluster SKU. If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details.
-        /// Serialized Name: ManagedClusterSKU.tier
-        /// </summary>
+        /// <summary> The tier of a managed cluster SKU. If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details. </summary>
         [WirePath("tier")]
         public ManagedClusterSkuTier? Tier { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSkuName.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSkuName.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The name of a managed cluster SKU.
-    /// Serialized Name: ManagedClusterSKUName
-    /// </summary>
+    /// <summary> The name of a managed cluster SKU. </summary>
     public readonly partial struct ManagedClusterSkuName : IEquatable<ManagedClusterSkuName>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string BaseValue = "Base";
         private const string AutomaticValue = "Automatic";
 
-        /// <summary>
-        /// Base option for the AKS control plane.
-        /// Serialized Name: ManagedClusterSKUName.Base
-        /// </summary>
+        /// <summary> Base option for the AKS control plane. </summary>
         public static ManagedClusterSkuName Base { get; } = new ManagedClusterSkuName(BaseValue);
-        /// <summary>
-        /// Automatic clusters are optimized to run most production workloads with configuration that follows AKS best practices and recommendations for cluster and workload setup, scalability, and security. For more details about Automatic clusters see aka.ms/aks/automatic.
-        /// Serialized Name: ManagedClusterSKUName.Automatic
-        /// </summary>
+        /// <summary> Automatic clusters are optimized to run most production workloads with configuration that follows AKS best practices and recommendations for cluster and workload setup, scalability, and security. For more details about Automatic clusters see aka.ms/aks/automatic. </summary>
         public static ManagedClusterSkuName Automatic { get; } = new ManagedClusterSkuName(AutomaticValue);
         /// <summary> Determines if two <see cref="ManagedClusterSkuName"/> values are the same. </summary>
         public static bool operator ==(ManagedClusterSkuName left, ManagedClusterSkuName right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSkuTier.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterSkuTier.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The tier of a managed cluster SKU. If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details.
-    /// Serialized Name: ManagedClusterSKUTier
-    /// </summary>
+    /// <summary> The tier of a managed cluster SKU. If not specified, the default is 'Free'. See [AKS Pricing Tier](https://learn.microsoft.com/azure/aks/free-standard-pricing-tiers) for more details. </summary>
     public readonly partial struct ManagedClusterSkuTier : IEquatable<ManagedClusterSkuTier>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string StandardValue = "Standard";
         private const string FreeValue = "Free";
 
-        /// <summary>
-        /// Cluster has premium capabilities in addition to all of the capabilities included in 'Standard'. Premium enables selection of LongTermSupport (aka.ms/aks/lts) for certain Kubernetes versions.
-        /// Serialized Name: ManagedClusterSKUTier.Premium
-        /// </summary>
+        /// <summary> Cluster has premium capabilities in addition to all of the capabilities included in 'Standard'. Premium enables selection of LongTermSupport (aka.ms/aks/lts) for certain Kubernetes versions. </summary>
         public static ManagedClusterSkuTier Premium { get; } = new ManagedClusterSkuTier(PremiumValue);
-        /// <summary>
-        /// Recommended for mission-critical and production workloads. Includes Kubernetes control plane autoscaling, workload-intensive testing, and up to 5,000 nodes per cluster. Guarantees 99.95% availability of the Kubernetes API server endpoint for clusters that use Availability Zones and 99.9% of availability for clusters that don't use Availability Zones.
-        /// Serialized Name: ManagedClusterSKUTier.Standard
-        /// </summary>
+        /// <summary> Recommended for mission-critical and production workloads. Includes Kubernetes control plane autoscaling, workload-intensive testing, and up to 5,000 nodes per cluster. Guarantees 99.95% availability of the Kubernetes API server endpoint for clusters that use Availability Zones and 99.9% of availability for clusters that don't use Availability Zones. </summary>
         public static ManagedClusterSkuTier Standard { get; } = new ManagedClusterSkuTier(StandardValue);
-        /// <summary>
-        /// The cluster management is free, but charged for VM, storage, and networking usage. Best for experimenting, learning, simple testing, or workloads with fewer than 10 nodes. Not recommended for production use cases.
-        /// Serialized Name: ManagedClusterSKUTier.Free
-        /// </summary>
+        /// <summary> The cluster management is free, but charged for VM, storage, and networking usage. Best for experimenting, learning, simple testing, or workloads with fewer than 10 nodes. Not recommended for production use cases. </summary>
         public static ManagedClusterSkuTier Free { get; } = new ManagedClusterSkuTier(FreeValue);
         /// <summary> Determines if two <see cref="ManagedClusterSkuTier"/> values are the same. </summary>
         public static bool operator ==(ManagedClusterSkuTier left, ManagedClusterSkuTier right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStaticEgressGatewayProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStaticEgressGatewayProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The Static Egress Gateway addon configuration for the cluster.
-    /// Serialized Name: ManagedClusterStaticEgressGatewayProfile
-    /// </summary>
+    /// <summary> The Static Egress Gateway addon configuration for the cluster. </summary>
     internal partial class ManagedClusterStaticEgressGatewayProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterStaticEgressGatewayProfile"/>. </summary>
-        /// <param name="isStaticEgressGatewayAddonEnabled">
-        /// Enable Static Egress Gateway addon. Indicates if Static Egress Gateway addon is enabled or not.
-        /// Serialized Name: ManagedClusterStaticEgressGatewayProfile.enabled
-        /// </param>
+        /// <param name="isStaticEgressGatewayAddonEnabled"> Enable Static Egress Gateway addon. Indicates if Static Egress Gateway addon is enabled or not. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterStaticEgressGatewayProfile(bool? isStaticEgressGatewayAddonEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Enable Static Egress Gateway addon. Indicates if Static Egress Gateway addon is enabled or not.
-        /// Serialized Name: ManagedClusterStaticEgressGatewayProfile.enabled
-        /// </summary>
+        /// <summary> Enable Static Egress Gateway addon. Indicates if Static Egress Gateway addon is enabled or not. </summary>
         [WirePath("enabled")]
         public bool? IsStaticEgressGatewayAddonEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStatus.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStatus.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Contains read-only information about the Managed Cluster.
-    /// Serialized Name: ManagedClusterStatus
-    /// </summary>
+    /// <summary> Contains read-only information about the Managed Cluster. </summary>
     internal partial class ManagedClusterStatus
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterStatus"/>. </summary>
-        /// <param name="provisioningError">
-        /// The error details information of the managed cluster. Preserves the detailed info of failure. If there was no error, this field is omitted.
-        /// Serialized Name: ManagedClusterStatus.provisioningError
-        /// </param>
+        /// <param name="provisioningError"> The error details information of the managed cluster. Preserves the detailed info of failure. If there was no error, this field is omitted. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterStatus(ResponseError provisioningError, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The error details information of the managed cluster. Preserves the detailed info of failure. If there was no error, this field is omitted.
-        /// Serialized Name: ManagedClusterStatus.provisioningError
-        /// </summary>
+        /// <summary> The error details information of the managed cluster. Preserves the detailed info of failure. If there was no error, this field is omitted. </summary>
         [WirePath("provisioningError")]
         public ResponseError ProvisioningError { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Storage profile for the container service cluster.
-    /// Serialized Name: ManagedClusterStorageProfile
-    /// </summary>
+    /// <summary> Storage profile for the container service cluster. </summary>
     public partial class ManagedClusterStorageProfile
     {
         /// <summary>
@@ -54,22 +51,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterStorageProfile"/>. </summary>
-        /// <param name="diskCsiDriver">
-        /// AzureDisk CSI Driver settings for the storage profile.
-        /// Serialized Name: ManagedClusterStorageProfile.diskCSIDriver
-        /// </param>
-        /// <param name="fileCsiDriver">
-        /// AzureFile CSI Driver settings for the storage profile.
-        /// Serialized Name: ManagedClusterStorageProfile.fileCSIDriver
-        /// </param>
-        /// <param name="snapshotController">
-        /// Snapshot Controller settings for the storage profile.
-        /// Serialized Name: ManagedClusterStorageProfile.snapshotController
-        /// </param>
-        /// <param name="blobCsiDriver">
-        /// AzureBlob CSI Driver settings for the storage profile.
-        /// Serialized Name: ManagedClusterStorageProfile.blobCSIDriver
-        /// </param>
+        /// <param name="diskCsiDriver"> AzureDisk CSI Driver settings for the storage profile. </param>
+        /// <param name="fileCsiDriver"> AzureFile CSI Driver settings for the storage profile. </param>
+        /// <param name="snapshotController"> Snapshot Controller settings for the storage profile. </param>
+        /// <param name="blobCsiDriver"> AzureBlob CSI Driver settings for the storage profile. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterStorageProfile(ManagedClusterStorageProfileDiskCsiDriver diskCsiDriver, ManagedClusterStorageProfileFileCsiDriver fileCsiDriver, ManagedClusterStorageProfileSnapshotController snapshotController, ManagedClusterStorageProfileBlobCsiDriver blobCsiDriver, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -80,28 +65,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// AzureDisk CSI Driver settings for the storage profile.
-        /// Serialized Name: ManagedClusterStorageProfile.diskCSIDriver
-        /// </summary>
+        /// <summary> AzureDisk CSI Driver settings for the storage profile. </summary>
         internal ManagedClusterStorageProfileDiskCsiDriver DiskCsiDriver { get; set; }
 
-        /// <summary>
-        /// AzureFile CSI Driver settings for the storage profile.
-        /// Serialized Name: ManagedClusterStorageProfile.fileCSIDriver
-        /// </summary>
+        /// <summary> AzureFile CSI Driver settings for the storage profile. </summary>
         internal ManagedClusterStorageProfileFileCsiDriver FileCsiDriver { get; set; }
 
-        /// <summary>
-        /// Snapshot Controller settings for the storage profile.
-        /// Serialized Name: ManagedClusterStorageProfile.snapshotController
-        /// </summary>
+        /// <summary> Snapshot Controller settings for the storage profile. </summary>
         internal ManagedClusterStorageProfileSnapshotController SnapshotController { get; set; }
 
-        /// <summary>
-        /// AzureBlob CSI Driver settings for the storage profile.
-        /// Serialized Name: ManagedClusterStorageProfile.blobCSIDriver
-        /// </summary>
+        /// <summary> AzureBlob CSI Driver settings for the storage profile. </summary>
         internal ManagedClusterStorageProfileBlobCsiDriver BlobCsiDriver { get; set; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfileBlobCsiDriver.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfileBlobCsiDriver.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// AzureBlob CSI Driver settings for the storage profile.
-    /// Serialized Name: ManagedClusterStorageProfileBlobCSIDriver
-    /// </summary>
+    /// <summary> AzureBlob CSI Driver settings for the storage profile. </summary>
     internal partial class ManagedClusterStorageProfileBlobCsiDriver
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterStorageProfileBlobCsiDriver"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable AzureBlob CSI Driver. The default value is false.
-        /// Serialized Name: ManagedClusterStorageProfileBlobCSIDriver.enabled
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable AzureBlob CSI Driver. The default value is false. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterStorageProfileBlobCsiDriver(bool? isEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable AzureBlob CSI Driver. The default value is false.
-        /// Serialized Name: ManagedClusterStorageProfileBlobCSIDriver.enabled
-        /// </summary>
+        /// <summary> Whether to enable AzureBlob CSI Driver. The default value is false. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfileDiskCsiDriver.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfileDiskCsiDriver.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// AzureDisk CSI Driver settings for the storage profile.
-    /// Serialized Name: ManagedClusterStorageProfileDiskCSIDriver
-    /// </summary>
+    /// <summary> AzureDisk CSI Driver settings for the storage profile. </summary>
     internal partial class ManagedClusterStorageProfileDiskCsiDriver
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterStorageProfileDiskCsiDriver"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable AzureDisk CSI Driver. The default value is true.
-        /// Serialized Name: ManagedClusterStorageProfileDiskCSIDriver.enabled
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable AzureDisk CSI Driver. The default value is true. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterStorageProfileDiskCsiDriver(bool? isEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable AzureDisk CSI Driver. The default value is true.
-        /// Serialized Name: ManagedClusterStorageProfileDiskCSIDriver.enabled
-        /// </summary>
+        /// <summary> Whether to enable AzureDisk CSI Driver. The default value is true. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfileFileCsiDriver.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfileFileCsiDriver.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// AzureFile CSI Driver settings for the storage profile.
-    /// Serialized Name: ManagedClusterStorageProfileFileCSIDriver
-    /// </summary>
+    /// <summary> AzureFile CSI Driver settings for the storage profile. </summary>
     internal partial class ManagedClusterStorageProfileFileCsiDriver
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterStorageProfileFileCsiDriver"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable AzureFile CSI Driver. The default value is true.
-        /// Serialized Name: ManagedClusterStorageProfileFileCSIDriver.enabled
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable AzureFile CSI Driver. The default value is true. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterStorageProfileFileCsiDriver(bool? isEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable AzureFile CSI Driver. The default value is true.
-        /// Serialized Name: ManagedClusterStorageProfileFileCSIDriver.enabled
-        /// </summary>
+        /// <summary> Whether to enable AzureFile CSI Driver. The default value is true. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfileSnapshotController.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterStorageProfileSnapshotController.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Snapshot Controller settings for the storage profile.
-    /// Serialized Name: ManagedClusterStorageProfileSnapshotController
-    /// </summary>
+    /// <summary> Snapshot Controller settings for the storage profile. </summary>
     internal partial class ManagedClusterStorageProfileSnapshotController
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterStorageProfileSnapshotController"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable Snapshot Controller. The default value is true.
-        /// Serialized Name: ManagedClusterStorageProfileSnapshotController.enabled
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable Snapshot Controller. The default value is true. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterStorageProfileSnapshotController(bool? isEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,10 +59,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable Snapshot Controller. The default value is true.
-        /// Serialized Name: ManagedClusterStorageProfileSnapshotController.enabled
-        /// </summary>
+        /// <summary> Whether to enable Snapshot Controller. The default value is true. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterVerticalPodAutoscaler.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterVerticalPodAutoscaler.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.
-    /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler
-    /// </summary>
+    /// <summary> VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile. </summary>
     internal partial class ManagedClusterVerticalPodAutoscaler
     {
         /// <summary>
@@ -49,20 +46,14 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterVerticalPodAutoscaler"/>. </summary>
-        /// <param name="isVpaEnabled">
-        /// Whether to enable VPA. Default value is false.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler.enabled
-        /// </param>
+        /// <param name="isVpaEnabled"> Whether to enable VPA. Default value is false. </param>
         public ManagedClusterVerticalPodAutoscaler(bool isVpaEnabled)
         {
             IsVpaEnabled = isVpaEnabled;
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterVerticalPodAutoscaler"/>. </summary>
-        /// <param name="isVpaEnabled">
-        /// Whether to enable VPA. Default value is false.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler.enabled
-        /// </param>
+        /// <param name="isVpaEnabled"> Whether to enable VPA. Default value is false. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterVerticalPodAutoscaler(bool isVpaEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,10 +66,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Whether to enable VPA. Default value is false.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler.enabled
-        /// </summary>
+        /// <summary> Whether to enable VPA. Default value is false. </summary>
         [WirePath("enabled")]
         public bool IsVpaEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterWindowsProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterWindowsProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Profile for Windows VMs in the managed cluster.
-    /// Serialized Name: ManagedClusterWindowsProfile
-    /// </summary>
+    /// <summary> Profile for Windows VMs in the managed cluster. </summary>
     public partial class ManagedClusterWindowsProfile
     {
         /// <summary>
@@ -49,10 +46,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterWindowsProfile"/>. </summary>
-        /// <param name="adminUsername">
-        /// Specifies the name of the administrator account. &lt;br&gt;&lt;br&gt; **Restriction:** Cannot end in "." &lt;br&gt;&lt;br&gt; **Disallowed values:** "administrator", "admin", "user", "user1", "test", "user2", "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm", "admin2", "aspnet", "backup", "console", "david", "guest", "john", "owner", "root", "server", "sql", "support", "support_388945a0", "sys", "test2", "test3", "user4", "user5". &lt;br&gt;&lt;br&gt; **Minimum-length:** 1 character &lt;br&gt;&lt;br&gt; **Max-length:** 20 characters
-        /// Serialized Name: ManagedClusterWindowsProfile.adminUsername
-        /// </param>
+        /// <param name="adminUsername"> Specifies the name of the administrator account. &lt;br&gt;&lt;br&gt; **Restriction:** Cannot end in "." &lt;br&gt;&lt;br&gt; **Disallowed values:** "administrator", "admin", "user", "user1", "test", "user2", "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm", "admin2", "aspnet", "backup", "console", "david", "guest", "john", "owner", "root", "server", "sql", "support", "support_388945a0", "sys", "test2", "test3", "user4", "user5". &lt;br&gt;&lt;br&gt; **Minimum-length:** 1 character &lt;br&gt;&lt;br&gt; **Max-length:** 20 characters. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="adminUsername"/> is null. </exception>
         public ManagedClusterWindowsProfile(string adminUsername)
         {
@@ -62,26 +56,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterWindowsProfile"/>. </summary>
-        /// <param name="adminUsername">
-        /// Specifies the name of the administrator account. &lt;br&gt;&lt;br&gt; **Restriction:** Cannot end in "." &lt;br&gt;&lt;br&gt; **Disallowed values:** "administrator", "admin", "user", "user1", "test", "user2", "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm", "admin2", "aspnet", "backup", "console", "david", "guest", "john", "owner", "root", "server", "sql", "support", "support_388945a0", "sys", "test2", "test3", "user4", "user5". &lt;br&gt;&lt;br&gt; **Minimum-length:** 1 character &lt;br&gt;&lt;br&gt; **Max-length:** 20 characters
-        /// Serialized Name: ManagedClusterWindowsProfile.adminUsername
-        /// </param>
-        /// <param name="adminPassword">
-        /// Specifies the password of the administrator account. &lt;br&gt;&lt;br&gt; **Minimum-length:** 8 characters &lt;br&gt;&lt;br&gt; **Max-length:** 123 characters &lt;br&gt;&lt;br&gt; **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled &lt;br&gt; Has lower characters &lt;br&gt;Has upper characters &lt;br&gt; Has a digit &lt;br&gt; Has a special character (Regex match [\W_]) &lt;br&gt;&lt;br&gt; **Disallowed values:** "abc@123", "P@$$w0rd", "P@ssw0rd", "P@ssword123", "Pa$$word", "pass@word1", "Password!", "Password1", "Password22", "iloveyou!"
-        /// Serialized Name: ManagedClusterWindowsProfile.adminPassword
-        /// </param>
-        /// <param name="licenseType">
-        /// The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.
-        /// Serialized Name: ManagedClusterWindowsProfile.licenseType
-        /// </param>
-        /// <param name="isCsiProxyEnabled">
-        /// Whether to enable CSI proxy. For more details on CSI proxy, see the [CSI proxy GitHub repo](https://github.com/kubernetes-csi/csi-proxy).
-        /// Serialized Name: ManagedClusterWindowsProfile.enableCSIProxy
-        /// </param>
-        /// <param name="gmsaProfile">
-        /// The Windows gMSA Profile in the Managed Cluster.
-        /// Serialized Name: ManagedClusterWindowsProfile.gmsaProfile
-        /// </param>
+        /// <param name="adminUsername"> Specifies the name of the administrator account. &lt;br&gt;&lt;br&gt; **Restriction:** Cannot end in "." &lt;br&gt;&lt;br&gt; **Disallowed values:** "administrator", "admin", "user", "user1", "test", "user2", "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm", "admin2", "aspnet", "backup", "console", "david", "guest", "john", "owner", "root", "server", "sql", "support", "support_388945a0", "sys", "test2", "test3", "user4", "user5". &lt;br&gt;&lt;br&gt; **Minimum-length:** 1 character &lt;br&gt;&lt;br&gt; **Max-length:** 20 characters. </param>
+        /// <param name="adminPassword"> Specifies the password of the administrator account. &lt;br&gt;&lt;br&gt; **Minimum-length:** 8 characters &lt;br&gt;&lt;br&gt; **Max-length:** 123 characters &lt;br&gt;&lt;br&gt; **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled &lt;br&gt; Has lower characters &lt;br&gt;Has upper characters &lt;br&gt; Has a digit &lt;br&gt; Has a special character (Regex match [\W_]) &lt;br&gt;&lt;br&gt; **Disallowed values:** "abc@123", "P@$$w0rd", "P@ssw0rd", "P@ssword123", "Pa$$word", "pass@word1", "Password!", "Password1", "Password22", "iloveyou!". </param>
+        /// <param name="licenseType"> The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details. </param>
+        /// <param name="isCsiProxyEnabled"> Whether to enable CSI proxy. For more details on CSI proxy, see the [CSI proxy GitHub repo](https://github.com/kubernetes-csi/csi-proxy). </param>
+        /// <param name="gmsaProfile"> The Windows gMSA Profile in the Managed Cluster. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterWindowsProfile(string adminUsername, string adminPassword, WindowsVmLicenseType? licenseType, bool? isCsiProxyEnabled, WindowsGmsaProfile gmsaProfile, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -98,34 +77,19 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Specifies the name of the administrator account. &lt;br&gt;&lt;br&gt; **Restriction:** Cannot end in "." &lt;br&gt;&lt;br&gt; **Disallowed values:** "administrator", "admin", "user", "user1", "test", "user2", "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm", "admin2", "aspnet", "backup", "console", "david", "guest", "john", "owner", "root", "server", "sql", "support", "support_388945a0", "sys", "test2", "test3", "user4", "user5". &lt;br&gt;&lt;br&gt; **Minimum-length:** 1 character &lt;br&gt;&lt;br&gt; **Max-length:** 20 characters
-        /// Serialized Name: ManagedClusterWindowsProfile.adminUsername
-        /// </summary>
+        /// <summary> Specifies the name of the administrator account. &lt;br&gt;&lt;br&gt; **Restriction:** Cannot end in "." &lt;br&gt;&lt;br&gt; **Disallowed values:** "administrator", "admin", "user", "user1", "test", "user2", "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm", "admin2", "aspnet", "backup", "console", "david", "guest", "john", "owner", "root", "server", "sql", "support", "support_388945a0", "sys", "test2", "test3", "user4", "user5". &lt;br&gt;&lt;br&gt; **Minimum-length:** 1 character &lt;br&gt;&lt;br&gt; **Max-length:** 20 characters. </summary>
         [WirePath("adminUsername")]
         public string AdminUsername { get; set; }
-        /// <summary>
-        /// Specifies the password of the administrator account. &lt;br&gt;&lt;br&gt; **Minimum-length:** 8 characters &lt;br&gt;&lt;br&gt; **Max-length:** 123 characters &lt;br&gt;&lt;br&gt; **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled &lt;br&gt; Has lower characters &lt;br&gt;Has upper characters &lt;br&gt; Has a digit &lt;br&gt; Has a special character (Regex match [\W_]) &lt;br&gt;&lt;br&gt; **Disallowed values:** "abc@123", "P@$$w0rd", "P@ssw0rd", "P@ssword123", "Pa$$word", "pass@word1", "Password!", "Password1", "Password22", "iloveyou!"
-        /// Serialized Name: ManagedClusterWindowsProfile.adminPassword
-        /// </summary>
+        /// <summary> Specifies the password of the administrator account. &lt;br&gt;&lt;br&gt; **Minimum-length:** 8 characters &lt;br&gt;&lt;br&gt; **Max-length:** 123 characters &lt;br&gt;&lt;br&gt; **Complexity requirements:** 3 out of 4 conditions below need to be fulfilled &lt;br&gt; Has lower characters &lt;br&gt;Has upper characters &lt;br&gt; Has a digit &lt;br&gt; Has a special character (Regex match [\W_]) &lt;br&gt;&lt;br&gt; **Disallowed values:** "abc@123", "P@$$w0rd", "P@ssw0rd", "P@ssword123", "Pa$$word", "pass@word1", "Password!", "Password1", "Password22", "iloveyou!". </summary>
         [WirePath("adminPassword")]
         public string AdminPassword { get; set; }
-        /// <summary>
-        /// The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.
-        /// Serialized Name: ManagedClusterWindowsProfile.licenseType
-        /// </summary>
+        /// <summary> The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details. </summary>
         [WirePath("licenseType")]
         public WindowsVmLicenseType? LicenseType { get; set; }
-        /// <summary>
-        /// Whether to enable CSI proxy. For more details on CSI proxy, see the [CSI proxy GitHub repo](https://github.com/kubernetes-csi/csi-proxy).
-        /// Serialized Name: ManagedClusterWindowsProfile.enableCSIProxy
-        /// </summary>
+        /// <summary> Whether to enable CSI proxy. For more details on CSI proxy, see the [CSI proxy GitHub repo](https://github.com/kubernetes-csi/csi-proxy). </summary>
         [WirePath("enableCSIProxy")]
         public bool? IsCsiProxyEnabled { get; set; }
-        /// <summary>
-        /// The Windows gMSA Profile in the Managed Cluster.
-        /// Serialized Name: ManagedClusterWindowsProfile.gmsaProfile
-        /// </summary>
+        /// <summary> The Windows gMSA Profile in the Managed Cluster. </summary>
         [WirePath("gmsaProfile")]
         public WindowsGmsaProfile GmsaProfile { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterWorkloadAutoScalerProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterWorkloadAutoScalerProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Workload Auto-scaler profile for the managed cluster.
-    /// Serialized Name: ManagedClusterWorkloadAutoScalerProfile
-    /// </summary>
+    /// <summary> Workload Auto-scaler profile for the managed cluster. </summary>
     public partial class ManagedClusterWorkloadAutoScalerProfile
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterWorkloadAutoScalerProfile"/>. </summary>
-        /// <param name="keda">
-        /// KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfile.keda
-        /// </param>
-        /// <param name="verticalPodAutoscaler">
-        /// VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfile.verticalPodAutoscaler
-        /// </param>
+        /// <param name="keda"> KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile. </param>
+        /// <param name="verticalPodAutoscaler"> VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterWorkloadAutoScalerProfile(ManagedClusterWorkloadAutoScalerProfileKeda keda, ManagedClusterVerticalPodAutoscaler verticalPodAutoscaler, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,15 +61,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfile.keda
-        /// </summary>
+        /// <summary> KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile. </summary>
         internal ManagedClusterWorkloadAutoScalerProfileKeda Keda { get; set; }
-        /// <summary>
-        /// Whether to enable KEDA.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileKeda.enabled
-        /// </summary>
+        /// <summary> Whether to enable KEDA. </summary>
         [WirePath("keda.enabled")]
         public bool? IsKedaEnabled
         {
@@ -89,15 +74,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             }
         }
 
-        /// <summary>
-        /// VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfile.verticalPodAutoscaler
-        /// </summary>
+        /// <summary> VPA (Vertical Pod Autoscaler) settings for the workload auto-scaler profile. </summary>
         internal ManagedClusterVerticalPodAutoscaler VerticalPodAutoscaler { get; set; }
-        /// <summary>
-        /// Whether to enable VPA. Default value is false.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileVerticalPodAutoscaler.enabled
-        /// </summary>
+        /// <summary> Whether to enable VPA. Default value is false. </summary>
         [WirePath("verticalPodAutoscaler.enabled")]
         public bool? IsVpaEnabled
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterWorkloadAutoScalerProfileKeda.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedClusterWorkloadAutoScalerProfileKeda.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile.
-    /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileKeda
-    /// </summary>
+    /// <summary> KEDA (Kubernetes Event-driven Autoscaling) settings for the workload auto-scaler profile. </summary>
     internal partial class ManagedClusterWorkloadAutoScalerProfileKeda
     {
         /// <summary>
@@ -49,20 +46,14 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterWorkloadAutoScalerProfileKeda"/>. </summary>
-        /// <param name="isKedaEnabled">
-        /// Whether to enable KEDA.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileKeda.enabled
-        /// </param>
+        /// <param name="isKedaEnabled"> Whether to enable KEDA. </param>
         public ManagedClusterWorkloadAutoScalerProfileKeda(bool isKedaEnabled)
         {
             IsKedaEnabled = isKedaEnabled;
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedClusterWorkloadAutoScalerProfileKeda"/>. </summary>
-        /// <param name="isKedaEnabled">
-        /// Whether to enable KEDA.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileKeda.enabled
-        /// </param>
+        /// <param name="isKedaEnabled"> Whether to enable KEDA. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedClusterWorkloadAutoScalerProfileKeda(bool isKedaEnabled, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,10 +66,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Whether to enable KEDA.
-        /// Serialized Name: ManagedClusterWorkloadAutoScalerProfileKeda.enabled
-        /// </summary>
+        /// <summary> Whether to enable KEDA. </summary>
         [WirePath("enabled")]
         public bool IsKedaEnabled { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedNamespaceListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManagedNamespaceListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The result of a request to list managed namespaces in a managed cluster.
-    /// Serialized Name: ManagedNamespaceListResult
-    /// </summary>
+    /// <summary> The result of a request to list managed namespaces in a managed cluster. </summary>
     internal partial class ManagedNamespaceListResult
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManagedNamespaceListResult"/>. </summary>
-        /// <param name="value">
-        /// The list of managed namespaces.
-        /// Serialized Name: ManagedNamespaceListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The URI to fetch the next page of results, if any.
-        /// Serialized Name: ManagedNamespaceListResult.nextLink
-        /// </param>
+        /// <param name="value"> The list of managed namespaces. </param>
+        /// <param name="nextLink"> The URI to fetch the next page of results, if any. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManagedNamespaceListResult(IReadOnlyList<ManagedClusterNamespaceData> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The list of managed namespaces.
-        /// Serialized Name: ManagedNamespaceListResult.value
-        /// </summary>
+        /// <summary> The list of managed namespaces. </summary>
         public IReadOnlyList<ManagedClusterNamespaceData> Value { get; }
-        /// <summary>
-        /// The URI to fetch the next page of results, if any.
-        /// Serialized Name: ManagedNamespaceListResult.nextLink
-        /// </summary>
+        /// <summary> The URI to fetch the next page of results, if any. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManualScaleProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ManualScaleProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Specifications on number of machines.
-    /// Serialized Name: ManualScaleProfile
-    /// </summary>
+    /// <summary> Specifications on number of machines. </summary>
     public partial class ManualScaleProfile
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ManualScaleProfile"/>. </summary>
-        /// <param name="size">
-        /// VM size that AKS will use when creating and scaling e.g. 'Standard_E4s_v3', 'Standard_E16s_v3' or 'Standard_D16s_v5'.
-        /// Serialized Name: ManualScaleProfile.size
-        /// </param>
-        /// <param name="count">
-        /// Number of nodes.
-        /// Serialized Name: ManualScaleProfile.count
-        /// </param>
+        /// <param name="size"> VM size that AKS will use when creating and scaling e.g. 'Standard_E4s_v3', 'Standard_E16s_v3' or 'Standard_D16s_v5'. </param>
+        /// <param name="count"> Number of nodes. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ManualScaleProfile(string size, int? count, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// VM size that AKS will use when creating and scaling e.g. 'Standard_E4s_v3', 'Standard_E16s_v3' or 'Standard_D16s_v5'.
-        /// Serialized Name: ManualScaleProfile.size
-        /// </summary>
+        /// <summary> VM size that AKS will use when creating and scaling e.g. 'Standard_E4s_v3', 'Standard_E16s_v3' or 'Standard_D16s_v5'. </summary>
         [WirePath("size")]
         public string Size { get; set; }
-        /// <summary>
-        /// Number of nodes.
-        /// Serialized Name: ManualScaleProfile.count
-        /// </summary>
+        /// <summary> Number of nodes. </summary>
         [WirePath("count")]
         public int? Count { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshRevision.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshRevision.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Holds information on upgrades and compatibility for given major.minor mesh release.
-    /// Serialized Name: MeshRevision
-    /// </summary>
+    /// <summary> Holds information on upgrades and compatibility for given major.minor mesh release. </summary>
     public partial class MeshRevision
     {
         /// <summary>
@@ -56,18 +53,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="MeshRevision"/>. </summary>
-        /// <param name="revision">
-        /// The revision of the mesh release.
-        /// Serialized Name: MeshRevision.revision
-        /// </param>
-        /// <param name="upgrades">
-        /// List of revisions available for upgrade of a specific mesh revision
-        /// Serialized Name: MeshRevision.upgrades
-        /// </param>
-        /// <param name="compatibleWith">
-        /// List of items this revision of service mesh is compatible with, and their associated versions.
-        /// Serialized Name: MeshRevision.compatibleWith
-        /// </param>
+        /// <param name="revision"> The revision of the mesh release. </param>
+        /// <param name="upgrades"> List of revisions available for upgrade of a specific mesh revision. </param>
+        /// <param name="compatibleWith"> List of items this revision of service mesh is compatible with, and their associated versions. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MeshRevision(string revision, IList<string> upgrades, IList<CompatibleVersions> compatibleWith, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -77,22 +65,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// The revision of the mesh release.
-        /// Serialized Name: MeshRevision.revision
-        /// </summary>
+        /// <summary> The revision of the mesh release. </summary>
         [WirePath("revision")]
         public string Revision { get; set; }
-        /// <summary>
-        /// List of revisions available for upgrade of a specific mesh revision
-        /// Serialized Name: MeshRevision.upgrades
-        /// </summary>
+        /// <summary> List of revisions available for upgrade of a specific mesh revision. </summary>
         [WirePath("upgrades")]
         public IList<string> Upgrades { get; }
-        /// <summary>
-        /// List of items this revision of service mesh is compatible with, and their associated versions.
-        /// Serialized Name: MeshRevision.compatibleWith
-        /// </summary>
+        /// <summary> List of items this revision of service mesh is compatible with, and their associated versions. </summary>
         [WirePath("compatibleWith")]
         public IList<CompatibleVersions> CompatibleWith { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshRevisionProfileList.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshRevisionProfileList.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Holds an array of MeshRevisionsProfiles
-    /// Serialized Name: MeshRevisionProfileList
-    /// </summary>
+    /// <summary> Holds an array of MeshRevisionsProfiles. </summary>
     internal partial class MeshRevisionProfileList
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="MeshRevisionProfileList"/>. </summary>
-        /// <param name="value">
-        /// Array of service mesh add-on revision profiles for all supported mesh modes.
-        /// Serialized Name: MeshRevisionProfileList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The URL to get the next set of mesh revision profile.
-        /// Serialized Name: MeshRevisionProfileList.nextLink
-        /// </param>
+        /// <param name="value"> Array of service mesh add-on revision profiles for all supported mesh modes. </param>
+        /// <param name="nextLink"> The URL to get the next set of mesh revision profile. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MeshRevisionProfileList(IReadOnlyList<MeshRevisionProfileData> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Array of service mesh add-on revision profiles for all supported mesh modes.
-        /// Serialized Name: MeshRevisionProfileList.value
-        /// </summary>
+        /// <summary> Array of service mesh add-on revision profiles for all supported mesh modes. </summary>
         public IReadOnlyList<MeshRevisionProfileData> Value { get; }
-        /// <summary>
-        /// The URL to get the next set of mesh revision profile.
-        /// Serialized Name: MeshRevisionProfileList.nextLink
-        /// </summary>
+        /// <summary> The URL to get the next set of mesh revision profile. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshRevisionProfileProperties.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshRevisionProfileProperties.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Mesh revision profile properties for a mesh
-    /// Serialized Name: MeshRevisionProfileProperties
-    /// </summary>
+    /// <summary> Mesh revision profile properties for a mesh. </summary>
     internal partial class MeshRevisionProfileProperties
     {
         /// <summary>
@@ -55,7 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="MeshRevisionProfileProperties"/>. </summary>
-        /// <param name="meshRevisions"> Serialized Name: MeshRevisionProfileProperties.meshRevisions. </param>
+        /// <param name="meshRevisions"></param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MeshRevisionProfileProperties(IList<MeshRevision> meshRevisions, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -63,7 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary> Serialized Name: MeshRevisionProfileProperties.meshRevisions. </summary>
+        /// <summary> Gets the mesh revisions. </summary>
         [WirePath("meshRevisions")]
         public IList<MeshRevision> MeshRevisions { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshUpgradeProfileList.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshUpgradeProfileList.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Holds an array of MeshUpgradeProfiles
-    /// Serialized Name: MeshUpgradeProfileList
-    /// </summary>
+    /// <summary> Holds an array of MeshUpgradeProfiles. </summary>
     internal partial class MeshUpgradeProfileList
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="MeshUpgradeProfileList"/>. </summary>
-        /// <param name="value">
-        /// Array of supported service mesh add-on upgrade profiles.
-        /// Serialized Name: MeshUpgradeProfileList.value
-        /// </param>
-        /// <param name="nextLink">
-        /// The URL to get the next set of mesh upgrade profile.
-        /// Serialized Name: MeshUpgradeProfileList.nextLink
-        /// </param>
+        /// <param name="value"> Array of supported service mesh add-on upgrade profiles. </param>
+        /// <param name="nextLink"> The URL to get the next set of mesh upgrade profile. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MeshUpgradeProfileList(IReadOnlyList<MeshUpgradeProfileData> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Array of supported service mesh add-on upgrade profiles.
-        /// Serialized Name: MeshUpgradeProfileList.value
-        /// </summary>
+        /// <summary> Array of supported service mesh add-on upgrade profiles. </summary>
         public IReadOnlyList<MeshUpgradeProfileData> Value { get; }
-        /// <summary>
-        /// The URL to get the next set of mesh upgrade profile.
-        /// Serialized Name: MeshUpgradeProfileList.nextLink
-        /// </summary>
+        /// <summary> The URL to get the next set of mesh upgrade profile. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshUpgradeProfileProperties.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/MeshUpgradeProfileProperties.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Mesh upgrade profile properties for a major.minor release.
-    /// Serialized Name: MeshUpgradeProfileProperties
-    /// </summary>
+    /// <summary> Mesh upgrade profile properties for a major.minor release. </summary>
     public partial class MeshUpgradeProfileProperties : MeshRevision
     {
         /// <summary> Initializes a new instance of <see cref="MeshUpgradeProfileProperties"/>. </summary>
@@ -22,18 +19,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="MeshUpgradeProfileProperties"/>. </summary>
-        /// <param name="revision">
-        /// The revision of the mesh release.
-        /// Serialized Name: MeshRevision.revision
-        /// </param>
-        /// <param name="upgrades">
-        /// List of revisions available for upgrade of a specific mesh revision
-        /// Serialized Name: MeshRevision.upgrades
-        /// </param>
-        /// <param name="compatibleWith">
-        /// List of items this revision of service mesh is compatible with, and their associated versions.
-        /// Serialized Name: MeshRevision.compatibleWith
-        /// </param>
+        /// <param name="revision"> The revision of the mesh release. </param>
+        /// <param name="upgrades"> List of revisions available for upgrade of a specific mesh revision. </param>
+        /// <param name="compatibleWith"> List of items this revision of service mesh is compatible with, and their associated versions. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal MeshUpgradeProfileProperties(string revision, IList<string> upgrades, IList<CompatibleVersions> compatibleWith, IDictionary<string, BinaryData> serializedAdditionalRawData) : base(revision, upgrades, compatibleWith, serializedAdditionalRawData)
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceAdoptionPolicy.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceAdoptionPolicy.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Action if Kubernetes namespace with same name already exists.
-    /// Serialized Name: AdoptionPolicy
-    /// </summary>
+    /// <summary> Action if Kubernetes namespace with same name already exists. </summary>
     public readonly partial struct NamespaceAdoptionPolicy : IEquatable<NamespaceAdoptionPolicy>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string IfIdenticalValue = "IfIdentical";
         private const string AlwaysValue = "Always";
 
-        /// <summary>
-        /// If the namespace already exists in Kubernetes, attempts to create that same namespace in ARM will fail.
-        /// Serialized Name: AdoptionPolicy.Never
-        /// </summary>
+        /// <summary> If the namespace already exists in Kubernetes, attempts to create that same namespace in ARM will fail. </summary>
         public static NamespaceAdoptionPolicy Never { get; } = new NamespaceAdoptionPolicy(NeverValue);
-        /// <summary>
-        /// Take over the existing namespace to be managed by ARM, if there is no difference.
-        /// Serialized Name: AdoptionPolicy.IfIdentical
-        /// </summary>
+        /// <summary> Take over the existing namespace to be managed by ARM, if there is no difference. </summary>
         public static NamespaceAdoptionPolicy IfIdentical { get; } = new NamespaceAdoptionPolicy(IfIdenticalValue);
-        /// <summary>
-        /// Always take over the existing namespace to be managed by ARM, some fields might be overwritten.
-        /// Serialized Name: AdoptionPolicy.Always
-        /// </summary>
+        /// <summary> Always take over the existing namespace to be managed by ARM, some fields might be overwritten. </summary>
         public static NamespaceAdoptionPolicy Always { get; } = new NamespaceAdoptionPolicy(AlwaysValue);
         /// <summary> Determines if two <see cref="NamespaceAdoptionPolicy"/> values are the same. </summary>
         public static bool operator ==(NamespaceAdoptionPolicy left, NamespaceAdoptionPolicy right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceDeletePolicy.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceDeletePolicy.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Delete options of a namespace.
-    /// Serialized Name: DeletePolicy
-    /// </summary>
+    /// <summary> Delete options of a namespace. </summary>
     public readonly partial struct NamespaceDeletePolicy : IEquatable<NamespaceDeletePolicy>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string KeepValue = "Keep";
         private const string DeleteValue = "Delete";
 
-        /// <summary>
-        /// Only delete the ARM resource, keep the Kubernetes namespace. Also delete the ManagedByARM label.
-        /// Serialized Name: DeletePolicy.Keep
-        /// </summary>
+        /// <summary> Only delete the ARM resource, keep the Kubernetes namespace. Also delete the ManagedByARM label. </summary>
         public static NamespaceDeletePolicy Keep { get; } = new NamespaceDeletePolicy(KeepValue);
-        /// <summary>
-        /// Delete both the ARM resource and the Kubernetes namespace together.
-        /// Serialized Name: DeletePolicy.Delete
-        /// </summary>
+        /// <summary> Delete both the ARM resource and the Kubernetes namespace together. </summary>
         public static NamespaceDeletePolicy Delete { get; } = new NamespaceDeletePolicy(DeleteValue);
         /// <summary> Determines if two <see cref="NamespaceDeletePolicy"/> values are the same. </summary>
         public static bool operator ==(NamespaceDeletePolicy left, NamespaceDeletePolicy right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceNetworkPolicies.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceNetworkPolicies.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Default network policy of the namespace, specifying ingress and egress rules.
-    /// Serialized Name: NetworkPolicies
-    /// </summary>
+    /// <summary> Default network policy of the namespace, specifying ingress and egress rules. </summary>
     public partial class NamespaceNetworkPolicies
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="NamespaceNetworkPolicies"/>. </summary>
-        /// <param name="ingress">
-        /// Ingress policy for the network.
-        /// Serialized Name: NetworkPolicies.ingress
-        /// </param>
-        /// <param name="egress">
-        /// Egress policy for the network.
-        /// Serialized Name: NetworkPolicies.egress
-        /// </param>
+        /// <param name="ingress"> Ingress policy for the network. </param>
+        /// <param name="egress"> Egress policy for the network. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal NamespaceNetworkPolicies(NamespaceNetworkPolicyRule? ingress, NamespaceNetworkPolicyRule? egress, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Ingress policy for the network.
-        /// Serialized Name: NetworkPolicies.ingress
-        /// </summary>
+        /// <summary> Ingress policy for the network. </summary>
         [WirePath("ingress")]
         public NamespaceNetworkPolicyRule? Ingress { get; set; }
-        /// <summary>
-        /// Egress policy for the network.
-        /// Serialized Name: NetworkPolicies.egress
-        /// </summary>
+        /// <summary> Egress policy for the network. </summary>
         [WirePath("egress")]
         public NamespaceNetworkPolicyRule? Egress { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceNetworkPolicyRule.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceNetworkPolicyRule.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Enum representing different network policy rules.
-    /// Serialized Name: PolicyRule
-    /// </summary>
+    /// <summary> Enum representing different network policy rules. </summary>
     public readonly partial struct NamespaceNetworkPolicyRule : IEquatable<NamespaceNetworkPolicyRule>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string AllowAllValue = "AllowAll";
         private const string AllowSameNamespaceValue = "AllowSameNamespace";
 
-        /// <summary>
-        /// Deny all network traffic.
-        /// Serialized Name: PolicyRule.DenyAll
-        /// </summary>
+        /// <summary> Deny all network traffic. </summary>
         public static NamespaceNetworkPolicyRule DenyAll { get; } = new NamespaceNetworkPolicyRule(DenyAllValue);
-        /// <summary>
-        /// Allow all network traffic.
-        /// Serialized Name: PolicyRule.AllowAll
-        /// </summary>
+        /// <summary> Allow all network traffic. </summary>
         public static NamespaceNetworkPolicyRule AllowAll { get; } = new NamespaceNetworkPolicyRule(AllowAllValue);
-        /// <summary>
-        /// Allow traffic within the same namespace.
-        /// Serialized Name: PolicyRule.AllowSameNamespace
-        /// </summary>
+        /// <summary> Allow traffic within the same namespace. </summary>
         public static NamespaceNetworkPolicyRule AllowSameNamespace { get; } = new NamespaceNetworkPolicyRule(AllowSameNamespaceValue);
         /// <summary> Determines if two <see cref="NamespaceNetworkPolicyRule"/> values are the same. </summary>
         public static bool operator ==(NamespaceNetworkPolicyRule left, NamespaceNetworkPolicyRule right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceResourceQuota.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NamespaceResourceQuota.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Resource quota for the namespace.
-    /// Serialized Name: ResourceQuota
-    /// </summary>
+    /// <summary> Resource quota for the namespace. </summary>
     public partial class NamespaceResourceQuota
     {
         /// <summary>
@@ -54,22 +51,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="NamespaceResourceQuota"/>. </summary>
-        /// <param name="cpuRequest">
-        /// CPU request of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details.
-        /// Serialized Name: ResourceQuota.cpuRequest
-        /// </param>
-        /// <param name="cpuLimit">
-        /// CPU limit of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details.
-        /// Serialized Name: ResourceQuota.cpuLimit
-        /// </param>
-        /// <param name="memoryRequest">
-        /// Memory request of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details.
-        /// Serialized Name: ResourceQuota.memoryRequest
-        /// </param>
-        /// <param name="memoryLimit">
-        /// Memory limit of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details.
-        /// Serialized Name: ResourceQuota.memoryLimit
-        /// </param>
+        /// <param name="cpuRequest"> CPU request of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details. </param>
+        /// <param name="cpuLimit"> CPU limit of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details. </param>
+        /// <param name="memoryRequest"> Memory request of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details. </param>
+        /// <param name="memoryLimit"> Memory limit of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal NamespaceResourceQuota(string cpuRequest, string cpuLimit, string memoryRequest, string memoryLimit, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -80,28 +65,16 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// CPU request of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details.
-        /// Serialized Name: ResourceQuota.cpuRequest
-        /// </summary>
+        /// <summary> CPU request of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details. </summary>
         [WirePath("cpuRequest")]
         public string CpuRequest { get; set; }
-        /// <summary>
-        /// CPU limit of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details.
-        /// Serialized Name: ResourceQuota.cpuLimit
-        /// </summary>
+        /// <summary> CPU limit of the namespace in one-thousandth CPU form. See [CPU resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu) for more details. </summary>
         [WirePath("cpuLimit")]
         public string CpuLimit { get; set; }
-        /// <summary>
-        /// Memory request of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details.
-        /// Serialized Name: ResourceQuota.memoryRequest
-        /// </summary>
+        /// <summary> Memory request of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details. </summary>
         [WirePath("memoryRequest")]
         public string MemoryRequest { get; set; }
-        /// <summary>
-        /// Memory limit of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details.
-        /// Serialized Name: ResourceQuota.memoryLimit
-        /// </summary>
+        /// <summary> Memory limit of the namespace in the power-of-two equivalents form: Ei, Pi, Ti, Gi, Mi, Ki. See [Memory resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) for more details. </summary>
         [WirePath("memoryLimit")]
         public string MemoryLimit { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NetworkDataplane.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NetworkDataplane.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Network dataplane used in the Kubernetes cluster.
-    /// Serialized Name: NetworkDataplane
-    /// </summary>
+    /// <summary> Network dataplane used in the Kubernetes cluster. </summary>
     public readonly partial struct NetworkDataplane : IEquatable<NetworkDataplane>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string AzureValue = "azure";
         private const string CiliumValue = "cilium";
 
-        /// <summary>
-        /// Use Azure network dataplane.
-        /// Serialized Name: NetworkDataplane.azure
-        /// </summary>
+        /// <summary> Use Azure network dataplane. </summary>
         public static NetworkDataplane Azure { get; } = new NetworkDataplane(AzureValue);
-        /// <summary>
-        /// Use Cilium network dataplane. See [Azure CNI Powered by Cilium](https://learn.microsoft.com/azure/aks/azure-cni-powered-by-cilium) for more information.
-        /// Serialized Name: NetworkDataplane.cilium
-        /// </summary>
+        /// <summary> Use Cilium network dataplane. See [Azure CNI Powered by Cilium](https://learn.microsoft.com/azure/aks/azure-cni-powered-by-cilium) for more information. </summary>
         public static NetworkDataplane Cilium { get; } = new NetworkDataplane(CiliumValue);
         /// <summary> Determines if two <see cref="NetworkDataplane"/> values are the same. </summary>
         public static bool operator ==(NetworkDataplane left, NetworkDataplane right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NginxIngressControllerType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NginxIngressControllerType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Ingress type for the default NginxIngressController custom resource
-    /// Serialized Name: NginxIngressControllerType
-    /// </summary>
+    /// <summary> Ingress type for the default NginxIngressController custom resource. </summary>
     public readonly partial struct NginxIngressControllerType : IEquatable<NginxIngressControllerType>
     {
         private readonly string _value;
@@ -30,25 +27,13 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string InternalValue = "Internal";
         private const string NoneValue = "None";
 
-        /// <summary>
-        /// The default NginxIngressController will be created. Users can edit the default NginxIngressController Custom Resource to configure load balancer annotations.
-        /// Serialized Name: NginxIngressControllerType.AnnotationControlled
-        /// </summary>
+        /// <summary> The default NginxIngressController will be created. Users can edit the default NginxIngressController Custom Resource to configure load balancer annotations. </summary>
         public static NginxIngressControllerType AnnotationControlled { get; } = new NginxIngressControllerType(AnnotationControlledValue);
-        /// <summary>
-        /// The default NginxIngressController will be created and the operator will provision an external loadbalancer with it. Any annotation to make the default loadbalancer internal will be overwritten.
-        /// Serialized Name: NginxIngressControllerType.External
-        /// </summary>
+        /// <summary> The default NginxIngressController will be created and the operator will provision an external loadbalancer with it. Any annotation to make the default loadbalancer internal will be overwritten. </summary>
         public static NginxIngressControllerType External { get; } = new NginxIngressControllerType(ExternalValue);
-        /// <summary>
-        /// The default NginxIngressController will be created and the operator will provision an internal loadbalancer with it. Any annotation to make the default loadbalancer external will be overwritten.
-        /// Serialized Name: NginxIngressControllerType.Internal
-        /// </summary>
+        /// <summary> The default NginxIngressController will be created and the operator will provision an internal loadbalancer with it. Any annotation to make the default loadbalancer external will be overwritten. </summary>
         public static NginxIngressControllerType Internal { get; } = new NginxIngressControllerType(InternalValue);
-        /// <summary>
-        /// The default Ingress Controller will not be created. It will not be deleted by the system if it exists. Users should delete the default NginxIngressController Custom Resource manually if desired.
-        /// Serialized Name: NginxIngressControllerType.None
-        /// </summary>
+        /// <summary> The default Ingress Controller will not be created. It will not be deleted by the system if it exists. Users should delete the default NginxIngressController Custom Resource manually if desired. </summary>
         public static NginxIngressControllerType None { get; } = new NginxIngressControllerType(NoneValue);
         /// <summary> Determines if two <see cref="NginxIngressControllerType"/> values are the same. </summary>
         public static bool operator ==(NginxIngressControllerType left, NginxIngressControllerType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NodeProvisioningDefaultNodePool.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NodeProvisioningDefaultNodePool.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The set of default Karpenter NodePools (CRDs) configured for node provisioning. This field has no effect unless mode is 'Auto'. Warning: Changing this from Auto to None on an existing cluster will cause the default Karpenter NodePools to be deleted, which will drain and delete the nodes associated with those pools. It is strongly recommended to not do this unless there are idle nodes ready to take the pods evicted by that action. If not specified, the default is Auto. For more information see aka.ms/aks/nap#node-pools.
-    /// Serialized Name: NodeProvisioningDefaultNodePools
-    /// </summary>
+    /// <summary> The set of default Karpenter NodePools (CRDs) configured for node provisioning. This field has no effect unless mode is 'Auto'. Warning: Changing this from Auto to None on an existing cluster will cause the default Karpenter NodePools to be deleted, which will drain and delete the nodes associated with those pools. It is strongly recommended to not do this unless there are idle nodes ready to take the pods evicted by that action. If not specified, the default is Auto. For more information see aka.ms/aks/nap#node-pools. </summary>
     public readonly partial struct NodeProvisioningDefaultNodePool : IEquatable<NodeProvisioningDefaultNodePool>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string NoneValue = "None";
         private const string AutoValue = "Auto";
 
-        /// <summary>
-        /// No Karpenter NodePools are provisioned automatically. Automatic scaling will not happen unless the user creates one or more NodePool CRD instances.
-        /// Serialized Name: NodeProvisioningDefaultNodePools.None
-        /// </summary>
+        /// <summary> No Karpenter NodePools are provisioned automatically. Automatic scaling will not happen unless the user creates one or more NodePool CRD instances. </summary>
         public static NodeProvisioningDefaultNodePool None { get; } = new NodeProvisioningDefaultNodePool(NoneValue);
-        /// <summary>
-        /// A standard set of Karpenter NodePools are provisioned
-        /// Serialized Name: NodeProvisioningDefaultNodePools.Auto
-        /// </summary>
+        /// <summary> A standard set of Karpenter NodePools are provisioned. </summary>
         public static NodeProvisioningDefaultNodePool Auto { get; } = new NodeProvisioningDefaultNodePool(AutoValue);
         /// <summary> Determines if two <see cref="NodeProvisioningDefaultNodePool"/> values are the same. </summary>
         public static bool operator ==(NodeProvisioningDefaultNodePool left, NodeProvisioningDefaultNodePool right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NodeProvisioningMode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/NodeProvisioningMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The node provisioning mode. If not specified, the default is Manual.
-    /// Serialized Name: NodeProvisioningMode
-    /// </summary>
+    /// <summary> The node provisioning mode. If not specified, the default is Manual. </summary>
     public readonly partial struct NodeProvisioningMode : IEquatable<NodeProvisioningMode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string ManualValue = "Manual";
         private const string AutoValue = "Auto";
 
-        /// <summary>
-        /// Nodes are provisioned manually by the user
-        /// Serialized Name: NodeProvisioningMode.Manual
-        /// </summary>
+        /// <summary> Nodes are provisioned manually by the user. </summary>
         public static NodeProvisioningMode Manual { get; } = new NodeProvisioningMode(ManualValue);
-        /// <summary>
-        /// Nodes are provisioned automatically by AKS using Karpenter (See aka.ms/aks/nap for more details). Fixed size Node Pools can still be created, but autoscaling Node Pools cannot be. (See aka.ms/aks/nap for more details).
-        /// Serialized Name: NodeProvisioningMode.Auto
-        /// </summary>
+        /// <summary> Nodes are provisioned automatically by AKS using Karpenter (See aka.ms/aks/nap for more details). Fixed size Node Pools can still be created, but autoscaling Node Pools cannot be. (See aka.ms/aks/nap for more details). </summary>
         public static NodeProvisioningMode Auto { get; } = new NodeProvisioningMode(AutoValue);
         /// <summary> Determines if two <see cref="NodeProvisioningMode"/> values are the same. </summary>
         public static bool operator ==(NodeProvisioningMode left, NodeProvisioningMode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/OutboundEnvironmentEndpointListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/OutboundEnvironmentEndpointListResult.cs
@@ -11,10 +11,7 @@ using System.Linq;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Collection of OutboundEnvironmentEndpoint
-    /// Serialized Name: OutboundEnvironmentEndpointCollection
-    /// </summary>
+    /// <summary> Collection of OutboundEnvironmentEndpoint. </summary>
     internal partial class OutboundEnvironmentEndpointListResult
     {
         /// <summary>
@@ -50,10 +47,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="OutboundEnvironmentEndpointListResult"/>. </summary>
-        /// <param name="value">
-        /// Collection of resources.
-        /// Serialized Name: OutboundEnvironmentEndpointCollection.value
-        /// </param>
+        /// <param name="value"> Collection of resources. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
         internal OutboundEnvironmentEndpointListResult(IEnumerable<ContainerServiceOutboundEnvironmentEndpoint> value)
         {
@@ -63,14 +57,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="OutboundEnvironmentEndpointListResult"/>. </summary>
-        /// <param name="value">
-        /// Collection of resources.
-        /// Serialized Name: OutboundEnvironmentEndpointCollection.value
-        /// </param>
-        /// <param name="nextLink">
-        /// Link to next page of resources.
-        /// Serialized Name: OutboundEnvironmentEndpointCollection.nextLink
-        /// </param>
+        /// <param name="value"> Collection of resources. </param>
+        /// <param name="nextLink"> Link to next page of resources. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal OutboundEnvironmentEndpointListResult(IReadOnlyList<ContainerServiceOutboundEnvironmentEndpoint> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -84,15 +72,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Collection of resources.
-        /// Serialized Name: OutboundEnvironmentEndpointCollection.value
-        /// </summary>
+        /// <summary> Collection of resources. </summary>
         public IReadOnlyList<ContainerServiceOutboundEnvironmentEndpoint> Value { get; }
-        /// <summary>
-        /// Link to next page of resources.
-        /// Serialized Name: OutboundEnvironmentEndpointCollection.nextLink
-        /// </summary>
+        /// <summary> Link to next page of resources. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/PodIPAllocationMode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/PodIPAllocationMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'.
-    /// Serialized Name: PodIPAllocationMode
-    /// </summary>
+    /// <summary> Pod IP Allocation Mode. The IP allocation mode for pods in the agent pool. Must be used with podSubnetId. The default is 'DynamicIndividual'. </summary>
     public readonly partial struct PodIPAllocationMode : IEquatable<PodIPAllocationMode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string DynamicIndividualValue = "DynamicIndividual";
         private const string StaticBlockValue = "StaticBlock";
 
-        /// <summary>
-        /// Each node gets allocated with a non-contiguous list of IP addresses assignable to pods. This is better for maximizing a small to medium subnet of size /16 or smaller. The Azure CNI cluster with dynamic IP allocation defaults to this mode if the customer does not explicitly specify a podIPAllocationMode
-        /// Serialized Name: PodIPAllocationMode.DynamicIndividual
-        /// </summary>
+        /// <summary> Each node gets allocated with a non-contiguous list of IP addresses assignable to pods. This is better for maximizing a small to medium subnet of size /16 or smaller. The Azure CNI cluster with dynamic IP allocation defaults to this mode if the customer does not explicitly specify a podIPAllocationMode. </summary>
         public static PodIPAllocationMode DynamicIndividual { get; } = new PodIPAllocationMode(DynamicIndividualValue);
-        /// <summary>
-        /// Each node is statically allocated CIDR block(s) of size /28 = 16 IPs per block to satisfy the maxPods per node. Number of CIDR blocks &gt;= (maxPods / 16). The block, rather than a single IP, counts against the Azure Vnet Private IP limit of 65K. Therefore block mode is suitable for running larger workloads with more than the current limit of 65K pods in a cluster. This mode is better suited to scale with larger subnets of /15 or bigger
-        /// Serialized Name: PodIPAllocationMode.StaticBlock
-        /// </summary>
+        /// <summary> Each node is statically allocated CIDR block(s) of size /28 = 16 IPs per block to satisfy the maxPods per node. Number of CIDR blocks &gt;= (maxPods / 16). The block, rather than a single IP, counts against the Azure Vnet Private IP limit of 65K. Therefore block mode is suitable for running larger workloads with more than the current limit of 65K pods in a cluster. This mode is better suited to scale with larger subnets of /15 or bigger. </summary>
         public static PodIPAllocationMode StaticBlock { get; } = new PodIPAllocationMode(StaticBlockValue);
         /// <summary> Determines if two <see cref="PodIPAllocationMode"/> values are the same. </summary>
         public static bool operator ==(PodIPAllocationMode left, PodIPAllocationMode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ScaleDownMode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ScaleDownMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Describes how VMs are added to or removed from Agent Pools. See [billing states](https://docs.microsoft.com/azure/virtual-machines/states-billing).
-    /// Serialized Name: ScaleDownMode
-    /// </summary>
+    /// <summary> Describes how VMs are added to or removed from Agent Pools. See [billing states](https://docs.microsoft.com/azure/virtual-machines/states-billing). </summary>
     public readonly partial struct ScaleDownMode : IEquatable<ScaleDownMode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string DeleteValue = "Delete";
         private const string DeallocateValue = "Deallocate";
 
-        /// <summary>
-        /// Create new instances during scale up and remove instances during scale down.
-        /// Serialized Name: ScaleDownMode.Delete
-        /// </summary>
+        /// <summary> Create new instances during scale up and remove instances during scale down. </summary>
         public static ScaleDownMode Delete { get; } = new ScaleDownMode(DeleteValue);
-        /// <summary>
-        /// Attempt to start deallocated instances (if they exist) during scale up and deallocate instances during scale down.
-        /// Serialized Name: ScaleDownMode.Deallocate
-        /// </summary>
+        /// <summary> Attempt to start deallocated instances (if they exist) during scale up and deallocate instances during scale down. </summary>
         public static ScaleDownMode Deallocate { get; } = new ScaleDownMode(DeallocateValue);
         /// <summary> Determines if two <see cref="ScaleDownMode"/> values are the same. </summary>
         public static bool operator ==(ScaleDownMode left, ScaleDownMode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ScaleProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ScaleProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Specifications on how to scale a VirtualMachines agent pool.
-    /// Serialized Name: ScaleProfile
-    /// </summary>
+    /// <summary> Specifications on how to scale a VirtualMachines agent pool. </summary>
     internal partial class ScaleProfile
     {
         /// <summary>
@@ -55,10 +52,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="ScaleProfile"/>. </summary>
-        /// <param name="manual">
-        /// Specifications on how to scale the VirtualMachines agent pool to a fixed size.
-        /// Serialized Name: ScaleProfile.manual
-        /// </param>
+        /// <param name="manual"> Specifications on how to scale the VirtualMachines agent pool to a fixed size. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ScaleProfile(IList<ManualScaleProfile> manual, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -66,10 +60,7 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Specifications on how to scale the VirtualMachines agent pool to a fixed size.
-        /// Serialized Name: ScaleProfile.manual
-        /// </summary>
+        /// <summary> Specifications on how to scale the VirtualMachines agent pool to a fixed size. </summary>
         [WirePath("manual")]
         public IList<ManualScaleProfile> Manual { get; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ScaleSetEvictionPolicy.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ScaleSetEvictionPolicy.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The Virtual Machine Scale Set eviction policy. The eviction policy specifies what to do with the VM when it is evicted. The default is Delete. For more information about eviction see [spot VMs](https://docs.microsoft.com/azure/virtual-machines/spot-vms)
-    /// Serialized Name: ScaleSetEvictionPolicy
-    /// </summary>
+    /// <summary> The Virtual Machine Scale Set eviction policy. The eviction policy specifies what to do with the VM when it is evicted. The default is Delete. For more information about eviction see [spot VMs](https://docs.microsoft.com/azure/virtual-machines/spot-vms). </summary>
     public readonly partial struct ScaleSetEvictionPolicy : IEquatable<ScaleSetEvictionPolicy>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string DeleteValue = "Delete";
         private const string DeallocateValue = "Deallocate";
 
-        /// <summary>
-        /// Nodes in the underlying Scale Set of the node pool are deleted when they're evicted.
-        /// Serialized Name: ScaleSetEvictionPolicy.Delete
-        /// </summary>
+        /// <summary> Nodes in the underlying Scale Set of the node pool are deleted when they're evicted. </summary>
         public static ScaleSetEvictionPolicy Delete { get; } = new ScaleSetEvictionPolicy(DeleteValue);
-        /// <summary>
-        /// Nodes in the underlying Scale Set of the node pool are set to the stopped-deallocated state upon eviction. Nodes in the stopped-deallocated state count against your compute quota and can cause issues with cluster scaling or upgrading.
-        /// Serialized Name: ScaleSetEvictionPolicy.Deallocate
-        /// </summary>
+        /// <summary> Nodes in the underlying Scale Set of the node pool are set to the stopped-deallocated state upon eviction. Nodes in the stopped-deallocated state count against your compute quota and can cause issues with cluster scaling or upgrading. </summary>
         public static ScaleSetEvictionPolicy Deallocate { get; } = new ScaleSetEvictionPolicy(DeallocateValue);
         /// <summary> Determines if two <see cref="ScaleSetEvictionPolicy"/> values are the same. </summary>
         public static bool operator ==(ScaleSetEvictionPolicy left, ScaleSetEvictionPolicy right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ScaleSetPriority.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ScaleSetPriority.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The Virtual Machine Scale Set priority.
-    /// Serialized Name: ScaleSetPriority
-    /// </summary>
+    /// <summary> The Virtual Machine Scale Set priority. </summary>
     public readonly partial struct ScaleSetPriority : IEquatable<ScaleSetPriority>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string SpotValue = "Spot";
         private const string RegularValue = "Regular";
 
-        /// <summary>
-        /// Spot priority VMs will be used. There is no SLA for spot nodes. See [spot on AKS](https://docs.microsoft.com/azure/aks/spot-node-pool) for more information.
-        /// Serialized Name: ScaleSetPriority.Spot
-        /// </summary>
+        /// <summary> Spot priority VMs will be used. There is no SLA for spot nodes. See [spot on AKS](https://docs.microsoft.com/azure/aks/spot-node-pool) for more information. </summary>
         public static ScaleSetPriority Spot { get; } = new ScaleSetPriority(SpotValue);
-        /// <summary>
-        /// Regular VMs will be used.
-        /// Serialized Name: ScaleSetPriority.Regular
-        /// </summary>
+        /// <summary> Regular VMs will be used. </summary>
         public static ScaleSetPriority Regular { get; } = new ScaleSetPriority(RegularValue);
         /// <summary> Determines if two <see cref="ScaleSetPriority"/> values are the same. </summary>
         public static bool operator ==(ScaleSetPriority left, ScaleSetPriority right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ServiceMeshMode.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ServiceMeshMode.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Mode of the service mesh.
-    /// Serialized Name: ServiceMeshMode
-    /// </summary>
+    /// <summary> Mode of the service mesh. </summary>
     public readonly partial struct ServiceMeshMode : IEquatable<ServiceMeshMode>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string IstioValue = "Istio";
         private const string DisabledValue = "Disabled";
 
-        /// <summary>
-        /// Istio deployed as an AKS addon.
-        /// Serialized Name: ServiceMeshMode.Istio
-        /// </summary>
+        /// <summary> Istio deployed as an AKS addon. </summary>
         public static ServiceMeshMode Istio { get; } = new ServiceMeshMode(IstioValue);
-        /// <summary>
-        /// Mesh is disabled.
-        /// Serialized Name: ServiceMeshMode.Disabled
-        /// </summary>
+        /// <summary> Mesh is disabled. </summary>
         public static ServiceMeshMode Disabled { get; } = new ServiceMeshMode(DisabledValue);
         /// <summary> Determines if two <see cref="ServiceMeshMode"/> values are the same. </summary>
         public static bool operator ==(ServiceMeshMode left, ServiceMeshMode right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ServiceMeshProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/ServiceMeshProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Service mesh profile for a managed cluster.
-    /// Serialized Name: ServiceMeshProfile
-    /// </summary>
+    /// <summary> Service mesh profile for a managed cluster. </summary>
     public partial class ServiceMeshProfile
     {
         /// <summary>
@@ -49,24 +46,15 @@ namespace Azure.ResourceManager.ContainerService.Models
         private IDictionary<string, BinaryData> _serializedAdditionalRawData;
 
         /// <summary> Initializes a new instance of <see cref="ServiceMeshProfile"/>. </summary>
-        /// <param name="mode">
-        /// Mode of the service mesh.
-        /// Serialized Name: ServiceMeshProfile.mode
-        /// </param>
+        /// <param name="mode"> Mode of the service mesh. </param>
         public ServiceMeshProfile(ServiceMeshMode mode)
         {
             Mode = mode;
         }
 
         /// <summary> Initializes a new instance of <see cref="ServiceMeshProfile"/>. </summary>
-        /// <param name="mode">
-        /// Mode of the service mesh.
-        /// Serialized Name: ServiceMeshProfile.mode
-        /// </param>
-        /// <param name="istio">
-        /// Istio service mesh configuration.
-        /// Serialized Name: ServiceMeshProfile.istio
-        /// </param>
+        /// <param name="mode"> Mode of the service mesh. </param>
+        /// <param name="istio"> Istio service mesh configuration. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal ServiceMeshProfile(ServiceMeshMode mode, IstioServiceMesh istio, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -80,16 +68,10 @@ namespace Azure.ResourceManager.ContainerService.Models
         {
         }
 
-        /// <summary>
-        /// Mode of the service mesh.
-        /// Serialized Name: ServiceMeshProfile.mode
-        /// </summary>
+        /// <summary> Mode of the service mesh. </summary>
         [WirePath("mode")]
         public ServiceMeshMode Mode { get; set; }
-        /// <summary>
-        /// Istio service mesh configuration.
-        /// Serialized Name: ServiceMeshProfile.istio
-        /// </summary>
+        /// <summary> Istio service mesh configuration. </summary>
         [WirePath("istio")]
         public IstioServiceMesh Istio { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/SnapshotType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/SnapshotType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The type of a snapshot. The default is NodePool.
-    /// Serialized Name: SnapshotType
-    /// </summary>
+    /// <summary> The type of a snapshot. The default is NodePool. </summary>
     public readonly partial struct SnapshotType : IEquatable<SnapshotType>
     {
         private readonly string _value;
@@ -27,10 +24,7 @@ namespace Azure.ResourceManager.ContainerService.Models
 
         private const string NodePoolValue = "NodePool";
 
-        /// <summary>
-        /// The snapshot is a snapshot of a node pool.
-        /// Serialized Name: SnapshotType.NodePool
-        /// </summary>
+        /// <summary> The snapshot is a snapshot of a node pool. </summary>
         public static SnapshotType NodePool { get; } = new SnapshotType(NodePoolValue);
         /// <summary> Determines if two <see cref="SnapshotType"/> values are the same. </summary>
         public static bool operator ==(SnapshotType left, SnapshotType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/SysctlConfig.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/SysctlConfig.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Sysctl settings for Linux agent nodes.
-    /// Serialized Name: SysctlConfig
-    /// </summary>
+    /// <summary> Sysctl settings for Linux agent nodes. </summary>
     public partial class SysctlConfig
     {
         /// <summary>
@@ -54,118 +51,34 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="SysctlConfig"/>. </summary>
-        /// <param name="netCoreSomaxconn">
-        /// Sysctl setting net.core.somaxconn.
-        /// Serialized Name: SysctlConfig.netCoreSomaxconn
-        /// </param>
-        /// <param name="netCoreNetdevMaxBacklog">
-        /// Sysctl setting net.core.netdev_max_backlog.
-        /// Serialized Name: SysctlConfig.netCoreNetdevMaxBacklog
-        /// </param>
-        /// <param name="netCoreRmemDefault">
-        /// Sysctl setting net.core.rmem_default.
-        /// Serialized Name: SysctlConfig.netCoreRmemDefault
-        /// </param>
-        /// <param name="netCoreRmemMax">
-        /// Sysctl setting net.core.rmem_max.
-        /// Serialized Name: SysctlConfig.netCoreRmemMax
-        /// </param>
-        /// <param name="netCoreWmemDefault">
-        /// Sysctl setting net.core.wmem_default.
-        /// Serialized Name: SysctlConfig.netCoreWmemDefault
-        /// </param>
-        /// <param name="netCoreWmemMax">
-        /// Sysctl setting net.core.wmem_max.
-        /// Serialized Name: SysctlConfig.netCoreWmemMax
-        /// </param>
-        /// <param name="netCoreOptmemMax">
-        /// Sysctl setting net.core.optmem_max.
-        /// Serialized Name: SysctlConfig.netCoreOptmemMax
-        /// </param>
-        /// <param name="netIPv4TcpMaxSynBacklog">
-        /// Sysctl setting net.ipv4.tcp_max_syn_backlog.
-        /// Serialized Name: SysctlConfig.netIpv4TcpMaxSynBacklog
-        /// </param>
-        /// <param name="netIPv4TcpMaxTwBuckets">
-        /// Sysctl setting net.ipv4.tcp_max_tw_buckets.
-        /// Serialized Name: SysctlConfig.netIpv4TcpMaxTwBuckets
-        /// </param>
-        /// <param name="netIPv4TcpFinTimeout">
-        /// Sysctl setting net.ipv4.tcp_fin_timeout.
-        /// Serialized Name: SysctlConfig.netIpv4TcpFinTimeout
-        /// </param>
-        /// <param name="netIPv4TcpKeepaliveTime">
-        /// Sysctl setting net.ipv4.tcp_keepalive_time.
-        /// Serialized Name: SysctlConfig.netIpv4TcpKeepaliveTime
-        /// </param>
-        /// <param name="netIPv4TcpKeepaliveProbes">
-        /// Sysctl setting net.ipv4.tcp_keepalive_probes.
-        /// Serialized Name: SysctlConfig.netIpv4TcpKeepaliveProbes
-        /// </param>
-        /// <param name="netIPv4TcpKeepaliveIntvl">
-        /// Sysctl setting net.ipv4.tcp_keepalive_intvl.
-        /// Serialized Name: SysctlConfig.netIpv4TcpkeepaliveIntvl
-        /// </param>
-        /// <param name="netIPv4TcpTwReuse">
-        /// Sysctl setting net.ipv4.tcp_tw_reuse.
-        /// Serialized Name: SysctlConfig.netIpv4TcpTwReuse
-        /// </param>
-        /// <param name="netIPv4IPLocalPortRange">
-        /// Sysctl setting net.ipv4.ip_local_port_range.
-        /// Serialized Name: SysctlConfig.netIpv4IpLocalPortRange
-        /// </param>
-        /// <param name="netIPv4NeighDefaultGcThresh1">
-        /// Sysctl setting net.ipv4.neigh.default.gc_thresh1.
-        /// Serialized Name: SysctlConfig.netIpv4NeighDefaultGcThresh1
-        /// </param>
-        /// <param name="netIPv4NeighDefaultGcThresh2">
-        /// Sysctl setting net.ipv4.neigh.default.gc_thresh2.
-        /// Serialized Name: SysctlConfig.netIpv4NeighDefaultGcThresh2
-        /// </param>
-        /// <param name="netIPv4NeighDefaultGcThresh3">
-        /// Sysctl setting net.ipv4.neigh.default.gc_thresh3.
-        /// Serialized Name: SysctlConfig.netIpv4NeighDefaultGcThresh3
-        /// </param>
-        /// <param name="netNetfilterNfConntrackMax">
-        /// Sysctl setting net.netfilter.nf_conntrack_max.
-        /// Serialized Name: SysctlConfig.netNetfilterNfConntrackMax
-        /// </param>
-        /// <param name="netNetfilterNfConntrackBuckets">
-        /// Sysctl setting net.netfilter.nf_conntrack_buckets.
-        /// Serialized Name: SysctlConfig.netNetfilterNfConntrackBuckets
-        /// </param>
-        /// <param name="fsInotifyMaxUserWatches">
-        /// Sysctl setting fs.inotify.max_user_watches.
-        /// Serialized Name: SysctlConfig.fsInotifyMaxUserWatches
-        /// </param>
-        /// <param name="fsFileMax">
-        /// Sysctl setting fs.file-max.
-        /// Serialized Name: SysctlConfig.fsFileMax
-        /// </param>
-        /// <param name="fsAioMaxNr">
-        /// Sysctl setting fs.aio-max-nr.
-        /// Serialized Name: SysctlConfig.fsAioMaxNr
-        /// </param>
-        /// <param name="fsNrOpen">
-        /// Sysctl setting fs.nr_open.
-        /// Serialized Name: SysctlConfig.fsNrOpen
-        /// </param>
-        /// <param name="kernelThreadsMax">
-        /// Sysctl setting kernel.threads-max.
-        /// Serialized Name: SysctlConfig.kernelThreadsMax
-        /// </param>
-        /// <param name="vmMaxMapCount">
-        /// Sysctl setting vm.max_map_count.
-        /// Serialized Name: SysctlConfig.vmMaxMapCount
-        /// </param>
-        /// <param name="vmSwappiness">
-        /// Sysctl setting vm.swappiness.
-        /// Serialized Name: SysctlConfig.vmSwappiness
-        /// </param>
-        /// <param name="vmVfsCachePressure">
-        /// Sysctl setting vm.vfs_cache_pressure.
-        /// Serialized Name: SysctlConfig.vmVfsCachePressure
-        /// </param>
+        /// <param name="netCoreSomaxconn"> Sysctl setting net.core.somaxconn. </param>
+        /// <param name="netCoreNetdevMaxBacklog"> Sysctl setting net.core.netdev_max_backlog. </param>
+        /// <param name="netCoreRmemDefault"> Sysctl setting net.core.rmem_default. </param>
+        /// <param name="netCoreRmemMax"> Sysctl setting net.core.rmem_max. </param>
+        /// <param name="netCoreWmemDefault"> Sysctl setting net.core.wmem_default. </param>
+        /// <param name="netCoreWmemMax"> Sysctl setting net.core.wmem_max. </param>
+        /// <param name="netCoreOptmemMax"> Sysctl setting net.core.optmem_max. </param>
+        /// <param name="netIPv4TcpMaxSynBacklog"> Sysctl setting net.ipv4.tcp_max_syn_backlog. </param>
+        /// <param name="netIPv4TcpMaxTwBuckets"> Sysctl setting net.ipv4.tcp_max_tw_buckets. </param>
+        /// <param name="netIPv4TcpFinTimeout"> Sysctl setting net.ipv4.tcp_fin_timeout. </param>
+        /// <param name="netIPv4TcpKeepaliveTime"> Sysctl setting net.ipv4.tcp_keepalive_time. </param>
+        /// <param name="netIPv4TcpKeepaliveProbes"> Sysctl setting net.ipv4.tcp_keepalive_probes. </param>
+        /// <param name="netIPv4TcpKeepaliveIntvl"> Sysctl setting net.ipv4.tcp_keepalive_intvl. </param>
+        /// <param name="netIPv4TcpTwReuse"> Sysctl setting net.ipv4.tcp_tw_reuse. </param>
+        /// <param name="netIPv4IPLocalPortRange"> Sysctl setting net.ipv4.ip_local_port_range. </param>
+        /// <param name="netIPv4NeighDefaultGcThresh1"> Sysctl setting net.ipv4.neigh.default.gc_thresh1. </param>
+        /// <param name="netIPv4NeighDefaultGcThresh2"> Sysctl setting net.ipv4.neigh.default.gc_thresh2. </param>
+        /// <param name="netIPv4NeighDefaultGcThresh3"> Sysctl setting net.ipv4.neigh.default.gc_thresh3. </param>
+        /// <param name="netNetfilterNfConntrackMax"> Sysctl setting net.netfilter.nf_conntrack_max. </param>
+        /// <param name="netNetfilterNfConntrackBuckets"> Sysctl setting net.netfilter.nf_conntrack_buckets. </param>
+        /// <param name="fsInotifyMaxUserWatches"> Sysctl setting fs.inotify.max_user_watches. </param>
+        /// <param name="fsFileMax"> Sysctl setting fs.file-max. </param>
+        /// <param name="fsAioMaxNr"> Sysctl setting fs.aio-max-nr. </param>
+        /// <param name="fsNrOpen"> Sysctl setting fs.nr_open. </param>
+        /// <param name="kernelThreadsMax"> Sysctl setting kernel.threads-max. </param>
+        /// <param name="vmMaxMapCount"> Sysctl setting vm.max_map_count. </param>
+        /// <param name="vmSwappiness"> Sysctl setting vm.swappiness. </param>
+        /// <param name="vmVfsCachePressure"> Sysctl setting vm.vfs_cache_pressure. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal SysctlConfig(int? netCoreSomaxconn, int? netCoreNetdevMaxBacklog, int? netCoreRmemDefault, int? netCoreRmemMax, int? netCoreWmemDefault, int? netCoreWmemMax, int? netCoreOptmemMax, int? netIPv4TcpMaxSynBacklog, int? netIPv4TcpMaxTwBuckets, int? netIPv4TcpFinTimeout, int? netIPv4TcpKeepaliveTime, int? netIPv4TcpKeepaliveProbes, int? netIPv4TcpKeepaliveIntvl, bool? netIPv4TcpTwReuse, string netIPv4IPLocalPortRange, int? netIPv4NeighDefaultGcThresh1, int? netIPv4NeighDefaultGcThresh2, int? netIPv4NeighDefaultGcThresh3, int? netNetfilterNfConntrackMax, int? netNetfilterNfConntrackBuckets, int? fsInotifyMaxUserWatches, int? fsFileMax, int? fsAioMaxNr, int? fsNrOpen, int? kernelThreadsMax, int? vmMaxMapCount, int? vmSwappiness, int? vmVfsCachePressure, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -200,172 +113,88 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Sysctl setting net.core.somaxconn.
-        /// Serialized Name: SysctlConfig.netCoreSomaxconn
-        /// </summary>
+        /// <summary> Sysctl setting net.core.somaxconn. </summary>
         [WirePath("netCoreSomaxconn")]
         public int? NetCoreSomaxconn { get; set; }
-        /// <summary>
-        /// Sysctl setting net.core.netdev_max_backlog.
-        /// Serialized Name: SysctlConfig.netCoreNetdevMaxBacklog
-        /// </summary>
+        /// <summary> Sysctl setting net.core.netdev_max_backlog. </summary>
         [WirePath("netCoreNetdevMaxBacklog")]
         public int? NetCoreNetdevMaxBacklog { get; set; }
-        /// <summary>
-        /// Sysctl setting net.core.rmem_default.
-        /// Serialized Name: SysctlConfig.netCoreRmemDefault
-        /// </summary>
+        /// <summary> Sysctl setting net.core.rmem_default. </summary>
         [WirePath("netCoreRmemDefault")]
         public int? NetCoreRmemDefault { get; set; }
-        /// <summary>
-        /// Sysctl setting net.core.rmem_max.
-        /// Serialized Name: SysctlConfig.netCoreRmemMax
-        /// </summary>
+        /// <summary> Sysctl setting net.core.rmem_max. </summary>
         [WirePath("netCoreRmemMax")]
         public int? NetCoreRmemMax { get; set; }
-        /// <summary>
-        /// Sysctl setting net.core.wmem_default.
-        /// Serialized Name: SysctlConfig.netCoreWmemDefault
-        /// </summary>
+        /// <summary> Sysctl setting net.core.wmem_default. </summary>
         [WirePath("netCoreWmemDefault")]
         public int? NetCoreWmemDefault { get; set; }
-        /// <summary>
-        /// Sysctl setting net.core.wmem_max.
-        /// Serialized Name: SysctlConfig.netCoreWmemMax
-        /// </summary>
+        /// <summary> Sysctl setting net.core.wmem_max. </summary>
         [WirePath("netCoreWmemMax")]
         public int? NetCoreWmemMax { get; set; }
-        /// <summary>
-        /// Sysctl setting net.core.optmem_max.
-        /// Serialized Name: SysctlConfig.netCoreOptmemMax
-        /// </summary>
+        /// <summary> Sysctl setting net.core.optmem_max. </summary>
         [WirePath("netCoreOptmemMax")]
         public int? NetCoreOptmemMax { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.tcp_max_syn_backlog.
-        /// Serialized Name: SysctlConfig.netIpv4TcpMaxSynBacklog
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.tcp_max_syn_backlog. </summary>
         [WirePath("netIpv4TcpMaxSynBacklog")]
         public int? NetIPv4TcpMaxSynBacklog { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.tcp_max_tw_buckets.
-        /// Serialized Name: SysctlConfig.netIpv4TcpMaxTwBuckets
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.tcp_max_tw_buckets. </summary>
         [WirePath("netIpv4TcpMaxTwBuckets")]
         public int? NetIPv4TcpMaxTwBuckets { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.tcp_fin_timeout.
-        /// Serialized Name: SysctlConfig.netIpv4TcpFinTimeout
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.tcp_fin_timeout. </summary>
         [WirePath("netIpv4TcpFinTimeout")]
         public int? NetIPv4TcpFinTimeout { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.tcp_keepalive_time.
-        /// Serialized Name: SysctlConfig.netIpv4TcpKeepaliveTime
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.tcp_keepalive_time. </summary>
         [WirePath("netIpv4TcpKeepaliveTime")]
         public int? NetIPv4TcpKeepaliveTime { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.tcp_keepalive_probes.
-        /// Serialized Name: SysctlConfig.netIpv4TcpKeepaliveProbes
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.tcp_keepalive_probes. </summary>
         [WirePath("netIpv4TcpKeepaliveProbes")]
         public int? NetIPv4TcpKeepaliveProbes { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.tcp_keepalive_intvl.
-        /// Serialized Name: SysctlConfig.netIpv4TcpkeepaliveIntvl
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.tcp_keepalive_intvl. </summary>
         [WirePath("netIpv4TcpkeepaliveIntvl")]
         public int? NetIPv4TcpKeepaliveIntvl { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.tcp_tw_reuse.
-        /// Serialized Name: SysctlConfig.netIpv4TcpTwReuse
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.tcp_tw_reuse. </summary>
         [WirePath("netIpv4TcpTwReuse")]
         public bool? NetIPv4TcpTwReuse { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.ip_local_port_range.
-        /// Serialized Name: SysctlConfig.netIpv4IpLocalPortRange
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.ip_local_port_range. </summary>
         [WirePath("netIpv4IpLocalPortRange")]
         public string NetIPv4IPLocalPortRange { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.neigh.default.gc_thresh1.
-        /// Serialized Name: SysctlConfig.netIpv4NeighDefaultGcThresh1
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.neigh.default.gc_thresh1. </summary>
         [WirePath("netIpv4NeighDefaultGcThresh1")]
         public int? NetIPv4NeighDefaultGcThresh1 { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.neigh.default.gc_thresh2.
-        /// Serialized Name: SysctlConfig.netIpv4NeighDefaultGcThresh2
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.neigh.default.gc_thresh2. </summary>
         [WirePath("netIpv4NeighDefaultGcThresh2")]
         public int? NetIPv4NeighDefaultGcThresh2 { get; set; }
-        /// <summary>
-        /// Sysctl setting net.ipv4.neigh.default.gc_thresh3.
-        /// Serialized Name: SysctlConfig.netIpv4NeighDefaultGcThresh3
-        /// </summary>
+        /// <summary> Sysctl setting net.ipv4.neigh.default.gc_thresh3. </summary>
         [WirePath("netIpv4NeighDefaultGcThresh3")]
         public int? NetIPv4NeighDefaultGcThresh3 { get; set; }
-        /// <summary>
-        /// Sysctl setting net.netfilter.nf_conntrack_max.
-        /// Serialized Name: SysctlConfig.netNetfilterNfConntrackMax
-        /// </summary>
+        /// <summary> Sysctl setting net.netfilter.nf_conntrack_max. </summary>
         [WirePath("netNetfilterNfConntrackMax")]
         public int? NetNetfilterNfConntrackMax { get; set; }
-        /// <summary>
-        /// Sysctl setting net.netfilter.nf_conntrack_buckets.
-        /// Serialized Name: SysctlConfig.netNetfilterNfConntrackBuckets
-        /// </summary>
+        /// <summary> Sysctl setting net.netfilter.nf_conntrack_buckets. </summary>
         [WirePath("netNetfilterNfConntrackBuckets")]
         public int? NetNetfilterNfConntrackBuckets { get; set; }
-        /// <summary>
-        /// Sysctl setting fs.inotify.max_user_watches.
-        /// Serialized Name: SysctlConfig.fsInotifyMaxUserWatches
-        /// </summary>
+        /// <summary> Sysctl setting fs.inotify.max_user_watches. </summary>
         [WirePath("fsInotifyMaxUserWatches")]
         public int? FsInotifyMaxUserWatches { get; set; }
-        /// <summary>
-        /// Sysctl setting fs.file-max.
-        /// Serialized Name: SysctlConfig.fsFileMax
-        /// </summary>
+        /// <summary> Sysctl setting fs.file-max. </summary>
         [WirePath("fsFileMax")]
         public int? FsFileMax { get; set; }
-        /// <summary>
-        /// Sysctl setting fs.aio-max-nr.
-        /// Serialized Name: SysctlConfig.fsAioMaxNr
-        /// </summary>
+        /// <summary> Sysctl setting fs.aio-max-nr. </summary>
         [WirePath("fsAioMaxNr")]
         public int? FsAioMaxNr { get; set; }
-        /// <summary>
-        /// Sysctl setting fs.nr_open.
-        /// Serialized Name: SysctlConfig.fsNrOpen
-        /// </summary>
+        /// <summary> Sysctl setting fs.nr_open. </summary>
         [WirePath("fsNrOpen")]
         public int? FsNrOpen { get; set; }
-        /// <summary>
-        /// Sysctl setting kernel.threads-max.
-        /// Serialized Name: SysctlConfig.kernelThreadsMax
-        /// </summary>
+        /// <summary> Sysctl setting kernel.threads-max. </summary>
         [WirePath("kernelThreadsMax")]
         public int? KernelThreadsMax { get; set; }
-        /// <summary>
-        /// Sysctl setting vm.max_map_count.
-        /// Serialized Name: SysctlConfig.vmMaxMapCount
-        /// </summary>
+        /// <summary> Sysctl setting vm.max_map_count. </summary>
         [WirePath("vmMaxMapCount")]
         public int? VmMaxMapCount { get; set; }
-        /// <summary>
-        /// Sysctl setting vm.swappiness.
-        /// Serialized Name: SysctlConfig.vmSwappiness
-        /// </summary>
+        /// <summary> Sysctl setting vm.swappiness. </summary>
         [WirePath("vmSwappiness")]
         public int? VmSwappiness { get; set; }
-        /// <summary>
-        /// Sysctl setting vm.vfs_cache_pressure.
-        /// Serialized Name: SysctlConfig.vmVfsCachePressure
-        /// </summary>
+        /// <summary> Sysctl setting vm.vfs_cache_pressure. </summary>
         [WirePath("vmVfsCachePressure")]
         public int? VmVfsCachePressure { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/TrustedAccessRoleBindingListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/TrustedAccessRoleBindingListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// List of trusted access role bindings
-    /// Serialized Name: TrustedAccessRoleBindingListResult
-    /// </summary>
+    /// <summary> List of trusted access role bindings. </summary>
     internal partial class TrustedAccessRoleBindingListResult
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="TrustedAccessRoleBindingListResult"/>. </summary>
-        /// <param name="value">
-        /// Role binding list
-        /// Serialized Name: TrustedAccessRoleBindingListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// Link to next page of resources.
-        /// Serialized Name: TrustedAccessRoleBindingListResult.nextLink
-        /// </param>
+        /// <param name="value"> Role binding list. </param>
+        /// <param name="nextLink"> Link to next page of resources. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal TrustedAccessRoleBindingListResult(IReadOnlyList<ContainerServiceTrustedAccessRoleBindingData> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Role binding list
-        /// Serialized Name: TrustedAccessRoleBindingListResult.value
-        /// </summary>
+        /// <summary> Role binding list. </summary>
         public IReadOnlyList<ContainerServiceTrustedAccessRoleBindingData> Value { get; }
-        /// <summary>
-        /// Link to next page of resources.
-        /// Serialized Name: TrustedAccessRoleBindingListResult.nextLink
-        /// </summary>
+        /// <summary> Link to next page of resources. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/TrustedAccessRoleListResult.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/TrustedAccessRoleListResult.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// List of trusted access roles
-    /// Serialized Name: TrustedAccessRoleListResult
-    /// </summary>
+    /// <summary> List of trusted access roles. </summary>
     internal partial class TrustedAccessRoleListResult
     {
         /// <summary>
@@ -55,14 +52,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="TrustedAccessRoleListResult"/>. </summary>
-        /// <param name="value">
-        /// Role list
-        /// Serialized Name: TrustedAccessRoleListResult.value
-        /// </param>
-        /// <param name="nextLink">
-        /// Link to next page of resources.
-        /// Serialized Name: TrustedAccessRoleListResult.nextLink
-        /// </param>
+        /// <param name="value"> Role list. </param>
+        /// <param name="nextLink"> Link to next page of resources. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal TrustedAccessRoleListResult(IReadOnlyList<ContainerServiceTrustedAccessRole> value, string nextLink, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -71,15 +62,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Role list
-        /// Serialized Name: TrustedAccessRoleListResult.value
-        /// </summary>
+        /// <summary> Role list. </summary>
         public IReadOnlyList<ContainerServiceTrustedAccessRole> Value { get; }
-        /// <summary>
-        /// Link to next page of resources.
-        /// Serialized Name: TrustedAccessRoleListResult.nextLink
-        /// </summary>
+        /// <summary> Link to next page of resources. </summary>
         public string NextLink { get; }
     }
 }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/UndrainableNodeBehavior.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/UndrainableNodeBehavior.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes.
-    /// Serialized Name: UndrainableNodeBehavior
-    /// </summary>
+    /// <summary> Defines the behavior for undrainable nodes during upgrade. The most common cause of undrainable nodes is Pod Disruption Budgets (PDBs), but other issues, such as pod termination grace period is exceeding the remaining per-node drain timeout or pod is still being in a running state, can also cause undrainable nodes. </summary>
     public readonly partial struct UndrainableNodeBehavior : IEquatable<UndrainableNodeBehavior>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string CordonValue = "Cordon";
         private const string ScheduleValue = "Schedule";
 
-        /// <summary>
-        /// AKS will cordon the blocked nodes and replace them with surge nodes during upgrade. The blocked nodes will be cordoned and replaced by surge nodes. The blocked nodes will have label 'kubernetes.azure.com/upgrade-status:Quarantined'. A surge node will be retained for each blocked node. A best-effort attempt will be made to delete all other surge nodes. If there are enough surge nodes to replace blocked nodes, then the upgrade operation and the managed cluster will be in failed state. Otherwise, the upgrade operation and the managed cluster will be in canceled state.
-        /// Serialized Name: UndrainableNodeBehavior.Cordon
-        /// </summary>
+        /// <summary> AKS will cordon the blocked nodes and replace them with surge nodes during upgrade. The blocked nodes will be cordoned and replaced by surge nodes. The blocked nodes will have label 'kubernetes.azure.com/upgrade-status:Quarantined'. A surge node will be retained for each blocked node. A best-effort attempt will be made to delete all other surge nodes. If there are enough surge nodes to replace blocked nodes, then the upgrade operation and the managed cluster will be in failed state. Otherwise, the upgrade operation and the managed cluster will be in canceled state. </summary>
         public static UndrainableNodeBehavior Cordon { get; } = new UndrainableNodeBehavior(CordonValue);
-        /// <summary>
-        /// AKS will mark the blocked nodes schedulable, but the blocked nodes are not upgraded. A best-effort attempt will be made to delete all surge nodes. The upgrade operation and the managed cluster will be in failed state if there are any blocked nodes.
-        /// Serialized Name: UndrainableNodeBehavior.Schedule
-        /// </summary>
+        /// <summary> AKS will mark the blocked nodes schedulable, but the blocked nodes are not upgraded. A best-effort attempt will be made to delete all surge nodes. The upgrade operation and the managed cluster will be in failed state if there are any blocked nodes. </summary>
         public static UndrainableNodeBehavior Schedule { get; } = new UndrainableNodeBehavior(ScheduleValue);
         /// <summary> Determines if two <see cref="UndrainableNodeBehavior"/> values are the same. </summary>
         public static bool operator ==(UndrainableNodeBehavior left, UndrainableNodeBehavior right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/UpgradeChannel.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/UpgradeChannel.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The upgrade channel for auto upgrade. The default is 'none'. For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel).
-    /// Serialized Name: UpgradeChannel
-    /// </summary>
+    /// <summary> The upgrade channel for auto upgrade. The default is 'none'. For more information see [setting the AKS cluster auto-upgrade channel](https://docs.microsoft.com/azure/aks/upgrade-cluster#set-auto-upgrade-channel). </summary>
     public readonly partial struct UpgradeChannel : IEquatable<UpgradeChannel>
     {
         private readonly string _value;
@@ -31,30 +28,15 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string NodeImageValue = "node-image";
         private const string NoneValue = "none";
 
-        /// <summary>
-        /// Automatically upgrade the cluster to the latest supported patch release on the latest supported minor version. In cases where the cluster is at a version of Kubernetes that is at an N-2 minor version where N is the latest supported minor version, the cluster first upgrades to the latest supported patch version on N-1 minor version. For example, if a cluster is running version 1.17.7 and versions 1.17.9, 1.18.4, 1.18.6, and 1.19.1 are available, your cluster first is upgraded to 1.18.6, then is upgraded to 1.19.1.
-        /// Serialized Name: UpgradeChannel.rapid
-        /// </summary>
+        /// <summary> Automatically upgrade the cluster to the latest supported patch release on the latest supported minor version. In cases where the cluster is at a version of Kubernetes that is at an N-2 minor version where N is the latest supported minor version, the cluster first upgrades to the latest supported patch version on N-1 minor version. For example, if a cluster is running version 1.17.7 and versions 1.17.9, 1.18.4, 1.18.6, and 1.19.1 are available, your cluster first is upgraded to 1.18.6, then is upgraded to 1.19.1. </summary>
         public static UpgradeChannel Rapid { get; } = new UpgradeChannel(RapidValue);
-        /// <summary>
-        /// Automatically upgrade the cluster to the latest supported patch release on minor version N-1, where N is the latest supported minor version. For example, if a cluster is running version 1.17.7 and versions 1.17.9, 1.18.4, 1.18.6, and 1.19.1 are available, your cluster is upgraded to 1.18.6.
-        /// Serialized Name: UpgradeChannel.stable
-        /// </summary>
+        /// <summary> Automatically upgrade the cluster to the latest supported patch release on minor version N-1, where N is the latest supported minor version. For example, if a cluster is running version 1.17.7 and versions 1.17.9, 1.18.4, 1.18.6, and 1.19.1 are available, your cluster is upgraded to 1.18.6. </summary>
         public static UpgradeChannel Stable { get; } = new UpgradeChannel(StableValue);
-        /// <summary>
-        /// Automatically upgrade the cluster to the latest supported patch version when it becomes available while keeping the minor version the same. For example, if a cluster is running version 1.17.7 and versions 1.17.9, 1.18.4, 1.18.6, and 1.19.1 are available, your cluster is upgraded to 1.17.9.
-        /// Serialized Name: UpgradeChannel.patch
-        /// </summary>
+        /// <summary> Automatically upgrade the cluster to the latest supported patch version when it becomes available while keeping the minor version the same. For example, if a cluster is running version 1.17.7 and versions 1.17.9, 1.18.4, 1.18.6, and 1.19.1 are available, your cluster is upgraded to 1.17.9. </summary>
         public static UpgradeChannel Patch { get; } = new UpgradeChannel(PatchValue);
-        /// <summary>
-        /// Automatically upgrade the node image to the latest version available. Consider using nodeOSUpgradeChannel instead as that allows you to configure node OS patching separate from Kubernetes version patching
-        /// Serialized Name: UpgradeChannel.node-image
-        /// </summary>
+        /// <summary> Automatically upgrade the node image to the latest version available. Consider using nodeOSUpgradeChannel instead as that allows you to configure node OS patching separate from Kubernetes version patching. </summary>
         public static UpgradeChannel NodeImage { get; } = new UpgradeChannel(NodeImageValue);
-        /// <summary>
-        /// Disables auto-upgrades and keeps the cluster at its current version of Kubernetes.
-        /// Serialized Name: UpgradeChannel.none
-        /// </summary>
+        /// <summary> Disables auto-upgrades and keeps the cluster at its current version of Kubernetes. </summary>
         public static UpgradeChannel None { get; } = new UpgradeChannel(NoneValue);
         /// <summary> Determines if two <see cref="UpgradeChannel"/> values are the same. </summary>
         public static bool operator ==(UpgradeChannel left, UpgradeChannel right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/UpgradeOverrideSettings.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/UpgradeOverrideSettings.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Settings for overrides when upgrading a cluster.
-    /// Serialized Name: UpgradeOverrideSettings
-    /// </summary>
+    /// <summary> Settings for overrides when upgrading a cluster. </summary>
     public partial class UpgradeOverrideSettings
     {
         /// <summary>
@@ -54,14 +51,8 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="UpgradeOverrideSettings"/>. </summary>
-        /// <param name="forceUpgrade">
-        /// Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution.
-        /// Serialized Name: UpgradeOverrideSettings.forceUpgrade
-        /// </param>
-        /// <param name="until">
-        /// Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect.
-        /// Serialized Name: UpgradeOverrideSettings.until
-        /// </param>
+        /// <param name="forceUpgrade"> Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution. </param>
+        /// <param name="until"> Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal UpgradeOverrideSettings(bool? forceUpgrade, DateTimeOffset? until, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -70,16 +61,10 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution.
-        /// Serialized Name: UpgradeOverrideSettings.forceUpgrade
-        /// </summary>
+        /// <summary> Whether to force upgrade the cluster. Note that this option instructs upgrade operation to bypass upgrade protections such as checking for deprecated API usage. Enable this option only with caution. </summary>
         [WirePath("forceUpgrade")]
         public bool? ForceUpgrade { get; set; }
-        /// <summary>
-        /// Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect.
-        /// Serialized Name: UpgradeOverrideSettings.until
-        /// </summary>
+        /// <summary> Until when the overrides are effective. Note that this only matches the start time of an upgrade, and the effectiveness won't change once an upgrade starts even if the `until` expires as upgrade proceeds. This field is not set by default. It must be set for the overrides to take effect. </summary>
         [WirePath("until")]
         public DateTimeOffset? Until { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/VirtualMachinesProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/VirtualMachinesProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Specifications on VirtualMachines agent pool.
-    /// Serialized Name: VirtualMachinesProfile
-    /// </summary>
+    /// <summary> Specifications on VirtualMachines agent pool. </summary>
     internal partial class VirtualMachinesProfile
     {
         /// <summary>
@@ -54,10 +51,7 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="VirtualMachinesProfile"/>. </summary>
-        /// <param name="scale">
-        /// Specifications on how to scale a VirtualMachines agent pool.
-        /// Serialized Name: VirtualMachinesProfile.scale
-        /// </param>
+        /// <param name="scale"> Specifications on how to scale a VirtualMachines agent pool. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal VirtualMachinesProfile(ScaleProfile scale, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -65,15 +59,9 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Specifications on how to scale a VirtualMachines agent pool.
-        /// Serialized Name: VirtualMachinesProfile.scale
-        /// </summary>
+        /// <summary> Specifications on how to scale a VirtualMachines agent pool. </summary>
         internal ScaleProfile Scale { get; set; }
-        /// <summary>
-        /// Specifications on how to scale the VirtualMachines agent pool to a fixed size.
-        /// Serialized Name: ScaleProfile.manual
-        /// </summary>
+        /// <summary> Specifications on how to scale the VirtualMachines agent pool to a fixed size. </summary>
         [WirePath("scale.manual")]
         public IList<ManualScaleProfile> ScaleManual
         {

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/WindowsGmsaProfile.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/WindowsGmsaProfile.cs
@@ -10,10 +10,7 @@ using System.Collections.Generic;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Windows gMSA Profile in the managed cluster.
-    /// Serialized Name: WindowsGmsaProfile
-    /// </summary>
+    /// <summary> Windows gMSA Profile in the managed cluster. </summary>
     public partial class WindowsGmsaProfile
     {
         /// <summary>
@@ -54,18 +51,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         }
 
         /// <summary> Initializes a new instance of <see cref="WindowsGmsaProfile"/>. </summary>
-        /// <param name="isEnabled">
-        /// Whether to enable Windows gMSA. Specifies whether to enable Windows gMSA in the managed cluster.
-        /// Serialized Name: WindowsGmsaProfile.enabled
-        /// </param>
-        /// <param name="dnsServer">
-        /// Specifies the DNS server for Windows gMSA. &lt;br&gt;&lt;br&gt; Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster.
-        /// Serialized Name: WindowsGmsaProfile.dnsServer
-        /// </param>
-        /// <param name="rootDomainName">
-        /// Specifies the root domain name for Windows gMSA. &lt;br&gt;&lt;br&gt; Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster.
-        /// Serialized Name: WindowsGmsaProfile.rootDomainName
-        /// </param>
+        /// <param name="isEnabled"> Whether to enable Windows gMSA. Specifies whether to enable Windows gMSA in the managed cluster. </param>
+        /// <param name="dnsServer"> Specifies the DNS server for Windows gMSA. &lt;br&gt;&lt;br&gt; Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. </param>
+        /// <param name="rootDomainName"> Specifies the root domain name for Windows gMSA. &lt;br&gt;&lt;br&gt; Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. </param>
         /// <param name="serializedAdditionalRawData"> Keeps track of any properties unknown to the library. </param>
         internal WindowsGmsaProfile(bool? isEnabled, string dnsServer, string rootDomainName, IDictionary<string, BinaryData> serializedAdditionalRawData)
         {
@@ -75,22 +63,13 @@ namespace Azure.ResourceManager.ContainerService.Models
             _serializedAdditionalRawData = serializedAdditionalRawData;
         }
 
-        /// <summary>
-        /// Whether to enable Windows gMSA. Specifies whether to enable Windows gMSA in the managed cluster.
-        /// Serialized Name: WindowsGmsaProfile.enabled
-        /// </summary>
+        /// <summary> Whether to enable Windows gMSA. Specifies whether to enable Windows gMSA in the managed cluster. </summary>
         [WirePath("enabled")]
         public bool? IsEnabled { get; set; }
-        /// <summary>
-        /// Specifies the DNS server for Windows gMSA. &lt;br&gt;&lt;br&gt; Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster.
-        /// Serialized Name: WindowsGmsaProfile.dnsServer
-        /// </summary>
+        /// <summary> Specifies the DNS server for Windows gMSA. &lt;br&gt;&lt;br&gt; Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. </summary>
         [WirePath("dnsServer")]
         public string DnsServer { get; set; }
-        /// <summary>
-        /// Specifies the root domain name for Windows gMSA. &lt;br&gt;&lt;br&gt; Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster.
-        /// Serialized Name: WindowsGmsaProfile.rootDomainName
-        /// </summary>
+        /// <summary> Specifies the root domain name for Windows gMSA. &lt;br&gt;&lt;br&gt; Set it to empty if you have configured the DNS server in the vnet which is used to create the managed cluster. </summary>
         [WirePath("rootDomainName")]
         public string RootDomainName { get; set; }
     }

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/WindowsVmLicenseType.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/WindowsVmLicenseType.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details.
-    /// Serialized Name: LicenseType
-    /// </summary>
+    /// <summary> The license type to use for Windows VMs. See [Azure Hybrid User Benefits](https://azure.microsoft.com/pricing/hybrid-benefit/faq/) for more details. </summary>
     public readonly partial struct WindowsVmLicenseType : IEquatable<WindowsVmLicenseType>
     {
         private readonly string _value;
@@ -28,15 +25,9 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string NoneValue = "None";
         private const string WindowsServerValue = "Windows_Server";
 
-        /// <summary>
-        /// No additional licensing is applied.
-        /// Serialized Name: LicenseType.None
-        /// </summary>
+        /// <summary> No additional licensing is applied. </summary>
         public static WindowsVmLicenseType None { get; } = new WindowsVmLicenseType(NoneValue);
-        /// <summary>
-        /// Enables Azure Hybrid User Benefits for Windows VMs.
-        /// Serialized Name: LicenseType.Windows_Server
-        /// </summary>
+        /// <summary> Enables Azure Hybrid User Benefits for Windows VMs. </summary>
         public static WindowsVmLicenseType WindowsServer { get; } = new WindowsVmLicenseType(WindowsServerValue);
         /// <summary> Determines if two <see cref="WindowsVmLicenseType"/> values are the same. </summary>
         public static bool operator ==(WindowsVmLicenseType left, WindowsVmLicenseType right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/WorkloadRuntime.cs
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/Generated/Models/WorkloadRuntime.cs
@@ -10,10 +10,7 @@ using System.ComponentModel;
 
 namespace Azure.ResourceManager.ContainerService.Models
 {
-    /// <summary>
-    /// Determines the type of workload a node can run.
-    /// Serialized Name: WorkloadRuntime
-    /// </summary>
+    /// <summary> Determines the type of workload a node can run. </summary>
     public readonly partial struct WorkloadRuntime : IEquatable<WorkloadRuntime>
     {
         private readonly string _value;
@@ -29,20 +26,11 @@ namespace Azure.ResourceManager.ContainerService.Models
         private const string WasmWasiValue = "WasmWasi";
         private const string KataVmIsolationValue = "KataVmIsolation";
 
-        /// <summary>
-        /// Nodes will use Kubelet to run standard OCI container workloads.
-        /// Serialized Name: WorkloadRuntime.OCIContainer
-        /// </summary>
+        /// <summary> Nodes will use Kubelet to run standard OCI container workloads. </summary>
         public static WorkloadRuntime OciContainer { get; } = new WorkloadRuntime(OciContainerValue);
-        /// <summary>
-        /// Nodes will use Krustlet to run WASM workloads using the WASI provider (Preview).
-        /// Serialized Name: WorkloadRuntime.WasmWasi
-        /// </summary>
+        /// <summary> Nodes will use Krustlet to run WASM workloads using the WASI provider (Preview). </summary>
         public static WorkloadRuntime WasmWasi { get; } = new WorkloadRuntime(WasmWasiValue);
-        /// <summary>
-        /// Nodes can use (Kata + Cloud Hypervisor + Hyper-V) to enable Nested VM-based pods. Due to the use Hyper-V, AKS node OS itself is a nested VM (the root OS) of Hyper-V. Thus it can only be used with VM series that support Nested Virtualization such as Dv3 series.
-        /// Serialized Name: WorkloadRuntime.KataVmIsolation
-        /// </summary>
+        /// <summary> Nodes can use (Kata + Cloud Hypervisor + Hyper-V) to enable Nested VM-based pods. Due to the use Hyper-V, AKS node OS itself is a nested VM (the root OS) of Hyper-V. Thus it can only be used with VM series that support Nested Virtualization such as Dv3 series. </summary>
         public static WorkloadRuntime KataVmIsolation { get; } = new WorkloadRuntime(KataVmIsolationValue);
         /// <summary> Determines if two <see cref="WorkloadRuntime"/> values are the same. </summary>
         public static bool operator ==(WorkloadRuntime left, WorkloadRuntime right) => left.Equals(right);

--- a/sdk/containerservice/Azure.ResourceManager.ContainerService/src/autorest.md
+++ b/sdk/containerservice/Azure.ResourceManager.ContainerService/src/autorest.md
@@ -21,9 +21,6 @@ modelerfour:
 use-model-reader-writer: true
 enable-bicep-serialization: true
 
-mgmt-debug:
-  show-serialized-names: true
-
 rename-mapping:
   ManagedClusterPodIdentityProvisioningError.error: 'ErrorDetail'
   Code: ContainerServiceStateCode


### PR DESCRIPTION
## Summary

Remove the `mgmt-debug: show-serialized-names` flag that was accidentally left in the released `Azure.ResourceManager.ContainerService` 1.3.0 library. This flag adds unnecessary `Serialized Name:` comments to all generated XML doc comments which should not be present in released packages.

## Changes

- Removed `mgmt-debug` section from `autorest.md`
- Regenerated all code (222 files changed, ~2067 serialized name comments removed)
- Updated version to `1.3.1` with release date `2026-02-28`
- Build succeeds with 0 warnings, 0 errors