### PR TITLE
[CODEOWNERS] Remove invalid owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -263,7 +263,7 @@
 /sdk/communication/Azure.Communication.Rooms/                      @alexokun @allchiang-msft @mikehang-msft @minnieliu @Mrayyan @paolamvhz @shwali-msft
 
 # PRLabel: %Communication - Short Codes
-/sdk/communication/Azure.Communication.ShortCodes/                 @Arazan @danielortega-msft @whisper6284
+/sdk/communication/Azure.Communication.ShortCodes/                 @Arazan @whisper6284
 
 # PRLabel: %Communication - SMS
 /sdk/communication/Azure.Communication.Sms/                        @besh2014 @gfeitosa-msft @ilyapaliakou-msft @phermanov-msft
@@ -478,7 +478,7 @@
 /sdk/search/                                                       @Azure/azure-sdk-write-search
 
 # ServiceLabel: %Search
-# ServiceOwners:                                                   @efrainretana @kuanlu95 @mattgotteiner
+# ServiceOwners:                                                   @efrainretana @mattgotteiner
 
 # PRLabel: %Service Bus
 /sdk/servicebus/                                                   @EldertGrootenboer @j7nw4r @jsquire @skarri-microsoft


### PR DESCRIPTION
# Summary

The focus of these changes is to remove owners flagged by the linter as no longer valid.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5987805&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_