### PR TITLE
Fix PUT operation body parameter marked as optional instead of required

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/OperationMethodParameterHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/OperationMethodParameterHelper.cs
@@ -93,19 +93,15 @@ namespace Azure.Generator.Management.Utilities
                 }
 
                 // For PUT/PATCH operations, the body parameter is always required.
-                // For other parameters, use the DefaultValue check.
-                bool isRequired;
+                // We must also clear DefaultValue so that "= default" is not written in the output.
                 if (convenienceParam.Location == ParameterLocation.Body &&
-                    (serviceMethod.Operation.HttpMethod == "PUT" || serviceMethod.Operation.HttpMethod == "PATCH"))
+                    (serviceMethod.Operation.HttpMethod == "PUT" || serviceMethod.Operation.HttpMethod == "PATCH") &&
+                    outputParameter.DefaultValue != null)
                 {
-                    isRequired = true;
-                }
-                else
-                {
-                    isRequired = outputParameter.DefaultValue == null;
+                    outputParameter = ClearDefaultValue(outputParameter);
                 }
 
-                if (isRequired)
+                if (outputParameter.DefaultValue == null)
                 {
                     requiredParameters.Add(outputParameter);
                 }
@@ -119,6 +115,24 @@ namespace Azure.Generator.Management.Utilities
 
             return [.. requiredParameters, .. optionalParameters];
         }
+
+        private static ParameterProvider ClearDefaultValue(ParameterProvider parameter)
+            => new(
+                    name: parameter.Name,
+                    description: parameter.Description,
+                    type: parameter.Type,
+                    defaultValue: null,
+                    isRef: parameter.IsRef,
+                    isOut: parameter.IsOut,
+                    isIn: parameter.IsIn,
+                    isParams: parameter.IsParams,
+                    attributes: parameter.Attributes,
+                    property: parameter.Property,
+                    field: parameter.Field,
+                    initializationValue: parameter.InitializationValue,
+                    location: parameter.Location,
+                    wireInfo: parameter.WireInfo,
+                    validation: parameter.Validation);
 
         private static ParameterProvider RenameWithNewInstance(ParameterProvider outputParameter, string normalizedName, FormattableString? description = null, Type? type = null)
             => new(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/OperationMethodParameterHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/OperationMethodParameterHelper.cs
@@ -36,19 +36,6 @@ namespace Azure.Generator.Management.Utilities
                 requiredParameters.Add(KnownAzureParameters.WaitUntil);
             }
 
-            // Pre-compute body parameter required status from the input model.
-            // The convenience method may incorrectly mark required body parameters as optional
-            // by adding a default value (e.g., = null), so we use the input model as source of truth.
-            bool isBodyParamRequired = false;
-            foreach (var inputParam in serviceMethod.Operation.Parameters)
-            {
-                if (inputParam is InputBodyParameter && inputParam.IsRequired)
-                {
-                    isBodyParamRequired = true;
-                    break;
-                }
-            }
-
             // Iterate through the convenience method parameters directly
             // The convenience method has already been processed by visitors (e.g., MatchConditionsHeadersVisitor)
             // and contains the correct types (e.g., MatchConditions instead of separate ifMatch/ifNoneMatch)
@@ -105,12 +92,18 @@ namespace Azure.Generator.Management.Utilities
                     scopeParameterTransformed = true;
                 }
 
-                // Determine if required: for body parameters, use the input model's IsRequired status
-                // since convenience method generation may incorrectly add default values to required body parameters.
-                // For other parameters (e.g., MatchConditions), use the DefaultValue check.
-                bool isRequired = convenienceParam.Location == ParameterLocation.Body
-                    ? isBodyParamRequired
-                    : outputParameter.DefaultValue == null;
+                // For PUT/PATCH operations, the body parameter is always required.
+                // For other parameters, use the DefaultValue check.
+                bool isRequired;
+                if (convenienceParam.Location == ParameterLocation.Body &&
+                    (serviceMethod.Operation.HttpMethod == "PUT" || serviceMethod.Operation.HttpMethod == "PATCH"))
+                {
+                    isRequired = true;
+                }
+                else
+                {
+                    isRequired = outputParameter.DefaultValue == null;
+                }
 
                 if (isRequired)
                 {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/OperationMethodParameterHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/OperationMethodParameterHelper.cs
@@ -36,6 +36,19 @@ namespace Azure.Generator.Management.Utilities
                 requiredParameters.Add(KnownAzureParameters.WaitUntil);
             }
 
+            // Pre-compute body parameter required status from the input model.
+            // The convenience method may incorrectly mark required body parameters as optional
+            // by adding a default value (e.g., = null), so we use the input model as source of truth.
+            bool isBodyParamRequired = false;
+            foreach (var inputParam in serviceMethod.Operation.Parameters)
+            {
+                if (inputParam is InputBodyParameter && inputParam.IsRequired)
+                {
+                    isBodyParamRequired = true;
+                    break;
+                }
+            }
+
             // Iterate through the convenience method parameters directly
             // The convenience method has already been processed by visitors (e.g., MatchConditionsHeadersVisitor)
             // and contains the correct types (e.g., MatchConditions instead of separate ifMatch/ifNoneMatch)
@@ -92,8 +105,12 @@ namespace Azure.Generator.Management.Utilities
                     scopeParameterTransformed = true;
                 }
 
-                // Determine if required based on whether parameter has a default value
-                bool isRequired = outputParameter.DefaultValue == null;
+                // Determine if required: for body parameters, use the input model's IsRequired status
+                // since convenience method generation may incorrectly add default values to required body parameters.
+                // For other parameters (e.g., MatchConditions), use the DefaultValue check.
+                bool isRequired = convenienceParam.Location == ParameterLocation.Body
+                    ? isBodyParamRequired
+                    : outputParameter.DefaultValue == null;
 
                 if (isRequired)
                 {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/OperationMethodParameterHelper.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/OperationMethodParameterHelper.cs
@@ -93,12 +93,11 @@ namespace Azure.Generator.Management.Utilities
                 }
 
                 // For PUT/PATCH operations, the body parameter is always required.
-                // We must also clear DefaultValue so that "= default" is not written in the output.
+                // Clear DefaultValue so that "= default" is not written in the output.
                 if (convenienceParam.Location == ParameterLocation.Body &&
-                    (serviceMethod.Operation.HttpMethod == "PUT" || serviceMethod.Operation.HttpMethod == "PATCH") &&
-                    outputParameter.DefaultValue != null)
+                    (serviceMethod.Operation.HttpMethod == "PUT" || serviceMethod.Operation.HttpMethod == "PATCH"))
                 {
-                    outputParameter = ClearDefaultValue(outputParameter);
+                    outputParameter.DefaultValue = null;
                 }
 
                 if (outputParameter.DefaultValue == null)
@@ -115,24 +114,6 @@ namespace Azure.Generator.Management.Utilities
 
             return [.. requiredParameters, .. optionalParameters];
         }
-
-        private static ParameterProvider ClearDefaultValue(ParameterProvider parameter)
-            => new(
-                    name: parameter.Name,
-                    description: parameter.Description,
-                    type: parameter.Type,
-                    defaultValue: null,
-                    isRef: parameter.IsRef,
-                    isOut: parameter.IsOut,
-                    isIn: parameter.IsIn,
-                    isParams: parameter.IsParams,
-                    attributes: parameter.Attributes,
-                    property: parameter.Property,
-                    field: parameter.Field,
-                    initializationValue: parameter.InitializationValue,
-                    location: parameter.Location,
-                    wireInfo: parameter.WireInfo,
-                    validation: parameter.Validation);
 
         private static ParameterProvider RenameWithNewInstance(ParameterProvider outputParameter, string normalizedName, FormattableString? description = null, Type? type = null)
             => new(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
@@ -594,6 +594,7 @@ namespace Azure.Generator.Management.Tests.Common
         /// <param name="path"></param>
         /// <param name="decorators"></param>
         /// <param name="ns"></param>
+        /// <param name="httpMethod"></param>
         /// <returns></returns>
         public static InputOperation Operation(
             string name,
@@ -603,7 +604,8 @@ namespace Azure.Generator.Management.Tests.Common
             IEnumerable<string>? requestMediaTypes = null,
             string? path = null,
             IReadOnlyList<InputDecoratorInfo>? decorators = null,
-            string? ns = null)
+            string? ns = null,
+            string httpMethod = "GET")
         {
             var operation = new InputOperation(
                 name,
@@ -614,7 +616,7 @@ namespace Azure.Generator.Management.Tests.Common
                 access,
                 parameters is null ? [] : [.. parameters],
                 responses is null ? [OperationResponse()] : [.. responses],
-                "GET",
+                httpMethod,
                 string.Empty,
                 path ?? string.Empty,
                 null,

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
@@ -32,13 +32,66 @@ namespace Azure.Generator.Management.Tests.Common
             var testNameOpParameter = InputFactory.PathParameter("testName", InputPrimitiveType.String, isRequired: true);
             var dataOpParameter = InputFactory.BodyParameter("data", responseModel, isRequired: true);
             var getOperation = InputFactory.Operation(name: "get", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}");
-            var createOperation = InputFactory.Operation(name: "createTest", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter, dataOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}");
-            var updateOperation = InputFactory.Operation(name: "update", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter, dataOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}");
+            var createOperation = InputFactory.Operation(name: "createTest", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter, dataOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}", httpMethod: "PUT");
+            var updateOperation = InputFactory.Operation(name: "update", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter, dataOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}", httpMethod: "PATCH");
             // the method parameters
             var subscriptionIdParameter = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
             var resourceGroupParameter = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
             var testNameParameter = InputFactory.MethodParameter("testName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
             var dataParameter = InputFactory.MethodParameter("data", responseModel, location: InputRequestLocation.Body, isRequired: true);
+            var getMethod = InputFactory.BasicServiceMethod("get", getOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var createMethod = InputFactory.BasicServiceMethod("createTest", createOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var updateMethod = InputFactory.BasicServiceMethod("update", updateOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+
+            var resourceIdPattern = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}";
+            var armProviderDecorator = BuildArmProviderSchema(responseModel, [
+                new ResourceMethod(ResourceOperationKind.Read, getMethod, getMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!),
+                new ResourceMethod(ResourceOperationKind.Create, createMethod, createMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!),
+                new ResourceMethod(ResourceOperationKind.Update, updateMethod, updateMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!)
+            ], resourceIdPattern, "Microsoft.Tests/tests", null, ResourceScope.ResourceGroup, "ResponseType");
+
+            var client = InputFactory.Client(
+                TestClientName,
+                methods: [getMethod, createMethod, updateMethod],
+                decorators: [armProviderDecorator],
+                crossLanguageDefinitionId: $"Test.{TestClientName}");
+
+            return (client, [responseModel]);
+        }
+
+        /// <summary>
+        /// Creates a client with a resource where PUT/PATCH body parameters are marked as optional in the spec.
+        /// This tests that the generator still emits them as required.
+        /// </summary>
+        public static (InputClient InputClient, IReadOnlyList<InputModelType> InputModels) ClientWithResourceOptionalBody()
+        {
+            const string TestClientName = "TestClient";
+            const string ResourceModelName = "ResponseType";
+            var responseModel = InputFactory.Model(ResourceModelName,
+                        usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                        properties:
+                        [
+                            InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("tags", new InputDictionaryType("dict", InputPrimitiveType.String, InputPrimitiveType.String), isReadOnly: false),
+                        ],
+                        decorators: []);
+            var responseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: responseModel);
+            var uuidType = new InputPrimitiveType(InputPrimitiveTypeKind.String, "uuid", "Azure.Core.uuid");
+            var subsIdOpParameter = InputFactory.PathParameter("subscriptionId", uuidType, isRequired: true);
+            var rgOpParameter = InputFactory.PathParameter("resourceGroupName", InputPrimitiveType.String, isRequired: true);
+            var testNameOpParameter = InputFactory.PathParameter("testName", InputPrimitiveType.String, isRequired: true);
+            // Body parameter is optional in the spec
+            var dataOpParameter = InputFactory.BodyParameter("data", responseModel, isRequired: false);
+            var getOperation = InputFactory.Operation(name: "get", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}");
+            var createOperation = InputFactory.Operation(name: "createTest", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter, dataOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}", httpMethod: "PUT");
+            var updateOperation = InputFactory.Operation(name: "update", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter, dataOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}", httpMethod: "PATCH");
+            var subscriptionIdParameter = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
+            var resourceGroupParameter = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var testNameParameter = InputFactory.MethodParameter("testName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            // Method parameter is also optional
+            var dataParameter = InputFactory.MethodParameter("data", responseModel, location: InputRequestLocation.Body, isRequired: false);
             var getMethod = InputFactory.BasicServiceMethod("get", getOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
             var createMethod = InputFactory.BasicServiceMethod("createTest", createOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
             var updateMethod = InputFactory.BasicServiceMethod("update", updateOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
@@ -202,5 +202,41 @@ namespace Azure.Generator.Management.Tests.Providers
             var expected = Helpers.GetExpectedFromFile();
             Assert.AreEqual(expected, bodyStatements);
         }
+
+        [TestCase]
+        public void Verify_PutBodyParameterIsRequiredEvenWhenOptionalInSpec()
+        {
+            var (client, models) = InputResourceData.ClientWithResourceOptionalBody();
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => models, clients: () => [client]);
+            var resourceProvider = plugin.Object.OutputLibrary.TypeProviders.FirstOrDefault(p => p is ResourceCollectionClientProvider) as ResourceCollectionClientProvider;
+            Assert.NotNull(resourceProvider);
+
+            var createOrUpdate = resourceProvider!.Methods.FirstOrDefault(m => m.Signature.Name == "CreateOrUpdate");
+            Assert.NotNull(createOrUpdate);
+            var signature = createOrUpdate!.Signature;
+
+            // Body parameter (Data) should be required even though it's optional in the spec
+            var dataParam = signature.Parameters.FirstOrDefault(p => p.Type.Name.EndsWith("Data"));
+            Assert.NotNull(dataParam, "Body parameter should exist");
+            Assert.IsNull(dataParam!.DefaultValue, "PUT body parameter should be required (no default value) even when optional in spec");
+        }
+
+        [TestCase]
+        public void Verify_PatchBodyParameterIsRequiredEvenWhenOptionalInSpec()
+        {
+            var (client, models) = InputResourceData.ClientWithResourceOptionalBody();
+            var plugin = ManagementMockHelpers.LoadMockPlugin(inputModels: () => models, clients: () => [client]);
+            var resourceProvider = plugin.Object.OutputLibrary.TypeProviders.FirstOrDefault(p => p is ResourceClientProvider) as ResourceClientProvider;
+            Assert.NotNull(resourceProvider);
+
+            var update = resourceProvider!.Methods.FirstOrDefault(m => m.Signature.Name == "Update");
+            Assert.NotNull(update);
+            var signature = update!.Signature;
+
+            // Body parameter should be required even though it's optional in the spec
+            var bodyParam = signature.Parameters.FirstOrDefault(p => p.Location == ParameterLocation.Body);
+            Assert.NotNull(bodyParam, "Body parameter should exist");
+            Assert.IsNull(bodyParam!.DefaultValue, "PATCH body parameter should be required (no default value) even when optional in spec");
+        }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/ResourceCollectionClientProviderTests.cs
@@ -165,6 +165,8 @@ namespace Azure.Generator.Management.Tests.Providers
             Assert.AreEqual(typeof(WaitUntil), signature.Parameters[0].Type.FrameworkType);
             Assert.AreEqual(typeof(string), signature.Parameters[1].Type.FrameworkType);
             Assert.IsTrue(signature.Parameters[2].Type.Name.EndsWith("Data"));
+            // Body parameter for PUT operations must be required (no default value)
+            Assert.IsNull(signature.Parameters[2].DefaultValue, "Body parameter should be required for PUT operations");
             Assert.AreEqual(typeof(CancellationToken), signature.Parameters[3].Type.FrameworkType);
             Assert.AreEqual(typeof(ArmOperation<>), signature.ReturnType?.FrameworkType);
 
@@ -188,6 +190,8 @@ namespace Azure.Generator.Management.Tests.Providers
             Assert.AreEqual(typeof(WaitUntil), signature.Parameters[0].Type.FrameworkType);
             Assert.AreEqual(typeof(string), signature.Parameters[1].Type.FrameworkType);
             Assert.IsTrue(signature.Parameters[2].Type.Name.EndsWith("Data"));
+            // Body parameter for PUT operations must be required (no default value)
+            Assert.IsNull(signature.Parameters[2].DefaultValue, "Body parameter should be required for PUT operations");
             Assert.AreEqual(typeof(CancellationToken), signature.Parameters[3].Type.FrameworkType);
             Assert.AreEqual(typeof(Task<>), signature.ReturnType?.FrameworkType);
             Assert.AreEqual(typeof(ArmOperation<>), signature.ReturnType?.Arguments[0].FrameworkType);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_CreateOrUpdateAsyncOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_CreateOrUpdateAsyncOperationMethod.cs
@@ -13,7 +13,7 @@ try
     global::Azure.Response result = await this.Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
     global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
     global::Azure.Core.RequestUriBuilder uri = message.Request.Uri;
-    global::Azure.Core.RehydrationToken rehydrationToken = global::Azure.Core.NextLinkOperationImplementation.GetRehydrationToken(global::Azure.Core.RequestMethod.Get, uri.ToUri(), uri.ToString(), "None", null, global::Azure.Core.OperationFinalStateVia.OriginalUri.ToString());
+    global::Azure.Core.RehydrationToken rehydrationToken = global::Azure.Core.NextLinkOperationImplementation.GetRehydrationToken(global::Azure.Core.RequestMethod.Put, uri.ToUri(), uri.ToString(), "None", null, global::Azure.Core.OperationFinalStateVia.OriginalUri.ToString());
     global::Samples.SamplesArmOperation<global::Samples.ResponseTypeResource> operation = new global::Samples.SamplesArmOperation<global::Samples.ResponseTypeResource>(global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse()), rehydrationToken);
     if ((waitUntil == global::Azure.WaitUntil.Completed))
     {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_CreateOrUpdateOperationMethod.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TestData/ResourceCollectionClientProviderTests/Verify_CreateOrUpdateOperationMethod.cs
@@ -13,7 +13,7 @@ try
     global::Azure.Response result = this.Pipeline.ProcessMessage(message, context);
     global::Azure.Response<global::Samples.ResponseTypeData> response = global::Azure.Response.FromValue(global::Samples.ResponseTypeData.FromResponse(result), result);
     global::Azure.Core.RequestUriBuilder uri = message.Request.Uri;
-    global::Azure.Core.RehydrationToken rehydrationToken = global::Azure.Core.NextLinkOperationImplementation.GetRehydrationToken(global::Azure.Core.RequestMethod.Get, uri.ToUri(), uri.ToString(), "None", null, global::Azure.Core.OperationFinalStateVia.OriginalUri.ToString());
+    global::Azure.Core.RehydrationToken rehydrationToken = global::Azure.Core.NextLinkOperationImplementation.GetRehydrationToken(global::Azure.Core.RequestMethod.Put, uri.ToUri(), uri.ToString(), "None", null, global::Azure.Core.OperationFinalStateVia.OriginalUri.ToString());
     global::Samples.SamplesArmOperation<global::Samples.ResponseTypeResource> operation = new global::Samples.SamplesArmOperation<global::Samples.ResponseTypeResource>(global::Azure.Response.FromValue(new global::Samples.ResponseTypeResource(this.Client, response.Value), response.GetRawResponse()), rehydrationToken);
     if ((waitUntil == global::Azure.WaitUntil.Completed))
     {

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/GroupQuotaLimitListCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/GroupQuotaLimitListCollection.cs
@@ -78,7 +78,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="groupQuotaName"/> or <paramref name="resourceProviderName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="groupQuotaName"/> or <paramref name="resourceProviderName"/> is an empty string, and was expected to be non-empty. </exception>
-        public virtual async Task<ArmOperation<GroupQuotaLimitListResource>> CreateOrUpdateAsync(WaitUntil waitUntil, string groupQuotaName, string resourceProviderName, AzureLocation location, GroupQuotaLimitListData data = default, CancellationToken cancellationToken = default)
+        public virtual async Task<ArmOperation<GroupQuotaLimitListResource>> CreateOrUpdateAsync(WaitUntil waitUntil, string groupQuotaName, string resourceProviderName, AzureLocation location, GroupQuotaLimitListData data, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(groupQuotaName, nameof(groupQuotaName));
             Argument.AssertNotNullOrEmpty(resourceProviderName, nameof(resourceProviderName));
@@ -138,7 +138,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <param name="cancellationToken"> The cancellation token to use. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="groupQuotaName"/> or <paramref name="resourceProviderName"/> is null. </exception>
         /// <exception cref="ArgumentException"> <paramref name="groupQuotaName"/> or <paramref name="resourceProviderName"/> is an empty string, and was expected to be non-empty. </exception>
-        public virtual ArmOperation<GroupQuotaLimitListResource> CreateOrUpdate(WaitUntil waitUntil, string groupQuotaName, string resourceProviderName, AzureLocation location, GroupQuotaLimitListData data = default, CancellationToken cancellationToken = default)
+        public virtual ArmOperation<GroupQuotaLimitListResource> CreateOrUpdate(WaitUntil waitUntil, string groupQuotaName, string resourceProviderName, AzureLocation location, GroupQuotaLimitListData data, CancellationToken cancellationToken = default)
         {
             Argument.AssertNotNullOrEmpty(groupQuotaName, nameof(groupQuotaName));
             Argument.AssertNotNullOrEmpty(resourceProviderName, nameof(resourceProviderName));

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/GroupQuotaLimitListResource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/GroupQuotaLimitListResource.cs
@@ -214,7 +214,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
         /// <param name="patch"> Resource create parameters. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual async Task<ArmOperation<GroupQuotaLimitListResource>> UpdateAsync(WaitUntil waitUntil, GroupQuotaLimitListPatch patch = default, CancellationToken cancellationToken = default)
+        public virtual async Task<ArmOperation<GroupQuotaLimitListResource>> UpdateAsync(WaitUntil waitUntil, GroupQuotaLimitListPatch patch, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _groupQuotaLimitListsClientDiagnostics.CreateScope("GroupQuotaLimitListResource.Update");
             scope.Start();
@@ -271,7 +271,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         /// <param name="waitUntil"> <see cref="WaitUntil.Completed"/> if the method should wait to return until the long-running operation has completed on the service; <see cref="WaitUntil.Started"/> if it should return after starting the operation. For more information on long-running operations, please see <see href="https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/LongRunningOperations.md"> Azure.Core Long-Running Operation samples</see>. </param>
         /// <param name="patch"> Resource create parameters. </param>
         /// <param name="cancellationToken"> The cancellation token to use. </param>
-        public virtual ArmOperation<GroupQuotaLimitListResource> Update(WaitUntil waitUntil, GroupQuotaLimitListPatch patch = default, CancellationToken cancellationToken = default)
+        public virtual ArmOperation<GroupQuotaLimitListResource> Update(WaitUntil waitUntil, GroupQuotaLimitListPatch patch, CancellationToken cancellationToken = default)
         {
             using DiagnosticScope scope = _groupQuotaLimitListsClientDiagnostics.CreateScope("GroupQuotaLimitListResource.Update");
             scope.Start();


### PR DESCRIPTION
## Description

Fixes #56966

The management generator was using `outputParameter.DefaultValue == null` to determine if a parameter is required. This is incorrect for body parameters because the convenience method generation may add default values to body parameters even when the TypeSpec input model marks them as required.

## Changes

**`OperationMethodParameterHelper.cs`**:
- Pre-compute body parameter required status from the input model (`InputBodyParameter.IsRequired`)
- For body parameters, use the input model's `IsRequired` as the source of truth instead of checking `DefaultValue`
- For non-body parameters (e.g., `MatchConditions`), the existing `DefaultValue` check is preserved

**`ResourceCollectionClientProviderTests.cs`**:
- Added explicit assertions verifying body parameters of PUT operations are required (no default value)

## Root Cause

Commit ea2e55e8bca refactored the parameter iteration to use convenience method parameters (to correctly handle synthetic `MatchConditions` parameters), but changed the required/optional determination from `inputParameter.IsRequired` to `outputParameter.DefaultValue == null`. Body parameters in convenience methods may have `DefaultValue` set even when the TypeSpec definition marks them as required, causing PUT body parameters to be incorrectly emitted as optional.