### PR TITLE
Add provisioning generator and mgmt peer library columns to library inventory

### DIFF
--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -396,7 +396,7 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 
 | Service | Library | Mgmt Dependency | Generator |
 | ------- | ------- | --------------- | --------- |
-| provisioning | Azure.Provisioning | Azure.ResourceManager, Azure.ResourceManager.Resources, Azure.ResourceManager.Authorization, Azure.ResourceManager.ManagedServiceIdentities | Reflection |
+| provisioning | Azure.Provisioning | Azure.ResourceManager<br>Azure.ResourceManager.Resources<br>Azure.ResourceManager.Authorization<br>Azure.ResourceManager.ManagedServiceIdentities | Reflection |
 | provisioning | Azure.Provisioning.AppConfiguration | Azure.ResourceManager.AppConfiguration ✅ | Reflection |
 | provisioning | Azure.Provisioning.AppContainers | Azure.ResourceManager.AppContainers | Reflection |
 | provisioning | Azure.Provisioning.ApplicationInsights | Azure.ResourceManager.ApplicationInsights | Reflection |
@@ -406,7 +406,7 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 | provisioning | Azure.Provisioning.ContainerRegistry | Azure.ResourceManager.ContainerRegistry | Reflection |
 | provisioning | Azure.Provisioning.ContainerService | Azure.ResourceManager.ContainerService | Reflection |
 | provisioning | Azure.Provisioning.CosmosDB | Azure.ResourceManager.CosmosDB | Reflection |
-| provisioning | Azure.Provisioning.Deployment | Azure.ResourceManager, Azure.ResourceManager.Resources | Reflection |
+| provisioning | Azure.Provisioning.Deployment | Azure.ResourceManager<br>Azure.ResourceManager.Resources | Reflection |
 | provisioning | Azure.Provisioning.Dns | Azure.ResourceManager.Dns | Reflection |
 | provisioning | Azure.Provisioning.EventGrid | Azure.ResourceManager.EventGrid | Reflection |
 | provisioning | Azure.Provisioning.EventHubs | Azure.ResourceManager.EventHubs | Reflection |

--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -15,15 +15,16 @@
 
 - Total libraries: 404
 - Management Plane (MPG): 229
-  - Autorest/Swagger: 136
-  - New Emitter (TypeSpec): 93
+  - Autorest/Swagger: 133
+  - New Emitter (TypeSpec): 96
   - Old TypeSpec: 0
 - Data Plane (DPG): 144
   - Autorest/Swagger: 55
   - New Emitter (TypeSpec): 35
   - Old TypeSpec: 5
 - Provisioning: 31
-  - Custom reflection-based generator: 31
+  - Reflection-based generator: 31
+  - TypeSpec-based generator: 0
 - No generator: 49
 
 
@@ -38,7 +39,6 @@ Libraries that provide client APIs for Azure services and have been migrated to 
 | ai | Azure.AI.Agents.Persistent |  |  |
 | ai | Azure.AI.Projects | ✅ | ✅ |
 | ai | Azure.AI.Projects.OpenAI | ✅ | ✅ |
-| ai | Azure.AI.VoiceLive | ✅ |  |
 | anomalydetector | Azure.AI.AnomalyDetector | ✅ |  |
 | appconfiguration | Azure.Data.AppConfiguration | ✅ |  |
 | batch | Azure.Compute.Batch | ✅ |  |
@@ -75,6 +75,7 @@ Libraries that provide client APIs for Azure services and have been migrated to 
 | translation | Azure.AI.Translation.Document |  |  |
 | translation | Azure.AI.Translation.Text | ✅ |  |
 | vision | Azure.AI.Vision.ImageAnalysis | ✅ |  |
+| voicelive | Azure.AI.VoiceLive | ✅ |  |
 
 
 ## Data Plane Libraries (DPG) - Still on Swagger
@@ -144,7 +145,7 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 55
 
 Libraries that provide resource management APIs for Azure services and have been migrated to the new TypeSpec emitter.
 
-**Migration Status**: 93 / 93 (100%)
+**Migration Status**: 96 / 96 (100%)
 
 | Service | Library | New Emitter |
 | ------- | ------- | ----------- |
@@ -189,6 +190,7 @@ Libraries that provide resource management APIs for Azure services and have been
 | fileshares | Azure.ResourceManager.FileShares | ✅ |
 | fleet | Azure.ResourceManager.ContainerServiceFleet | ✅ |
 | grafana | Azure.ResourceManager.Grafana | ✅ |
+| guestconfiguration | Azure.ResourceManager.GuestConfiguration | ✅ |
 | hardwaresecuritymodules | Azure.ResourceManager.HardwareSecurityModules | ✅ |
 | healthbot | Azure.ResourceManager.HealthBot | ✅ |
 | healthdataaiservices | Azure.ResourceManager.HealthDataAIServices | ✅ |
@@ -200,6 +202,7 @@ Libraries that provide resource management APIs for Azure services and have been
 | keyvault | Azure.ResourceManager.KeyVault | ✅ |
 | lambdatesthyperexecute | Azure.ResourceManager.LambdaTestHyperExecute | ✅ |
 | loadtestservice | Azure.ResourceManager.LoadTesting | ✅ |
+| managedops | Azure.ResourceManager.ManagedOps | ✅ |
 | mongocluster | Azure.ResourceManager.MongoCluster | ✅ |
 | mongodbatlas | Azure.ResourceManager.MongoDBAtlas | ✅ |
 | mysql | Azure.ResourceManager.MySql | ✅ |
@@ -229,6 +232,7 @@ Libraries that provide resource management APIs for Azure services and have been
 | servicenetworking | Azure.ResourceManager.ServiceNetworking | ✅ |
 | signalr | Azure.ResourceManager.SignalR | ✅ |
 | sitemanager | Azure.ResourceManager.SiteManager | ✅ |
+| sphere | Azure.ResourceManager.Sphere | ✅ |
 | sqlvirtualmachine | Azure.ResourceManager.SqlVirtualMachine | ✅ |
 | standbypool | Azure.ResourceManager.StandbyPool | ✅ |
 | storageactions | Azure.ResourceManager.StorageActions | ✅ |
@@ -245,7 +249,7 @@ Libraries that provide resource management APIs for Azure services and have been
 
 ## Management Plane Libraries (MPG) - Still on Swagger
 
-Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 136
+Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 133
 
 | Service | Library |
 | ------- | ------- |
@@ -278,7 +282,6 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 13
 | containerapps | Azure.ResourceManager.AppContainers |
 | containerinstance | Azure.ResourceManager.ContainerInstance |
 | containerregistry | Azure.ResourceManager.ContainerRegistry |
-| containerregistry-tasks | Azure.ResourceManager.ContainerRegistry.Tasks |
 | containerservice | Azure.ResourceManager.ContainerService |
 | cosmosdb | Azure.ResourceManager.CosmosDB |
 | cosmosdbforpostgresql | Azure.ResourceManager.CosmosDBForPostgreSql |
@@ -306,7 +309,6 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 13
 | fluidrelay | Azure.ResourceManager.FluidRelay |
 | frontdoor | Azure.ResourceManager.FrontDoor |
 | graphservices | Azure.ResourceManager.GraphServices |
-| guestconfiguration | Azure.ResourceManager.GuestConfiguration |
 | hdinsight | Azure.ResourceManager.HDInsight |
 | healthcareapis | Azure.ResourceManager.HealthcareApis |
 | hybridaks | Azure.ResourceManager.HybridContainerService |
@@ -369,7 +371,6 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 13
 | servicefabric | Azure.ResourceManager.ServiceFabric |
 | servicegroups | Azure.ResourceManager.ServiceGroups |
 | servicelinker | Azure.ResourceManager.ServiceLinker |
-| sphere | Azure.ResourceManager.Sphere |
 | springappdiscovery | Azure.ResourceManager.SpringAppDiscovery |
 | sqlmanagement | Azure.ResourceManager.Sql |
 | storage | Azure.ResourceManager.Storage |
@@ -389,45 +390,43 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 13
 
 ## Provisioning Libraries
 
-Libraries that provide infrastructure-as-code capabilities for Azure services using a custom reflection-based generator. These libraries allow you to declaratively specify Azure infrastructure natively in .NET and generate Bicep templates for deployment.
+Libraries that provide infrastructure-as-code capabilities for Azure services. These libraries allow you to declaratively specify Azure infrastructure natively in .NET and generate Bicep templates for deployment.
 
-**Note**: Unlike other Azure SDK libraries, Provisioning libraries use a custom reflection-based generator that analyzes Azure Resource Manager SDK types to produce strongly-typed infrastructure definition APIs.
+**Migration Status**: 0 / 31 migrated to TypeSpec-based generator
 
-Total: 31
-
-| Service | Library |
-| ------- | ------- |
-| provisioning | Azure.Provisioning |
-| provisioning | Azure.Provisioning.AppConfiguration |
-| provisioning | Azure.Provisioning.AppContainers |
-| provisioning | Azure.Provisioning.ApplicationInsights |
-| provisioning | Azure.Provisioning.AppService |
-| provisioning | Azure.Provisioning.CognitiveServices |
-| provisioning | Azure.Provisioning.Communication |
-| provisioning | Azure.Provisioning.ContainerRegistry |
-| provisioning | Azure.Provisioning.ContainerService |
-| provisioning | Azure.Provisioning.CosmosDB |
-| provisioning | Azure.Provisioning.Deployment |
-| provisioning | Azure.Provisioning.Dns |
-| provisioning | Azure.Provisioning.EventGrid |
-| provisioning | Azure.Provisioning.EventHubs |
-| provisioning | Azure.Provisioning.FrontDoor |
-| provisioning | Azure.Provisioning.KeyVault |
-| provisioning | Azure.Provisioning.Kubernetes |
-| provisioning | Azure.Provisioning.KubernetesConfiguration |
-| provisioning | Azure.Provisioning.Kusto |
-| provisioning | Azure.Provisioning.Network |
-| provisioning | Azure.Provisioning.OperationalInsights |
-| provisioning | Azure.Provisioning.PostgreSql |
-| provisioning | Azure.Provisioning.PrivateDns |
-| provisioning | Azure.Provisioning.Redis |
-| provisioning | Azure.Provisioning.RedisEnterprise |
-| provisioning | Azure.Provisioning.Search |
-| provisioning | Azure.Provisioning.ServiceBus |
-| provisioning | Azure.Provisioning.SignalR |
-| provisioning | Azure.Provisioning.Sql |
-| provisioning | Azure.Provisioning.Storage |
-| provisioning | Azure.Provisioning.WebPubSub |
+| Service | Library | Generator |
+| ------- | ------- | --------- |
+| provisioning | Azure.Provisioning | Reflection |
+| provisioning | Azure.Provisioning.AppConfiguration | Reflection |
+| provisioning | Azure.Provisioning.AppContainers | Reflection |
+| provisioning | Azure.Provisioning.ApplicationInsights | Reflection |
+| provisioning | Azure.Provisioning.AppService | Reflection |
+| provisioning | Azure.Provisioning.CognitiveServices | Reflection |
+| provisioning | Azure.Provisioning.Communication | Reflection |
+| provisioning | Azure.Provisioning.ContainerRegistry | Reflection |
+| provisioning | Azure.Provisioning.ContainerService | Reflection |
+| provisioning | Azure.Provisioning.CosmosDB | Reflection |
+| provisioning | Azure.Provisioning.Deployment | Reflection |
+| provisioning | Azure.Provisioning.Dns | Reflection |
+| provisioning | Azure.Provisioning.EventGrid | Reflection |
+| provisioning | Azure.Provisioning.EventHubs | Reflection |
+| provisioning | Azure.Provisioning.FrontDoor | Reflection |
+| provisioning | Azure.Provisioning.KeyVault | Reflection |
+| provisioning | Azure.Provisioning.Kubernetes | Reflection |
+| provisioning | Azure.Provisioning.KubernetesConfiguration | Reflection |
+| provisioning | Azure.Provisioning.Kusto | Reflection |
+| provisioning | Azure.Provisioning.Network | Reflection |
+| provisioning | Azure.Provisioning.OperationalInsights | Reflection |
+| provisioning | Azure.Provisioning.PostgreSql | Reflection |
+| provisioning | Azure.Provisioning.PrivateDns | Reflection |
+| provisioning | Azure.Provisioning.Redis | Reflection |
+| provisioning | Azure.Provisioning.RedisEnterprise | Reflection |
+| provisioning | Azure.Provisioning.Search | Reflection |
+| provisioning | Azure.Provisioning.ServiceBus | Reflection |
+| provisioning | Azure.Provisioning.SignalR | Reflection |
+| provisioning | Azure.Provisioning.Sql | Reflection |
+| provisioning | Azure.Provisioning.Storage | Reflection |
+| provisioning | Azure.Provisioning.WebPubSub | Reflection |
 
 
 ## Libraries with No Generator

--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -13,9 +13,9 @@
 
 ## Summary
 
-- Total libraries: 404
-- Management Plane (MPG): 229
-  - Autorest/Swagger: 133
+- Total libraries: 405
+- Management Plane (MPG): 230
+  - Autorest/Swagger: 134
   - New Emitter (TypeSpec): 96
   - Old TypeSpec: 0
 - Data Plane (DPG): 144
@@ -249,7 +249,7 @@ Libraries that provide resource management APIs for Azure services and have been
 
 ## Management Plane Libraries (MPG) - Still on Swagger
 
-Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 133
+Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 134
 
 | Service | Library |
 | ------- | ------- |
@@ -282,6 +282,7 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 13
 | containerapps | Azure.ResourceManager.AppContainers |
 | containerinstance | Azure.ResourceManager.ContainerInstance |
 | containerregistry | Azure.ResourceManager.ContainerRegistry |
+| containerregistry-tasks | Azure.ResourceManager.ContainerRegistry.Tasks |
 | containerservice | Azure.ResourceManager.ContainerService |
 | cosmosdb | Azure.ResourceManager.CosmosDB |
 | cosmosdbforpostgresql | Azure.ResourceManager.CosmosDBForPostgreSql |

--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -394,39 +394,39 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 
 **Migration Status**: 0 / 31 migrated to TypeSpec-based generator
 
-| Service | Library | Generator |
-| ------- | ------- | --------- |
-| provisioning | Azure.Provisioning | Reflection |
-| provisioning | Azure.Provisioning.AppConfiguration | Reflection |
-| provisioning | Azure.Provisioning.AppContainers | Reflection |
-| provisioning | Azure.Provisioning.ApplicationInsights | Reflection |
-| provisioning | Azure.Provisioning.AppService | Reflection |
-| provisioning | Azure.Provisioning.CognitiveServices | Reflection |
-| provisioning | Azure.Provisioning.Communication | Reflection |
-| provisioning | Azure.Provisioning.ContainerRegistry | Reflection |
-| provisioning | Azure.Provisioning.ContainerService | Reflection |
-| provisioning | Azure.Provisioning.CosmosDB | Reflection |
-| provisioning | Azure.Provisioning.Deployment | Reflection |
-| provisioning | Azure.Provisioning.Dns | Reflection |
-| provisioning | Azure.Provisioning.EventGrid | Reflection |
-| provisioning | Azure.Provisioning.EventHubs | Reflection |
-| provisioning | Azure.Provisioning.FrontDoor | Reflection |
-| provisioning | Azure.Provisioning.KeyVault | Reflection |
-| provisioning | Azure.Provisioning.Kubernetes | Reflection |
-| provisioning | Azure.Provisioning.KubernetesConfiguration | Reflection |
-| provisioning | Azure.Provisioning.Kusto | Reflection |
-| provisioning | Azure.Provisioning.Network | Reflection |
-| provisioning | Azure.Provisioning.OperationalInsights | Reflection |
-| provisioning | Azure.Provisioning.PostgreSql | Reflection |
-| provisioning | Azure.Provisioning.PrivateDns | Reflection |
-| provisioning | Azure.Provisioning.Redis | Reflection |
-| provisioning | Azure.Provisioning.RedisEnterprise | Reflection |
-| provisioning | Azure.Provisioning.Search | Reflection |
-| provisioning | Azure.Provisioning.ServiceBus | Reflection |
-| provisioning | Azure.Provisioning.SignalR | Reflection |
-| provisioning | Azure.Provisioning.Sql | Reflection |
-| provisioning | Azure.Provisioning.Storage | Reflection |
-| provisioning | Azure.Provisioning.WebPubSub | Reflection |
+| Service | Library | Mgmt Dependency | Generator |
+| ------- | ------- | --------------- | --------- |
+| provisioning | Azure.Provisioning | Azure.ResourceManager, Resources, Authorization, ManagedServiceIdentities | Reflection |
+| provisioning | Azure.Provisioning.AppConfiguration | Azure.ResourceManager.AppConfiguration | Reflection |
+| provisioning | Azure.Provisioning.AppContainers | Azure.ResourceManager.AppContainers | Reflection |
+| provisioning | Azure.Provisioning.ApplicationInsights | Azure.ResourceManager.ApplicationInsights | Reflection |
+| provisioning | Azure.Provisioning.AppService | Azure.ResourceManager.AppService | Reflection |
+| provisioning | Azure.Provisioning.CognitiveServices | Azure.ResourceManager.CognitiveServices | Reflection |
+| provisioning | Azure.Provisioning.Communication | Azure.ResourceManager.Communication | Reflection |
+| provisioning | Azure.Provisioning.ContainerRegistry | Azure.ResourceManager.ContainerRegistry | Reflection |
+| provisioning | Azure.Provisioning.ContainerService | Azure.ResourceManager.ContainerService | Reflection |
+| provisioning | Azure.Provisioning.CosmosDB | Azure.ResourceManager.CosmosDB | Reflection |
+| provisioning | Azure.Provisioning.Deployment | Azure.ResourceManager, Resources | Reflection |
+| provisioning | Azure.Provisioning.Dns | Azure.ResourceManager.Dns | Reflection |
+| provisioning | Azure.Provisioning.EventGrid | Azure.ResourceManager.EventGrid | Reflection |
+| provisioning | Azure.Provisioning.EventHubs | Azure.ResourceManager.EventHubs | Reflection |
+| provisioning | Azure.Provisioning.FrontDoor | Azure.ResourceManager.FrontDoor | Reflection |
+| provisioning | Azure.Provisioning.KeyVault | Azure.ResourceManager.KeyVault | Reflection |
+| provisioning | Azure.Provisioning.Kubernetes | Azure.ResourceManager.Kubernetes | Reflection |
+| provisioning | Azure.Provisioning.KubernetesConfiguration | Azure.ResourceManager.KubernetesConfiguration | Reflection |
+| provisioning | Azure.Provisioning.Kusto | Azure.ResourceManager.Kusto | Reflection |
+| provisioning | Azure.Provisioning.Network | Azure.ResourceManager.Network | Reflection |
+| provisioning | Azure.Provisioning.OperationalInsights | Azure.ResourceManager.OperationalInsights | Reflection |
+| provisioning | Azure.Provisioning.PostgreSql | Azure.ResourceManager.PostgreSql | Reflection |
+| provisioning | Azure.Provisioning.PrivateDns | Azure.ResourceManager.PrivateDns | Reflection |
+| provisioning | Azure.Provisioning.Redis | Azure.ResourceManager.Redis | Reflection |
+| provisioning | Azure.Provisioning.RedisEnterprise | Azure.ResourceManager.RedisEnterprise | Reflection |
+| provisioning | Azure.Provisioning.Search | Azure.ResourceManager.Search | Reflection |
+| provisioning | Azure.Provisioning.ServiceBus | Azure.ResourceManager.ServiceBus | Reflection |
+| provisioning | Azure.Provisioning.SignalR | Azure.ResourceManager.SignalR | Reflection |
+| provisioning | Azure.Provisioning.Sql | Azure.ResourceManager.Sql | Reflection |
+| provisioning | Azure.Provisioning.Storage | Azure.ResourceManager.Storage | Reflection |
+| provisioning | Azure.Provisioning.WebPubSub | Azure.ResourceManager.WebPubSub | Reflection |
 
 
 ## Libraries with No Generator

--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -396,8 +396,8 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 
 | Service | Library | Mgmt Dependency | Generator |
 | ------- | ------- | --------------- | --------- |
-| provisioning | Azure.Provisioning | Azure.ResourceManager, Resources, Authorization, ManagedServiceIdentities | Reflection |
-| provisioning | Azure.Provisioning.AppConfiguration | Azure.ResourceManager.AppConfiguration | Reflection |
+| provisioning | Azure.Provisioning | Azure.ResourceManager, Azure.ResourceManager.Resources, Azure.ResourceManager.Authorization, Azure.ResourceManager.ManagedServiceIdentities | Reflection |
+| provisioning | Azure.Provisioning.AppConfiguration | Azure.ResourceManager.AppConfiguration ✅ | Reflection |
 | provisioning | Azure.Provisioning.AppContainers | Azure.ResourceManager.AppContainers | Reflection |
 | provisioning | Azure.Provisioning.ApplicationInsights | Azure.ResourceManager.ApplicationInsights | Reflection |
 | provisioning | Azure.Provisioning.AppService | Azure.ResourceManager.AppService | Reflection |
@@ -406,13 +406,13 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 | provisioning | Azure.Provisioning.ContainerRegistry | Azure.ResourceManager.ContainerRegistry | Reflection |
 | provisioning | Azure.Provisioning.ContainerService | Azure.ResourceManager.ContainerService | Reflection |
 | provisioning | Azure.Provisioning.CosmosDB | Azure.ResourceManager.CosmosDB | Reflection |
-| provisioning | Azure.Provisioning.Deployment | Azure.ResourceManager, Resources | Reflection |
+| provisioning | Azure.Provisioning.Deployment | Azure.ResourceManager, Azure.ResourceManager.Resources | Reflection |
 | provisioning | Azure.Provisioning.Dns | Azure.ResourceManager.Dns | Reflection |
 | provisioning | Azure.Provisioning.EventGrid | Azure.ResourceManager.EventGrid | Reflection |
 | provisioning | Azure.Provisioning.EventHubs | Azure.ResourceManager.EventHubs | Reflection |
 | provisioning | Azure.Provisioning.FrontDoor | Azure.ResourceManager.FrontDoor | Reflection |
-| provisioning | Azure.Provisioning.KeyVault | Azure.ResourceManager.KeyVault | Reflection |
-| provisioning | Azure.Provisioning.Kubernetes | Azure.ResourceManager.Kubernetes | Reflection |
+| provisioning | Azure.Provisioning.KeyVault | Azure.ResourceManager.KeyVault ✅ | Reflection |
+| provisioning | Azure.Provisioning.Kubernetes | Azure.ResourceManager.Kubernetes ✅ | Reflection |
 | provisioning | Azure.Provisioning.KubernetesConfiguration | Azure.ResourceManager.KubernetesConfiguration | Reflection |
 | provisioning | Azure.Provisioning.Kusto | Azure.ResourceManager.Kusto | Reflection |
 | provisioning | Azure.Provisioning.Network | Azure.ResourceManager.Network | Reflection |
@@ -423,7 +423,7 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 | provisioning | Azure.Provisioning.RedisEnterprise | Azure.ResourceManager.RedisEnterprise | Reflection |
 | provisioning | Azure.Provisioning.Search | Azure.ResourceManager.Search | Reflection |
 | provisioning | Azure.Provisioning.ServiceBus | Azure.ResourceManager.ServiceBus | Reflection |
-| provisioning | Azure.Provisioning.SignalR | Azure.ResourceManager.SignalR | Reflection |
+| provisioning | Azure.Provisioning.SignalR | Azure.ResourceManager.SignalR ✅ | Reflection |
 | provisioning | Azure.Provisioning.Sql | Azure.ResourceManager.Sql | Reflection |
 | provisioning | Azure.Provisioning.Storage | Azure.ResourceManager.Storage | Reflection |
 | provisioning | Azure.Provisioning.WebPubSub | Azure.ResourceManager.WebPubSub | Reflection |

--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -394,8 +394,8 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 
 **Migration Status**: 0 / 31 migrated to TypeSpec-based generator
 
-| Service | Library | Mgmt Dependency | Generator |
-| ------- | ------- | --------------- | --------- |
+| Service | Library | Mgmt Peer Library | Generator |
+| ------- | ------- | ----------------- | --------- |
 | provisioning | Azure.Provisioning | Azure.ResourceManager<br>Azure.ResourceManager.Resources<br>Azure.ResourceManager.Authorization<br>Azure.ResourceManager.ManagedServiceIdentities | Reflection |
 | provisioning | Azure.Provisioning.AppConfiguration | Azure.ResourceManager.AppConfiguration ✅ | Reflection |
 | provisioning | Azure.Provisioning.AppContainers | Azure.ResourceManager.AppContainers | Reflection |

--- a/doc/GeneratorMigration/Library_Inventory.ps1
+++ b/doc/GeneratorMigration/Library_Inventory.ps1
@@ -37,11 +37,13 @@ function Test-ProvisioningLibrary {
     return ($libraryName -match "^Azure\.Provisioning")
 }
 
-function Get-ProvisioningMgmtDependency {
+function Get-ProvisioningMgmtPeerLibrary {
     param([string]$LibraryName)
 
-    # Map a provisioning library to its underlying mgmt library dependencies.
-    # Returns an array of full Azure.ResourceManager.* names.
+    # Map a provisioning library to its peer mgmt library.
+    # Azure.Provisioning (base) has multiple peer mgmt libraries.
+    # Azure.Provisioning.Deployment peers with Azure.ResourceManager + Resources.
+    # All others follow the pattern: Azure.Provisioning.X -> Azure.ResourceManager.X
 
     switch ($LibraryName) {
         "Azure.Provisioning" {
@@ -201,7 +203,7 @@ function Get-SdkLibraries {
                     type = $libraryType
                     generator = $generator
                     hasTspLocation = $hasTspLocation
-                    mgmtDependency = if (Test-ProvisioningLibrary $libraryDir.FullName) { @(Get-ProvisioningMgmtDependency $libraryDir.Name) } else { @() }
+                    mgmtPeerLibrary = if (Test-ProvisioningLibrary $libraryDir.FullName) { @(Get-ProvisioningMgmtPeerLibrary $libraryDir.Name) } else { @() }
                 }
             }
         }
@@ -349,13 +351,13 @@ function New-MarkdownReport {
         $report += "## Provisioning Libraries`n"
         $report += "Libraries that provide infrastructure-as-code capabilities for Azure services. These libraries allow you to declaratively specify Azure infrastructure natively in .NET and generate Bicep templates for deployment.`n"
         $report += "**Migration Status**: $provTypeSpec / $($provisioningLibraries.Count) migrated to TypeSpec-based generator`n"
-        $report += "| Service | Library | Mgmt Dependency | Generator |"
-        $report += "| ------- | ------- | --------------- | --------- |"
+        $report += "| Service | Library | Mgmt Peer Library | Generator |"
+        $report += "| ------- | ------- | ----------------- | --------- |"
         $sortedProvisioning = $provisioningLibraries | Sort-Object service, library
         foreach ($lib in $sortedProvisioning) {
             $generatorLabel = if ($lib.generator -eq "Provisioning (TypeSpec)") { "TypeSpec ✅" } else { "Reflection" }
             # Format each mgmt dependency with ✅ if it uses the new TypeSpec emitter
-            $depsFormatted = ($lib.mgmtDependency | ForEach-Object {
+            $depsFormatted = ($lib.mgmtPeerLibrary | ForEach-Object {
                 if ($mgmtNewEmitterSet.ContainsKey($_)) { "$_ ✅" } else { $_ }
             }) -join "<br>"
             $report += "| $($lib.service) | $($lib.library) | $depsFormatted | $generatorLabel |"

--- a/doc/GeneratorMigration/Library_Inventory.ps1
+++ b/doc/GeneratorMigration/Library_Inventory.ps1
@@ -40,21 +40,19 @@ function Test-ProvisioningLibrary {
 function Get-ProvisioningMgmtDependency {
     param([string]$LibraryName)
 
-    # Map a provisioning library to its underlying mgmt library dependency.
-    # Azure.Provisioning (base) depends on multiple mgmt libraries.
-    # Azure.Provisioning.Deployment depends on Azure.ResourceManager + Resources.
-    # All others follow the pattern: Azure.Provisioning.X -> Azure.ResourceManager.X
+    # Map a provisioning library to its underlying mgmt library dependencies.
+    # Returns an array of full Azure.ResourceManager.* names.
 
     switch ($LibraryName) {
         "Azure.Provisioning" {
-            return "Azure.ResourceManager, Resources, Authorization, ManagedServiceIdentities"
+            return @("Azure.ResourceManager", "Azure.ResourceManager.Resources", "Azure.ResourceManager.Authorization", "Azure.ResourceManager.ManagedServiceIdentities")
         }
         "Azure.Provisioning.Deployment" {
-            return "Azure.ResourceManager, Resources"
+            return @("Azure.ResourceManager", "Azure.ResourceManager.Resources")
         }
         default {
             $suffix = $LibraryName -replace "^Azure\.Provisioning\.", ""
-            return "Azure.ResourceManager.$suffix"
+            return @("Azure.ResourceManager.$suffix")
         }
     }
 }
@@ -203,7 +201,7 @@ function Get-SdkLibraries {
                     type = $libraryType
                     generator = $generator
                     hasTspLocation = $hasTspLocation
-                    mgmtDependency = if (Test-ProvisioningLibrary $libraryDir.FullName) { Get-ProvisioningMgmtDependency $libraryDir.Name } else { "" }
+                    mgmtDependency = if (Test-ProvisioningLibrary $libraryDir.FullName) { @(Get-ProvisioningMgmtDependency $libraryDir.Name) } else { @() }
                 }
             }
         }
@@ -342,6 +340,12 @@ function New-MarkdownReport {
 
     # Provisioning Libraries
     if ($provisioningLibraries.Count -gt 0) {
+        # Build a lookup of mgmt libraries that use the new TypeSpec emitter
+        $mgmtNewEmitterSet = @{}
+        foreach ($lib in $mgmtNewEmitter) {
+            $mgmtNewEmitterSet[$lib.library] = $true
+        }
+
         $report += "## Provisioning Libraries`n"
         $report += "Libraries that provide infrastructure-as-code capabilities for Azure services. These libraries allow you to declaratively specify Azure infrastructure natively in .NET and generate Bicep templates for deployment.`n"
         $report += "**Migration Status**: $provTypeSpec / $($provisioningLibraries.Count) migrated to TypeSpec-based generator`n"
@@ -350,7 +354,11 @@ function New-MarkdownReport {
         $sortedProvisioning = $provisioningLibraries | Sort-Object service, library
         foreach ($lib in $sortedProvisioning) {
             $generatorLabel = if ($lib.generator -eq "Provisioning (TypeSpec)") { "TypeSpec ✅" } else { "Reflection" }
-            $report += "| $($lib.service) | $($lib.library) | $($lib.mgmtDependency) | $generatorLabel |"
+            # Format each mgmt dependency with ✅ if it uses the new TypeSpec emitter
+            $depsFormatted = ($lib.mgmtDependency | ForEach-Object {
+                if ($mgmtNewEmitterSet.ContainsKey($_)) { "$_ ✅" } else { $_ }
+            }) -join ", "
+            $report += "| $($lib.service) | $($lib.library) | $depsFormatted | $generatorLabel |"
         }
         $report += "`n"
     }

--- a/doc/GeneratorMigration/Library_Inventory.ps1
+++ b/doc/GeneratorMigration/Library_Inventory.ps1
@@ -357,7 +357,7 @@ function New-MarkdownReport {
             # Format each mgmt dependency with ✅ if it uses the new TypeSpec emitter
             $depsFormatted = ($lib.mgmtDependency | ForEach-Object {
                 if ($mgmtNewEmitterSet.ContainsKey($_)) { "$_ ✅" } else { $_ }
-            }) -join ", "
+            }) -join "<br>"
             $report += "| $($lib.service) | $($lib.library) | $depsFormatted | $generatorLabel |"
         }
         $report += "`n"

--- a/doc/GeneratorMigration/Library_Inventory.ps1
+++ b/doc/GeneratorMigration/Library_Inventory.ps1
@@ -18,6 +18,7 @@ Param (
 $EmitterMap = @{
     'eng/azure-typespec-http-client-csharp-emitter-package.json' = '@azure-typespec/http-client-csharp'
     'eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json' = '@azure-typespec/http-client-csharp-mgmt'
+    # NOTE: The provisioning emitter package json does not exist yet; it will be added when the provisioning generator PR merges.
     'eng/azure-typespec-http-client-csharp-provisioning-emitter-package.json' = '@azure-typespec/http-client-csharp-provisioning'
     'eng/http-client-csharp-emitter-package.json' = '@typespec/http-client-csharp'
 }
@@ -63,12 +64,17 @@ function Get-GeneratorType {
     param([string]$Path)
 
     # Identify if a library is generated using swagger or tsp.
-    # Returns: "Swagger", a specific TypeSpec generator name, "TSP-Old", "Provisioning", or "No Generator"
+    # Returns: "Swagger", a specific TypeSpec generator name, "TSP-Old", "Provisioning (Reflection)", "Provisioning (TypeSpec)", or "No Generator"
+
+    # Discover tsp-location.yaml files once upfront to avoid redundant directory traversal
+    $tspLocationFiles = @()
+    if (Test-Path $Path) {
+        $tspLocationFiles = Get-ChildItem -Path $Path -Recurse -Filter "tsp-location*" -ErrorAction SilentlyContinue
+    }
 
     # Special case for Provisioning libraries which use a custom reflection-based generator
     # Check if the library has a tsp-location.yaml with the provisioning emitter first
     if (Test-ProvisioningLibrary $Path) {
-        $tspLocationFiles = Get-ChildItem -Path $Path -Recurse -Filter "tsp-location*" -ErrorAction SilentlyContinue
         foreach ($tspLocationFile in $tspLocationFiles) {
             try {
                 $content = Get-Content $tspLocationFile.FullName -Raw -ErrorAction SilentlyContinue
@@ -96,11 +102,8 @@ function Get-GeneratorType {
     $tspDir = Join-Path $Path "src\tsp"
     $tspFiles = Get-ChildItem -Path (Join-Path $Path "src") -Filter "*.tsp" -ErrorAction SilentlyContinue
 
-    # Check for tsp-location.yaml files
-    $tspLocationPaths = @()
-    if (Test-Path $Path) {
-        $tspLocationPaths = Get-ChildItem -Path $Path -Recurse -Filter "tsp-location*" -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
-    }
+    # Check for tsp-location.yaml files (reuse the list discovered earlier)
+    $tspLocationPaths = $tspLocationFiles | ForEach-Object { $_.FullName }
 
     # If there's a tsp-location.yaml file and it contains emitterPackageJsonPath, extract the generator name
     foreach ($tspLocationPath in $tspLocationPaths) {

--- a/doc/GeneratorMigration/Library_Inventory.ps1
+++ b/doc/GeneratorMigration/Library_Inventory.ps1
@@ -37,6 +37,28 @@ function Test-ProvisioningLibrary {
     return ($libraryName -match "^Azure\.Provisioning")
 }
 
+function Get-ProvisioningMgmtDependency {
+    param([string]$LibraryName)
+
+    # Map a provisioning library to its underlying mgmt library dependency.
+    # Azure.Provisioning (base) depends on multiple mgmt libraries.
+    # Azure.Provisioning.Deployment depends on Azure.ResourceManager + Resources.
+    # All others follow the pattern: Azure.Provisioning.X -> Azure.ResourceManager.X
+
+    switch ($LibraryName) {
+        "Azure.Provisioning" {
+            return "Azure.ResourceManager, Resources, Authorization, ManagedServiceIdentities"
+        }
+        "Azure.Provisioning.Deployment" {
+            return "Azure.ResourceManager, Resources"
+        }
+        default {
+            $suffix = $LibraryName -replace "^Azure\.Provisioning\.", ""
+            return "Azure.ResourceManager.$suffix"
+        }
+    }
+}
+
 function Get-GeneratorType {
     param([string]$Path)
 
@@ -181,6 +203,7 @@ function Get-SdkLibraries {
                     type = $libraryType
                     generator = $generator
                     hasTspLocation = $hasTspLocation
+                    mgmtDependency = if (Test-ProvisioningLibrary $libraryDir.FullName) { Get-ProvisioningMgmtDependency $libraryDir.Name } else { "" }
                 }
             }
         }
@@ -322,12 +345,12 @@ function New-MarkdownReport {
         $report += "## Provisioning Libraries`n"
         $report += "Libraries that provide infrastructure-as-code capabilities for Azure services. These libraries allow you to declaratively specify Azure infrastructure natively in .NET and generate Bicep templates for deployment.`n"
         $report += "**Migration Status**: $provTypeSpec / $($provisioningLibraries.Count) migrated to TypeSpec-based generator`n"
-        $report += "| Service | Library | Generator |"
-        $report += "| ------- | ------- | --------- |"
+        $report += "| Service | Library | Mgmt Dependency | Generator |"
+        $report += "| ------- | ------- | --------------- | --------- |"
         $sortedProvisioning = $provisioningLibraries | Sort-Object service, library
         foreach ($lib in $sortedProvisioning) {
             $generatorLabel = if ($lib.generator -eq "Provisioning (TypeSpec)") { "TypeSpec ✅" } else { "Reflection" }
-            $report += "| $($lib.service) | $($lib.library) | $generatorLabel |"
+            $report += "| $($lib.service) | $($lib.library) | $($lib.mgmtDependency) | $generatorLabel |"
         }
         $report += "`n"
     }

--- a/doc/GeneratorMigration/Library_Inventory.ps1
+++ b/doc/GeneratorMigration/Library_Inventory.ps1
@@ -18,6 +18,7 @@ Param (
 $EmitterMap = @{
     'eng/azure-typespec-http-client-csharp-emitter-package.json' = '@azure-typespec/http-client-csharp'
     'eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json' = '@azure-typespec/http-client-csharp-mgmt'
+    'eng/azure-typespec-http-client-csharp-provisioning-emitter-package.json' = '@azure-typespec/http-client-csharp-provisioning'
     'eng/http-client-csharp-emitter-package.json' = '@typespec/http-client-csharp'
 }
 
@@ -43,8 +44,24 @@ function Get-GeneratorType {
     # Returns: "Swagger", a specific TypeSpec generator name, "TSP-Old", "Provisioning", or "No Generator"
 
     # Special case for Provisioning libraries which use a custom reflection-based generator
+    # Check if the library has a tsp-location.yaml with the provisioning emitter first
     if (Test-ProvisioningLibrary $Path) {
-        return "Provisioning"
+        $tspLocationFiles = Get-ChildItem -Path $Path -Recurse -Filter "tsp-location*" -ErrorAction SilentlyContinue
+        foreach ($tspLocationFile in $tspLocationFiles) {
+            try {
+                $content = Get-Content $tspLocationFile.FullName -Raw -ErrorAction SilentlyContinue
+                if ($content -and $content -match 'emitterPackageJsonPath:\s*(?<val>"[^"]+"|[^,\s]+)\s*,?') {
+                    $emitterPath = $matches['val'].Trim('"')
+                    if ($EmitterMap.ContainsKey($emitterPath) -and $EmitterMap[$emitterPath] -eq '@azure-typespec/http-client-csharp-provisioning') {
+                        return "Provisioning (TypeSpec)"
+                    }
+                }
+            }
+            catch {
+                # Continue
+            }
+        }
+        return "Provisioning (Reflection)"
     }
 
     # Special case for Azure.AI.OpenAI which uses TypeSpec with new generator via special handling
@@ -178,16 +195,16 @@ function New-MarkdownReport {
     # Generate a markdown report from the library inventory.
 
     # Define exclusion list for generator types that are not TypeSpec new emitters
-    $excludedGenerators = @("Swagger", "TSP-Old", "No Generator", "Provisioning")
+    $excludedGenerators = @("Swagger", "TSP-Old", "No Generator", "Provisioning (Reflection)", "Provisioning (TypeSpec)")
 
     # Group by type and generator
     $mgmtLibraries = $Libraries | Where-Object { $_.type -eq "Management" }
     $dataLibraries = $Libraries | Where-Object { $_.type -eq "Data Plane" }
-    $provisioningLibraries = $Libraries | Where-Object { $_.generator -eq "Provisioning" }
+    $provisioningLibraries = $Libraries | Where-Object { $_.generator -like "Provisioning*" }
     $noGenerator = $Libraries | Where-Object { $_.generator -eq "No Generator" }
     
     # Calculate the count of Data Plane libraries excluding provisioning
-    $dataPlaneNonProvisioning = $dataLibraries | Where-Object { $_.generator -ne "Provisioning" }
+    $dataPlaneNonProvisioning = $dataLibraries | Where-Object { $_.generator -notlike "Provisioning*" }
 
     # Count libraries by generator type (excluding provisioning from data plane)
     $mgmtSwagger = $mgmtLibraries | Where-Object { $_.generator -eq "Swagger" }
@@ -238,7 +255,10 @@ function New-MarkdownReport {
     $report += "  - New Emitter (TypeSpec): $($dataNewEmitter.Count)"
     $report += "  - Old TypeSpec: $($dataTspOld.Count)"
     $report += "- Provisioning: $($provisioningLibraries.Count)"
-    $report += "  - Custom reflection-based generator: $($provisioningLibraries.Count)"
+    $provReflection = ($provisioningLibraries | Where-Object { $_.generator -eq "Provisioning (Reflection)" }).Count
+    $provTypeSpec = ($provisioningLibraries | Where-Object { $_.generator -eq "Provisioning (TypeSpec)" }).Count
+    $report += "  - Reflection-based generator: $provReflection"
+    $report += "  - TypeSpec-based generator: $provTypeSpec"
     $report += "- No generator: $($noGenerator.Count)"
     $report += "`n"
 
@@ -300,14 +320,14 @@ function New-MarkdownReport {
     # Provisioning Libraries
     if ($provisioningLibraries.Count -gt 0) {
         $report += "## Provisioning Libraries`n"
-        $report += "Libraries that provide infrastructure-as-code capabilities for Azure services using a custom reflection-based generator. These libraries allow you to declaratively specify Azure infrastructure natively in .NET and generate Bicep templates for deployment.`n"
-        $report += "**Note**: Unlike other Azure SDK libraries, Provisioning libraries use a custom reflection-based generator that analyzes Azure Resource Manager SDK types to produce strongly-typed infrastructure definition APIs.`n"
-        $report += "Total: $($provisioningLibraries.Count)`n"
-        $report += "| Service | Library |"
-        $report += "| ------- | ------- |"
+        $report += "Libraries that provide infrastructure-as-code capabilities for Azure services. These libraries allow you to declaratively specify Azure infrastructure natively in .NET and generate Bicep templates for deployment.`n"
+        $report += "**Migration Status**: $provTypeSpec / $($provisioningLibraries.Count) migrated to TypeSpec-based generator`n"
+        $report += "| Service | Library | Generator |"
+        $report += "| ------- | ------- | --------- |"
         $sortedProvisioning = $provisioningLibraries | Sort-Object service, library
         foreach ($lib in $sortedProvisioning) {
-            $report += "| $($lib.service) | $($lib.library) |"
+            $generatorLabel = if ($lib.generator -eq "Provisioning (TypeSpec)") { "TypeSpec ✅" } else { "Reflection" }
+            $report += "| $($lib.service) | $($lib.library) | $generatorLabel |"
         }
         $report += "`n"
     }


### PR DESCRIPTION
## What

Enhances the provisioning libraries section of the library inventory report with two new columns:

1. **Generator**  shows whether each provisioning library uses the old reflection-based generator or the new TypeSpec-based provisioning generator (migration tracking)
2. **Mgmt Peer Library**  shows the corresponding `Azure.ResourceManager.*` peer library for each provisioning library, with a checkmark for mgmt libraries already migrated to the new TypeSpec emitter

## Changes

- **Library_Inventory.ps1**:
  - Added provisioning emitter to `EmitterMap`
  - Updated `Get-GeneratorType` to differentiate `Provisioning (Reflection)` vs `Provisioning (TypeSpec)` by checking for `tsp-location.yaml`
  - Added `Get-ProvisioningMgmtPeerLibrary` function mapping each provisioning library to its mgmt SDK peer
  - Updated provisioning table with Generator and Mgmt Peer Library columns
  - Peer libraries show full `Azure.ResourceManager.*` names with checkmarks for TypeSpec-migrated ones
  - Multi-line rendering for libraries with multiple mgmt peers (e.g. Azure.Provisioning base)

- **Library_Inventory.md**: Regenerated with new columns