### PR TITLE
Update PR review skill to use inline review comments

### DIFF
--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -17,7 +17,7 @@ This phase checks version-related rules that are simple and rule-based. **If any
 
 1. Check the `.csproj` file and CHANGELOG.md for the rules below.
 2. If all versioning rules pass, proceed to Phase 2.
-3. If any rule is violated, add review comments on the violations, submit the review as **"Request Changes"** with a summary explaining the versioning violations, and **stop** — do not proceed to Phase 2.
+3. If any rule is violated, record inline review comments on the violations (with file path and line number), submit the review as **"Request Changes"** with a summary explaining the versioning violations, and **stop** — do not proceed to Phase 2.
 
 ### Versioning Rules
 
@@ -45,7 +45,7 @@ To determine the review scope:
 2. Examine API surface files (api/*.cs) for public API, focusing on new/changed surface.
 3. Check Generated models and resources in src/Generated/.
 4. Review TypeSpec customizations (e.g., `client.tsp`, `tspconfig.yaml`).
-5. Add review comments directly to the PR using GitHub MCP tools.
+5. For each issue found, record the exact file path, line number, and comment body to include as an inline review comment.
 
 ### API Review Checklist
 
@@ -137,7 +137,7 @@ This phase runs after Phase 2. If `ApiCompatVersion` is present in the `.csproj`
 2. Inspect the build output for `ApiCompat` errors — these indicate breaking changes against the last stable version (removals, signature changes, etc.).
 3. If the build succeeds with no `ApiCompat` errors, this phase passes.
 4. If `ApiCompat` errors are found:
-   - For each error, add a review comment listing the breaking change (what was removed or changed).
+   - For each error, record an inline review comment listing the breaking change (what was removed or changed), targeting the relevant file and line.
    - Do **not** attempt to fix or mitigate the breaking changes yourself. Instead, list all detected breaking changes and ask the user to mitigate them. Mitigation options include customization code via partial classes and generator features (e.g., `rename-mapping`, custom properties, shim methods) to preserve backward compatibility. The `mitigate-breaking-changes` skill can be invoked to assist with this.
    - Submit the review as **"Request Changes"** with the list of breaking changes that need mitigation.
 
@@ -145,12 +145,34 @@ If `ApiCompatVersion` is not present in the `.csproj`, skip this phase — there
 
 ## Output Format
 
-1. Report Phase 1 (Versioning) result: pass or fail with details
-2. If Phase 1 fails, submit review as **"Request Changes"** and stop
-3. If Phase 1 passes, report Phase 2 (API Review) results:
-   - Summarize what passes review
-   - For each issue found, add a review comment directly to the PR on the relevant file and line using GitHub MCP tools
-4. If `ApiCompatVersion` exists, report Phase 3 (Breaking Change Detection) results:
-   - Build the project and check for `ApiCompat` errors
-   - If breaking changes are found, submit review as **"Request Changes"** and ask the user to mitigate them
-5. Provide a final summary of all comments added
+Submit a single **pull request review** with all findings as **inline comments** attached to the relevant file and line. Do not post findings as general PR comments.
+
+### How to submit the review
+
+1. Collect all review findings across all phases. For each finding, record:
+   - **file path** (relative to repo root)
+   - **line number** (in the PR diff, use the last line of the relevant range)
+   - **comment body** (the review feedback)
+2. Submit **one** pull request review that includes all findings as inline review comments. Use the `gh` CLI:
+   ```
+   gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews \
+     --method POST \
+     -f event="REQUEST_CHANGES" \
+     -f body="<overall summary>" \
+     --jsonc comments="[{\"path\":\"<file>\",\"line\":<line>,\"body\":\"<comment>\"},...]"
+   ```
+   - Use `event: "REQUEST_CHANGES"` if any phase fails or issues are found.
+   - Use `event: "APPROVE"` if all phases pass with no issues.
+   - Use `event: "COMMENT"` if there are only minor suggestions but nothing blocking.
+
+### Review content
+
+1. Report Phase 1 (Versioning) result: pass or fail with details.
+2. If Phase 1 fails, submit the review as **"Request Changes"** and stop.
+3. If Phase 1 passes, include Phase 2 (API Review) results:
+   - Summarize what passes review in the review body.
+   - Each issue becomes an inline comment on the relevant file and line.
+4. If `ApiCompatVersion` exists, include Phase 3 (Breaking Change Detection) results:
+   - Build the project and check for `ApiCompat` errors.
+   - Each breaking change becomes an inline comment on the relevant file and line.
+5. The review body should contain a final summary of all phases and the total number of inline comments added.

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -157,13 +157,25 @@ Submit a single **pull request review** with all findings as **inline comments**
    ```
    gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews \
      --method POST \
-     -f event="REQUEST_CHANGES" \
-     -f body="<overall summary>" \
-     --jsonc comments="[{\"path\":\"<file>\",\"line\":<line>,\"body\":\"<comment>\"},...]"
+     --header "Accept: application/vnd.github+json" \
+     --input - << 'EOF'
+   {
+     "event": "REQUEST_CHANGES",
+     "body": "<overall summary>",
+     "comments": [
+       {
+         "path": "<file>",
+         "line": <line>,
+         "side": "RIGHT",
+         "body": "<comment>"
+       }
+     ]
+   }
+   EOF
    ```
-   - Use `event: "REQUEST_CHANGES"` if any phase fails or issues are found.
-   - Use `event: "APPROVE"` if all phases pass with no issues.
-   - Use `event: "COMMENT"` if there are only minor suggestions but nothing blocking.
+   - Use `event: "REQUEST_CHANGES"` if any phase fails or there are blocking issues that must be resolved before merge.
+   - Use `event: "APPROVE"` if all phases pass and there are no issues requiring changes.
+   - Use `event: "COMMENT"` if all phases pass and there are only non-blocking/minor suggestions.
 
 ### Review content
 


### PR DESCRIPTION
## Update PR review skill to use inline review comments

### Changes
Update the `azure-sdk-mgmt-pr-review` skill to submit review findings as **inline PR review comments** on specific files and lines, instead of posting general PR comments.

### What changed
- **Phase 1/2/3 instructions**: Each phase now records file path + line number for every finding, to be included as inline comments
- **Output format**: Rewritten to submit a single PR review with all findings as inline comments using the GitHub Pulls Review API
- **Removed** hardcoded `using GitHub MCP tools` references - Copilot will choose the right tool
- **Added** guidance on review event types (`REQUEST_CHANGES` / `APPROVE` / `COMMENT`)
