### PR TITLE
Add naming fix recommendation guidance to mgmt PR review skill

### DIFF
--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -97,7 +97,7 @@ When flagging a naming issue, the recommended fix depends on whether the type is
 2. **Type is NOT defined in the service's TypeSpec**: `@@clientName` cannot be used. Instead, recommend **SDK-side custom code** — create a customization file (e.g., `src/Customize/Models/<NewName>.cs`) using `[CodeGenType("OriginalGeneratedName")]` to rename the type.
    - Example: `[CodeGenType("OptionalPropertiesUpdateableProperties")]` on a class named `DurableTaskPrivateEndpointConnectionPatchProperties`.
 
-To determine whether a type is defined in the service's TypeSpec, search all `.tsp` files under the spec folder **except** `client.tsp` and `back-compatible.tsp` for a `model`, `union`, or `enum` declaration with the same name.
+To determine whether a type is defined in the service's TypeSpec, search all `.tsp` files under the spec folder for a `model`, `union`, or `enum` declaration with the same name.
 
 #### Enums
 - Use singular type name (not plural) unless bit flags

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -88,6 +88,17 @@ To determine the review scope:
 - **Good examples:** `StorageAccountPublicNetworkAccess`, `CosmosDBEncryptionStatus`, `KeyVaultPrivateEndpointConnection` — these names include the service or resource context.
 - Exception: If the type is scoped within a clearly named parent model or the namespace already provides unambiguous context (e.g., a property type used exclusively by one resource), a shorter name may be acceptable.
 
+#### Naming Fix Recommendations
+
+When flagging a naming issue, the recommended fix depends on whether the type is explicitly defined in the service's TypeSpec.
+
+1. **Type is defined in the service's TypeSpec**: Recommend adding a `@@clientName` decorator in `client.tsp`.
+   - Example: `@@clientName(PublicNetworkAccess, "DurableTaskPublicNetworkAccess", "csharp");`
+2. **Type is NOT defined in the service's TypeSpec**: `@@clientName` cannot be used. Instead, recommend **SDK-side custom code** — create a customization file (e.g., `src/Customize/Models/<NewName>.cs`) using `[CodeGenType("OriginalGeneratedName")]` to rename the type.
+   - Example: `[CodeGenType("OptionalPropertiesUpdateableProperties")]` on a class named `DurableTaskPrivateEndpointConnectionPatchProperties`.
+
+To determine whether a type is defined in the service's TypeSpec, search all `.tsp` files under the spec folder **except** `client.tsp` and `back-compatible.tsp` for a `model`, `union`, or `enum` declaration with the same name.
+
 #### Enums
 - Use singular type name (not plural) unless bit flags
 - Numeric version enums should use underscore: `Tls1_0`, `Ver5_6`

--- a/.github/skills/mgmt-review-comment-resolution/SKILL.md
+++ b/.github/skills/mgmt-review-comment-resolution/SKILL.md
@@ -18,7 +18,7 @@ Management-plane SDK code is generated from TypeSpec definitions in `azure-rest-
 ### Key Concepts
 
 - **`@@clientName(TypeSpecName, "CSharpName", "csharp")`** — renames a TypeSpec model/union/enum/property to a different name in the generated C# SDK. This is the primary tool for resolving naming comments.
-- **`@@clientName` only works on types defined in the service's TypeSpec** — you can only target models, unions, enums, and interfaces that are explicitly declared in the service's `.tsp` files (all `.tsp` files under the spec folder **except** `client.tsp` and `back-compatible.tsp`). If a type is not defined there (e.g., it comes from ARM common types or TypeSpec templates), `@@clientName` cannot target it. See "Renaming via SDK Custom Code" below.
+- **`@@clientName` only works on types defined in the service's TypeSpec** — you can only target models, unions, enums, and interfaces that are explicitly declared in the service's `.tsp` files. If a type is not defined there (e.g., it comes from ARM common types or TypeSpec templates), `@@clientName` cannot target it. See "Renaming via SDK Custom Code" below.
 - **`@@clientName` cannot target aliases** — if a type is defined as an `alias`, `@@clientName` cannot target it. See "Handling Unsupported Cases" below.
 - **Only `client.tsp` may be changed** in the spec repo — do not modify any other `.tsp` files or config files. If resolving a comment would require changes to other files, skip that change and inform the user with the reason after processing all other comments. Since only `client.tsp` is modified, swagger regeneration is never needed.
 
@@ -67,7 +67,7 @@ Fetch the PR's review comments using GitHub MCP tools. For each unresolved comme
 1. Identify what change is requested (rename type, rename property, change type, etc.)
 2. Find the corresponding TypeSpec type/property in the spec
 3. Determine the appropriate new name or change
-4. **Determine if the type is defined in the service's TypeSpec**: Search all `.tsp` files under the spec folder **except** `client.tsp` and `back-compatible.tsp` for a `model`, `union`, or `enum` declaration with the same name.
+4. **Determine if the type is defined in the service's TypeSpec**: Search all `.tsp` files under the spec folder for a `model`, `union`, or `enum` declaration with the same name.
    - If defined → the rename will use `@@clientName` in `client.tsp` (Step 3)
    - If NOT defined → the rename must use SDK-side custom code (Step 3b)
 

--- a/.github/skills/mgmt-review-comment-resolution/SKILL.md
+++ b/.github/skills/mgmt-review-comment-resolution/SKILL.md
@@ -18,8 +18,9 @@ Management-plane SDK code is generated from TypeSpec definitions in `azure-rest-
 ### Key Concepts
 
 - **`@@clientName(TypeSpecName, "CSharpName", "csharp")`** — renames a TypeSpec model/union/enum/property to a different name in the generated C# SDK. This is the primary tool for resolving naming comments.
-- **`@@clientName` only works on named types** — models, unions, enums, and interfaces. If a type is defined as an `alias`, `@@clientName` cannot target it. See "Handling Unsupported Cases" below.
-- **Only `client.tsp` may be changed** — do not modify any other `.tsp` files or config files. If resolving a comment would require changes to other files, skip that change and inform the user with the reason after processing all other comments. Since only `client.tsp` is modified, swagger regeneration is never needed.
+- **`@@clientName` only works on types defined in the service's TypeSpec** — you can only target models, unions, enums, and interfaces that are explicitly declared in the service's `.tsp` files (all `.tsp` files under the spec folder **except** `client.tsp` and `back-compatible.tsp`). If a type is not defined there (e.g., it comes from ARM common types or TypeSpec templates), `@@clientName` cannot target it. See "Renaming via SDK Custom Code" below.
+- **`@@clientName` cannot target aliases** — if a type is defined as an `alias`, `@@clientName` cannot target it. See "Handling Unsupported Cases" below.
+- **Only `client.tsp` may be changed** in the spec repo — do not modify any other `.tsp` files or config files. If resolving a comment would require changes to other files, skip that change and inform the user with the reason after processing all other comments. Since only `client.tsp` is modified, swagger regeneration is never needed.
 
 ## Types of Review Comments
 
@@ -66,6 +67,9 @@ Fetch the PR's review comments using GitHub MCP tools. For each unresolved comme
 1. Identify what change is requested (rename type, rename property, change type, etc.)
 2. Find the corresponding TypeSpec type/property in the spec
 3. Determine the appropriate new name or change
+4. **Determine if the type is defined in the service's TypeSpec**: Search all `.tsp` files under the spec folder **except** `client.tsp` and `back-compatible.tsp` for a `model`, `union`, or `enum` declaration with the same name.
+   - If defined → the rename will use `@@clientName` in `client.tsp` (Step 3)
+   - If NOT defined → the rename must use SDK-side custom code (Step 3b)
 
 If a comment is ambiguous about what the new name should be, **ask the user** before proceeding.
 
@@ -84,7 +88,9 @@ If a comment is ambiguous about what the new name should be, **ask the user** be
    - `client.tsp` — where `@@clientName` and `@@alternateType` decorators go (this is the only `.tsp` file you should modify)
    - Other `.tsp` files — read-only reference for understanding models, unions, and aliases
 
-### Step 3: Apply Changes in the Spec Repo
+### Step 3: Apply Changes in the Spec Repo (for types defined in TypeSpec)
+
+This step applies only to types that are defined in the service's TypeSpec files. For types NOT defined in the service's TypeSpec, skip to **Step 3b**.
 
 Locate the spec repo. It may be:
 - A local clone (typically at `../azure-rest-api-specs` relative to the SDK repo)
@@ -100,6 +106,30 @@ Add `@@clientName` decorators to `client.tsp`. Read the existing `client.tsp` to
 ```
 
 Make sure the `using` statement for the service namespace is present so that type names resolve correctly. Check the `namespace` declaration in `main.tsp` or other `.tsp` files to find the correct namespace.
+
+### Step 3b: Apply Changes via SDK Custom Code (for types NOT defined in TypeSpec)
+
+Types that are not defined in the service's TypeSpec (e.g., from ARM common types or TypeSpec templates) cannot be renamed via `@@clientName`. Instead, create SDK-side customization files to rename them.
+
+1. Create a customization file in the SDK package's `src/Customize/Models/` directory (create the directory if it doesn't exist).
+2. Define a `partial class` (or `partial struct` for value types) with the **desired name**, and apply the `[CodeGenType("OriginalGeneratedName")]` attribute to map it to the generated type.
+
+**Example:** To rename `OptionalPropertiesUpdateableProperties` to `DurableTaskPrivateEndpointConnectionPatchProperties`:
+
+```csharp
+// src/Customize/Models/DurableTaskPrivateEndpointConnectionPatchProperties.cs
+using Azure.ResourceManager.DurableTask.Models;
+
+namespace Azure.ResourceManager.DurableTask.Models
+{
+    [CodeGenType("OptionalPropertiesUpdateableProperties")]
+    public partial class DurableTaskPrivateEndpointConnectionPatchProperties
+    {
+    }
+}
+```
+
+After creating customization files, proceed to **Step 6** (Regenerate the SDK) — Steps 4 and 5 (commit spec changes and update `tsp-location.yaml`) are only needed if `client.tsp` was also modified.
 
 ### Step 4: Commit and Push Spec Changes
 
@@ -150,7 +180,7 @@ Check the API surface file (`api/*.cs`) to confirm the review comments have been
 Some changes cannot be done purely through `@@clientName` or `@@alternateType` in `client.tsp`. When you encounter any of the following, **skip the change** and continue processing other comments. After all processable changes are done, inform the user about the skipped changes with the reason, and let them choose how to proceed:
 
 - **Aliases** — `@@clientName` cannot target TypeSpec aliases (e.g., `alias foo = "A" | "B" | string;`). Explain to the user that the alias needs to be converted to a named type (e.g., `union`) in the spec `.tsp` file first.
-- **Changes requiring other file modifications** — any change that cannot be expressed via `client.tsp` decorators alone (e.g., structural changes, flattening/unflattening models, adding/removing properties, or changing inheritance). Only `client.tsp` may be modified.
+- **Changes requiring spec file modifications beyond `client.tsp`** — any change that cannot be expressed via `client.tsp` decorators or SDK custom code alone (e.g., structural changes, flattening/unflattening models, adding/removing properties, or changing inheritance).
 - **Ambiguous naming** — if a review comment says "rename this" but doesn't specify the new name, ask the user what name they prefer.
 
 ## Common Pitfalls


### PR DESCRIPTION
## What

Adds guidance for handling naming fixes for types that are NOT defined in the service's TypeSpec to two skills:

1. **`azure-sdk-mgmt-pr-review`**  Added `Naming Fix Recommendations` subsection to Phase 2 API Review
2. **`mgmt-review-comment-resolution`**  Added `Step 3b` for SDK custom code path and updated Key Concepts/workflow

## Why

During review of PR #56886 (Azure.ResourceManager.DurableTask), naming issues were flagged with incorrect fix guidance  `@@clientName` was recommended for types that come from ARM common types/templates, which doesn't work because those types have no declaration in the service TypeSpec to target.

## Rule

| Type Origin | Recommended Fix |
|-------------|----------------|
| Defined in service TypeSpec (`.tsp` files under spec folder, excluding `client.tsp` and `back-compatible.tsp`) | `@@clientName` in `client.tsp` |
| Not defined in service TypeSpec | SDK-side custom code using `[CodeGenType("OriginalName")]` |

## Changes

- `.github/skills/azure-sdk-mgmt-pr-review/SKILL.md`: Added `Naming Fix Recommendations` subsection
- `.github/skills/mgmt-review-comment-resolution/SKILL.md`: Added Step 3b (SDK custom code), updated Key Concepts, Step 1, Step 3, and Handling Unsupported Cases