### PR TITLE
Update mgmt PR review skill: add scope of review and contextual naming rule

### DIFF
--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -7,32 +7,52 @@ description: Review Azure SDK management-plane pull requests, check naming conve
 
 Review Azure SDK for .NET management library pull requests against the official API review guidelines.
 
-## Scope of Review
+The review is split into two sequential phases: **Versioning Review** (gate) and **API Review**. Versioning must pass before proceeding to API review.
+
+## Phase 1: Versioning Review
+
+This phase checks version-related rules that are simple and rule-based. **If any violation is found in this phase, stop the review immediately, submit the review with "Request Changes", and do not proceed to Phase 2.**
+
+### Instructions
+
+1. Fetch PR details and diff using GitHub MCP tools.
+2. Check the `.csproj` file and CHANGELOG.md for the rules below.
+3. If all versioning rules pass, proceed to Phase 2.
+4. If any rule is violated, add review comments on the violations, submit the review as **"Request Changes"** with a summary explaining the versioning violations, and **stop** — do not proceed to Phase 2.
+
+### Versioning Rules
+
+- **No major version bump.** Management SDK packages follow a unified versioning strategy. No individual package is allowed to bump its major version unless a major version bump decision has been explicitly made by the .NET architects for all mgmt packages. If a PR bumps the major version (e.g., from `1.x` to `2.0.0`), flag as **Critical**: "You must not bump the major version without the .NET architects' explicit requirement."
+- **Do not remove `ApiCompatVersion`.** If a PR removes the `ApiCompatVersion` property from the `.csproj` file, flag as **Critical**. This property enforces API compatibility checks against the last stable release and must not be deleted. Removing it would allow breaking changes to slip through undetected.
+- **Mitigate breaking changes.** When the new API version introduces breaking changes (e.g., removed properties, renamed types), the SDK must mitigate them at the API surface level so there are no breaking changes to customers. Use customization code via partial classes and generator features (e.g., `rename-mapping`, custom properties, shim methods) to preserve backward compatibility. The goal is to avoid breaking changes entirely so a major version bump is not needed.
+
+## Phase 2: API Review
+
+This phase reviews the API surface for naming conventions, type correctness, and adherence to design guidelines. It runs only after Phase 1 passes.
+
+### Scope of Review
 
 The review should focus **only on new or changed API surface** compared to the RP's latest released stable version. Types, properties, and methods that were already shipped in a prior stable release cannot be changed and should not be flagged.
 
 To determine the review scope:
-1. Find the RP's latest released stable version. Check the `ApiCompatVersion` property in the package's `.csproj` file first — this is the most authoritative source. If not present, fall back to checking the CHANGELOG.md for the most recent non-beta, non-Unreleased entry (e.g., `1.0.0`, `1.1.0`).
+1. Find the RP's latest released stable version. Check the `ApiCompatVersion` property in the package's `.csproj` file — since Phase 1 passed, this property is guaranteed to be present if it existed before. If not present, fall back to checking the CHANGELOG.md for the most recent non-beta, non-Unreleased entry (e.g., `1.0.0`, `1.1.0`).
 2. Retrieve that version's API surface file from the corresponding git tag (tag format: `<PackageName>_<Version>`, e.g., `Azure.ResourceManager.Foo_1.0.0`). The API file is at `sdk/<service>/<PackageName>/api/<PackageName>.net10.0.cs` (or earlier TFM variants like `netstandard2.0.cs`).
 3. Diff the released API surface against the PR's API surface file.
 4. Only review types, properties, methods, and enums that appear in the diff (i.e., newly added or modified). Anything unchanged from the stable release is out of scope.
 
 If no prior stable version exists (i.e., this is the first GA or only betas have been released), then the entire API surface is in scope for review.
 
-## Instructions
+### Instructions
 
-When asked to review an Azure SDK .NET management-plane library PR (packages `Azure.ResourceManager` and `Azure.ResourceManager.*`):
+1. Determine review scope per the "Scope of Review" section above.
+2. Examine API surface files (api/*.cs) for public API, focusing on new/changed surface.
+3. Check Generated models and resources in src/Generated/.
+4. Review TypeSpec customizations (e.g., `client.tsp`, `tspconfig.yaml`).
+5. Add review comments directly to the PR using GitHub MCP tools.
 
-1. Fetch PR details and diff using GitHub MCP tools
-2. Determine review scope per the "Scope of Review" section above
-3. Examine API surface files (api/*.cs) for public API, focusing on new/changed surface
-4. Check Generated models and resources in src/Generated/
-5. Review TypeSpec customizations (e.g., `client.tsp`, `tspconfig.yaml`)
-6. Add review comments directly to the PR using GitHub MCP tools
+### API Review Checklist
 
-## Review Checklist
-
-### Naming - Avoid These Suffixes
+#### Naming - Avoid These Suffixes
 | Suffix | Replace With | Exception |
 |--------|--------------|-----------|
 | Parameter(s) | Content/Patch | - |
@@ -44,38 +64,38 @@ When asked to review an Azure SDK .NET management-plane library PR (packages `Az
 | Operation | Data or Info | Unless derives from Operation<T> |
 | Collection | Group/List | Unless domain-specific (e.g., MongoDBCollection) |
 
-### Resource Naming
+#### Resource Naming
 - Remove "Resource" suffix if remaining noun is still descriptive (e.g., VirtualMachine not VirtualMachineResource)
 - Keep "Resource" if removing makes it non-descriptive (e.g., GenericResource stays)
 - For models: append "Data" suffix if inherits ResourceData/TrackedResourceData, otherwise "Info"
 
-### Operation Body Parameters
+#### Operation Body Parameters
 - **PATCH operation body:** Must be named `[Model]Patch`
 - **PUT/POST operation body:** Must be named `[Model]Content` or `[Model]Data`
 
-### Property Naming
+#### Property Naming
 - **Boolean properties:** Must start with verb prefix: `Is`, `Can`, `Has`
 - **DateTimeOffset properties:** Should end with `On` (e.g., `CreatedOn`, `StartOn`, `EndOn`)
 - **Interval/Duration (integer):** Include units in name (e.g., `MonitoringIntervalInSeconds`)
 - **TTL properties:** Rename to `TimeToLiveIn<Unit>`
 
-### Acronyms
+#### Acronyms
 - Use PascalCase (capitalize first letter only): `Aes`, `Tcp`, `Http`
 - 2-letter acronyms: uppercase if standalone (`IO`), except `Id`, `Vm`
 - Expand acronyms if not clearly explained in first page of search results with context
 
-### Contextual Naming for Types
+#### Contextual Naming for Types
 - All types must have a name that includes sufficient context about what the type represents.
 - Avoid generic or ambiguous names that could apply to many different services. The type name should make it clear which service or resource it belongs to.
 - **Bad examples:** `PublicNetworkAccess`, `EncryptionStatus`, `PrivateEndpointConnection` — these names lack context; a reader cannot tell which service they belong to without looking at the namespace.
 - **Good examples:** `StorageAccountPublicNetworkAccess`, `CosmosDBEncryptionStatus`, `KeyVaultPrivateEndpointConnection` — these names include the service or resource context.
 - Exception: If the type is scoped within a clearly named parent model or the namespace already provides unambiguous context (e.g., a property type used exclusively by one resource), a shorter name may be acceptable.
 
-### Enums
+#### Enums
 - Use singular type name (not plural) unless bit flags
 - Numeric version enums should use underscore: `Tls1_0`, `Ver5_6`
 
-### Type Formatting
+#### Type Formatting
 
 The following table applies to the **generated C# API surface** (public types/properties in `api/*.cs`).
 
@@ -90,28 +110,25 @@ The following table applies to the **generated C# API surface** (public types/pr
 
 For **TypeSpec**, UUID-valued properties should use the `uuid` scalar and map to `Guid` in the generated .NET SDK.
 
-### Duration/Interval Format
+#### Duration/Interval Format
 - ISO 8601 duration (P1DT2H59M59S): use `duration` scalar in TypeSpec
 - ISO 8601 constant (2.2:59:59.5000000): use `@encode(DurationConstant)` in TypeSpec
 
-### CheckNameAvailability Operation
+#### CheckNameAvailability Operation
 - Method: `Check[Resource/RP name]NameAvailability`
 - Parameter/Response model: `[Resource/RP name]NameAvailabilityXXX`
 - Unavailable reason enum: `[Resource/RP name]NameUnavailableReason`
 
-### Versioning
-- **Management SDK packages follow a unified versioning strategy.** No individual package is allowed to bump its major version unless a major version bump decision has been explicitly made by the .NET architects for all mgmt packages.
-- If a PR bumps the major version (e.g., from `1.x` to `2.0.0`) due to breaking changes, flag this as a **Must Fix**: "You must not bump the major version without the .NET architects' explicit requirement. Even with breaking changes, mgmt packages must stay on the current major version unless a coordinated major bump is in progress."
-- When the new API version introduces breaking changes (e.g., removed properties, renamed types), the SDK must **mitigate them at the API surface level** so there are no breaking changes to customers. Use customization code via partial classes and generator features (e.g., `rename-mapping`, custom properties, shim methods) to preserve backward compatibility. The goal is to avoid breaking changes entirely so a major version bump is not needed.
-- **Do not remove `ApiCompatVersion` from the `.csproj` file.** If a PR removes the `ApiCompatVersion` property, flag this as a **Must Fix**. This property enforces API compatibility checks against the last stable release and must not be deleted. Removing it would allow breaking changes to slip through undetected.
-
-### Other API Rules
+#### Other API Rules
 - PUT/PATCH optional body parameters should be changed to required
 - Discriminator models should make base model `abstract`
 - Remove all `ListOperations` methods (SDK exposes operations via public APIs)
 
 ## Output Format
 
-1. Summarize what passes review
-2. For each issue found, add a review comment directly to the PR on the relevant file and line using GitHub MCP tools
-3. Provide a final summary of all comments added
+1. Report Phase 1 (Versioning) result: pass or fail with details
+2. If Phase 1 fails, submit review as **"Request Changes"** and stop
+3. If Phase 1 passes, report Phase 2 (API Review) results:
+   - Summarize what passes review
+   - For each issue found, add a review comment directly to the PR on the relevant file and line using GitHub MCP tools
+4. Provide a final summary of all comments added

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -12,7 +12,7 @@ Review Azure SDK for .NET management library pull requests against the official 
 The review should focus **only on new or changed API surface** compared to the RP's latest released stable version. Types, properties, and methods that were already shipped in a prior stable release cannot be changed and should not be flagged.
 
 To determine the review scope:
-1. Find the RP's latest released stable version by checking the CHANGELOG.md for the most recent non-beta, non-Unreleased entry (e.g., `1.0.0`, `1.1.0`).
+1. Find the RP's latest released stable version. Check the `ApiCompatVersion` property in the package's `.csproj` file first — this is the most authoritative source. If not present, fall back to checking the CHANGELOG.md for the most recent non-beta, non-Unreleased entry (e.g., `1.0.0`, `1.1.0`).
 2. Retrieve that version's API surface file from the corresponding git tag (tag format: `<PackageName>_<Version>`, e.g., `Azure.ResourceManager.Foo_1.0.0`). The API file is at `sdk/<service>/<PackageName>/api/<PackageName>.net10.0.cs` (or earlier TFM variants like `netstandard2.0.cs`).
 3. Diff the released API surface against the PR's API surface file.
 4. Only review types, properties, methods, and enums that appear in the diff (i.e., newly added or modified). Anything unchanged from the stable release is out of scope.
@@ -103,6 +103,7 @@ For **TypeSpec**, UUID-valued properties should use the `uuid` scalar and map to
 - **Management SDK packages follow a unified versioning strategy.** No individual package is allowed to bump its major version unless a major version bump decision has been explicitly made by the .NET architects for all mgmt packages.
 - If a PR bumps the major version (e.g., from `1.x` to `2.0.0`) due to breaking changes, flag this as a **Must Fix**: "You must not bump the major version without the .NET architects' explicit requirement. Even with breaking changes, mgmt packages must stay on the current major version unless a coordinated major bump is in progress."
 - When the new API version introduces breaking changes (e.g., removed properties, renamed types), the SDK must **mitigate them at the API surface level** so there are no breaking changes to customers. Use customization code via partial classes and generator features (e.g., `rename-mapping`, custom properties, shim methods) to preserve backward compatibility. The goal is to avoid breaking changes entirely so a major version bump is not needed.
+- **Do not remove `ApiCompatVersion` from the `.csproj` file.** If a PR removes the `ApiCompatVersion` property, flag this as a **Must Fix**. This property enforces API compatibility checks against the last stable release and must not be deleted. Removing it would allow breaking changes to slip through undetected.
 
 ### Other API Rules
 - PUT/PATCH optional body parameters should be changed to required

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -15,15 +15,15 @@ This phase checks version-related rules that are simple and rule-based. **If any
 
 ### Instructions
 
-1. Fetch PR details and diff using GitHub MCP tools.
-2. Check the `.csproj` file and CHANGELOG.md for the rules below.
-3. If all versioning rules pass, proceed to Phase 2.
-4. If any rule is violated, add review comments on the violations, submit the review as **"Request Changes"** with a summary explaining the versioning violations, and **stop** — do not proceed to Phase 2.
+1. Check the `.csproj` file and CHANGELOG.md for the rules below.
+2. If all versioning rules pass, proceed to Phase 2.
+3. If any rule is violated, add review comments on the violations, submit the review as **"Request Changes"** with a summary explaining the versioning violations, and **stop** — do not proceed to Phase 2.
 
 ### Versioning Rules
 
 - **No major version bump.** Management SDK packages follow a unified versioning strategy. No individual package is allowed to bump its major version unless a major version bump decision has been explicitly made by the .NET architects for all mgmt packages. If a PR bumps the major version (e.g., from `1.x` to `2.0.0`), flag as **Critical**: "You must not bump the major version without the .NET architects' explicit requirement."
 - **Do not remove `ApiCompatVersion`.** If a PR removes the `ApiCompatVersion` property from the `.csproj` file, flag as **Critical**. This property enforces API compatibility checks against the last stable release and must not be deleted. Removing it would allow breaking changes to slip through undetected.
+- **No newly added content in `ApiCompatBaseline.txt`.** If the PR adds new entries to the `ApiCompatBaseline.txt` file (which suppresses ApiCompat errors), flag as **Critical**. Suppressing API compatibility errors hides breaking changes from customers. The correct approach is to mitigate breaking changes through customization code, not to baseline them away.
 
 ## Phase 2: API Review
 

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -34,12 +34,10 @@ This phase reviews the API surface for naming conventions, type correctness, and
 The review should focus **only on new or changed API surface** compared to the RP's latest released stable version. Types, properties, and methods that were already shipped in a prior stable release cannot be changed and should not be flagged.
 
 To determine the review scope:
-1. Find the RP's latest released stable version. Check the `ApiCompatVersion` property in the package's `.csproj` file — since Phase 1 passed, this property is guaranteed to be present if it existed before. If not present, fall back to checking the CHANGELOG.md for the most recent non-beta, non-Unreleased entry (e.g., `1.0.0`, `1.1.0`).
-2. Retrieve that version's API surface file from the corresponding git tag (tag format: `<PackageName>_<Version>`, e.g., `Azure.ResourceManager.Foo_1.0.0`). The API file is at `sdk/<service>/<PackageName>/api/<PackageName>.net10.0.cs` (or earlier TFM variants like `netstandard2.0.cs`).
+1. Find the RP's latest released stable version. Check the `ApiCompatVersion` property in the package's `.csproj` file — since Phase 1 passed, this property is guaranteed to be present if it existed before. If `ApiCompatVersion` is not present, assume there is no prior stable version — the entire API surface is in scope for review and no breaking changes are possible.
+2. If `ApiCompatVersion` is present, retrieve that version's API surface file from the corresponding git tag (tag format: `<PackageName>_<Version>`, e.g., `Azure.ResourceManager.Foo_1.0.0`). The API file is at `sdk/<service>/<PackageName>/api/<PackageName>.net10.0.cs` (or earlier TFM variants like `netstandard2.0.cs`).
 3. Diff the released API surface against the PR's API surface file.
 4. Only review types, properties, methods, and enums that appear in the diff (i.e., newly added or modified). Anything unchanged from the stable release is out of scope.
-
-If no prior stable version exists (i.e., this is the first GA or only betas have been released), then the entire API surface is in scope for review.
 
 ### Instructions
 
@@ -125,18 +123,19 @@ For **TypeSpec**, UUID-valued properties should use the `uuid` scalar and map to
 
 ## Phase 3: Breaking Change Detection
 
-This phase runs after Phase 2. If a prior stable version exists (i.e., `ApiCompatVersion` is present in the `.csproj`), compare the PR's API surface against the last stable version's API surface to detect **removals or signature changes** of previously shipped types, properties, methods, or enum values.
+This phase runs after Phase 2. If `ApiCompatVersion` is present in the `.csproj` (i.e., a prior stable version exists), check for breaking changes by building the project. The `ApiCompat` tooling will report breaking changes as build errors automatically.
 
 ### Instructions
 
-1. Using the same stable-version API surface file retrieved during Phase 2's scope determination, identify any types, properties, methods, or enum values that existed in the stable release but are **missing or changed** in the PR's API surface.
-2. For each breaking change found, add a review comment listing:
-   - What was removed or changed (type name, property, method signature, enum value)
-   - Where it previously existed (file and line in the stable version)
-3. Do **not** attempt to fix or mitigate the breaking changes yourself. Instead, list all detected breaking changes and ask the user to mitigate them. Mitigation options include customization code via partial classes and generator features (e.g., `rename-mapping`, custom properties, shim methods) to preserve backward compatibility. The `mitigate-breaking-changes` skill can be invoked to assist with this.
-4. If breaking changes are found, submit the review as **"Request Changes"** with the list of breaking changes that need mitigation.
+1. Build the project using `dotnet build` (or the appropriate build command for the package).
+2. Inspect the build output for `ApiCompat` errors — these indicate breaking changes against the last stable version (removals, signature changes, etc.).
+3. If the build succeeds with no `ApiCompat` errors, this phase passes.
+4. If `ApiCompat` errors are found:
+   - For each error, add a review comment listing the breaking change (what was removed or changed).
+   - Do **not** attempt to fix or mitigate the breaking changes yourself. Instead, list all detected breaking changes and ask the user to mitigate them. Mitigation options include customization code via partial classes and generator features (e.g., `rename-mapping`, custom properties, shim methods) to preserve backward compatibility. The `mitigate-breaking-changes` skill can be invoked to assist with this.
+   - Submit the review as **"Request Changes"** with the list of breaking changes that need mitigation.
 
-If no prior stable version exists, skip this phase.
+If `ApiCompatVersion` is not present in the `.csproj`, skip this phase — there is no prior stable version to compare against.
 
 ## Output Format
 
@@ -145,7 +144,7 @@ If no prior stable version exists, skip this phase.
 3. If Phase 1 passes, report Phase 2 (API Review) results:
    - Summarize what passes review
    - For each issue found, add a review comment directly to the PR on the relevant file and line using GitHub MCP tools
-4. If a prior stable version exists, report Phase 3 (Breaking Change Detection) results:
-   - List all breaking changes detected (removals, signature changes)
+4. If `ApiCompatVersion` exists, report Phase 3 (Breaking Change Detection) results:
+   - Build the project and check for `ApiCompat` errors
    - If breaking changes are found, submit review as **"Request Changes"** and ask the user to mitigate them
 5. Provide a final summary of all comments added

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -7,7 +7,7 @@ description: Review Azure SDK management-plane pull requests, check naming conve
 
 Review Azure SDK for .NET management library pull requests against the official API review guidelines.
 
-The review is split into two sequential phases: **Versioning Review** (gate) and **API Review**. Versioning must pass before proceeding to API review.
+The review is split into three sequential phases: **Phase 1: Versioning Review** (gate), **Phase 2: API Review**, and **Phase 3: Breaking Change Detection**. Each phase must pass before proceeding to the next.
 
 ## Phase 1: Versioning Review
 
@@ -24,7 +24,6 @@ This phase checks version-related rules that are simple and rule-based. **If any
 
 - **No major version bump.** Management SDK packages follow a unified versioning strategy. No individual package is allowed to bump its major version unless a major version bump decision has been explicitly made by the .NET architects for all mgmt packages. If a PR bumps the major version (e.g., from `1.x` to `2.0.0`), flag as **Critical**: "You must not bump the major version without the .NET architects' explicit requirement."
 - **Do not remove `ApiCompatVersion`.** If a PR removes the `ApiCompatVersion` property from the `.csproj` file, flag as **Critical**. This property enforces API compatibility checks against the last stable release and must not be deleted. Removing it would allow breaking changes to slip through undetected.
-- **Mitigate breaking changes.** When the new API version introduces breaking changes (e.g., removed properties, renamed types), the SDK must mitigate them at the API surface level so there are no breaking changes to customers. Use customization code via partial classes and generator features (e.g., `rename-mapping`, custom properties, shim methods) to preserve backward compatibility. The goal is to avoid breaking changes entirely so a major version bump is not needed.
 
 ## Phase 2: API Review
 
@@ -124,6 +123,21 @@ For **TypeSpec**, UUID-valued properties should use the `uuid` scalar and map to
 - Discriminator models should make base model `abstract`
 - Remove all `ListOperations` methods (SDK exposes operations via public APIs)
 
+## Phase 3: Breaking Change Detection
+
+This phase runs after Phase 2. If a prior stable version exists (i.e., `ApiCompatVersion` is present in the `.csproj`), compare the PR's API surface against the last stable version's API surface to detect **removals or signature changes** of previously shipped types, properties, methods, or enum values.
+
+### Instructions
+
+1. Using the same stable-version API surface file retrieved during Phase 2's scope determination, identify any types, properties, methods, or enum values that existed in the stable release but are **missing or changed** in the PR's API surface.
+2. For each breaking change found, add a review comment listing:
+   - What was removed or changed (type name, property, method signature, enum value)
+   - Where it previously existed (file and line in the stable version)
+3. Do **not** attempt to fix or mitigate the breaking changes yourself. Instead, list all detected breaking changes and ask the user to mitigate them. Mitigation options include customization code via partial classes and generator features (e.g., `rename-mapping`, custom properties, shim methods) to preserve backward compatibility. The `mitigate-breaking-changes` skill can be invoked to assist with this.
+4. If breaking changes are found, submit the review as **"Request Changes"** with the list of breaking changes that need mitigation.
+
+If no prior stable version exists, skip this phase.
+
 ## Output Format
 
 1. Report Phase 1 (Versioning) result: pass or fail with details
@@ -131,4 +145,7 @@ For **TypeSpec**, UUID-valued properties should use the `uuid` scalar and map to
 3. If Phase 1 passes, report Phase 2 (API Review) results:
    - Summarize what passes review
    - For each issue found, add a review comment directly to the PR on the relevant file and line using GitHub MCP tools
-4. Provide a final summary of all comments added
+4. If a prior stable version exists, report Phase 3 (Breaking Change Detection) results:
+   - List all breaking changes detected (removals, signature changes)
+   - If breaking changes are found, submit review as **"Request Changes"** and ask the user to mitigate them
+5. Provide a final summary of all comments added

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -7,15 +7,28 @@ description: Review Azure SDK management-plane pull requests, check naming conve
 
 Review Azure SDK for .NET management library pull requests against the official API review guidelines.
 
+## Scope of Review
+
+The review should focus **only on new or changed API surface** compared to the RP's latest released stable version. Types, properties, and methods that were already shipped in a prior stable release cannot be changed and should not be flagged.
+
+To determine the review scope:
+1. Find the RP's latest released stable version by checking the CHANGELOG.md for the most recent non-beta, non-Unreleased entry (e.g., `1.0.0`, `1.1.0`).
+2. Retrieve that version's API surface file from the corresponding git tag (tag format: `<PackageName>_<Version>`, e.g., `Azure.ResourceManager.Foo_1.0.0`). The API file is at `sdk/<service>/<PackageName>/api/<PackageName>.net10.0.cs` (or earlier TFM variants like `netstandard2.0.cs`).
+3. Diff the released API surface against the PR's API surface file.
+4. Only review types, properties, methods, and enums that appear in the diff (i.e., newly added or modified). Anything unchanged from the stable release is out of scope.
+
+If no prior stable version exists (i.e., this is the first GA or only betas have been released), then the entire API surface is in scope for review.
+
 ## Instructions
 
 When asked to review an Azure SDK .NET management-plane library PR (packages `Azure.ResourceManager` and `Azure.ResourceManager.*`):
 
 1. Fetch PR details and diff using GitHub MCP tools
-2. Examine API surface files (api/*.cs) for public API
-3. Check Generated models and resources in src/Generated/
-4. Review TypeSpec customizations (e.g., `client.tsp`, `tspconfig.yaml`)
-5. Add review comments directly to the PR using GitHub MCP tools
+2. Determine review scope per the "Scope of Review" section above
+3. Examine API surface files (api/*.cs) for public API, focusing on new/changed surface
+4. Check Generated models and resources in src/Generated/
+5. Review TypeSpec customizations (e.g., `client.tsp`, `tspconfig.yaml`)
+6. Add review comments directly to the PR using GitHub MCP tools
 
 ## Review Checklist
 
@@ -50,6 +63,13 @@ When asked to review an Azure SDK .NET management-plane library PR (packages `Az
 - Use PascalCase (capitalize first letter only): `Aes`, `Tcp`, `Http`
 - 2-letter acronyms: uppercase if standalone (`IO`), except `Id`, `Vm`
 - Expand acronyms if not clearly explained in first page of search results with context
+
+### Contextual Naming for Types
+- All types must have a name that includes sufficient context about what the type represents.
+- Avoid generic or ambiguous names that could apply to many different services. The type name should make it clear which service or resource it belongs to.
+- **Bad examples:** `PublicNetworkAccess`, `EncryptionStatus`, `PrivateEndpointConnection` — these names lack context; a reader cannot tell which service they belong to without looking at the namespace.
+- **Good examples:** `StorageAccountPublicNetworkAccess`, `CosmosDBEncryptionStatus`, `KeyVaultPrivateEndpointConnection` — these names include the service or resource context.
+- Exception: If the type is scoped within a clearly named parent model or the namespace already provides unambiguous context (e.g., a property type used exclusively by one resource), a shorter name may be acceptable.
 
 ### Enums
 - Use singular type name (not plural) unless bit flags


### PR DESCRIPTION
## Changes

### 1. Added 'Scope of Review' section
Reviews should focus **only on new or changed API surface** compared to the RP's latest released stable version. Types, properties, and methods already shipped in a prior stable release cannot be changed and should not be flagged.

The section provides steps to:
- Find the latest released stable version from CHANGELOG.md
- Retrieve the API surface file from the corresponding git tag
- Diff against the PR's API surface to determine what's in scope

### 2. Added 'Contextual Naming for Types' rule
All types must have names that include sufficient context about what they represent. Generic or ambiguous names that could apply to many different services should be avoided.

- **Bad examples:** `PublicNetworkAccess`, `EncryptionStatus`, `PrivateEndpointConnection`
- **Good examples:** `StorageAccountPublicNetworkAccess`, `CosmosDBEncryptionStatus`, `KeyVaultPrivateEndpointConnection`

Exception: Types scoped within a clearly named parent model or namespace may use shorter names.