### PR TITLE
Fix mgmt emitter: deduplicate methods during incomplete resource merging

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -302,7 +302,7 @@ export function postProcessArmResources(
         (r) => r.resourceModelId === metadata.parentResourceModelId
       );
       if (parent) {
-        parent.metadata.methods.push(...metadata.methods);
+        mergeMethodsWithoutDuplicates(parent, metadata.methods);
         merged = true;
       }
     }
@@ -313,7 +313,7 @@ export function postProcessArmResources(
         (r) => r.resourceModelId === resource.resourceModelId
       );
       if (sibling) {
-        sibling.metadata.methods.push(...metadata.methods);
+        mergeMethodsWithoutDuplicates(sibling, metadata.methods);
         merged = true;
       }
     }
@@ -442,6 +442,31 @@ export function postProcessArmResources(
   }
 
   return filteredResources;
+}
+
+/**
+ * Merges methods from an incomplete resource into a target resource, skipping
+ * methods whose combination of kind and operationPath already exists in the
+ * target. This prevents duplicate methods (in particular duplicate List methods)
+ * when multiple TypeSpec interfaces expose operations with the same REST path
+ * (e.g., ConfigurationAssignments and ConfigurationAssignmentsForResourceGroup
+ * both listing at the same endpoint), while still allowing different kinds at
+ * the same path to coexist.
+ */
+function mergeMethodsWithoutDuplicates(
+  target: ArmResourceSchema,
+  methods: ResourceMethod[]
+): void {
+  const makeKey = (m: ResourceMethod): string =>
+    `${m.kind ?? ""}|${m.operationPath}`;
+  const existingKeys = new Set(target.metadata.methods.map((m) => makeKey(m)));
+  for (const method of methods) {
+    const key = makeKey(method);
+    if (!existingKeys.has(key)) {
+      target.metadata.methods.push(method);
+      existingKeys.add(key);
+    }
+  }
 }
 
 /**

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/non-resource-methods.test.ts
@@ -14,11 +14,13 @@ import { ok, strictEqual, deepStrictEqual } from "assert";
 import {
   ResourceScope,
   ResourceOperationKind,
-  assignNonResourceMethodsToResources
+  assignNonResourceMethodsToResources,
+  postProcessArmResources
 } from "../src/resource-metadata.js";
 import type {
   ArmResourceSchema,
-  NonResourceMethod
+  NonResourceMethod,
+  ParentResourceLookupContext
 } from "../src/resource-metadata.js";
 
 describe("Non-Resource Methods Detection", () => {
@@ -990,10 +992,12 @@ interface ChildResources {
 
     const resources: ArmResourceSchema[] = [
       {
-        resourceModelId: "Microsoft.GuestConfiguration.GuestConfigurationAssignment",
+        resourceModelId:
+          "Microsoft.GuestConfiguration.GuestConfigurationAssignment",
         metadata: {
           resourceName: "GuestConfigurationVmAssignment",
-          resourceType: "Microsoft.GuestConfiguration/guestConfigurationAssignments",
+          resourceType:
+            "Microsoft.GuestConfiguration/guestConfigurationAssignments",
           resourceIdPattern:
             "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/providers/Microsoft.GuestConfiguration/guestConfigurationAssignments/{guestConfigurationAssignmentName}",
           resourceScope: ResourceScope.ResourceGroup,
@@ -1126,6 +1130,129 @@ interface ChildResources {
       listMethods.length,
       0,
       "DeletedVault resource should have no List methods"
+    );
+  });
+
+  it("should not produce duplicate methods when merging incomplete resources with same operationPath into sibling", () => {
+    // Reproduces the Maintenance SDK duplicate GetConfigurationAssignments bug.
+    // Multiple TypeSpec interfaces (ConfigurationAssignments, ConfigurationAssignmentsForResourceGroup)
+    // expose list operations with the same REST path but different crossLanguageDefinitionIds.
+    // During processMethod, each interface's List operation may land in a DIFFERENT incomplete
+    // resource entry (different metadataKey) when the prefix-match logic resolves to different
+    // paths. In postProcessArmResources Step 3, all incomplete entries for the same model get
+    // merged into the valid sibling — without deduplication on kind+operationPath, the sibling
+    // ends up with duplicate List methods that generate identical C# method signatures (CS0111).
+
+    // Valid resource: established by a Read (CRUD) operation in the first pass
+    const validResource: ArmResourceSchema = {
+      resourceModelId: "Microsoft.Maintenance.ConfigurationAssignment",
+      metadata: {
+        resourceName: "ConfigurationAssignment",
+        resourceType: "Microsoft.Maintenance/configurationAssignments",
+        resourceIdPattern:
+          "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}",
+        resourceScope: ResourceScope.Extension,
+        singletonResourceName: undefined,
+        parentResourceId: undefined,
+        parentResourceModelId: undefined,
+        methods: [
+          {
+            methodId: "Microsoft.Maintenance.ConfigurationAssignment.get",
+            kind: ResourceOperationKind.Read,
+            operationPath:
+              "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}",
+            operationScope: ResourceScope.ResourceGroup,
+            resourceScope:
+              "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceParentType}/{resourceParentName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments/{configurationAssignmentName}"
+          }
+        ]
+      }
+    };
+
+    // Two incomplete resources: created when list operations from different interfaces
+    // (same model, same REST path) resolve to different metadataKeys via the prefix-match
+    // logic in processMethod, each creating a separate incomplete resource entry.
+    const incompleteResource1: ArmResourceSchema = {
+      resourceModelId: "Microsoft.Maintenance.ConfigurationAssignment",
+      metadata: {
+        resourceName: "ConfigurationAssignment",
+        resourceType: "Microsoft.Maintenance/configurationAssignments",
+        resourceIdPattern: "", // incomplete — no CRUD operation
+        resourceScope: ResourceScope.ResourceGroup,
+        singletonResourceName: undefined,
+        parentResourceId: undefined,
+        parentResourceModelId: undefined,
+        methods: [
+          {
+            methodId:
+              "Microsoft.Maintenance.ConfigurationAssignmentForResourceGroupOperationGroup.list",
+            kind: ResourceOperationKind.List,
+            operationPath:
+              "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments",
+            operationScope: ResourceScope.ResourceGroup,
+            resourceScope: undefined
+          }
+        ]
+      }
+    };
+
+    const incompleteResource2: ArmResourceSchema = {
+      resourceModelId: "Microsoft.Maintenance.ConfigurationAssignment",
+      metadata: {
+        resourceName: "ConfigurationAssignment",
+        resourceType: "Microsoft.Maintenance/configurationAssignments",
+        resourceIdPattern: "", // incomplete — no CRUD operation
+        resourceScope: ResourceScope.ResourceGroup,
+        singletonResourceName: undefined,
+        parentResourceId: undefined,
+        parentResourceModelId: undefined,
+        methods: [
+          {
+            // Different interface, SAME operationPath and kind
+            methodId:
+              "Microsoft.Maintenance.ConfigurationAssignments.listParent",
+            kind: ResourceOperationKind.List,
+            operationPath:
+              "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}/providers/Microsoft.Maintenance/configurationAssignments",
+            operationScope: ResourceScope.ResourceGroup,
+            resourceScope: undefined
+          }
+        ]
+      }
+    };
+
+    const allResources = [
+      validResource,
+      incompleteResource1,
+      incompleteResource2
+    ];
+    const nonResourceMethods: NonResourceMethod[] = [];
+    const noopParentLookup: ParentResourceLookupContext = {
+      getParentResource: () => undefined
+    };
+
+    const result = postProcessArmResources(
+      allResources,
+      nonResourceMethods,
+      noopParentLookup
+    );
+
+    // The valid resource should have exactly 1 List method (deduplicated),
+    // not 2 from the two incomplete resources
+    const listMethods = result[0].metadata.methods.filter(
+      (m) => m.kind === ResourceOperationKind.List
+    );
+    strictEqual(
+      listMethods.length,
+      1,
+      "ConfigurationAssignment resource should have exactly 1 List method (no duplicates from merging)"
+    );
+
+    // No methods should have leaked to nonResourceMethods
+    strictEqual(
+      nonResourceMethods.length,
+      0,
+      "All methods should be merged into the valid resource, none should be non-resource"
     );
   });
 });


### PR DESCRIPTION
## Fix duplicate methods from incomplete resource merging

### Problem

When multiple TypeSpec interfaces expose operations with the same REST path but different `crossLanguageDefinitionId`s (e.g., `ConfigurationAssignments` and `ConfigurationAssignmentsForResourceGroup` in the Maintenance service), each may create a separate incomplete resource entry via `processMethod` (different `metadataKey`s from prefix-match logic resolving to different paths).

In `postProcessArmResources` Step 3, all incomplete entries for the same model get merged into the valid sibling resource. Without deduplication, the sibling ends up with duplicate methods that generate identical C# method signatures (CS0111).

### Root Cause

`postProcessArmResources` Step 3 blindly pushes all methods from incomplete resources into the merge target:

```typescript
sibling.metadata.methods.push(...metadata.methods);  // no dedup check
```

When two incomplete resources have methods with the same `kind` and `operationPath`, both get pushed — duplicate.

### Fix

Replace the blind `push` with `mergeMethodsWithoutDuplicates()` — a helper that uses a compound key (`kind|operationPath`) to skip methods that already exist in the target. This prevents duplicates while allowing different kinds at the same path to coexist (e.g., Read and Create on the same endpoint).

### Test

Added test: **"should not produce duplicate methods when merging incomplete resources with same operationPath into sibling"** — directly tests `postProcessArmResources` with two incomplete resources sharing the same `kind + operationPath` being merged into a valid sibling.

### Validation

- All 53 emitter tests pass
- Lint clean
- Prettier clean