### PR TITLE
Fix type segment matching to compare full resource type path

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -48,8 +48,8 @@ import {
   isVariableSegment,
   isPrefix,
   findLongestPrefixMatch,
-  getResourceTypeSegment,
-  getLastPathSegment
+  getProviderDepth,
+  getResourceTypePath
 } from "./utils.js";
 import { getAllSdkClients } from "./sdk-client-utils.js";
 import {
@@ -634,17 +634,22 @@ function assignListOperationsToResources(
           }
         );
 
-        // Fall back to type segment matching if prefix matching didn't find a match
+        // Fall back to resource type path matching if prefix matching didn't find a match
         if (!targetResource) {
-          const listLastSegment = getLastPathSegment(listOp.path);
-          if (listLastSegment) {
+          const listTypePath = getResourceTypePath(listOp.path);
+          if (listTypePath) {
+            const listProviderDepth = getProviderDepth(listOp.path);
             targetResource = resourcesForModel.find((r) => {
-              const typeSegment = getResourceTypeSegment(
+              if (
+                getProviderDepth(r.metadata.resourceIdPattern) !==
+                listProviderDepth
+              ) {
+                return false;
+              }
+              const resourceTypePath = getResourceTypePath(
                 r.metadata.resourceIdPattern
               );
-              return (
-                typeSegment?.toLowerCase() === listLastSegment.toLowerCase()
-              );
+              return resourceTypePath === listTypePath;
             });
           }
         }

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -48,7 +48,7 @@ import {
   isVariableSegment,
   isPrefix,
   findLongestPrefixMatch,
-  getProviderDepth,
+  countProviderSegments,
   getResourceTypePath
 } from "./utils.js";
 import { getAllSdkClients } from "./sdk-client-utils.js";
@@ -638,10 +638,10 @@ function assignListOperationsToResources(
         if (!targetResource) {
           const listTypePath = getResourceTypePath(listOp.path);
           if (listTypePath) {
-            const listProviderDepth = getProviderDepth(listOp.path);
+            const listProviderDepth = countProviderSegments(listOp.path);
             targetResource = resourcesForModel.find((r) => {
               if (
-                getProviderDepth(r.metadata.resourceIdPattern) !==
+                countProviderSegments(r.metadata.resourceIdPattern) !==
                 listProviderDepth
               ) {
                 return false;

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -40,7 +40,8 @@ import {
   ResourceScope,
   postProcessArmResources,
   ParentResourceLookupContext,
-  assignNonResourceMethodsToResources
+  assignNonResourceMethodsToResources,
+  calculateResourceTypeFromPath
 } from "./resource-metadata.js";
 import { CSharpEmitterContext } from "@typespec/http-client-csharp";
 import { getCrossLanguageDefinitionId } from "@azure-tools/typespec-client-generator-core";
@@ -48,8 +49,7 @@ import {
   isVariableSegment,
   isPrefix,
   findLongestPrefixMatch,
-  countProviderSegments,
-  getResourceTypePath
+  countProviderSegments
 } from "./utils.js";
 import { getAllSdkClients } from "./sdk-client-utils.js";
 import {
@@ -634,24 +634,19 @@ function assignListOperationsToResources(
           }
         );
 
-        // Fall back to resource type path matching if prefix matching didn't find a match
-        if (!targetResource) {
-          const listTypePath = getResourceTypePath(listOp.path);
-          if (listTypePath) {
-            const listProviderDepth = countProviderSegments(listOp.path);
-            targetResource = resourcesForModel.find((r) => {
-              if (
-                countProviderSegments(r.metadata.resourceIdPattern) !==
-                listProviderDepth
-              ) {
-                return false;
-              }
-              const resourceTypePath = getResourceTypePath(
-                r.metadata.resourceIdPattern
-              );
-              return resourceTypePath === listTypePath;
-            });
-          }
+        // Fall back to resource type matching if prefix matching didn't find a match
+        if (!targetResource && listOp.path.includes("/providers/")) {
+          const listType = calculateResourceTypeFromPath(listOp.path);
+          const listProviderDepth = countProviderSegments(listOp.path);
+          targetResource = resourcesForModel.find((r) => {
+            if (
+              countProviderSegments(r.metadata.resourceIdPattern) !==
+              listProviderDepth
+            ) {
+              return false;
+            }
+            return r.metadata.resourceType === listType;
+          });
         }
       }
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -4,8 +4,8 @@
 import {
   isVariableSegment,
   findLongestPrefixMatch,
-  getResourceTypeSegment,
-  getLastPathSegment
+  getProviderDepth,
+  getResourceTypePath
 } from "./utils.js";
 
 const ResourceGroupScopePrefix =
@@ -454,8 +454,10 @@ export function postProcessArmResources(
  *    This handles extension resources where list paths have different parent structures.
  * 3. Type segment matching: if both prefix and model ID matching fail, the method's last path
  *    segment is compared against each resource's type segment (second-to-last segment of the
- *    resource ID pattern). This handles "missing operations" from resolveArmResources that
- *    lack resourceModelId but share a type segment with a known resource.
+ *    resource ID pattern), AND the provider hierarchy depth (number of "providers/" segments)
+ *    must match to prevent false matches across different scopes. This handles "missing
+ *    operations" from resolveArmResources that lack resourceModelId but share a type segment
+ *    with a known resource at the same provider depth.
  *
  * @param resources - The list of valid resources
  * @param nonResourceMethods - The array of non-resource methods (will be mutated: matched methods are removed)
@@ -501,22 +503,32 @@ export function assignNonResourceMethodsToResources(
         methodsToRemove.add(method.methodId);
       }
     } else {
-      // Both prefix and model ID matching failed — try matching by type segment.
+      // Both prefix and model ID matching failed — try matching by resource type path.
       // Extension resource list paths may have fewer parent segments than the resource
       // ID pattern (e.g., {providerName}/{resourceType}/{resourceName} vs
       // {providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}),
       // causing a structural length mismatch that prefix matching cannot resolve.
-      // As a final fallback, compare the operation path's last segment against the
-      // resource's type segment (second-to-last segment of the resource ID pattern).
-      const lastSegment = getLastPathSegment(method.operationPath);
-      if (lastSegment) {
+      // As a final fallback, compare the full resource type path after the last provider
+      // namespace in both paths. This checks that:
+      //   1. Both paths have the same provider hierarchy depth (preventing cross-scope
+      //      false matches, e.g., RG-scoped list matching a VM-scoped extension resource)
+      //   2. The type structure after the provider namespace matches, including any
+      //      intermediate segments (preventing matches where one path has extra segments
+      //      like "locations/{location}" that the other lacks)
+      const operationTypePath = getResourceTypePath(method.operationPath);
+      if (operationTypePath) {
+        const operationProviderDepth = getProviderDepth(method.operationPath);
         const match = resources.find((r) => {
-          const typeSegment = getResourceTypeSegment(
+          if (
+            getProviderDepth(r.metadata.resourceIdPattern) !==
+            operationProviderDepth
+          ) {
+            return false;
+          }
+          const resourceTypePath = getResourceTypePath(
             r.metadata.resourceIdPattern
           );
-          return (
-            typeSegment?.toLowerCase() === lastSegment.toLowerCase()
-          );
+          return resourceTypePath === operationTypePath;
         });
         if (match) {
           match.metadata.methods.push({

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -4,8 +4,7 @@
 import {
   isVariableSegment,
   findLongestPrefixMatch,
-  countProviderSegments,
-  getResourceTypePath
+  countProviderSegments
 } from "./utils.js";
 
 const ResourceGroupScopePrefix =
@@ -452,13 +451,12 @@ export function postProcessArmResources(
  * 2. Resource model ID matching: if prefix matching fails but the method has a resourceModelId,
  *    it is matched to a valid resource with the same model ID and assigned as a List operation.
  *    This handles extension resources where list paths have different parent structures.
- * 3. Resource type path matching: if both prefix and model ID matching fail, the full resource
- *    type path (everything after the last provider namespace) is extracted from both the
- *    method's operation path and each resource's ID pattern, then compared. This requires
- *    the same provider hierarchy depth and the same type structure (including intermediate
- *    segments), preventing false matches across scopes or paths with different structures.
+ * 3. Resource type matching: if both prefix and model ID matching fail, the resource type
+ *    is extracted from the operation path using calculateResourceTypeFromPath (which includes
+ *    the provider namespace) and compared against each resource's metadata.resourceType.
+ *    The provider hierarchy depth must also match to prevent cross-scope false matches.
  *    This handles operations from resolveArmResources that lack resourceModelId but share
- *    a resource type path with a known resource.
+ *    a resource type with a known resource.
  *
  * @param resources - The list of valid resources
  * @param nonResourceMethods - The array of non-resource methods (will be mutated: matched methods are removed)
@@ -504,21 +502,20 @@ export function assignNonResourceMethodsToResources(
         methodsToRemove.add(method.methodId);
       }
     } else {
-      // Both prefix and model ID matching failed — try matching by resource type path.
+      // Both prefix and model ID matching failed — try matching by resource type.
       // Extension resource list paths may have fewer parent segments than the resource
-      // ID pattern (e.g., {providerName}/{resourceType}/{resourceName} vs
-      // {providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}),
-      // causing a structural length mismatch that prefix matching cannot resolve.
-      // As a final fallback, compare the full resource type path after the last provider
-      // namespace in both paths. This checks that:
-      //   1. Both paths have the same provider hierarchy depth (preventing cross-scope
-      //      false matches, e.g., RG-scoped list matching a VM-scoped extension resource)
-      //   2. The type structure after the provider namespace matches, including any
-      //      intermediate segments (preventing matches where one path has extra segments
-      //      like "locations/{location}" that the other lacks)
-      const operationTypePath = getResourceTypePath(method.operationPath);
-      if (operationTypePath) {
-        const operationProviderDepth = countProviderSegments(method.operationPath);
+      // ID pattern, causing a structural length mismatch that prefix matching cannot resolve.
+      // As a final fallback, compare the resource type (extracted via calculateResourceTypeFromPath,
+      // which includes the provider namespace) against each resource's metadata.resourceType.
+      // The provider hierarchy depth must also match to prevent cross-scope false matches
+      // (e.g., RG-scoped list matching a VM-scoped extension resource).
+      if (method.operationPath.includes("/providers/")) {
+        const operationType = calculateResourceTypeFromPath(
+          method.operationPath
+        );
+        const operationProviderDepth = countProviderSegments(
+          method.operationPath
+        );
         const match = resources.find((r) => {
           if (
             countProviderSegments(r.metadata.resourceIdPattern) !==
@@ -526,10 +523,7 @@ export function assignNonResourceMethodsToResources(
           ) {
             return false;
           }
-          const resourceTypePath = getResourceTypePath(
-            r.metadata.resourceIdPattern
-          );
-          return resourceTypePath === operationTypePath;
+          return r.metadata.resourceType === operationType;
         });
         if (match) {
           match.metadata.methods.push({

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -4,7 +4,7 @@
 import {
   isVariableSegment,
   findLongestPrefixMatch,
-  getProviderDepth,
+  countProviderSegments,
   getResourceTypePath
 } from "./utils.js";
 
@@ -518,10 +518,10 @@ export function assignNonResourceMethodsToResources(
       //      like "locations/{location}" that the other lacks)
       const operationTypePath = getResourceTypePath(method.operationPath);
       if (operationTypePath) {
-        const operationProviderDepth = getProviderDepth(method.operationPath);
+        const operationProviderDepth = countProviderSegments(method.operationPath);
         const match = resources.find((r) => {
           if (
-            getProviderDepth(r.metadata.resourceIdPattern) !==
+            countProviderSegments(r.metadata.resourceIdPattern) !==
             operationProviderDepth
           ) {
             return false;

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -452,12 +452,13 @@ export function postProcessArmResources(
  * 2. Resource model ID matching: if prefix matching fails but the method has a resourceModelId,
  *    it is matched to a valid resource with the same model ID and assigned as a List operation.
  *    This handles extension resources where list paths have different parent structures.
- * 3. Type segment matching: if both prefix and model ID matching fail, the method's last path
- *    segment is compared against each resource's type segment (second-to-last segment of the
- *    resource ID pattern), AND the provider hierarchy depth (number of "providers/" segments)
- *    must match to prevent false matches across different scopes. This handles "missing
- *    operations" from resolveArmResources that lack resourceModelId but share a type segment
- *    with a known resource at the same provider depth.
+ * 3. Resource type path matching: if both prefix and model ID matching fail, the full resource
+ *    type path (everything after the last provider namespace) is extracted from both the
+ *    method's operation path and each resource's ID pattern, then compared. This requires
+ *    the same provider hierarchy depth and the same type structure (including intermediate
+ *    segments), preventing false matches across scopes or paths with different structures.
+ *    This handles operations from resolveArmResources that lack resourceModelId but share
+ *    a resource type path with a known resource.
  *
  * @param resources - The list of valid resources
  * @param nonResourceMethods - The array of non-resource methods (will be mutated: matched methods are removed)

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
@@ -61,39 +61,6 @@ export function getSharedSegmentCount(left: string, right: string): number {
  * @returns the best matching candidate, or undefined if no match
  */
 /**
- * Gets the resource type segment from a resource ID pattern.
- * The type segment is the second-to-last segment, since the last is the key variable.
- * E.g., for ".../configurationAssignments/{configurationAssignmentName}", returns "configurationAssignments".
- */
-export function getResourceTypeSegment(
-  resourceIdPattern: string
-): string | undefined {
-  const segments = resourceIdPattern.split("/").filter((s) => s !== "");
-  if (segments.length < 2) return undefined;
-
-  const lastSegment = segments[segments.length - 1];
-  const typeCandidate = segments[segments.length - 2];
-
-  // The last segment must be a variable (e.g., "{name}")
-  if (!isVariableSegment(lastSegment)) return undefined;
-  // The type segment itself must not be a variable
-  if (isVariableSegment(typeCandidate)) return undefined;
-
-  return typeCandidate;
-}
-
-/**
- * Gets the last segment of a path.
- * For list operation paths, this is the resource type/collection segment.
- * E.g., for ".../configurationAssignments", returns "configurationAssignments".
- */
-export function getLastPathSegment(path: string): string | undefined {
-  const segments = path.split("/").filter((s) => s !== "");
-  if (segments.length === 0) return undefined;
-  return segments[segments.length - 1];
-}
-
-/**
  * Counts the number of "providers" segments in a path.
  * This indicates the provider hierarchy depth — direct resources have 1, extension resources have 2+.
  * E.g., ".../providers/Microsoft.Compute/.../providers/Microsoft.GuestConfiguration/..." returns 2.

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
@@ -54,12 +54,12 @@ export function getSharedSegmentCount(left: string, right: string): number {
 
 /**
  * Counts the number of "providers" segments in a path.
- * This indicates the provider hierarchy depth — direct resources have 1, extension resources have 2+.
+ * Direct resources have 1, extension resources have 2+.
  * E.g., ".../providers/Microsoft.Compute/.../providers/Microsoft.GuestConfiguration/..." returns 2.
  */
-export function getProviderDepth(path: string): number {
+export function countProviderSegments(path: string): number {
   const segments = path.split("/").filter((s) => s !== "");
-  return segments.filter((s) => s.toLowerCase() === "providers").length;
+  return segments.filter((s) => s === "providers").length;
 }
 
 /**

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
@@ -63,51 +63,6 @@ export function countProviderSegments(path: string): number {
 }
 
 /**
- * Extracts the resource type path after the last provider namespace in a path.
- * The trailing variable segment (resource name), if present, is stripped.
- * Variables in intermediate positions are normalized to "{}" for comparison.
- *
- * Examples:
- *   ".../providers/Microsoft.Maintenance/configurationAssignments"
- *     → "configurationAssignments"
- *   ".../providers/Microsoft.Maintenance/configurationAssignments/{name}"
- *     → "configurationAssignments"
- *   ".../providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{name}"
- *     → "locations/{}/deletedVaults"
- *   ".../providers/Microsoft.KeyVault/deletedVaults"
- *     → "deletedVaults"
- */
-export function getResourceTypePath(path: string): string | undefined {
-  const lastProviderIdx = path.lastIndexOf("/providers/");
-  if (lastProviderIdx === -1) return undefined;
-
-  const afterProviders = path
-    .substring(lastProviderIdx + "/providers/".length)
-    .split("/")
-    .filter((s) => s !== "");
-
-  // First segment is the provider namespace (e.g., "Microsoft.KeyVault")
-  if (afterProviders.length < 2) return undefined;
-
-  // Type path = everything after the namespace
-  const typeSegments = afterProviders.slice(1);
-
-  // Strip trailing variable (resource name for ID patterns, not present for list paths)
-  if (
-    typeSegments.length > 0 &&
-    isVariableSegment(typeSegments[typeSegments.length - 1])
-  ) {
-    typeSegments.pop();
-  }
-  if (typeSegments.length === 0) return undefined;
-
-  // Normalize variables to "{}" for comparison
-  return typeSegments
-    .map((s) => (isVariableSegment(s) ? "{}" : s.toLowerCase()))
-    .join("/");
-}
-
-/**
  * Finds the candidate whose path is the longest prefix match against the target path.
  * @param targetPath the path to match against
  * @param candidates the list of candidates to search

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
@@ -53,14 +53,6 @@ export function getSharedSegmentCount(left: string, right: string): number {
 }
 
 /**
- * Finds the candidate whose path is the longest prefix match against the target path.
- * @param targetPath the path to match against
- * @param candidates the list of candidates to search
- * @param getPath extracts the path from a candidate; return undefined to skip
- * @param properPrefix if true, requires the candidate path to be a proper prefix (not equal)
- * @returns the best matching candidate, or undefined if no match
- */
-/**
  * Counts the number of "providers" segments in a path.
  * This indicates the provider hierarchy depth — direct resources have 1, extension resources have 2+.
  * E.g., ".../providers/Microsoft.Compute/.../providers/Microsoft.GuestConfiguration/..." returns 2.
@@ -72,8 +64,7 @@ export function getProviderDepth(path: string): number {
 
 /**
  * Extracts the resource type path after the last provider namespace in a path.
- * For resource ID patterns, the trailing variable (resource name) is stripped.
- * For operation paths (list endpoints), all segments are kept.
+ * The trailing variable segment (resource name), if present, is stripped.
  * Variables in intermediate positions are normalized to "{}" for comparison.
  *
  * Examples:
@@ -116,6 +107,14 @@ export function getResourceTypePath(path: string): string | undefined {
     .join("/");
 }
 
+/**
+ * Finds the candidate whose path is the longest prefix match against the target path.
+ * @param targetPath the path to match against
+ * @param candidates the list of candidates to search
+ * @param getPath extracts the path from a candidate; return undefined to skip
+ * @param properPrefix if true, requires the candidate path to be a proper prefix (not equal)
+ * @returns the best matching candidate, or undefined if no match
+ */
 export function findLongestPrefixMatch<T>(
   targetPath: string,
   candidates: T[],

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/utils.ts
@@ -93,6 +93,62 @@ export function getLastPathSegment(path: string): string | undefined {
   return segments[segments.length - 1];
 }
 
+/**
+ * Counts the number of "providers" segments in a path.
+ * This indicates the provider hierarchy depth — direct resources have 1, extension resources have 2+.
+ * E.g., ".../providers/Microsoft.Compute/.../providers/Microsoft.GuestConfiguration/..." returns 2.
+ */
+export function getProviderDepth(path: string): number {
+  const segments = path.split("/").filter((s) => s !== "");
+  return segments.filter((s) => s.toLowerCase() === "providers").length;
+}
+
+/**
+ * Extracts the resource type path after the last provider namespace in a path.
+ * For resource ID patterns, the trailing variable (resource name) is stripped.
+ * For operation paths (list endpoints), all segments are kept.
+ * Variables in intermediate positions are normalized to "{}" for comparison.
+ *
+ * Examples:
+ *   ".../providers/Microsoft.Maintenance/configurationAssignments"
+ *     → "configurationAssignments"
+ *   ".../providers/Microsoft.Maintenance/configurationAssignments/{name}"
+ *     → "configurationAssignments"
+ *   ".../providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{name}"
+ *     → "locations/{}/deletedVaults"
+ *   ".../providers/Microsoft.KeyVault/deletedVaults"
+ *     → "deletedVaults"
+ */
+export function getResourceTypePath(path: string): string | undefined {
+  const lastProviderIdx = path.lastIndexOf("/providers/");
+  if (lastProviderIdx === -1) return undefined;
+
+  const afterProviders = path
+    .substring(lastProviderIdx + "/providers/".length)
+    .split("/")
+    .filter((s) => s !== "");
+
+  // First segment is the provider namespace (e.g., "Microsoft.KeyVault")
+  if (afterProviders.length < 2) return undefined;
+
+  // Type path = everything after the namespace
+  const typeSegments = afterProviders.slice(1);
+
+  // Strip trailing variable (resource name for ID patterns, not present for list paths)
+  if (
+    typeSegments.length > 0 &&
+    isVariableSegment(typeSegments[typeSegments.length - 1])
+  ) {
+    typeSegments.pop();
+  }
+  if (typeSegments.length === 0) return undefined;
+
+  // Normalize variables to "{}" for comparison
+  return typeSegments
+    .map((s) => (isVariableSegment(s) ? "{}" : s.toLowerCase()))
+    .join("/");
+}
+
 export function findLongestPrefixMatch<T>(
   targetPath: string,
   candidates: T[],

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
@@ -828,6 +828,7 @@ interface ChildResources {
         resourceModelId: "Microsoft.Maintenance.ConfigurationAssignment",
         metadata: {
           resourceName: "ConfigurationAssignment",
+          resourceType: "Microsoft.Maintenance/configurationAssignments",
           resourceIdPattern:
             "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}",
           resourceScope: ResourceScope.Extension,
@@ -908,6 +909,7 @@ interface ChildResources {
         resourceModelId: "Microsoft.Maintenance.ConfigurationAssignment",
         metadata: {
           resourceName: "ConfigurationAssignment",
+          resourceType: "Microsoft.Maintenance/configurationAssignments",
           resourceIdPattern:
             "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}",
           resourceScope: ResourceScope.Extension,
@@ -991,6 +993,7 @@ interface ChildResources {
         resourceModelId: "Microsoft.GuestConfiguration.GuestConfigurationAssignment",
         metadata: {
           resourceName: "GuestConfigurationVmAssignment",
+          resourceType: "Microsoft.GuestConfiguration/guestConfigurationAssignments",
           resourceIdPattern:
             "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/{guestConfigurationAssignmentName}",
           resourceScope: ResourceScope.ResourceGroup,
@@ -1071,6 +1074,7 @@ interface ChildResources {
         resourceModelId: "Microsoft.KeyVault.DeletedVault",
         metadata: {
           resourceName: "DeletedVault",
+          resourceType: "Microsoft.KeyVault/locations/deletedVaults",
           resourceIdPattern:
             "/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{vaultName}",
           resourceScope: ResourceScope.Subscription,

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
@@ -977,4 +977,151 @@ interface ChildResources {
       "The remaining non-resource method should be the Updates list"
     );
   });
+
+  it("should NOT match by type segment when provider hierarchy depth differs", () => {
+    // Reproduces the GuestConfiguration false-match bug: the RGList operation
+    // at resource-group scope (1 provider: Microsoft.GuestConfiguration) was
+    // incorrectly matched to the VM-scoped extension resource (2 providers:
+    // Microsoft.Compute + Microsoft.GuestConfiguration) because only the type
+    // segment name was compared. With provider-depth validation, this match
+    // is correctly rejected.
+
+    const resources: ArmResourceSchema[] = [
+      {
+        resourceModelId: "Microsoft.GuestConfiguration.GuestConfigurationAssignment",
+        metadata: {
+          resourceName: "GuestConfigurationVmAssignment",
+          resourceIdPattern:
+            "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/{guestConfigurationAssignmentName}",
+          resourceScope: ResourceScope.ResourceGroup,
+          singletonResourceName: undefined,
+          parentResourceId: undefined,
+          parentResourceModelId: undefined,
+          methods: [
+            {
+              methodId:
+                "Microsoft.GuestConfiguration.GuestConfigurationAssignment.get",
+              kind: ResourceOperationKind.Read,
+              operationPath:
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/{guestConfigurationAssignmentName}",
+              operationScope: ResourceScope.ResourceGroup,
+              resourceScope:
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/{guestConfigurationAssignmentName}"
+            },
+            {
+              methodId:
+                "Microsoft.GuestConfiguration.GuestConfigurationAssignment.list",
+              kind: ResourceOperationKind.List,
+              operationPath:
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments",
+              operationScope: ResourceScope.ResourceGroup,
+              resourceScope: undefined
+            }
+          ]
+        }
+      }
+    ];
+
+    // The RGList operation path has only 1 "providers/" segment (Microsoft.GuestConfiguration)
+    // while the resource ID pattern has 2 (Microsoft.Compute + Microsoft.GuestConfiguration).
+    // Type segment matching should reject this because of the provider depth mismatch.
+    const nonResourceMethods: NonResourceMethod[] = [
+      {
+        methodId:
+          "Microsoft.GuestConfiguration.GuestConfigurationAssignmentsOperationGroup.RGList",
+        operationPath:
+          "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments",
+        operationScope: ResourceScope.ResourceGroup
+        // resourceModelId intentionally NOT set — the list path uses a different model
+      }
+    ];
+
+    assignNonResourceMethodsToResources(resources, nonResourceMethods);
+
+    // The RGList should NOT be matched — it must remain as a non-resource method
+    strictEqual(
+      nonResourceMethods.length,
+      1,
+      "RGList should remain as a non-resource method (not matched to VM-scoped resource)"
+    );
+    ok(
+      nonResourceMethods[0].methodId.includes("RGList"),
+      "The remaining non-resource method should be the RGList operation"
+    );
+
+    // The resource should NOT have gained an extra List method
+    const listMethods = resources[0].metadata.methods.filter(
+      (m) => m.kind === ResourceOperationKind.List
+    );
+    strictEqual(
+      listMethods.length,
+      1,
+      "Resource should still have only its original List method (VM-scoped), not the RG-scoped RGList"
+    );
+  });
+
+  it("should NOT match by type path when resource has intermediate segments the operation lacks", () => {
+    // Reproduces the KeyVault/EdgeOrder pattern: the resource ID has intermediate segments
+    // (e.g., "locations/{location}") between the provider namespace and the type segment,
+    // but the list operation path doesn't. Even though the last segment name matches,
+    // the structural difference means these are at different scopes within the same provider.
+
+    const resources: ArmResourceSchema[] = [
+      {
+        resourceModelId: "Microsoft.KeyVault.DeletedVault",
+        metadata: {
+          resourceName: "DeletedVault",
+          resourceIdPattern:
+            "/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{vaultName}",
+          resourceScope: ResourceScope.Subscription,
+          singletonResourceName: undefined,
+          parentResourceId: undefined,
+          parentResourceModelId: undefined,
+          methods: [
+            {
+              methodId: "Microsoft.KeyVault.DeletedVault.get",
+              kind: ResourceOperationKind.Read,
+              operationPath:
+                "/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{vaultName}",
+              operationScope: ResourceScope.Subscription,
+              resourceScope:
+                "/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/locations/{location}/deletedVaults/{vaultName}"
+            }
+          ]
+        }
+      }
+    ];
+
+    // The list operation path has NO "locations/{location}" intermediate segments.
+    // The resource type path after the provider namespace differs:
+    //   Operation: "deletedVaults"
+    //   Resource:  "locations/{}/deletedVaults"
+    const nonResourceMethods: NonResourceMethod[] = [
+      {
+        methodId: "Microsoft.KeyVault.VaultsOperationGroup.listDeleted",
+        operationPath:
+          "/subscriptions/{subscriptionId}/providers/Microsoft.KeyVault/deletedVaults",
+        operationScope: ResourceScope.Subscription
+      }
+    ];
+
+    assignNonResourceMethodsToResources(resources, nonResourceMethods);
+
+    // The list should NOT be matched — different type path structure
+    strictEqual(
+      nonResourceMethods.length,
+      1,
+      "listDeleted should remain as a non-resource method (type path mismatch)"
+    );
+
+    // The resource should NOT have gained a List method
+    const listMethods = resources[0].metadata.methods.filter(
+      (m) => m.kind === ResourceOperationKind.List
+    );
+    strictEqual(
+      listMethods.length,
+      0,
+      "DeletedVault resource should have no List methods"
+    );
+  });
 });


### PR DESCRIPTION
## Problem

PR #56823 added a "type segment matching" fallback in `assignNonResourceMethodsToResources` that matched operations purely by their last path segment name. This was too aggressive, causing:

1. **GuestConfiguration**: RG-scoped list operation (1 provider depth) falsely matched to VM-scoped extension resource (2 provider depths), then silently dropped as duplicate since the collection already had `GetAll` — resulting in `CS0103` build errors.
2. **KeyVault/EdgeOrder**: Cross-location list operations (path lacks `locations/{location}`) incorrectly matched to location-scoped resources, moving them to collections — breaking ApiCompat and existing SDK customizations.

## Root Cause

The matching only compared the operation path's last segment against the resource's type segment name, without verifying the structural compatibility of the type path after the provider namespace.

## Fix

Replace the loose last-segment comparison with **full resource type path matching** via `getResourceTypePath()`. This function:
1. Extracts everything after the last `providers/{namespace}/` in the path
2. Strips the trailing variable (resource name) from resource ID patterns
3. Normalizes intermediate variables to `{}` for comparison

The matching now requires:
- **Same provider hierarchy depth** (rejects GuestConfiguration: depth 1 ≠ 2)
- **Same resource type path structure** (rejects KeyVault: `deletedVaults` ≠ `locations/{}/deletedVaults`)
- Still correctly matches Maintenance extension resources (same type path `configurationAssignments`, same depth)

## Changes

- `utils.ts`: Added `getResourceTypePath()` function
- `resource-metadata.ts`: Updated type segment matching to use full type path comparison
- `non-resource-methods.test.ts`: Added test for intermediate segment mismatch (KeyVault pattern)

No SDK customization changes needed — the generator now produces correct output for all affected packages.