### PR TITLE
Promote mgmt generator resource schema types to public

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
@@ -140,7 +140,8 @@ namespace Azure.Generator.Management
 
         private IReadOnlyDictionary<InputModelType, (string ResourceName, bool IsAlsoUsedInCreate)> ResourceUpdateModelToResourceNameMap => _resourceUpdateModelToResourceNameMap ??= BuildResourceUpdateModelToResourceNameMap();
 
-        internal ArmProviderSchema ArmProviderSchema => _providerSchema ??= BuildArmProviderSchema();
+        /// <summary> Gets the ARM provider schema containing all resource metadata and non-resource methods. </summary>
+        public ArmProviderSchema ArmProviderSchema => _providerSchema ??= BuildArmProviderSchema();
 
         // If there're multiple API versions in the input namespace, use the last one as the default.
         internal string DefaultApiVersion => InputNamespace.ApiVersions.Last();
@@ -263,7 +264,10 @@ namespace Azure.Generator.Management
         internal InputClient? GetClientByMethod(InputServiceMethod method)
             => InputMethodClientMap.TryGetValue(method, out var client) ? client : null;
 
-        internal bool IsResourceModel(InputModelType model) => ResourceModels.Contains(model);
+        /// <summary> Determines whether the specified model is a resource model. </summary>
+        /// <param name="model"> The input model type to check. </param>
+        /// <returns> <c>true</c> if the model is a resource model; otherwise, <c>false</c>. </returns>
+        public bool IsResourceModel(InputModelType model) => ResourceModels.Contains(model);
 
         internal bool TryFindEnclosingResourceNameForResourceUpdateModel(InputModelType model, [NotNullWhen(true)] out string? resourceName, out bool isAlsoUsedInCreate)
         {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementTypeFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementTypeFactory.cs
@@ -35,7 +35,11 @@ namespace Azure.Generator.Management
         /// </summary>
         public string ResourceProviderName => _resourceProviderName ??= BuildResourceProviderName();
 
-        private string BuildResourceProviderName()
+        /// <summary>
+        /// Builds the resource provider name from the primary namespace.
+        /// Override this method to customize the prefix used for known type renaming.
+        /// </summary>
+        protected virtual string BuildResourceProviderName()
         {
             const string armNamespacePrefix = "Azure.ResourceManager.";
             if (PrimaryNamespace.StartsWith(armNamespacePrefix))

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ArmProviderSchema.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ArmProviderSchema.cs
@@ -11,11 +11,17 @@ namespace Azure.Generator.Management.Models;
 /// Represents the unified ARM provider schema containing all resource metadata and non-resource methods.
 /// This consolidates information previously scattered across @resourceSchema and @nonResourceMethodSchema decorators.
 /// </summary>
-internal class ArmProviderSchema
+public class ArmProviderSchema
 {
+    /// <summary> Gets the list of ARM resource metadata. </summary>
     public IReadOnlyList<ResourceMetadata> Resources { get; }
+
+    /// <summary> Gets the list of non-resource methods. </summary>
     public IReadOnlyList<NonResourceMethod> NonResourceMethods { get; }
 
+    /// <summary> Initializes a new instance of <see cref="ArmProviderSchema"/>. </summary>
+    /// <param name="resources"> The list of resource metadata. </param>
+    /// <param name="nonResourceMethods"> The list of non-resource methods. </param>
     public ArmProviderSchema(IReadOnlyList<ResourceMetadata> resources, IReadOnlyList<NonResourceMethod> nonResourceMethods)
     {
         Resources = resources;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/NonResourceMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/NonResourceMethod.cs
@@ -7,7 +7,11 @@ using System.Text.Json;
 
 namespace Azure.Generator.Management.Models;
 
-internal record NonResourceMethod(
+/// <summary> Represents a method that is not associated with a specific ARM resource. </summary>
+/// <param name="OperationScope"> The scope of the operation. </param>
+/// <param name="InputMethod"> The input service method. </param>
+/// <param name="InputClient"> The input client. </param>
+public record NonResourceMethod(
     ResourceScope OperationScope,
     InputServiceMethod InputMethod,
     InputClient InputClient)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceMetadata.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceMetadata.cs
@@ -8,7 +8,17 @@ using System.Text.Json;
 
 namespace Azure.Generator.Management.Models;
 
-internal record ResourceMetadata(
+/// <summary> Represents the metadata for an ARM resource, including its identity, scope, methods, and hierarchy. </summary>
+/// <param name="ResourceIdPattern"> The ARM resource ID pattern. </param>
+/// <param name="ResourceName"> The resource name. </param>
+/// <param name="ResourceType"> The ARM resource type. </param>
+/// <param name="ResourceModel"> The input model type for the resource. </param>
+/// <param name="ResourceScope"> The scope of the resource. </param>
+/// <param name="Methods"> The list of methods associated with the resource. </param>
+/// <param name="SingletonResourceName"> The singleton resource name, if applicable. </param>
+/// <param name="ParentResourceId"> The parent resource ID pattern, if applicable. </param>
+/// <param name="ChildResourceIds"> The list of child resource ID patterns. </param>
+public record ResourceMetadata(
     string ResourceIdPattern,
     string ResourceName,
     string ResourceType,

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceMethod.cs
@@ -7,7 +7,14 @@ using System.Text.Json;
 
 namespace Azure.Generator.Management.Models;
 
-internal record ResourceMethod(
+/// <summary> Represents a method associated with an ARM resource. </summary>
+/// <param name="Kind"> The kind of resource operation. </param>
+/// <param name="InputMethod"> The input service method. </param>
+/// <param name="OperationPath"> The operation path. </param>
+/// <param name="OperationScope"> The scope of the operation. </param>
+/// <param name="ResourceScope"> The resource scope, if applicable. </param>
+/// <param name="InputClient"> The input client. </param>
+public record ResourceMethod(
     ResourceOperationKind Kind,
     InputServiceMethod InputMethod,
     string OperationPath,

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceMethod.cs
@@ -12,14 +12,14 @@ namespace Azure.Generator.Management.Models;
 /// <param name="InputMethod"> The input service method. </param>
 /// <param name="OperationPath"> The operation path. </param>
 /// <param name="OperationScope"> The scope of the operation. </param>
-/// <param name="ResourceScope"> The resource scope, if applicable. </param>
+/// <param name="ResourceScopeIdPattern"> The resource ID pattern specifying the scope, if applicable. </param>
 /// <param name="InputClient"> The input client. </param>
 public record ResourceMethod(
     ResourceOperationKind Kind,
     InputServiceMethod InputMethod,
     string OperationPath,
     ResourceScope OperationScope,
-    string? ResourceScope,
+    string? ResourceScopeIdPattern,
     InputClient InputClient)
 {
     internal static ResourceMethod DeserializeResourceMethod(JsonElement element)
@@ -28,7 +28,7 @@ public record ResourceMethod(
         ResourceOperationKind? operationKind = null;
         string? operationPath = null;
         ResourceScope? operationScope = null;
-        string? resourceScope = null;
+        string? resourceScopeIdPattern = null;
         foreach (var prop in element.EnumerateObject())
         {
             if (prop.NameEquals("methodId"u8))
@@ -50,7 +50,7 @@ public record ResourceMethod(
             }
             if (prop.NameEquals("resourceScope"u8))
             {
-                resourceScope = prop.Value.GetString();
+                resourceScopeIdPattern = prop.Value.GetString();
             }
         }
         var inputMethod = ManagementClientGenerator.Instance.InputLibrary.GetMethodByCrossLanguageDefinitionId(methodId ?? throw new JsonException("id cannot be null"));
@@ -61,7 +61,7 @@ public record ResourceMethod(
             inputMethod,
             operationPath ?? throw new JsonException("operationPath cannot be null"),
             operationScope ?? throw new JsonException("operationScope cannot be null"),
-            resourceScope,
+            resourceScopeIdPattern,
             inputClient ?? throw new JsonException($"cannot find method {inputMethod.CrossLanguageDefinitionId}'s client"));
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceMethodCategory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceMethodCategory.cs
@@ -5,7 +5,11 @@ using System.Collections.Generic;
 
 namespace Azure.Generator.Management.Models;
 
-internal record ResourceMethodCategory(
+/// <summary> Categorizes resource methods by where they are generated (resource, collection, or extension). </summary>
+/// <param name="MethodsInResource"> Methods generated in the resource class. </param>
+/// <param name="MethodsInCollection"> Methods generated in the collection class. </param>
+/// <param name="MethodsInExtension"> Methods generated in the extension class. </param>
+public record ResourceMethodCategory(
     IReadOnlyList<ResourceMethod> MethodsInResource,
     IReadOnlyList<ResourceMethod> MethodsInCollection,
     IReadOnlyList<ResourceMethod> MethodsInExtension);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceOperationKind.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceOperationKind.cs
@@ -3,12 +3,19 @@
 
 namespace Azure.Generator.Management.Models;
 
-internal enum ResourceOperationKind
+/// <summary> Represents the kind of operation on an ARM resource. </summary>
+public enum ResourceOperationKind
 {
+    /// <summary> A custom action operation. </summary>
     Action,
+    /// <summary> A create or update operation. </summary>
     Create,
+    /// <summary> A delete operation. </summary>
     Delete,
+    /// <summary> A read (get) operation. </summary>
     Read,
+    /// <summary> A list operation. </summary>
     List,
+    /// <summary> An update (patch) operation. </summary>
     Update,
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceScope.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ResourceScope.cs
@@ -3,11 +3,17 @@
 
 namespace Azure.Generator.Management.Models;
 
-internal enum ResourceScope
+/// <summary> Represents the ARM resource scope. </summary>
+public enum ResourceScope
 {
+    /// <summary> Tenant scope. </summary>
     Tenant,
+    /// <summary> Subscription scope. </summary>
     Subscription,
+    /// <summary> Resource group scope. </summary>
     ResourceGroup,
+    /// <summary> Management group scope. </summary>
     ManagementGroup,
+    /// <summary> Extension resource scope. </summary>
     Extension,
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceMetadataExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ResourceMetadataExtensions.cs
@@ -88,7 +88,7 @@ namespace Azure.Generator.Management.Utilities
                     case ResourceOperationKind.List:
                         // list method goes to resource if the method's resource scope matches the resource's ID pattern
                         // This handles cases like listByParent where we list children of a specific parent instance
-                        if (method.ResourceScope == resourceMetadata.ResourceIdPattern)
+                        if (method.ResourceScopeIdPattern == resourceMetadata.ResourceIdPattern)
                         {
                             methodsInResource.Add(method);
                         }
@@ -96,7 +96,7 @@ namespace Azure.Generator.Management.Utilities
                         // when the resource has a parent
                         else if (resourceMetadata.ParentResourceId is not null)
                         {
-                            if (method.ResourceScope == resourceMetadata.ParentResourceId)
+                            if (method.ResourceScopeIdPattern == resourceMetadata.ParentResourceId)
                             {
                                 methodsInCollection.Add(method);
                             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
@@ -95,9 +95,9 @@ namespace Azure.Generator.Management.Tests.Common
                     ["operationPath"] = m.OperationPath,
                     ["operationScope"] = m.OperationScope.ToString()
                 };
-                if (m.ResourceScope != null)
+                if (m.ResourceScopeIdPattern != null)
                 {
-                    result["resourceScope"] = m.ResourceScope;
+                    result["resourceScope"] = m.ResourceScopeIdPattern;
                 }
                 return result;
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/OperationSourceProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/OperationSourceProviderTests.cs
@@ -335,9 +335,9 @@ namespace Azure.Generator.Management.Tests.Providers
                     ["operationPath"] = m.OperationPath,
                     ["operationScope"] = m.OperationScope.ToString()
                 };
-                if (m.ResourceScope != null)
+                if (m.ResourceScopeIdPattern != null)
                 {
-                    result["resourceScope"] = m.ResourceScope;
+                    result["resourceScope"] = m.ResourceScopeIdPattern;
                 }
                 return result;
             }


### PR DESCRIPTION
## Summary

Promote internal resource schema types and members to public so they can be consumed by downstream generators (e.g., the provisioning generator).

## Changes

### Types promoted from `internal` to `public`
- `ArmProviderSchema`  unified ARM provider schema
- `ResourceMetadata`  resource identity, scope, methods, and hierarchy
- `ResourceMethod`  method associated with an ARM resource
- `ResourceMethodCategory`  categorizes methods by generation target
- `NonResourceMethod`  method not associated with a specific resource
- `ResourceOperationKind`  enum for operation kinds (Action, Create, Delete, Read, List, Update)
- `ResourceScope`  enum for ARM scopes (Tenant, Subscription, ResourceGroup, ManagementGroup, Extension)

### Members promoted
- `ManagementInputLibrary.ArmProviderSchema`: `internal`  `public`
- `ManagementInputLibrary.IsResourceModel()`: `internal`  `public`
- `ManagementTypeFactory.BuildResourceProviderName()`: `private`  `protected virtual`

### Documentation
All promoted types and members include XML documentation comments.

## Motivation

The provisioning generator (`http-client-csharp-provisioning`) inherits from the mgmt generator and needs access to resource schema metadata to build provisioning resource providers. Making `BuildResourceProviderName()` virtual allows the provisioning generator to customize the prefix used for known type renaming (e.g., `KeyVaultSku` instead of `AzureProvisioningKeyVaultSku`).

Related: #56627, #56749