### PR TITLE
Update mgmt PR review rule for method renames

### DIFF
--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -119,7 +119,7 @@ For **TypeSpec**, UUID-valued properties should use the `uuid` scalar and map to
 #### Method Renaming in SDK Migration
 - When a previously shipped method name changes during SDK migration, prefer to **rename the newly generated API back to the previously shipped name** rather than keeping both names.
 - Do not keep both the old and new method names just because generation produced a different name. Carrying both methods forward unnecessarily expands the public API surface and creates confusion.
-- Only replace the old name with a new one when the old name is clearly wrong and the rename is intentional. In that case, treat the old member as a backward-compatibility shim and make sure the review explicitly calls out why the old name is a mistake.
+- Only replace the old name with a new one when the old name is clearly wrong and the rename is intentional. In that case, treat the old member as a backward compatibility shim and make sure the review explicitly calls out why the old name is a mistake.
 - A common compatibility smell is custom code that adds the old API method name back, but its implementation only forwards to the newly renamed method. That pattern usually means the change is name-only, and the generated method should be renamed back to the previously shipped API name instead of keeping both.
 
 #### Other API Rules

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -116,6 +116,12 @@ For **TypeSpec**, UUID-valued properties should use the `uuid` scalar and map to
 - Parameter/Response model: `[Resource/RP name]NameAvailabilityXXX`
 - Unavailable reason enum: `[Resource/RP name]NameUnavailableReason`
 
+#### Method Renaming in SDK Migration
+- When a previously shipped method name changes during SDK migration, prefer to **rename the newly generated API back to the previously shipped name** rather than keeping both names.
+- Do not keep both the old and new method names just because generation produced a different name. Carrying both methods forward unnecessarily expands the public API surface and creates confusion.
+- Only replace the old name with a new one when the old name is clearly wrong and the rename is intentional. In that case, treat the old member as a backward-compatibility shim and make sure the review explicitly calls out why the old name is a mistake.
+- A common compatibility smell is custom code that adds the old API method name back, but its implementation only forwards to the newly renamed method. That pattern usually means the change is name-only, and the generated method should be renamed back to the previously shipped API name instead of keeping both.
+
 #### Other API Rules
 - PUT/PATCH optional body parameters should be changed to required
 - Discriminator models should make base model `abstract`


### PR DESCRIPTION
This change updates the azure-sdk-mgmt-pr-review skill with a new review rule for method renaming during SDK migration.

The rule says that when a generated method name changes but the old shipped name is still valid, we should rename the generated method back to the shipped name instead of keeping both names.

It also calls out the common compatibility pattern where custom code adds the old method name back and only forwards to the renamed method. That usually indicates a name-only change and should be reviewed as a rename, not as two APIs that both need to remain public.