### PR TITLE
Add AddKeyVaultSecrets extension to Azure.Extensions.AspNetCore.Configuration.Secrets

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `AddKeyVaultSecrets` extension methods on `IConfigurationBuilder` that create a `SecretClient` from configuration using the `Azure.Core` configuration extensions (built on `System.ClientModel`).
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.net10.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.net10.0.cs
@@ -35,5 +35,9 @@ namespace Microsoft.Extensions.Configuration
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager manager) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddKeyVaultSecrets(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string sectionName) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddKeyVaultSecrets(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string sectionName, System.Action<Azure.Security.KeyVault.Secrets.SecretClientSettings> configureSettings) { throw null; }
     }
 }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.net8.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.net8.0.cs
@@ -35,5 +35,9 @@ namespace Microsoft.Extensions.Configuration
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager manager) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddKeyVaultSecrets(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string sectionName) { throw null; }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddKeyVaultSecrets(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string sectionName, System.Action<Azure.Security.KeyVault.Secrets.SecretClientSettings> configureSettings) { throw null; }
     }
 }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/api/Azure.Extensions.AspNetCore.Configuration.Secrets.netstandard2.0.cs
@@ -35,5 +35,7 @@ namespace Microsoft.Extensions.Configuration
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.AzureKeyVaultConfigurationOptions options) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddAzureKeyVault(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, System.Uri vaultUri, Azure.Core.TokenCredential credential, Azure.Extensions.AspNetCore.Configuration.Secrets.KeyVaultSecretManager manager) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddKeyVaultSecrets(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string sectionName) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddKeyVaultSecrets(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string sectionName, System.Action<Azure.Security.KeyVault.Secrets.SecretClientSettings> configureSettings) { throw null; }
     }
 }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
@@ -13,13 +13,13 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <!-- Use package reference after Package.Data.props has a version higher than 4.7.0 -->
-    <!--<PackageReference Include="Azure.Security.KeyVault.Secrets" />-->
-    <ProjectReference Include="..\..\..\keyvault\Azure.Security.KeyVault.Secrets\src\Azure.Security.KeyVault.Secrets.csproj" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="$(AzureCoreSharedSources)Argument.cs" />
+    <Compile Include="$(AzureCoreSharedSources)ExperimentalAttribute.cs" />
   </ItemGroup>
 </Project>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
@@ -152,10 +152,7 @@ namespace Microsoft.Extensions.Configuration
             Action<SecretClientSettings> configureSettings)
         {
             Argument.AssertNotNull(configurationBuilder, nameof(configurationBuilder));
-            if (string.IsNullOrEmpty(sectionName))
-            {
-                throw new ArgumentException("Value cannot be null or empty.", nameof(sectionName));
-            }
+            Argument.AssertNotNullOrEmpty(sectionName, nameof(sectionName));
 
             IConfiguration configuration = configurationBuilder.Build();
             SecretClientSettings settings = configuration.GetAzureClientSettings<SecretClientSettings>(sectionName);

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/AzureKeyVaultConfigurationExtensions.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Azure.Core;
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
+using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 
 namespace Microsoft.Extensions.Configuration
@@ -101,6 +103,66 @@ namespace Microsoft.Extensions.Configuration
             Argument.AssertNotNull(options.Manager, $"{nameof(options)}.{nameof(options.Manager)}");
 
             configurationBuilder.Add(new AzureKeyVaultConfigurationSource(client, options));
+
+            return configurationBuilder;
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from Azure Key Vault.
+        /// The <see cref="SecretClient"/> is created from the specified configuration section using
+        /// <see cref="SecretClientSettings"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method uses the <c>Azure.Core</c> configuration extensions (built on <c>System.ClientModel</c>) to create a
+        /// <see cref="SecretClient"/> from the specified configuration section. The section should contain the <c>VaultUri</c>
+        /// and <c>Credential</c> properties. For more information, see
+        /// <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/docs/ConfigurationAndDependencyInjection.md">Configuration and Dependency Injection for Azure SDK Clients</see>.
+        /// </remarks>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="sectionName">The name of the configuration section that contains the <see cref="SecretClientSettings"/>.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        [Experimental("SCME0002")]
+        public static IConfigurationBuilder AddKeyVaultSecrets(
+            this IConfigurationBuilder configurationBuilder,
+            string sectionName)
+        {
+            return AddKeyVaultSecrets(configurationBuilder, sectionName, null);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from Azure Key Vault.
+        /// The <see cref="SecretClient"/> is created from the specified configuration section using
+        /// <see cref="SecretClientSettings"/>. The <paramref name="configureSettings"/> callback can be used
+        /// to modify the settings before the client is created.
+        /// </summary>
+        /// <remarks>
+        /// This method uses the <c>Azure.Core</c> configuration extensions (built on <c>System.ClientModel</c>) to create a
+        /// <see cref="SecretClient"/> from the specified configuration section. The section should contain the <c>VaultUri</c>
+        /// and <c>Credential</c> properties. For more information, see
+        /// <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/docs/ConfigurationAndDependencyInjection.md">Configuration and Dependency Injection for Azure SDK Clients</see>.
+        /// </remarks>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="sectionName">The name of the configuration section that contains the <see cref="SecretClientSettings"/>.</param>
+        /// <param name="configureSettings">An optional callback to configure the <see cref="SecretClientSettings"/> before the client is created.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        [Experimental("SCME0002")]
+        public static IConfigurationBuilder AddKeyVaultSecrets(
+            this IConfigurationBuilder configurationBuilder,
+            string sectionName,
+            Action<SecretClientSettings> configureSettings)
+        {
+            Argument.AssertNotNull(configurationBuilder, nameof(configurationBuilder));
+            if (string.IsNullOrEmpty(sectionName))
+            {
+                throw new ArgumentException("Value cannot be null or empty.", nameof(sectionName));
+            }
+
+            IConfiguration configuration = configurationBuilder.Build();
+            SecretClientSettings settings = configuration.GetAzureClientSettings<SecretClientSettings>(sectionName);
+            configureSettings?.Invoke(settings);
+
+            SecretClient client = new SecretClient(settings);
+            configurationBuilder.Add(new AzureKeyVaultConfigurationSource(client, new AzureKeyVaultConfigurationOptions()));
 
             return configurationBuilder;
         }

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
@@ -689,6 +689,83 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
                 "Polling task should complete without faulting after disposal");
         }
 
+#pragma warning disable SCME0002
+        [Test]
+        public void AddKeyVaultSecretsThrowsOnNullBuilder()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                AzureKeyVaultConfigurationExtensions.AddKeyVaultSecrets(null, "section"));
+        }
+
+        [Test]
+        public void AddKeyVaultSecretsThrowsOnNullSectionName()
+        {
+            var builder = new ConfigurationBuilder();
+            Assert.Throws<ArgumentException>(() =>
+                builder.AddKeyVaultSecrets(null));
+        }
+
+        [Test]
+        public void AddKeyVaultSecretsThrowsOnEmptySectionName()
+        {
+            var builder = new ConfigurationBuilder();
+            Assert.Throws<ArgumentException>(() =>
+                builder.AddKeyVaultSecrets(string.Empty));
+        }
+
+        [Test]
+        public void AddKeyVaultSecretsAddsConfigurationSource()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["KeyVault:VaultUri"] = "https://myvault.vault.azure.net/",
+                ["KeyVault:Credential:CredentialSource"] = "AzureCliCredential",
+            });
+
+            int sourceCountBefore = builder.Sources.Count;
+            builder.AddKeyVaultSecrets("KeyVault");
+
+            Assert.AreEqual(sourceCountBefore + 1, builder.Sources.Count);
+            Assert.IsInstanceOf<AzureKeyVaultConfigurationSource>(builder.Sources[builder.Sources.Count - 1]);
+        }
+
+        [Test]
+        public void AddKeyVaultSecretsInvokesConfigureCallback()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["KeyVault:VaultUri"] = "https://myvault.vault.azure.net/",
+                ["KeyVault:Credential:CredentialSource"] = "AzureCliCredential",
+            });
+
+            bool callbackInvoked = false;
+            builder.AddKeyVaultSecrets("KeyVault", settings =>
+            {
+                callbackInvoked = true;
+                Assert.IsNotNull(settings);
+            });
+
+            Assert.IsTrue(callbackInvoked);
+        }
+
+        [Test]
+        public void AddKeyVaultSecretsWithCallbackAddsConfigurationSource()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["KeyVault:VaultUri"] = "https://myvault.vault.azure.net/",
+                ["KeyVault:Credential:CredentialSource"] = "AzureCliCredential",
+            });
+
+            builder.AddKeyVaultSecrets("KeyVault", settings => { });
+
+            Assert.IsInstanceOf<AzureKeyVaultConfigurationSource>(builder.Sources[builder.Sources.Count - 1]);
+        }
+#pragma warning restore SCME0002
+
         private class EndsWithOneKeyVaultSecretManager : KeyVaultSecretManager
         {
             public override bool Load(SecretProperties secret)

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/tests/AzureKeyVaultConfigurationTests.cs
@@ -701,7 +701,7 @@ namespace Azure.Extensions.AspNetCore.Configuration.Secrets.Tests
         public void AddKeyVaultSecretsThrowsOnNullSectionName()
         {
             var builder = new ConfigurationBuilder();
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
                 builder.AddKeyVaultSecrets(null));
         }
 


### PR DESCRIPTION
## Description

Adds two new \AddKeyVaultSecrets\ extension methods to the existing \AzureKeyVaultConfigurationExtensions\ class that create a \SecretClient\ from an \IConfiguration\ section using the Azure.Core configuration extensions (built on System.ClientModel).

### New API

\\\csharp
[Experimental("SCME0002")]
public static IConfigurationBuilder AddKeyVaultSecrets(
    this IConfigurationBuilder configurationBuilder, string sectionName);

[Experimental("SCME0002")]
public static IConfigurationBuilder AddKeyVaultSecrets(
    this IConfigurationBuilder configurationBuilder, string sectionName,
    Action<SecretClientSettings> configureSettings);
\\\

### Other Changes

- Converted \Azure.Security.KeyVault.Secrets\ from ProjectReference to PackageReference (v4.9.0 available, above the 4.7.0 threshold noted in the old comment)
- Added \Azure.Identity\ PackageReference for \GetAzureClientSettings<T>()\
- Added \ExperimentalAttribute.cs\ shared source for netstandard2.0 polyfill
- Added 6 tests (3 validation + 3 positive DI-flow tests)

Supersedes #56536

Fixes #55507