### PR TITLE
Accept ApiKeyCredential as CredentialSource in AuthenticationPolicy

### DIFF
--- a/sdk/core/System.ClientModel/src/Pipeline/AuthenticationPolicy.cs
+++ b/sdk/core/System.ClientModel/src/Pipeline/AuthenticationPolicy.cs
@@ -36,7 +36,7 @@ public abstract class AuthenticationPolicy : PipelinePolicy
 
         return settings.Credential.CredentialSource switch
         {
-            "ApiKey" => CreateWithApiKey(settings, scope),
+            "ApiKey" or "ApiKeyCredential" => CreateWithApiKey(settings, scope),
             _ => CreateWithTokenCredential(settings, scope)
         };
     }

--- a/sdk/core/System.ClientModel/tests/Convenience/AuthenticationPolicyCreateTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/AuthenticationPolicyCreateTests.cs
@@ -116,6 +116,30 @@ public class AuthenticationPolicyCreateTests
     }
 
     [Test]
+    public void Create_WithApiKeyCredentialCredentialSource_AndKey_ReturnsApiKeyAuthenticationPolicy()
+    {
+        TestClientSettings settings = new();
+        IConfigurationRoot config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["TestClient:Credential:CredentialSource"] = "ApiKeyCredential",
+                ["TestClient:Credential:Key"] = "test-api-key-12345"
+            })
+            .Build();
+        settings.Bind(config.GetSection("TestClient"));
+
+        AuthenticationPolicy policy = AuthenticationPolicy.Create(settings);
+
+        Assert.That(policy, Is.Not.Null);
+        Assert.That(policy, Is.InstanceOf<ApiKeyAuthenticationPolicy>());
+
+        ApiKeyAuthenticationPolicy apiKeyPolicy = (ApiKeyAuthenticationPolicy)policy;
+        string? key = GetKeyFromApiKeyPolicy(apiKeyPolicy);
+        Assert.That(key, Is.Not.Null);
+        Assert.That(key, Is.EqualTo("test-api-key-12345"));
+    }
+
+    [Test]
     public void Create_WithApiKeyCredentialSource_AndNullKey_ThrowsInvalidOperationException()
     {
         TestClientSettings settings = new();


### PR DESCRIPTION
Updated the `AuthenticationPolicy.Create` switch expression to accept both `"ApiKey"` and `"ApiKeyCredential"` as valid `CredentialSource` values, routing both to `CreateWithApiKey`.