### PR TITLE
Add Sample21_ExceptionHandling covering ServiceBusException patterns

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
@@ -28,3 +28,4 @@ description: Samples for the Azure.Messaging.ServiceBus client library
 - [Interact with the AMQP message](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample14_AMQPMessage.md)
 - [Mocking Client Types](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample15_MockingClientTypes.md)
 - [Cross-receiver message settlement](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample16_CrossReceiverMessageSettlement.md)
+- [Exception handling](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
@@ -28,4 +28,5 @@ description: Samples for the Azure.Messaging.ServiceBus client library
 - [Interact with the AMQP message](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample14_AMQPMessage.md)
 - [Mocking Client Types](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample15_MockingClientTypes.md)
 - [Cross-receiver message settlement](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample16_CrossReceiverMessageSettlement.md)
+- [Batch delete messages](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample17_BatchDelete.md)
 - [Exception handling](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md)

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -44,22 +44,26 @@ catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.Messag
     // Permanent: the message payload is too large for the tier. This will never succeed
     // without reducing the message size or upgrading to Premium.
     Console.WriteLine($"Message too large ({ex.Message}). Reduce payload size.");
+    throw;
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
 {
     // Permanent: the queue, topic, or subscription does not exist. Check the entity name
     // and ensure it has been provisioned.
     Console.WriteLine($"Entity not found: {ex.Message}");
+    throw;
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityDisabled)
 {
     // Permanent: the entity is disabled in the portal or via management API.
     Console.WriteLine($"Entity is disabled: {ex.Message}");
+    throw;
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
 {
     // Permanent: attempted to create an entity that already exists.
     Console.WriteLine($"Entity already exists: {ex.Message}");
+    throw;
 }
 catch (ServiceBusException ex)
 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -89,6 +89,11 @@ string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 string queueName = "<queue_name>";
 
 await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
+
+// Send a message so the queue has something to receive.
+ServiceBusSender sender = client.CreateSender(queueName);
+await sender.SendMessageAsync(new ServiceBusMessage("Hello"));
+
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -93,6 +93,12 @@ ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();
 
+if (message is null)
+{
+    Console.WriteLine("No message available.");
+    return;
+}
+
 try
 {
     // Process the message — if handling takes longer than the lock duration,
@@ -189,7 +195,7 @@ async Task MessageHandler(ProcessMessageEventArgs args)
 
 Task ErrorHandler(ProcessErrorEventArgs args)
 {
-    // Infrastructure-level errors: connection drops, auth failures, etc.
+    // Errors from message processing, settlement, lock renewal, and service communication.
     Console.WriteLine($"Error source: {args.ErrorSource}");
     Console.WriteLine($"Entity path: {args.EntityPath}");
     Console.WriteLine($"Namespace: {args.FullyQualifiedNamespace}");

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -129,7 +129,7 @@ catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.Sessio
 
 To avoid lock expiration in the first place:
 - **Use the processor**: `ServiceBusProcessor` automatically renews message locks via `MaxAutoLockRenewalDuration`.
-- **Keep processing fast**: if processing takes longer than the lock duration (default 60 seconds for queues), either increase the lock duration on the entity or use auto-lock renewal.
+- **Keep processing fast**: if processing takes longer than the lock duration configured for the queue or subscription, either increase the lock duration on the entity or use auto-lock renewal.
 - **Use `MaxAutoLockRenewalDuration`**: set this to at least the longest expected processing time (including retries or delays in your handler), plus ~25% margin. Set this on `ServiceBusProcessorOptions` or call receiver-level lock renewal for long-running work.
 
 ## Error handling in the processor

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -22,22 +22,26 @@ catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.Servic
     // Transient: the service is temporarily overloaded. Back off and let the caller decide whether to retry.
     Console.WriteLine("Service is busy, backing off for 10 seconds...");
     await Task.Delay(TimeSpan.FromSeconds(10));
+    throw;
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceTimeout)
 {
     // Transient: the operation timed out. Retry with a longer timeout or backoff.
     Console.WriteLine($"Operation timed out: {ex.Message}");
+    throw;
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceCommunicationProblem)
 {
     // Transient: network-level failure. Check connectivity and retry.
     Console.WriteLine($"Communication problem: {ex.Message}");
+    throw;
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.QuotaExceeded)
 {
     // Capacity: the namespace or entity has hit its size or throughput limit.
     // Do not retry immediately — either wait for space to free up or scale the namespace.
     Console.WriteLine($"Quota exceeded: {ex.Message}");
+    throw;
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageSizeExceeded)
 {
@@ -279,9 +283,9 @@ while (attempt < maxAttempts)
 | `MessageSizeExceeded` | No | Reduce payload or upgrade to Premium tier |
 | `MessagingEntityDisabled` | No | Re-enable the entity in the portal |
 | `QuotaExceeded` | No | Free space or scale the namespace |
-| `ServiceBusy` | Yes | Back off and retry |
-| `ServiceTimeout` | Yes | Retry; consider increasing operation timeout |
-| `ServiceCommunicationProblem` | Yes | Check network connectivity and retry |
+| `ServiceBusy` | Yes | Back off and rethrow; see Section 4 for retry patterns |
+| `ServiceTimeout` | Yes | Log and rethrow; see Section 4 for retry patterns |
+| `ServiceCommunicationProblem` | Yes | Check network connectivity and rethrow; see Section 4 for retry patterns |
 | `SessionCannotBeLocked` | No | Session is locked by another receiver |
 | `SessionLockLost` | No | Re-accept the session to continue |
 | `MessagingEntityAlreadyExists` | No | Entity already exists; skip creation |

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -74,6 +74,7 @@ catch (ServiceBusException ex)
     // Catch-all for any other ServiceBusFailureReason (GeneralError, MessageNotFound, etc.).
     Console.WriteLine($"Service Bus error ({ex.Reason}): {ex.Message}");
     Console.WriteLine($"Is transient: {ex.IsTransient}");
+    throw;
 }
 ```
 
@@ -283,9 +284,9 @@ while (attempt < maxAttempts)
 | `MessageSizeExceeded` | No | Reduce payload or upgrade to Premium tier |
 | `MessagingEntityDisabled` | No | Re-enable the entity in the portal |
 | `QuotaExceeded` | No | Free space or scale the namespace |
-| `ServiceBusy` | Yes | Back off and rethrow; see Section 4 for retry patterns |
-| `ServiceTimeout` | Yes | Log and rethrow; see Section 4 for retry patterns |
-| `ServiceCommunicationProblem` | Yes | Check network connectivity and rethrow; see Section 4 for retry patterns |
+| `ServiceBusy` | Yes | Back off and rethrow; see [Using IsTransient for retry decisions](#using-istransient-for-retry-decisions) below |
+| `ServiceTimeout` | Yes | Log and rethrow; see [Using IsTransient for retry decisions](#using-istransient-for-retry-decisions) below |
+| `ServiceCommunicationProblem` | Yes | Check network connectivity and rethrow; see [Using IsTransient for retry decisions](#using-istransient-for-retry-decisions) below |
 | `SessionCannotBeLocked` | No | Session is locked by another receiver |
 | `SessionLockLost` | No | Re-accept the session to continue |
 | `MessagingEntityAlreadyExists` | No | Entity already exists; skip creation |

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -137,6 +137,14 @@ string queueName = "<queue_name>";
 
 await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
 
+// Seed the queue with messages so the processor has something to work with.
+ServiceBusSender sender = client.CreateSender(queueName);
+await sender.SendMessagesAsync(new ServiceBusMessage[]
+{
+    new ServiceBusMessage("First"),
+    new ServiceBusMessage("Second")
+});
+
 await using ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
 {
     MaxConcurrentCalls = 5,

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -223,7 +223,6 @@ await processor.StartProcessingAsync();
 // Since the processing happens in the background, we add a Console.ReadKey to
 // allow the processing to continue until a key is pressed.
 Console.ReadKey();
-
 await processor.StopProcessingAsync();
 ```
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -1,0 +1,232 @@
+# Exception Handling
+
+This sample covers patterns for handling `ServiceBusException` and its `Reason` property to build resilient applications. The `ServiceBusFailureReason` enum tells you exactly what went wrong, so your code can take the right recovery action instead of applying a generic retry to every error.
+
+## Structured handling with ServiceBusFailureReason
+
+Every `ServiceBusException` includes a `Reason` property of type `ServiceBusFailureReason`. Switching on this value lets you separate transient failures (retry) from permanent failures (fail fast) from lock-related failures (reprocess).
+
+```C# Snippet:ServiceBusStructuredExceptionHandling
+string connectionString = "<connection_string>";
+string queueName = "<queue_name>";
+
+await using var client = new ServiceBusClient(connectionString);
+ServiceBusSender sender = client.CreateSender(queueName);
+
+try
+{
+    await sender.SendMessageAsync(new ServiceBusMessage("Hello"));
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceBusy)
+{
+    // Transient: the service is temporarily overloaded. Back off and retry.
+    Console.WriteLine("Service is busy, retrying after delay...");
+    await Task.Delay(TimeSpan.FromSeconds(10));
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceTimeout)
+{
+    // Transient: the operation timed out. Retry with a longer timeout or backoff.
+    Console.WriteLine($"Operation timed out: {ex.Message}");
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceCommunicationProblem)
+{
+    // Transient: network-level failure. Check connectivity and retry.
+    Console.WriteLine($"Communication problem: {ex.Message}");
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.QuotaExceeded)
+{
+    // Capacity: the namespace or entity has hit its size or throughput limit.
+    // Do not retry immediately — either wait for space to free up or scale the namespace.
+    Console.WriteLine($"Quota exceeded: {ex.Message}");
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageSizeExceeded)
+{
+    // Permanent: the message payload is too large for the tier. This will never succeed
+    // without reducing the message size or upgrading to Premium.
+    Console.WriteLine($"Message too large ({ex.Message}). Reduce payload size.");
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
+{
+    // Permanent: the queue, topic, or subscription does not exist. Check the entity name
+    // and ensure it has been provisioned.
+    Console.WriteLine($"Entity not found: {ex.Message}");
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityDisabled)
+{
+    // Permanent: the entity is disabled in the portal or via management API.
+    Console.WriteLine($"Entity is disabled: {ex.Message}");
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+{
+    // Permanent: attempted to create an entity that already exists.
+    Console.WriteLine($"Entity already exists: {ex.Message}");
+}
+catch (ServiceBusException ex)
+{
+    // Catch-all for any other ServiceBusFailureReason (GeneralError, MessageNotFound, etc.).
+    Console.WriteLine($"Service Bus error ({ex.Reason}): {ex.Message}");
+    Console.WriteLine($"Is transient: {ex.IsTransient}");
+}
+```
+
+## Handling lock-related failures
+
+When processing messages with peek-lock (the default), the lock can expire if processing takes too long. The two lock-related failure reasons require different recovery strategies.
+
+```C# Snippet:ServiceBusLockExceptionHandling
+string connectionString = "<connection_string>";
+string queueName = "<queue_name>";
+
+await using var client = new ServiceBusClient(connectionString);
+ServiceBusReceiver receiver = client.CreateReceiver(queueName);
+
+ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();
+
+try
+{
+    // Simulate slow processing that might exceed the lock duration.
+    await ProcessMessageAsync(message);
+    await receiver.CompleteMessageAsync(message);
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageLockLost)
+{
+    // The lock on this specific message has expired. Another receiver may
+    // pick it up and reprocess it. Do not attempt to complete or abandon —
+    // the lock token is no longer valid.
+    Console.WriteLine($"Message lock lost for MessageId={message.MessageId}. " +
+        "The message will be redelivered.");
+}
+catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.SessionLockLost)
+{
+    // The lock on the entire session has expired. All messages received
+    // under this session lock are now invalid. Close the session receiver
+    // and re-accept the session to continue processing.
+    Console.WriteLine($"Session lock lost for SessionId={message.SessionId}. " +
+        "Re-accept the session to continue.");
+}
+```
+
+To avoid lock expiration in the first place:
+- **Use the processor**: `ServiceBusProcessor` automatically renews message locks via `MaxAutoLockRenewalDuration`.
+- **Keep processing fast**: if processing takes longer than the lock duration (default 30 seconds for queues), either increase the lock duration on the entity or use auto-lock renewal.
+- **Use `MaxAutoLockRenewalDuration`**: set this on `ServiceBusProcessorOptions` or call receiver-level lock renewal for long-running work.
+
+## Error handling in the processor
+
+The `ServiceBusProcessor` invokes `ProcessErrorAsync` for infrastructure-level errors (connection failures, authorization issues) that are not tied to a specific message. Message-level errors should be handled inside `ProcessMessageAsync`.
+
+```C# Snippet:ServiceBusProcessorErrorHandler
+string connectionString = "<connection_string>";
+string queueName = "<queue_name>";
+
+await using var client = new ServiceBusClient(connectionString);
+
+ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
+{
+    MaxConcurrentCalls = 5,
+    AutoCompleteMessages = false
+});
+
+processor.ProcessMessageAsync += async args =>
+{
+    try
+    {
+        await ProcessMessageAsync(args.Message);
+        await args.CompleteMessageAsync(args.Message);
+    }
+    catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageLockLost)
+    {
+        // Lock expired during processing. The message will be redelivered.
+        // Log and move on — do not try to complete or abandon.
+        Console.WriteLine($"Lock lost for {args.Message.MessageId}, will be redelivered.");
+    }
+    catch (Exception ex)
+    {
+        // Application-level failure. Abandon the message so it can be retried
+        // (up to the entity's MaxDeliveryCount).
+        Console.WriteLine($"Processing failed: {ex.Message}");
+        await args.AbandonMessageAsync(args.Message);
+    }
+};
+
+processor.ProcessErrorAsync += args =>
+{
+    // Infrastructure-level errors: connection drops, auth failures, etc.
+    Console.WriteLine($"Error source: {args.ErrorSource}");
+    Console.WriteLine($"Entity path: {args.EntityPath}");
+    Console.WriteLine($"Namespace: {args.FullyQualifiedNamespace}");
+
+    if (args.Exception is ServiceBusException sbEx)
+    {
+        Console.WriteLine($"Reason: {sbEx.Reason}, IsTransient: {sbEx.IsTransient}");
+
+        if (sbEx.IsTransient)
+        {
+            // The processor retries automatically for transient errors.
+            Console.WriteLine("Transient error — processor will retry automatically.");
+        }
+    }
+    else
+    {
+        Console.WriteLine($"Non-ServiceBus exception: {args.Exception}");
+    }
+
+    return Task.CompletedTask;
+};
+
+await processor.StartProcessingAsync();
+
+// Let the processor run. It handles retries internally for transient errors.
+await Task.Delay(TimeSpan.FromMinutes(5));
+await processor.StopProcessingAsync();
+```
+
+## Using IsTransient for retry decisions
+
+The `ServiceBusException.IsTransient` property indicates whether the error is expected to resolve on its own. Use it as a quick check when you don't need reason-specific logic.
+
+```C# Snippet:ServiceBusRetryWithIsTransient
+int maxRetries = 3;
+int attempt = 0;
+
+while (attempt < maxRetries)
+{
+    try
+    {
+        await sender.SendMessageAsync(new ServiceBusMessage("Retry example"));
+        break; // Success — exit the loop.
+    }
+    catch (ServiceBusException ex) when (ex.IsTransient)
+    {
+        attempt++;
+        Console.WriteLine($"Transient error (attempt {attempt}/{maxRetries}): {ex.Message}");
+        await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt))); // Exponential backoff.
+    }
+    catch (ServiceBusException ex)
+    {
+        // Non-transient — retrying won't help.
+        Console.WriteLine($"Permanent error ({ex.Reason}): {ex.Message}");
+        throw;
+    }
+}
+```
+
+Note that the `ServiceBusClient` already has built-in retry logic (configurable via `ServiceBusClientOptions.RetryOptions`). Manual retry loops are only needed when you want application-level retry behavior beyond what the client provides — for example, recreating senders after a connection reset or implementing circuit-breaker patterns.
+
+## ServiceBusFailureReason reference
+
+| Reason | Transient | Recovery |
+|--------|-----------|----------|
+| `GeneralError` | Depends | Inspect the exception message for details |
+| `MessagingEntityNotFound` | No | Verify entity name and provisioning |
+| `MessageLockLost` | No | Message will be redelivered; do not settle |
+| `MessageNotFound` | No | The message was already settled or expired |
+| `MessageSizeExceeded` | No | Reduce payload or upgrade to Premium tier |
+| `MessagingEntityDisabled` | No | Re-enable the entity in the portal |
+| `QuotaExceeded` | No | Free space or scale the namespace |
+| `ServiceBusy` | Yes | Back off and retry |
+| `ServiceTimeout` | Yes | Retry; consider increasing operation timeout |
+| `ServiceCommunicationProblem` | Yes | Check network connectivity and retry |
+| `SessionCannotBeLocked` | No | Session is locked by another receiver |
+| `SessionLockLost` | No | Re-accept the session to continue |
+| `MessagingEntityAlreadyExists` | No | Entity already exists; skip creation |

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -95,8 +95,9 @@ ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();
 
 try
 {
-    // Simulate slow processing that might exceed the lock duration.
-    // ProcessMessageAsync represents your application logic (defined elsewhere).
+    // Process the message — if handling takes longer than the lock duration,
+    // the lock may expire. ProcessMessageAsync represents your application logic
+    // (defined elsewhere).
     await ProcessMessageAsync(message);
 
     // Ensure processing is idempotent — if the lock expires before settlement,
@@ -112,18 +113,6 @@ catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.Messag
     // the lock token is no longer valid.
     Console.WriteLine($"Message lock lost for MessageId={message.MessageId}. " +
         "The message will be redelivered.");
-}
-catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.SessionLockLost)
-{
-    // The lock on the entire session has expired. All messages received
-    // under this session lock are now invalid. Close the session receiver
-    // and re-accept the session to continue processing.
-    //
-    // Note: SessionLockLost only applies when using session-enabled receivers
-    // (via AcceptNextSessionAsync). It is shown here alongside MessageLockLost
-    // for completeness.
-    Console.WriteLine($"Session lock lost for SessionId={message.SessionId}. " +
-        "Re-accept the session to continue.");
 }
 ```
 
@@ -225,8 +214,10 @@ Task ErrorHandler(ProcessErrorEventArgs args)
 
 await processor.StartProcessingAsync();
 
-// Let the processor run. It handles retries internally for transient errors.
-await Task.Delay(TimeSpan.FromMinutes(5));
+// Since the processing happens in the background, we add a Console.ReadKey to
+// allow the processing to continue until a key is pressed.
+Console.ReadKey();
+
 await processor.StopProcessingAsync();
 ```
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -237,6 +237,8 @@ string queueName = "<queue_name>";
 await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
 ServiceBusSender sender = client.CreateSender(queueName);
 
+// Application-level retries — on top of the client's built-in retries (default: 3).
+// Set ServiceBusClientOptions.RetryOptions.MaxRetries = 0 for full manual control.
 int maxAttempts = 3;
 int attempt = 0;
 
@@ -280,9 +282,9 @@ while (attempt < maxAttempts)
 | `MessageSizeExceeded` | No | Reduce payload or upgrade to Premium tier |
 | `MessagingEntityDisabled` | No | Re-enable the entity in the portal |
 | `QuotaExceeded` | No | Free space or scale the namespace |
-| `ServiceBusy` | Yes | Back off and rethrow; see [Using IsTransient for retry decisions](#using-istransient-for-retry-decisions) below |
-| `ServiceTimeout` | Yes | Log and rethrow; see [Using IsTransient for retry decisions](#using-istransient-for-retry-decisions) below |
-| `ServiceCommunicationProblem` | Yes | Check network connectivity and rethrow; see [Using IsTransient for retry decisions](#using-istransient-for-retry-decisions) below |
+| `ServiceBusy` | Yes | Back off and rethrow; see [Using IsTransient for retry decisions](#using-istransient-for-retry-decisions) |
+| `ServiceTimeout` | Yes | Log and rethrow; see [Using IsTransient for retry decisions](#using-istransient-for-retry-decisions) |
+| `ServiceCommunicationProblem` | Yes | Check network connectivity and rethrow; see [Using IsTransient for retry decisions](#using-istransient-for-retry-decisions) |
 | `SessionCannotBeLocked` | No | Session is locked by another receiver |
 | `SessionLockLost` | No | Re-accept the session to continue |
 | `MessagingEntityAlreadyExists` | No | Entity already exists; skip creation |

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -232,10 +232,10 @@ string queueName = "<queue_name>";
 await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
 ServiceBusSender sender = client.CreateSender(queueName);
 
-int maxRetries = 3;
+int maxAttempts = 3;
 int attempt = 0;
 
-while (attempt < maxRetries)
+while (attempt < maxAttempts)
 {
     try
     {
@@ -245,11 +245,11 @@ while (attempt < maxRetries)
     catch (ServiceBusException ex) when (ex.IsTransient)
     {
         attempt++;
-        Console.WriteLine($"Transient error (attempt {attempt}/{maxRetries}): {ex.Message}");
+        Console.WriteLine($"Transient error (attempt {attempt}/{maxAttempts}): {ex.Message}");
 
-        if (attempt == maxRetries)
+        if (attempt == maxAttempts)
         {
-            Console.WriteLine("Max retries reached. Giving up.");
+            Console.WriteLine("Max attempts reached. Giving up.");
             throw;
         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -1,16 +1,16 @@
 # Exception Handling
 
-This sample covers patterns for handling `ServiceBusException` and its `Reason` property to build resilient applications. The `ServiceBusFailureReason` enum tells you exactly what went wrong, so your code can take the right recovery action instead of applying a generic retry to every error.
+This sample covers patterns for handling `ServiceBusException` and its `Reason` property to build resilient applications. The `ServiceBusFailureReason` enum identifies well-known failure categories, so your code can take the right recovery action instead of applying a generic retry to every error.
 
 ## Structured handling with ServiceBusFailureReason
 
-Every `ServiceBusException` includes a `Reason` property of type `ServiceBusFailureReason`. Switching on this value lets you separate transient failures (retry) from permanent failures (fail fast) from lock-related failures (reprocess).
+Every `ServiceBusException` includes a `Reason` property of type `ServiceBusFailureReason`. Switching on this value lets you separate transient failures (retry) from permanent failures (fail fast) from lock-related failures (let the message be redelivered).
 
 ```C# Snippet:ServiceBusStructuredExceptionHandling
-string connectionString = "<connection_string>";
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 string queueName = "<queue_name>";
 
-await using var client = new ServiceBusClient(connectionString);
+await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
 ServiceBusSender sender = client.CreateSender(queueName);
 
 try
@@ -69,15 +69,17 @@ catch (ServiceBusException ex)
 }
 ```
 
+Note that `ServiceBusException` does not cover all failure types. Authentication and authorization errors surface as `UnauthorizedAccessException`, and cancellation (e.g., from shutdown tokens) surfaces as `OperationCanceledException`. Add separate catch clauses for these when appropriate.
+
 ## Handling lock-related failures
 
 When processing messages with peek-lock (the default), the lock can expire if processing takes too long. The two lock-related failure reasons require different recovery strategies.
 
 ```C# Snippet:ServiceBusLockExceptionHandling
-string connectionString = "<connection_string>";
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 string queueName = "<queue_name>";
 
-await using var client = new ServiceBusClient(connectionString);
+await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
 ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();
@@ -85,7 +87,13 @@ ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();
 try
 {
     // Simulate slow processing that might exceed the lock duration.
+    // ProcessMessageAsync represents your application logic (defined elsewhere).
     await ProcessMessageAsync(message);
+
+    // Ensure processing is idempotent — if the lock expires before settlement,
+    // the message will be redelivered and processed again. Common strategies
+    // include deduplication checks and upsert semantics.
+    // See https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement
     await receiver.CompleteMessageAsync(message);
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageLockLost)
@@ -101,6 +109,10 @@ catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.Sessio
     // The lock on the entire session has expired. All messages received
     // under this session lock are now invalid. Close the session receiver
     // and re-accept the session to continue processing.
+    //
+    // Note: SessionLockLost only applies when using session-enabled receivers
+    // (via AcceptNextSessionAsync). It is shown here alongside MessageLockLost
+    // for completeness.
     Console.WriteLine($"Session lock lost for SessionId={message.SessionId}. " +
         "Re-accept the session to continue.");
 }
@@ -108,18 +120,18 @@ catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.Sessio
 
 To avoid lock expiration in the first place:
 - **Use the processor**: `ServiceBusProcessor` automatically renews message locks via `MaxAutoLockRenewalDuration`.
-- **Keep processing fast**: if processing takes longer than the lock duration (default 30 seconds for queues), either increase the lock duration on the entity or use auto-lock renewal.
-- **Use `MaxAutoLockRenewalDuration`**: set this on `ServiceBusProcessorOptions` or call receiver-level lock renewal for long-running work.
+- **Keep processing fast**: if processing takes longer than the lock duration (default 60 seconds for queues), either increase the lock duration on the entity or use auto-lock renewal.
+- **Use `MaxAutoLockRenewalDuration`**: set this to at least the longest expected processing time (including retries or delays in your handler), plus ~25% margin. Set this on `ServiceBusProcessorOptions` or call receiver-level lock renewal for long-running work.
 
 ## Error handling in the processor
 
-The `ServiceBusProcessor` invokes `ProcessErrorAsync` for infrastructure-level errors (connection failures, authorization issues) that are not tied to a specific message. Message-level errors should be handled inside `ProcessMessageAsync`.
+The `ServiceBusProcessor` invokes `ProcessErrorAsync` for errors that occur outside your message handler — including connection failures, authorization issues, auto-lock-renewal failures, and auto-complete/abandon failures. Check `args.ErrorSource` to distinguish the origin. Message-level errors from your own processing logic should be handled inside `ProcessMessageAsync`.
 
 ```C# Snippet:ServiceBusProcessorErrorHandler
-string connectionString = "<connection_string>";
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
 string queueName = "<queue_name>";
 
-await using var client = new ServiceBusClient(connectionString);
+await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
 
 ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
 {
@@ -127,29 +139,57 @@ ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBus
     AutoCompleteMessages = false
 });
 
-processor.ProcessMessageAsync += async args =>
+// configure the message and error handler to use
+processor.ProcessMessageAsync += MessageHandler;
+processor.ProcessErrorAsync += ErrorHandler;
+
+async Task MessageHandler(ProcessMessageEventArgs args)
 {
     try
     {
         await ProcessMessageAsync(args.Message);
+    }
+    catch (Exception ex)
+    {
+        // Application-level processing failure. Abandon the message so it
+        // can be retried (up to the entity's MaxDeliveryCount).
+        Console.WriteLine($"Processing failed: {ex.Message}");
+
+        try
+        {
+            await args.AbandonMessageAsync(args.Message);
+        }
+        catch (ServiceBusException abandonEx)
+        {
+            Console.WriteLine($"Abandon failed for {args.Message.MessageId}: {abandonEx.Message}");
+        }
+
+        return;
+    }
+
+    // Processing succeeded — settle the message.
+    // Because lock loss causes redelivery, ensure your processing logic is
+    // idempotent — it should produce the same result if a message is processed
+    // more than once. Common strategies include deduplication checks and upsert
+    // semantics.
+    // See https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement
+    try
+    {
         await args.CompleteMessageAsync(args.Message);
     }
     catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageLockLost)
     {
-        // Lock expired during processing. The message will be redelivered.
-        // Log and move on — do not try to complete or abandon.
+        // Lock expired before settlement. The message will be redelivered.
         Console.WriteLine($"Lock lost for {args.Message.MessageId}, will be redelivered.");
     }
-    catch (Exception ex)
+    catch (ServiceBusException ex)
     {
-        // Application-level failure. Abandon the message so it can be retried
-        // (up to the entity's MaxDeliveryCount).
-        Console.WriteLine($"Processing failed: {ex.Message}");
-        await args.AbandonMessageAsync(args.Message);
+        // Settlement failed for another reason — log for diagnostics.
+        Console.WriteLine($"Settlement failed for {args.Message.MessageId} ({ex.Reason}): {ex.Message}");
     }
-};
+}
 
-processor.ProcessErrorAsync += args =>
+Task ErrorHandler(ProcessErrorEventArgs args)
 {
     // Infrastructure-level errors: connection drops, auth failures, etc.
     Console.WriteLine($"Error source: {args.ErrorSource}");
@@ -172,7 +212,7 @@ processor.ProcessErrorAsync += args =>
     }
 
     return Task.CompletedTask;
-};
+}
 
 await processor.StartProcessingAsync();
 
@@ -183,9 +223,15 @@ await processor.StopProcessingAsync();
 
 ## Using IsTransient for retry decisions
 
-The `ServiceBusException.IsTransient` property indicates whether the error is expected to resolve on its own. Use it as a quick check when you don't need reason-specific logic.
+The `ServiceBusClient` retries transient errors automatically (default: 3 retries with exponential backoff, configurable via `ServiceBusClientOptions.RetryOptions`). The following manual retry loop is only needed for application-level patterns the built-in retry cannot handle — for example, recreating senders after a connection reset or implementing circuit-breaker logic.
 
 ```C# Snippet:ServiceBusRetryWithIsTransient
+string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+string queueName = "<queue_name>";
+
+await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
+ServiceBusSender sender = client.CreateSender(queueName);
+
 int maxRetries = 3;
 int attempt = 0;
 
@@ -200,6 +246,13 @@ while (attempt < maxRetries)
     {
         attempt++;
         Console.WriteLine($"Transient error (attempt {attempt}/{maxRetries}): {ex.Message}");
+
+        if (attempt == maxRetries)
+        {
+            Console.WriteLine("Max retries reached. Giving up.");
+            throw;
+        }
+
         await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt))); // Exponential backoff.
     }
     catch (ServiceBusException ex)
@@ -210,8 +263,6 @@ while (attempt < maxRetries)
     }
 }
 ```
-
-Note that the `ServiceBusClient` already has built-in retry logic (configurable via `ServiceBusClientOptions.RetryOptions`). Manual retry loops are only needed when you want application-level retry behavior beyond what the client provides — for example, recreating senders after a connection reset or implementing circuit-breaker patterns.
 
 ## ServiceBusFailureReason reference
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -19,8 +19,8 @@ try
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceBusy)
 {
-    // Transient: the service is temporarily overloaded. Back off and retry.
-    Console.WriteLine("Service is busy, retrying after delay...");
+    // Transient: the service is temporarily overloaded. Back off and let the caller decide whether to retry.
+    Console.WriteLine("Service is busy, backing off for 10 seconds...");
     await Task.Delay(TimeSpan.FromSeconds(10));
 }
 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceTimeout)
@@ -133,7 +133,7 @@ string queueName = "<queue_name>";
 
 await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
 
-ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
+await using ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
 {
     MaxConcurrentCalls = 5,
     AutoCompleteMessages = false

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample21_ExceptionHandling.md
@@ -82,7 +82,7 @@ Note that `ServiceBusException` does not cover all failure types. Authentication
 
 ## Handling lock-related failures
 
-When processing messages with peek-lock (the default), the lock can expire if processing takes too long. The two lock-related failure reasons require different recovery strategies.
+When processing messages with peek-lock (the default), the lock can expire if processing takes too long. This example focuses on handling `MessageLockLost` for non-session receivers. For session-enabled entities, apply the same pattern to `SessionLockLost` when using `ServiceBusSessionReceiver` or a session-enabled processor.
 
 ```C# Snippet:ServiceBusLockExceptionHandling
 string fullyQualifiedNamespace = "<fully_qualified_namespace>";

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -267,10 +267,10 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 #endif
                 ServiceBusSender sender = client.CreateSender(queueName);
 
-                int maxRetries = 3;
+                int maxAttempts = 3;
                 int attempt = 0;
 
-                while (attempt < maxRetries)
+                while (attempt < maxAttempts)
                 {
                     try
                     {
@@ -280,11 +280,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                     catch (ServiceBusException ex) when (ex.IsTransient)
                     {
                         attempt++;
-                        Console.WriteLine($"Transient error (attempt {attempt}/{maxRetries}): {ex.Message}");
+                        Console.WriteLine($"Transient error (attempt {attempt}/{maxAttempts}): {ex.Message}");
 
-                        if (attempt == maxRetries)
+                        if (attempt == maxAttempts)
                         {
-                            Console.WriteLine("Max retries reached. Giving up.");
+                            Console.WriteLine("Max attempts reached. Giving up.");
                             throw;
                         }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -1,0 +1,310 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Identity;
+using NUnit.Framework;
+
+namespace Azure.Messaging.ServiceBus.Tests.Samples
+{
+    public class Sample21_ExceptionHandling : ServiceBusLiveTestBase
+    {
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task StructuredExceptionHandling()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                #region Snippet:ServiceBusStructuredExceptionHandling
+#if SNIPPET
+                string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+                string queueName = "<queue_name>";
+
+                await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
+#else
+                string queueName = scope.QueueName;
+                await using var client = CreateClient();
+#endif
+                ServiceBusSender sender = client.CreateSender(queueName);
+
+                try
+                {
+                    await sender.SendMessageAsync(new ServiceBusMessage("Hello"));
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceBusy)
+                {
+                    // Transient: the service is temporarily overloaded. Back off and retry.
+                    Console.WriteLine("Service is busy, retrying after delay...");
+                    await Task.Delay(TimeSpan.FromSeconds(10));
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceTimeout)
+                {
+                    // Transient: the operation timed out. Retry with a longer timeout or backoff.
+                    Console.WriteLine($"Operation timed out: {ex.Message}");
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceCommunicationProblem)
+                {
+                    // Transient: network-level failure. Check connectivity and retry.
+                    Console.WriteLine($"Communication problem: {ex.Message}");
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.QuotaExceeded)
+                {
+                    // Capacity: the namespace or entity has hit its size or throughput limit.
+                    // Do not retry immediately — either wait for space to free up or scale the namespace.
+                    Console.WriteLine($"Quota exceeded: {ex.Message}");
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageSizeExceeded)
+                {
+                    // Permanent: the message payload is too large for the tier. This will never succeed
+                    // without reducing the message size or upgrading to Premium.
+                    Console.WriteLine($"Message too large ({ex.Message}). Reduce payload size.");
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
+                {
+                    // Permanent: the queue, topic, or subscription does not exist. Check the entity name
+                    // and ensure it has been provisioned.
+                    Console.WriteLine($"Entity not found: {ex.Message}");
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityDisabled)
+                {
+                    // Permanent: the entity is disabled in the portal or via management API.
+                    Console.WriteLine($"Entity is disabled: {ex.Message}");
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
+                {
+                    // Permanent: attempted to create an entity that already exists.
+                    Console.WriteLine($"Entity already exists: {ex.Message}");
+                }
+                catch (ServiceBusException ex)
+                {
+                    // Catch-all for any other ServiceBusFailureReason (GeneralError, MessageNotFound, etc.).
+                    Console.WriteLine($"Service Bus error ({ex.Reason}): {ex.Message}");
+                    Console.WriteLine($"Is transient: {ex.IsTransient}");
+                }
+                #endregion
+            }
+        }
+
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task LockExceptionHandling()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                #region Snippet:ServiceBusLockExceptionHandling
+#if SNIPPET
+                string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+                string queueName = "<queue_name>";
+
+                await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
+#else
+                string queueName = scope.QueueName;
+                await using var client = CreateClient();
+#endif
+                ServiceBusReceiver receiver = client.CreateReceiver(queueName);
+
+                ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();
+
+                try
+                {
+                    // Simulate slow processing that might exceed the lock duration.
+                    // ProcessMessageAsync represents your application logic (defined elsewhere).
+                    await ProcessMessageAsync(message);
+
+                    // Ensure processing is idempotent — if the lock expires before settlement,
+                    // the message will be redelivered and processed again. Common strategies
+                    // include deduplication checks and upsert semantics.
+                    // See https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement
+                    await receiver.CompleteMessageAsync(message);
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageLockLost)
+                {
+                    // The lock on this specific message has expired. Another receiver may
+                    // pick it up and reprocess it. Do not attempt to complete or abandon —
+                    // the lock token is no longer valid.
+                    Console.WriteLine($"Message lock lost for MessageId={message.MessageId}. " +
+                        "The message will be redelivered.");
+                }
+                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.SessionLockLost)
+                {
+                    // The lock on the entire session has expired. All messages received
+                    // under this session lock are now invalid. Close the session receiver
+                    // and re-accept the session to continue processing.
+                    //
+                    // Note: SessionLockLost only applies when using session-enabled receivers
+                    // (via AcceptNextSessionAsync). It is shown here alongside MessageLockLost
+                    // for completeness.
+                    Console.WriteLine($"Session lock lost for SessionId={message.SessionId}. " +
+                        "Re-accept the session to continue.");
+                }
+                #endregion
+            }
+        }
+
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task ProcessorErrorHandler()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                #region Snippet:ServiceBusProcessorErrorHandler
+#if SNIPPET
+                string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+                string queueName = "<queue_name>";
+
+                await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
+#else
+                string queueName = scope.QueueName;
+                await using var client = CreateClient();
+#endif
+
+                ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
+                {
+                    MaxConcurrentCalls = 5,
+                    AutoCompleteMessages = false
+                });
+
+                // configure the message and error handler to use
+                processor.ProcessMessageAsync += MessageHandler;
+                processor.ProcessErrorAsync += ErrorHandler;
+
+                async Task MessageHandler(ProcessMessageEventArgs args)
+                {
+                    try
+                    {
+                        await ProcessMessageAsync(args.Message);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Application-level processing failure. Abandon the message so it
+                        // can be retried (up to the entity's MaxDeliveryCount).
+                        Console.WriteLine($"Processing failed: {ex.Message}");
+
+                        try
+                        {
+                            await args.AbandonMessageAsync(args.Message);
+                        }
+                        catch (ServiceBusException abandonEx)
+                        {
+                            Console.WriteLine($"Abandon failed for {args.Message.MessageId}: {abandonEx.Message}");
+                        }
+
+                        return;
+                    }
+
+                    // Processing succeeded — settle the message.
+                    // Because lock loss causes redelivery, ensure your processing logic is
+                    // idempotent — it should produce the same result if a message is processed
+                    // more than once. Common strategies include deduplication checks and upsert
+                    // semantics.
+                    // See https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement
+                    try
+                    {
+                        await args.CompleteMessageAsync(args.Message);
+                    }
+                    catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageLockLost)
+                    {
+                        // Lock expired before settlement. The message will be redelivered.
+                        Console.WriteLine($"Lock lost for {args.Message.MessageId}, will be redelivered.");
+                    }
+                    catch (ServiceBusException ex)
+                    {
+                        // Settlement failed for another reason — log for diagnostics.
+                        Console.WriteLine($"Settlement failed for {args.Message.MessageId} ({ex.Reason}): {ex.Message}");
+                    }
+                }
+
+                Task ErrorHandler(ProcessErrorEventArgs args)
+                {
+                    // Infrastructure-level errors: connection drops, auth failures, etc.
+                    Console.WriteLine($"Error source: {args.ErrorSource}");
+                    Console.WriteLine($"Entity path: {args.EntityPath}");
+                    Console.WriteLine($"Namespace: {args.FullyQualifiedNamespace}");
+
+                    if (args.Exception is ServiceBusException sbEx)
+                    {
+                        Console.WriteLine($"Reason: {sbEx.Reason}, IsTransient: {sbEx.IsTransient}");
+
+                        if (sbEx.IsTransient)
+                        {
+                            // The processor retries automatically for transient errors.
+                            Console.WriteLine("Transient error — processor will retry automatically.");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Non-ServiceBus exception: {args.Exception}");
+                    }
+
+                    return Task.CompletedTask;
+                }
+
+                await processor.StartProcessingAsync();
+
+                // Let the processor run. It handles retries internally for transient errors.
+                await Task.Delay(TimeSpan.FromMinutes(5));
+                await processor.StopProcessingAsync();
+                #endregion
+            }
+        }
+
+        [Test]
+        [Ignore("Only verifying that the code builds")]
+        public async Task RetryWithIsTransient()
+        {
+            await using (var scope = await ServiceBusScope.CreateWithQueue(enablePartitioning: false, enableSession: false))
+            {
+                #region Snippet:ServiceBusRetryWithIsTransient
+#if SNIPPET
+                string fullyQualifiedNamespace = "<fully_qualified_namespace>";
+                string queueName = "<queue_name>";
+
+                await using var client = new ServiceBusClient(fullyQualifiedNamespace, new DefaultAzureCredential());
+#else
+                string queueName = scope.QueueName;
+                await using var client = CreateClient();
+#endif
+                ServiceBusSender sender = client.CreateSender(queueName);
+
+                int maxRetries = 3;
+                int attempt = 0;
+
+                while (attempt < maxRetries)
+                {
+                    try
+                    {
+                        await sender.SendMessageAsync(new ServiceBusMessage("Retry example"));
+                        break; // Success — exit the loop.
+                    }
+                    catch (ServiceBusException ex) when (ex.IsTransient)
+                    {
+                        attempt++;
+                        Console.WriteLine($"Transient error (attempt {attempt}/{maxRetries}): {ex.Message}");
+
+                        if (attempt == maxRetries)
+                        {
+                            Console.WriteLine("Max retries reached. Giving up.");
+                            throw;
+                        }
+
+                        await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt))); // Exponential backoff.
+                    }
+                    catch (ServiceBusException ex)
+                    {
+                        // Non-transient — retrying won't help.
+                        Console.WriteLine($"Permanent error ({ex.Reason}): {ex.Message}");
+                        throw;
+                    }
+                }
+                #endregion
+            }
+        }
+
+        private static Task ProcessMessageAsync(ServiceBusReceivedMessage message)
+        {
+            Console.WriteLine($"Processing message: {message.MessageId}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -115,6 +115,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();
 
+                if (message == null)
+                {
+                    return;
+                }
+
                 try
                 {
                     // Process the message — if handling takes longer than the lock duration,
@@ -215,7 +220,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 Task ErrorHandler(ProcessErrorEventArgs args)
                 {
-                    // Infrastructure-level errors: connection drops, auth failures, etc.
+                    // Errors from message processing, settlement, lock renewal, and service communication.
                     Console.WriteLine($"Error source: {args.ErrorSource}");
                     Console.WriteLine($"Entity path: {args.EntityPath}");
                     Console.WriteLine($"Namespace: {args.FullyQualifiedNamespace}");

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -34,8 +34,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceBusy)
                 {
-                    // Transient: the service is temporarily overloaded. Back off and retry.
-                    Console.WriteLine("Service is busy, retrying after delay...");
+                    // Transient: the service is temporarily overloaded. Back off and let the caller decide whether to retry.
+                    Console.WriteLine("Service is busy, backing off for 10 seconds...");
                     await Task.Delay(TimeSpan.FromSeconds(10));
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceTimeout)
@@ -159,7 +159,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 await using var client = CreateClient();
 #endif
 
-                ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
+                await using ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
                 {
                     MaxConcurrentCalls = 5,
                     AutoCompleteMessages = false

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -277,6 +277,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 #endif
                 ServiceBusSender sender = client.CreateSender(queueName);
 
+                // Application-level retries — on top of the client's built-in retries (default: 3).
+                // Set ServiceBusClientOptions.RetryOptions.MaxRetries = 0 for full manual control.
                 int maxAttempts = 3;
                 int attempt = 0;
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -117,8 +117,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 try
                 {
-                    // Simulate slow processing that might exceed the lock duration.
-                    // ProcessMessageAsync represents your application logic (defined elsewhere).
+                    // Process the message — if handling takes longer than the lock duration,
+                    // the lock may expire. ProcessMessageAsync represents your application logic
+                    // (defined elsewhere).
                     await ProcessMessageAsync(message);
 
                     // Ensure processing is idempotent — if the lock expires before settlement,
@@ -134,18 +135,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                     // the lock token is no longer valid.
                     Console.WriteLine($"Message lock lost for MessageId={message.MessageId}. " +
                         "The message will be redelivered.");
-                }
-                catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.SessionLockLost)
-                {
-                    // The lock on the entire session has expired. All messages received
-                    // under this session lock are now invalid. Close the session receiver
-                    // and re-accept the session to continue processing.
-                    //
-                    // Note: SessionLockLost only applies when using session-enabled receivers
-                    // (via AcceptNextSessionAsync). It is shown here alongside MessageLockLost
-                    // for completeness.
-                    Console.WriteLine($"Session lock lost for SessionId={message.SessionId}. " +
-                        "Re-accept the session to continue.");
                 }
                 #endregion
             }
@@ -251,8 +240,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 await processor.StartProcessingAsync();
 
+#if SNIPPET
+                // Since the processing happens in the background, we add a Console.ReadKey to
+                // allow the processing to continue until a key is pressed.
+                Console.ReadKey();
+#else
                 // Let the processor run. It handles retries internally for transient errors.
                 await Task.Delay(TimeSpan.FromMinutes(5));
+#endif
                 await processor.StopProcessingAsync();
                 #endregion
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -89,6 +89,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                     // Catch-all for any other ServiceBusFailureReason (GeneralError, MessageNotFound, etc.).
                     Console.WriteLine($"Service Bus error ({ex.Reason}): {ex.Message}");
                     Console.WriteLine($"Is transient: {ex.IsTransient}");
+                    throw;
                 }
                 #endregion
             }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -59,22 +59,26 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                     // Permanent: the message payload is too large for the tier. This will never succeed
                     // without reducing the message size or upgrading to Premium.
                     Console.WriteLine($"Message too large ({ex.Message}). Reduce payload size.");
+                    throw;
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityNotFound)
                 {
                     // Permanent: the queue, topic, or subscription does not exist. Check the entity name
                     // and ensure it has been provisioned.
                     Console.WriteLine($"Entity not found: {ex.Message}");
+                    throw;
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityDisabled)
                 {
                     // Permanent: the entity is disabled in the portal or via management API.
                     Console.WriteLine($"Entity is disabled: {ex.Message}");
+                    throw;
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessagingEntityAlreadyExists)
                 {
                     // Permanent: attempted to create an entity that already exists.
                     Console.WriteLine($"Entity already exists: {ex.Message}");
+                    throw;
                 }
                 catch (ServiceBusException ex)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -37,22 +37,26 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                     // Transient: the service is temporarily overloaded. Back off and let the caller decide whether to retry.
                     Console.WriteLine("Service is busy, backing off for 10 seconds...");
                     await Task.Delay(TimeSpan.FromSeconds(10));
+                    throw;
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceTimeout)
                 {
                     // Transient: the operation timed out. Retry with a longer timeout or backoff.
                     Console.WriteLine($"Operation timed out: {ex.Message}");
+                    throw;
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.ServiceCommunicationProblem)
                 {
                     // Transient: network-level failure. Check connectivity and retry.
                     Console.WriteLine($"Communication problem: {ex.Message}");
+                    throw;
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.QuotaExceeded)
                 {
                     // Capacity: the namespace or entity has hit its size or throughput limit.
                     // Do not retry immediately — either wait for space to free up or scale the namespace.
                     Console.WriteLine($"Quota exceeded: {ex.Message}");
+                    throw;
                 }
                 catch (ServiceBusException ex) when (ex.Reason == ServiceBusFailureReason.MessageSizeExceeded)
                 {

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -111,6 +111,11 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 string queueName = scope.QueueName;
                 await using var client = CreateClient();
 #endif
+
+                // Send a message so the queue has something to receive.
+                ServiceBusSender sender = client.CreateSender(queueName);
+                await sender.SendMessageAsync(new ServiceBusMessage("Hello"));
+
                 ServiceBusReceiver receiver = client.CreateReceiver(queueName);
 
                 ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -115,8 +115,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
 
                 ServiceBusReceivedMessage message = await receiver.ReceiveMessageAsync();
 
-                if (message == null)
+                if (message is null)
                 {
+                    Console.WriteLine("No message available.");
                     return;
                 }
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Samples/Sample21_ExceptionHandling.cs
@@ -163,6 +163,14 @@ namespace Azure.Messaging.ServiceBus.Tests.Samples
                 await using var client = CreateClient();
 #endif
 
+                // Seed the queue with messages so the processor has something to work with.
+                ServiceBusSender sender = client.CreateSender(queueName);
+                await sender.SendMessagesAsync(new ServiceBusMessage[]
+                {
+                    new ServiceBusMessage("First"),
+                    new ServiceBusMessage("Second")
+                });
+
                 await using ServiceBusProcessor processor = client.CreateProcessor(queueName, new ServiceBusProcessorOptions
                 {
                     MaxConcurrentCalls = 5,


### PR DESCRIPTION
## Description

Adds a new sample document and companion snippet test for exception handling with `ServiceBusException` and `ServiceBusFailureReason`.

### What's included

- **Sample21_ExceptionHandling.md** — structured exception handling patterns:
  - Switching on `ServiceBusFailureReason` (transient vs permanent vs lock-related)
  - Lock-related failures (message lock lost, session lock lost)
  - Processor error handling with separated processing/settlement error paths
  - Manual retry with `IsTransient` (with built-in retry clarification)
  - Complete `ServiceBusFailureReason` reference table

- **Sample21_ExceptionHandling.cs** — compile-verified snippet tests backing all 4 code blocks

### Conventions followed

- `DefaultAzureCredential` in all SNIPPET paths (matching Sample02/04 convention)
- Named local functions for processor event handlers (SA-002, matching Sample04)
- Idempotency guidance with docs links at settlement calls (SA-006)
- Processing errors separated from settlement errors (SA-009)
- Quantified lock renewal margin (~25%) (SA-004)
- Note about `UnauthorizedAccessException` and `OperationCanceledException` coverage gaps
- `SessionLockLost` clarification (session-enabled receivers only)

### Checklist

- [x] Build passes (0 warnings, 0 errors)
- [x] SA-011: All 4 snippet regions match between .md and .cs
- [x] Multi-agent code review (3 reviewers x 2 rounds, 12 issues resolved)
