### PR TITLE
Fix duplicate GetAll methods for extension resource non-resource list operations

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -47,7 +47,9 @@ import { getCrossLanguageDefinitionId } from "@azure-tools/typespec-client-gener
 import {
   isVariableSegment,
   isPrefix,
-  findLongestPrefixMatch
+  findLongestPrefixMatch,
+  getResourceTypeSegment,
+  getLastPathSegment
 } from "./utils.js";
 import { getAllSdkClients } from "./sdk-client-utils.js";
 import {
@@ -662,26 +664,4 @@ function assignListOperationsToResources(
       });
     }
   }
-}
-
-/**
- * Gets the resource type segment from a resource ID pattern.
- * The type segment is the second-to-last segment, since the last is the key variable.
- * E.g., for ".../configs/{resourceName}", returns "configs".
- */
-function getResourceTypeSegment(resourceIdPattern: string): string | undefined {
-  const segments = resourceIdPattern.split("/").filter((s) => s !== "");
-  if (segments.length < 2) return undefined;
-  return segments[segments.length - 2];
-}
-
-/**
- * Gets the last segment of a path.
- * For list operation paths, this is the resource type/collection segment.
- * E.g., for ".../configs", returns "configs".
- */
-function getLastPathSegment(path: string): string | undefined {
-  const segments = path.split("/").filter((s) => s !== "");
-  if (segments.length === 0) return undefined;
-  return segments[segments.length - 1];
 }

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { isVariableSegment, findLongestPrefixMatch } from "./utils.js";
+import {
+  isVariableSegment,
+  findLongestPrefixMatch,
+  getResourceTypeSegment,
+  getLastPathSegment
+} from "./utils.js";
 
 const ResourceGroupScopePrefix =
   "/subscriptions/{subscriptionId}/resourceGroups";
@@ -534,30 +539,6 @@ export function assignNonResourceMethodsToResources(
       sortResourceMethods(resource.metadata.methods);
     }
   }
-}
-
-/**
- * Gets the resource type segment from a resource ID pattern.
- * The type segment is the second-to-last segment, since the last is the key variable.
- * E.g., for ".../configurationAssignments/{configurationAssignmentName}", returns "configurationAssignments".
- */
-function getResourceTypeSegment(
-  resourceIdPattern: string
-): string | undefined {
-  const segments = resourceIdPattern.split("/").filter((s) => s !== "");
-  if (segments.length < 2) return undefined;
-  return segments[segments.length - 2];
-}
-
-/**
- * Gets the last segment of a path.
- * For list operation paths, this is the resource type/collection segment.
- * E.g., for ".../configurationAssignments", returns "configurationAssignments".
- */
-function getLastPathSegment(path: string): string | undefined {
-  const segments = path.split("/").filter((s) => s !== "");
-  if (segments.length === 0) return undefined;
-  return segments[segments.length - 1];
 }
 
 /**

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -435,12 +435,16 @@ export function postProcessArmResources(
 }
 
 /**
- * Assigns non-resource methods to resources based on two matching strategies:
+ * Assigns non-resource methods to resources based on three matching strategies:
  * 1. Prefix matching: if the method's operationPath has a prefix that matches a resource's
  *    resourceIdPattern, the method is moved to that resource as an Action.
  * 2. Resource model ID matching: if prefix matching fails but the method has a resourceModelId,
  *    it is matched to a valid resource with the same model ID and assigned as a List operation.
  *    This handles extension resources where list paths have different parent structures.
+ * 3. Type segment matching: if both prefix and model ID matching fail, the method's last path
+ *    segment is compared against each resource's type segment (second-to-last segment of the
+ *    resource ID pattern). This handles "missing operations" from resolveArmResources that
+ *    lack resourceModelId but share a type segment with a known resource.
  *
  * @param resources - The list of valid resources
  * @param nonResourceMethods - The array of non-resource methods (will be mutated: matched methods are removed)
@@ -485,6 +489,35 @@ export function assignNonResourceMethodsToResources(
         });
         methodsToRemove.add(method.methodId);
       }
+    } else {
+      // Both prefix and model ID matching failed — try matching by type segment.
+      // Extension resource list paths may have fewer parent segments than the resource
+      // ID pattern (e.g., {providerName}/{resourceType}/{resourceName} vs
+      // {providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}),
+      // causing a structural length mismatch that prefix matching cannot resolve.
+      // As a final fallback, compare the operation path's last segment against the
+      // resource's type segment (second-to-last segment of the resource ID pattern).
+      const lastSegment = getLastPathSegment(method.operationPath);
+      if (lastSegment) {
+        const match = resources.find((r) => {
+          const typeSegment = getResourceTypeSegment(
+            r.metadata.resourceIdPattern
+          );
+          return (
+            typeSegment?.toLowerCase() === lastSegment.toLowerCase()
+          );
+        });
+        if (match) {
+          match.metadata.methods.push({
+            methodId: method.methodId,
+            kind: ResourceOperationKind.List,
+            operationPath: method.operationPath,
+            operationScope: method.operationScope,
+            resourceScope: undefined
+          });
+          methodsToRemove.add(method.methodId);
+        }
+      }
     }
   }
 
@@ -501,6 +534,30 @@ export function assignNonResourceMethodsToResources(
       sortResourceMethods(resource.metadata.methods);
     }
   }
+}
+
+/**
+ * Gets the resource type segment from a resource ID pattern.
+ * The type segment is the second-to-last segment, since the last is the key variable.
+ * E.g., for ".../configurationAssignments/{configurationAssignmentName}", returns "configurationAssignments".
+ */
+function getResourceTypeSegment(
+  resourceIdPattern: string
+): string | undefined {
+  const segments = resourceIdPattern.split("/").filter((s) => s !== "");
+  if (segments.length < 2) return undefined;
+  return segments[segments.length - 2];
+}
+
+/**
+ * Gets the last segment of a path.
+ * For list operation paths, this is the resource type/collection segment.
+ * E.g., for ".../configurationAssignments", returns "configurationAssignments".
+ */
+function getLastPathSegment(path: string): string | undefined {
+  const segments = path.split("/").filter((s) => s !== "");
+  if (segments.length === 0) return undefined;
+  return segments[segments.length - 1];
 }
 
 /**

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
@@ -60,6 +60,39 @@ export function getSharedSegmentCount(left: string, right: string): number {
  * @param properPrefix if true, requires the candidate path to be a proper prefix (not equal)
  * @returns the best matching candidate, or undefined if no match
  */
+/**
+ * Gets the resource type segment from a resource ID pattern.
+ * The type segment is the second-to-last segment, since the last is the key variable.
+ * E.g., for ".../configurationAssignments/{configurationAssignmentName}", returns "configurationAssignments".
+ */
+export function getResourceTypeSegment(
+  resourceIdPattern: string
+): string | undefined {
+  const segments = resourceIdPattern.split("/").filter((s) => s !== "");
+  if (segments.length < 2) return undefined;
+
+  const lastSegment = segments[segments.length - 1];
+  const typeCandidate = segments[segments.length - 2];
+
+  // The last segment must be a variable (e.g., "{name}")
+  if (!isVariableSegment(lastSegment)) return undefined;
+  // The type segment itself must not be a variable
+  if (isVariableSegment(typeCandidate)) return undefined;
+
+  return typeCandidate;
+}
+
+/**
+ * Gets the last segment of a path.
+ * For list operation paths, this is the resource type/collection segment.
+ * E.g., for ".../configurationAssignments", returns "configurationAssignments".
+ */
+export function getLastPathSegment(path: string): string | undefined {
+  const segments = path.split("/").filter((s) => s !== "");
+  if (segments.length === 0) return undefined;
+  return segments[segments.length - 1];
+}
+
 export function findLongestPrefixMatch<T>(
   targetPath: string,
   candidates: T[],

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
@@ -16,7 +16,10 @@ import {
   ResourceOperationKind,
   assignNonResourceMethodsToResources
 } from "../src/resource-metadata.js";
-import type { ArmResourceSchema } from "../src/resource-metadata.js";
+import type {
+  ArmResourceSchema,
+  NonResourceMethod
+} from "../src/resource-metadata.js";
 
 describe("Non-Resource Methods Detection", () => {
   let runner: TestHost;

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
@@ -891,4 +891,87 @@ interface ChildResources {
       "The remaining non-resource method should be the Updates list"
     );
   });
+
+  it("should assign non-resource list methods by type segment when prefix matching fails due to structural path length mismatch", () => {
+    // Reproduces the duplicate GetAll bug: extension resource list paths may have fewer
+    // parent segments than the resource ID pattern (e.g., {providerName}/{resourceType}/
+    // {resourceName} vs {providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/
+    // {resourceName}), causing a structural length mismatch that prefix matching cannot resolve
+    // even with variable-as-wildcard semantics. The type-segment fallback matches the operation
+    // path's last segment against the resource's type segment to correctly assign the method.
+
+    const resources: ArmResourceSchema[] = [
+      {
+        resourceModelId: "Microsoft.Maintenance.ConfigurationAssignment",
+        metadata: {
+          resourceName: "ConfigurationAssignment",
+          resourceIdPattern:
+            "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}",
+          resourceScope: ResourceScope.Extension,
+          singletonResourceName: undefined,
+          parentResourceId: undefined,
+          parentResourceModelId: undefined,
+          methods: [
+            {
+              methodId: "Microsoft.Maintenance.ConfigurationAssignment.get",
+              kind: ResourceOperationKind.Read,
+              operationPath:
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}",
+              operationScope: ResourceScope.ResourceGroup,
+              resourceScope:
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}"
+            }
+          ]
+        }
+      }
+    ];
+
+    // The operation path has fewer variable segments than the resource ID pattern
+    // (e.g., {providerName}/{resourceType}/{resourceName} vs {providerName}/{resourceParentType}/
+    // {resourceParentName}/{resourceType}/{resourceName}). This structural length mismatch means
+    // prefix matching fails even with variable-as-wildcard semantics — literal segments at
+    // corresponding positions don't align. The type-segment fallback resolves this.
+    const nonResourceMethods: NonResourceMethod[] = [
+      {
+        methodId:
+          "Microsoft.Maintenance.ConfigurationAssignmentForResourceGroupOperationGroup.list",
+        operationPath:
+          "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments",
+        operationScope: ResourceScope.ResourceGroup
+        // resourceModelId intentionally NOT set
+      },
+      {
+        methodId: "Microsoft.Maintenance.UpdatesOperationGroup.list",
+        operationPath:
+          "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/updates",
+        operationScope: ResourceScope.ResourceGroup
+        // resourceModelId intentionally NOT set
+      }
+    ];
+
+    assignNonResourceMethodsToResources(resources, nonResourceMethods);
+
+    // The ConfigurationAssignment list should be assigned via type-segment matching:
+    // operation path ends with "configurationAssignments" which matches the resource's
+    // type segment (second-to-last segment of the resource ID pattern).
+    const configMethods = resources[0].metadata.methods.filter(
+      (m) => m.kind === ResourceOperationKind.List
+    );
+    strictEqual(
+      configMethods.length,
+      1,
+      "ConfigurationAssignment resource should have 1 List method via type-segment matching"
+    );
+
+    // The Updates list should remain as a non-resource method (no matching resource)
+    strictEqual(
+      nonResourceMethods.length,
+      1,
+      "Only the Updates list should remain as a non-resource method"
+    );
+    ok(
+      nonResourceMethods[0].methodId.includes("Updates"),
+      "The remaining non-resource method should be the Updates list"
+    );
+  });
 });


### PR DESCRIPTION
## Problem

The `assignNonResourceMethodsToResources` function in the mgmt emitter fails to match extension resource list operations when:
1. `resourceModelId` is missing (operations added as "missing operations" in `resolve-arm-resources-converter.ts`)
2. Prefix matching fails due to different parent path structures (variable segments in extension resource paths don't match resource base paths)

This causes two different list operations to both generate methods named `GetAll` with identical parameter types but different return types, resulting in CS0111 build errors. Observed in the Maintenance SDK migration (PR #55330).

## Fix

Added **type-segment matching** as a third fallback strategy in `assignNonResourceMethodsToResources`:
- Extracts the last path segment from the operation path (e.g., `configurationAssignments`)
- Compares it against each resource's type segment (second-to-last segment of the resource type pattern)
- Correctly routes the operation to its resource, producing `GetConfigurationAssignments` instead of a duplicate `GetAll`

## Changes
- `resource-metadata.ts`: Added `getResourceTypeSegment`, `getLastPathSegment` helpers and type-segment matching logic
- `non-resource-methods.test.ts`: New test reproducing the bug
- `metadata.json`: Regenerated test project output via `Generate.ps1`

## Validation
- All 49 emitter tests pass ✅
-  and  pass 
- `Generate.ps1` test projects regenerate and build successfully ✅
- Maintenance SDK regenerated with fix builds successfully ✅
