### PR TITLE
[Mgmt Generator] Fix RegenSdkLocal.ps1 to work on Linux

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/eng/scripts/Invoke-SdkRegeneration.ps1
+++ b/eng/packages/http-client-csharp-mgmt/eng/scripts/Invoke-SdkRegeneration.ps1
@@ -163,10 +163,11 @@ try {
         Rename-Item $sdkNodeModules $sdkNodeModulesBackup -Force
     }
     
-    # Create junction from TempTypeSpecFiles/node_modules to mgmt package's node_modules
+    # Create symlink from TempTypeSpecFiles/node_modules to mgmt package's node_modules
+    # Use SymbolicLink instead of Junction for cross-platform compatibility (Junction doesn't work on Linux)
     $linkPath = Join-Path $tempTypeSpecDir "node_modules"
     if (Test-Path $linkPath) { Remove-Item $linkPath -Recurse -Force }
-    New-Item -ItemType Junction -Path $linkPath -Target (Join-Path $MgmtPackageRoot "node_modules") | Out-Null
+    New-Item -ItemType SymbolicLink -Path $linkPath -Target (Join-Path $MgmtPackageRoot "node_modules") | Out-Null
     
     try {
         # Run tsp compile using local emitter path

--- a/eng/packages/http-client-csharp-mgmt/eng/scripts/Invoke-SdkRegeneration.ps1
+++ b/eng/packages/http-client-csharp-mgmt/eng/scripts/Invoke-SdkRegeneration.ps1
@@ -163,11 +163,19 @@ try {
         Rename-Item $sdkNodeModules $sdkNodeModulesBackup -Force
     }
     
-    # Create symlink from TempTypeSpecFiles/node_modules to mgmt package's node_modules
-    # Use SymbolicLink instead of Junction for cross-platform compatibility (Junction doesn't work on Linux)
+    # Create a link from TempTypeSpecFiles/node_modules to mgmt package's node_modules
+    # Use Junction on Windows (works without elevation) and SymbolicLink on Linux/macOS
     $linkPath = Join-Path $tempTypeSpecDir "node_modules"
     if (Test-Path $linkPath) { Remove-Item $linkPath -Recurse -Force }
-    New-Item -ItemType SymbolicLink -Path $linkPath -Target (Join-Path $MgmtPackageRoot "node_modules") | Out-Null
+    $linkTarget = Join-Path $MgmtPackageRoot "node_modules"
+    if ($IsWindows) {
+        New-Item -ItemType Junction -Path $linkPath -Target $linkTarget -ErrorAction Stop | Out-Null
+    } else {
+        New-Item -ItemType SymbolicLink -Path $linkPath -Target $linkTarget -ErrorAction Stop | Out-Null
+    }
+    if (-not (Test-Path $linkPath)) {
+        throw "Failed to create link from '$linkPath' to '$linkTarget'"
+    }
     
     try {
         # Run tsp compile using local emitter path


### PR DESCRIPTION
## Fix

`New-Item -ItemType Junction` silently fails on Linux/macOS, causing `RegenSdkLocal.ps1` to fail with `import-not-found` errors because the `TempTypeSpecFiles/node_modules` link is never created.

Changed to `New-Item -ItemType SymbolicLink` which works cross-platform (Windows, Linux, macOS).

## Error before fix

```
FAILED: tsp compile failed: .../client.tsp:1:1 - error import-not-found: Couldn't resolve import "@azure-tools/typespec-client-generator-core"
```

## Testing

Verified `RegenSdkLocal.ps1 -Services Maintenance` succeeds on Linux after the fix.