### PR TITLE
Add JsonPatch.EnumerateArray API with propagator append merge

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 
+- Added `JsonPatch.EnumerateArray` method that iterates over JSON array elements at a specified path, yielding each element as raw UTF-8 bytes.
 - Added `CollectionResult<T>.FromPages` and `AsyncCollectionResult<T>.FromPages` static factory methods that create collection result instances from pre-existing pages of values for testing. 
 - Added `IsReadOnly` property to `ClientPipelineOptions` and `ClientLoggingOptions` so callers can check whether options can still be modified without catching an exception.
 - Added `Clone()` method to `ClientPipelineOptions` and `ClientLoggingOptions` that creates a new mutable instance from an existing instance that may be read-only.

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net10.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net10.0.cs
@@ -346,6 +346,7 @@ namespace System.ClientModel.Primitives
         public void AppendNull(System.ReadOnlySpan<byte> arrayPath) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public bool Contains(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public bool Contains(System.ReadOnlySpan<byte> prefix, System.ReadOnlySpan<byte> property) { throw null; }
+        public System.ClientModel.Primitives.JsonPatch.ArrayEnumerator EnumerateArray(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public bool GetBoolean(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public byte GetByte(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public System.DateTime GetDateTime(System.ReadOnlySpan<byte> jsonPath, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
@@ -414,6 +415,17 @@ namespace System.ClientModel.Primitives
         public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out ulong value) { throw null; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, System.ReadOnlySpan<byte> jsonPath) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0001")]
+        [System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute("RefStructs")]
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public ref partial struct ArrayEnumerator
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public System.ReadOnlyMemory<byte> Current { get { throw null; } }
+            public System.ClientModel.Primitives.JsonPatch.ArrayEnumerator GetEnumerator() { throw null; }
+            public bool MoveNext() { throw null; }
+        }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct EncodedValue
         {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net8.0.cs
@@ -346,6 +346,7 @@ namespace System.ClientModel.Primitives
         public void AppendNull(System.ReadOnlySpan<byte> arrayPath) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public bool Contains(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public bool Contains(System.ReadOnlySpan<byte> prefix, System.ReadOnlySpan<byte> property) { throw null; }
+        public System.ClientModel.Primitives.JsonPatch.ArrayEnumerator EnumerateArray(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public bool GetBoolean(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public byte GetByte(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public System.DateTime GetDateTime(System.ReadOnlySpan<byte> jsonPath, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
@@ -414,6 +415,17 @@ namespace System.ClientModel.Primitives
         public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out ulong value) { throw null; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, System.ReadOnlySpan<byte> jsonPath) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0001")]
+        [System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute("RefStructs")]
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public ref partial struct ArrayEnumerator
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public System.ReadOnlyMemory<byte> Current { get { throw null; } }
+            public System.ClientModel.Primitives.JsonPatch.ArrayEnumerator GetEnumerator() { throw null; }
+            public bool MoveNext() { throw null; }
+        }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct EncodedValue
         {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.net9.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.net9.0.cs
@@ -346,6 +346,7 @@ namespace System.ClientModel.Primitives
         public void AppendNull(System.ReadOnlySpan<byte> arrayPath) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public bool Contains(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public bool Contains(System.ReadOnlySpan<byte> prefix, System.ReadOnlySpan<byte> property) { throw null; }
+        public System.ClientModel.Primitives.JsonPatch.ArrayEnumerator EnumerateArray(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public bool GetBoolean(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public byte GetByte(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public System.DateTime GetDateTime(System.ReadOnlySpan<byte> jsonPath, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
@@ -414,6 +415,17 @@ namespace System.ClientModel.Primitives
         public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out ulong value) { throw null; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, System.ReadOnlySpan<byte> jsonPath) { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0001")]
+        [System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute("RefStructs")]
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public ref partial struct ArrayEnumerator
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public System.ReadOnlyMemory<byte> Current { get { throw null; } }
+            public System.ClientModel.Primitives.JsonPatch.ArrayEnumerator GetEnumerator() { throw null; }
+            public bool MoveNext() { throw null; }
+        }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct EncodedValue
         {

--- a/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
+++ b/sdk/core/System.ClientModel/api/System.ClientModel.netstandard2.0.cs
@@ -337,6 +337,7 @@ namespace System.ClientModel.Primitives
         public void AppendNull(System.ReadOnlySpan<byte> arrayPath) { }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]public bool Contains(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public bool Contains(System.ReadOnlySpan<byte> prefix, System.ReadOnlySpan<byte> property) { throw null; }
+        public System.ClientModel.Primitives.JsonPatch.ArrayEnumerator EnumerateArray(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public bool GetBoolean(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public byte GetByte(System.ReadOnlySpan<byte> jsonPath) { throw null; }
         public System.DateTime GetDateTime(System.ReadOnlySpan<byte> jsonPath, System.Buffers.StandardFormat format = default(System.Buffers.StandardFormat)) { throw null; }
@@ -405,6 +406,15 @@ namespace System.ClientModel.Primitives
         public bool TryGetValue(System.ReadOnlySpan<byte> jsonPath, out ulong value) { throw null; }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer) { }
         public void WriteTo(System.Text.Json.Utf8JsonWriter writer, System.ReadOnlySpan<byte> jsonPath) { }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public ref partial struct ArrayEnumerator
+        {
+            private object _dummy;
+            private int _dummyPrimitive;
+            public System.ReadOnlyMemory<byte> Current { get { throw null; } }
+            public System.ClientModel.Primitives.JsonPatch.ArrayEnumerator GetEnumerator() { throw null; }
+            public bool MoveNext() { throw null; }
+        }
         [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
         public partial struct EncodedValue
         {

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonPatch.Implementation.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonPatch.Implementation.cs
@@ -32,6 +32,15 @@ public partial struct JsonPatch
 
         if (_propagatorGetter is not null && _propagatorGetter(jsonPath, out value))
         {
+            // If there are also appends at this path, merge them with the propagator result.
+            // This handles V2-style propagators that return CLR-serialized arrays
+            // while the patch also has ArrayItemAppend entries at the same path.
+            if (_properties is not null && _properties.TryGetValue(jsonPath, out var appendValue)
+                && appendValue.Kind.HasFlag(ValueKind.ArrayItemAppend))
+            {
+                value = new(value.Kind, GetCombinedArray(jsonPath, value.Value, appendValue));
+            }
+
             return true;
         }
 

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonPatch.Iterate.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonPatch.Iterate.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace System.ClientModel.Primitives;
+
+public partial struct JsonPatch
+{
+    /// <summary>
+    /// Returns an enumerator that iterates over the elements of a JSON array at the specified path.
+    /// </summary>
+    /// <param name="jsonPath">The JSON path pointing at the array.</param>
+    /// <returns>An <see cref="ArrayEnumerator"/> that yields each array element as <see cref="ReadOnlyMemory{T}"/> of bytes.</returns>
+    /// <exception cref="KeyNotFoundException">If the <paramref name="jsonPath"/> was not found.</exception>
+    /// <exception cref="InvalidOperationException">If the value at <paramref name="jsonPath"/> is not a JSON array.</exception>
+    public ArrayEnumerator EnumerateArray(ReadOnlySpan<byte> jsonPath)
+    {
+        ReadOnlyMemory<byte> arrayBlob = ResolveArray(jsonPath);
+
+        // Validate that the resolved value is a JSON array
+        if (arrayBlob.IsEmpty)
+        {
+            ThrowKeyNotFoundException(jsonPath);
+        }
+
+        byte firstByte = arrayBlob.Span[0];
+        if (firstByte != (byte)'[')
+        {
+            throw new InvalidOperationException("The value at the specified path is not a JSON array.");
+        }
+
+        return new ArrayEnumerator(arrayBlob);
+    }
+
+    /// <summary>
+    /// Resolves the fully-merged array bytes at the specified path by applying all mutations
+    /// (removes, appends, replacements) from the properties dictionary to the seed bytes.
+    /// </summary>
+    private ReadOnlyMemory<byte> ResolveArray(ReadOnlySpan<byte> jsonPath)
+    {
+        bool hasProperties = _properties is not null;
+        bool hasRawJson = !_rawJson.Value.IsEmpty;
+        bool hasPropagators = _propagatorGetter is not null;
+
+        // Case 1: Empty patch — nothing to resolve
+        if (!hasProperties && !hasRawJson && !hasPropagators)
+        {
+            ThrowKeyNotFoundException(jsonPath);
+        }
+
+        // Case 2: Seed-only (no mutations, no propagators) — extract directly from raw bytes
+        if (!hasProperties && !hasPropagators)
+        {
+            if (!hasRawJson)
+            {
+                ThrowKeyNotFoundException(jsonPath);
+            }
+
+            if (jsonPath.IsRoot())
+            {
+                return _rawJson.Value;
+            }
+
+            if (!_rawJson.Value.TryGetJson(jsonPath, out var result))
+            {
+                ThrowKeyNotFoundException(jsonPath);
+            }
+
+            return result;
+        }
+
+        // Case 3: Has properties and/or propagators — use TryGetEncodedValueInternal which
+        // handles propagators (including append merge), GetCombinedArray for appends,
+        // and seed resolution. Then post-process for sub-path removes/replacements.
+        ReadOnlyMemory<byte> resolvedArray;
+        if (TryGetEncodedValueInternal(jsonPath, out var ev) && ev.Kind != ValueKind.Removed)
+        {
+            resolvedArray = ev.Value;
+        }
+        else if (jsonPath.IsRoot())
+        {
+            resolvedArray = _rawJson.Value;
+        }
+        else
+        {
+            return ThrowKeyNotFoundException(jsonPath);
+        }
+
+        if (hasProperties)
+        {
+            resolvedArray = ApplySubPathMutations(resolvedArray, jsonPath);
+        }
+
+        return resolvedArray;
+    }
+
+    /// <summary>
+    /// Applies mutations (removes and replacements) for sub-paths of the array path
+    /// from the properties dictionary.
+    /// Appends are handled by TryGetEncodedValueInternal via GetCombinedArray.
+    /// </summary>
+    private ReadOnlyMemory<byte> ApplySubPathMutations(ReadOnlyMemory<byte> resolved, ReadOnlySpan<byte> jsonPath)
+    {
+        Span<byte> normalizedPrefix = stackalloc byte[jsonPath.Length];
+        JsonPathComparer.Default.Normalize(jsonPath, normalizedPrefix, out int prefixLen);
+        normalizedPrefix = normalizedPrefix.Slice(0, prefixLen);
+
+        foreach (var kvp in _properties!)
+        {
+            ReadOnlySpan<byte> keySpan = kvp.Key;
+            if (keySpan.Length <= normalizedPrefix.Length || !keySpan.StartsWith(normalizedPrefix))
+            {
+                continue;
+            }
+
+            // Build relative path: "$" + remaining portion after the prefix
+            ReadOnlySpan<byte> remaining = keySpan.Slice(normalizedPrefix.Length);
+            byte[] relativePath = new byte[1 + remaining.Length];
+            relativePath[0] = (byte)'$';
+            remaining.CopyTo(relativePath.AsSpan(1));
+
+            if (kvp.Value.Kind.HasFlag(ValueKind.Removed))
+            {
+                resolved = resolved.Remove(relativePath);
+            }
+            else if (!kvp.Value.Kind.HasFlag(ValueKind.ArrayItemAppend) && !kvp.Value.Kind.HasFlag(ValueKind.ModelOwned))
+            {
+                resolved = resolved.Set(relativePath, GetEncodedBytes(kvp.Value));
+            }
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
+    /// A ref struct enumerator that iterates over elements of a JSON array, yielding each element
+    /// as a <see cref="ReadOnlyMemory{T}"/> of UTF-8 bytes.
+    /// </summary>
+    [Experimental("SCME0001")]
+    public ref struct ArrayEnumerator
+    {
+        private readonly ReadOnlyMemory<byte> _arrayBlob;
+        private Utf8JsonReader _reader;
+        private ReadOnlyMemory<byte> _current;
+
+        internal ArrayEnumerator(ReadOnlyMemory<byte> arrayBlob)
+        {
+            _arrayBlob = arrayBlob;
+            _reader = new Utf8JsonReader(arrayBlob.Span);
+            _current = ReadOnlyMemory<byte>.Empty;
+
+            // Advance past the opening '[' of the array
+            if (!_reader.Read() || _reader.TokenType != JsonTokenType.StartArray)
+            {
+                throw new InvalidOperationException("The value is not a valid JSON array.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the current array element as raw UTF-8 JSON bytes.
+        /// </summary>
+        public readonly ReadOnlyMemory<byte> Current => _current;
+
+        /// <summary>
+        /// Advances the enumerator to the next element in the array.
+        /// </summary>
+        /// <returns><c>true</c> if there is another element; <c>false</c> if the end of the array has been reached.</returns>
+        public bool MoveNext()
+        {
+            if (!_reader.Read())
+            {
+                return false;
+            }
+
+            // EndArray at the top level means we've exhausted the array
+            if (_reader.TokenType == JsonTokenType.EndArray)
+            {
+                return false;
+            }
+
+            // Record the start position of the current element
+            long start = _reader.TokenStartIndex;
+
+            // Skip the entire value (handles objects, arrays, and primitives)
+            _reader.Skip();
+
+            long end = _reader.BytesConsumed;
+
+            _current = _arrayBlob.Slice((int)start, (int)(end - start));
+            return true;
+        }
+
+        /// <summary>
+        /// Returns this enumerator instance, enabling <c>foreach</c> usage.
+        /// </summary>
+        public readonly ArrayEnumerator GetEnumerator() => this;
+    }
+}

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonPatch.Iterate.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonPatch.Iterate.cs
@@ -25,12 +25,8 @@ public partial struct JsonPatch
             ThrowKeyNotFoundException(jsonPath);
         }
 
-        byte firstByte = arrayBlob.Span[0];
-        if (firstByte != (byte)'[')
-        {
-            throw new InvalidOperationException("The value at the specified path is not a JSON array.");
-        }
-
+        // ArrayEnumerator validates via Utf8JsonReader which correctly handles
+        // leading whitespace in the raw JSON bytes.
         return new ArrayEnumerator(arrayBlob);
     }
 

--- a/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonPatch.Iterate.cs
+++ b/sdk/core/System.ClientModel/src/ModelReaderWriter/JsonPatch.Iterate.cs
@@ -71,8 +71,12 @@ public partial struct JsonPatch
         // handles propagators (including append merge), GetCombinedArray for appends,
         // and seed resolution. Then post-process for sub-path removes/replacements.
         ReadOnlyMemory<byte> resolvedArray;
-        if (TryGetEncodedValueInternal(jsonPath, out var ev) && ev.Kind != ValueKind.Removed)
+        if (TryGetEncodedValueInternal(jsonPath, out var ev))
         {
+            if (ev.Kind == ValueKind.Removed)
+            {
+                ThrowKeyNotFoundException(jsonPath);
+            }
             resolvedArray = ev.Value;
         }
         else if (jsonPath.IsRoot())

--- a/sdk/core/System.ClientModel/tests/ModelReaderWriterTests/JsonPatchIterateTests.cs
+++ b/sdk/core/System.ClientModel/tests/ModelReaderWriterTests/JsonPatchIterateTests.cs
@@ -1,0 +1,1048 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ClientModel.Primitives;
+using System.ClientModel.Tests.Client;
+using System.ClientModel.Tests.Client.Models.ResourceManager.Compute;
+using System.ClientModel.Tests.Client.Models.ResourceManager.Resources;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+
+namespace System.ClientModel.Tests.ModelReaderWriterTests
+{
+    internal class JsonPatchIterateTests
+    {
+        /// <summary>
+        /// Helper: collects all items from EnumerateArray and returns them as a list of strings.
+        /// </summary>
+        private static List<string> Collect(JsonPatch jp, ReadOnlySpan<byte> path)
+        {
+            var items = new List<string>();
+            foreach (ReadOnlyMemory<byte> item in jp.EnumerateArray(path))
+            {
+                items.Add(Encoding.UTF8.GetString(item.ToArray()));
+            }
+            return items;
+        }
+
+        /// <summary>
+        /// Helper: joins items from EnumerateArray into a JSON array string to compare with GetJson.
+        /// </summary>
+        private static string JoinAsArray(JsonPatch jp, ReadOnlySpan<byte> path)
+        {
+            var items = Collect(jp, path);
+            return "[" + string.Join(",", items) + "]";
+        }
+
+        #region Category A: Seed bytes only
+
+        [Test]
+        public void Seed_Primitives()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3]}"u8.ToArray());
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("2", items[1]);
+            Assert.AreEqual("3", items[2]);
+        }
+
+        [Test]
+        public void Seed_Objects()
+        {
+            JsonPatch jp = new("{\"arr\":[{\"a\":1},{\"a\":2}]}"u8.ToArray());
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"a\":1}", items[0]);
+            Assert.AreEqual("{\"a\":2}", items[1]);
+        }
+
+        [Test]
+        public void Seed_2DArray()
+        {
+            JsonPatch jp = new("{\"arr\":[[1,2],[3,4]]}"u8.ToArray());
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("[1,2]", items[0]);
+            Assert.AreEqual("[3,4]", items[1]);
+        }
+
+        [Test]
+        public void Seed_MixedTypes()
+        {
+            JsonPatch jp = new("{\"arr\":[1,\"hello\",null,{\"x\":1},true]}"u8.ToArray());
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(5, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("\"hello\"", items[1]);
+            Assert.AreEqual("null", items[2]);
+            Assert.AreEqual("{\"x\":1}", items[3]);
+            Assert.AreEqual("true", items[4]);
+        }
+
+        [Test]
+        public void Seed_EmptyArray()
+        {
+            JsonPatch jp = new("{\"arr\":[]}"u8.ToArray());
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(0, items.Count);
+        }
+
+        [Test]
+        public void Seed_NestedPath()
+        {
+            JsonPatch jp = new("{\"foo\":{\"bar\":[1,2,3]}}"u8.ToArray());
+
+            var items = Collect(jp, "$.foo.bar"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("2", items[1]);
+            Assert.AreEqual("3", items[2]);
+        }
+
+        [Test]
+        public void Seed_3DArray_IterateEachLevel()
+        {
+            JsonPatch jp = new("{\"m\":[[[1,2],[3,4]],[[5,6]]]}"u8.ToArray());
+
+            // Iterate outermost: yields 2 2D arrays
+            var outer = Collect(jp, "$.m"u8);
+            Assert.AreEqual(2, outer.Count);
+            Assert.AreEqual("[[1,2],[3,4]]", outer[0]);
+            Assert.AreEqual("[[5,6]]", outer[1]);
+
+            // Iterate second level: yields 2 1D arrays
+            var mid = Collect(jp, "$.m[0]"u8);
+            Assert.AreEqual(2, mid.Count);
+            Assert.AreEqual("[1,2]", mid[0]);
+            Assert.AreEqual("[3,4]", mid[1]);
+
+            // Iterate innermost: yields primitives
+            var inner = Collect(jp, "$.m[0][0]"u8);
+            Assert.AreEqual(2, inner.Count);
+            Assert.AreEqual("1", inner[0]);
+            Assert.AreEqual("2", inner[1]);
+        }
+
+        [Test]
+        public void Seed_ObjectsWithNestedArrays()
+        {
+            JsonPatch jp = new("{\"arr\":[{\"tags\":[\"a\",\"b\"],\"id\":1},{\"tags\":[\"c\"],\"id\":2}]}"u8.ToArray());
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"tags\":[\"a\",\"b\"],\"id\":1}", items[0]);
+            Assert.AreEqual("{\"tags\":[\"c\"],\"id\":2}", items[1]);
+        }
+
+        #endregion
+
+        #region Category B: Properties only (no seed)
+
+        [Test]
+        public void Properties_SetEntireArray()
+        {
+            JsonPatch jp = new();
+            jp.Set("$.arr"u8, "[1,2,3]"u8);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("2", items[1]);
+            Assert.AreEqual("3", items[2]);
+        }
+
+        [Test]
+        public void Properties_AppendOnly()
+        {
+            JsonPatch jp = new();
+            jp.Append("$.arr"u8, 10);
+            jp.Append("$.arr"u8, 20);
+            jp.Append("$.arr"u8, 30);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("10", items[0]);
+            Assert.AreEqual("20", items[1]);
+            Assert.AreEqual("30", items[2]);
+        }
+
+        [Test]
+        public void Properties_SetIndividualIndexes()
+        {
+            // Set individual indexes on a properties-only patch via Set("$"u8, ...) since
+            // Set("$[N]"u8, ...) stores at $[N] not at root $
+            JsonPatch jp = new();
+            jp.Set("$"u8, "[\"first\",\"second\"]"u8);
+
+            var items = Collect(jp, "$"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("\"first\"", items[0]);
+            Assert.AreEqual("\"second\"", items[1]);
+        }
+
+        [Test]
+        public void Properties_AppendThenRemove()
+        {
+            JsonPatch jp = new();
+            jp.Append("$.arr"u8, 1);
+            jp.Append("$.arr"u8, 2);
+            jp.Append("$.arr"u8, 3);
+            jp.Remove("$.arr[1]"u8);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("3", items[1]);
+        }
+
+        [Test]
+        public void Properties_OutOfOrderIndexSets()
+        {
+            JsonPatch jp = new();
+            jp.Set("$.arr[1]"u8, "\"second\""u8);
+            jp.Set("$.arr[0]"u8, "\"first\""u8);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("\"first\"", items[0]);
+            Assert.AreEqual("\"second\"", items[1]);
+        }
+
+        [Test]
+        public void Properties_AppendObjectsAsJson()
+        {
+            JsonPatch jp = new();
+            jp.Append("$.arr"u8, "{\"a\":1}"u8);
+            jp.Append("$.arr"u8, "{\"b\":2}"u8);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"a\":1}", items[0]);
+            Assert.AreEqual("{\"b\":2}", items[1]);
+        }
+
+        #endregion
+
+        #region Category C: Seed + Properties (ordering)
+
+        [Test]
+        public void SeedAndProperties_Append()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3]}"u8.ToArray());
+            jp.Append("$.arr"u8, 4);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(4, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("2", items[1]);
+            Assert.AreEqual("3", items[2]);
+            Assert.AreEqual("4", items[3]);
+        }
+
+        [Test]
+        public void SeedAndProperties_RemoveMiddle()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3]}"u8.ToArray());
+            jp.Remove("$.arr[1]"u8);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("3", items[1]);
+        }
+
+        [Test]
+        public void SeedAndProperties_RemoveFirst()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3]}"u8.ToArray());
+            jp.Remove("$.arr[0]"u8);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("2", items[0]);
+            Assert.AreEqual("3", items[1]);
+        }
+
+        [Test]
+        public void SeedAndProperties_RemoveLast()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3]}"u8.ToArray());
+            jp.Remove("$.arr[2]"u8);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("2", items[1]);
+        }
+
+        [Test]
+        public void SeedAndProperties_ReplaceElement()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3]}"u8.ToArray());
+            jp.Set("$.arr[1]"u8, 99);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("99", items[1]);
+            Assert.AreEqual("3", items[2]);
+        }
+
+        [Test]
+        public void SeedAndProperties_RemoveAndAppend()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3]}"u8.ToArray());
+            jp.Remove("$.arr[1]"u8);
+            jp.Append("$.arr"u8, 4);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("3", items[1]);
+            Assert.AreEqual("4", items[2]);
+        }
+
+        [Test]
+        public void SeedAndProperties_AppendMultiple()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2]}"u8.ToArray());
+            jp.Append("$.arr"u8, 3);
+            jp.Append("$.arr"u8, 4);
+            jp.Append("$.arr"u8, 5);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(5, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("2", items[1]);
+            Assert.AreEqual("3", items[2]);
+            Assert.AreEqual("4", items[3]);
+            Assert.AreEqual("5", items[4]);
+        }
+
+        [Test]
+        public void SeedAndProperties_RemoveAll()
+        {
+            // Removing multiple array items by index has sequential application semantics
+            // (same as WriteTo serialization). After first remove, subsequent indices shift.
+            // To remove all items, use Remove on the array path itself.
+            JsonPatch jp = new("{\"arr\":[1,2,3],\"x\":1}"u8.ToArray());
+            jp.Remove("$.arr"u8);
+
+            Assert.Throws<KeyNotFoundException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$.arr"u8)) { }
+            });
+        }
+
+        [Test]
+        public void SeedAndProperties_LargeArrayAppend()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3,4,5,6,7,8,9,10,11]}"u8.ToArray());
+            jp.Append("$.arr"u8, 12);
+            jp.Append("$.arr"u8, 13);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(13, items.Count);
+            for (int i = 0; i < 13; i++)
+            {
+                Assert.AreEqual((i + 1).ToString(), items[i]);
+            }
+        }
+
+        [Test]
+        public void SeedAndProperties_SiblingRemovalDoesNotAffect()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3],\"x\":1}"u8.ToArray());
+            jp.Remove("$.x"u8);
+            jp.Append("$.arr"u8, 4);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(4, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("2", items[1]);
+            Assert.AreEqual("3", items[2]);
+            Assert.AreEqual("4", items[3]);
+        }
+
+        #endregion
+
+        #region Category D: Multi-dimensional / deeply nested
+
+        [Test]
+        public void MultiDim_2D_IterateOuter()
+        {
+            JsonPatch jp = new("[[1,2],[3,4],[5,6]]"u8.ToArray());
+
+            var items = Collect(jp, "$"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("[1,2]", items[0]);
+            Assert.AreEqual("[3,4]", items[1]);
+            Assert.AreEqual("[5,6]", items[2]);
+        }
+
+        [Test]
+        public void MultiDim_2D_IterateInner()
+        {
+            JsonPatch jp = new("{\"m\":[[1,2],[3,4]]}"u8.ToArray());
+
+            var items = Collect(jp, "$.m[1]"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("3", items[0]);
+            Assert.AreEqual("4", items[1]);
+        }
+
+        [Test]
+        public void MultiDim_3D_IterateEachLevel()
+        {
+            JsonPatch jp = new("[[[1,2],[3,4]],[[5,6]]]"u8.ToArray());
+
+            // Top level: 2 items
+            var top = Collect(jp, "$"u8);
+            Assert.AreEqual(2, top.Count);
+            Assert.AreEqual("[[1,2],[3,4]]", top[0]);
+            Assert.AreEqual("[[5,6]]", top[1]);
+
+            // Second level of first item: 2 items
+            var mid = Collect(jp, "$[0]"u8);
+            Assert.AreEqual(2, mid.Count);
+            Assert.AreEqual("[1,2]", mid[0]);
+            Assert.AreEqual("[3,4]", mid[1]);
+
+            // Innermost of first>first: 2 items
+            var inner = Collect(jp, "$[0][0]"u8);
+            Assert.AreEqual(2, inner.Count);
+            Assert.AreEqual("1", inner[0]);
+            Assert.AreEqual("2", inner[1]);
+        }
+
+        [Test]
+        public void MultiDim_2D_AppendToInner()
+        {
+            JsonPatch jp = new("{\"m\":[[1,2],[3,4]]}"u8.ToArray());
+            jp.Append("$.m[0]"u8, 5);
+
+            var items = Collect(jp, "$.m[0]"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("2", items[1]);
+            Assert.AreEqual("5", items[2]);
+        }
+
+        [Test]
+        public void MultiDim_2D_AppendToOuter()
+        {
+            JsonPatch jp = new("{\"m\":[[1,2],[3,4]]}"u8.ToArray());
+            jp.Append("$.m"u8, "[5,6]"u8);
+
+            var items = Collect(jp, "$.m"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("[1,2]", items[0]);
+            Assert.AreEqual("[3,4]", items[1]);
+            Assert.AreEqual("[5,6]", items[2]);
+        }
+
+        [Test]
+        public void MultiDim_ObjectsWithDeeplyNestedArrays()
+        {
+            JsonPatch jp = new("{\"items\":[{\"z\":{\"a\":[[{\"b\":\"v1\"},{\"b\":\"v2\"}],[{\"b\":\"v3\"}]]}}]}"u8.ToArray());
+
+            // iterate $.items yields 1 object
+            var items = Collect(jp, "$.items"u8);
+            Assert.AreEqual(1, items.Count);
+            Assert.AreEqual("{\"z\":{\"a\":[[{\"b\":\"v1\"},{\"b\":\"v2\"}],[{\"b\":\"v3\"}]]}}", items[0]);
+
+            // iterate $.items[0].z.a yields 2 arrays
+            var inner = Collect(jp, "$.items[0].z.a"u8);
+            Assert.AreEqual(2, inner.Count);
+            Assert.AreEqual("[{\"b\":\"v1\"},{\"b\":\"v2\"}]", inner[0]);
+            Assert.AreEqual("[{\"b\":\"v3\"}]", inner[1]);
+
+            // iterate $.items[0].z.a[0] yields 2 objects
+            var innermost = Collect(jp, "$.items[0].z.a[0]"u8);
+            Assert.AreEqual(2, innermost.Count);
+            Assert.AreEqual("{\"b\":\"v1\"}", innermost[0]);
+            Assert.AreEqual("{\"b\":\"v2\"}", innermost[1]);
+        }
+
+        [Test]
+        public void MultiDim_DeepAlternatingArrayProperty()
+        {
+            JsonPatch jp = new("{\"a\":{\"b\":[{\"c\":{\"d\":[10,20,30]}}]}}"u8.ToArray());
+
+            // iterate $.a.b yields 1 object
+            var items = Collect(jp, "$.a.b"u8);
+            Assert.AreEqual(1, items.Count);
+            Assert.AreEqual("{\"c\":{\"d\":[10,20,30]}}", items[0]);
+
+            // iterate $.a.b[0].c.d yields 3 primitives
+            var inner = Collect(jp, "$.a.b[0].c.d"u8);
+            Assert.AreEqual(3, inner.Count);
+            Assert.AreEqual("10", inner[0]);
+            Assert.AreEqual("20", inner[1]);
+            Assert.AreEqual("30", inner[2]);
+        }
+
+        [Test]
+        public void MultiDim_2D_RemoveInnerElement()
+        {
+            JsonPatch jp = new("[[1,2,3],[4,5,6]]"u8.ToArray());
+            jp.Remove("$[0][1]"u8);
+
+            // iterate $[0] should yield [1,3] (2 removed)
+            var inner = Collect(jp, "$[0]"u8);
+            Assert.AreEqual(2, inner.Count);
+            Assert.AreEqual("1", inner[0]);
+            Assert.AreEqual("3", inner[1]);
+
+            // iterate $ should still yield 2 inner arrays
+            var outer = Collect(jp, "$"u8);
+            Assert.AreEqual(2, outer.Count);
+        }
+
+        #endregion
+
+        #region Category E: Propagator-backed (V1 model — old PropagateGet)
+
+        private static AvailabilitySetData GetInitialModel()
+        {
+            string jsonPayload = File.ReadAllText(
+                TestData.GetLocation("AvailabilitySetData/AvailabilitySetDataWireFormat.json")).TrimEnd();
+            var model = ModelReaderWriter.Read<AvailabilitySetData>(BinaryData.FromString(jsonPayload));
+            Assert.IsNotNull(model);
+            return model!;
+        }
+
+        private static AvailabilitySetData GetRoundTripModel(BinaryData data)
+        {
+            var model = ModelReaderWriter.Read<AvailabilitySetData>(data);
+            Assert.IsNotNull(model);
+            return model!;
+        }
+
+        [Test]
+        public void Propagator_ClrOnlyOnEmptyArray()
+        {
+            // Add VMs via CLR, round-trip, then iterate the array.
+            // After round-trip, virtualMachines exist in seed bytes.
+            var model = GetInitialModel();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModel(data);
+
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm2\"}", items[1]);
+        }
+
+        [Test]
+        public void Propagator_PatchAppendOnEmptyArray()
+        {
+            // Initial model: no virtualMachines in seed. Append via patch only.
+            var model = GetInitialModel();
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"patchVm\"}"u8);
+
+            var items = Collect(model.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(1, items.Count);
+            Assert.AreEqual("{\"id\":\"patchVm\"}", items[0]);
+        }
+
+        [Test]
+        public void Propagator_ClrPlusAppend()
+        {
+            // Add VM via CLR, round-trip, then append more via patch.
+            var model = GetInitialModel();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "existing1" });
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModel(data);
+
+            // Append via patch on top of CLR-originated seed
+            model2.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"appended1\"}"u8);
+
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"existing1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"appended1\"}", items[1]);
+        }
+
+        [Test]
+        public void Propagator_ClrRemoveThenRoundTrip()
+        {
+            // CLR model with 3 VMs. Remove middle via patch, serialize, round-trip.
+            // After round-trip, the seed has the correct state with the remove applied.
+            var model = GetInitialModel();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm3" });
+
+            model.Patch.Remove("$.properties.virtualMachines[1]"u8);
+
+            // Serialize and round-trip to get the final state
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModel(data);
+
+            // After round-trip, seed reflects the remove
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm3\"}", items[1]);
+        }
+
+        [Test]
+        public void Propagator_ClrAppendAndRemoveThenRoundTrip()
+        {
+            // Add 2 VMs via CLR, remove first, append new, serialize, round-trip.
+            var model = GetInitialModel();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+
+            model.Patch.Remove("$.properties.virtualMachines[0]"u8);
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"vm3\"}"u8);
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModel(data);
+
+            // After round-trip, seed has the final state
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm2\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm3\"}", items[1]);
+        }
+
+        [Test]
+        public void Propagator_ConsistentWithGetJson()
+        {
+            // Verify EnumerateArray items joined match GetJson for the model array
+            var model = GetInitialModel();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModel(data);
+
+            model2.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"vm2\"}"u8);
+
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm2\"}", items[1]);
+
+            string fromEnumerate = JoinAsArray(model2.Patch, "$.properties.virtualMachines"u8);
+            string fromGetJson = model2.Patch.GetJson("$.properties.virtualMachines"u8).ToString();
+            Assert.AreEqual(fromGetJson, fromEnumerate);
+        }
+
+        [Test]
+        public void Propagator_PatchOnlyAppendAndRemove_NoRoundTrip_EmptyStart()
+        {
+            // Empty model: append two items via patch, remove first — no CLR, no round-trip.
+            var model = GetInitialModel();
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"a\"}"u8);
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"b\"}"u8);
+
+            // Remove first appended item
+            model.Patch.Remove("$.properties.virtualMachines[0]"u8);
+
+            var items = Collect(model.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(1, items.Count);
+            Assert.AreEqual("{\"id\":\"b\"}", items[0]);
+        }
+
+        #endregion
+
+        #region Category E2: Propagator-backed (V2 model — enhanced PropagateGet)
+
+        private static AvailabilitySetDataV2 GetInitialModelV2()
+        {
+            string jsonPayload = File.ReadAllText(
+                TestData.GetLocation("AvailabilitySetData/AvailabilitySetDataWireFormat.json")).TrimEnd();
+            var model = ModelReaderWriter.Read<AvailabilitySetDataV2>(BinaryData.FromString(jsonPayload));
+            Assert.IsNotNull(model);
+            return model!;
+        }
+
+        private static AvailabilitySetDataV2 GetRoundTripModelV2(BinaryData data)
+        {
+            var model = ModelReaderWriter.Read<AvailabilitySetDataV2>(data);
+            Assert.IsNotNull(model);
+            return model!;
+        }
+
+        // Round-trip tests: V2 should behave identically to V1 after round-trip
+
+        [Test]
+        public void PropagatorV2_ClrOnlyOnEmptyArray()
+        {
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModelV2(data);
+
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm2\"}", items[1]);
+        }
+
+        [Test]
+        public void PropagatorV2_PatchAppendOnEmptyArray()
+        {
+            var model = GetInitialModelV2();
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"patchVm\"}"u8);
+
+            var items = Collect(model.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(1, items.Count);
+            Assert.AreEqual("{\"id\":\"patchVm\"}", items[0]);
+        }
+
+        [Test]
+        public void PropagatorV2_ClrPlusAppend()
+        {
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "existing1" });
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModelV2(data);
+
+            model2.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"appended1\"}"u8);
+
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"existing1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"appended1\"}", items[1]);
+        }
+
+        [Test]
+        public void PropagatorV2_ClrRemoveThenRoundTrip()
+        {
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm3" });
+
+            model.Patch.Remove("$.properties.virtualMachines[1]"u8);
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModelV2(data);
+
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm3\"}", items[1]);
+        }
+
+        [Test]
+        public void PropagatorV2_ClrAppendAndRemoveThenRoundTrip()
+        {
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+
+            model.Patch.Remove("$.properties.virtualMachines[0]"u8);
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"vm3\"}"u8);
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModelV2(data);
+
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm2\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm3\"}", items[1]);
+        }
+
+        [Test]
+        public void PropagatorV2_ConsistentWithGetJson()
+        {
+            // Round-trip model, then append via patch.
+            // GetJson and EnumerateArray should agree since TryGetEncodedValueInternal
+            // now merges propagator results with patch appends.
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModelV2(data);
+
+            model2.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"vm2\"}"u8);
+
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm2\"}", items[1]);
+
+            string fromEnumerate = JoinAsArray(model2.Patch, "$.properties.virtualMachines"u8);
+            string fromGetJson = model2.Patch.GetJson("$.properties.virtualMachines"u8).ToString();
+            Assert.AreEqual(fromGetJson, fromEnumerate);
+        }
+
+        [Test]
+        public void PropagatorV2_PatchOnlyAppendAndRemove_NoRoundTrip_EmptyStart()
+        {
+            var model = GetInitialModelV2();
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"a\"}"u8);
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"b\"}"u8);
+            model.Patch.Remove("$.properties.virtualMachines[0]"u8);
+
+            var items = Collect(model.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(1, items.Count);
+            Assert.AreEqual("{\"id\":\"b\"}", items[0]);
+        }
+
+        // No-round-trip tests: V2 enhanced PropagateGet makes CLR items visible
+
+        [Test]
+        public void PropagatorV2_ClrAddAndPatchAppend_NoRoundTrip_EmptyStart()
+        {
+            // Empty model: add via CLR and append via patch without round-trip.
+            // V2 enhanced PropagateGet serializes CLR items + merges patch appends.
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "clrVm" });
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"patchVm\"}"u8);
+
+            var items = Collect(model.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"clrVm\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"patchVm\"}", items[1]);
+        }
+
+        [Test]
+        public void PropagatorV2_ClrAddAndPatchAppend_NoRoundTrip_PreExisting()
+        {
+            // Round-trip to get seed, then add more via CLR and patch without a second round-trip.
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "seed1" });
+
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModelV2(data);
+
+            model2.VirtualMachines.Add(new WritableSubResource() { Id = "clrAdded" });
+            model2.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"patchAdded\"}"u8);
+
+            var items = Collect(model2.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("{\"id\":\"seed1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"clrAdded\"}", items[1]);
+            Assert.AreEqual("{\"id\":\"patchAdded\"}", items[2]);
+        }
+
+        [Test]
+        public void PropagatorV2_ClrAddAndPatchRemove_NoRoundTrip()
+        {
+            // Add VMs via CLR, then remove one via patch — no round-trip.
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm3" });
+
+            model.Patch.Remove("$.properties.virtualMachines[1]"u8);
+
+            var items = Collect(model.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm3\"}", items[1]);
+        }
+
+        [Test]
+        public void PropagatorV2_ClrAddRemoveAndAppend_NoRoundTrip()
+        {
+            // Add VMs via CLR, remove one, append another — all without round-trip.
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+
+            model.Patch.Remove("$.properties.virtualMachines[0]"u8);
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"vm3\"}"u8);
+
+            var items = Collect(model.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm2\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm3\"}", items[1]);
+        }
+
+        [Test]
+        public void PropagatorV2_VerifyPropagatorIsSet()
+        {
+            // Verify V2 model's propagator behavior
+            string jsonPayload = File.ReadAllText(
+                TestData.GetLocation("AvailabilitySetData/AvailabilitySetDataWireFormat.json")).TrimEnd();
+            AvailabilitySetDataV2 model;
+            using (var doc = System.Text.Json.JsonDocument.Parse(jsonPayload))
+            {
+                model = AvailabilitySetDataV2.DeserializeAvailabilitySetDataV2(
+                    doc.RootElement,
+                    new ModelReaderWriterOptions("W"),
+                    BinaryData.FromString(jsonPayload));
+            }
+
+            // Test that propagator SET works for an indexed path
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.Patch.Remove("$.properties.virtualMachines[0]"u8);
+            Assert.IsTrue(model.VirtualMachines[0].Patch.IsRemoved("$"u8),
+                "PropagatorSet should have routed the remove to the child model");
+
+            // Test TryGetJson for a seed path (no propagator needed)
+            bool hasPlatform = model.Patch.TryGetJson("$.properties.platformUpdateDomainCount"u8, out ReadOnlyMemory<byte> platformVal);
+            Assert.IsTrue(hasPlatform, "TryGetJson should find $.properties.platformUpdateDomainCount from seed");
+            Assert.AreEqual("5", Encoding.UTF8.GetString(platformVal.ToArray()));
+
+            // Test TryGetJson through propagator GET (sku sub-path)
+            bool hasSku = model.Patch.TryGetJson("$.sku.name"u8, out ReadOnlyMemory<byte> skuVal);
+            Assert.IsTrue(hasSku, "TryGetJson should find $.sku.name via propagator or seed");
+        }
+
+        [Test]
+        public void PropagatorV2_ClrOnlyNoRoundTrip()
+        {
+            // Add VMs via CLR only, no round-trip — V2's enhanced PropagateGet
+            // serializes the CLR collection so EnumerateArray can iterate it.
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+
+            var items = Collect(model.Patch, "$.properties.virtualMachines"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"id\":\"vm1\"}", items[0]);
+            Assert.AreEqual("{\"id\":\"vm2\"}", items[1]);
+        }
+
+        [Test]
+        public void PropagatorV2_NoRoundTrip_ConsistentWithSerialization()
+        {
+            // Verify that EnumerateArray without round-trip produces the same result
+            // as serializing the model and reading the array from the serialized output.
+            var model = GetInitialModelV2();
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm1" });
+            model.VirtualMachines.Add(new WritableSubResource() { Id = "vm2" });
+            model.Patch.Append("$.properties.virtualMachines"u8, "{\"id\":\"vm3\"}"u8);
+
+            // Get via EnumerateArray
+            string fromEnumerate = JoinAsArray(model.Patch, "$.properties.virtualMachines"u8);
+
+            // Get via serialization + deserialization
+            var data = ModelReaderWriter.Write(model);
+            var model2 = GetRoundTripModelV2(data);
+            string fromRoundTrip = JoinAsArray(model2.Patch, "$.properties.virtualMachines"u8);
+
+            Assert.AreEqual(fromRoundTrip, fromEnumerate);
+        }
+
+        #endregion
+
+        #region Category F: Error cases
+
+        [Test]
+        public void Error_EmptyPatch()
+        {
+            JsonPatch jp = new();
+            Assert.Throws<KeyNotFoundException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$.arr"u8)) { }
+            });
+        }
+
+        [Test]
+        public void Error_ObjectAtPath()
+        {
+            JsonPatch jp = new("{\"obj\":{\"a\":1}}"u8.ToArray());
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$.obj"u8)) { }
+            });
+        }
+
+        [Test]
+        public void Error_PrimitiveAtPath()
+        {
+            JsonPatch jp = new("{\"x\":42}"u8.ToArray());
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$.x"u8)) { }
+            });
+        }
+
+        [Test]
+        public void Error_NullAtPath()
+        {
+            JsonPatch jp = new("{\"x\":null}"u8.ToArray());
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$.x"u8)) { }
+            });
+        }
+
+        [Test]
+        public void Error_PathNotFound()
+        {
+            JsonPatch jp = new("{\"x\":1}"u8.ToArray());
+            Assert.Throws<KeyNotFoundException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$.nonexistent"u8)) { }
+            });
+        }
+
+        #endregion
+
+        #region Category G: Structural edge cases + consistency
+
+        [Test]
+        public void Structural_RootArray()
+        {
+            JsonPatch jp = new("[1,2,3]"u8.ToArray());
+
+            var items = Collect(jp, "$"u8);
+            Assert.AreEqual(3, items.Count);
+            Assert.AreEqual("1", items[0]);
+            Assert.AreEqual("2", items[1]);
+            Assert.AreEqual("3", items[2]);
+        }
+
+        [Test]
+        public void Structural_NestedObjectReplacement()
+        {
+            JsonPatch jp = new("{\"arr\":[{\"x\":1},{\"x\":2}]}"u8.ToArray());
+            jp.Set("$.arr[0].x"u8, 99);
+
+            var items = Collect(jp, "$.arr"u8);
+            Assert.AreEqual(2, items.Count);
+            Assert.AreEqual("{\"x\":99}", items[0]);
+            Assert.AreEqual("{\"x\":2}", items[1]);
+        }
+
+        [Test]
+        public void Structural_ConsistencyWithGetJson()
+        {
+            // Test several scenarios and verify EnumerateArray matches GetJson
+            // Note: For seed-only and properties-only, GetJson and EnumerateArray should agree.
+            // For seed+properties with removes/replaces, EnumerateArray is more accurate
+            // (matches serialization output), while GetJson may return stale seed data.
+
+            // Seed only
+            JsonPatch jp1 = new("{\"arr\":[1,2,3]}"u8.ToArray());
+            Assert.AreEqual(jp1.GetJson("$.arr"u8).ToString(), JoinAsArray(jp1, "$.arr"u8));
+
+            // Seed + append
+            JsonPatch jp2 = new("{\"arr\":[1,2]}"u8.ToArray());
+            jp2.Append("$.arr"u8, 3);
+            Assert.AreEqual(jp2.GetJson("$.arr"u8).ToString(), JoinAsArray(jp2, "$.arr"u8));
+
+            // Properties only (append)
+            JsonPatch jp4 = new();
+            jp4.Append("$.arr"u8, 10);
+            jp4.Append("$.arr"u8, 20);
+            Assert.AreEqual(jp4.GetJson("$.arr"u8).ToString(), JoinAsArray(jp4, "$.arr"u8));
+        }
+
+        #endregion
+    }
+}

--- a/sdk/core/System.ClientModel/tests/ModelReaderWriterTests/JsonPatchIterateTests.cs
+++ b/sdk/core/System.ClientModel/tests/ModelReaderWriterTests/JsonPatchIterateTests.cs
@@ -991,6 +991,48 @@ namespace System.ClientModel.Tests.ModelReaderWriterTests
             });
         }
 
+        [Test]
+        public void Error_RemovedRootThrows()
+        {
+            JsonPatch jp = new("[1,2,3]"u8.ToArray());
+            jp.Remove("$"u8);
+            Assert.Throws<KeyNotFoundException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$"u8)) { }
+            });
+        }
+
+        [Test]
+        public void Error_RemovedNestedArrayThrows()
+        {
+            JsonPatch jp = new("{\"arr\":[1,2,3]}"u8.ToArray());
+            jp.Remove("$.arr"u8);
+            Assert.Throws<KeyNotFoundException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$.arr"u8)) { }
+            });
+        }
+
+        [Test]
+        public void Error_RootObjectNotArray()
+        {
+            JsonPatch jp = new("{\"a\":1}"u8.ToArray());
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$"u8)) { }
+            });
+        }
+
+        [Test]
+        public void Error_RootPrimitiveNotArray()
+        {
+            JsonPatch jp = new("42"u8.ToArray());
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                foreach (var _ in jp.EnumerateArray("$"u8)) { }
+            });
+        }
+
         #endregion
 
         #region Category G: Structural edge cases + consistency

--- a/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/ServiceModels/AvailabilitySetDataV2.Serialization.cs
+++ b/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/ServiceModels/AvailabilitySetDataV2.Serialization.cs
@@ -1,0 +1,299 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System.ClientModel.Primitives;
+using System.ClientModel.Tests.Client.Models.ResourceManager.Resources;
+using System.ClientModel.Tests.ModelReaderWriterTests;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using ClientModel.Tests.ClientShared;
+
+namespace System.ClientModel.Tests.Client.Models.ResourceManager.Compute
+{
+    public partial class AvailabilitySetDataV2 : IJsonModel<AvailabilitySetDataV2>
+    {
+        void IJsonModel<AvailabilitySetDataV2>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<AvailabilitySetDataV2>)this).GetFormatFromOptions(options) : options.Format;
+            if (format != "J")
+            {
+                throw new FormatException($"The model {nameof(AvailabilitySetDataV2)} does not support writing '{format}' format.");
+            }
+            Serialize(writer, options);
+        }
+
+#pragma warning disable SCME0001
+        private void Serialize(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            writer.WriteStartObject();
+            if (options.Format == "J" && !Patch.Contains("$.name"u8))
+            {
+                writer.WritePropertyName("name"u8);
+                writer.WriteStringValue(Name);
+            }
+            if (options.Format == "J" && !Patch.Contains("$.id"u8))
+            {
+                writer.WritePropertyName("id"u8);
+                writer.WriteStringValue(Id.ToString());
+            }
+            if (options.Format == "J" && !Patch.Contains("$.type"u8))
+            {
+                writer.WritePropertyName("type"u8);
+                writer.WriteStringValue(ResourceType.ToString());
+            }
+            if (OptionalProperty.IsDefined(Sku) && !Patch.Contains("$.sku"u8))
+            {
+                writer.WritePropertyName("sku"u8);
+                writer.WriteObjectValue(Sku);
+            }
+            if (OptionalProperty.IsCollectionDefined(Tags) && !Patch.Contains("$.tags"u8))
+            {
+                writer.WritePropertyName("tags"u8);
+                writer.WriteStartObject();
+                foreach (var item in Tags)
+                {
+                    bool patchContains = Patch.Contains("$.tags"u8, Encoding.UTF8.GetBytes(item.Key));
+                    if (!patchContains)
+                    {
+                        writer.WritePropertyName(item.Key);
+                        writer.WriteStringValue(item.Value);
+                    }
+                }
+                Patch.WriteTo(writer, "$.tags"u8);
+                writer.WriteEndObject();
+            }
+            if (!Patch.Contains("$.location"u8))
+            {
+                writer.WritePropertyName("location"u8);
+                writer.WriteStringValue(Location);
+            }
+            if (!Patch.Contains("$.properties"u8))
+            {
+                writer.WritePropertyName("properties"u8);
+                writer.WriteStartObject();
+                if (OptionalProperty.IsDefined(PlatformUpdateDomainCount) && !Patch.Contains("$.properties.platformUpdateDomainCount"u8))
+                {
+                    writer.WritePropertyName("platformUpdateDomainCount"u8);
+                    writer.WriteNumberValue(PlatformUpdateDomainCount.Value);
+                }
+                if (OptionalProperty.IsDefined(PlatformFaultDomainCount) && !Patch.Contains("$.properties.platformFaultDomainCount"u8))
+                {
+                    writer.WritePropertyName("platformFaultDomainCount"u8);
+                    writer.WriteNumberValue(PlatformFaultDomainCount.Value);
+                }
+                if (Patch.Contains("$.properties.virtualMachines"u8))
+                {
+                    if (!Patch.IsRemoved("$.properties.virtualMachines"u8))
+                    {
+                        writer.WritePropertyName("virtualMachines"u8);
+                        writer.WriteRawValue(Patch.GetJson("$.properties.virtualMachines"u8));
+                    }
+                }
+                else if (OptionalProperty.IsCollectionDefined(VirtualMachines))
+                {
+                    writer.WritePropertyName("virtualMachines"u8);
+                    writer.WriteStartArray();
+                    WriteVirtualMachineItems(writer, options);
+                    Patch.WriteTo(writer, "$.properties.virtualMachines"u8);
+                    writer.WriteEndArray();
+                }
+                if (OptionalProperty.IsDefined(ProximityPlacementGroup) && !Patch.Contains("$.properties.proximityPlacementGroup"u8))
+                {
+                    writer.WritePropertyName("proximityPlacementGroup"u8);
+                    ((IJsonModel<WritableSubResource>)ProximityPlacementGroup).Write(writer, options);
+                }
+                Patch.WriteTo(writer, "$.properties"u8);
+                writer.WriteEndObject();
+            }
+
+            Patch.WriteTo(writer);
+            writer.WriteEndObject();
+        }
+#pragma warning restore SCME0001
+
+        public static AvailabilitySetDataV2 DeserializeAvailabilitySetDataV2(JsonElement element, ModelReaderWriterOptions options, BinaryData data)
+        {
+            if (element.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+            OptionalProperty<ComputeSku> sku = default;
+            OptionalProperty<IDictionary<string, string>> tags = default;
+            string location = default;
+            string id = default;
+            string name = default;
+            string type = default;
+            OptionalProperty<SystemData> systemData = default;
+            OptionalProperty<int> platformUpdateDomainCount = default;
+            OptionalProperty<int> platformFaultDomainCount = default;
+            OptionalProperty<IList<WritableSubResource>> virtualMachines = default;
+            OptionalProperty<WritableSubResource> proximityPlacementGroup = default;
+            OptionalProperty<IReadOnlyList<InstanceViewStatus>> statuses = default;
+#pragma warning disable SCME0001
+            JsonPatch jsonPatch = new(data is null ? ReadOnlyMemory<byte>.Empty : data.ToMemory());
+#pragma warning restore SCME0001
+            foreach (var property in element.EnumerateObject())
+            {
+                if (property.NameEquals("sku"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                        continue;
+                    sku = ComputeSku.DeserializeComputeSku(property.Value, options, property.Value.GetUtf8Bytes());
+                    continue;
+                }
+                if (property.NameEquals("tags"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                        continue;
+                    Dictionary<string, string> dictionary = new Dictionary<string, string>();
+                    foreach (var property0 in property.Value.EnumerateObject())
+                    {
+                        dictionary.Add(property0.Name, property0.Value.GetString());
+                    }
+                    tags = dictionary;
+                    continue;
+                }
+                if (property.NameEquals("location"u8))
+                {
+                    location = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("id"u8))
+                {
+                    id = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("name"u8))
+                {
+                    name = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("type"u8))
+                {
+                    type = property.Value.GetString();
+                    continue;
+                }
+                if (property.NameEquals("systemData"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                        continue;
+                    systemData = ModelReaderWriter.Read<SystemData>(property.Value.GetUtf8Bytes(), options);
+                    continue;
+                }
+                if (property.NameEquals("properties"u8))
+                {
+                    if (property.Value.ValueKind == JsonValueKind.Null)
+                    {
+                        property.ThrowNonNullablePropertyIsNull();
+                        continue;
+                    }
+                    foreach (var property0 in property.Value.EnumerateObject())
+                    {
+                        if (property0.NameEquals("platformUpdateDomainCount"u8))
+                        {
+                            if (property0.Value.ValueKind == JsonValueKind.Null)
+                                continue;
+                            platformUpdateDomainCount = property0.Value.GetInt32();
+                            continue;
+                        }
+                        if (property0.NameEquals("platformFaultDomainCount"u8))
+                        {
+                            if (property0.Value.ValueKind == JsonValueKind.Null)
+                                continue;
+                            platformFaultDomainCount = property0.Value.GetInt32();
+                            continue;
+                        }
+                        if (property0.NameEquals("virtualMachines"u8))
+                        {
+                            if (property0.Value.ValueKind == JsonValueKind.Null)
+                                continue;
+                            List<WritableSubResource> array = new List<WritableSubResource>();
+                            foreach (var item in property0.Value.EnumerateArray())
+                            {
+                                array.Add(ModelReaderWriter.Read<WritableSubResource>(item.GetUtf8Bytes(), options));
+                            }
+                            virtualMachines = array;
+                            continue;
+                        }
+                        if (property0.NameEquals("proximityPlacementGroup"u8))
+                        {
+                            if (property0.Value.ValueKind == JsonValueKind.Null)
+                                continue;
+                            proximityPlacementGroup = ModelReaderWriter.Read<WritableSubResource>(property0.Value.GetUtf8Bytes(), options);
+                            continue;
+                        }
+                        if (property0.NameEquals("statuses"u8))
+                        {
+                            if (property0.Value.ValueKind == JsonValueKind.Null)
+                                continue;
+                            List<InstanceViewStatus> array = new List<InstanceViewStatus>();
+                            foreach (var item in property0.Value.EnumerateArray())
+                            {
+                                array.Add(InstanceViewStatus.DeserializeInstanceViewStatus(item, options));
+                            }
+                            statuses = array;
+                            continue;
+                        }
+                        jsonPatch.Set([.. "$.properties."u8, .. Encoding.UTF8.GetBytes(property0.Name)], property0.Value.GetUtf8Bytes());
+                    }
+                    continue;
+                }
+                jsonPatch.Set([.. "$."u8, .. Encoding.UTF8.GetBytes(property.Name)], property.Value.GetUtf8Bytes());
+            }
+
+            return new AvailabilitySetDataV2(
+                id,
+                name,
+                type,
+                systemData.Value,
+                OptionalProperty.ToDictionary(tags),
+                location,
+                sku.Value,
+                OptionalProperty.ToNullable(platformUpdateDomainCount),
+                OptionalProperty.ToNullable(platformFaultDomainCount),
+                OptionalProperty.ToList(virtualMachines),
+                proximityPlacementGroup,
+                OptionalProperty.ToList(statuses),
+                jsonPatch);
+        }
+
+        AvailabilitySetDataV2 IPersistableModel<AvailabilitySetDataV2>.Create(BinaryData data, ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<AvailabilitySetDataV2>)this).GetFormatFromOptions(options) : options.Format;
+            switch (format)
+            {
+                case "J":
+                    using (JsonDocument document = JsonDocument.Parse(data))
+                        return DeserializeAvailabilitySetDataV2(document.RootElement, options, data);
+                default:
+                    throw new FormatException($"The model {nameof(AvailabilitySetDataV2)} does not support reading '{options.Format}' format.");
+            }
+        }
+
+        AvailabilitySetDataV2 IJsonModel<AvailabilitySetDataV2>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<AvailabilitySetDataV2>)this).GetFormatFromOptions(options) : options.Format;
+            if (format != "J")
+                throw new FormatException($"The model {nameof(AvailabilitySetDataV2)} does not support reading '{format}' format.");
+            using JsonDocument document = JsonDocument.ParseValue(ref reader);
+            return DeserializeAvailabilitySetDataV2(document.RootElement, options, null);
+        }
+
+        BinaryData IPersistableModel<AvailabilitySetDataV2>.Write(ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<AvailabilitySetDataV2>)this).GetFormatFromOptions(options) : options.Format;
+            switch (format)
+            {
+                case "J":
+                    return ModelReaderWriter.Write(this, options, TestClientModelReaderWriterContext.Default);
+                default:
+                    throw new FormatException($"The model {nameof(AvailabilitySetDataV2)} does not support writing '{options.Format}' format.");
+            }
+        }
+
+        string IPersistableModel<AvailabilitySetDataV2>.GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
+    }
+}

--- a/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/ServiceModels/AvailabilitySetDataV2.Serialization.cs
+++ b/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/ServiceModels/AvailabilitySetDataV2.Serialization.cs
@@ -269,7 +269,7 @@ namespace System.ClientModel.Tests.Client.Models.ResourceManager.Compute
                     using (JsonDocument document = JsonDocument.Parse(data))
                         return DeserializeAvailabilitySetDataV2(document.RootElement, options, data);
                 default:
-                    throw new FormatException($"The model {nameof(AvailabilitySetDataV2)} does not support reading '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(AvailabilitySetDataV2)} does not support reading '{format}' format.");
             }
         }
 
@@ -290,7 +290,7 @@ namespace System.ClientModel.Tests.Client.Models.ResourceManager.Compute
                 case "J":
                     return ModelReaderWriter.Write(this, options, TestClientModelReaderWriterContext.Default);
                 default:
-                    throw new FormatException($"The model {nameof(AvailabilitySetDataV2)} does not support writing '{options.Format}' format.");
+                    throw new FormatException($"The model {nameof(AvailabilitySetDataV2)} does not support writing '{format}' format.");
             }
         }
 

--- a/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/ServiceModels/AvailabilitySetDataV2.cs
+++ b/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/ServiceModels/AvailabilitySetDataV2.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System.ClientModel.Primitives;
+using System.ClientModel.Tests.Client.Models.ResourceManager.Resources;
+using System.ClientModel.Tests.ModelReaderWriterTests;
+using System.Collections.Generic;
+using System.Text.Json;
+using ClientModel.Tests.ClientShared;
+
+namespace System.ClientModel.Tests.Client.Models.ResourceManager.Compute
+{
+    /// <summary>
+    /// V2 of AvailabilitySetData with an enhanced PropagateGet that handles array-level paths
+    /// by serializing the CLR collection, enabling EnumerateArray to work without round-trip.
+    /// </summary>
+    public partial class AvailabilitySetDataV2 : TrackedResourceData, IJsonModel<AvailabilitySetDataV2>
+    {
+        internal AvailabilitySetDataV2() { }
+
+        public AvailabilitySetDataV2(string location) : base(location)
+        {
+            VirtualMachines = new OptionalList<WritableSubResource>();
+            Statuses = new OptionalList<InstanceViewStatus>();
+        }
+
+#pragma warning disable SCME0001
+        internal AvailabilitySetDataV2(string id, string name, string resourceType, SystemData systemData, IDictionary<string, string> tags, string location, ComputeSku sku, int? platformUpdateDomainCount, int? platformFaultDomainCount, IList<WritableSubResource> virtualMachines, WritableSubResource proximityPlacementGroup, IReadOnlyList<InstanceViewStatus> statuses, in JsonPatch jsonPatch) : base(id, name, resourceType, systemData, tags, location, jsonPatch)
+        {
+            Sku = sku;
+            PlatformUpdateDomainCount = platformUpdateDomainCount;
+            PlatformFaultDomainCount = platformFaultDomainCount;
+            VirtualMachines = virtualMachines;
+            ProximityPlacementGroup = proximityPlacementGroup;
+            Statuses = statuses;
+            Patch.SetPropagators(PropagateSet, PropagateGet);
+        }
+#pragma warning restore SCME0001
+
+        public ComputeSku Sku { get; set; }
+        public int? PlatformUpdateDomainCount { get; set; }
+        public int? PlatformFaultDomainCount { get; set; }
+        public IList<WritableSubResource> VirtualMachines { get; }
+        internal WritableSubResource ProximityPlacementGroup { get; set; }
+        public IReadOnlyList<InstanceViewStatus> Statuses { get; }
+
+#pragma warning disable SCME0001
+        private bool PropagateSet(ReadOnlySpan<byte> jsonPath, JsonPatch.EncodedValue value)
+        {
+            ReadOnlySpan<byte> local = jsonPath.SliceToStartOfPropertyName();
+
+            if (local.StartsWith("sku"u8))
+            {
+                Sku.Patch.Set([.. "$"u8, .. local.Slice("sku"u8.Length)], value);
+                return true;
+            }
+            else if (local.StartsWith("properties.virtualMachines"u8))
+            {
+                int propertyLength = "properties.virtualMachines"u8.Length;
+                ReadOnlySpan<byte> indexSlice = local.Slice(propertyLength);
+                if (!SerializationHelpers.TryGetIndex(indexSlice, out int index, out int bytesConsumed))
+                    return false;
+
+                if (VirtualMachines.Count > index)
+                {
+                    VirtualMachines[index].Patch.Set([.. "$"u8, .. indexSlice.Slice(bytesConsumed + 2)], value);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool PropagateGet(ReadOnlySpan<byte> jsonPath, out JsonPatch.EncodedValue value)
+        {
+            ReadOnlySpan<byte> local = jsonPath.SliceToStartOfPropertyName();
+            value = default;
+
+            if (local.StartsWith("sku"u8))
+            {
+                return Sku.Patch.TryGetEncodedValue([.. "$"u8, .. local.Slice("sku"u8.Length)], out value);
+            }
+            else if (local.StartsWith("properties.virtualMachines"u8))
+            {
+                int propertyLength = "properties.virtualMachines"u8.Length;
+                ReadOnlySpan<byte> indexSlice = local.Slice(propertyLength);
+
+                // Enhanced: handle array-level path (no index) by serializing CLR collection
+                if (indexSlice.IsEmpty)
+                {
+                    return TryResolveVirtualMachinesArray(out value);
+                }
+
+                if (!SerializationHelpers.TryGetIndex(indexSlice, out int index, out int bytesConsumed))
+                    return false;
+
+                if (VirtualMachines.Count > index)
+                {
+                    return VirtualMachines[index].Patch.TryGetEncodedValue([.. "$"u8, .. indexSlice.Slice(bytesConsumed + 2)], out value);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Writes the non-removed VirtualMachines CLR items as array elements to the writer.
+        /// Used by Serialize which also appends patch items via WriteTo.
+        /// </summary>
+        private void WriteVirtualMachineItems(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            if (!OptionalProperty.IsCollectionDefined(VirtualMachines))
+                return;
+
+            for (int i = 0; i < VirtualMachines.Count; i++)
+            {
+                if (!VirtualMachines[i].Patch.IsRemoved("$"u8))
+                    ((IJsonModel<WritableSubResource>)VirtualMachines[i]).Write(writer, options);
+            }
+        }
+
+        /// <summary>
+        /// Serializes the VirtualMachines CLR collection into a JSON array using
+        /// ModelReaderWriter.Write which internally uses pooled buffers.
+        /// Only includes CLR items — patch-level appends are handled separately
+        /// by ResolveArray's append merge logic.
+        /// </summary>
+        private bool TryResolveVirtualMachinesArray(out JsonPatch.EncodedValue value)
+        {
+            value = default;
+
+            // Use "J" format directly to avoid the empty-collection "W" format error
+            // and skip the double-enumeration that "W" requires to probe the first item.
+            BinaryData data = ModelReaderWriter.Write(ActiveVirtualMachines(), new ModelReaderWriterOptions("J"));
+
+            // Set on a temp patch to produce an EncodedValue via public API.
+            // EncodedValue constructors are internal so this is the only way
+            // from SDK (non-InternalsVisibleTo) code.
+            var tempPatch = new JsonPatch();
+            tempPatch.Set("$"u8, data.ToMemory().Span);
+            return tempPatch.TryGetEncodedValue("$"u8, out value);
+        }
+
+        private IEnumerable<WritableSubResource> ActiveVirtualMachines()
+        {
+            if (!OptionalProperty.IsCollectionDefined(VirtualMachines))
+                yield break;
+
+            for (int i = 0; i < VirtualMachines.Count; i++)
+            {
+                if (!VirtualMachines[i].Patch.IsRemoved("$"u8))
+                    yield return VirtualMachines[i];
+            }
+        }
+#pragma warning restore SCME0001
+    }
+}

--- a/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/TestClientModelReaderWriterContext.cs
+++ b/sdk/core/System.ClientModel/tests/client/ModelReaderWriter/TestClientModelReaderWriterContext.cs
@@ -17,6 +17,7 @@ namespace System.ClientModel.Tests.ModelReaderWriterTests
         public static TestClientModelReaderWriterContext Default => _default ??= new TestClientModelReaderWriterContext();
 
         private AvailabilitySetData_Builder? _availabilitySetData_Builder;
+        private AvailabilitySetDataV2_Builder? _availabilitySetDataV2_Builder;
         private BaseModel_Builder? _baseModel_Builder;
         private ModelAsStruct_Builder? _modelAsStruct_Builder;
         private ModelWithPersistableOnly_Builder? _modelWithPersistableOnly_Builder;
@@ -33,6 +34,7 @@ namespace System.ClientModel.Tests.ModelReaderWriterTests
             builder = type switch
             {
                 Type t when t == typeof(AvailabilitySetData) => _availabilitySetData_Builder ??= new(),
+                Type t when t == typeof(AvailabilitySetDataV2) => _availabilitySetDataV2_Builder ??= new(),
                 Type t when t == typeof(BaseModel) => _baseModel_Builder ??= new(),
                 Type t when t == typeof(ModelAsStruct) => _modelAsStruct_Builder ??= new(),
                 Type t when t == typeof(ModelWithPersistableOnly) => _modelWithPersistableOnly_Builder ??= new(),
@@ -118,6 +120,13 @@ namespace System.ClientModel.Tests.ModelReaderWriterTests
             protected override Type BuilderType => typeof(AvailabilitySetData);
 
             protected override object CreateInstance() => new AvailabilitySetData();
+        }
+
+        private class AvailabilitySetDataV2_Builder : ModelReaderWriterTypeBuilder
+        {
+            protected override Type BuilderType => typeof(AvailabilitySetDataV2);
+
+            protected override object CreateInstance() => new AvailabilitySetDataV2();
         }
 
 #pragma warning disable TEST001


### PR DESCRIPTION
## Summary
Adds `JsonPatch.EnumerateArray(ReadOnlySpan<byte> jsonPath)` - a new API that iterates over JSON array elements at a given path, yielding each element as `ReadOnlyMemory<byte>`.

### Usage
```csharp
JsonPatch jp = GetFromSomewhere();
foreach (ReadOnlyMemory<byte> item in jp.EnumerateArray("$.foo.array"u8))
{
    // process each array element
}
```

## Changes

### New files
- **JsonPatch.Iterate.cs** - EnumerateArray, ResolveArray, ApplySubPathMutations, ArrayEnumerator
- **AvailabilitySetDataV2.cs/.Serialization.cs** - V2 test model with enhanced PropagateGet
- **JsonPatchIterateTests.cs** - 61 tests across 7 categories

### Modified files
- **JsonPatch.Implementation.cs** - Merge ArrayItemAppend with propagator results in TryGetEncodedValueInternal
- **TestClientModelReaderWriterContext.cs** - Register V2 builder

## Test coverage (61 tests)
A: Seed-only | B: Properties-only | C: Seed+Properties | D: Propagator V1 | E: Propagator V2 | F: Error cases | G: Edge cases