### PR TITLE
[WebPubSub] Support `InvokeEventAsync` for WebPubSub client

### DIFF
--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/CHANGELOG.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0-beta.1 (Unreleased)
 
 ### Features Added
+- Added preview `InvokeEventAsync` API for invoking upstream events and awaiting correlated responses from the service.
 
 ### Breaking Changes
 

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/README.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/README.md
@@ -10,6 +10,7 @@ Use this library to:
 
 - Send messages to groups
 - Send events to the [server](https://learn.microsoft.com/azure/azure-web-pubsub/concept-service-internals#terms)
+- Invoke upstream events and await correlated responses (preview)
 - Join and leave groups
 - Listen messages from groups and servers
 
@@ -209,6 +210,30 @@ catch (SendMessageFailedException ex)
     {
         await client.JoinGroupAsync("testGroup", ackId: ex.AckId);
     }
+}
+```
+
+### Invoke upstream event and await response (preview)
+
+Use `client.InvokeEventAsync()` to send an upstream event and await its correlated `invokeResponse` payload.
+
+```C# Snippet:WebPubSubClient_InvokeEvent
+var result = await client.InvokeEventAsync("processOrder", BinaryData.FromObjectAsJson(new { orderId = 1 }), WebPubSubDataType.Json);
+Console.WriteLine($"Invocation result: {result.Data}");
+```
+
+If the service returns an invocation error, `InvocationFailedException` is thrown with the invocation ID and service error code.
+
+If the operation is canceled through `CancellationToken`, `OperationCanceledException` is thrown.
+
+```C# Snippet:WebPubSubClient_InvokeEventFailure
+try
+{
+    await client.InvokeEventAsync("processOrder", BinaryData.FromObjectAsJson(new { orderId = 1 }), WebPubSubDataType.Json);
+}
+catch (InvocationFailedException ex)
+{
+    Console.WriteLine($"Invocation {ex.InvocationId} failed: {ex.Message}, Code: {ex.Code}");
 }
 ```
 

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/README.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/README.md
@@ -252,8 +252,6 @@ catch (OperationCanceledException)
 }
 ```
 
-To cancel a pending invocation, you can cancel the `CancellationTokenSource` to send a cancel message to the server.
-
 _Streaming and service-initiated invocations are not yet supported._
 
 ## Troubleshooting

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/README.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/README.md
@@ -237,6 +237,25 @@ catch (InvocationFailedException ex)
 }
 ```
 
+To enforce a timeout on the invocation, use `CancellationTokenSource` with a deadline. When the timeout elapses, the client automatically sends a `cancelInvocation` message to the service.
+
+```C# Snippet:WebPubSubClient_InvokeEventTimeout
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+try
+{
+    var result = await client.InvokeEventAsync("processOrder", BinaryData.FromObjectAsJson(new { orderId = 1 }), WebPubSubDataType.Json, cancellationToken: cts.Token);
+    Console.WriteLine($"Invocation result: {result.Data}");
+}
+catch (OperationCanceledException)
+{
+    Console.WriteLine("Invocation timed out and was cancelled.");
+}
+```
+
+To cancel a pending invocation, you can cancel the `CancellationTokenSource` to send a cancel message to the server.
+
+_Streaming and service-initiated invocations are not yet supported._
+
 ## Troubleshooting
 
 ### Setting up console logging

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.net10.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.net10.0.cs
@@ -45,6 +45,13 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string Code { get { throw null; } }
         public string InvocationId { get { throw null; } }
     }
+    public partial class InvokeEventResult
+    {
+        internal InvokeEventResult() { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+    }
     public partial class InvokeMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
     {
         public InvokeMessage(string invocationId, string eventName, System.BinaryData data, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, string target = "event") { }
@@ -53,13 +60,6 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string EventName { get { throw null; } }
         public string InvocationId { get { throw null; } }
         public string Target { get { throw null; } }
-    }
-    public partial class InvokeEventResult
-    {
-        internal InvokeEventResult() { }
-        public System.BinaryData Data { get { throw null; } }
-        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
-        public string InvocationId { get { throw null; } }
     }
     public partial class InvokeResponseError
     {

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.net10.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.net10.0.cs
@@ -13,6 +13,11 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string Message { get { throw null; } }
         public string Name { get { throw null; } }
     }
+    public partial class CancelInvocationMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
+    {
+        public CancelInvocationMessage(string invocationId) { }
+        public string InvocationId { get { throw null; } }
+    }
     public partial class ConnectedMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
     {
         public ConnectedMessage(string userId, string connectionId, string reconnectionToken) { }
@@ -33,6 +38,43 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string FromUserId { get { throw null; } }
         public string Group { get { throw null; } }
         public long? SequenceId { get { throw null; } }
+    }
+    public partial class InvocationFailedException : System.Exception
+    {
+        internal InvocationFailedException() { }
+        public string Code { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+    }
+    public partial class InvokeMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
+    {
+        public InvokeMessage(string invocationId, string eventName, System.BinaryData data, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, string target = "event") { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType DataType { get { throw null; } }
+        public string EventName { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+        public string Target { get { throw null; } }
+    }
+    public partial class InvokeEventResult
+    {
+        internal InvokeEventResult() { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+    }
+    public partial class InvokeResponseError
+    {
+        public InvokeResponseError(string name, string message) { }
+        public string Message { get { throw null; } }
+        public string Name { get { throw null; } }
+    }
+    public partial class InvokeResponseMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
+    {
+        public InvokeResponseMessage(string invocationId, bool success, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? dataType, System.BinaryData data, Azure.Messaging.WebPubSub.Clients.InvokeResponseError error) { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.InvokeResponseError Error { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+        public bool Success { get { throw null; } }
     }
     public partial class JoinGroupMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
     {
@@ -96,6 +138,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         public event System.Func<Azure.Messaging.WebPubSub.Clients.WebPubSubStoppedEventArgs, System.Threading.Tasks.Task> Stopped { add { } remove { } }
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.InvokeEventResult> InvokeEventAsync(string eventName, System.BinaryData content, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, string invocationId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.WebPubSubResult> JoinGroupAsync(string group, long? ackId = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.WebPubSubResult> LeaveGroupAsync(string group, long? ackId = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.WebPubSubResult> SendEventAsync(string eventName, System.BinaryData content, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, long? ackId = default(long?), bool fireAndForget = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.net8.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.net8.0.cs
@@ -45,6 +45,13 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string Code { get { throw null; } }
         public string InvocationId { get { throw null; } }
     }
+    public partial class InvokeEventResult
+    {
+        internal InvokeEventResult() { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+    }
     public partial class InvokeMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
     {
         public InvokeMessage(string invocationId, string eventName, System.BinaryData data, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, string target = "event") { }
@@ -53,13 +60,6 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string EventName { get { throw null; } }
         public string InvocationId { get { throw null; } }
         public string Target { get { throw null; } }
-    }
-    public partial class InvokeEventResult
-    {
-        internal InvokeEventResult() { }
-        public System.BinaryData Data { get { throw null; } }
-        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
-        public string InvocationId { get { throw null; } }
     }
     public partial class InvokeResponseError
     {

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.net8.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.net8.0.cs
@@ -13,6 +13,11 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string Message { get { throw null; } }
         public string Name { get { throw null; } }
     }
+    public partial class CancelInvocationMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
+    {
+        public CancelInvocationMessage(string invocationId) { }
+        public string InvocationId { get { throw null; } }
+    }
     public partial class ConnectedMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
     {
         public ConnectedMessage(string userId, string connectionId, string reconnectionToken) { }
@@ -33,6 +38,43 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string FromUserId { get { throw null; } }
         public string Group { get { throw null; } }
         public long? SequenceId { get { throw null; } }
+    }
+    public partial class InvocationFailedException : System.Exception
+    {
+        internal InvocationFailedException() { }
+        public string Code { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+    }
+    public partial class InvokeMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
+    {
+        public InvokeMessage(string invocationId, string eventName, System.BinaryData data, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, string target = "event") { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType DataType { get { throw null; } }
+        public string EventName { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+        public string Target { get { throw null; } }
+    }
+    public partial class InvokeEventResult
+    {
+        internal InvokeEventResult() { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+    }
+    public partial class InvokeResponseError
+    {
+        public InvokeResponseError(string name, string message) { }
+        public string Message { get { throw null; } }
+        public string Name { get { throw null; } }
+    }
+    public partial class InvokeResponseMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
+    {
+        public InvokeResponseMessage(string invocationId, bool success, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? dataType, System.BinaryData data, Azure.Messaging.WebPubSub.Clients.InvokeResponseError error) { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.InvokeResponseError Error { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+        public bool Success { get { throw null; } }
     }
     public partial class JoinGroupMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
     {
@@ -96,6 +138,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         public event System.Func<Azure.Messaging.WebPubSub.Clients.WebPubSubStoppedEventArgs, System.Threading.Tasks.Task> Stopped { add { } remove { } }
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.InvokeEventResult> InvokeEventAsync(string eventName, System.BinaryData content, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, string invocationId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.WebPubSubResult> JoinGroupAsync(string group, long? ackId = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.WebPubSubResult> LeaveGroupAsync(string group, long? ackId = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.WebPubSubResult> SendEventAsync(string eventName, System.BinaryData content, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, long? ackId = default(long?), bool fireAndForget = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.netstandard2.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.netstandard2.0.cs
@@ -45,6 +45,13 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string Code { get { throw null; } }
         public string InvocationId { get { throw null; } }
     }
+    public partial class InvokeEventResult
+    {
+        internal InvokeEventResult() { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+    }
     public partial class InvokeMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
     {
         public InvokeMessage(string invocationId, string eventName, System.BinaryData data, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, string target = "event") { }
@@ -53,13 +60,6 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string EventName { get { throw null; } }
         public string InvocationId { get { throw null; } }
         public string Target { get { throw null; } }
-    }
-    public partial class InvokeEventResult
-    {
-        internal InvokeEventResult() { }
-        public System.BinaryData Data { get { throw null; } }
-        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
-        public string InvocationId { get { throw null; } }
     }
     public partial class InvokeResponseError
     {

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.netstandard2.0.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/api/Azure.Messaging.WebPubSub.Client.netstandard2.0.cs
@@ -13,6 +13,11 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string Message { get { throw null; } }
         public string Name { get { throw null; } }
     }
+    public partial class CancelInvocationMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
+    {
+        public CancelInvocationMessage(string invocationId) { }
+        public string InvocationId { get { throw null; } }
+    }
     public partial class ConnectedMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
     {
         public ConnectedMessage(string userId, string connectionId, string reconnectionToken) { }
@@ -33,6 +38,43 @@ namespace Azure.Messaging.WebPubSub.Clients
         public string FromUserId { get { throw null; } }
         public string Group { get { throw null; } }
         public long? SequenceId { get { throw null; } }
+    }
+    public partial class InvocationFailedException : System.Exception
+    {
+        internal InvocationFailedException() { }
+        public string Code { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+    }
+    public partial class InvokeMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
+    {
+        public InvokeMessage(string invocationId, string eventName, System.BinaryData data, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, string target = "event") { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType DataType { get { throw null; } }
+        public string EventName { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+        public string Target { get { throw null; } }
+    }
+    public partial class InvokeEventResult
+    {
+        internal InvokeEventResult() { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+    }
+    public partial class InvokeResponseError
+    {
+        public InvokeResponseError(string name, string message) { }
+        public string Message { get { throw null; } }
+        public string Name { get { throw null; } }
+    }
+    public partial class InvokeResponseMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
+    {
+        public InvokeResponseMessage(string invocationId, bool success, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? dataType, System.BinaryData data, Azure.Messaging.WebPubSub.Clients.InvokeResponseError error) { }
+        public System.BinaryData Data { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.WebPubSubDataType? DataType { get { throw null; } }
+        public Azure.Messaging.WebPubSub.Clients.InvokeResponseError Error { get { throw null; } }
+        public string InvocationId { get { throw null; } }
+        public bool Success { get { throw null; } }
     }
     public partial class JoinGroupMessage : Azure.Messaging.WebPubSub.Clients.WebPubSubMessage
     {
@@ -96,6 +138,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         public event System.Func<Azure.Messaging.WebPubSub.Clients.WebPubSubStoppedEventArgs, System.Threading.Tasks.Task> Stopped { add { } remove { } }
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
+        public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.InvokeEventResult> InvokeEventAsync(string eventName, System.BinaryData content, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, string invocationId = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.WebPubSubResult> JoinGroupAsync(string group, long? ackId = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.WebPubSubResult> LeaveGroupAsync(string group, long? ackId = default(long?), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Messaging.WebPubSub.Clients.WebPubSubResult> SendEventAsync(string eventName, System.BinaryData content, Azure.Messaging.WebPubSub.Clients.WebPubSubDataType dataType, long? ackId = default(long?), bool fireAndForget = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/samples/Sample1_HelloWorld.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/samples/Sample1_HelloWorld.md
@@ -81,3 +81,29 @@ await client.SendToGroupAsync("testGroup", BinaryData.FromString("hello world"),
 // Send custom event to server
 await client.SendEventAsync("testEvent", BinaryData.FromString("hello world"), WebPubSubDataType.Text);
 ```
+
+## Invoke upstream event and await response
+
+This section demonstrates how to invoke an upstream event and wait for a correlated response from the service.
+
+### Invoke event
+
+```C# Snippet:WebPubSubClient_InvokeEvent
+var result = await client.InvokeEventAsync("processOrder", BinaryData.FromObjectAsJson(new { orderId = 1 }), WebPubSubDataType.Json);
+Console.WriteLine($"Invocation result: {result.Data}");
+```
+
+### Handle invocation failure
+
+If the invocation fails, `InvocationFailedException` is thrown. The exception includes the invocation ID and service error code.
+
+```C# Snippet:WebPubSubClient_InvokeEventFailure
+try
+{
+    await client.InvokeEventAsync("processOrder", BinaryData.FromObjectAsJson(new { orderId = 1 }), WebPubSubDataType.Json);
+}
+catch (InvocationFailedException ex)
+{
+    Console.WriteLine($"Invocation {ex.InvocationId} failed: {ex.Message}, Code: {ex.Code}");
+}
+```

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/samples/Sample1_HelloWorld.md
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/samples/Sample1_HelloWorld.md
@@ -107,3 +107,18 @@ catch (InvocationFailedException ex)
     Console.WriteLine($"Invocation {ex.InvocationId} failed: {ex.Message}, Code: {ex.Code}");
 }
 ```
+
+### Invoke event with timeout
+
+```C# Snippet:WebPubSubClient_InvokeEventTimeout
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+try
+{
+    var result = await client.InvokeEventAsync("processOrder", BinaryData.FromObjectAsJson(new { orderId = 1 }), WebPubSubDataType.Json, cancellationToken: cts.Token);
+    Console.WriteLine($"Invocation result: {result.Data}");
+}
+catch (OperationCanceledException)
+{
+    Console.WriteLine("Invocation timed out and was cancelled.");
+}
+```

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Exceptions/InvocationFailedException.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Exceptions/InvocationFailedException.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.WebPubSub.Clients
+{
+    /// <summary>
+    /// Exception thrown when an invocation fails.
+    /// </summary>
+    public class InvocationFailedException : Exception
+    {
+        /// <summary>
+        /// The invocation id of the request.
+        /// </summary>
+        public string InvocationId { get; }
+
+        /// <summary>
+        /// The error code response from the service. If the error is not from the service, code is empty.
+        /// </summary>
+        public string Code { get; }
+
+        internal InvocationFailedException(string message, string invocationId, string code) : base(message)
+        {
+            InvocationId = invocationId;
+            Code = code ?? string.Empty;
+        }
+
+        internal InvocationFailedException(string message, string invocationId, Exception innerException) : base(message, innerException)
+        {
+            InvocationId = invocationId;
+            Code = string.Empty;
+        }
+    }
+}

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/InvokeEventResult.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/InvokeEventResult.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.WebPubSub.Clients
+{
+    /// <summary>
+    /// Result of an invoke event operation.
+    /// </summary>
+    public class InvokeEventResult
+    {
+        /// <summary>
+        /// Invocation identifier correlated with the response.
+        /// </summary>
+        public string InvocationId { get; }
+
+        /// <summary>
+        /// The response payload data type.
+        /// </summary>
+        public WebPubSubDataType? DataType { get; }
+
+        /// <summary>
+        /// The response payload.
+        /// </summary>
+        public BinaryData Data { get; }
+
+        internal InvokeEventResult(string invocationId, WebPubSubDataType? dataType, BinaryData data)
+        {
+            InvocationId = invocationId;
+            DataType = dataType;
+            Data = data;
+        }
+    }
+}

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Messages/CancelInvocationMessage.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Messages/CancelInvocationMessage.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Messaging.WebPubSub.Clients
+{
+    /// <summary>
+    /// The message representing a cancel invocation request.
+    /// </summary>
+    public class CancelInvocationMessage : WebPubSubMessage
+    {
+        /// <summary>
+        /// The invocation ID to cancel.
+        /// </summary>
+        public string InvocationId { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CancelInvocationMessage"/> class.
+        /// </summary>
+        /// <param name="invocationId">The invocation id to cancel</param>
+        public CancelInvocationMessage(string invocationId)
+        {
+            InvocationId = invocationId;
+        }
+    }
+}

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Messages/InvokeMessage.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Messages/InvokeMessage.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.WebPubSub.Clients
+{
+    /// <summary>
+    /// The message representing an invoke request to the service.
+    /// </summary>
+    public class InvokeMessage : WebPubSubMessage
+    {
+        /// <summary>
+        /// The invocation id
+        /// </summary>
+        public string InvocationId { get; }
+
+        /// <summary>
+        /// The target type of the invocation. Defaults to "event".
+        /// </summary>
+        public string Target { get; }
+
+        /// <summary>
+        /// The event name when targeting upstream events.
+        /// </summary>
+        public string EventName { get; }
+
+        /// <summary>
+        /// Type of the data
+        /// </summary>
+        public WebPubSubDataType DataType { get; }
+
+        /// <summary>
+        /// The data content
+        /// </summary>
+        public BinaryData Data { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeMessage"/> class.
+        /// </summary>
+        /// <param name="invocationId">The invocation id</param>
+        /// <param name="eventName">The event name</param>
+        /// <param name="data">The data content</param>
+        /// <param name="dataType">Type of the data</param>
+        /// <param name="target">The target type of the invocation. Defaults to "event".</param>
+        public InvokeMessage(string invocationId, string eventName, BinaryData data, WebPubSubDataType dataType, string target = "event")
+        {
+            InvocationId = invocationId;
+            Target = target;
+            EventName = eventName;
+            Data = data;
+            DataType = dataType;
+        }
+    }
+}

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Messages/InvokeResponseError.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Messages/InvokeResponseError.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Messaging.WebPubSub.Clients
+{
+    /// <summary>
+    /// Error details from an invoke response.
+    /// </summary>
+    public class InvokeResponseError
+    {
+        /// <summary>
+        /// The error name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The error message.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeResponseError"/> class.
+        /// </summary>
+        /// <param name="name">The error name</param>
+        /// <param name="message">The error message</param>
+        public InvokeResponseError(string name, string message)
+        {
+            Name = name;
+            Message = message;
+        }
+    }
+}

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Messages/InvokeResponseMessage.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Messages/InvokeResponseMessage.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.WebPubSub.Clients
+{
+    /// <summary>
+    /// The message representing an invoke response from the service.
+    /// </summary>
+    public class InvokeResponseMessage : WebPubSubMessage
+    {
+        /// <summary>
+        /// The invocation ID that this response is for.
+        /// </summary>
+        public string InvocationId { get; }
+
+        /// <summary>
+        /// Indicates whether the invocation was successful.
+        /// </summary>
+        public bool Success { get; }
+
+        /// <summary>
+        /// Type of the data
+        /// </summary>
+        public WebPubSubDataType? DataType { get; }
+
+        /// <summary>
+        /// The data content
+        /// </summary>
+        public BinaryData Data { get; }
+
+        /// <summary>
+        /// Error details if the invocation failed.
+        /// </summary>
+        public InvokeResponseError Error { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeResponseMessage"/> class.
+        /// </summary>
+        /// <param name="invocationId">The invocation id</param>
+        /// <param name="success">Whether the invocation succeeded</param>
+        /// <param name="dataType">Type of the data</param>
+        /// <param name="data">The data content</param>
+        /// <param name="error">Error details if the invocation failed</param>
+        public InvokeResponseMessage(string invocationId, bool success, WebPubSubDataType? dataType, BinaryData data, InvokeResponseError error)
+        {
+            InvocationId = invocationId;
+            Success = success;
+            DataType = dataType;
+            Data = data;
+            Error = error;
+        }
+    }
+}

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocolBase.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocolBase.cs
@@ -55,6 +55,13 @@ namespace Azure.Messaging.WebPubSub.Clients
         private static readonly JsonEncodedText SendToGroupTypeBytes = JsonEncodedText.Encode("sendToGroup");
         private static readonly JsonEncodedText SendEventTypeBytes = JsonEncodedText.Encode("event");
         private static readonly JsonEncodedText SequenceAckTypeBytes = JsonEncodedText.Encode("sequenceAck");
+        private static readonly JsonEncodedText InvokeTypeBytes = JsonEncodedText.Encode("invoke");
+        private static readonly JsonEncodedText CancelInvocationTypeBytes = JsonEncodedText.Encode("cancelInvocation");
+
+        private const string InvocationIdPropertyName = "invocationId";
+        private static readonly JsonEncodedText InvocationIdPropertyNameBytes = JsonEncodedText.Encode(InvocationIdPropertyName);
+        private const string TargetPropertyName = "target";
+        private static readonly JsonEncodedText TargetPropertyNameBytes = JsonEncodedText.Encode(TargetPropertyName);
 
         private const byte Quote = (byte)'"';
         private const byte KeyValueSeperator = (byte)':';
@@ -83,11 +90,14 @@ namespace Azure.Messaging.WebPubSub.Clients
                 FromType fromType = FromType.Server;
                 AckMessageError errorDetail = null;
                 WebPubSubDataType dataType = WebPubSubDataType.Text;
+                bool hasDataType = false;
                 string userId = null;
                 string connectionId = null;
                 string reconnectionToken = null;
                 string message = null;
                 string fromUserId = null;
+                string invocationId = null;
+                InvokeResponseError invokeResponseError = null;
 
                 var completed = false;
                 bool hasDataToken = false;
@@ -138,6 +148,11 @@ namespace Azure.Messaging.WebPubSub.Clients
                                 {
                                     throw new InvalidDataException($"Unknown '{DataTypePropertyName}': {dataTypeValue}.");
                                 }
+                                hasDataType = true;
+                            }
+                            else if (reader.ValueTextEquals(InvocationIdPropertyNameBytes.EncodedUtf8Bytes))
+                            {
+                                invocationId = reader.ReadAsNullableString(InvocationIdPropertyName);
                             }
                             else if (reader.ValueTextEquals(AckIdPropertyNameBytes.EncodedUtf8Bytes))
                             {
@@ -174,7 +189,14 @@ namespace Azure.Messaging.WebPubSub.Clients
                             }
                             else if (reader.ValueTextEquals(ErrorPropertyNameBytes.EncodedUtf8Bytes))
                             {
-                                errorDetail = ReadErrorDetail(reader);
+                                if (eventType == DownstreamEventType.InvokeResponse)
+                                {
+                                    invokeResponseError = ReadInvokeResponseError(reader);
+                                }
+                                else
+                                {
+                                    errorDetail = ReadErrorDetail(reader);
+                                }
                             }
                             else if (reader.ValueTextEquals(FromPropertyNameBytes.EncodedUtf8Bytes))
                             {
@@ -265,6 +287,11 @@ namespace Azure.Messaging.WebPubSub.Clients
                         AssertNotNull(ackId, AckIdPropertyName);
                         AssertNotNull(success, SuccessPropertyName);
                         return new List<WebPubSubMessage> { new AckMessage(ackId.Value, success.Value, errorDetail) };
+
+                    case DownstreamEventType.InvokeResponse:
+                        AssertNotNull(invocationId, InvocationIdPropertyName);
+                        AssertNotNull(success, SuccessPropertyName);
+                        return new List<WebPubSubMessage> { new InvokeResponseMessage(invocationId, success.Value, hasDataType ? dataType : (WebPubSubDataType?)null, data, invokeResponseError) };
 
                     case DownstreamEventType.Message:
                         AssertNotNull(from, FromPropertyName);
@@ -364,6 +391,18 @@ namespace Azure.Messaging.WebPubSub.Clients
                         writer.WriteString(TypePropertyNameBytes, SequenceAckTypeBytes);
                         writer.WriteNumber(SequenceIdPropertyNameBytes, sequenceAckMessage.SequenceId);
                         break;
+                    case InvokeMessage invokeMessage:
+                        writer.WriteString(TypePropertyNameBytes, InvokeTypeBytes);
+                        writer.WriteString(InvocationIdPropertyNameBytes, invokeMessage.InvocationId);
+                        writer.WriteString(TargetPropertyNameBytes, invokeMessage.Target);
+                        writer.WriteString(EventPropertyNameBytes, invokeMessage.EventName);
+                        writer.WriteString(DataTypePropertyNameBytes, invokeMessage.DataType.ToString());
+                        WriteData(output, writer, invokeMessage.Data, invokeMessage.DataType);
+                        break;
+                    case CancelInvocationMessage cancelInvocationMessage:
+                        writer.WriteString(TypePropertyNameBytes, CancelInvocationTypeBytes);
+                        writer.WriteString(InvocationIdPropertyNameBytes, cancelInvocationMessage.InvocationId);
+                        break;
                     default:
                         throw new InvalidDataException($"{message.GetType()} is not supported.");
                 }
@@ -375,6 +414,38 @@ namespace Azure.Messaging.WebPubSub.Clients
             {
                 ReusableUtf8JsonWriter.Return(jsonWriterLease);
             }
+        }
+
+        private static InvokeResponseError ReadInvokeResponseError(Utf8JsonReader reader)
+        {
+            string errorName = null;
+            string errorMessage = null;
+
+            var completed = false;
+            reader.CheckRead();
+            reader.EnsureObjectStart();
+            do
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonTokenType.PropertyName:
+                        if (reader.ValueTextEquals(ErrorNamePropertyNameBytes.EncodedUtf8Bytes))
+                        {
+                            errorName = reader.ReadAsNullableString(ErrorNamePropertyName);
+                        }
+                        else if (reader.ValueTextEquals(MessagePropertyNameBytes.EncodedUtf8Bytes))
+                        {
+                            errorMessage = reader.ReadAsNullableString(MessagePropertyName);
+                        }
+                        break;
+                    case JsonTokenType.EndObject:
+                        completed = true;
+                        break;
+                }
+            }
+            while (!completed && reader.CheckRead());
+
+            return new InvokeResponseError(errorName, errorMessage);
         }
 
         private static AckMessageError ReadErrorDetail(Utf8JsonReader reader)
@@ -451,6 +522,7 @@ namespace Azure.Messaging.WebPubSub.Clients
             Ack,
             Message,
             System,
+            InvokeResponse,
         }
 
         private enum FromType

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocolBase.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/Protocols/WebPubSubJsonProtocolBase.cs
@@ -101,6 +101,9 @@ namespace Azure.Messaging.WebPubSub.Clients
 
                 var completed = false;
                 bool hasDataToken = false;
+                bool hasErrorToken = false;
+                string parsedErrorName = null;
+                string parsedErrorMessage = null;
                 BinaryData data = null;
                 SequencePosition dataStart = default;
                 Utf8JsonReader dataReader = default;
@@ -189,14 +192,30 @@ namespace Azure.Messaging.WebPubSub.Clients
                             }
                             else if (reader.ValueTextEquals(ErrorPropertyNameBytes.EncodedUtf8Bytes))
                             {
-                                if (eventType == DownstreamEventType.InvokeResponse)
+                                hasErrorToken = true;
+                                var errorCompleted = false;
+                                reader.CheckRead();
+                                reader.EnsureObjectStart();
+                                do
                                 {
-                                    invokeResponseError = ReadInvokeResponseError(reader);
+                                    switch (reader.TokenType)
+                                    {
+                                        case JsonTokenType.PropertyName:
+                                            if (reader.ValueTextEquals(ErrorNamePropertyNameBytes.EncodedUtf8Bytes))
+                                            {
+                                                parsedErrorName = reader.ReadAsNullableString(ErrorNamePropertyName);
+                                            }
+                                            else if (reader.ValueTextEquals(MessagePropertyNameBytes.EncodedUtf8Bytes))
+                                            {
+                                                parsedErrorMessage = reader.ReadAsNullableString(MessagePropertyName);
+                                            }
+                                            break;
+                                        case JsonTokenType.EndObject:
+                                            errorCompleted = true;
+                                            break;
+                                    }
                                 }
-                                else
-                                {
-                                    errorDetail = ReadErrorDetail(reader);
-                                }
+                                while (!errorCompleted && reader.CheckRead());
                             }
                             else if (reader.ValueTextEquals(FromPropertyNameBytes.EncodedUtf8Bytes))
                             {
@@ -242,6 +261,18 @@ namespace Azure.Messaging.WebPubSub.Clients
                 if (type == null)
                 {
                     throw new InvalidDataException($"Missing required property '{TypePropertyName}'.");
+                }
+
+                if (hasErrorToken)
+                {
+                    if (eventType == DownstreamEventType.InvokeResponse)
+                    {
+                        invokeResponseError = new InvokeResponseError(parsedErrorName, parsedErrorMessage);
+                    }
+                    else
+                    {
+                        errorDetail = new AckMessageError(parsedErrorName, parsedErrorMessage);
+                    }
                 }
 
                 if (hasDataToken)
@@ -414,71 +445,6 @@ namespace Azure.Messaging.WebPubSub.Clients
             {
                 ReusableUtf8JsonWriter.Return(jsonWriterLease);
             }
-        }
-
-        private static InvokeResponseError ReadInvokeResponseError(Utf8JsonReader reader)
-        {
-            string errorName = null;
-            string errorMessage = null;
-
-            var completed = false;
-            reader.CheckRead();
-            reader.EnsureObjectStart();
-            do
-            {
-                switch (reader.TokenType)
-                {
-                    case JsonTokenType.PropertyName:
-                        if (reader.ValueTextEquals(ErrorNamePropertyNameBytes.EncodedUtf8Bytes))
-                        {
-                            errorName = reader.ReadAsNullableString(ErrorNamePropertyName);
-                        }
-                        else if (reader.ValueTextEquals(MessagePropertyNameBytes.EncodedUtf8Bytes))
-                        {
-                            errorMessage = reader.ReadAsNullableString(MessagePropertyName);
-                        }
-                        break;
-                    case JsonTokenType.EndObject:
-                        completed = true;
-                        break;
-                }
-            }
-            while (!completed && reader.CheckRead());
-
-            return new InvokeResponseError(errorName, errorMessage);
-        }
-
-        private static AckMessageError ReadErrorDetail(Utf8JsonReader reader)
-        {
-            string errorName = null;
-            string errorMessage = null;
-
-            var completed = false;
-            reader.CheckRead();
-            // Error detail should start with object
-            reader.EnsureObjectStart();
-            do
-            {
-                switch (reader.TokenType)
-                {
-                    case JsonTokenType.PropertyName:
-                        if (reader.ValueTextEquals(ErrorNamePropertyNameBytes.EncodedUtf8Bytes))
-                        {
-                            errorName = reader.ReadAsNullableString(ErrorNamePropertyName);
-                        }
-                        else if (reader.ValueTextEquals(MessagePropertyNameBytes.EncodedUtf8Bytes))
-                        {
-                            errorMessage = reader.ReadAsNullableString(MessagePropertyName);
-                        }
-                        break;
-                    case JsonTokenType.EndObject:
-                        completed = true;
-                        break;
-                }
-            }
-            while (!completed && reader.CheckRead());
-
-            return new AckMessageError(errorName, errorMessage);
         }
 
         private static void AssertNotNull<T>(T value, string propertyName)

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
@@ -52,10 +52,12 @@ namespace Azure.Messaging.WebPubSub.Clients
 
         private readonly object _ackIdLock = new();
         private readonly object _stopLock = new();
+        private readonly object _invocationIdLock = new();
 #pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(1);
 #pragma warning restore CA2213 // Disposable fields should be disposed
         private long _nextAckId = 0;
+        private long _nextInvocationId = 0;
 
         // Fields per start stop
         private Task _stoppingTask;
@@ -70,6 +72,7 @@ namespace Azure.Messaging.WebPubSub.Clients
         private bool _isInitialConnected;
         private DisconnectedMessage _latestDisconnectedMessage;
         private ConcurrentDictionary<long, AckEntity> _ackCache = new();
+        private readonly ConcurrentDictionary<string, InvocationEntity> _invocationCache = new();
 
         // Fields per websocket
         private Task _receiveTask;
@@ -222,6 +225,7 @@ namespace Azure.Messaging.WebPubSub.Clients
             _reconnectionToken = null;
             _connectionId = null;
             _ackCache.Clear();
+            _invocationCache.Clear();
 
             _clientAccessUri = await _webPubSubClientCredential.GetClientAccessUriAsync(cancellationToken).ConfigureAwait(false);
             await ConnectAsync(_clientAccessUri, cancellationToken).ConfigureAwait(false);
@@ -436,6 +440,60 @@ namespace Azure.Messaging.WebPubSub.Clients
             {
                 return new SendEventMessage(eventName, content, dataType, id);
             }, ackId, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Invoke an upstream event and wait for the correlated response.
+        /// </summary>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="content">The data content.</param>
+        /// <param name="dataType">The data type.</param>
+        /// <param name="invocationId">An optional invocation identifier. If not specified, the client generates one.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>The result of the invocation.</returns>
+        public virtual async Task<InvokeEventResult> InvokeEventAsync(string eventName, BinaryData content, WebPubSubDataType dataType, string invocationId = null, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            return await OperationExecuteWithRetry(token => InvokeEventAttemptAsync(eventName, content, dataType, invocationId, token), cancellationToken).ConfigureAwait(false);
+        }
+
+        internal virtual async Task<InvokeEventResult> InvokeEventAttemptAsync(string eventName, BinaryData content, WebPubSubDataType dataType, string invocationId, CancellationToken cancellationToken)
+        {
+            var resolvedId = invocationId ?? NextInvocationId();
+
+            var entity = new InvocationEntity(resolvedId);
+            if (!_invocationCache.TryAdd(resolvedId, entity))
+            {
+                throw new InvocationFailedException("Invocation id is already registered.", resolvedId, string.Empty);
+            }
+
+            var invokeMessage = new InvokeMessage(resolvedId, eventName, content, dataType);
+
+            InvokeResponseMessage response;
+            try
+            {
+                try
+                {
+                    await SendCoreAsync(_protocol.GetMessageBytes(invokeMessage), _protocol.WebSocketMessageType, true, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvocationFailedException("Failed to send invocation message.", resolvedId, ex);
+                }
+
+                response = await entity.Task.AwaitWithCancellation<InvokeResponseMessage>(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                await SendCancelInvocationAsync(resolvedId).ConfigureAwait(false);
+                throw;
+            }
+            finally
+            {
+                _invocationCache.TryRemove(resolvedId, out _);
+            }
+
+            return MapInvokeResponse(response);
         }
 
         /// <summary>
@@ -767,6 +825,17 @@ namespace Azure.Messaging.WebPubSub.Clients
                 }
             }
 
+            foreach (var entry in _invocationCache)
+            {
+                if (_invocationCache.TryRemove(entry.Key, out var invEntity))
+                {
+                    invEntity.SetException(new InvocationFailedException(
+                        "Connection is disconnected before receiving invoke response from the service",
+                        entry.Key,
+                        string.Empty));
+                }
+            }
+
             if (closeStatus == WebSocketCloseStatus.PolicyViolation)
             {
                 WebPubSubClientEventSource.Log.StopRecovery(_connectionId, $"The websocket close with status: {WebSocketCloseStatus.PolicyViolation}");
@@ -860,6 +929,9 @@ namespace Azure.Messaging.WebPubSub.Clients
                 case ServerDataMessage serverResponseMessage:
                     HandleServerMessage(serverResponseMessage);
                     break;
+                case InvokeResponseMessage invokeResponseMessage:
+                    HandleInvokeResponseMessage(invokeResponseMessage);
+                    break;
                 default:
                     throw new InvalidDataException($"Received unknown type of message {message.GetType()}");
             }
@@ -909,6 +981,14 @@ namespace Azure.Messaging.WebPubSub.Clients
                 }
 
                 _serverDataChannel.Writer.TryWrite(serverResponseMessage);
+            }
+        }
+
+        internal void HandleInvokeResponseMessage(InvokeResponseMessage invokeResponseMessage)
+        {
+            if (_invocationCache.TryRemove(invokeResponseMessage.InvocationId, out var entity))
+            {
+                entity.SetResult(invokeResponseMessage);
             }
         }
 
@@ -1020,12 +1100,18 @@ namespace Azure.Messaging.WebPubSub.Clients
                 {
                     return await task(cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     retryAttempt++;
                     var delay = _messageRetryPolicy.NextRetryDelay(new RetryContext { RetryAttempt = retryAttempt });
 
                     if (delay == null)
+                    {
+                        throw;
+                    }
+
+                    // InvocationFailedException should not be retried
+                    if (typeof(T) == typeof(InvokeEventResult) && ex is InvocationFailedException)
                     {
                         throw;
                     }
@@ -1059,6 +1145,55 @@ namespace Azure.Messaging.WebPubSub.Clients
             public void SetCancelled() => _tcs.TrySetException(new OperationCanceledException());
             public void SetException(Exception ex) => _tcs.TrySetException(ex);
             public Task<WebPubSubResult> Task => _tcs.Task;
+        }
+
+        private class InvocationEntity
+        {
+            public string InvocationId { get; }
+
+            public InvocationEntity(string invocationId)
+            {
+                InvocationId = invocationId;
+            }
+
+            private readonly TaskCompletionSource<InvokeResponseMessage> _tcs = new TaskCompletionSource<InvokeResponseMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public void SetResult(InvokeResponseMessage message) => _tcs.TrySetResult(message);
+            public void SetException(Exception ex) => _tcs.TrySetException(ex);
+            public Task<InvokeResponseMessage> Task => _tcs.Task;
+        }
+
+        private string NextInvocationId()
+        {
+            lock (_invocationIdLock)
+            {
+                return (++_nextInvocationId).ToString();
+            }
+        }
+
+        private static InvokeEventResult MapInvokeResponse(InvokeResponseMessage message)
+        {
+            if (!message.Success)
+            {
+                throw new InvocationFailedException(
+                    message.Error?.Message ?? "Invocation failed.",
+                    message.InvocationId,
+                    message.Error?.Name);
+            }
+
+            return new InvokeEventResult(message.InvocationId, message.DataType, message.Data);
+        }
+
+        private async Task SendCancelInvocationAsync(string invocationId)
+        {
+            try
+            {
+                var message = new CancelInvocationMessage(invocationId);
+                await SendMessageWithoutAckAsync(message, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort, ignore failures
+            }
         }
 
         private class SequenceId

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
@@ -52,7 +52,6 @@ namespace Azure.Messaging.WebPubSub.Clients
 
         private readonly object _ackIdLock = new();
         private readonly object _stopLock = new();
-        private readonly object _invocationIdLock = new();
 #pragma warning disable CA2213 // Disposable fields should be disposed
         private readonly SemaphoreSlim _connectionLock = new SemaphoreSlim(1);
 #pragma warning restore CA2213 // Disposable fields should be disposed
@@ -1147,7 +1146,7 @@ namespace Azure.Messaging.WebPubSub.Clients
             public Task<WebPubSubResult> Task => _tcs.Task;
         }
 
-        private class InvocationEntity
+        private sealed class InvocationEntity
         {
             public string InvocationId { get; }
 
@@ -1164,10 +1163,7 @@ namespace Azure.Messaging.WebPubSub.Clients
 
         private string NextInvocationId()
         {
-            lock (_invocationIdLock)
-            {
-                return (++_nextInvocationId).ToString();
-            }
+            return Interlocked.Increment(ref _nextInvocationId).ToString();
         }
 
         private static InvokeEventResult MapInvokeResponse(InvokeResponseMessage message)

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/src/WebPubSubClient.cs
@@ -478,7 +478,7 @@ namespace Azure.Messaging.WebPubSub.Clients
                 }
                 catch (Exception ex)
                 {
-                    throw new InvocationFailedException("Failed to send invocation message.", resolvedId, ex);
+                    throw new SendMessageFailedException("Failed to send invocation message.", null, ex);
                 }
 
                 response = await entity.Task.AwaitWithCancellation<InvokeResponseMessage>(cancellationToken);
@@ -829,9 +829,9 @@ namespace Azure.Messaging.WebPubSub.Clients
             {
                 if (_invocationCache.TryRemove(entry.Key, out var invEntity))
                 {
-                    invEntity.SetException(new InvocationFailedException(
+                    invEntity.SetException(new SendMessageFailedException(
                         "Connection is disconnected before receiving invoke response from the service",
-                        entry.Key,
+                        null,
                         string.Empty));
                 }
             }
@@ -1110,8 +1110,8 @@ namespace Azure.Messaging.WebPubSub.Clients
                         throw;
                     }
 
-                    // InvocationFailedException should not be retried
-                    if (typeof(T) == typeof(InvokeEventResult) && ex is InvocationFailedException)
+                    // InvocationFailedException is non-retryable (service-originated or logic error)
+                    if (ex is InvocationFailedException)
                     {
                         throw;
                     }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Protocols/JsonProtocolTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Protocols/JsonProtocolTests.cs
@@ -124,6 +124,34 @@ namespace Azure.Messaging.WebPubSub.Client.Tests.Protocols
                 var disconnectedMessage = message as DisconnectedMessage;
                 Assert.AreEqual("msg", disconnectedMessage.Reason);
             });
+            yield return GetData(new { type = "invokeResponse", invocationId = "inv-1", success = true, dataType = "text", data = "pong" }, message =>
+            {
+                Assert.True(message is InvokeResponseMessage);
+                var invokeResponse = message as InvokeResponseMessage;
+                Assert.AreEqual("inv-1", invokeResponse.InvocationId);
+                Assert.True(invokeResponse.Success);
+                Assert.AreEqual(WebPubSubDataType.Text, invokeResponse.DataType);
+                Assert.AreEqual("pong", invokeResponse.Data.ToString());
+                Assert.Null(invokeResponse.Error);
+            });
+            yield return GetData(new { type = "invokeResponse", invocationId = "inv-2", success = false, error = new { name = "BadRequest", message = "oops" } }, message =>
+            {
+                Assert.True(message is InvokeResponseMessage);
+                var invokeResponse = message as InvokeResponseMessage;
+                Assert.AreEqual("inv-2", invokeResponse.InvocationId);
+                Assert.False(invokeResponse.Success);
+                Assert.AreEqual("BadRequest", invokeResponse.Error.Name);
+                Assert.AreEqual("oops", invokeResponse.Error.Message);
+            });
+            yield return GetData(new { type = "invokeResponse", invocationId = "inv-3", success = true, dataType = "json", data = new { key = "value" } }, message =>
+            {
+                Assert.True(message is InvokeResponseMessage);
+                var invokeResponse = message as InvokeResponseMessage;
+                Assert.AreEqual("inv-3", invokeResponse.InvocationId);
+                Assert.True(invokeResponse.Success);
+                Assert.AreEqual(WebPubSubDataType.Json, invokeResponse.DataType);
+                Assert.IsNotNull(invokeResponse.Data);
+            });
         }
 
         public static IEnumerable<object[]> GetSerializingTestData()
@@ -147,6 +175,10 @@ namespace Azure.Messaging.WebPubSub.Client.Tests.Protocols
             yield return GetData(new SendEventMessage("event", BinaryData.FromBytes(Convert.FromBase64String("eHl6")), WebPubSubDataType.Protobuf, 738476327894), new { type = "event", @event = "event", ackId = 738476327894u, dataType = "Protobuf", data = "eHl6" });
             yield return GetData(new SequenceAckMessage(123), new { type = "sequenceAck", sequenceId = 123 });
             yield return GetData(new SequenceAckMessage(738476327894), new { type = "sequenceAck", sequenceId = 738476327894u });
+            yield return GetData(new InvokeMessage("inv-1", "echo", BinaryData.FromString("ping"), WebPubSubDataType.Text), new { type = "invoke", invocationId = "inv-1", target = "event", @event = "echo", dataType = "Text", data = "ping" });
+            yield return GetData(new InvokeMessage("inv-2", "process", BinaryData.FromObjectAsJson(new JsonData { Value = "xyz" }), WebPubSubDataType.Json), new { type = "invoke", invocationId = "inv-2", target = "event", @event = "process", dataType = "Json", data = new { Value = "xyz" } });
+            yield return GetData(new InvokeMessage("inv-3", "upload", BinaryData.FromBytes(Convert.FromBase64String("eHl6")), WebPubSubDataType.Binary), new { type = "invoke", invocationId = "inv-3", target = "event", @event = "upload", dataType = "Binary", data = "eHl6" });
+            yield return GetData(new CancelInvocationMessage("inv-cancel"), new { type = "cancelInvocation", invocationId = "inv-cancel" });
         }
 
         [TestCaseSource(nameof(GetParsingTestData))]

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Samples/WebPubSubClientSample.HelloWorld.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Samples/WebPubSubClientSample.HelloWorld.cs
@@ -158,5 +158,27 @@ namespace Azure.Messaging.WebPubSub.Client.Tests
             await client.SendEventAsync("testEvent", BinaryData.FromString("hello world"), WebPubSubDataType.Text);
             #endregion
         }
+
+        public async Task WebPubSubClientInvokeEvent(WebPubSubClient client)
+        {
+            #region Snippet:WebPubSubClient_InvokeEvent
+            var result = await client.InvokeEventAsync("processOrder", BinaryData.FromObjectAsJson(new { orderId = 1 }), WebPubSubDataType.Json);
+            Console.WriteLine($"Invocation result: {result.Data}");
+            #endregion
+        }
+
+        public async Task WebPubSubClientHandleInvokeEventFailure(WebPubSubClient client)
+        {
+            #region Snippet:WebPubSubClient_InvokeEventFailure
+            try
+            {
+                await client.InvokeEventAsync("processOrder", BinaryData.FromObjectAsJson(new { orderId = 1 }), WebPubSubDataType.Json);
+            }
+            catch (InvocationFailedException ex)
+            {
+                Console.WriteLine($"Invocation {ex.InvocationId} failed: {ex.Message}, Code: {ex.Code}");
+            }
+            #endregion
+        }
     }
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Samples/WebPubSubClientSample.HelloWorld.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/Samples/WebPubSubClientSample.HelloWorld.cs
@@ -180,5 +180,21 @@ namespace Azure.Messaging.WebPubSub.Client.Tests
             }
             #endregion
         }
+
+        public async Task WebPubSubClientInvokeEventTimeout(WebPubSubClient client)
+        {
+            #region Snippet:WebPubSubClient_InvokeEventTimeout
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            try
+            {
+                var result = await client.InvokeEventAsync("processOrder", BinaryData.FromObjectAsJson(new { orderId = 1 }), WebPubSubDataType.Json, cancellationToken: cts.Token);
+                Console.WriteLine($"Invocation result: {result.Data}");
+            }
+            catch (OperationCanceledException)
+            {
+                Console.WriteLine("Invocation timed out and was cancelled.");
+            }
+            #endregion
+        }
     }
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/WebPubSubClientInvokeEventTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/WebPubSubClientInvokeEventTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+using Azure.Messaging.WebPubSub.Client.Tests.Utils;
+using Azure.Messaging.WebPubSub.Clients;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.WebPubSub.Client.Tests
+{
+    [Parallelizable(ParallelScope.Self)]
+    [TestFixture]
+    public class WebPubSubClientInvokeEventTests
+    {
+        private Mock<IWebSocketClient> _webSocketClientMoc;
+        private Mock<IWebSocketClientFactory> _factoryMoc;
+        private WebPubSubProtocol _protocol;
+
+        [SetUp]
+        public void Setup()
+        {
+            _protocol = new WebPubSubJsonReliableProtocol();
+            _webSocketClientMoc = new Mock<IWebSocketClient>();
+            _webSocketClientMoc.SetReturnsDefault(Task.CompletedTask);
+            _webSocketClientMoc.Setup(c => c.ReceiveOneFrameAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(async token =>
+            {
+                await Task.Delay(int.MaxValue).AwaitWithCancellation(token);
+                return new WebSocketReadResult(new ReadOnlySequence<byte>(), false);
+            });
+            _factoryMoc = new Mock<IWebSocketClientFactory>();
+            _factoryMoc.Setup(f => f.CreateWebSocketClient(It.IsAny<Uri>(), It.IsAny<string>())).Returns(_webSocketClientMoc.Object);
+        }
+
+        [Test]
+        public async Task InvokeEventResolvesWithInvokeResponsePayload()
+        {
+            var clientMoc = new Mock<WebPubSubClient>(new Uri("wss://test.com"), new WebPubSubClientOptions() { AutoReconnect = false });
+            clientMoc.CallBase = true;
+            clientMoc.Setup(c => c.SendCoreAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebPubSubProtocolMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(() =>
+            {
+                return Task.CompletedTask;
+            });
+            var client = clientMoc.Object;
+            client.WebSocketClientFactory = _factoryMoc.Object;
+
+            var t = client.InvokeEventAttemptAsync("echo", BinaryData.FromString("ping"), WebPubSubDataType.Text, "invoke-1", default);
+            TestUtils.AssertTimeout(t);
+
+            client.HandleInvokeResponseMessage(new InvokeResponseMessage("invoke-1", true, WebPubSubDataType.Text, BinaryData.FromString("pong"), null));
+            var result = await t.OrTimeout();
+
+            Assert.AreEqual("invoke-1", result.InvocationId);
+            Assert.AreEqual(WebPubSubDataType.Text, result.DataType);
+            Assert.AreEqual("pong", result.Data.ToString());
+        }
+
+        [Test]
+        public void InvokeEventRejectsWhenServiceReturnsError()
+        {
+            var clientMoc = new Mock<WebPubSubClient>(new Uri("wss://test.com"), new WebPubSubClientOptions() { AutoReconnect = false });
+            clientMoc.CallBase = true;
+            clientMoc.Setup(c => c.SendCoreAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebPubSubProtocolMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(() =>
+            {
+                return Task.CompletedTask;
+            });
+            var client = clientMoc.Object;
+            client.WebSocketClientFactory = _factoryMoc.Object;
+
+            var t = client.InvokeEventAttemptAsync("echo", BinaryData.FromString("ping"), WebPubSubDataType.Text, "invoke-error", default);
+            TestUtils.AssertTimeout(t);
+
+            client.HandleInvokeResponseMessage(new InvokeResponseMessage("invoke-error", false, null, null, new InvokeResponseError("BadRequest", "oops")));
+            var ex = Assert.ThrowsAsync<InvocationFailedException>(() => t);
+            Assert.AreEqual("invoke-error", ex.InvocationId);
+            Assert.AreEqual("BadRequest", ex.Code);
+            Assert.AreEqual("oops", ex.Message);
+        }
+
+        [Test]
+        public async Task InvokeEventWithJsonResponsePayload()
+        {
+            var clientMoc = new Mock<WebPubSubClient>(new Uri("wss://test.com"), new WebPubSubClientOptions() { AutoReconnect = false });
+            clientMoc.CallBase = true;
+            clientMoc.Setup(c => c.SendCoreAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebPubSubProtocolMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(() =>
+            {
+                return Task.CompletedTask;
+            });
+            var client = clientMoc.Object;
+            client.WebSocketClientFactory = _factoryMoc.Object;
+
+            var t = client.InvokeEventAttemptAsync("echo", BinaryData.FromObjectAsJson(new { key = "value" }), WebPubSubDataType.Json, "invoke-json", default);
+            TestUtils.AssertTimeout(t);
+
+            client.HandleInvokeResponseMessage(new InvokeResponseMessage("invoke-json", true, WebPubSubDataType.Json, BinaryData.FromObjectAsJson(new { key = "value" }), null));
+            var result = await t.OrTimeout();
+
+            Assert.AreEqual("invoke-json", result.InvocationId);
+            Assert.AreEqual(WebPubSubDataType.Json, result.DataType);
+            Assert.IsNotNull(result.Data);
+        }
+
+        [Test]
+        public void InvokeEventCancellationThrowsOperationCanceledException()
+        {
+            var clientMoc = new Mock<WebPubSubClient>(new Uri("wss://test.com"), new WebPubSubClientOptions() { AutoReconnect = false });
+            clientMoc.CallBase = true;
+            clientMoc.Setup(c => c.SendCoreAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<WebPubSubProtocolMessageType>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(() =>
+            {
+                return Task.CompletedTask;
+            });
+            var client = clientMoc.Object;
+            client.WebSocketClientFactory = _factoryMoc.Object;
+
+            using var cts = new CancellationTokenSource();
+            var task = client.InvokeEventAttemptAsync("echo", BinaryData.FromString("ping"), WebPubSubDataType.Text, "invoke-cancel", cts.Token);
+
+            cts.Cancel();
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
+        }
+
+        [Test]
+        public async Task InvokeEventSendMessageTest()
+        {
+            var tcs = new MultipleTimesTaskCompletionSource<WebPubSubMessage>(100);
+            var webSocketClientMoc = new Mock<IWebSocketClient>();
+            webSocketClientMoc.SetReturnsDefault(Task.CompletedTask);
+            webSocketClientMoc.Setup(c => c.ReceiveOneFrameAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(async token =>
+            {
+                await Task.Delay(int.MaxValue).AwaitWithCancellation(token);
+                return new WebSocketReadResult(new ReadOnlySequence<byte>(), false);
+            });
+            var factoryMoc = new Mock<IWebSocketClientFactory>();
+            factoryMoc.Setup(f => f.CreateWebSocketClient(It.IsAny<Uri>(), It.IsAny<string>())).Returns(webSocketClientMoc.Object);
+            var protocolMoc = new Mock<WebPubSubProtocol>();
+            protocolMoc.Setup(p => p.GetMessageBytes(It.IsAny<WebPubSubMessage>())).Returns<WebPubSubMessage>(msg =>
+            {
+                tcs.IncreaseCallTimes(msg);
+                return default;
+            });
+            var wpsClient = new WebPubSubClient(new Uri("wss://test.com"), new WebPubSubClientOptions() { Protocol = protocolMoc.Object });
+
+            // Fire and forget - we just want to verify the message is sent
+            _ = wpsClient.InvokeEventAttemptAsync("event", BinaryData.FromString("text"), WebPubSubDataType.Text, "test-invoke-id", default);
+            var msg = (InvokeMessage)await tcs.VerifyCalledTimesAsync(1).OrTimeout();
+            Assert.AreEqual("event", msg.EventName);
+            Assert.AreEqual("text", msg.Data.ToString());
+            Assert.AreEqual(WebPubSubDataType.Text, msg.DataType);
+            Assert.AreEqual("test-invoke-id", msg.InvocationId);
+        }
+    }
+}

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/WebPubSubClientTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/WebPubSubClientTests.cs
@@ -417,6 +417,48 @@ namespace Azure.Messaging.WebPubSub.Client.Tests
             tcs.AssertNoMoreCalls();
         }
 
+        [Test]
+        public async Task InvokeEventRetryTest()
+        {
+            var tcs = new MultipleTimesTaskCompletionSource<object>(10);
+
+            var clientMoc = new Mock<WebPubSubClient>(new Uri("wss://test.com"), TestUtils.GetClientOptionsForRetryTest());
+            clientMoc.Setup(c => c.InvokeEventAttemptAsync(It.IsAny<string>(), It.IsAny<BinaryData>(), It.IsAny<WebPubSubDataType>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
+            {
+                tcs.IncreaseCallTimes(null);
+                throw new SendMessageFailedException("msg", null, string.Empty);
+            });
+            clientMoc.CallBase = true;
+            var client = clientMoc.Object;
+
+            Assert.ThrowsAsync<SendMessageFailedException>(() => client.InvokeEventAsync("event", BinaryData.FromString("text"), WebPubSubDataType.Text));
+            await tcs.VerifyCalledTimesAsync(1).OrTimeout();
+            await tcs.VerifyCalledTimesAsync(2).OrTimeout();
+            await tcs.VerifyCalledTimesAsync(3).OrTimeout();
+            await tcs.VerifyCalledTimesAsync(4).OrTimeout();
+            tcs.AssertNoMoreCalls();
+        }
+
+        [Test]
+        public async Task InvokeEventNoRetryOnInvocationFailureTest()
+        {
+            var tcs = new MultipleTimesTaskCompletionSource<object>(10);
+
+            var clientMoc = new Mock<WebPubSubClient>(new Uri("wss://test.com"), TestUtils.GetClientOptionsForRetryTest());
+            clientMoc.Setup(c => c.InvokeEventAttemptAsync(It.IsAny<string>(), It.IsAny<BinaryData>(), It.IsAny<WebPubSubDataType>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
+            {
+                tcs.IncreaseCallTimes(null);
+                throw new InvocationFailedException("invocation failed", "invoke-1", string.Empty);
+            });
+            clientMoc.CallBase = true;
+            var client = clientMoc.Object;
+
+            Assert.ThrowsAsync<InvocationFailedException>(() => client.InvokeEventAsync("event", BinaryData.FromString("text"), WebPubSubDataType.Text));
+            await tcs.VerifyCalledTimesAsync(1).OrTimeout();
+            TestUtils.AssertTimeout(tcs.VerifyCalledTimesAsync(2));
+            tcs.AssertNoMoreCalls();
+        }
+
         private TaskCompletionSource<object> NewTcs() => new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/WebPubSubClientTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub.Client/tests/WebPubSubClientTests.cs
@@ -448,7 +448,7 @@ namespace Azure.Messaging.WebPubSub.Client.Tests
             clientMoc.Setup(c => c.InvokeEventAttemptAsync(It.IsAny<string>(), It.IsAny<BinaryData>(), It.IsAny<WebPubSubDataType>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(() =>
             {
                 tcs.IncreaseCallTimes(null);
-                throw new InvocationFailedException("invocation failed", "invoke-1", string.Empty);
+                throw new InvocationFailedException("invocation failed", "invoke-1", "BadRequest");
             });
             clientMoc.CallBase = true;
             var client = clientMoc.Object;


### PR DESCRIPTION
Add `InvokeEventAsync` to `WebPubSubClient`, enabling callers to invoke an upstream event and asynchronously await a correlated response. 

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
