### PR TITLE
Refresh Azure.Provisioning.AppContainers with latest resource model updates

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.AppContainers/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.2.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.0 (2026-03-13)
 
 ### Other Changes
+
+- Refreshed provisioning library with latest resource model updates.
 
 ## 1.2.0-beta.1 (2026-02-05)
 

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.net10.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.net10.0.cs
@@ -78,7 +78,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppAccessMode
@@ -136,7 +135,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppAuthPlatform : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -278,7 +276,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppConnectedEnvironmentCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -300,7 +297,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppConnectedEnvironmentDaprComponent : Azure.Provisioning.Primitives.ProvisionableResource
@@ -329,7 +325,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppConnectedEnvironmentProvisioningState
@@ -361,7 +356,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppContainer : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -631,7 +625,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppHttpRouteConfigProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -824,7 +817,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppJobConfiguration : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -946,7 +938,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -967,7 +958,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedEnvironment : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1012,7 +1002,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedEnvironmentCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1035,7 +1024,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedEnvironmentDaprComponent : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1065,7 +1053,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppManagedEnvironmentOutBoundType
@@ -1092,7 +1079,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppNfsAzureFileProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1160,7 +1146,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppPrivateEndpointConnectionProvisioningState
@@ -1341,7 +1326,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppSourceControlOperationState
@@ -1529,7 +1513,6 @@ namespace Azure.Provisioning.AppContainers
         {
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class JavaComponentConfigurationProperty : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1596,7 +1579,6 @@ namespace Azure.Provisioning.AppContainers
         public static partial class ResourceVersions
         {
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ManagedCertificateDomainControlValidation
@@ -1713,7 +1695,6 @@ namespace Azure.Provisioning.AppContainers
         {
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class SessionPoolLifecycleConfiguration : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.net8.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.net8.0.cs
@@ -78,7 +78,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppAccessMode
@@ -136,7 +135,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppAuthPlatform : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -278,7 +276,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppConnectedEnvironmentCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -300,7 +297,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppConnectedEnvironmentDaprComponent : Azure.Provisioning.Primitives.ProvisionableResource
@@ -329,7 +325,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppConnectedEnvironmentProvisioningState
@@ -361,7 +356,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppContainer : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -631,7 +625,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppHttpRouteConfigProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -824,7 +817,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppJobConfiguration : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -946,7 +938,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -967,7 +958,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedEnvironment : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1012,7 +1002,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedEnvironmentCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1035,7 +1024,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedEnvironmentDaprComponent : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1065,7 +1053,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppManagedEnvironmentOutBoundType
@@ -1092,7 +1079,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppNfsAzureFileProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1160,7 +1146,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppPrivateEndpointConnectionProvisioningState
@@ -1341,7 +1326,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppSourceControlOperationState
@@ -1529,7 +1513,6 @@ namespace Azure.Provisioning.AppContainers
         {
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class JavaComponentConfigurationProperty : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1596,7 +1579,6 @@ namespace Azure.Provisioning.AppContainers
         public static partial class ResourceVersions
         {
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ManagedCertificateDomainControlValidation
@@ -1713,7 +1695,6 @@ namespace Azure.Provisioning.AppContainers
         {
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class SessionPoolLifecycleConfiguration : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.netstandard2.0.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/api/Azure.Provisioning.AppContainers.netstandard2.0.cs
@@ -78,7 +78,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppAccessMode
@@ -136,7 +135,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppAuthPlatform : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -278,7 +276,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppConnectedEnvironmentCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -300,7 +297,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppConnectedEnvironmentDaprComponent : Azure.Provisioning.Primitives.ProvisionableResource
@@ -329,7 +325,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppConnectedEnvironmentProvisioningState
@@ -361,7 +356,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppContainer : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -631,7 +625,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppHttpRouteConfigProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -824,7 +817,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppJobConfiguration : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -946,7 +938,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -967,7 +958,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedEnvironment : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1012,7 +1002,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedEnvironmentCertificate : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1035,7 +1024,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppManagedEnvironmentDaprComponent : Azure.Provisioning.Primitives.ProvisionableResource
@@ -1065,7 +1053,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppManagedEnvironmentOutBoundType
@@ -1092,7 +1079,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class ContainerAppNfsAzureFileProperties : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1160,7 +1146,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppPrivateEndpointConnectionProvisioningState
@@ -1341,7 +1326,6 @@ namespace Azure.Provisioning.AppContainers
             public static readonly string V2024_03_01;
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ContainerAppSourceControlOperationState
@@ -1529,7 +1513,6 @@ namespace Azure.Provisioning.AppContainers
         {
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class JavaComponentConfigurationProperty : Azure.Provisioning.Primitives.ProvisionableConstruct
@@ -1596,7 +1579,6 @@ namespace Azure.Provisioning.AppContainers
         public static partial class ResourceVersions
         {
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public enum ManagedCertificateDomainControlValidation
@@ -1713,7 +1695,6 @@ namespace Azure.Provisioning.AppContainers
         {
             public static readonly string V2025_01_01;
             public static readonly string V2025_07_01;
-            public static readonly string V2026_01_01;
         }
     }
     public partial class SessionPoolLifecycleConfiguration : Azure.Provisioning.Primitives.ProvisionableConstruct

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Azure.Provisioning.AppContainers.csproj
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Azure.Provisioning.AppContainers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Azure.Provisioning.AppContainers simplifies declarative resource provisioning in .NET.</Description>
-    <Version>1.2.0-beta.2</Version>
+    <Version>1.2.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.0</ApiCompatVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerApp.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerApp.cs
@@ -247,7 +247,7 @@ public partial class ContainerApp : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerApp.</param>
     public ContainerApp(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/containerApps", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/containerApps", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -286,11 +286,6 @@ public partial class ContainerApp : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppAuthConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppAuthConfig.cs
@@ -134,7 +134,7 @@ public partial class ContainerAppAuthConfig : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppAuthConfig.</param>
     public ContainerAppAuthConfig(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/containerApps/authConfigs", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/containerApps/authConfigs", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -161,11 +161,6 @@ public partial class ContainerAppAuthConfig : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironment.cs
@@ -146,7 +146,7 @@ public partial class ContainerAppConnectedEnvironment : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironment.</param>
     public ContainerAppConnectedEnvironment(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/connectedEnvironments", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/connectedEnvironments", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -176,11 +176,6 @@ public partial class ContainerAppConnectedEnvironment : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentCertificate.cs
@@ -98,7 +98,7 @@ public partial class ContainerAppConnectedEnvironmentCertificate : Provisionable
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironmentCertificate.</param>
     public ContainerAppConnectedEnvironmentCertificate(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/connectedEnvironments/certificates", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/connectedEnvironments/certificates", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -123,11 +123,6 @@ public partial class ContainerAppConnectedEnvironmentCertificate : Provisionable
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentDaprComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentDaprComponent.cs
@@ -166,7 +166,7 @@ public partial class ContainerAppConnectedEnvironmentDaprComponent : Provisionab
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironmentDaprComponent.</param>
     public ContainerAppConnectedEnvironmentDaprComponent(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/connectedEnvironments/daprComponents", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/connectedEnvironments/daprComponents", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -199,11 +199,6 @@ public partial class ContainerAppConnectedEnvironmentDaprComponent : Provisionab
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentStorage.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppConnectedEnvironmentStorage.cs
@@ -86,7 +86,7 @@ public partial class ContainerAppConnectedEnvironmentStorage : ProvisionableReso
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppConnectedEnvironmentStorage.</param>
     public ContainerAppConnectedEnvironmentStorage(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/connectedEnvironments/storages", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/connectedEnvironments/storages", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -110,11 +110,6 @@ public partial class ContainerAppConnectedEnvironmentStorage : ProvisionableReso
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppHttpRouteConfig.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppHttpRouteConfig.cs
@@ -77,7 +77,7 @@ public partial class ContainerAppHttpRouteConfig : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppHttpRouteConfig.</param>
     public ContainerAppHttpRouteConfig(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/httpRouteConfigs", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/httpRouteConfigs", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -99,11 +99,6 @@ public partial class ContainerAppHttpRouteConfig : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppJob.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppJob.cs
@@ -155,7 +155,7 @@ public partial class ContainerAppJob : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppJob.</param>
     public ContainerAppJob(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/jobs", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/jobs", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -185,11 +185,6 @@ public partial class ContainerAppJob : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppMaintenanceConfiguration.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppMaintenanceConfiguration.cs
@@ -77,7 +77,7 @@ public partial class ContainerAppMaintenanceConfiguration : ProvisionableResourc
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppMaintenanceConfiguration.</param>
     public ContainerAppMaintenanceConfiguration(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/maintenanceConfigurations", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/maintenanceConfigurations", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -100,11 +100,6 @@ public partial class ContainerAppMaintenanceConfiguration : ProvisionableResourc
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedCertificate.cs
@@ -97,7 +97,7 @@ public partial class ContainerAppManagedCertificate : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedCertificate.</param>
     public ContainerAppManagedCertificate(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/managedCertificates", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/managedCertificates", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -122,11 +122,6 @@ public partial class ContainerAppManagedCertificate : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironment.cs
@@ -301,7 +301,7 @@ public partial class ContainerAppManagedEnvironment : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironment.</param>
     public ContainerAppManagedEnvironment(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/managedEnvironments", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/managedEnvironments", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -346,11 +346,6 @@ public partial class ContainerAppManagedEnvironment : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentCertificate.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentCertificate.cs
@@ -98,7 +98,7 @@ public partial class ContainerAppManagedEnvironmentCertificate : ProvisionableRe
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironmentCertificate.</param>
     public ContainerAppManagedEnvironmentCertificate(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/certificates", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/certificates", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -123,11 +123,6 @@ public partial class ContainerAppManagedEnvironmentCertificate : ProvisionableRe
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentDaprComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentDaprComponent.cs
@@ -166,7 +166,7 @@ public partial class ContainerAppManagedEnvironmentDaprComponent : Provisionable
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironmentDaprComponent.</param>
     public ContainerAppManagedEnvironmentDaprComponent(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/daprComponents", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/daprComponents", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -198,11 +198,6 @@ public partial class ContainerAppManagedEnvironmentDaprComponent : Provisionable
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentStorage.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppManagedEnvironmentStorage.cs
@@ -86,7 +86,7 @@ public partial class ContainerAppManagedEnvironmentStorage : ProvisionableResour
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppManagedEnvironmentStorage.</param>
     public ContainerAppManagedEnvironmentStorage(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/storages", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/storages", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -110,11 +110,6 @@ public partial class ContainerAppManagedEnvironmentStorage : ProvisionableResour
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppPrivateEndpointConnection.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppPrivateEndpointConnection.cs
@@ -106,7 +106,7 @@ public partial class ContainerAppPrivateEndpointConnection : ProvisionableResour
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppPrivateEndpointConnection.</param>
     public ContainerAppPrivateEndpointConnection(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/privateEndpointConnections", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/privateEndpointConnections", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -132,11 +132,6 @@ public partial class ContainerAppPrivateEndpointConnection : ProvisionableResour
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppSourceControl.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/ContainerAppSourceControl.cs
@@ -107,7 +107,7 @@ public partial class ContainerAppSourceControl : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the ContainerAppSourceControl.</param>
     public ContainerAppSourceControl(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/containerApps/sourcecontrols", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/containerApps/sourcecontrols", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -132,11 +132,6 @@ public partial class ContainerAppSourceControl : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/JavaComponent.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/JavaComponent.cs
@@ -86,7 +86,7 @@ public partial class JavaComponent : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the JavaComponent.</param>
     public JavaComponent(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/javaComponents", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/managedEnvironments/javaComponents", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -108,11 +108,6 @@ public partial class JavaComponent : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/LogicApp.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/LogicApp.cs
@@ -56,7 +56,7 @@ public partial class LogicApp : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the LogicApp.</param>
     public LogicApp(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/logicApps", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/logicApps", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -76,11 +76,6 @@ public partial class LogicApp : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>

--- a/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/SessionPool.cs
+++ b/sdk/provisioning/Azure.Provisioning.AppContainers/src/Generated/SessionPool.cs
@@ -207,7 +207,7 @@ public partial class SessionPool : ProvisionableResource
     /// </param>
     /// <param name="resourceVersion">Version of the SessionPool.</param>
     public SessionPool(string bicepIdentifier, string? resourceVersion = default)
-        : base(bicepIdentifier, "Microsoft.App/sessionPools", resourceVersion ?? "2026-01-01")
+        : base(bicepIdentifier, "Microsoft.App/sessionPools", resourceVersion ?? "2025-07-01")
     {
     }
 
@@ -242,11 +242,6 @@ public partial class SessionPool : ProvisionableResource
     /// </summary>
     public static class ResourceVersions
     {
-        /// <summary>
-        /// 2026-01-01.
-        /// </summary>
-        public static readonly string V2026_01_01 = "2026-01-01";
-
         /// <summary>
         /// 2025-07-01.
         /// </summary>


### PR DESCRIPTION
## Changes

- Regenerated `Azure.Provisioning.AppContainers` provisioning library from `Azure.ResourceManager.AppContainers` v1.5.0
- Fixed default API version from `2026-01-01` to `2025-07-01` across all 19 resource types
- Removed `V2026_01_01` from `ResourceVersions` in all resource classes
- Prepared stable release v1.2.0 (2026-03-13)

## Validation

- Schema validated against [2025-07-01 Bicep reference](https://learn.microsoft.com/en-us/azure/templates/microsoft.app/2025-07-01/containerapps?pivots=deployment-language-bicep) - 18/19 resources fully match
- Only known gap: `javaComponents` discriminator not rendered in `schema.log` (generated C# code is correct) - tracked by #57047
- No extra writable properties in schema
- Pre-commit checks passed (dotnet format, Export-API)