### PR TITLE
Enable NuGet package publishing for mgmt generator pipeline

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/ci.yml
+++ b/eng/packages/http-client-csharp-mgmt/ci.yml
@@ -35,6 +35,10 @@ parameters:
     displayName: "Regenerate clients"
     type: boolean
     default: false
+  - name: PublishNugetPackages
+    displayName: "Publish NuGet package artifacts"
+    type: boolean
+    default: false
 
 variables:
   - template: /eng/pipelines/templates/variables/image.yml
@@ -57,6 +61,7 @@ extends:
       ${{ if eq(variables['Build.Reason'], 'Manual') }}:
         ShouldPublish: ${{ parameters.ShouldPublish }}
         ShouldRegenerate: ${{ parameters.ShouldRegenerate }}
+        HasNugetPackages: ${{ parameters.PublishNugetPackages }}
         ${{ if startswith(variables['Build.SourceBranch'], 'refs/pull/') }}:  # PR ref's can't be published to public, even in a manual run
           PublishPublic: false
           PublishDependsOnTest: false
@@ -68,6 +73,7 @@ extends:
         ShouldRegenerate: true
         PublishDependsOnTest: false
         PublishPublic: ${{ and(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}
+        HasNugetPackages: true
       RegenerationJobCount: 5
       MinimumPerJob: 10
       OnlyGenerateTypespec: true


### PR DESCRIPTION
## Summary

Add NuGet package publishing support to the `http-client-csharp-mgmt` CI pipeline, matching the pattern used by the base `http-client-csharp` pipeline.

## Changes

- Added `PublishNugetPackages` parameter to allow manual triggering of NuGet publishing
- Added `HasNugetPackages` support for both manual and automatic runs:
  - **Manual runs**: controlled by the `PublishNugetPackages` parameter
  - **Automatic runs (CI of main)**: always enabled

This enables the Publish job's 'Publish NuGet Packages to DevOps feed' step to publish `Azure.Generator.Management` NuGet packages to the `azure-sdk-for-net` DevOps feed.