### PR TITLE
Fix config propagation for EnvironmentCredential and WorkloadIdentityCredential properties

### DIFF
--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -117,6 +117,41 @@ namespace Azure.Identity
                 IsAzureProxyEnabled = isAzureProxyEnabled;
             }
 
+            if (section[nameof(EnvironmentCredentialOptions.ClientSecret)] is string clientSecret)
+            {
+                EnvironmentClientSecret = clientSecret;
+            }
+
+            if (section[nameof(EnvironmentCredentialOptions.ClientCertificatePath)] is string clientCertificatePath)
+            {
+                EnvironmentClientCertificatePath = clientCertificatePath;
+            }
+
+            if (section[nameof(EnvironmentCredentialOptions.ClientCertificatePassword)] is string clientCertificatePassword)
+            {
+                EnvironmentClientCertificatePassword = clientCertificatePassword;
+            }
+
+            if (bool.TryParse(section[nameof(EnvironmentCredentialOptions.SendCertificateChain)], out bool sendCertificateChain))
+            {
+                EnvironmentSendCertificateChain = sendCertificateChain;
+            }
+
+            if (section[nameof(EnvironmentCredentialOptions.Username)] is string username)
+            {
+                EnvironmentUsername = username;
+            }
+
+            if (section[nameof(EnvironmentCredentialOptions.Password)] is string password)
+            {
+                EnvironmentPassword = password;
+            }
+
+            if (section[nameof(WorkloadIdentityCredentialOptions.TokenFilePath)] is string tokenFilePath)
+            {
+                WorkloadTokenFilePath = tokenFilePath;
+            }
+
             if (section[nameof(AzurePipelinesServiceConnectionId)] is string azurePipelinesServiceConnectionId)
             {
                 AzurePipelinesServiceConnectionId = azurePipelinesServiceConnectionId;
@@ -546,6 +581,41 @@ namespace Azure.Identity
         /// </summary>
         internal string AzureCloud { get; set; }
 
+        /// <summary>
+        /// Specifies the client secret for the EnvironmentCredential.
+        /// </summary>
+        internal string EnvironmentClientSecret { get; set; }
+
+        /// <summary>
+        /// Specifies the client certificate path for the EnvironmentCredential.
+        /// </summary>
+        internal string EnvironmentClientCertificatePath { get; set; }
+
+        /// <summary>
+        /// Specifies the client certificate password for the EnvironmentCredential.
+        /// </summary>
+        internal string EnvironmentClientCertificatePassword { get; set; }
+
+        /// <summary>
+        /// Specifies whether to send the certificate chain for the EnvironmentCredential.
+        /// </summary>
+        internal bool? EnvironmentSendCertificateChain { get; set; }
+
+        /// <summary>
+        /// Specifies the username for the EnvironmentCredential.
+        /// </summary>
+        internal string EnvironmentUsername { get; set; }
+
+        /// <summary>
+        /// Specifies the password for the EnvironmentCredential.
+        /// </summary>
+        internal string EnvironmentPassword { get; set; }
+
+        /// <summary>
+        /// Specifies the token file path for the WorkloadIdentityCredential.
+        /// </summary>
+        internal string WorkloadTokenFilePath { get; set; }
+
         internal bool DisableAutomaticAuthentication { get; set; }
 
         internal string LoginHint { get; set; }
@@ -622,6 +692,13 @@ namespace Azure.Identity
                 dacClone.TokenCachePersistenceOptions = TokenCachePersistenceOptions;
                 dacClone.UseDefaultBrokerAccount = UseDefaultBrokerAccount;
                 dacClone.IsLegacyMsaPassthroughEnabled = IsLegacyMsaPassthroughEnabled;
+                dacClone.EnvironmentClientSecret = EnvironmentClientSecret;
+                dacClone.EnvironmentClientCertificatePath = EnvironmentClientCertificatePath;
+                dacClone.EnvironmentClientCertificatePassword = EnvironmentClientCertificatePassword;
+                dacClone.EnvironmentSendCertificateChain = EnvironmentSendCertificateChain;
+                dacClone.EnvironmentUsername = EnvironmentUsername;
+                dacClone.EnvironmentPassword = EnvironmentPassword;
+                dacClone.WorkloadTokenFilePath = WorkloadTokenFilePath;
             }
             else if (clone is InteractiveBrowserCredentialOptions ibcClone)
             {

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -259,9 +259,44 @@ namespace Azure.Identity
         {
             var options = Options.Clone<EnvironmentCredentialOptions>();
 
-            if (!string.IsNullOrEmpty(options.TenantId))
+            if (!string.IsNullOrEmpty(Options.TenantId))
             {
                 options.TenantId = Options.TenantId;
+            }
+
+            if (!string.IsNullOrEmpty(Options.ClientId))
+            {
+                options.ClientId = Options.ClientId;
+            }
+
+            if (!string.IsNullOrEmpty(Options.EnvironmentClientSecret))
+            {
+                options.ClientSecret = Options.EnvironmentClientSecret;
+            }
+
+            if (!string.IsNullOrEmpty(Options.EnvironmentClientCertificatePath))
+            {
+                options.ClientCertificatePath = Options.EnvironmentClientCertificatePath;
+            }
+
+            if (!string.IsNullOrEmpty(Options.EnvironmentClientCertificatePassword))
+            {
+                options.ClientCertificatePassword = Options.EnvironmentClientCertificatePassword;
+            }
+
+            if (Options.EnvironmentSendCertificateChain.HasValue)
+            {
+                options.SendCertificateChain = Options.EnvironmentSendCertificateChain.Value;
+            }
+
+            if (!string.IsNullOrEmpty(Options.EnvironmentUsername))
+            {
+                options.Username = Options.EnvironmentUsername;
+            }
+
+            if (!string.IsNullOrEmpty(Options.EnvironmentPassword))
+            {
+                options.Password = Options.EnvironmentPassword;
             }
 
             return new EnvironmentCredential(Pipeline, options);
@@ -275,6 +310,11 @@ namespace Azure.Identity
             options.TenantId = Options.TenantId;
             options.Pipeline = Pipeline;
             options.IsAzureProxyEnabled = Options.IsAzureProxyEnabled;
+
+            if (!string.IsNullOrEmpty(Options.WorkloadTokenFilePath))
+            {
+                options.TokenFilePath = Options.WorkloadTokenFilePath;
+            }
 
             return new WorkloadIdentityCredential(options);
         }

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
@@ -96,6 +96,249 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Environment
 
         [Test]
         [NonParallelizable]
+        public void ClientId_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars(clientId: "env-client-id");
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ClientId"] = "config-client-id";
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                Assert.AreEqual("config-client-id", ReadProperty<string>(inner, "ClientId"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientSecret_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: "env-secret");
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ClientSecret"] = "config-secret";
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                Assert.AreEqual("config-secret", ReadProperty<string>(inner, "ClientSecret"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientSecret_FallsBackToEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: "env-secret");
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var inner = GetInner(GetUnderlying(CreateFromConfig(config)));
+                Assert.AreEqual("env-secret", ReadProperty<string>(inner, "ClientSecret"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientCertificatePath_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_CLIENT_CERTIFICATE_PATH"] = "/env/cert.pem";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ClientCertificatePath"] = "/config/cert.pem";
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as ClientCertificateCredential;
+                Assert.IsNotNull(inner, "Should create a ClientCertificateCredential");
+
+                var provider = ReadProperty<object>(inner, "ClientCertificateProvider");
+                Assert.AreEqual("/config/cert.pem", ReadProperty<string>(provider, "CertificatePath"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientCertificatePath_FallsBackToEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_CLIENT_CERTIFICATE_PATH"] = "/env/cert.pem";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as ClientCertificateCredential;
+                Assert.IsNotNull(inner, "Should create a ClientCertificateCredential");
+
+                var provider = ReadProperty<object>(inner, "ClientCertificateProvider");
+                Assert.AreEqual("/env/cert.pem", ReadProperty<string>(provider, "CertificatePath"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientCertificatePassword_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_CLIENT_CERTIFICATE_PATH"] = "/env/cert.pfx";
+            env["AZURE_CLIENT_CERTIFICATE_PASSWORD"] = "env-password";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:ClientCertificatePassword"] = "config-password";
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as ClientCertificateCredential;
+                Assert.IsNotNull(inner, "Should create a ClientCertificateCredential");
+
+                var provider = ReadProperty<object>(inner, "ClientCertificateProvider");
+                Assert.AreEqual("config-password", ReadProperty<string>(provider, "CertificatePassword"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void ClientCertificatePassword_FallsBackToEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_CLIENT_CERTIFICATE_PATH"] = "/env/cert.pfx";
+            env["AZURE_CLIENT_CERTIFICATE_PASSWORD"] = "env-password";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as ClientCertificateCredential;
+                Assert.IsNotNull(inner, "Should create a ClientCertificateCredential");
+
+                var provider = ReadProperty<object>(inner, "ClientCertificateProvider");
+                Assert.AreEqual("env-password", ReadProperty<string>(provider, "CertificatePassword"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void SendCertificateChain_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_CLIENT_CERTIFICATE_PATH"] = "/env/cert.pem";
+            env["AZURE_CLIENT_SEND_CERTIFICATE_CHAIN"] = "false";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:SendCertificateChain"] = "true";
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as ClientCertificateCredential;
+                Assert.IsNotNull(inner, "Should create a ClientCertificateCredential");
+
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.IsTrue(ReadField<bool>(msal, "_includeX5CClaimHeader"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void SendCertificateChain_FallsBackToEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_CLIENT_CERTIFICATE_PATH"] = "/env/cert.pem";
+            env["AZURE_CLIENT_SEND_CERTIFICATE_CHAIN"] = "true";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as ClientCertificateCredential;
+                Assert.IsNotNull(inner, "Should create a ClientCertificateCredential");
+
+                var msal = ReadProperty<object>(inner, "Client");
+                Assert.IsTrue(ReadField<bool>(msal, "_includeX5CClaimHeader"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void Username_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_USERNAME"] = "env-user";
+            env["AZURE_PASSWORD"] = "env-pass";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:Username"] = "config-user";
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as UsernamePasswordCredential;
+                Assert.IsNotNull(inner, "Should create a UsernamePasswordCredential");
+
+                Assert.AreEqual("config-user", ReadField<string>(inner, "_username"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void Username_FallsBackToEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_USERNAME"] = "env-user";
+            env["AZURE_PASSWORD"] = "env-pass";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as UsernamePasswordCredential;
+                Assert.IsNotNull(inner, "Should create a UsernamePasswordCredential");
+
+                Assert.AreEqual("env-user", ReadField<string>(inner, "_username"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void Password_ConfigWinsOverEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_USERNAME"] = "env-user";
+            env["AZURE_PASSWORD"] = "env-pass";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:Password"] = "config-pass";
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as UsernamePasswordCredential;
+                Assert.IsNotNull(inner, "Should create a UsernamePasswordCredential");
+
+                Assert.AreEqual("config-pass", ReadField<string>(inner, "_password"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void Password_FallsBackToEnvVar()
+        {
+            var env = BaseEnvVars(clientSecret: null);
+            env["AZURE_USERNAME"] = "env-user";
+            env["AZURE_PASSWORD"] = "env-pass";
+            using (new TestEnvVar(env))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+
+                var envCred = GetUnderlying(CreateFromConfig(config));
+                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as UsernamePasswordCredential;
+                Assert.IsNotNull(inner, "Should create a UsernamePasswordCredential");
+
+                Assert.AreEqual("env-pass", ReadField<string>(inner, "_password"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
         public void NoCredential_WhenRequiredEnvVarsMissing()
         {
             var env = BaseEnvVars(tenantId: null, clientId: null, clientSecret: null);

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
@@ -222,6 +222,30 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.WorkloadIdentity
 
         [Test]
         [NonParallelizable]
+        public void TokenFilePath_FromConfigOnly_CreatesCredential()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", null },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:ClientId"] = "test-client";
+                config["MyClient:Credential:TokenFilePath"] = "/config/token";
+
+                var wic = GetUnderlying(CreateFromConfig(config));
+                var tokenFileCache = ReadField<object>(wic, "_tokenFileCache");
+                Assert.IsNotNull(tokenFileCache, "WorkloadIdentityCredential should be created from config-only TokenFilePath");
+
+                Assert.AreEqual("/config/token", ReadField<string>(tokenFileCache, "_tokenFilePath"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
         public void AuthorityHost_ConfigWinsOverEnvVar()
         {
             using (new TestEnvVar(new Dictionary<string, string>

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/WorkloadIdentityCredentialCreationTests.cs
@@ -175,6 +175,53 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.WorkloadIdentity
 
         [Test]
         [NonParallelizable]
+        public void TokenFilePath_ConfigWinsOverEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/env/token" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:ClientId"] = "test-client";
+                config["MyClient:Credential:TokenFilePath"] = "/config/token";
+
+                var wic = GetUnderlying(CreateFromConfig(config));
+                var tokenFileCache = ReadField<object>(wic, "_tokenFileCache");
+                Assert.IsNotNull(tokenFileCache);
+
+                Assert.AreEqual("/config/token", ReadField<string>(tokenFileCache, "_tokenFilePath"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
+        public void TokenFilePath_FallsBackToEnvVar()
+        {
+            using (new TestEnvVar(new Dictionary<string, string>
+            {
+                { "AZURE_TENANT_ID", null },
+                { "AZURE_CLIENT_ID", null },
+                { "AZURE_FEDERATED_TOKEN_FILE", "/env/token" },
+            }))
+            {
+                IConfiguration config = Helper.GetConfiguration();
+                config["MyClient:Credential:TenantId"] = "test-tenant";
+                config["MyClient:Credential:ClientId"] = "test-client";
+
+                var wic = GetUnderlying(CreateFromConfig(config));
+                var tokenFileCache = ReadField<object>(wic, "_tokenFileCache");
+                Assert.IsNotNull(tokenFileCache);
+
+                Assert.AreEqual("/env/token", ReadField<string>(tokenFileCache, "_tokenFilePath"));
+            }
+        }
+
+        [Test]
+        [NonParallelizable]
         public void AuthorityHost_ConfigWinsOverEnvVar()
         {
             using (new TestEnvVar(new Dictionary<string, string>


### PR DESCRIPTION
## Summary

Fixes #56715

All 8 credential properties on `EnvironmentCredentialOptions` and `WorkloadIdentityCredentialOptions` that default to environment variables can now be overridden from `IConfigurationSection`. Config values take priority, with env vars as fallback.

## Properties now settable via config

| # | Property | Credential | Env Var Fallback |
|---|---|---|---|
| 1 | `ClientId` | EnvironmentCredential | `AZURE_CLIENT_ID` |
| 2 | `ClientSecret` | EnvironmentCredential | `AZURE_CLIENT_SECRET` |
| 3 | `ClientCertificatePath` | EnvironmentCredential | `AZURE_CLIENT_CERTIFICATE_PATH` |
| 4 | `ClientCertificatePassword` | EnvironmentCredential | `AZURE_CLIENT_CERTIFICATE_PASSWORD` |
| 5 | `SendCertificateChain` | EnvironmentCredential | `AZURE_CLIENT_SEND_CERTIFICATE_CHAIN` |
| 6 | `Username` | EnvironmentCredential | `AZURE_USERNAME` |
| 7 | `Password` | EnvironmentCredential | `AZURE_PASSWORD` |
| 8 | `TokenFilePath` | WorkloadIdentityCredential | `AZURE_FEDERATED_TOKEN_FILE` |

## Changes

- **DefaultAzureCredentialOptions**: Added 7 internal properties, read them from `IConfigurationSection` in the constructor, propagate in `Clone()`
- **DefaultAzureCredentialFactory**: Propagate properties in `CreateEnvironmentCredential()` and `CreateWorkloadIdentityCredential()`
- **Tests**: Added 14 new tests validating config-wins-over-env-var and fallback-to-env-var behavior for all 8 properties