### PR TITLE
Move Azure.Provisioning.Cdn to compute SDKType in service.projects

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.Network/src/Properties/AssemblyInfo.cs
+++ b/sdk/provisioning/Azure.Provisioning.Network/src/Properties/AssemblyInfo.cs
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: Experimental("AZPROVISION001")]

--- a/sdk/provisioning/service.projects
+++ b/sdk/provisioning/service.projects
@@ -17,7 +17,6 @@
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.AppConfiguration\**\*.csproj" />
-    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.Cdn\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.CognitiveServices\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.CosmosDB\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.EventHubs\**\*.csproj" />
@@ -41,6 +40,7 @@
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.AppContainers\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.ApplicationInsights\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.AppService\**\*.csproj" />
+    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.Cdn\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.CloudMachine\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.Communication\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.ContainerRegistry\**\*.csproj" />

--- a/sdk/provisioning/service.projects
+++ b/sdk/provisioning/service.projects
@@ -15,7 +15,6 @@
 <Project>
   <ItemGroup Condition="'$(SDKType)' == 'data' Or '$(SDKType)' == 'all'">
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning\**\*.csproj" />
-    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.AppConfiguration\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.CognitiveServices\**\*.csproj" />
     <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.Provisioning.CosmosDB\**\*.csproj" />


### PR DESCRIPTION
CDN is defined in `ci.compute.yml`, so it belongs in the `compute` ItemGroup rather than the `data` ItemGroup in `service.projects`. Also fixes alphabetical ordering and removes unused `AssemblyInfo.cs` for `Azure.Provisioning.Network`.