### PR TITLE
Refresh library inventory

### DIFF
--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -15,8 +15,8 @@
 
 - Total libraries: 405
 - Management Plane (MPG): 229
-  - Autorest/Swagger: 131
-  - New Emitter (TypeSpec): 98
+  - Autorest/Swagger: 130
+  - New Emitter (TypeSpec): 99
   - Old TypeSpec: 0
 - Data Plane (DPG): 145
   - Autorest/Swagger: 54
@@ -146,7 +146,7 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 54
 
 Libraries that provide resource management APIs for Azure services and have been migrated to the new TypeSpec emitter.
 
-**Migration Status**: 98 / 98 (100%)
+**Migration Status**: 99 / 99 (100%)
 
 | Service | Library | New Emitter |
 | ------- | ------- | ----------- |
@@ -225,6 +225,7 @@ Libraries that provide resource management APIs for Azure services and have been
 | quota | Azure.ResourceManager.Quota | ✅ |
 | recoveryservices | Azure.ResourceManager.RecoveryServices | ✅ |
 | recoveryservices-datareplication | Azure.ResourceManager.RecoveryServicesDataReplication | ✅ |
+| redisenterprise | Azure.ResourceManager.RedisEnterprise | ✅ |
 | resourceconnector | Azure.ResourceManager.ResourceConnector | ✅ |
 | resources | Azure.ResourceManager.Resources.Bicep | ✅ |
 | resources | Azure.ResourceManager.Resources.DeploymentStacks | ✅ |
@@ -252,7 +253,7 @@ Libraries that provide resource management APIs for Azure services and have been
 
 ## Management Plane Libraries (MPG) - Still on Swagger
 
-Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 131
+Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 130
 
 | Service | Library |
 | ------- | ------- |
@@ -356,7 +357,6 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 13
 | recoveryservices-backup | Azure.ResourceManager.RecoveryServicesBackup |
 | recoveryservices-siterecovery | Azure.ResourceManager.RecoveryServicesSiteRecovery |
 | redis | Azure.ResourceManager.Redis |
-| redisenterprise | Azure.ResourceManager.RedisEnterprise |
 | relay | Azure.ResourceManager.Relay |
 | reservations | Azure.ResourceManager.Reservations |
 | resourcegraph | Azure.ResourceManager.ResourceGraph |
@@ -421,7 +421,7 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 | provisioning | Azure.Provisioning.PostgreSql | Azure.ResourceManager.PostgreSql | Reflection |
 | provisioning | Azure.Provisioning.PrivateDns | Azure.ResourceManager.PrivateDns | Reflection |
 | provisioning | Azure.Provisioning.Redis | Azure.ResourceManager.Redis | Reflection |
-| provisioning | Azure.Provisioning.RedisEnterprise | Azure.ResourceManager.RedisEnterprise | Reflection |
+| provisioning | Azure.Provisioning.RedisEnterprise | Azure.ResourceManager.RedisEnterprise ✅ | Reflection |
 | provisioning | Azure.Provisioning.Search | Azure.ResourceManager.Search | Reflection |
 | provisioning | Azure.Provisioning.ServiceBus | Azure.ResourceManager.ServiceBus | Reflection |
 | provisioning | Azure.Provisioning.SignalR | Azure.ResourceManager.SignalR ✅ | Reflection |

--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -23,8 +23,9 @@
   - New Emitter (TypeSpec): 38
   - Old TypeSpec: 4
 - Provisioning: 31
-  - Reflection-based generator: 31
+  - Reflection-based generator: 29
   - TypeSpec-based generator: 0
+  - No generator: 2
 - No generator: 49
 
 
@@ -407,8 +408,8 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 | provisioning | Azure.Provisioning.ContainerRegistry | Azure.ResourceManager.ContainerRegistry | Reflection |
 | provisioning | Azure.Provisioning.ContainerService | Azure.ResourceManager.ContainerService | Reflection |
 | provisioning | Azure.Provisioning.CosmosDB | Azure.ResourceManager.CosmosDB | Reflection |
-| provisioning | Azure.Provisioning.Deployment | Azure.ResourceManager<br>Azure.ResourceManager.Resources | Reflection |
-| provisioning | Azure.Provisioning.Dns | Azure.ResourceManager.Dns | Reflection |
+| provisioning | Azure.Provisioning.Deployment | Azure.ResourceManager<br>Azure.ResourceManager.Resources | None |
+| provisioning | Azure.Provisioning.Dns | Azure.ResourceManager.Dns | None |
 | provisioning | Azure.Provisioning.EventGrid | Azure.ResourceManager.EventGrid | Reflection |
 | provisioning | Azure.Provisioning.EventHubs | Azure.ResourceManager.EventHubs | Reflection |
 | provisioning | Azure.Provisioning.FrontDoor | Azure.ResourceManager.FrontDoor | Reflection |

--- a/doc/GeneratorMigration/Library_Inventory.ps1
+++ b/doc/GeneratorMigration/Library_Inventory.ps1
@@ -89,7 +89,11 @@ function Get-GeneratorType {
                 # Continue
             }
         }
-        return "Provisioning (Reflection)"
+        # Check if the library actually has a Generated folder (reflection-based provisioning uses it)
+        if (Test-Path (Join-Path $Path "src\Generated")) {
+            return "Provisioning (Reflection)"
+        }
+        return "Provisioning (No Generator)"
     }
 
     # Special case for Azure.AI.OpenAI which uses TypeSpec with new generator via special handling
@@ -221,7 +225,7 @@ function New-MarkdownReport {
     # Generate a markdown report from the library inventory.
 
     # Define exclusion list for generator types that are not TypeSpec new emitters
-    $excludedGenerators = @("Swagger", "TSP-Old", "No Generator", "Provisioning (Reflection)", "Provisioning (TypeSpec)")
+    $excludedGenerators = @("Swagger", "TSP-Old", "No Generator", "Provisioning (Reflection)", "Provisioning (TypeSpec)", "Provisioning (No Generator)")
 
     # Group by type and generator
     $mgmtLibraries = $Libraries | Where-Object { $_.type -eq "Management" }
@@ -283,8 +287,10 @@ function New-MarkdownReport {
     $report += "- Provisioning: $($provisioningLibraries.Count)"
     $provReflection = ($provisioningLibraries | Where-Object { $_.generator -eq "Provisioning (Reflection)" }).Count
     $provTypeSpec = ($provisioningLibraries | Where-Object { $_.generator -eq "Provisioning (TypeSpec)" }).Count
+    $provNoGenerator = ($provisioningLibraries | Where-Object { $_.generator -eq "Provisioning (No Generator)" }).Count
     $report += "  - Reflection-based generator: $provReflection"
     $report += "  - TypeSpec-based generator: $provTypeSpec"
+    $report += "  - No generator: $provNoGenerator"
     $report += "- No generator: $($noGenerator.Count)"
     $report += "`n"
 
@@ -358,7 +364,11 @@ function New-MarkdownReport {
         $report += "| ------- | ------- | ----------------- | --------- |"
         $sortedProvisioning = $provisioningLibraries | Sort-Object service, library
         foreach ($lib in $sortedProvisioning) {
-            $generatorLabel = if ($lib.generator -eq "Provisioning (TypeSpec)") { "TypeSpec ✅" } else { "Reflection" }
+            $generatorLabel = switch ($lib.generator) {
+                "Provisioning (TypeSpec)" { "TypeSpec ✅" }
+                "Provisioning (No Generator)" { "None" }
+                default { "Reflection" }
+            }
             # Format each mgmt dependency with ✅ if it uses the new TypeSpec emitter
             $depsFormatted = ($lib.mgmtPeerLibrary | ForEach-Object {
                 if ($mgmtNewEmitterSet.ContainsKey($_)) { "$_ ✅" } else { $_ }


### PR DESCRIPTION
Update Library_Inventory.md to reflect RedisEnterprise migration from Swagger to the new TypeSpec emitter.

- MPG Swagger: 131 → 130
- MPG TypeSpec: 98 → 99
- RedisEnterprise moved to TypeSpec emitter section