### PR TITLE
Remove Experimental AZPROVISION001 from Azure.Provisioning.Network

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.Network/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Network/src/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: Experimental("AZPROVISION001")]


### PR DESCRIPTION
This library has shipped stable. We should remove the Experimental attribute from it.

cc @ArcturusZhang 