### PR TITLE
Add Configuration and DI support to Azure.ResourceManager

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.net10.0.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.net10.0.cs
@@ -6,6 +6,8 @@ namespace Azure.ResourceManager
         public ArmClient(Azure.Core.TokenCredential credential) { }
         public ArmClient(Azure.Core.TokenCredential credential, string defaultSubscriptionId) { }
         public ArmClient(Azure.Core.TokenCredential credential, string defaultSubscriptionId, Azure.ResourceManager.ArmClientOptions options) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public ArmClient(Azure.ResourceManager.ArmClientSettings settings) { }
         public virtual T GetCachedClient<T>(System.Func<Azure.ResourceManager.ArmClient, T> clientFactory) where T : class { throw null; }
         public virtual Azure.ResourceManager.Resources.DataPolicyManifestResource GetDataPolicyManifestResource(Azure.Core.ResourceIdentifier id) { throw null; }
         public virtual Azure.ResourceManager.Resources.SubscriptionResource GetDefaultSubscription(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -46,6 +48,14 @@ namespace Azure.ResourceManager
         public Azure.ResourceManager.ArmEnvironment? Environment { get { throw null; } set { } }
         public void SetApiVersion(Azure.Core.ResourceType resourceType, string apiVersion) { }
         public void SetApiVersionsFromProfile(Azure.ResourceManager.AzureStackProfile profile) { }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+    public partial class ArmClientSettings : System.ClientModel.Primitives.ClientSettings
+    {
+        public ArmClientSettings() { }
+        public string? DefaultSubscriptionId { get { throw null; } set { } }
+        public Azure.ResourceManager.ArmClientOptions? Options { get { throw null; } set { } }
+        protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
     }
     public abstract partial class ArmCollection
     {

--- a/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.net8.0.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.net8.0.cs
@@ -6,6 +6,8 @@ namespace Azure.ResourceManager
         public ArmClient(Azure.Core.TokenCredential credential) { }
         public ArmClient(Azure.Core.TokenCredential credential, string defaultSubscriptionId) { }
         public ArmClient(Azure.Core.TokenCredential credential, string defaultSubscriptionId, Azure.ResourceManager.ArmClientOptions options) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public ArmClient(Azure.ResourceManager.ArmClientSettings settings) { }
         public virtual T GetCachedClient<T>(System.Func<Azure.ResourceManager.ArmClient, T> clientFactory) where T : class { throw null; }
         public virtual Azure.ResourceManager.Resources.DataPolicyManifestResource GetDataPolicyManifestResource(Azure.Core.ResourceIdentifier id) { throw null; }
         public virtual Azure.ResourceManager.Resources.SubscriptionResource GetDefaultSubscription(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -46,6 +48,14 @@ namespace Azure.ResourceManager
         public Azure.ResourceManager.ArmEnvironment? Environment { get { throw null; } set { } }
         public void SetApiVersion(Azure.Core.ResourceType resourceType, string apiVersion) { }
         public void SetApiVersionsFromProfile(Azure.ResourceManager.AzureStackProfile profile) { }
+    }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+    public partial class ArmClientSettings : System.ClientModel.Primitives.ClientSettings
+    {
+        public ArmClientSettings() { }
+        public string? DefaultSubscriptionId { get { throw null; } set { } }
+        public Azure.ResourceManager.ArmClientOptions? Options { get { throw null; } set { } }
+        protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
     }
     public abstract partial class ArmCollection
     {

--- a/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/api/Azure.ResourceManager.netstandard2.0.cs
@@ -6,6 +6,7 @@ namespace Azure.ResourceManager
         public ArmClient(Azure.Core.TokenCredential credential) { }
         public ArmClient(Azure.Core.TokenCredential credential, string defaultSubscriptionId) { }
         public ArmClient(Azure.Core.TokenCredential credential, string defaultSubscriptionId, Azure.ResourceManager.ArmClientOptions options) { }
+        public ArmClient(Azure.ResourceManager.ArmClientSettings settings) { }
         public virtual T GetCachedClient<T>(System.Func<Azure.ResourceManager.ArmClient, T> clientFactory) where T : class { throw null; }
         public virtual Azure.ResourceManager.Resources.DataPolicyManifestResource GetDataPolicyManifestResource(Azure.Core.ResourceIdentifier id) { throw null; }
         public virtual Azure.ResourceManager.Resources.SubscriptionResource GetDefaultSubscription(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -46,6 +47,13 @@ namespace Azure.ResourceManager
         public Azure.ResourceManager.ArmEnvironment? Environment { get { throw null; } set { } }
         public void SetApiVersion(Azure.Core.ResourceType resourceType, string apiVersion) { }
         public void SetApiVersionsFromProfile(Azure.ResourceManager.AzureStackProfile profile) { }
+    }
+    public partial class ArmClientSettings : System.ClientModel.Primitives.ClientSettings
+    {
+        public ArmClientSettings() { }
+        public string? DefaultSubscriptionId { get { throw null; } set { } }
+        public Azure.ResourceManager.ArmClientOptions? Options { get { throw null; } set { } }
+        protected override void BindCore(Microsoft.Extensions.Configuration.IConfigurationSection section) { }
     }
     public abstract partial class ArmCollection
     {

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmClient.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -86,6 +87,17 @@ namespace Azure.ResourceManager
             _tenant = new TenantResource(this);
             _defaultSubscription = string.IsNullOrWhiteSpace(defaultSubscriptionId) ? null :
                 new SubscriptionResource(this, SubscriptionResource.CreateResourceIdentifier(defaultSubscriptionId));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArmClient"/> class.
+        /// </summary>
+        /// <param name="settings"> The settings used to configure the client. </param>
+        /// <exception cref="ArgumentNullException"> If <paramref name="settings"/> is null. </exception>
+        [Experimental("SCME0002")]
+        public ArmClient(ArmClientSettings settings)
+            : this(settings?.CredentialProvider as TokenCredential, settings?.DefaultSubscriptionId, settings?.Options)
+        {
         }
 
         internal virtual bool CanUseTagResource(CancellationToken cancellationToken = default)

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientOptions.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientOptions.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
 using Azure.Core;
 using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
+using Microsoft.Extensions.Configuration;
 
 namespace Azure.ResourceManager
 {
@@ -25,6 +27,38 @@ namespace Azure.ResourceManager
         /// Gets or sets Azure cloud environment.
         /// </summary>
         public ArmEnvironment? Environment { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArmClientOptions"/> class.
+        /// </summary>
+        public ArmClientOptions()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ArmClientOptions"/> from a <see cref="IConfigurationSection"/>.
+        /// </summary>
+        /// <param name="section">The <see cref="IConfigurationSection"/> to read from.</param>
+        [Experimental("SCME0002")]
+        internal ArmClientOptions(IConfigurationSection section)
+            : base(section, null)
+        {
+            if (section is null || !section.Exists())
+            {
+                return;
+            }
+
+            IConfigurationSection envSection = section.GetSection(nameof(Environment));
+            if (envSection.Exists())
+            {
+                string endpoint = envSection[nameof(ArmEnvironment.Endpoint)];
+                string audience = envSection[nameof(ArmEnvironment.Audience)];
+                if (!string.IsNullOrEmpty(endpoint) && !string.IsNullOrEmpty(audience))
+                {
+                    Environment = new ArmEnvironment(new Uri(endpoint), audience);
+                }
+            }
+        }
 
         /// <summary>
         /// Sets the api version to use for a given resource type.

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientSettings.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientSettings.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.ClientModel.Primitives;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;

--- a/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientSettings.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/src/ArmClientSettings.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Configuration;
+
+#nullable enable
+
+namespace Azure.ResourceManager
+{
+    /// <summary>
+    /// Represents the settings used to configure an <see cref="ArmClient"/> that can be loaded from an <see cref="IConfigurationSection"/>.
+    /// </summary>
+    [Experimental("SCME0002")]
+    public class ArmClientSettings : ClientSettings
+    {
+        /// <summary>
+        /// Gets or sets the default Azure subscription ID.
+        /// </summary>
+        public string? DefaultSubscriptionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ArmClientOptions"/> used to configure the <see cref="ArmClient"/>.
+        /// </summary>
+        public ArmClientOptions? Options { get; set; }
+
+        /// <inheritdoc/>
+        protected override void BindCore(IConfigurationSection section)
+        {
+            if (section is null || !section.Exists())
+            {
+                return;
+            }
+
+            if (section[nameof(DefaultSubscriptionId)] is string defaultSubscriptionId)
+            {
+                DefaultSubscriptionId = defaultSubscriptionId;
+            }
+
+            IConfigurationSection optionsSection = section.GetSection(nameof(Options));
+            if (optionsSection.Exists())
+            {
+                Options = new ArmClientOptions(optionsSection);
+            }
+        }
+    }
+}

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/Azure.ResourceManager.Tests.csproj
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/Azure.ResourceManager.Tests.csproj
@@ -10,6 +10,7 @@
 
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 

--- a/sdk/resourcemanager/Azure.ResourceManager/tests/Unit/ArmClientSettingsTests.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager/tests/Unit/ArmClientSettingsTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma warning disable SCME0002 // Type is for evaluation purposes only
+
+using System;
+using System.ClientModel;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+
+namespace Azure.ResourceManager.Tests
+{
+    public class ArmClientSettingsTests
+    {
+        [Test]
+        public void BindLoadsDefaultSubscriptionId()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:DefaultSubscriptionId"] = "00000000-0000-0000-0000-000000000001"
+                })
+                .Build();
+
+            ArmClientSettings settings = config.GetClientSettings<ArmClientSettings>("Client");
+
+            Assert.That(settings.DefaultSubscriptionId, Is.EqualTo("00000000-0000-0000-0000-000000000001"));
+        }
+
+        [Test]
+        public void BindLoadsOptions()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Options:Environment:Endpoint"] = "https://management.chinacloudapi.cn",
+                    ["Client:Options:Environment:Audience"] = "https://management.chinacloudapi.cn"
+                })
+                .Build();
+
+            ArmClientSettings settings = config.GetClientSettings<ArmClientSettings>("Client");
+
+            Assert.That(settings.Options, Is.Not.Null);
+            Assert.That(settings.Options.Environment.HasValue, Is.True);
+            Assert.That(settings.Options.Environment.Value.Endpoint, Is.EqualTo(new Uri("https://management.chinacloudapi.cn")));
+            Assert.That(settings.Options.Environment.Value.Audience, Is.EqualTo("https://management.chinacloudapi.cn"));
+        }
+
+        [Test]
+        public void BindLoadsCredential()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Credential:CredentialSource"] = "ManagedIdentity"
+                })
+                .Build();
+
+            ArmClientSettings settings = config.GetClientSettings<ArmClientSettings>("Client");
+
+            Assert.That(settings.Credential, Is.Not.Null);
+            Assert.That(settings.Credential.CredentialSource, Is.EqualTo("ManagedIdentity"));
+        }
+
+        [Test]
+        public void BindLoadsAllPropertiesTogether()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:DefaultSubscriptionId"] = "00000000-0000-0000-0000-000000000002",
+                    ["Client:Options:Environment:Endpoint"] = "https://management.usgovcloudapi.net",
+                    ["Client:Options:Environment:Audience"] = "https://management.usgovcloudapi.net",
+                    ["Client:Credential:CredentialSource"] = "ManagedIdentity"
+                })
+                .Build();
+
+            ArmClientSettings settings = config.GetClientSettings<ArmClientSettings>("Client");
+
+            Assert.That(settings.DefaultSubscriptionId, Is.EqualTo("00000000-0000-0000-0000-000000000002"));
+            Assert.That(settings.Options, Is.Not.Null);
+            Assert.That(settings.Options.Environment.HasValue, Is.True);
+            Assert.That(settings.Options.Environment.Value.Endpoint, Is.EqualTo(new Uri("https://management.usgovcloudapi.net")));
+            Assert.That(settings.Options.Environment.Value.Audience, Is.EqualTo("https://management.usgovcloudapi.net"));
+            Assert.That(settings.Credential, Is.Not.Null);
+            Assert.That(settings.Credential.CredentialSource, Is.EqualTo("ManagedIdentity"));
+        }
+
+        [Test]
+        public void BindHandlesMissingOptionalProperties()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:DefaultSubscriptionId"] = "00000000-0000-0000-0000-000000000003"
+                })
+                .Build();
+
+            ArmClientSettings settings = config.GetClientSettings<ArmClientSettings>("Client");
+
+            Assert.That(settings.DefaultSubscriptionId, Is.EqualTo("00000000-0000-0000-0000-000000000003"));
+            Assert.That(settings.Options, Is.Null);
+        }
+
+        [Test]
+        public void BindHandlesMissingSubscriptionId()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Options:Environment:Endpoint"] = "https://management.azure.com",
+                    ["Client:Options:Environment:Audience"] = "https://management.azure.com/"
+                })
+                .Build();
+
+            ArmClientSettings settings = config.GetClientSettings<ArmClientSettings>("Client");
+
+            Assert.That(settings.DefaultSubscriptionId, Is.Null);
+            Assert.That(settings.Options, Is.Not.Null);
+        }
+
+        [Test]
+        public void BindHandlesMissingSection()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>())
+                .Build();
+
+            ArmClientSettings settings = config.GetClientSettings<ArmClientSettings>("NonExistentSection");
+
+            Assert.That(settings, Is.Not.Null);
+            Assert.That(settings.DefaultSubscriptionId, Is.Null);
+            Assert.That(settings.Options, Is.Null);
+            Assert.That(settings.Credential, Is.Not.Null);
+        }
+
+        [Test]
+        public void EnvironmentNotSetWhenPartialConfig()
+        {
+            IConfigurationRoot config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["Client:Options:Environment:Endpoint"] = "https://management.azure.com"
+                })
+                .Build();
+
+            ArmClientSettings settings = config.GetClientSettings<ArmClientSettings>("Client");
+
+            Assert.That(settings.Options, Is.Not.Null);
+            Assert.That(settings.Options.Environment.HasValue, Is.False);
+        }
+
+        [Test]
+        public void DefaultSubscriptionIdCanBeSetDirectly()
+        {
+            var settings = new ArmClientSettings
+            {
+                DefaultSubscriptionId = "00000000-0000-0000-0000-000000000004"
+            };
+
+            Assert.That(settings.DefaultSubscriptionId, Is.EqualTo("00000000-0000-0000-0000-000000000004"));
+        }
+
+        [Test]
+        public void OptionsCanBeSetDirectly()
+        {
+            var options = new ArmClientOptions();
+            var settings = new ArmClientSettings
+            {
+                Options = options
+            };
+
+            Assert.That(settings.Options, Is.SameAs(options));
+        }
+
+        [Test]
+        public void CredentialProviderCanBeSetDirectly()
+        {
+            var settings = new ArmClientSettings();
+
+            Assert.That(settings.CredentialProvider, Is.Null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implement the `ClientSettings` pattern for `ArmClient` to enable configuration via `Microsoft.Extensions.Configuration` and registration with `Microsoft.Extensions.DependencyInjection`.

### Changes

- **`ArmClientSettings`** — New class deriving from `ClientSettings` with `DefaultSubscriptionId` and `Options` properties, and `BindCore` override for `IConfigurationSection` binding
- **`ArmClient(ArmClientSettings)`** — New public constructor marked `[Experimental(""SCME0002"")]` that chains to the existing 3-parameter constructor
- **`ArmClientOptions(IConfigurationSection)`** — New internal constructor for config-based initialization, reads `Environment` (Endpoint/Audience) from configuration
- **`ArmClientOptions()`** — Explicit parameterless constructor (previously implicit)
- **Unit tests** — 11 tests covering settings binding, missing sections, partial config, and direct property setters

### Pattern

Follows the same pattern established by `ConfigurationClientSettings` and `SecretClientSettings`.

Resolves #55511