### PR TITLE
[CODEOWNERS] Fix linter failures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1176,14 +1176,11 @@
 # PRLabel: %App Services %Mgmt
 /sdk/websites/Azure.ResourceManager.AppService/                    @antcp @AzureAppServiceCLI
 
-# PRLabel: %Weights & Biases
+# PRLabel: %Weights & Biases %Mgmt
 /sdk/weightsandbiases/Azure.ResourceManager.*/                     @ArcturusZhang @ArthurMa1978
 
-# PRLabel: %Workload Orchestration
-/sdk/workloadorchestration/Azure.ResourceManager.*/                @atharvau
-
-# ServiceLabel: %Workload Orchestration %Mgmt
-# ServiceOwners:                                                   @atharvau
+# PRLabel: %Workload Orchestration %Mgmt
+/sdk/workloadorchestration/Azure.ResourceManager.*/                @ArcturusZhang @ArthurMa1978
 
 # ######## Eng Sys ########
 /eng/                                                              @hallipr @weshaggard @benbp


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an invalid owner that the linter has begun flagging.   Also riding along is addition of missing labels for PR paths in the area.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5943462&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_