### PR TITLE
Add JSON schema IntelliSense for System.ClientModel client configuration (Clients section)

### DIFF
--- a/eng/Directory.Build.Common.targets
+++ b/eng/Directory.Build.Common.targets
@@ -155,7 +155,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(HasConfigurationSchema)' == 'true'">
-    <None Include="$(ConfigurationSchemaPath)" Pack="true" PackagePath="ConfigurationSchema.json" />
+    <None Include="$(ConfigurationSchemaPath)" Pack="true" PackagePath="ConfigurationSchema.json" Link="schema/ConfigurationSchema.json" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(HasConfigurationSchema)' == 'true'">

--- a/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
+++ b/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
@@ -1,0 +1,152 @@
+# Secure Credential Handling
+
+This document describes best practices for keeping secrets out of
+`appsettings.json` when configuring `System.ClientModel`-based clients.
+
+## Never store API keys in configuration files
+
+Configuration files such as `appsettings.json` are typically checked into
+source control. Storing API keys, connection strings, or other secrets in
+these files risks accidental exposure.
+
+```json
+// ❌ DON'T — secret will end up in source control
+{
+  "Clients": {
+    "MyClient": {
+      "Credential": {
+        "CredentialSource": "ApiKeyCredential",
+        "Key": "my-secret-key"
+      }
+    }
+  }
+}
+```
+
+If you attempt to add a `Key` property in `appsettings.json`, the JSON
+Schema IntelliSense will display a validation warning reminding you not to
+store secrets in configuration files.
+
+## Recommended approaches
+
+### 1. Environment variables
+
+Use an environment variable to supply the API key at runtime. The .NET
+configuration system automatically maps environment variables to
+configuration keys using the `__` (double underscore) separator.
+
+**appsettings.json:**
+
+```json
+{
+  "Clients": {
+    "MyClient": {
+      "Endpoint": "https://api.example.com",
+      "Credential": {
+        "CredentialSource": "ApiKeyCredential"
+      }
+    }
+  }
+}
+```
+
+Set the environment variable:
+
+```bash
+# Linux / macOS
+export Clients__MyClient__Credential__Key=my-secret-key
+
+# Windows (PowerShell)
+$env:Clients__MyClient__Credential__Key = "my-secret-key"
+```
+
+**Configuration code:**
+
+```csharp
+ConfigurationManager configuration = new();
+configuration.AddJsonFile("appsettings.json");
+configuration.AddEnvironmentVariables();
+
+MyClientSettings settings = configuration.GetClientSettings<MyClientSettings>("Clients:MyClient");
+MyClient client = new(settings);
+```
+
+> [!NOTE]
+> For details on the environment variable naming convention, see
+> [Environment variable configuration provider](https://learn.microsoft.com/dotnet/core/extensions/configuration-providers#environment-variable-configuration-provider).
+
+### 2. User Secrets (development)
+
+During local development, use the .NET
+[Secret Manager](https://learn.microsoft.com/aspnet/core/security/app-secrets)
+tool to store secrets outside of your project tree:
+
+```bash
+dotnet user-secrets set "Clients:MyClient:Credential:Key" "my-secret-key"
+```
+
+**Configuration code:**
+
+```csharp
+HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+builder.AddClient<MyClient, MyClientSettings>("Clients:MyClient");
+```
+
+User secrets are added automatically in the Development environment.
+
+### 3. Azure Key Vault (production)
+
+For production workloads, store secrets in
+[Azure Key Vault](https://learn.microsoft.com/azure/key-vault/general/overview)
+and use the
+[Azure.Extensions.AspNetCore.Configuration.Secrets](https://www.nuget.org/packages/Azure.Extensions.AspNetCore.Configuration.Secrets)
+package to load them into the .NET configuration system at startup.
+
+```bash
+dotnet add package Azure.Extensions.AspNetCore.Configuration.Secrets
+```
+
+Create a secret in Key Vault. The secret manager maps `--` in secret
+names to `:` in configuration keys:
+
+```bash
+az keyvault secret set \
+  --vault-name my-vault \
+  --name "Clients--MyClient--Credential--Key" \
+  --value "my-secret-key"
+```
+
+**appsettings.json:**
+
+```json
+{
+  "AzureClients": {
+    "KeyVault": {
+      "VaultUri": "https://my-vault.vault.azure.net/",
+      "Credential": {
+        "CredentialSource": "ManagedIdentityCredential",
+        "ManagedIdentityIdKind": "ClientId",
+        "ManagedIdentityId": "<your-client-id>"
+      }
+    }
+  },
+  "Clients": {
+    "MyClient": {
+      "Endpoint": "https://api.example.com",
+      "Credential": {
+        "CredentialSource": "ApiKeyCredential"
+      }
+    }
+  }
+}
+```
+
+**Configuration code:**
+
+```csharp
+HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+
+builder.Configuration.AddKeyVaultSecrets("AzureClients:KeyVault");
+
+builder.AddClient<MyClient, MyClientSettings>("Clients:MyClient");
+```

--- a/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
+++ b/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
@@ -116,6 +116,8 @@ az keyvault secret set \
   --value "my-secret-key"
 ```
 
+This maps the Key Vault secret to the configuration path `Clients:MyClient:Credential:Key`. The value will not appear in your `appsettings.json`, but it will effectively act as if the secret from Key Vault is at that path.
+
 **appsettings.json:**
 
 ```json

--- a/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
+++ b/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
@@ -75,7 +75,7 @@ MyClient client = new(settings);
 > For details on the environment variable naming convention, see
 > [Environment variable configuration provider](https://learn.microsoft.com/dotnet/core/extensions/configuration-providers#environment-variable-configuration-provider).
 
-### 2. User Secrets (development)
+### 2. User secrets (development)
 
 During local development, use the .NET
 [Secret Manager](https://learn.microsoft.com/aspnet/core/security/app-secrets)

--- a/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
+++ b/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
@@ -1,4 +1,4 @@
-# Secure Credential Handling
+# Secure credential handling
 
 This document describes best practices for keeping secrets out of
 `appsettings.json` when configuring `System.ClientModel`-based clients.

--- a/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
+++ b/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
@@ -71,20 +71,6 @@
           "type": "integer",
           "description": "Maximum size of logged message content in bytes.",
           "minimum": 0
-        },
-        "AllowedHeaderNames": {
-          "type": "array",
-          "description": "HTTP header names to include in logs.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "AllowedQueryParameters": {
-          "type": "array",
-          "description": "Query parameter names to include in logs.",
-          "items": {
-            "type": "string"
-          }
         }
       },
       "additionalProperties": false

--- a/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
+++ b/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
@@ -39,8 +39,7 @@
       "properties": {
         "NetworkTimeout": {
           "type": "string",
-          "description": "Timeout for network operations (TimeSpan format, e.g. '00:01:40').",
-          "pattern": "^(\\d+\\.)?(\\d{1,2}):(\\d{2}):(\\d{2})(\\.\\d+)?$"
+          "description": "Timeout for network operations (TimeSpan format, e.g. '00:01:40')."
         },
         "EnableDistributedTracing": {
           "type": "boolean",

--- a/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
+++ b/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
@@ -1,0 +1,113 @@
+{
+  "definitions": {
+    "scmCredential": {
+      "type": "object",
+      "description": "Credential configuration for System.ClientModel clients.",
+      "properties": {
+        "CredentialSource": {
+          "type": "string",
+          "description": "The credential type to use for authentication.",
+          "enum": ["ApiKeyCredential"]
+        },
+        "AdditionalProperties": {
+          "type": "object",
+          "description": "Additional credential properties."
+        }
+      },
+      "required": ["CredentialSource"],
+      "allOf": [
+        {
+          "if": {
+            "required": ["Key"]
+          },
+          "then": {
+            "title": "⚠️ Do NOT put API keys in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put API keys in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "Key": {
+                "not": {},
+                "description": "⚠️ Do NOT put API keys in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "options": {
+      "type": "object",
+      "description": "Client pipeline options.",
+      "properties": {
+        "NetworkTimeout": {
+          "type": "string",
+          "description": "Timeout for network operations (TimeSpan format, e.g. '00:01:40').",
+          "pattern": "^(\\d+\\.)?(\\d{1,2}):(\\d{2}):(\\d{2})(\\.\\d+)?$"
+        },
+        "EnableDistributedTracing": {
+          "type": "boolean",
+          "description": "Enable distributed tracing."
+        },
+        "ClientLoggingOptions": {
+          "$ref": "#/definitions/clientLoggingOptions"
+        }
+      },
+      "additionalProperties": true
+    },
+    "clientLoggingOptions": {
+      "type": "object",
+      "description": "Logging configuration for the client pipeline.",
+      "properties": {
+        "EnableLogging": {
+          "type": "boolean",
+          "description": "Enable logging."
+        },
+        "EnableMessageLogging": {
+          "type": "boolean",
+          "description": "Enable HTTP message logging."
+        },
+        "EnableMessageContentLogging": {
+          "type": "boolean",
+          "description": "Enable logging of request and response body content."
+        },
+        "MessageContentSizeLimit": {
+          "type": "integer",
+          "description": "Maximum size of logged message content in bytes.",
+          "minimum": 0
+        },
+        "AllowedHeaderNames": {
+          "type": "array",
+          "description": "HTTP header names to include in logs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AllowedQueryParameters": {
+          "type": "array",
+          "description": "Query parameter names to include in logs.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "Clients": {
+      "type": "object",
+      "description": "Configuration for System.ClientModel-based clients.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "Credential": {
+            "$ref": "#/definitions/scmCredential"
+          },
+          "Options": {
+            "$ref": "#/definitions/options"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
+++ b/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
@@ -8,10 +8,6 @@
           "type": "string",
           "description": "The credential type to use for authentication.",
           "enum": ["ApiKeyCredential"]
-        },
-        "AdditionalProperties": {
-          "type": "object",
-          "description": "Additional credential properties."
         }
       },
       "required": ["CredentialSource"],
@@ -71,9 +67,30 @@
           "type": "integer",
           "description": "Maximum size of logged message content in bytes.",
           "minimum": 0
+        },
+        "AdditionalAllowedHeaderNames": {
+          "type": "array",
+          "description": "Additional header names to log (appended to defaults). ⚠️ Avoid adding headers that may contain secrets (e.g., Authorization, Cookie, X-Api-Key) — these could leak sensitive data in logs.",
+          "not": {
+            "contains": {
+              "enum": ["Authorization", "Proxy-Authorization", "Cookie", "Set-Cookie", "X-Api-Key"]
+            }
+          },
+          "items": {
+            "type": "string",
+            "not": {
+              "enum": ["Authorization", "Proxy-Authorization", "Cookie", "Set-Cookie", "X-Api-Key"]
+            }
+          }
+        },
+        "AdditionalAllowedQueryParameters":{
+          "type": "array",
+          "description": "Additional query parameter names to log (appended to defaults: api-version).",
+          "items": {
+            "type": "string"
+          }
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
   "type": "object",

--- a/sdk/core/System.ClientModel/src/Options/ClientLoggingOptions.cs
+++ b/sdk/core/System.ClientModel/src/Options/ClientLoggingOptions.cs
@@ -94,6 +94,8 @@ public class ClientLoggingOptions
         {
             MessageContentSizeLimit = messageContentSizeLimit;
         }
+
+        BindStringListProperties(section);
     }
 
     /// <summary>
@@ -334,6 +336,80 @@ public class ClientLoggingOptions
             && EnableMessageContentLogging == true)
         {
             throw new InvalidOperationException("HTTP Message content logging cannot be enabled when HTTP message logging is disabled.");
+        }
+    }
+
+    private const string AdditionalAllowedHeaderNamesKey = "AdditionalAllowedHeaderNames";
+    private const string AdditionalAllowedQueryParametersKey = "AdditionalAllowedQueryParameters";
+
+    private void BindStringListProperties(IConfigurationSection section)
+    {
+        IConfigurationSection allowedHeaders = section.GetSection(nameof(AllowedHeaderNames));
+        IConfigurationSection additionalHeaders = section.GetSection(AdditionalAllowedHeaderNamesKey);
+
+        if (allowedHeaders.Exists() && additionalHeaders.Exists())
+        {
+            throw new InvalidOperationException(
+                $"Cannot specify both '{nameof(AllowedHeaderNames)}' and '{AdditionalAllowedHeaderNamesKey}'. " +
+                $"Use '{nameof(AllowedHeaderNames)}' to replace the defaults or '{AdditionalAllowedHeaderNamesKey}' to add to them.");
+        }
+
+        IConfigurationSection allowedQueryParams = section.GetSection(nameof(AllowedQueryParameters));
+        IConfigurationSection additionalQueryParams = section.GetSection(AdditionalAllowedQueryParametersKey);
+
+        if (allowedQueryParams.Exists() && additionalQueryParams.Exists())
+        {
+            throw new InvalidOperationException(
+                $"Cannot specify both '{nameof(AllowedQueryParameters)}' and '{AdditionalAllowedQueryParametersKey}'. " +
+                $"Use '{nameof(AllowedQueryParameters)}' to replace the defaults or '{AdditionalAllowedQueryParametersKey}' to add to them.");
+        }
+
+        if (allowedHeaders.Exists())
+        {
+            ChangeTrackingStringList headers = new();
+            foreach (IConfigurationSection child in allowedHeaders.GetChildren())
+            {
+                if (child.Value is not null)
+                {
+                    headers.Add(child.Value);
+                }
+            }
+            _allowedHeaderNames = headers;
+        }
+        else if (additionalHeaders.Exists())
+        {
+            HashSet<string> existing = new(AllowedHeaderNames, StringComparer.OrdinalIgnoreCase);
+            foreach (IConfigurationSection child in additionalHeaders.GetChildren())
+            {
+                if (child.Value is not null && existing.Add(child.Value))
+                {
+                    AllowedHeaderNames.Add(child.Value);
+                }
+            }
+        }
+
+        if (allowedQueryParams.Exists())
+        {
+            ChangeTrackingStringList queryParams = new();
+            foreach (IConfigurationSection child in allowedQueryParams.GetChildren())
+            {
+                if (child.Value is not null)
+                {
+                    queryParams.Add(child.Value);
+                }
+            }
+            _allowedQueryParameters = queryParams;
+        }
+        else if (additionalQueryParams.Exists())
+        {
+            HashSet<string> existing = new(AllowedQueryParameters, StringComparer.OrdinalIgnoreCase);
+            foreach (IConfigurationSection child in additionalQueryParams.GetChildren())
+            {
+                if (child.Value is not null && existing.Add(child.Value))
+                {
+                    AllowedQueryParameters.Add(child.Value);
+                }
+            }
         }
     }
 

--- a/sdk/core/System.ClientModel/src/Options/ClientLoggingOptions.cs
+++ b/sdk/core/System.ClientModel/src/Options/ClientLoggingOptions.cs
@@ -344,39 +344,8 @@ public class ClientLoggingOptions
 
     private void BindStringListProperties(IConfigurationSection section)
     {
-        IConfigurationSection allowedHeaders = section.GetSection(nameof(AllowedHeaderNames));
         IConfigurationSection additionalHeaders = section.GetSection(AdditionalAllowedHeaderNamesKey);
-
-        if (allowedHeaders.Exists() && additionalHeaders.Exists())
-        {
-            throw new InvalidOperationException(
-                $"Cannot specify both '{nameof(AllowedHeaderNames)}' and '{AdditionalAllowedHeaderNamesKey}'. " +
-                $"Use '{nameof(AllowedHeaderNames)}' to replace the defaults or '{AdditionalAllowedHeaderNamesKey}' to add to them.");
-        }
-
-        IConfigurationSection allowedQueryParams = section.GetSection(nameof(AllowedQueryParameters));
-        IConfigurationSection additionalQueryParams = section.GetSection(AdditionalAllowedQueryParametersKey);
-
-        if (allowedQueryParams.Exists() && additionalQueryParams.Exists())
-        {
-            throw new InvalidOperationException(
-                $"Cannot specify both '{nameof(AllowedQueryParameters)}' and '{AdditionalAllowedQueryParametersKey}'. " +
-                $"Use '{nameof(AllowedQueryParameters)}' to replace the defaults or '{AdditionalAllowedQueryParametersKey}' to add to them.");
-        }
-
-        if (allowedHeaders.Exists())
-        {
-            ChangeTrackingStringList headers = new();
-            foreach (IConfigurationSection child in allowedHeaders.GetChildren())
-            {
-                if (child.Value is not null)
-                {
-                    headers.Add(child.Value);
-                }
-            }
-            _allowedHeaderNames = headers;
-        }
-        else if (additionalHeaders.Exists())
+        if (additionalHeaders.Exists())
         {
             HashSet<string> existing = new(AllowedHeaderNames, StringComparer.OrdinalIgnoreCase);
             foreach (IConfigurationSection child in additionalHeaders.GetChildren())
@@ -388,19 +357,8 @@ public class ClientLoggingOptions
             }
         }
 
-        if (allowedQueryParams.Exists())
-        {
-            ChangeTrackingStringList queryParams = new();
-            foreach (IConfigurationSection child in allowedQueryParams.GetChildren())
-            {
-                if (child.Value is not null)
-                {
-                    queryParams.Add(child.Value);
-                }
-            }
-            _allowedQueryParameters = queryParams;
-        }
-        else if (additionalQueryParams.Exists())
+        IConfigurationSection additionalQueryParams = section.GetSection(AdditionalAllowedQueryParametersKey);
+        if (additionalQueryParams.Exists())
         {
             HashSet<string> existing = new(AllowedQueryParameters, StringComparer.OrdinalIgnoreCase);
             foreach (IConfigurationSection child in additionalQueryParams.GetChildren())

--- a/sdk/core/System.ClientModel/tests/Convenience/ConfigurationExtensionsTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/ConfigurationExtensionsTests.cs
@@ -233,4 +233,159 @@ public class ConfigurationExtensionsTests
         Assert.That(settings.Options.ApiVersion, Is.EqualTo("2024-11-01"));
         Assert.That(settings.Options.EnableDistributedTracing, Is.True);
     }
+
+    [Test]
+    public void GetClientSettings_AllowedHeaderNames_ReplacesDefaults()
+    {
+        ConfigurationBuilder builder = new();
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["TestClient:Options:ClientLoggingOptions:AllowedHeaderNames:0"] = "X-Custom-Header",
+            ["TestClient:Options:ClientLoggingOptions:AllowedHeaderNames:1"] = "X-Request-Id"
+        });
+        IConfigurationRoot config = builder.Build();
+
+        TestClientSettings settings = config.GetClientSettings<TestClientSettings>("TestClient");
+
+        Assert.That(settings.Options!.ClientLoggingOptions!.AllowedHeaderNames, Is.EquivalentTo(new[] { "X-Custom-Header", "X-Request-Id" }));
+    }
+
+    [Test]
+    public void GetClientSettings_AllowedQueryParameters_ReplacesDefaults()
+    {
+        ConfigurationBuilder builder = new();
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["TestClient:Options:ClientLoggingOptions:AllowedQueryParameters:0"] = "filter",
+            ["TestClient:Options:ClientLoggingOptions:AllowedQueryParameters:1"] = "top"
+        });
+        IConfigurationRoot config = builder.Build();
+
+        TestClientSettings settings = config.GetClientSettings<TestClientSettings>("TestClient");
+
+        Assert.That(settings.Options!.ClientLoggingOptions!.AllowedQueryParameters, Is.EquivalentTo(new[] { "filter", "top" }));
+    }
+
+    [Test]
+    public void GetClientSettings_AdditionalAllowedHeaderNames_AppendsToDefaults()
+    {
+        ConfigurationBuilder builder = new();
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedHeaderNames:0"] = "X-Custom-Header",
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedHeaderNames:1"] = "X-Request-Id"
+        });
+        IConfigurationRoot config = builder.Build();
+
+        TestClientSettings settings = config.GetClientSettings<TestClientSettings>("TestClient");
+
+        var headers = settings.Options!.ClientLoggingOptions!.AllowedHeaderNames;
+        Assert.That(headers, Has.Member("X-Custom-Header"));
+        Assert.That(headers, Has.Member("X-Request-Id"));
+        // Defaults are still present
+        Assert.That(headers, Has.Member("Accept"));
+        Assert.That(headers, Has.Member("Content-Type"));
+        Assert.That(headers, Has.Member("traceparent"));
+    }
+
+    [Test]
+    public void GetClientSettings_AdditionalAllowedQueryParameters_AppendsToDefaults()
+    {
+        ConfigurationBuilder builder = new();
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedQueryParameters:0"] = "filter",
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedQueryParameters:1"] = "top"
+        });
+        IConfigurationRoot config = builder.Build();
+
+        TestClientSettings settings = config.GetClientSettings<TestClientSettings>("TestClient");
+
+        var queryParams = settings.Options!.ClientLoggingOptions!.AllowedQueryParameters;
+        Assert.That(queryParams, Has.Member("filter"));
+        Assert.That(queryParams, Has.Member("top"));
+        // Default is still present
+        Assert.That(queryParams, Has.Member("api-version"));
+    }
+
+    [Test]
+    public void GetClientSettings_AdditionalAllowedHeaderNames_DeduplicatesExistingDefaults()
+    {
+        ConfigurationBuilder builder = new();
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedHeaderNames:0"] = "Content-Type",
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedHeaderNames:1"] = "X-New-Header",
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedHeaderNames:2"] = "accept"
+        });
+        IConfigurationRoot config = builder.Build();
+
+        TestClientSettings settings = config.GetClientSettings<TestClientSettings>("TestClient");
+
+        var headers = settings.Options!.ClientLoggingOptions!.AllowedHeaderNames;
+        Assert.That(headers, Has.Member("X-New-Header"));
+        // Content-Type and Accept were already in defaults — no duplicates
+        int contentTypeCount = 0;
+        int acceptCount = 0;
+        foreach (string h in headers)
+        {
+            if (string.Equals(h, "Content-Type", StringComparison.OrdinalIgnoreCase)) contentTypeCount++;
+            if (string.Equals(h, "Accept", StringComparison.OrdinalIgnoreCase)) acceptCount++;
+        }
+        Assert.That(contentTypeCount, Is.EqualTo(1), "Content-Type should not be duplicated");
+        Assert.That(acceptCount, Is.EqualTo(1), "Accept should not be duplicated");
+    }
+
+    [Test]
+    public void GetClientSettings_AdditionalAllowedQueryParameters_DeduplicatesExistingDefaults()
+    {
+        ConfigurationBuilder builder = new();
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedQueryParameters:0"] = "api-version",
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedQueryParameters:1"] = "filter"
+        });
+        IConfigurationRoot config = builder.Build();
+
+        TestClientSettings settings = config.GetClientSettings<TestClientSettings>("TestClient");
+
+        var queryParams = settings.Options!.ClientLoggingOptions!.AllowedQueryParameters;
+        Assert.That(queryParams, Has.Member("filter"));
+        int apiVersionCount = 0;
+        foreach (string q in queryParams)
+        {
+            if (string.Equals(q, "api-version", StringComparison.OrdinalIgnoreCase)) apiVersionCount++;
+        }
+        Assert.That(apiVersionCount, Is.EqualTo(1), "api-version should not be duplicated");
+    }
+
+    [Test]
+    public void GetClientSettings_AllowedAndAdditionalHeaderNames_ThrowsInvalidOperation()
+    {
+        ConfigurationBuilder builder = new();
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["TestClient:Options:ClientLoggingOptions:AllowedHeaderNames:0"] = "X-Custom",
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedHeaderNames:0"] = "X-Extra"
+        });
+        IConfigurationRoot config = builder.Build();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            config.GetClientSettings<TestClientSettings>("TestClient"));
+    }
+
+    [Test]
+    public void GetClientSettings_AllowedAndAdditionalQueryParameters_ThrowsInvalidOperation()
+    {
+        ConfigurationBuilder builder = new();
+        builder.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["TestClient:Options:ClientLoggingOptions:AllowedQueryParameters:0"] = "filter",
+            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedQueryParameters:0"] = "top"
+        });
+        IConfigurationRoot config = builder.Build();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            config.GetClientSettings<TestClientSettings>("TestClient"));
+    }
 }

--- a/sdk/core/System.ClientModel/tests/Convenience/ConfigurationExtensionsTests.cs
+++ b/sdk/core/System.ClientModel/tests/Convenience/ConfigurationExtensionsTests.cs
@@ -235,38 +235,6 @@ public class ConfigurationExtensionsTests
     }
 
     [Test]
-    public void GetClientSettings_AllowedHeaderNames_ReplacesDefaults()
-    {
-        ConfigurationBuilder builder = new();
-        builder.AddInMemoryCollection(new Dictionary<string, string?>
-        {
-            ["TestClient:Options:ClientLoggingOptions:AllowedHeaderNames:0"] = "X-Custom-Header",
-            ["TestClient:Options:ClientLoggingOptions:AllowedHeaderNames:1"] = "X-Request-Id"
-        });
-        IConfigurationRoot config = builder.Build();
-
-        TestClientSettings settings = config.GetClientSettings<TestClientSettings>("TestClient");
-
-        Assert.That(settings.Options!.ClientLoggingOptions!.AllowedHeaderNames, Is.EquivalentTo(new[] { "X-Custom-Header", "X-Request-Id" }));
-    }
-
-    [Test]
-    public void GetClientSettings_AllowedQueryParameters_ReplacesDefaults()
-    {
-        ConfigurationBuilder builder = new();
-        builder.AddInMemoryCollection(new Dictionary<string, string?>
-        {
-            ["TestClient:Options:ClientLoggingOptions:AllowedQueryParameters:0"] = "filter",
-            ["TestClient:Options:ClientLoggingOptions:AllowedQueryParameters:1"] = "top"
-        });
-        IConfigurationRoot config = builder.Build();
-
-        TestClientSettings settings = config.GetClientSettings<TestClientSettings>("TestClient");
-
-        Assert.That(settings.Options!.ClientLoggingOptions!.AllowedQueryParameters, Is.EquivalentTo(new[] { "filter", "top" }));
-    }
-
-    [Test]
     public void GetClientSettings_AdditionalAllowedHeaderNames_AppendsToDefaults()
     {
         ConfigurationBuilder builder = new();
@@ -357,35 +325,5 @@ public class ConfigurationExtensionsTests
             if (string.Equals(q, "api-version", StringComparison.OrdinalIgnoreCase)) apiVersionCount++;
         }
         Assert.That(apiVersionCount, Is.EqualTo(1), "api-version should not be duplicated");
-    }
-
-    [Test]
-    public void GetClientSettings_AllowedAndAdditionalHeaderNames_ThrowsInvalidOperation()
-    {
-        ConfigurationBuilder builder = new();
-        builder.AddInMemoryCollection(new Dictionary<string, string?>
-        {
-            ["TestClient:Options:ClientLoggingOptions:AllowedHeaderNames:0"] = "X-Custom",
-            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedHeaderNames:0"] = "X-Extra"
-        });
-        IConfigurationRoot config = builder.Build();
-
-        Assert.Throws<InvalidOperationException>(() =>
-            config.GetClientSettings<TestClientSettings>("TestClient"));
-    }
-
-    [Test]
-    public void GetClientSettings_AllowedAndAdditionalQueryParameters_ThrowsInvalidOperation()
-    {
-        ConfigurationBuilder builder = new();
-        builder.AddInMemoryCollection(new Dictionary<string, string?>
-        {
-            ["TestClient:Options:ClientLoggingOptions:AllowedQueryParameters:0"] = "filter",
-            ["TestClient:Options:ClientLoggingOptions:AdditionalAllowedQueryParameters:0"] = "top"
-        });
-        IConfigurationRoot config = builder.Build();
-
-        Assert.Throws<InvalidOperationException>(() =>
-            config.GetClientSettings<TestClientSettings>("TestClient"));
     }
 }


### PR DESCRIPTION
## What

Adds `ConfigurationSchema.json` to `sdk/core/System.ClientModel/schema/` defining the JSON Schema for the `Clients` top-level section in `appsettings.json`. This enables IntelliSense in Visual Studio for System.ClientModel-based client configuration.

### Schema defines:
- **Clients** top-level section (with `additionalProperties` for any client name)
- **scmCredential** definition (ApiKeyCredential only, with Key-blocking `if/then/not` pattern)
- **options** definition (pipeline options: `NetworkTimeout`, `EnableDistributedTracing`, `ClientLoggingOptions`)
- **clientLoggingOptions** definition (`EnableLogging`, `EnableMessageLogging`, `EnableMessageContentLogging`, `MessageContentSizeLimit`, `AllowedHeaderNames`, `AllowedQueryParameters`)

Also adds `SecureCredentialHandling.md` to `sdk/core/Azure.Core/src/docs/` documenting best practices for keeping secrets out of `appsettings.json`.

### Verified
- All property names match the current C# source
- Schema auto-detected by build infrastructure and packed into nupkg with `.targets` for all TFMs

Fixes #56779