### PR TITLE
Gen AI - don't truncate specific properties

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -49,7 +49,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     {
                         if (!properties.ContainsKey(scopeItem.Key))
                         {
-                            properties.Add(scopeItem.Key, Convert.ToString(scopeItem.Value, CultureInfo.InvariantCulture)?.Truncate(SchemaConstants.MessageData_Properties_MaxValueLength)!);
+                            var stringValue = SchemaConstants.TruncationExemptProperties.Contains(scopeItem.Key)
+                                ? Convert.ToString(scopeItem.Value, CultureInfo.InvariantCulture)!
+                                : Convert.ToString(scopeItem.Value, CultureInfo.InvariantCulture)?.Truncate(SchemaConstants.MessageData_Properties_MaxValueLength)!;
+                            properties.Add(scopeItem.Key, stringValue);
                         }
                     }
                     catch (Exception ex)
@@ -187,7 +190,10 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                                 {
                                     if (!properties.ContainsKey(item.Key))
                                     {
-                                        properties.Add(item.Key, item.Value.ToString().Truncate(SchemaConstants.MessageData_Properties_MaxValueLength)!);
+                                        var stringValue = SchemaConstants.TruncationExemptProperties.Contains(item.Key)
+                                            ? item.Value.ToString()!
+                                            : item.Value.ToString().Truncate(SchemaConstants.MessageData_Properties_MaxValueLength)!;
+                                        properties.Add(item.Key, stringValue);
                                     }
                                 }
                             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SchemaConstants.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
@@ -126,5 +127,21 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         public const int Tags_AiCloudRole_MaxLength = 256;
         public const int Tags_AiCloudRoleInstance_MaxLength = 256;
         public const int Tags_AiInternalSdkVersion_MaxLength = 64;
+
+        /// <summary>
+        /// GenAI semantic convention property keys that are exempt from value truncation.
+        /// These properties may carry large payloads (e.g. full prompt/completion content)
+        /// and must not be truncated.
+        /// </summary>
+        public static readonly HashSet<string> TruncationExemptProperties = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "gen_ai.input.messages",
+            "gen_ai.output.messages",
+            "gen_ai.system_instructions",
+            "gen_ai.tool.definitions",
+            "gen_ai.tool.call.arguments",
+            "gen_ai.tool.call.result",
+            "gen_ai.evaluation.explanation",
+        };
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/TraceHelper.cs
@@ -109,12 +109,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             {
                 // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
                 // In case of duplicate keys, only the first occurence will be exported.
+                var stringValue = SchemaConstants.TruncationExemptProperties.Contains(keyValuePair.Key)
+                    ? Convert.ToString(keyValuePair.Value, CultureInfo.InvariantCulture) ?? "null"
+                    : Convert.ToString(keyValuePair.Value, CultureInfo.InvariantCulture).Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null";
 #if NET
-                destination.TryAdd(keyValuePair.Key, Convert.ToString(keyValuePair.Value, CultureInfo.InvariantCulture).Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null");
+                destination.TryAdd(keyValuePair.Key, stringValue);
 #else
                 if (!destination.ContainsKey(keyValuePair.Key))
                 {
-                    destination.Add(keyValuePair.Key, Convert.ToString(keyValuePair.Value, CultureInfo.InvariantCulture).Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null");
+                    destination.Add(keyValuePair.Key, stringValue);
                 }
 #endif
             }
@@ -127,12 +130,15 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
             {
                 // Note: if Key exceeds MaxLength or if Value is null, the entire KVP will be dropped.
                 // In case of duplicate keys, only the first occurence will be exported.
+                var sanitizedValue = SchemaConstants.TruncationExemptProperties.Contains(key)
+                    ? value
+                    : value.Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null";
 #if NET
-                destination.TryAdd(key, value.Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null");
+                destination.TryAdd(key, sanitizedValue);
 #else
                 if (!destination.ContainsKey(key))
                 {
-                    destination.Add(key, value.Truncate(SchemaConstants.KVP_MaxValueLength) ?? "null");
+                    destination.Add(key, sanitizedValue);
                 }
 #endif
             }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/GenAiTruncationExemptionTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/GenAiTruncationExemptionTests.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+using Azure.Monitor.OpenTelemetry.Exporter.Internals;
+using Azure.Monitor.OpenTelemetry.Exporter.Models;
+using Microsoft.Extensions.Logging;
+
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
+{
+    public class GenAiTruncationExemptionTests
+    {
+        private const int LargePayloadLength = 64_000;
+
+        private static readonly string s_largePayload = new string('x', LargePayloadLength);
+
+        static GenAiTruncationExemptionTests()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+
+            var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+            };
+
+            ActivitySource.AddActivityListener(listener);
+        }
+
+        [Theory]
+        [InlineData("gen_ai.input.messages")]
+        [InlineData("gen_ai.output.messages")]
+        [InlineData("gen_ai.system_instructions")]
+        [InlineData("gen_ai.tool.definitions")]
+        [InlineData("gen_ai.tool.call.arguments")]
+        [InlineData("gen_ai.tool.call.result")]
+        [InlineData("gen_ai.evaluation.explanation")]
+        public void GenAiProperties_AreNotTruncated_InAddPropertiesToTelemetry(string propertyKey)
+        {
+            // Arrange
+            IDictionary<string, string> destination = new Dictionary<string, string>();
+            var tagObjects = AzMonList.Initialize();
+            AzMonList.Add(ref tagObjects, new KeyValuePair<string, object?>(propertyKey, s_largePayload));
+
+            // Act
+            TraceHelper.AddPropertiesToTelemetry(destination, ref tagObjects);
+
+            // Assert
+            Assert.True(destination.TryGetValue(propertyKey, out var value));
+            Assert.Equal(LargePayloadLength, value!.Length);
+            Assert.Equal(s_largePayload, value);
+        }
+
+        [Theory]
+        [InlineData("gen_ai.input.messages")]
+        [InlineData("gen_ai.output.messages")]
+        [InlineData("gen_ai.system_instructions")]
+        [InlineData("gen_ai.tool.definitions")]
+        [InlineData("gen_ai.tool.call.arguments")]
+        [InlineData("gen_ai.tool.call.result")]
+        [InlineData("gen_ai.evaluation.explanation")]
+        public void GenAiProperties_AreNotTruncated_InAddKvpToDictionary_WithStringOverload(string propertyKey)
+        {
+            // Arrange
+            IDictionary<string, string> destination = new Dictionary<string, string>();
+
+            // Act
+            TraceHelper.AddKvpToDictionary(destination, propertyKey, s_largePayload);
+
+            // Assert
+            Assert.True(destination.TryGetValue(propertyKey, out var value));
+            Assert.Equal(LargePayloadLength, value!.Length);
+            Assert.Equal(s_largePayload, value);
+        }
+
+        [Fact]
+        public void NonGenAiProperties_AreTruncated_InAddPropertiesToTelemetry()
+        {
+            // Arrange
+            IDictionary<string, string> destination = new Dictionary<string, string>();
+            var tagObjects = AzMonList.Initialize();
+            AzMonList.Add(ref tagObjects, new KeyValuePair<string, object?>("regular.property", s_largePayload));
+
+            // Act
+            TraceHelper.AddPropertiesToTelemetry(destination, ref tagObjects);
+
+            // Assert
+            Assert.True(destination.TryGetValue("regular.property", out var value));
+            Assert.Equal(SchemaConstants.KVP_MaxValueLength, value!.Length);
+        }
+
+        [Fact]
+        public void NonGenAiProperties_AreTruncated_InAddKvpToDictionary_WithStringOverload()
+        {
+            // Arrange
+            IDictionary<string, string> destination = new Dictionary<string, string>();
+
+            // Act
+            TraceHelper.AddKvpToDictionary(destination, "regular.property", s_largePayload);
+
+            // Assert
+            Assert.True(destination.TryGetValue("regular.property", out var value));
+            Assert.Equal(SchemaConstants.KVP_MaxValueLength, value!.Length);
+        }
+
+        [Theory]
+        [InlineData("gen_ai.input.messages")]
+        [InlineData("gen_ai.output.messages")]
+        [InlineData("gen_ai.system_instructions")]
+        [InlineData("gen_ai.tool.definitions")]
+        [InlineData("gen_ai.tool.call.arguments")]
+        [InlineData("gen_ai.tool.call.result")]
+        [InlineData("gen_ai.evaluation.explanation")]
+        public void GenAiProperties_AreNotTruncated_InLogRecordAttributes(string propertyKey)
+        {
+            // Arrange
+            var logRecords = new List<LogRecord>();
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.IncludeFormattedMessage = true;
+                    options.AddInMemoryExporter(logRecords);
+                });
+                builder.AddFilter(typeof(GenAiTruncationExemptionTests).FullName, LogLevel.Trace);
+            });
+
+            var logger = loggerFactory.CreateLogger<GenAiTruncationExemptionTests>();
+
+            // Use LoggerMessage.Define pattern to add structured attributes
+            var state = new List<KeyValuePair<string, object?>>
+            {
+                new(propertyKey, s_largePayload),
+            };
+            logger.Log(LogLevel.Information, 0, state, null, (s, e) => "test message");
+
+            Assert.Single(logRecords);
+
+            var properties = new ChangeTrackingDictionary<string, string>();
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out _, out _, out _, out _);
+
+            // Assert
+            Assert.True(properties.TryGetValue(propertyKey, out var value), $"Property '{propertyKey}' should exist in the properties dictionary.");
+            Assert.Equal(LargePayloadLength, value!.Length);
+            Assert.Equal(s_largePayload, value);
+        }
+
+        [Fact]
+        public void NonGenAiProperties_AreTruncated_InLogRecordAttributes()
+        {
+            // Arrange
+            var logRecords = new List<LogRecord>();
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.IncludeFormattedMessage = true;
+                    options.AddInMemoryExporter(logRecords);
+                });
+                builder.AddFilter(typeof(GenAiTruncationExemptionTests).FullName, LogLevel.Trace);
+            });
+
+            var logger = loggerFactory.CreateLogger<GenAiTruncationExemptionTests>();
+
+            var state = new List<KeyValuePair<string, object?>>
+            {
+                new("regular.property", s_largePayload),
+            };
+            logger.Log(LogLevel.Information, 0, state, null, (s, e) => "test message");
+
+            Assert.Single(logRecords);
+
+            var properties = new ChangeTrackingDictionary<string, string>();
+            LogsHelper.ProcessLogRecordProperties(logRecords[0], properties, out _, out _, out _, out _);
+
+            // Assert
+            Assert.True(properties.TryGetValue("regular.property", out var value));
+            Assert.Equal(SchemaConstants.MessageData_Properties_MaxValueLength, value!.Length);
+        }
+
+        [Theory]
+        [InlineData("gen_ai.input.messages")]
+        [InlineData("gen_ai.output.messages")]
+        [InlineData("gen_ai.system_instructions")]
+        [InlineData("gen_ai.tool.definitions")]
+        [InlineData("gen_ai.tool.call.arguments")]
+        [InlineData("gen_ai.tool.call.result")]
+        [InlineData("gen_ai.evaluation.explanation")]
+        public void GenAiProperties_AreNotTruncated_InActivityCustomDimensions(string propertyKey)
+        {
+            // Arrange
+            using var activitySource = new ActivitySource(nameof(GenAiTruncationExemptionTests));
+            using var activity = activitySource.StartActivity(
+                "TestActivity",
+                ActivityKind.Client,
+                parentContext: default,
+                tags: new[] { new KeyValuePair<string, object?>(propertyKey, s_largePayload) });
+
+            Assert.NotNull(activity);
+            activity.Stop();
+
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var remoteDependencyData = new RemoteDependencyData(2, activity, ref activityTagsProcessor);
+
+            // Assert
+            Assert.True(remoteDependencyData.Properties.TryGetValue(propertyKey, out var value), $"Property '{propertyKey}' should exist in dependency custom dimensions.");
+            Assert.Equal(LargePayloadLength, value!.Length);
+            Assert.Equal(s_largePayload, value);
+        }
+
+        [Theory]
+        [InlineData("gen_ai.input.messages")]
+        [InlineData("gen_ai.output.messages")]
+        [InlineData("gen_ai.system_instructions")]
+        [InlineData("gen_ai.tool.definitions")]
+        [InlineData("gen_ai.tool.call.arguments")]
+        [InlineData("gen_ai.tool.call.result")]
+        [InlineData("gen_ai.evaluation.explanation")]
+        public void GenAiProperties_AreNotTruncated_InRequestDataCustomDimensions(string propertyKey)
+        {
+            // Arrange
+            using var activitySource = new ActivitySource(nameof(GenAiTruncationExemptionTests));
+            using var activity = activitySource.StartActivity(
+                "TestActivity",
+                ActivityKind.Server,
+                parentContext: default,
+                tags: new[] { new KeyValuePair<string, object?>(propertyKey, s_largePayload) });
+
+            Assert.NotNull(activity);
+            activity.Stop();
+
+            var activityTagsProcessor = TraceHelper.EnumerateActivityTags(activity);
+            var requestData = new RequestData(2, activity, ref activityTagsProcessor);
+
+            // Assert
+            Assert.True(requestData.Properties.TryGetValue(propertyKey, out var value), $"Property '{propertyKey}' should exist in request custom dimensions.");
+            Assert.Equal(LargePayloadLength, value!.Length);
+            Assert.Equal(s_largePayload, value);
+        }
+    }
+}


### PR DESCRIPTION
This PR removes truncation for specific gen ai custom dimensions that appear on spans and logs.
