### PR TITLE
Prepare Azure.Provisioning 1.6.0-beta.1 release

### DIFF
--- a/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 1.6.0-beta.1 (Unreleased)
+## 1.6.0-beta.1 (2026-03-11)
 
 ### Features Added
 
 - Added `Condition` property to `ResourceBicepMetadata` to support conditional resource deployment. The condition generates Bicep `if (condition)` syntax and accepts literal boolean values, parameter references, or complex expressions.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.5.0 (2026-03-04)
 


### PR DESCRIPTION
## Description

Prepare release for Azure.Provisioning 1.6.0-beta.1.

## Changes

- Set release date to 2026-03-11
- Removed empty changelog sections