### PR TITLE
Bump typespec-client-generator-core to 0.65.4 in mgmt emitter

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -17,7 +17,7 @@
         "@azure-tools/typespec-azure-core": "0.65.0",
         "@azure-tools/typespec-azure-resource-manager": "0.65.0",
         "@azure-tools/typespec-azure-rulesets": "0.65.0",
-        "@azure-tools/typespec-client-generator-core": "0.65.3",
+        "@azure-tools/typespec-client-generator-core": "0.65.4",
         "@azure-tools/typespec-liftr-base": "0.12.0",
         "@eslint/js": "^9.2.0",
         "@types/node": "~22.12.0",
@@ -218,9 +218,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.65.3",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.65.3.tgz",
-      "integrity": "sha512-sJ9J7cIhJE9aISIeJW7uuEdLXkulF6GY64VyHdkgziQADUVRKDwgyoA7uGCfAz84dKU5JtWTJuCsIvfiQDzfSA==",
+      "version": "0.65.4",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.65.4.tgz",
+      "integrity": "sha512-p+MZU/nEmU3ciLEuNbqQtAybPxUKo/fKeKT9feh+tZLVpDDFO5DTefYoN4cteZQkPu/xyzxhjeUnKKvyVQxd6A==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -48,7 +48,7 @@
     "@azure-tools/typespec-azure-core": "0.65.0",
     "@azure-tools/typespec-azure-resource-manager": "0.65.0",
     "@azure-tools/typespec-azure-rulesets": "0.65.0",
-    "@azure-tools/typespec-client-generator-core": "0.65.3",
+    "@azure-tools/typespec-client-generator-core": "0.65.4",
     "@azure-tools/typespec-liftr-base": "0.12.0",
     "@eslint/js": "^9.2.0",
     "@types/node": "~22.12.0",


### PR DESCRIPTION
## Fix CI dependency resolution failure

### Problem
[CI fails](https://dev.azure.com/azure-sdk/internal/internal%20Team/_build/results?buildId=5943263&view=logs&j=8801c396-f2ad-561a-91e9-39bda75f75d3&t=795e6424-8df6-507c-eceb-df9ceb2501cc&l=48) with `ERESOLVE unable to resolve dependency tree` because `@typespec/http-client-csharp@1.0.0-alpha.20260227.3` requires `@azure-tools/typespec-client-generator-core@">=0.65.4"`, but the mgmt emitter pins version `0.65.3`.

### Fix
Bump `@azure-tools/typespec-client-generator-core` from `0.65.3` to `0.65.4` in `eng/packages/http-client-csharp-mgmt/package.json` to match the base emitter's peer dependency requirement.

### Validation
- `npm install` succeeds after the change
