### PR TITLE
Prepare Azure.Extensions.AspNetCore.Configuration.Secrets 1.5.0 release

### DIFF
--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/CHANGELOG.md
@@ -1,18 +1,14 @@
 # Release History
 
-## 1.5.0-beta.1 (Unreleased)
+## 1.5.0 (2026-03-04)
 
 ### Features Added
 
 - Added `AddKeyVaultSecrets` extension methods on `IConfigurationBuilder` that create a `SecretClient` from configuration using the `Azure.Core` configuration extensions (built on `System.ClientModel`).
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Handle `OperationCanceledException` in `PollForSecretChangesAsync` so the background polling loop exits cleanly when the provider is disposed.
-
-### Other Changes
 
 ## 1.4.0 (2025-02-11)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Azure Key Vault configuration provider implementation for Microsoft.Extensions.Configuration.</Description>
     <PackageTags>$(PackageTags);azure;keyvault</PackageTags>
-    <Version>1.5.0-beta.1</Version>
+    <Version>1.5.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.4.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);AZC0102</NoWarn>


### PR DESCRIPTION
## Summary

Prepares `Azure.Extensions.AspNetCore.Configuration.Secrets` for the 1.5.0 GA release.

### Changes
- Updated version from `1.5.0-beta.1` to `1.5.0`
- Set release date to `2026-03-04`
- Cleaned up empty changelog sections

Fixes https://github.com/Azure/azure-sdk-for-net/issues/55506