### PR TITLE
[Storage] [DataMovement] Remove Blobs.Files.Shares tests from ci.datamovement.yml

### DIFF
--- a/sdk/storage/ci.datamovement.yml
+++ b/sdk/storage/ci.datamovement.yml
@@ -18,8 +18,5 @@ extends:
     - name: Azure.Storage.DataMovement.Files.Shares
       safeName: AzureStorageDataMovementFilesShares
       skipSmokeTests: true
-    - name: Azure.Storage.DataMovement.Blobs.Files.Shares
-      safeName: AzureStorageDataMovementBlobsFilesShares
-      skipSmokeTests: true
     TestSetupSteps:
     - template: /sdk/storage/tests-install-azurite.yml


### PR DESCRIPTION
The build would try to look for the Azure.Storage.DataMovement.Blobs.Files.Shares "package" but does not exist intentionally because the folder is meant E2E tests for Blobs to Files

I double checked CI runs with this removal and it will still run the test package, even with this removal from the datamovement CI pipeline.