### PR TITLE
codetransparency - do not share thread unsafe sha256 instance

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixes thread unsafe code in `VerifyTransparentStatement`
+
 ### Other Changes
 
 ## 1.0.0-beta.7 (2026-02-17)

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Receipt/CcfReceiptVerifier.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/Receipt/CcfReceiptVerifier.cs
@@ -27,12 +27,6 @@ namespace Azure.Security.CodeTransparency.Receipt
     public class CcfReceiptVerifier
     {
         /// <summary>
-        /// SHA-256 hash function.
-        /// Reference: https://datatracker.ietf.org/doc/draft-birkholz-scitt-receipts/ section 9.2.2. Hash Algorithms.
-        /// </summary>
-        private static readonly SHA256 s_sha256 = SHA256.Create();
-
-        /// <summary>
         /// Verify a CCF SCITT receipt.
         /// If the verification fails, an exception is thrown explaining in which step the verification failed.
         /// #1 Reference: https://datatracker.ietf.org/doc/draft-ietf-scitt-architecture/
@@ -44,7 +38,8 @@ namespace Azure.Security.CodeTransparency.Receipt
         /// <exception cref="InvalidOperationException">Thrown when the verification fails.</exception>
         public static void VerifyTransparentStatementReceipt(JsonWebKey jsonWebKey, byte[] receiptBytes, byte[] signedStatementBytes)
         {
-            byte[] claimsDigest = s_sha256.ComputeHash(signedStatementBytes);
+            using SHA256 sha256 = SHA256.Create();
+            byte[] claimsDigest = sha256.ComputeHash(signedStatementBytes);
 
             // Extract the expected KID from the public key used for verification,
             // and check it against the value set in the COSE header before using
@@ -151,21 +146,21 @@ namespace Azure.Security.CodeTransparency.Receipt
                 // Deserialize the ProofPaths into a List of ProofElement
                 List<ProofElement> proofElements = GetProofElements(proofPaths);
 
-                byte[] accumulator = s_sha256.ComputeHash(
+                byte[] accumulator = sha256.ComputeHash(
                     CombineByteArrays(
                         leaf.InternalTransactionHash,
-                        s_sha256.ComputeHash(Encoding.UTF8.GetBytes(leaf.InternalEvidence)),
+                        sha256.ComputeHash(Encoding.UTF8.GetBytes(leaf.InternalEvidence)),
                         leaf.DataHash));
 
                 foreach (ProofElement proofElement in proofElements)
                 {
                     if (proofElement.Left)
                     {
-                        accumulator = s_sha256.ComputeHash(CombineByteArrays(proofElement.Hash, accumulator));
+                        accumulator = sha256.ComputeHash(CombineByteArrays(proofElement.Hash, accumulator));
                     }
                     else
                     {
-                        accumulator = s_sha256.ComputeHash(CombineByteArrays(accumulator, proofElement.Hash));
+                        accumulator = sha256.ComputeHash(CombineByteArrays(accumulator, proofElement.Hash));
                     }
                 }
 

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyClientUnitTests.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Formats.Cbor;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
@@ -726,6 +728,56 @@ namespace Azure.Security.CodeTransparency.Tests
             Assert.DoesNotThrow(() =>
                 CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options));
             Assert.AreEqual(1, mockTransport.Requests.Count);
+#endif
+        }
+
+        [Test]
+        public void VerifyTransparentStatement_ThreadSafety_ParallelCallsShouldNotFail()
+        {
+#if NET462
+            Assert.Ignore("JsonWebKey to ECDsa is not supported on net462.");
+#else
+            byte[] transparentStatementBytes = readFileBytes(name: "transparent_statement.cose");
+            int threadCount = 8;
+            int iterationsPerThread = 3;
+
+            var barrier = new Barrier(threadCount);
+            var exceptions = new ConcurrentBag<Exception>();
+
+            var tasks = Enumerable.Range(0, threadCount).Select(_ => Task.Run(() =>
+            {
+                barrier.SignalAndWait(); // ensure all threads start at the same time
+                for (int i = 0; i < iterationsPerThread; i++)
+                {
+                    try
+                    {
+                        var content = createValidSignedStatementPublicKeyResponse();
+                        var mockTransport = new MockTransport(content);
+                        var options = new CodeTransparencyClientOptions
+                        {
+                            Transport = mockTransport,
+                            IdentityClientEndpoint = "https://foo.bar.com"
+                        };
+                        var verificationOptions = new CodeTransparencyVerificationOptions
+                        {
+                            AuthorizedDomains = new string[] { "foo.bar.com" },
+                        };
+
+                        CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                }
+            })).ToArray();
+
+            Task.WaitAll(tasks);
+
+            int totalCalls = threadCount * iterationsPerThread;
+            Assert.IsEmpty(exceptions,
+                $"Thread safety violation: {exceptions.Count} out of {totalCalls} parallel calls failed. " +
+                $"First error: {exceptions.FirstOrDefault()?.Message}");
 #endif
         }
     }


### PR DESCRIPTION
It was detected that statement verification method in codetransparency is not thread safe. This PR fixes the issue and adds a test to verify thread safety.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
