### PR TITLE
[AppContainers] Fix AppContainersSkuName NullReferenceException

### DIFF
--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.net10.0.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.net10.0.cs
@@ -934,6 +934,7 @@ namespace Azure.ResourceManager.AppContainers
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.AppContainers.ContainerAppPrivateEndpointConnectionData> PrivateEndpointConnections { get { throw null; } }
         public Azure.ResourceManager.AppContainers.Models.ContainerAppEnvironmentProvisioningState? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.AppContainers.Models.ContainerAppPublicNetworkAccess? PublicNetworkAccess { get { throw null; } set { } }
+        [System.ObsoleteAttribute("SkuName is no longer supported by the service and will be removed in a future release.")]
         public Azure.ResourceManager.AppContainers.Models.AppContainersSkuName? SkuName { get { throw null; } set { } }
         public System.Net.IPAddress StaticIP { get { throw null; } }
         public Azure.ResourceManager.AppContainers.Models.ContainerAppVnetConfiguration VnetConfiguration { get { throw null; } set { } }
@@ -1670,6 +1671,7 @@ namespace Azure.ResourceManager.AppContainers.Models
         string System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
+    [System.ObsoleteAttribute("AppContainersSkuName is no longer supported by the service and will be removed in a future release.")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AppContainersSkuName : System.IEquatable<Azure.ResourceManager.AppContainers.Models.AppContainersSkuName>
     {

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.net10.0.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.net10.0.cs
@@ -1670,9 +1670,11 @@ namespace Azure.ResourceManager.AppContainers.Models
         string System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AppContainersSkuName : System.IEquatable<Azure.ResourceManager.AppContainers.Models.AppContainersSkuName>
     {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public AppContainersSkuName(string value) { throw null; }
         public static Azure.ResourceManager.AppContainers.Models.AppContainersSkuName Consumption { get { throw null; } }
         public static Azure.ResourceManager.AppContainers.Models.AppContainersSkuName Premium { get { throw null; } }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.net8.0.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.net8.0.cs
@@ -934,6 +934,7 @@ namespace Azure.ResourceManager.AppContainers
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.AppContainers.ContainerAppPrivateEndpointConnectionData> PrivateEndpointConnections { get { throw null; } }
         public Azure.ResourceManager.AppContainers.Models.ContainerAppEnvironmentProvisioningState? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.AppContainers.Models.ContainerAppPublicNetworkAccess? PublicNetworkAccess { get { throw null; } set { } }
+        [System.ObsoleteAttribute("SkuName is no longer supported by the service and will be removed in a future release.")]
         public Azure.ResourceManager.AppContainers.Models.AppContainersSkuName? SkuName { get { throw null; } set { } }
         public System.Net.IPAddress StaticIP { get { throw null; } }
         public Azure.ResourceManager.AppContainers.Models.ContainerAppVnetConfiguration VnetConfiguration { get { throw null; } set { } }
@@ -1670,6 +1671,7 @@ namespace Azure.ResourceManager.AppContainers.Models
         string System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
+    [System.ObsoleteAttribute("AppContainersSkuName is no longer supported by the service and will be removed in a future release.")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AppContainersSkuName : System.IEquatable<Azure.ResourceManager.AppContainers.Models.AppContainersSkuName>
     {

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.net8.0.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.net8.0.cs
@@ -1670,9 +1670,11 @@ namespace Azure.ResourceManager.AppContainers.Models
         string System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AppContainersSkuName : System.IEquatable<Azure.ResourceManager.AppContainers.Models.AppContainersSkuName>
     {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public AppContainersSkuName(string value) { throw null; }
         public static Azure.ResourceManager.AppContainers.Models.AppContainersSkuName Consumption { get { throw null; } }
         public static Azure.ResourceManager.AppContainers.Models.AppContainersSkuName Premium { get { throw null; } }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.netstandard2.0.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.netstandard2.0.cs
@@ -934,6 +934,7 @@ namespace Azure.ResourceManager.AppContainers
         public System.Collections.Generic.IReadOnlyList<Azure.ResourceManager.AppContainers.ContainerAppPrivateEndpointConnectionData> PrivateEndpointConnections { get { throw null; } }
         public Azure.ResourceManager.AppContainers.Models.ContainerAppEnvironmentProvisioningState? ProvisioningState { get { throw null; } }
         public Azure.ResourceManager.AppContainers.Models.ContainerAppPublicNetworkAccess? PublicNetworkAccess { get { throw null; } set { } }
+        [System.ObsoleteAttribute("SkuName is no longer supported by the service and will be removed in a future release.")]
         public Azure.ResourceManager.AppContainers.Models.AppContainersSkuName? SkuName { get { throw null; } set { } }
         public System.Net.IPAddress StaticIP { get { throw null; } }
         public Azure.ResourceManager.AppContainers.Models.ContainerAppVnetConfiguration VnetConfiguration { get { throw null; } set { } }
@@ -1670,6 +1671,7 @@ namespace Azure.ResourceManager.AppContainers.Models
         string System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
+    [System.ObsoleteAttribute("AppContainersSkuName is no longer supported by the service and will be removed in a future release.")]
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AppContainersSkuName : System.IEquatable<Azure.ResourceManager.AppContainers.Models.AppContainersSkuName>
     {

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.netstandard2.0.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/api/Azure.ResourceManager.AppContainers.netstandard2.0.cs
@@ -1670,9 +1670,11 @@ namespace Azure.ResourceManager.AppContainers.Models
         string System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.ResourceManager.AppContainers.Models.AppContainerResources>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
     }
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, Size=1)]
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public readonly partial struct AppContainersSkuName : System.IEquatable<Azure.ResourceManager.AppContainers.Models.AppContainersSkuName>
     {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public AppContainersSkuName(string value) { throw null; }
         public static Azure.ResourceManager.AppContainers.Models.AppContainersSkuName Consumption { get { throw null; } }
         public static Azure.ResourceManager.AppContainers.Models.AppContainersSkuName Premium { get { throw null; } }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/AppContainersSkuName.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/AppContainersSkuName.cs
@@ -15,6 +15,7 @@ namespace Azure.ResourceManager.AppContainers.Models
 
     /// <summary> Name of the Sku. </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("AppContainersSkuName is no longer supported by the service and will be removed in a future release.")]
     public readonly partial struct AppContainersSkuName : IEquatable<AppContainersSkuName>
     {
         private readonly string _value;
@@ -48,7 +49,7 @@ namespace Azure.ResourceManager.AppContainers.Models
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+        public override int GetHashCode() => _value is null ? 0 : StringComparer.InvariantCultureIgnoreCase.GetHashCode(_value);
         /// <inheritdoc />
         public override string ToString() => _value;
     }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/AppContainersSkuName.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/AppContainersSkuName.cs
@@ -49,7 +49,7 @@ namespace Azure.ResourceManager.AppContainers.Models
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override int GetHashCode() => _value is null ? 0 : StringComparer.InvariantCultureIgnoreCase.GetHashCode(_value);
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
         /// <inheritdoc />
         public override string ToString() => _value;
     }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/AppContainersSkuName.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/AppContainersSkuName.cs
@@ -1,46 +1,55 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//#nullable disable
+#nullable disable
 
+using System;
 using System.ComponentModel;
 
 namespace Azure.ResourceManager.AppContainers.Models
 {
-    /// <summary> this class here is to keep the class public and add the AppContainersSkuName attribute </summary>
+    // This type was removed from the service spec but is preserved here as a hidden member
+    // to avoid breaking existing consumers. The implementation matches the original generated
+    // code before it was removed in commit 04dba6ae.
+    // See https://github.com/Azure/azure-sdk-for-net/issues/56807
+
+    /// <summary> Name of the Sku. </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public readonly partial struct AppContainersSkuName : System.IEquatable<Azure.ResourceManager.AppContainers.Models.AppContainersSkuName>
+    public readonly partial struct AppContainersSkuName : IEquatable<AppContainersSkuName>
     {
-        /// <summary> SkuName for container app. </summary>
-        public AppContainersSkuName(string value) { throw null; }
+        private readonly string _value;
 
-        /// <summary> SkuName for container app. </summary>
-        public static bool operator ==(Azure.ResourceManager.AppContainers.Models.AppContainersSkuName left, Azure.ResourceManager.AppContainers.Models.AppContainersSkuName right) { throw null; }
+        /// <summary> Initializes a new instance of <see cref="AppContainersSkuName"/>. </summary>
+        /// <exception cref="ArgumentNullException"> <paramref name="value"/> is null. </exception>
+        public AppContainersSkuName(string value)
+        {
+            _value = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
-        /// <summary> SkuName for container app. </summary>
-        public static implicit operator Azure.ResourceManager.AppContainers.Models.AppContainersSkuName(string value) { throw null; }
+        private const string ConsumptionValue = "Consumption";
+        private const string PremiumValue = "Premium";
 
-        /// <summary> SkuName for container app. </summary>
-        public static bool operator !=(Azure.ResourceManager.AppContainers.Models.AppContainersSkuName left, Azure.ResourceManager.AppContainers.Models.AppContainersSkuName right) { throw null; }
+        /// <summary> Consumption SKU of Managed Environment. </summary>
+        public static AppContainersSkuName Consumption { get; } = new AppContainersSkuName(ConsumptionValue);
+        /// <summary> Premium SKU of Managed Environment. </summary>
+        public static AppContainersSkuName Premium { get; } = new AppContainersSkuName(PremiumValue);
+        /// <summary> Determines if two <see cref="AppContainersSkuName"/> values are the same. </summary>
+        public static bool operator ==(AppContainersSkuName left, AppContainersSkuName right) => left.Equals(right);
+        /// <summary> Determines if two <see cref="AppContainersSkuName"/> values are not the same. </summary>
+        public static bool operator !=(AppContainersSkuName left, AppContainersSkuName right) => !left.Equals(right);
+        /// <summary> Converts a string to a <see cref="AppContainersSkuName"/>. </summary>
+        public static implicit operator AppContainersSkuName(string value) => new AppContainersSkuName(value);
 
-        /// <summary> SkuName for container app. </summary>
-        public static Azure.ResourceManager.AppContainers.Models.AppContainersSkuName Consumption { get { throw null; } }
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => obj is AppContainersSkuName other && Equals(other);
+        /// <inheritdoc />
+        public bool Equals(AppContainersSkuName other) => string.Equals(_value, other._value, StringComparison.InvariantCultureIgnoreCase);
 
-        /// <summary> SkuName for container app. </summary>
-        public static Azure.ResourceManager.AppContainers.Models.AppContainersSkuName Premium { get { throw null; } }
-
-        /// <summary> SkuName for container app. </summary>
-        public bool Equals(Azure.ResourceManager.AppContainers.Models.AppContainersSkuName other) { throw null; }
-
-        /// <summary> SkuName for container app. </summary>
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override bool Equals(object obj) { throw null; }
-
-        /// <summary> SkuName for container app. </summary>
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-        public override int GetHashCode() { throw null; }
-
-        /// <summary> SkuName for container app. </summary>
-        public override string ToString() { throw null; }
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+        /// <inheritdoc />
+        public override string ToString() => _value;
     }
 }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/ContainerAppManagedEnvironmentData.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/ContainerAppManagedEnvironmentData.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.ComponentModel;
 using Azure.ResourceManager.AppContainers.Models;
 using Azure.ResourceManager.Models;
@@ -18,6 +19,9 @@ namespace Azure.ResourceManager.AppContainers
 
         /// <summary> SkuName for container app. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("SkuName is no longer supported by the service and will be removed in a future release.")]
+#pragma warning disable CS0618 // Type or member is obsolete
         public AppContainersSkuName? SkuName { get; set; }
+#pragma warning restore CS0618
     }
 }

--- a/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/ContainerAppManagedEnvironmentData.cs
+++ b/sdk/containerapps/Azure.ResourceManager.AppContainers/src/Custom/ContainerAppManagedEnvironmentData.cs
@@ -3,11 +3,7 @@
 
 #nullable enable
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using Azure.Core;
 using Azure.ResourceManager.AppContainers.Models;
 using Azure.ResourceManager.Models;
 
@@ -16,8 +12,12 @@ namespace Azure.ResourceManager.AppContainers
     /// <summary> A class representing the ContainerAppManagedEnvironmentData data model. </summary>
     public partial class ContainerAppManagedEnvironmentData : TrackedResourceData
     {
+        // This property and the AppContainersSkuName type were removed from the service spec
+        // but are preserved here as hidden members to avoid breaking existing consumers.
+        // See https://github.com/Azure/azure-sdk-for-net/issues/56807
+
         /// <summary> SkuName for container app. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Azure.ResourceManager.AppContainers.Models.AppContainersSkuName? SkuName { get; set; }
+        public AppContainersSkuName? SkuName { get; set; }
     }
 }


### PR DESCRIPTION
## Fix

The custom `AppContainersSkuName` struct was written with `throw null;` stubs (API listing format) instead of actual implementations when it was added to preserve backward compatibility after the type was removed from the service spec. This caused `NullReferenceException` on every operation - constructor, static properties, operators, etc.

This PR restores the original generated extensible enum implementation (matching the code from before commit 04dba6ae which removed it).

## Repro (before fix)

```csharp
var sku = AppContainersSkuName.Premium; // throws NullReferenceException
var sku2 = new AppContainersSkuName("Premium"); // throws NullReferenceException
```

Fixes #56807
