### PR TITLE
Add Sample19_DistributedTracing for Service Bus

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
@@ -28,3 +28,4 @@ description: Samples for the Azure.Messaging.ServiceBus client library
 - [Interact with the AMQP message](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample14_AMQPMessage.md)
 - [Mocking Client Types](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample15_MockingClientTypes.md)
 - [Cross-receiver message settlement](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample16_CrossReceiverMessageSettlement.md)
+- [Distributed tracing and monitoring](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
@@ -6,7 +6,11 @@ For background on how Service Bus propagates trace context, see [Distributed tra
 
 ## Automatic tracing with OpenTelemetry
 
-The recommended approach is [OpenTelemetry](https://opentelemetry.io/docs/languages/dotnet/), which collects traces from the Service Bus client (and any other instrumented library) with no per-call code changes. The Service Bus client library supports OpenTelemetry in experimental mode starting with version 7.5.0. You opt in by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable or the `Azure.Experimental.EnableActivitySource` [AppContext](https://learn.microsoft.com/dotnet/api/system.appcontext) switch.
+The `Azure.Messaging.ServiceBus` client library is instrumented for distributed tracing using [OpenTelemetry](https://opentelemetry.io/docs/languages/dotnet/) or the Application Insights SDK. Both approaches collect traces with no per-call code changes.
+
+> **Experimental:** OpenTelemetry support in `Azure.Messaging.ServiceBus` remains experimental. You must opt in by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable to `true` or the `Azure.Experimental.EnableActivitySource` [AppContext](https://learn.microsoft.com/dotnet/api/system.appcontext) switch. See [Enabling experimental tracing features](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md#enabling-experimental-tracing-features) for details.
+
+This section shows OpenTelemetry configuration. For the Application Insights approach, see [Automatic tracing with Application Insights](#automatic-tracing-with-application-insights) below.
 
 ```C# Snippet:ServiceBusOpenTelemetrySetup
 // Enable the experimental OpenTelemetry support in Azure SDK client libraries.
@@ -27,7 +31,7 @@ await sender.SendMessageAsync(new ServiceBusMessage("Hello with tracing!"));
 // The send operation is automatically captured as a span by OpenTelemetry.
 ```
 
-When the processor handles a message, the SDK creates a `Process` activity that is automatically linked to the `Send` activity on the producer side via the `Diagnostic-Id` message property. This gives you end-to-end visibility from sender to receiver.
+When the processor handles a message, the client library creates a `Process` activity that is automatically linked to the `Send` activity on the producer side via the `Diagnostic-Id` message property. This gives you end-to-end visibility from sender to receiver.
 
 ```C# Snippet:ServiceBusOpenTelemetryProcessor
 AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
@@ -43,7 +47,7 @@ await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
 
 await using ServiceBusProcessor processor = client.CreateProcessor("<queue-name>");
 
-processor.ProcessMessageAsync += async args =>
+async Task MessageHandler(ProcessMessageEventArgs args)
 {
     // This handler runs inside an Activity that is correlated
     // with the sender's Activity through the Diagnostic-Id property.
@@ -51,16 +55,28 @@ processor.ProcessMessageAsync += async args =>
     Console.WriteLine($"Activity.Current: {Activity.Current?.Id}");
 
     await args.CompleteMessageAsync(args.Message);
-};
+}
 
-processor.ProcessErrorAsync += args =>
+Task ErrorHandler(ProcessErrorEventArgs args)
 {
     Console.WriteLine($"Error: {args.Exception}");
     return Task.CompletedTask;
-};
+}
 
-await processor.StartProcessingAsync();
-Console.ReadKey();
+try
+{
+    processor.ProcessMessageAsync += MessageHandler;
+    processor.ProcessErrorAsync += ErrorHandler;
+
+    await processor.StartProcessingAsync();
+    Console.ReadKey();
+    await processor.StopProcessingAsync();
+}
+finally
+{
+    processor.ProcessMessageAsync -= MessageHandler;
+    processor.ProcessErrorAsync -= ErrorHandler;
+}
 ```
 
 To export traces to Azure Monitor (Application Insights) instead of the console, replace `AddConsoleExporter()` with the Azure Monitor exporter:

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
@@ -128,28 +128,39 @@ async Task ProcessAsync(ProcessMessageEventArgs args)
 
 If you do not use OpenTelemetry or Application Insights, you can subscribe to Service Bus diagnostic events directly using `DiagnosticListener`. This gives you full control over which events to capture and how to record them.
 
-The Service Bus client emits events on the `Azure.Messaging.ServiceBus` diagnostic source. Each operation produces a `Start` and `Stop` event, and `Activity.Current` carries the trace context.
+The Service Bus client emits events on the `Azure.Messaging.ServiceBus` diagnostic source. Each operation produces a `Start` and `Stop` event, and `Activity.Current` carries the trace context. The `Subscribe` methods require an `IObserver<T>` implementation — the following helper adapts a callback:
+
+```csharp
+sealed class CallbackObserver<T>(Action<T> onNext) : IObserver<T>
+{
+    public void OnNext(T value) => onNext(value);
+    public void OnCompleted() { }
+    public void OnError(Exception error) { }
+}
+```
 
 ```C# Snippet:ServiceBusDiagnosticListener
 IDisposable innerSubscription = null;
-IDisposable outerSubscription = DiagnosticListener.AllListeners.Subscribe(listener =>
-{
-    if (listener.Name == "Azure.Messaging.ServiceBus")
+IDisposable outerSubscription = DiagnosticListener.AllListeners.Subscribe(
+    new CallbackObserver<DiagnosticListener>(listener =>
     {
-        innerSubscription = listener.Subscribe(evnt =>
+        if (listener.Name == "Azure.Messaging.ServiceBus")
         {
-            // Log the operation when it completes.
-            if (evnt.Key.EndsWith("Stop"))
-            {
-                Activity currentActivity = Activity.Current;
-                Console.WriteLine(
-                    $"Operation {currentActivity.OperationName} completed " +
-                    $"in {currentActivity.Duration.TotalMilliseconds:F1}ms " +
-                    $"[Id={currentActivity.Id}]");
-            }
-        });
-    }
-});
+            innerSubscription = listener.Subscribe(
+                new CallbackObserver<KeyValuePair<string, object>>(evnt =>
+                {
+                    // Log the operation when it completes.
+                    if (evnt.Key.EndsWith("Stop"))
+                    {
+                        Activity currentActivity = Activity.Current;
+                        Console.WriteLine(
+                            $"Operation {currentActivity.OperationName} completed " +
+                            $"in {currentActivity.Duration.TotalMilliseconds:F1}ms " +
+                            $"[Id={currentActivity.Id}]");
+                    }
+                }));
+        }
+    }));
 
 // Use the Service Bus client as normal — diagnostic events are emitted automatically.
 string fullyQualifiedNamespace = "<fully_qualified_namespace>";
@@ -166,11 +177,11 @@ outerSubscription?.Dispose();
 
 ## Filtering diagnostic events
 
-You can reduce overhead by subscribing only to the operations you care about. Use the `IsEnabled` callback to filter by operation name or entity.
+You can reduce overhead by subscribing only to the operations you care about. Use the `isEnabled` callback to filter by operation name or entity. This prevents `Activity` creation for non-matching operations.
 
 ```C# Snippet:ServiceBusDiagnosticFiltering
 innerSubscription = listener.Subscribe(
-    observer: evnt =>
+    new CallbackObserver<KeyValuePair<string, object>>(evnt =>
     {
         if (evnt.Key.EndsWith("Stop"))
         {
@@ -178,8 +189,8 @@ innerSubscription = listener.Subscribe(
             Console.WriteLine(
                 $"{currentActivity.OperationName}: {currentActivity.Duration.TotalMilliseconds:F1}ms");
         }
-    },
-    isEnabled: (eventName, _, _) =>
+    }),
+    (eventName, _, _) =>
     {
         // Only listen to send and process operations.
         return eventName.StartsWith("ServiceBusSender.Send")

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
@@ -22,6 +22,8 @@ using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddConsoleExporter()
     .Build();
 
+// The fully qualified Service Bus namespace. This is likely to be similar to
+// {yournamespace}.servicebus.windows.net.
 string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 DefaultAzureCredential credential = new();
 await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
@@ -41,6 +43,8 @@ using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddConsoleExporter()
     .Build();
 
+// The fully qualified Service Bus namespace. This is likely to be similar to
+// {yournamespace}.servicebus.windows.net.
 string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 DefaultAzureCredential credential = new();
 await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
@@ -104,7 +108,7 @@ async Task ProcessAsync(ProcessMessageEventArgs args)
     if (message.ApplicationProperties.TryGetValue("Diagnostic-Id", out var objectId)
         && objectId is string diagnosticId)
     {
-        var activity = new Activity("ServiceBusProcessor.ProcessMessage");
+        var activity = new Activity("MyApp.ProcessMessage");
         activity.SetParentId(diagnosticId);
 
         using var operation = telemetryClient.StartOperation<RequestTelemetry>(activity);
@@ -130,10 +134,12 @@ If you do not use OpenTelemetry or Application Insights, you can subscribe to Se
 
 The Service Bus client emits events on the `Azure.Messaging.ServiceBus` diagnostic source. Each operation produces a `Start` and `Stop` event, and `Activity.Current` carries the trace context. The `Subscribe` methods require an `IObserver<T>` implementation — the following helper adapts a callback:
 
-```csharp
-sealed class CallbackObserver<T>(Action<T> onNext) : IObserver<T>
+```C# Snippet:ServiceBusCallbackObserverHelper
+private sealed class CallbackObserver<T> : IObserver<T>
 {
-    public void OnNext(T value) => onNext(value);
+    private readonly Action<T> _onNext;
+    public CallbackObserver(Action<T> onNext) => _onNext = onNext;
+    public void OnNext(T value) => _onNext(value);
     public void OnCompleted() { }
     public void OnError(Exception error) { }
 }
@@ -162,17 +168,23 @@ IDisposable outerSubscription = DiagnosticListener.AllListeners.Subscribe(
         }
     }));
 
-// Use the Service Bus client as normal — diagnostic events are emitted automatically.
-string fullyQualifiedNamespace = "<fully_qualified_namespace>";
-DefaultAzureCredential credential = new();
-await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
+try
+{
+    // Use the Service Bus client as normal — diagnostic events are emitted automatically.
+    // The fully qualified Service Bus namespace. This is likely to be similar to
+    // {yournamespace}.servicebus.windows.net.
+    string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+    DefaultAzureCredential credential = new();
+    await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
 
-ServiceBusSender sender = client.CreateSender("<queue-name>");
-await sender.SendMessageAsync(new ServiceBusMessage("Traced message"));
-
-// Clean up the subscriptions when done.
-innerSubscription?.Dispose();
-outerSubscription?.Dispose();
+    ServiceBusSender sender = client.CreateSender("<queue-name>");
+    await sender.SendMessageAsync(new ServiceBusMessage("Traced message"));
+}
+finally
+{
+    innerSubscription?.Dispose();
+    outerSubscription?.Dispose();
+}
 ```
 
 ## Filtering diagnostic events

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
@@ -95,7 +95,7 @@ using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
 
 If you use the [Application Insights SDK](https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview) and the `ServiceBusProcessor`, send and process operations are tracked and correlated automatically — no extra code required.
 
-For manual processing (using `ServiceBusReceiver` directly), you can start a request telemetry operation that correlates with the incoming message:
+For finer-grained control — for example, to add custom telemetry or explicitly set the parent context — you can start a request telemetry operation manually within the processor callback:
 
 ```C# Snippet:ServiceBusAppInsightsManualProcessing
 async Task ProcessAsync(ProcessMessageEventArgs args)
@@ -203,11 +203,16 @@ The following operations emit diagnostic activities:
 | `ServiceBusReceiver.Complete` | `CompleteMessageAsync` |
 | `ServiceBusReceiver.DeadLetter` | `DeadLetterMessageAsync` |
 | `ServiceBusReceiver.Defer` | `DeferMessageAsync` |
+| `ServiceBusReceiver.Delete` | `DeleteMessagesAsync` |
+| `ServiceBusReceiver.Purge` | `PurgeMessagesAsync` |
 | `ServiceBusReceiver.RenewMessageLock` | `RenewMessageLockAsync` |
 | `ServiceBusSessionReceiver.RenewSessionLock` | `RenewSessionLockAsync` |
 | `ServiceBusSessionReceiver.GetSessionState` | `GetSessionStateAsync` |
 | `ServiceBusSessionReceiver.SetSessionState` | `SetSessionStateAsync` |
 | `ServiceBusProcessor.ProcessMessage` | Callback on `ProcessMessageAsync` |
 | `ServiceBusSessionProcessor.ProcessSessionMessage` | Callback on `ProcessMessageAsync` |
+| `ServiceBusRuleManager.CreateRule` | `CreateRuleAsync` |
+| `ServiceBusRuleManager.DeleteRule` | `DeleteRuleAsync` |
+| `ServiceBusRuleManager.GetRules` | `GetRulesAsync` |
 
 For more details on the Azure SDK distributed tracing conventions, see [Diagnostics samples](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md).

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
@@ -197,7 +197,7 @@ The following operations emit diagnostic activities:
 | `ServiceBusSender.Schedule` | `ScheduleMessageAsync`, `ScheduleMessagesAsync` |
 | `ServiceBusSender.Cancel` | `CancelScheduledMessageAsync`, `CancelScheduledMessagesAsync` |
 | `ServiceBusReceiver.Receive` | `ReceiveMessageAsync`, `ReceiveMessagesAsync` |
-| `ServiceBusReceiver.ReceiveDeferred` | `ReceiveDeferredMessagesAsync` |
+| `ServiceBusReceiver.ReceiveDeferred` | `ReceiveDeferredMessageAsync`, `ReceiveDeferredMessagesAsync` |
 | `ServiceBusReceiver.Peek` | `PeekMessageAsync`, `PeekMessagesAsync` |
 | `ServiceBusReceiver.Abandon` | `AbandonMessageAsync` |
 | `ServiceBusReceiver.Complete` | `CompleteMessageAsync` |

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md
@@ -1,0 +1,197 @@
+# Distributed tracing
+
+This sample demonstrates how to observe Service Bus operations using the built-in distributed tracing instrumentation. The `Azure.Messaging.ServiceBus` client library emits [Activity](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity) events for every operation, so you can monitor latency, trace message flow across services, and diagnose failures in production.
+
+For background on how Service Bus propagates trace context, see [Distributed tracing and correlation through Service Bus messaging](https://learn.microsoft.com/azure/service-bus-messaging/service-bus-end-to-end-tracing).
+
+## Automatic tracing with OpenTelemetry
+
+The recommended approach is [OpenTelemetry](https://opentelemetry.io/docs/languages/dotnet/), which collects traces from the Service Bus client (and any other instrumented library) with no per-call code changes. The Service Bus client library supports OpenTelemetry in experimental mode starting with version 7.5.0. You opt in by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable or the `Azure.Experimental.EnableActivitySource` [AppContext](https://learn.microsoft.com/dotnet/api/system.appcontext) switch.
+
+```C# Snippet:ServiceBusOpenTelemetrySetup
+// Enable the experimental OpenTelemetry support in Azure SDK client libraries.
+AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
+
+// Configure the OpenTelemetry tracer provider to listen to the Azure.Messaging.ServiceBus source.
+using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource("Azure.Messaging.ServiceBus.*")
+    .AddConsoleExporter()
+    .Build();
+
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+DefaultAzureCredential credential = new();
+await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
+
+ServiceBusSender sender = client.CreateSender("<queue-name>");
+await sender.SendMessageAsync(new ServiceBusMessage("Hello with tracing!"));
+// The send operation is automatically captured as a span by OpenTelemetry.
+```
+
+When the processor handles a message, the SDK creates a `Process` activity that is automatically linked to the `Send` activity on the producer side via the `Diagnostic-Id` message property. This gives you end-to-end visibility from sender to receiver.
+
+```C# Snippet:ServiceBusOpenTelemetryProcessor
+AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
+
+using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource("Azure.Messaging.ServiceBus.*")
+    .AddConsoleExporter()
+    .Build();
+
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+DefaultAzureCredential credential = new();
+await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
+
+await using ServiceBusProcessor processor = client.CreateProcessor("<queue-name>");
+
+processor.ProcessMessageAsync += async args =>
+{
+    // This handler runs inside an Activity that is correlated
+    // with the sender's Activity through the Diagnostic-Id property.
+    Console.WriteLine($"Processing message: {args.Message.Body}");
+    Console.WriteLine($"Activity.Current: {Activity.Current?.Id}");
+
+    await args.CompleteMessageAsync(args.Message);
+};
+
+processor.ProcessErrorAsync += args =>
+{
+    Console.WriteLine($"Error: {args.Exception}");
+    return Task.CompletedTask;
+};
+
+await processor.StartProcessingAsync();
+Console.ReadKey();
+```
+
+To export traces to Azure Monitor (Application Insights) instead of the console, replace `AddConsoleExporter()` with the Azure Monitor exporter:
+
+```C# Snippet:ServiceBusOpenTelemetryAzureMonitor
+using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource("Azure.Messaging.ServiceBus.*")
+    .AddAzureMonitorTraceExporter(options =>
+    {
+        options.ConnectionString = "<application-insights-connection-string>";
+    })
+    .Build();
+```
+
+## Automatic tracing with Application Insights
+
+If you use the [Application Insights SDK](https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview) and the `ServiceBusProcessor`, send and process operations are tracked and correlated automatically — no extra code required.
+
+For manual processing (using `ServiceBusReceiver` directly), you can start a request telemetry operation that correlates with the incoming message:
+
+```C# Snippet:ServiceBusAppInsightsManualProcessing
+async Task ProcessAsync(ProcessMessageEventArgs args)
+{
+    ServiceBusReceivedMessage message = args.Message;
+    if (message.ApplicationProperties.TryGetValue("Diagnostic-Id", out var objectId)
+        && objectId is string diagnosticId)
+    {
+        var activity = new Activity("ServiceBusProcessor.ProcessMessage");
+        activity.SetParentId(diagnosticId);
+
+        using var operation = telemetryClient.StartOperation<RequestTelemetry>(activity);
+        try
+        {
+            // Your message processing logic here.
+            telemetryClient.TrackTrace($"Processing message {message.MessageId}");
+            await args.CompleteMessageAsync(message);
+        }
+        catch (Exception ex)
+        {
+            telemetryClient.TrackException(ex);
+            operation.Telemetry.Success = false;
+            throw;
+        }
+    }
+}
+```
+
+## Listening to DiagnosticSource events directly
+
+If you do not use OpenTelemetry or Application Insights, you can subscribe to Service Bus diagnostic events directly using `DiagnosticListener`. This gives you full control over which events to capture and how to record them.
+
+The Service Bus client emits events on the `Azure.Messaging.ServiceBus` diagnostic source. Each operation produces a `Start` and `Stop` event, and `Activity.Current` carries the trace context.
+
+```C# Snippet:ServiceBusDiagnosticListener
+IDisposable innerSubscription = null;
+IDisposable outerSubscription = DiagnosticListener.AllListeners.Subscribe(listener =>
+{
+    if (listener.Name == "Azure.Messaging.ServiceBus")
+    {
+        innerSubscription = listener.Subscribe(evnt =>
+        {
+            // Log the operation when it completes.
+            if (evnt.Key.EndsWith("Stop"))
+            {
+                Activity currentActivity = Activity.Current;
+                Console.WriteLine(
+                    $"Operation {currentActivity.OperationName} completed " +
+                    $"in {currentActivity.Duration.TotalMilliseconds:F1}ms " +
+                    $"[Id={currentActivity.Id}]");
+            }
+        });
+    }
+});
+
+// Use the Service Bus client as normal — diagnostic events are emitted automatically.
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+DefaultAzureCredential credential = new();
+await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
+
+ServiceBusSender sender = client.CreateSender("<queue-name>");
+await sender.SendMessageAsync(new ServiceBusMessage("Traced message"));
+
+// Clean up the subscriptions when done.
+innerSubscription?.Dispose();
+outerSubscription?.Dispose();
+```
+
+## Filtering diagnostic events
+
+You can reduce overhead by subscribing only to the operations you care about. Use the `IsEnabled` callback to filter by operation name or entity.
+
+```C# Snippet:ServiceBusDiagnosticFiltering
+innerSubscription = listener.Subscribe(
+    observer: evnt =>
+    {
+        if (evnt.Key.EndsWith("Stop"))
+        {
+            Activity currentActivity = Activity.Current;
+            Console.WriteLine(
+                $"{currentActivity.OperationName}: {currentActivity.Duration.TotalMilliseconds:F1}ms");
+        }
+    },
+    isEnabled: (eventName, _, _) =>
+    {
+        // Only listen to send and process operations.
+        return eventName.StartsWith("ServiceBusSender.Send")
+            || eventName.StartsWith("ServiceBusProcessor.ProcessMessage");
+    });
+```
+
+## Instrumented operations
+
+The following operations emit diagnostic activities:
+
+| Operation | Source API |
+|-----------|-----------|
+| `ServiceBusSender.Send` | `SendMessageAsync`, `SendMessagesAsync` |
+| `ServiceBusSender.Schedule` | `ScheduleMessageAsync`, `ScheduleMessagesAsync` |
+| `ServiceBusSender.Cancel` | `CancelScheduledMessageAsync`, `CancelScheduledMessagesAsync` |
+| `ServiceBusReceiver.Receive` | `ReceiveMessageAsync`, `ReceiveMessagesAsync` |
+| `ServiceBusReceiver.ReceiveDeferred` | `ReceiveDeferredMessagesAsync` |
+| `ServiceBusReceiver.Peek` | `PeekMessageAsync`, `PeekMessagesAsync` |
+| `ServiceBusReceiver.Abandon` | `AbandonMessageAsync` |
+| `ServiceBusReceiver.Complete` | `CompleteMessageAsync` |
+| `ServiceBusReceiver.DeadLetter` | `DeadLetterMessageAsync` |
+| `ServiceBusReceiver.Defer` | `DeferMessageAsync` |
+| `ServiceBusReceiver.RenewMessageLock` | `RenewMessageLockAsync` |
+| `ServiceBusSessionReceiver.RenewSessionLock` | `RenewSessionLockAsync` |
+| `ServiceBusSessionReceiver.GetSessionState` | `GetSessionStateAsync` |
+| `ServiceBusSessionReceiver.SetSessionState` | `SetSessionStateAsync` |
+| `ServiceBusProcessor.ProcessMessage` | Callback on `ProcessMessageAsync` |
+| `ServiceBusSessionProcessor.ProcessSessionMessage` | Callback on `ProcessMessageAsync` |
+
+For more details on the Azure SDK distributed tracing conventions, see [Diagnostics samples](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md).

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Azure.Messaging.ServiceBus.Tests.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Azure.Messaging.ServiceBus.Tests.csproj
@@ -27,6 +27,10 @@
     <PackageReference Include="Polly" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <PackageReference Include="Microsoft.ApplicationInsights" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample19_DistributedTracing.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample19_DistributedTracing.cs
@@ -2,9 +2,21 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using NUnit.Framework;
+
+#if SNIPPET
+using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+#endif
+
+#pragma warning disable CS8321 // Local function is declared but never used
 
 namespace Azure.Messaging.ServiceBus.Tests.Samples
 {
@@ -113,6 +125,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
         [Ignore("Only verifying that the code builds")]
         public async Task AppInsightsManualProcessing()
         {
+#if SNIPPET
+            TelemetryClient telemetryClient = null!;
+#endif
             #region Snippet:ServiceBusAppInsightsManualProcessing
 #if SNIPPET
             async Task ProcessAsync(ProcessMessageEventArgs args)
@@ -151,24 +166,26 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
             #region Snippet:ServiceBusDiagnosticListener
 #if SNIPPET
             IDisposable innerSubscription = null;
-            IDisposable outerSubscription = DiagnosticListener.AllListeners.Subscribe(listener =>
-            {
-                if (listener.Name == "Azure.Messaging.ServiceBus")
+            IDisposable outerSubscription = DiagnosticListener.AllListeners.Subscribe(
+                new CallbackObserver<DiagnosticListener>(listener =>
                 {
-                    innerSubscription = listener.Subscribe(evnt =>
+                    if (listener.Name == "Azure.Messaging.ServiceBus")
                     {
-                        // Log the operation when it completes.
-                        if (evnt.Key.EndsWith("Stop"))
-                        {
-                            Activity currentActivity = Activity.Current;
-                            Console.WriteLine(
-                                $"Operation {currentActivity.OperationName} completed " +
-                                $"in {currentActivity.Duration.TotalMilliseconds:F1}ms " +
-                                $"[Id={currentActivity.Id}]");
-                        }
-                    });
-                }
-            });
+                        innerSubscription = listener.Subscribe(
+                            new CallbackObserver<KeyValuePair<string, object>>(evnt =>
+                            {
+                                // Log the operation when it completes.
+                                if (evnt.Key.EndsWith("Stop"))
+                                {
+                                    Activity currentActivity = Activity.Current;
+                                    Console.WriteLine(
+                                        $"Operation {currentActivity.OperationName} completed " +
+                                        $"in {currentActivity.Duration.TotalMilliseconds:F1}ms " +
+                                        $"[Id={currentActivity.Id}]");
+                                }
+                            }));
+                    }
+                }));
 
             // Use the Service Bus client as normal — diagnostic events are emitted automatically.
             string fullyQualifiedNamespace = "<fully_qualified_namespace>";
@@ -190,10 +207,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
         [Ignore("Only verifying that the code builds")]
         public async Task FilterDiagnosticEvents()
         {
+#if SNIPPET
+            IDisposable innerSubscription = null;
+            DiagnosticListener listener = null!;
+#endif
             #region Snippet:ServiceBusDiagnosticFiltering
 #if SNIPPET
             innerSubscription = listener.Subscribe(
-                observer: evnt =>
+                new CallbackObserver<KeyValuePair<string, object>>(evnt =>
                 {
                     if (evnt.Key.EndsWith("Stop"))
                     {
@@ -201,8 +222,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                         Console.WriteLine(
                             $"{currentActivity.OperationName}: {currentActivity.Duration.TotalMilliseconds:F1}ms");
                     }
-                },
-                isEnabled: (eventName, _, _) =>
+                }),
+                (eventName, _, _) =>
                 {
                     // Only listen to send and process operations.
                     return eventName.StartsWith("ServiceBusSender.Send")
@@ -211,6 +232,20 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 #endif
             #endregion
             await Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Adapts an <see cref="Action{T}"/> callback to <see cref="IObserver{T}"/>
+        /// for use with <see cref="DiagnosticListener.AllListeners"/> and
+        /// <see cref="DiagnosticListener.Subscribe(IObserver{KeyValuePair{string, object?}})"/>.
+        /// </summary>
+        private sealed class CallbackObserver<T> : IObserver<T>
+        {
+            private readonly Action<T> _onNext;
+            public CallbackObserver(Action<T> onNext) => _onNext = onNext;
+            public void OnNext(T value) => _onNext(value);
+            public void OnCompleted() { }
+            public void OnError(Exception error) { }
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample19_DistributedTracing.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample19_DistributedTracing.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Azure.Messaging.ServiceBus.Tests.Samples
+{
+    public class Sample19_DistributedTracing : ServiceBusLiveTestBase
+    {
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task OpenTelemetrySetup()
+        {
+            #region Snippet:ServiceBusOpenTelemetrySetup
+#if SNIPPET
+            // Enable the experimental OpenTelemetry support in Azure SDK client libraries.
+            AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
+
+            // Configure the OpenTelemetry tracer provider to listen to the Azure.Messaging.ServiceBus source.
+            using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource("Azure.Messaging.ServiceBus.*")
+                .AddConsoleExporter()
+                .Build();
+
+            string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+            DefaultAzureCredential credential = new();
+            await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
+
+            ServiceBusSender sender = client.CreateSender("<queue-name>");
+            await sender.SendMessageAsync(new ServiceBusMessage("Hello with tracing!"));
+            // The send operation is automatically captured as a span by OpenTelemetry.
+#endif
+            #endregion
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task OpenTelemetryProcessor()
+        {
+            #region Snippet:ServiceBusOpenTelemetryProcessor
+#if SNIPPET
+            AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
+
+            using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource("Azure.Messaging.ServiceBus.*")
+                .AddConsoleExporter()
+                .Build();
+
+            string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+            DefaultAzureCredential credential = new();
+            await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
+
+            await using ServiceBusProcessor processor = client.CreateProcessor("<queue-name>");
+
+            async Task MessageHandler(ProcessMessageEventArgs args)
+            {
+                // This handler runs inside an Activity that is correlated
+                // with the sender's Activity through the Diagnostic-Id property.
+                Console.WriteLine($"Processing message: {args.Message.Body}");
+                Console.WriteLine($"Activity.Current: {Activity.Current?.Id}");
+
+                await args.CompleteMessageAsync(args.Message);
+            }
+
+            Task ErrorHandler(ProcessErrorEventArgs args)
+            {
+                Console.WriteLine($"Error: {args.Exception}");
+                return Task.CompletedTask;
+            }
+
+            try
+            {
+                processor.ProcessMessageAsync += MessageHandler;
+                processor.ProcessErrorAsync += ErrorHandler;
+
+                await processor.StartProcessingAsync();
+                Console.ReadKey();
+                await processor.StopProcessingAsync();
+            }
+            finally
+            {
+                processor.ProcessMessageAsync -= MessageHandler;
+                processor.ProcessErrorAsync -= ErrorHandler;
+            }
+#endif
+            #endregion
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task OpenTelemetryAzureMonitor()
+        {
+            #region Snippet:ServiceBusOpenTelemetryAzureMonitor
+#if SNIPPET
+            using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource("Azure.Messaging.ServiceBus.*")
+                .AddAzureMonitorTraceExporter(options =>
+                {
+                    options.ConnectionString = "<application-insights-connection-string>";
+                })
+                .Build();
+#endif
+            #endregion
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task AppInsightsManualProcessing()
+        {
+            #region Snippet:ServiceBusAppInsightsManualProcessing
+#if SNIPPET
+            async Task ProcessAsync(ProcessMessageEventArgs args)
+            {
+                ServiceBusReceivedMessage message = args.Message;
+                if (message.ApplicationProperties.TryGetValue("Diagnostic-Id", out var objectId)
+                    && objectId is string diagnosticId)
+                {
+                    var activity = new Activity("ServiceBusProcessor.ProcessMessage");
+                    activity.SetParentId(diagnosticId);
+
+                    using var operation = telemetryClient.StartOperation<RequestTelemetry>(activity);
+                    try
+                    {
+                        // Your message processing logic here.
+                        telemetryClient.TrackTrace($"Processing message {message.MessageId}");
+                        await args.CompleteMessageAsync(message);
+                    }
+                    catch (Exception ex)
+                    {
+                        telemetryClient.TrackException(ex);
+                        operation.Telemetry.Success = false;
+                        throw;
+                    }
+                }
+            }
+#endif
+            #endregion
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task ListenToDiagnosticEvents()
+        {
+            #region Snippet:ServiceBusDiagnosticListener
+#if SNIPPET
+            IDisposable innerSubscription = null;
+            IDisposable outerSubscription = DiagnosticListener.AllListeners.Subscribe(listener =>
+            {
+                if (listener.Name == "Azure.Messaging.ServiceBus")
+                {
+                    innerSubscription = listener.Subscribe(evnt =>
+                    {
+                        // Log the operation when it completes.
+                        if (evnt.Key.EndsWith("Stop"))
+                        {
+                            Activity currentActivity = Activity.Current;
+                            Console.WriteLine(
+                                $"Operation {currentActivity.OperationName} completed " +
+                                $"in {currentActivity.Duration.TotalMilliseconds:F1}ms " +
+                                $"[Id={currentActivity.Id}]");
+                        }
+                    });
+                }
+            });
+
+            // Use the Service Bus client as normal — diagnostic events are emitted automatically.
+            string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+            DefaultAzureCredential credential = new();
+            await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
+
+            ServiceBusSender sender = client.CreateSender("<queue-name>");
+            await sender.SendMessageAsync(new ServiceBusMessage("Traced message"));
+
+            // Clean up the subscriptions when done.
+            innerSubscription?.Dispose();
+            outerSubscription?.Dispose();
+#endif
+            #endregion
+            await Task.CompletedTask;
+        }
+
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task FilterDiagnosticEvents()
+        {
+            #region Snippet:ServiceBusDiagnosticFiltering
+#if SNIPPET
+            innerSubscription = listener.Subscribe(
+                observer: evnt =>
+                {
+                    if (evnt.Key.EndsWith("Stop"))
+                    {
+                        Activity currentActivity = Activity.Current;
+                        Console.WriteLine(
+                            $"{currentActivity.OperationName}: {currentActivity.Duration.TotalMilliseconds:F1}ms");
+                    }
+                },
+                isEnabled: (eventName, _, _) =>
+                {
+                    // Only listen to send and process operations.
+                    return eventName.StartsWith("ServiceBusSender.Send")
+                        || eventName.StartsWith("ServiceBusProcessor.ProcessMessage");
+                });
+#endif
+            #endregion
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample19_DistributedTracing.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample19_DistributedTracing.cs
@@ -37,6 +37,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 .AddConsoleExporter()
                 .Build();
 
+            // The fully qualified Service Bus namespace. This is likely to be similar to
+            // {yournamespace}.servicebus.windows.net.
             string fullyQualifiedNamespace = "<fully_qualified_namespace>";
             DefaultAzureCredential credential = new();
             await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
@@ -62,6 +64,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 .AddConsoleExporter()
                 .Build();
 
+            // The fully qualified Service Bus namespace. This is likely to be similar to
+            // {yournamespace}.servicebus.windows.net.
             string fullyQualifiedNamespace = "<fully_qualified_namespace>";
             DefaultAzureCredential credential = new();
             await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
@@ -136,7 +140,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 if (message.ApplicationProperties.TryGetValue("Diagnostic-Id", out var objectId)
                     && objectId is string diagnosticId)
                 {
-                    var activity = new Activity("ServiceBusProcessor.ProcessMessage");
+                    var activity = new Activity("MyApp.ProcessMessage");
                     activity.SetParentId(diagnosticId);
 
                     using var operation = telemetryClient.StartOperation<RequestTelemetry>(activity);
@@ -187,17 +191,23 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                     }
                 }));
 
-            // Use the Service Bus client as normal — diagnostic events are emitted automatically.
-            string fullyQualifiedNamespace = "<fully_qualified_namespace>";
-            DefaultAzureCredential credential = new();
-            await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
+            try
+            {
+                // Use the Service Bus client as normal — diagnostic events are emitted automatically.
+                // The fully qualified Service Bus namespace. This is likely to be similar to
+                // {yournamespace}.servicebus.windows.net.
+                string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+                DefaultAzureCredential credential = new();
+                await using ServiceBusClient client = new(fullyQualifiedNamespace, credential);
 
-            ServiceBusSender sender = client.CreateSender("<queue-name>");
-            await sender.SendMessageAsync(new ServiceBusMessage("Traced message"));
-
-            // Clean up the subscriptions when done.
-            innerSubscription?.Dispose();
-            outerSubscription?.Dispose();
+                ServiceBusSender sender = client.CreateSender("<queue-name>");
+                await sender.SendMessageAsync(new ServiceBusMessage("Traced message"));
+            }
+            finally
+            {
+                innerSubscription?.Dispose();
+                outerSubscription?.Dispose();
+            }
 #endif
             #endregion
             await Task.CompletedTask;
@@ -239,6 +249,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
         /// for use with <see cref="DiagnosticListener.AllListeners"/> and
         /// <see cref="DiagnosticListener.Subscribe(IObserver{KeyValuePair{string, object?}})"/>.
         /// </summary>
+        #region Snippet:ServiceBusCallbackObserverHelper
         private sealed class CallbackObserver<T> : IObserver<T>
         {
             private readonly Action<T> _onNext;
@@ -247,5 +258,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
             public void OnCompleted() { }
             public void OnError(Exception error) { }
         }
+        #endregion
     }
 }


### PR DESCRIPTION
## Description

Add a new distributed tracing sample (Sample 19) for the Service Bus client library. The sample covers:

- **OpenTelemetry setup** — configuring a tracer provider to capture Service Bus activities
- **OpenTelemetry processor** — end-to-end tracing from sender to processor with named handlers
- **Azure Monitor exporter** — exporting traces to Application Insights via OpenTelemetry
- **Application Insights manual correlation** — correlating receiver processing with the sender's Diagnostic-Id
- **DiagnosticListener** — subscribing to diagnostic events directly without OpenTelemetry
- **Event filtering** — reducing overhead by subscribing only to specific operations
- **Instrumented operations table** — reference of all traced operations and their source APIs

## Changes

- **New:** `samples/Sample19_DistributedTracing.md` — sample documentation
- **New:** `tests/Samples/Sample19_DistributedTracing.cs` — snippet backing file (6 regions, all `[Ignore]` with `#if SNIPPET` bodies)
- **Modified:** `samples/README.md` — TOC entry for Sample 19

## Notes

- OTel and AppInsights are presented as equal options (matches Azure.Core Diagnostics.md positioning)
- Experimental status is called out with opt-in details and link to Azure.Core docs
- Processor snippet uses named handlers with try/finally subscribe/unsubscribe pattern (matches Sample 04)
- All snippet code is inside `#if SNIPPET` blocks since OTel/AppInsights packages are not in the test project