### PR TITLE
Add shared MSBuild infrastructure to auto-pack ConfigurationSchema.json

### DIFF
--- a/eng/ConfigurationSchema.targets
+++ b/eng/ConfigurationSchema.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <JsonSchemaSegment Include="$(MSBuildThisFileDirectory)..\..\ConfigurationSchema.json"
+                       FilePathPattern="appsettings.*.json" />
+  </ItemGroup>
+</Project>

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -142,6 +142,48 @@
     <None Condition="Exists('$(PackageRootDirectory)/CHANGELOG.md')" Include="$(PackageRootDirectory)/CHANGELOG.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
+  <!--
+    ConfigurationSchema.json auto-pack
+    Any shippable client library with a schema/ConfigurationSchema.json (sibling of src/)
+    gets the schema packed at the NuGet package root and a generated .targets file packed into
+    buildTransitive/{tfm}/ that registers the JsonSchemaSegment for appsettings.*.json.
+    Individual packages only need to add the JSON file — no extra MSBuild configuration.
+  -->
+  <PropertyGroup>
+    <ConfigurationSchemaPath>$(PackageRootDirectory)/schema/ConfigurationSchema.json</ConfigurationSchemaPath>
+    <HasConfigurationSchema Condition="'$(IsShippingClientLibrary)' == 'true' and Exists('$(ConfigurationSchemaPath)')">true</HasConfigurationSchema>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(HasConfigurationSchema)' == 'true'">
+    <None Include="$(ConfigurationSchemaPath)" Pack="true" PackagePath="ConfigurationSchema.json" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(HasConfigurationSchema)' == 'true'">
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_PackConfigurationSchemaTargets</TargetsForTfmSpecificContentInPackage>
+    <_ConfigurationSchemaTargetsContent><![CDATA[<Project>
+  <ItemGroup>
+    <JsonSchemaSegment Include="%24(MSBuildThisFileDirectory)..\..\ConfigurationSchema.json"
+                       FilePathPattern="appsettings.*.json" />
+  </ItemGroup>
+</Project>]]></_ConfigurationSchemaTargetsContent>
+  </PropertyGroup>
+
+  <Target Name="_PackConfigurationSchemaTargets">
+    <PropertyGroup>
+      <_ConfigurationSchemaTargetsPath>$(IntermediateOutputPath)$(PackageId).targets</_ConfigurationSchemaTargetsPath>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(_ConfigurationSchemaTargetsPath)"
+                     Lines="$(_ConfigurationSchemaTargetsContent)"
+                     Overwrite="true"
+                     WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(_ConfigurationSchemaTargetsPath)"
+                              PackagePath="buildTransitive/$(TargetFramework)/$(PackageId).targets" />
+    </ItemGroup>
+  </Target>
+
   <!-- Add App.config to enable server GC in net462 perf and stress projects -->
   <ItemGroup Condition="('$(IsPerfProject)' == 'true' or '$(IsStressProject)' == 'true') and '$(TargetFramework)' == 'net462'">
     <None Include="$(RepoRoot)/common/Perf/App.config" />

--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -145,7 +145,7 @@
   <!--
     ConfigurationSchema.json auto-pack
     Any shippable client library with a schema/ConfigurationSchema.json (sibling of src/)
-    gets the schema packed at the NuGet package root and a generated .targets file packed into
+    gets the schema packed at the NuGet package root and a static .targets file packed into
     buildTransitive/{tfm}/ that registers the JsonSchemaSegment for appsettings.*.json.
     Individual packages only need to add the JSON file — no extra MSBuild configuration.
   -->
@@ -160,26 +160,11 @@
 
   <PropertyGroup Condition="'$(HasConfigurationSchema)' == 'true'">
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_PackConfigurationSchemaTargets</TargetsForTfmSpecificContentInPackage>
-    <_ConfigurationSchemaTargetsContent><![CDATA[<Project>
-  <ItemGroup>
-    <JsonSchemaSegment Include="%24(MSBuildThisFileDirectory)..\..\ConfigurationSchema.json"
-                       FilePathPattern="appsettings.*.json" />
-  </ItemGroup>
-</Project>]]></_ConfigurationSchemaTargetsContent>
   </PropertyGroup>
 
   <Target Name="_PackConfigurationSchemaTargets">
-    <PropertyGroup>
-      <_ConfigurationSchemaTargetsPath>$(IntermediateOutputPath)$(PackageId).targets</_ConfigurationSchemaTargetsPath>
-    </PropertyGroup>
-
-    <WriteLinesToFile File="$(_ConfigurationSchemaTargetsPath)"
-                     Lines="$(_ConfigurationSchemaTargetsContent)"
-                     Overwrite="true"
-                     WriteOnlyWhenDifferent="true" />
-
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(_ConfigurationSchemaTargetsPath)"
+      <TfmSpecificPackageFile Include="$(RepoEngPath)/ConfigurationSchema.targets"
                               PackagePath="buildTransitive/$(TargetFramework)/$(PackageId).targets" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
## What

Adds shared packing logic to `eng/Directory.Build.Common.targets` so that any shippable client library with a `ConfigurationSchema.json` in its `schema/` directory automatically gets the schema packed into the NuGet **and** the `JsonSchemaSegment` registration included — all without the individual package needing any extra files or configuration.

## How it works

During pack, the new logic:
1. Checks if the project has a `schema/ConfigurationSchema.json` (sibling of `src/`)
2. Checks if the project is a shippable client library (`IsShippingClientLibrary`)
3. If both conditions are true:
   - Packs `ConfigurationSchema.json` at the NuGet package root
   - Generates a `{PackageId}.targets` file inline (via `WriteLinesToFile`) and packs it into `buildTransitive/{tfm}/` — this file registers the `JsonSchemaSegment` for `appsettings.*.json`

No physical `.targets` file exists in the repo; it's generated at pack time.

## Generated `.targets` content (same for every package)

```xml
<Project>
  <ItemGroup>
    <JsonSchemaSegment Include="$(MSBuildThisFileDirectory)..\\..\ConfigurationSchema.json"
                       FilePathPattern="appsettings.*.json" />
  </ItemGroup>
</Project>
```

## Verification

Tested by adding a temporary `ConfigurationSchema.json` to Azure.Core and running `dotnet pack`. The resulting `.nupkg` correctly contains:
- `ConfigurationSchema.json` at the package root
- `buildTransitive/{tfm}/Azure.Core.targets` for all TFMs with the correct `JsonSchemaSegment` registration

Fixes #56778