### PR TITLE
Add EditorBrowsable(Never) to ClientSettings.Bind method

### DIFF
--- a/sdk/core/System.ClientModel/src/Convenience/ClientSettings.cs
+++ b/sdk/core/System.ClientModel/src/Convenience/ClientSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 
@@ -27,6 +28,7 @@ public abstract class ClientSettings
     /// <summary>
     /// Binds the values from the <see cref="IConfigurationSection"/> to the properties of the <see cref="ClientSettings"/>.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Bind(IConfigurationSection section)
     {
         if (section is null)


### PR DESCRIPTION
The `Bind` method on `ClientSettings` is intended for internal/infrastructure use and should not appear in IntelliSense for customers. This PR adds `[EditorBrowsable(EditorBrowsableState.Never)]` to hide it from autocomplete while keeping it public for framework callers.