### PR TITLE
[Mgmt Generator] Fix FlattenPropertyVisitor crash when flattened model has no public constructor

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -692,12 +692,17 @@ namespace Azure.Generator.Management.Visitors
                                 }
                             }
 
-                            // we should only construct the flattened properties in the public constructor when assigning to the internal property
+                            // Construct the nested flattened property model and assign it to the internal property.
+                            // When the nested model has a public constructor, use its parameters to match
+                            // flattened properties by name; otherwise fall back to FullConstructor for
+                            // Output-only models that only have internal constructors.
                             if (currentInternalProperty is not null)
                             {
                                 var properties = value.Where(x => flattenedProperties.Contains(x.FlattenedProperty)).ToList();
-                                var conditionExpression = BuildConditionExpression(properties, publicConstructor: true);
-                                var instanceExpression = New.Instance(variable.Type, BuildConstructorParameters(variable.Type, properties, publicConstructor: true));
+                                var nestedModelType = ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap[variable.Type] as ModelProvider;
+                                bool nestedHasPublicCtor = nestedModelType?.Constructors.Any(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)) == true;
+                                var conditionExpression = BuildConditionExpression(properties, publicConstructor: nestedHasPublicCtor);
+                                var instanceExpression = New.Instance(variable.Type, BuildConstructorParameters(variable.Type, properties, publicConstructor: nestedHasPublicCtor));
                                 var assignmentExpression =
                                     conditionExpression is null
                                     ? instanceExpression

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Management;
+using Azure.Generator.Management.Tests.Common;
+using Azure.Generator.Management.Tests.TestHelpers;
+using Microsoft.TypeSpec.Generator;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Primitives;
+using NUnit.Framework;
+using System.Reflection;
+
+namespace Azure.Generator.Mgmt.Tests
+{
+    internal class FlattenPropertyVisitorTests
+    {
+        /// <summary>
+        /// Verifies that flattening works correctly when the nested properties model
+        /// has no public constructor (Output-only usage). Previously this crashed with
+        /// "Sequence contains no matching element" because UpdatePublicConstructorBody
+        /// unconditionally passed publicConstructor: true to BuildConstructorParameters.
+        /// </summary>
+        [Test]
+        public void TestFlattenWithNoPublicConstructorOnNestedModel()
+        {
+            // Create a nested "properties" model with Output-only usage.
+            // Output-only models don't get a public constructor — only an internal FullConstructor.
+            var innerProperty = InputFactory.Property("displayName", InputPrimitiveType.String, isRequired: true, serializedName: "displayName");
+            var propertiesModel = InputFactory.Model(
+                "TestProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties: [innerProperty]);
+
+            // Create a property on the parent model referencing the properties model,
+            // then apply the @flattenProperty decorator to it.
+            var propertiesProperty = InputFactory.Property("properties", propertiesModel, isRequired: true, serializedName: "properties");
+            ApplyFlattenDecorator(propertiesProperty);
+
+            // Create the parent model with Input+Output usage so it gets a public constructor.
+            var parentModel = InputFactory.Model(
+                "TestResource",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [propertiesProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [parentModel, propertiesModel]);
+
+            // Create the model provider (this runs PreVisit* visitors only).
+            var model = plugin.Object.TypeFactory.CreateModel(parentModel);
+            Assert.IsNotNull(model);
+
+            // Verify the Output-only nested model has no public constructor (precondition).
+            var nestedModel = plugin.Object.TypeFactory.CreateModel(propertiesModel);
+            Assert.IsNotNull(nestedModel);
+            Assert.IsFalse(
+                nestedModel!.Constructors.Any(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)),
+                "Precondition: Output-only nested model should have no public constructor");
+
+            // Now run the VisitType visitors on the parent model.
+            // FlattenPropertyVisitor.VisitType() processes @flattenProperty decorators and
+            // calls BuildConstructorParameters on the nested model. The fix checks whether
+            // the nested model has a public constructor and falls back to FullConstructor
+            // when it does not. Without the fix, this throws InvalidOperationException:
+            // "Sequence contains no matching element" from .First().
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(visitTypeCore, "Could not find LibraryVisitor.VisitTypeCore method");
+
+            Assert.DoesNotThrow(() =>
+            {
+                foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+                {
+                    visitTypeCore!.Invoke(visitor, [model]);
+                }
+            });
+        }
+
+        private static void ApplyFlattenDecorator(InputModelProperty property)
+        {
+            var decorator = new InputDecoratorInfo(
+                "Azure.ResourceManager.@flattenProperty",
+                new Dictionary<string, BinaryData>());
+            var decoratorsProperty = typeof(InputModelProperty).GetProperty(
+                nameof(InputModelProperty.Decorators),
+                BindingFlags.Public | BindingFlags.Instance);
+            Assert.IsNotNull(decoratorsProperty, "Could not find InputModelProperty.Decorators property");
+            decoratorsProperty!.SetValue(property, new[] { decorator });
+        }
+    }
+}


### PR DESCRIPTION
## Fix FlattenPropertyVisitor crash when flattened model has no public constructor

### Problem
`UpdatePublicConstructorBody` unconditionally passed `publicConstructor: true` to `BuildConstructorParameters` and `BuildConditionExpression`. This crashed with `InvalidOperationException` ("Sequence contains no matching element") when the nested flattened model has Output-only usage and therefore no public constructor — only internal constructors.

This was discovered during the Storage management-plane TypeSpec migration (PR #56896), where many response/result models (e.g., `FileServiceUsageProperties`, `StorageTaskAssignmentUpdateExecutionContext`) have Output-only usage with no public constructors.

### Fix
At the call site in `UpdatePublicConstructorBody`, check whether the nested model actually has a public constructor before deciding what to pass. If it does not, pass `publicConstructor: false` so that `BuildConstructorParameters` uses `FullConstructor` (which always exists). This keeps the `BuildConstructorParameters` contract unchanged — callers that pass `publicConstructor: true` still require a public constructor to exist.

### Test
Added `FlattenPropertyVisitorTests.TestFlattenWithNoPublicConstructorOnNestedModel` that:
1. Creates an Output-only nested model (no public constructor)
2. Creates a parent model with `@flattenProperty` decorator on the nested property
3. Verifies the precondition: nested model has no public constructor
4. Runs all registered visitors on the parent model via reflection
5. Confirms no exception is thrown (previously threw `InvalidOperationException`)

The test was verified to **fail without the fix** and **pass with it**.