### PR TITLE
Add conditional resource deployment support to Azure.Provisioning

### DIFF
--- a/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added `Condition` property to `ResourceBicepMetadata` to support conditional resource deployment. The condition generates Bicep `if (condition)` syntax and accepts literal boolean values, parameter references, or complex expressions.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net10.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net10.0.cs
@@ -767,6 +767,7 @@ namespace Azure.Provisioning.Expressions
     {
         public ResourceStatement(string name, Azure.Provisioning.Expressions.BicepExpression type, Azure.Provisioning.Expressions.BicepExpression body) { }
         public Azure.Provisioning.Expressions.BicepExpression Body { get { throw null; } }
+        public Azure.Provisioning.Expressions.BicepExpression? Condition { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.Provisioning.Expressions.DecoratorExpression> Decorators { get { throw null; } }
         public bool Existing { get { throw null; } set { } }
         public string Name { get { throw null; } }
@@ -940,6 +941,7 @@ namespace Azure.Provisioning.Primitives
     {
         public ResourceBicepMetadata() { }
         public uint? BatchSize { get { throw null; } set { } }
+        public string? Condition { get { throw null; } set { } }
         public string? Description { get { throw null; } set { } }
         public bool OnlyIfNotExists { get { throw null; } set { } }
     }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net10.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net10.0.cs
@@ -941,7 +941,7 @@ namespace Azure.Provisioning.Primitives
     {
         public ResourceBicepMetadata() { }
         public uint? BatchSize { get { throw null; } set { } }
-        public string? Condition { get { throw null; } set { } }
+        public Azure.Provisioning.BicepValue<bool> Condition { get { throw null; } set { } }
         public string? Description { get { throw null; } set { } }
         public bool OnlyIfNotExists { get { throw null; } set { } }
     }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
@@ -767,6 +767,7 @@ namespace Azure.Provisioning.Expressions
     {
         public ResourceStatement(string name, Azure.Provisioning.Expressions.BicepExpression type, Azure.Provisioning.Expressions.BicepExpression body) { }
         public Azure.Provisioning.Expressions.BicepExpression Body { get { throw null; } }
+        public Azure.Provisioning.Expressions.BicepExpression? Condition { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.Provisioning.Expressions.DecoratorExpression> Decorators { get { throw null; } }
         public bool Existing { get { throw null; } set { } }
         public string Name { get { throw null; } }
@@ -940,6 +941,7 @@ namespace Azure.Provisioning.Primitives
     {
         public ResourceBicepMetadata() { }
         public uint? BatchSize { get { throw null; } set { } }
+        public string? Condition { get { throw null; } set { } }
         public string? Description { get { throw null; } set { } }
         public bool OnlyIfNotExists { get { throw null; } set { } }
     }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.net8.0.cs
@@ -941,7 +941,7 @@ namespace Azure.Provisioning.Primitives
     {
         public ResourceBicepMetadata() { }
         public uint? BatchSize { get { throw null; } set { } }
-        public string? Condition { get { throw null; } set { } }
+        public Azure.Provisioning.BicepValue<bool> Condition { get { throw null; } set { } }
         public string? Description { get { throw null; } set { } }
         public bool OnlyIfNotExists { get { throw null; } set { } }
     }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -939,7 +939,7 @@ namespace Azure.Provisioning.Primitives
     {
         public ResourceBicepMetadata() { }
         public uint? BatchSize { get { throw null; } set { } }
-        public string? Condition { get { throw null; } set { } }
+        public Azure.Provisioning.BicepValue<bool> Condition { get { throw null; } set { } }
         public string? Description { get { throw null; } set { } }
         public bool OnlyIfNotExists { get { throw null; } set { } }
     }

--- a/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning/api/Azure.Provisioning.netstandard2.0.cs
@@ -765,6 +765,7 @@ namespace Azure.Provisioning.Expressions
     {
         public ResourceStatement(string name, Azure.Provisioning.Expressions.BicepExpression type, Azure.Provisioning.Expressions.BicepExpression body) { }
         public Azure.Provisioning.Expressions.BicepExpression Body { get { throw null; } }
+        public Azure.Provisioning.Expressions.BicepExpression? Condition { get { throw null; } set { } }
         public System.Collections.Generic.IList<Azure.Provisioning.Expressions.DecoratorExpression> Decorators { get { throw null; } }
         public bool Existing { get { throw null; } set { } }
         public string Name { get { throw null; } }
@@ -938,6 +939,7 @@ namespace Azure.Provisioning.Primitives
     {
         public ResourceBicepMetadata() { }
         public uint? BatchSize { get { throw null; } set { } }
+        public string? Condition { get { throw null; } set { } }
         public string? Description { get { throw null; } set { } }
         public bool OnlyIfNotExists { get { throw null; } set { } }
     }

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/AST/Statements/ResourceStatement.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/AST/Statements/ResourceStatement.cs
@@ -11,11 +11,13 @@ public class ResourceStatement(string name, BicepExpression type, BicepExpressio
     public BicepExpression Type { get; } = type;
     public BicepExpression Body { get; } = body;
     public bool Existing { get; set; }
+    public BicepExpression? Condition { get; set; }
     public IList<DecoratorExpression> Decorators { get; } = [];
     internal override BicepWriter Write(BicepWriter writer) =>
         writer.AppendAll(Decorators, (w, d) => w.Append(d).AppendLine())
             .Append("resource ").Append(Name).Append(' ').Append(Type)
             .AppendIf(Existing, w => w.Append(" existing"))
-            .Append(" = ")
+            .AppendIf(Condition is not null, w => w.Append(" = if (").Append(Condition!).Append(")"))
+            .AppendIf(Condition is null, w => w.Append(" = "))
             .Append(Body).AppendLine();
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/AST/Statements/ResourceStatement.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/AST/Statements/ResourceStatement.cs
@@ -17,7 +17,7 @@ public class ResourceStatement(string name, BicepExpression type, BicepExpressio
         writer.AppendAll(Decorators, (w, d) => w.Append(d).AppendLine())
             .Append("resource ").Append(Name).Append(' ').Append(Type)
             .AppendIf(Existing, w => w.Append(" existing"))
-            .AppendIf(Condition is not null, w => w.Append(" = if (").Append(Condition!).Append(")"))
+            .AppendIf(Condition is not null, w => w.Append(" = if (").Append(Condition!).Append(") "))
             .AppendIf(Condition is null, w => w.Append(" = "))
             .Append(Body).AppendLine();
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisionableResource.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisionableResource.cs
@@ -174,6 +174,12 @@ public abstract class ProvisionableResource(string bicepIdentifier, ResourceType
             resource = resource.Decorate("batchSize", BicepSyntax.Value(BicepMetadata.BatchSize.Value));
         }
 
+        // Apply condition if specified
+        if (BicepMetadata.Condition is not null)
+        {
+            resource.Condition = new IdentifierExpression(BicepMetadata.Condition);
+        }
+
         yield return resource;
     }
 

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisionableResource.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ProvisionableResource.cs
@@ -175,9 +175,9 @@ public abstract class ProvisionableResource(string bicepIdentifier, ResourceType
         }
 
         // Apply condition if specified
-        if (BicepMetadata.Condition is not null)
+        if (!BicepMetadata.Condition.IsEmpty)
         {
-            resource.Condition = new IdentifierExpression(BicepMetadata.Condition);
+            resource.Condition = BicepMetadata.Condition.Compile();
         }
 
         yield return resource;

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceBicepMetadata.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceBicepMetadata.cs
@@ -20,8 +20,8 @@ public sealed class ResourceBicepMetadata
     /// If set, the resource will be wrapped in an 'if (condition)' statement.
     /// Supports literal boolean values, parameter references, or complex expressions.
     /// </summary>
-    public BicepValue<bool> Condition { get => _condition; set => _condition.Assign(value); }
-    private readonly BicepValue<bool> _condition = new((BicepValueReference?)null);
+    public BicepValue<bool> Condition { get { Initialize(); return _condition!; } set { Initialize(); _condition!.Assign(value); } }
+    private BicepValue<bool>? _condition;
 
     /// <summary>
     /// Optional batch size for resource deployment.
@@ -34,4 +34,9 @@ public sealed class ResourceBicepMetadata
     /// This prevents recreation of the resource if it already exists.
     /// </summary>
     public bool OnlyIfNotExists { get; set; }
+
+    private void Initialize()
+    {
+        _condition ??= new BicepValue<bool>((BicepValueReference?)null);
+    }
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceBicepMetadata.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceBicepMetadata.cs
@@ -16,6 +16,13 @@ public sealed class ResourceBicepMetadata
     public string? Description { get; set; }
 
     /// <summary>
+    /// Optional condition string for conditional resource deployment.
+    /// If set, the resource will be wrapped in an 'if (condition)' statement.
+    /// The condition is used as-is without validation.
+    /// </summary>
+    public string? Condition { get; set; }
+
+    /// <summary>
     /// Optional batch size for resource deployment.
     /// If set, adds a @batchSize(n) decorator to control parallel deployment batching.
     /// </summary>

--- a/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceBicepMetadata.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Primitives/ResourceBicepMetadata.cs
@@ -16,11 +16,12 @@ public sealed class ResourceBicepMetadata
     public string? Description { get; set; }
 
     /// <summary>
-    /// Optional condition string for conditional resource deployment.
+    /// Optional condition for conditional resource deployment.
     /// If set, the resource will be wrapped in an 'if (condition)' statement.
-    /// The condition is used as-is without validation.
+    /// Supports literal boolean values, parameter references, or complex expressions.
     /// </summary>
-    public string? Condition { get; set; }
+    public BicepValue<bool> Condition { get => _condition; set => _condition.Assign(value); }
+    private readonly BicepValue<bool> _condition = new((BicepValueReference?)null);
 
     /// <summary>
     /// Optional batch size for resource deployment.

--- a/sdk/provisioning/Azure.Provisioning/tests/BicepMetadataTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/BicepMetadataTests.cs
@@ -114,6 +114,45 @@ public class BicepMetadataTests
     }
 
     [Test]
+    public void BicepMetadataConditionTest()
+    {
+        new Trycep()
+            .Define(ctx =>
+            {
+                Infrastructure infra = new();
+
+                ProvisioningParameter deployStorage = new("deployStorage", typeof(bool)) { Value = true };
+                infra.Add(deployStorage);
+
+                StorageAccount storage = new("storage", StorageAccount.ResourceVersions.V2023_01_01)
+                {
+                    Kind = StorageKind.StorageV2,
+                    Sku = { Name = StorageSkuName.StandardLrs }
+                };
+                storage.BicepMetadata.Condition = "deployStorage";
+                infra.Add(storage);
+
+                return infra;
+            })
+            .Compare(
+                """
+                param deployStorage bool = true
+
+                @description('The location for the resource(s) to be deployed.')
+                param location string = resourceGroup().location
+
+                resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = if (deployStorage){
+                  name: take('storage${uniqueString(resourceGroup().id)}', 24)
+                  kind: 'StorageV2'
+                  location: location
+                  sku: {
+                    name: 'Standard_LRS'
+                  }
+                }
+                """);
+    }
+
+    [Test]
     public void BicepMetadataAllCombinedTest()
     {
         new Trycep()
@@ -126,22 +165,28 @@ public class BicepMetadataTests
                     Kind = StorageKind.StorageV2,
                     Sku = { Name = StorageSkuName.StandardLrs }
                 };
+                ProvisioningParameter deployStorage = new("deployStorage", typeof(bool)) { Value = true };
+                infra.Add(deployStorage);
+
                 storage.BicepMetadata.OnlyIfNotExists = true;
                 storage.BicepMetadata.Description = "Production storage account";
                 storage.BicepMetadata.BatchSize = 1;
+                storage.BicepMetadata.Condition = "deployStorage";
                 infra.Add(storage);
 
                 return infra;
             })
             .Compare(
                 """
+                param deployStorage bool = true
+
                 @description('The location for the resource(s) to be deployed.')
                 param location string = resourceGroup().location
 
                 @onlyIfNotExists()
                 @description('Production storage account')
                 @batchSize(1)
-                resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+                resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = if (deployStorage){
                   name: take('storage${uniqueString(resourceGroup().id)}', 24)
                   kind: 'StorageV2'
                   location: location

--- a/sdk/provisioning/Azure.Provisioning/tests/BicepMetadataTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/BicepMetadataTests.cs
@@ -129,7 +129,7 @@ public class BicepMetadataTests
                     Kind = StorageKind.StorageV2,
                     Sku = { Name = StorageSkuName.StandardLrs }
                 };
-                storage.BicepMetadata.Condition = "deployStorage";
+                storage.BicepMetadata.Condition = deployStorage;
                 infra.Add(storage);
 
                 return infra;
@@ -141,7 +141,7 @@ public class BicepMetadataTests
                 @description('The location for the resource(s) to be deployed.')
                 param location string = resourceGroup().location
 
-                resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = if (deployStorage){
+                resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = if (deployStorage) {
                   name: take('storage${uniqueString(resourceGroup().id)}', 24)
                   kind: 'StorageV2'
                   location: location
@@ -171,7 +171,7 @@ public class BicepMetadataTests
                 storage.BicepMetadata.OnlyIfNotExists = true;
                 storage.BicepMetadata.Description = "Production storage account";
                 storage.BicepMetadata.BatchSize = 1;
-                storage.BicepMetadata.Condition = "deployStorage";
+                storage.BicepMetadata.Condition = deployStorage;
                 infra.Add(storage);
 
                 return infra;
@@ -186,7 +186,7 @@ public class BicepMetadataTests
                 @onlyIfNotExists()
                 @description('Production storage account')
                 @batchSize(1)
-                resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = if (deployStorage){
+                resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = if (deployStorage) {
                   name: take('storage${uniqueString(resourceGroup().id)}', 24)
                   kind: 'StorageV2'
                   location: location


### PR DESCRIPTION
## Summary

Re-adds the `Condition` property to `ResourceBicepMetadata` and `ResourceStatement` that was removed in commit 5c701c55 before PR #54632 was merged. This enables generating Bicep `if (condition)` syntax for conditional resource deployment.

Fixes #54119

## Changes

- **ResourceBicepMetadata.cs** - Added `Condition` string property for conditional resource deployment
- **ResourceStatement.cs** - Added `Condition` expression property and updated `Write()` to emit `= if (condition)` syntax
- **ProvisionableResource.cs** - Added condition application logic in `Compile()` using `IdentifierExpression`
- **BicepMetadataTests.cs** - Added `BicepMetadataConditionTest` and updated `BicepMetadataAllCombinedTest` to include condition
- **API baseline files** - Updated for all target frameworks (net8.0, net10.0, netstandard2.0)