### PR TITLE
Revert Azure.Provisioning 1.5.0 release to 1.5.0-beta.2 (Unreleased)

### DIFF
--- a/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Features Added
 
+- Regenerated from the latest `Azure.ResourceManager` (1.14.0).
+- Added `IsolationScope` property to `UserAssignedIdentity` resource to support regional restrictions on identity assignment.
+- Added `ResourceVersions` to `SubscriptionPolicyDefinition` and `SubscriptionPolicySetDefinition` resources.
+- Updated default API versions for `ArmDeployment` (2023-07-01 → 2025-04-01), `Subscription` (2019-10-01 → 2022-12-01), `SubscriptionPolicyDefinition`, and `SubscriptionPolicySetDefinition` resources.
+- Added `ResourceBicepMetadata` class (renamed from `BicepMetadata` introduced in 1.5.0-beta.1) that provides a clean, type-safe way to set Bicep metadata on resources.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.6.0-beta.1 (Unreleased)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 1.5.0 (2026-03-02)
 
 ### Features Added

--- a/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.6.0-beta.1 (Unreleased)
+## 1.5.0-beta.2 (Unreleased)
 
 ### Features Added
 
@@ -9,16 +9,6 @@
 ### Bugs Fixed
 
 ### Other Changes
-
-## 1.5.0 (2026-03-02)
-
-### Features Added
-
-- Regenerated from the latest `Azure.ResourceManager` (1.14.0).
-- Added `IsolationScope` property to `UserAssignedIdentity` resource to support regional restrictions on identity assignment.
-- Added `ResourceVersions` to `SubscriptionPolicyDefinition` and `SubscriptionPolicySetDefinition` resources.
-- Updated default API versions for `ArmDeployment` (2023-07-01 → 2025-04-01), `Subscription` (2019-10-01 → 2022-12-01), `SubscriptionPolicyDefinition`, and `SubscriptionPolicySetDefinition` resources.
-- Added `ResourceBicepMetadata` class (renamed from `BicepMetadata` introduced in 1.5.0-beta.1) that provides a clean, type-safe way to set Bicep metadata on resources.
 
 ## 1.5.0-beta.1 (2026-01-23)
 

--- a/sdk/provisioning/Azure.Provisioning/src/Azure.Provisioning.csproj
+++ b/sdk/provisioning/Azure.Provisioning/src/Azure.Provisioning.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains the core functionality for defining Azure infrastructure with dotnet code.</Description>
-    <Version>1.5.0</Version>
+    <Version>1.6.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.4.0</ApiCompatVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>

--- a/sdk/provisioning/Azure.Provisioning/src/Azure.Provisioning.csproj
+++ b/sdk/provisioning/Azure.Provisioning/src/Azure.Provisioning.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains the core functionality for defining Azure infrastructure with dotnet code.</Description>
-    <Version>1.6.0-beta.1</Version>
+    <Version>1.5.0-beta.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.4.0</ApiCompatVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>


### PR DESCRIPTION
Revert Azure.Provisioning 1.5.0 release since it has been delayed. Set version to 1.5.0-beta.2 with Unreleased changelog entry. The release date will be set again later when the release is scheduled.