### PR TITLE
[CU-SDK] Remove ignore link for CU SDK

### DIFF
--- a/eng/ignore-links.txt
+++ b/eng/ignore-links.txt
@@ -11,4 +11,3 @@ https://www.nuget.org/packages/Azure.Monitor.Query.Logs
 https://learn.microsoft.com/dotnet/api/azure.monitor.query.logs.logsqueryclient.queryworkspaceasync
 https://www.nuget.org/packages/Azure.Monitor.Query.Metrics
 https://learn.microsoft.com/dotnet/api/overview/azure/monitor.query.metrics-readme?view=azure-dotnet
-https://learn.microsoft.com/dotnet/api/azure.ai.contentunderstanding


### PR DESCRIPTION
The Azure AI Content Understanding .NET SDK is now GA, so the API docs page at https://learn.microsoft.com/dotnet/api/azure.ai.contentunderstanding is now live. This link no longer needs to be suppressed in the link checker.

This PR removes the ignore-links entry that was added during the preview/beta phase when the docs page didn't exist yet.
