### PR TITLE
Export AzureMgmtEmitterOptions from @azure-typespec/http-client-csharp-mgmt package

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/index.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/index.ts
@@ -3,3 +3,7 @@
 
 export { $lib } from "./lib/lib.js";
 export { $onEmit } from "./emitter.js";
+export {
+  AzureMgmtEmitterOptions,
+  AzureMgmtEmitterOptionsSchema
+} from "./options.js";


### PR DESCRIPTION
## What

Export `AzureMgmtEmitterOptions` and `AzureMgmtEmitterOptionsSchema` from the main entry point of the `@azure-typespec/http-client-csharp-mgmt` npm package.

## Why

Downstream emitters that extend the mgmt emitter (e.g., provisioning) cannot import `AzureMgmtEmitterOptions` because the package's `index.ts` only exports `\` and `\`. This forces downstream packages to import from `@azure-typespec/http-client-csharp` (the grandparent) instead, losing mgmt-specific options like `enable-wire-path-attribute` and `use-legacy-resource-detection`.

## Changes

- Added `AzureMgmtEmitterOptions` and `AzureMgmtEmitterOptionsSchema` exports to `emitter/src/index.ts`

Fixes #56637