### PR TITLE
Fix typo in batch sample documentation

### DIFF
--- a/sdk/batch/Azure.Compute.Batch/samples/Sample2_Creating_Multiple_Tasks.md
+++ b/sdk/batch/Azure.Compute.Batch/samples/Sample2_Creating_Multiple_Tasks.md
@@ -248,7 +248,7 @@ catch (OperationCanceledException)
 
 You can customize the result handling of the `CreateTasks()` method in processing the results from the `CreateTaskCollection` call. After the call to `CreateTaskCollection` each of the of `CreateTaskResult` are passed to an instance of `ICreateTaskResultHandler` to determine if that result passed, failed, needs to be Retried, or if an execption should be thrown.
 
-Here's and example of a custom implmentation of `ICreateTaskResultHandler`
+Here's an example of a custom implementation of `ICreateTaskResultHandler`
 
 ```C# Snippet:Batch_Sample02__CustomTaskCollectionResultHandler
 /// <summary>


### PR DESCRIPTION
Corrects typo in Sample2_Creating_Multiple_Tasks.md where 'implmentation' should be 'implementation'. Also fixed 'and' to 'an' in the same sentence.