### PR TITLE
Add Export-API step to post-release version increment flow

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -272,6 +272,10 @@ stages:
                           - /sdk
                           - '!**/*.cs'
                           - '/sdk/${{ parameters.ServiceDirectory }}/**/*.cs'
+                          # Shared sources compiled by SDKs outside their own service directory
+                          - '/sdk/core/Azure.Core/src/Shared/**/*.cs'
+                          - '/sdk/core/Azure.Core.Amqp/src/Shared/**/*.cs'
+                          - '/sdk/resourcemanager/Azure.ResourceManager/src/Shared/**/*.cs'
 
                     - template: /eng/pipelines/templates/steps/install-dotnet.yml
                       parameters:

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -271,6 +271,7 @@ stages:
                         paths:
                           - /sdk
                           - '!**/*.cs'
+                          - '/sdk/${{ parameters.ServiceDirectory }}/**/*.cs'
 
                     - template: /eng/pipelines/templates/steps/install-dotnet.yml
                       parameters:
@@ -278,6 +279,13 @@ stages:
                     - pwsh: |
                         eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -SkipCpmUpdate $false
                       displayName: Increment package version
+                    # Re-export API listings because preview feature flags can add
+                    # APIs in beta that are absent in GA. When the version bumps
+                    # from e.g. 1.0.0 to 1.1.0-beta.1 the public API surface may
+                    # change, so the listing files need to be regenerated.
+                    - pwsh: |
+                        eng/scripts/Export-API.ps1 '${{ parameters.ServiceDirectory }}'
+                      displayName: Export API listings
                     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                       parameters:
                         RepoName: azure-sdk-for-net

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -270,12 +270,6 @@ stages:
                       parameters:
                         paths:
                           - /sdk
-                          - '!**/*.cs'
-                          - '/sdk/${{ parameters.ServiceDirectory }}/**/*.cs'
-                          # Shared sources compiled by SDKs outside their own service directory
-                          - '/sdk/core/Azure.Core/src/Shared/**/*.cs'
-                          - '/sdk/core/Azure.Core.Amqp/src/Shared/**/*.cs'
-                          - '/sdk/resourcemanager/Azure.ResourceManager/src/Shared/**/*.cs'
 
                     - template: /eng/pipelines/templates/steps/install-dotnet.yml
                       parameters:


### PR DESCRIPTION
After incrementing the package version, run `Export-API.ps1` on the service directory so that updated API listing files are included in the version bump PR.

Preview feature flags can add APIs in beta that are absent in GA, so when the version bumps (e.g. `1.0.0` → `1.1.0-beta.1`) the public API surface may change and the listing files need to be regenerated.

Also updates the sparse checkout to include `.cs` files for the service directory so the `ExportApi` build target can compile.