### PR TITLE
Add automated naming rule scanner to mgmt PR review skill

### DIFF
--- a/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
+++ b/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
@@ -1,0 +1,663 @@
+<#
+.SYNOPSIS
+    Scans Azure Management SDK API surface files for naming rule violations.
+
+.DESCRIPTION
+    Checks all naming conventions defined in the azure-sdk-mgmt-pr-review skill:
+      - Type suffix rules (Parameter, Request, Options, Response, Data, Definition, Operation, Collection)
+      - Property naming (bool prefix, DateTimeOffset suffix, TTL, string-typed IDs)
+      - Acronym casing
+      - Contextual/ambiguous type names
+      - Enum plural names
+      - ListOperations methods
+
+.PARAMETER PackagePath
+    Path to the SDK package directory (e.g., sdk/compute/Azure.ResourceManager.Compute).
+    Can be absolute or relative to the repo root.
+
+.PARAMETER ApiFilePath
+    Direct path to an API surface file. Overrides PackagePath-based discovery.
+
+.PARAMETER ExcludeRules
+    Array of rule IDs to skip (e.g., 'SUFFIX001', 'BOOL001').
+
+.EXAMPLE
+    .\Check-MgmtNamingRules.ps1 -PackagePath sdk/compute/Azure.ResourceManager.Compute
+    .\Check-MgmtNamingRules.ps1 -ApiFilePath sdk/compute/Azure.ResourceManager.Compute/api/Azure.ResourceManager.Compute.net10.0.cs
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$PackagePath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ApiFilePath,
+
+    [Parameter(Mandatory = $false)]
+    [string[]]$ExcludeRules = @()
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+#region --- Helpers ---
+
+class NamingViolation {
+    [string]$RuleId
+    [string]$Severity     # Error, Warning
+    [string]$Category
+    [string]$TypeName
+    [string]$MemberName
+    [string]$Message
+    [string]$Suggestion
+    [int]$Line
+
+    NamingViolation([string]$ruleId, [string]$severity, [string]$category,
+                    [string]$typeName, [string]$memberName, [string]$message,
+                    [string]$suggestion, [int]$line) {
+        $this.RuleId    = $ruleId
+        $this.Severity  = $severity
+        $this.Category  = $category
+        $this.TypeName  = $typeName
+        $this.MemberName = $memberName
+        $this.Message   = $message
+        $this.Suggestion = $suggestion
+        $this.Line      = $line
+    }
+}
+
+function Get-ShortTypeName([string]$fullName) {
+    # Azure.ResourceManager.Compute.Models.Foo  ->  Foo
+    if ($fullName.Contains('.')) {
+        return $fullName.Split('.')[-1]
+    }
+    return $fullName
+}
+
+#endregion
+
+#region --- Resolve API file ---
+
+if (-not $ApiFilePath -and -not $PackagePath) {
+    Write-Error "Specify either -PackagePath or -ApiFilePath."
+    return
+}
+
+if (-not $ApiFilePath) {
+    # Prefer net10.0, then net8.0, then netstandard2.0
+    $apiDir = Join-Path $PackagePath 'api'
+    if (-not (Test-Path $apiDir)) {
+        Write-Error "API directory not found: $apiDir"
+        return
+    }
+    $candidates = @('net10.0', 'net8.0', 'netstandard2.0')
+    foreach ($tfm in $candidates) {
+        $files = @(Get-ChildItem $apiDir -Filter "*.$tfm.cs" -ErrorAction SilentlyContinue)
+        if ($files.Count -gt 0) {
+            $ApiFilePath = $files[0].FullName
+            break
+        }
+    }
+    if (-not $ApiFilePath) {
+        $allCs = @(Get-ChildItem $apiDir -Filter '*.cs' -ErrorAction SilentlyContinue)
+        if ($allCs.Count -gt 0) {
+            $ApiFilePath = $allCs[0].FullName
+        } else {
+            Write-Error "No API surface files found in $apiDir"
+            return
+        }
+    }
+}
+
+if (-not (Test-Path $ApiFilePath)) {
+    Write-Error "API file not found: $ApiFilePath"
+    return
+}
+
+Write-Host "Scanning: $ApiFilePath" -ForegroundColor Cyan
+$lines = Get-Content $ApiFilePath
+$totalLines = $lines.Count
+
+#endregion
+
+#region --- Parse API surface ---
+
+# We track: current namespace, type declarations (class/struct/enum), properties, methods.
+
+$violations = [System.Collections.Generic.List[NamingViolation]]::new()
+$currentNamespace = ''
+$currentTypeName = ''
+$currentTypeKind = ''   # class, struct, enum, interface
+$currentBasesRaw = ''
+$braceDepth = 0
+$typeStartDepth = 0
+
+# Collected type info for cross-referencing
+$typeInfos = @{}  # short name -> @{ Kind; Bases; Namespace; Line }
+
+# First pass: collect all type declarations and their base types.
+for ($i = 0; $i -lt $totalLines; $i++) {
+    $line = $lines[$i]
+
+    if ($line -match '^\s*namespace\s+([\w.]+)') {
+        $currentNamespace = $Matches[1]
+        continue
+    }
+
+    # Match type declarations: public partial class Foo : Bar, IBaz
+    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?<kind>class|struct|enum|interface)\s+(?<name>\w+)(?:<[^>]+>)?\s*(?::\s*(?<bases>.+?))?\s*$') {
+        $shortName = $Matches['name']
+        $kind = $Matches['kind']
+        $bases = if ($Matches['bases']) { $Matches['bases'].Trim() } else { '' }
+        $typeInfos[$shortName] = @{
+            Kind      = $kind
+            Bases     = $bases
+            Namespace = $currentNamespace
+            Line      = $i + 1
+        }
+    }
+}
+
+# Helper: check if a type inherits from a given base (simple string search in bases)
+function Test-InheritsFrom([string]$typeName, [string]$baseName) {
+    $info = $typeInfos[$typeName]
+    if (-not $info) { return $false }
+    return $info.Bases -match [regex]::Escape($baseName)
+}
+
+# Derive RP prefix from namespace for contextual naming checks
+# e.g., Azure.ResourceManager.Compute -> "Compute"
+function Get-RpPrefix([string]$ns) {
+    if ($ns -match 'Azure\.ResourceManager\.(.+?)(?:\.Models)?$') {
+        return $Matches[1]
+    }
+    return ''
+}
+
+#endregion
+
+#region --- Rule Checks ---
+
+# =====================================================
+# RULE: SUFFIX - Bad type name suffixes
+# =====================================================
+$badSuffixes = @(
+    @{ Suffix = 'Parameters'; Id = 'SUFFIX001'; Suggestion = "Rename to '*Content' or '*Patch'" }
+    @{ Suffix = 'Parameter';  Id = 'SUFFIX002'; Suggestion = "Rename to '*Content' or '*Patch'" }
+    @{ Suffix = 'Request';    Id = 'SUFFIX003'; Suggestion = "Rename to '*Content'" }
+    @{ Suffix = 'Response';   Id = 'SUFFIX005'; Suggestion = "Rename to '*Result'" }
+)
+
+foreach ($typeName in $typeInfos.Keys) {
+    $info = $typeInfos[$typeName]
+    if ($info.Kind -eq 'interface') { continue }
+
+    foreach ($rule in $badSuffixes) {
+        if ($typeName.EndsWith($rule.Suffix) -and $ExcludeRules -notcontains $rule.Id) {
+            $violations.Add([NamingViolation]::new(
+                $rule.Id, 'Error', 'Type Suffix',
+                $typeName, '',
+                "Type '$typeName' uses forbidden suffix '$($rule.Suffix)'.",
+                $rule.Suggestion,
+                $info.Line
+            ))
+        }
+    }
+
+    # Options suffix (except ClientOptions)
+    if ($typeName.EndsWith('Options') -and $typeName -ne 'ClientOptions' -and
+        -not (Test-InheritsFrom $typeName 'ClientPipelineOptions') -and
+        -not (Test-InheritsFrom $typeName 'ClientOptions') -and
+        $ExcludeRules -notcontains 'SUFFIX004') {
+        $violations.Add([NamingViolation]::new(
+            'SUFFIX004', 'Error', 'Type Suffix',
+            $typeName, '',
+            "Type '$typeName' uses suffix 'Options'. This suffix is reserved for ClientOptions subclasses.",
+            "Rename to '*Config'.",
+            $info.Line
+        ))
+    }
+
+    # Data suffix (except ResourceData/TrackedResourceData derivatives)
+    if ($typeName.EndsWith('Data') -and $info.Kind -eq 'class' -and
+        -not (Test-InheritsFrom $typeName 'ResourceData') -and
+        -not (Test-InheritsFrom $typeName 'TrackedResourceData') -and
+        $ExcludeRules -notcontains 'SUFFIX006') {
+        $violations.Add([NamingViolation]::new(
+            'SUFFIX006', 'Warning', 'Type Suffix',
+            $typeName, '',
+            "Type '$typeName' uses suffix 'Data' but does not inherit ResourceData/TrackedResourceData.",
+            "Remove 'Data' suffix or rename.",
+            $info.Line
+        ))
+    }
+
+    # Definition suffix
+    if ($typeName.EndsWith('Definition') -and $ExcludeRules -notcontains 'SUFFIX007') {
+        $violations.Add([NamingViolation]::new(
+            'SUFFIX007', 'Warning', 'Type Suffix',
+            $typeName, '',
+            "Type '$typeName' uses suffix 'Definition'. Remove unless needed to avoid conflict with another resource.",
+            "Remove 'Definition' suffix.",
+            $info.Line
+        ))
+    }
+
+    # Operation suffix (except Operation<T> derivatives)
+    if ($typeName.EndsWith('Operation') -and $info.Kind -eq 'class' -and
+        -not (Test-InheritsFrom $typeName 'Operation') -and
+        $ExcludeRules -notcontains 'SUFFIX008') {
+        $violations.Add([NamingViolation]::new(
+            'SUFFIX008', 'Warning', 'Type Suffix',
+            $typeName, '',
+            "Type '$typeName' uses suffix 'Operation' but does not inherit Operation<T>.",
+            "Rename to '*Data' or '*Info'.",
+            $info.Line
+        ))
+    }
+
+    # Collection suffix (except ArmCollection derivatives and well-known domain terms)
+    $domainCollections = @('MongoDBCollection', 'CosmosDBSqlCollection', 'CassandraCollection')
+    if ($typeName.EndsWith('Collection') -and $info.Kind -eq 'class' -and
+        -not (Test-InheritsFrom $typeName 'ArmCollection') -and
+        -not ($domainCollections | Where-Object { $typeName.EndsWith($_) }) -and
+        $ExcludeRules -notcontains 'SUFFIX009') {
+        $violations.Add([NamingViolation]::new(
+            'SUFFIX009', 'Warning', 'Type Suffix',
+            $typeName, '',
+            "Type '$typeName' uses suffix 'Collection' but does not inherit ArmCollection.",
+            "Rename to '*Group' or '*List'.",
+            $info.Line
+        ))
+    }
+}
+
+# =====================================================
+# RULE: BOOL - Boolean properties must start with Is/Can/Has
+# =====================================================
+$currentTypeName = ''
+for ($i = 0; $i -lt $totalLines; $i++) {
+    $line = $lines[$i]
+
+    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?:class|struct)\s+(\w+)') {
+        $currentTypeName = $Matches[1]
+        continue
+    }
+
+    # Match bool/bool? properties
+    if ($currentTypeName -and $ExcludeRules -notcontains 'BOOL001' -and
+        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*(?:bool|System\.Boolean)(\?)?\s+(\w+)\s*\{') {
+        $propName = $Matches[2]
+        if ($propName -notmatch '^(Is|Can|Has|Does|Should|Allow|Enable|Disable|Use|Support)') {
+            $violations.Add([NamingViolation]::new(
+                'BOOL001', 'Error', 'Property Naming',
+                $currentTypeName, $propName,
+                "Boolean property '$propName' does not start with a verb prefix (Is, Can, Has).",
+                "Rename to 'Is$propName', 'Can$propName', or 'Has$propName'.",
+                $i + 1
+            ))
+        }
+    }
+}
+
+# =====================================================
+# RULE: DATE - DateTimeOffset properties should end with "On"
+# =====================================================
+$currentTypeName = ''
+for ($i = 0; $i -lt $totalLines; $i++) {
+    $line = $lines[$i]
+
+    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?:class|struct)\s+(\w+)') {
+        $currentTypeName = $Matches[1]
+        continue
+    }
+
+    if ($currentTypeName -and $ExcludeRules -notcontains 'DATE001' -and
+        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*System\.DateTimeOffset(\?)?\s+(\w+)\s*\{') {
+        $propName = $Matches[2]
+        if ($propName -notmatch 'On$' -and $propName -notmatch 'At$') {
+            $violations.Add([NamingViolation]::new(
+                'DATE001', 'Warning', 'Property Naming',
+                $currentTypeName, $propName,
+                "DateTimeOffset property '$propName' does not end with 'On'.",
+                "Rename to '${propName}On' (e.g., 'CreatedOn', 'ExpireOn').",
+                $i + 1
+            ))
+        }
+    }
+}
+
+# =====================================================
+# RULE: TYPE - String-typed properties that should use strong types
+# =====================================================
+$currentTypeName = ''
+for ($i = 0; $i -lt $totalLines; $i++) {
+    $line = $lines[$i]
+
+    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?:class|struct)\s+(\w+)') {
+        $currentTypeName = $Matches[1]
+        continue
+    }
+
+    if (-not $currentTypeName) { continue }
+
+    # string properties ending in "Id" that might be ARM resource IDs -> ResourceIdentifier
+    # Focus on properties explicitly named *ResourceId or containing known ARM patterns
+    if ($ExcludeRules -notcontains 'TYPE001' -and
+        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*string\s+(\w+)\s*\{') {
+        $propName = $Matches[1]
+        # Known non-ARM IDs to exclude
+        $nonArmIdPatterns = @(
+            'ClientId', 'TenantId', 'ObjectId', 'PrincipalId', 'ApplicationId',
+            'AppId', 'SessionId', 'CorrelationId', 'RequestId', 'TrackingId',
+            'UniqueId', 'RunId', 'JobId', 'TaskId', 'OperationId', 'TransactionId',
+            'ReservationId', 'InstanceId', 'LeaseId', 'SequenceId', 'MessageId',
+            'PublisherId', 'OfferId', 'PlanId', 'SkuId', 'ImageId', 'OAuthId'
+        )
+        if ($propName -cmatch 'ResourceId$' -and $propName -notin $nonArmIdPatterns) {
+            $violations.Add([NamingViolation]::new(
+                'TYPE001', 'Warning', 'Type Formatting',
+                $currentTypeName, $propName,
+                "String property '$propName' ends with 'ResourceId' and likely holds an ARM resource ID. It should be typed as ResourceIdentifier.",
+                "Change type to Azure.Core.ResourceIdentifier.",
+                $i + 1
+            ))
+        }
+    }
+
+    # string etag property -> should be ETag
+    if ($ExcludeRules -notcontains 'TYPE002' -and
+        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*string\s+(ETag|Etag|ETagValue)\s*\{') {
+        $propName = $Matches[1]
+        $violations.Add([NamingViolation]::new(
+            'TYPE002', 'Error', 'Type Formatting',
+            $currentTypeName, $propName,
+            "Property '$propName' is typed as string but should use the ETag type.",
+            "Change type to Azure.ETag.",
+            $i + 1
+        ))
+    }
+
+    # string location/Location property -> should consider AzureLocation
+    if ($ExcludeRules -notcontains 'TYPE003' -and
+        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*string\s+(\w*[Ll]ocation)\s*\{') {
+        $propName = $Matches[1]
+        $violations.Add([NamingViolation]::new(
+            'TYPE003', 'Warning', 'Type Formatting',
+            $currentTypeName, $propName,
+            "String property '$propName' may represent an Azure location and should use AzureLocation type.",
+            "Change type to Azure.Core.AzureLocation.",
+            $i + 1
+        ))
+    }
+}
+
+# =====================================================
+# RULE: ACRONYM - Multi-letter acronyms should be PascalCase
+# =====================================================
+# Common acronyms that should NOT appear in ALL-CAPS form inside identifiers
+$acronymPatterns = @(
+    @{ AllCaps = 'HTTP';  PascalCase = 'Http';  Id = 'ACRONYM001' }
+    @{ AllCaps = 'HTTPS'; PascalCase = 'Https'; Id = 'ACRONYM001' }
+    @{ AllCaps = 'TCP';   PascalCase = 'Tcp';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'UDP';   PascalCase = 'Udp';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'SSL';   PascalCase = 'Ssl';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'TLS';   PascalCase = 'Tls';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'AES';   PascalCase = 'Aes';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'CPU';   PascalCase = 'Cpu';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'GPU';   PascalCase = 'Gpu';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'URL';   PascalCase = 'Url';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'URI';   PascalCase = 'Uri';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'API';   PascalCase = 'Api';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'DNS';   PascalCase = 'Dns';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'VPN';   PascalCase = 'Vpn';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'NAT';   PascalCase = 'Nat';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'NFS';   PascalCase = 'Nfs';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'SKU';   PascalCase = 'Sku';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'SSD';   PascalCase = 'Ssd';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'HDD';   PascalCase = 'Hdd';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'NIC';   PascalCase = 'Nic';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'SSH';   PascalCase = 'Ssh';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'SQL';   PascalCase = 'Sql';   Id = 'ACRONYM001' }
+    @{ AllCaps = 'AAD';   PascalCase = 'Aad';   Id = 'ACRONYM001' }
+)
+
+# Also check: "ID" should be "Id" (except when standalone or after a lowercase letter)
+# And "VM" should be "Vm"
+
+foreach ($typeName in $typeInfos.Keys) {
+    $info = $typeInfos[$typeName]
+    if ($ExcludeRules -contains 'ACRONYM001') { continue }
+
+    foreach ($acr in $acronymPatterns) {
+        # Check if the ALL-CAPS version appears as a substring in the type name
+        # but not as the PascalCase version
+        if ($typeName -cmatch "(?<![A-Z])$($acr.AllCaps)(?![a-z])") {
+            $violations.Add([NamingViolation]::new(
+                $acr.Id, 'Error', 'Acronym Casing',
+                $typeName, '',
+                "Type '$typeName' contains '$($acr.AllCaps)' in all-caps. Use PascalCase '$($acr.PascalCase)' instead.",
+                "Rename '$($acr.AllCaps)' to '$($acr.PascalCase)' in the type name.",
+                $info.Line
+            ))
+        }
+    }
+}
+
+# Also scan property names and enum members for acronym issues
+$currentTypeName = ''
+for ($i = 0; $i -lt $totalLines; $i++) {
+    $line = $lines[$i]
+
+    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?:class|struct|enum)\s+(\w+)') {
+        $currentTypeName = $Matches[1]
+        continue
+    }
+
+    if (-not $currentTypeName -or $ExcludeRules -contains 'ACRONYM001') { continue }
+
+    # Extract property or enum member name
+    $memberName = $null
+    if ($line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*\S+\s+(\w+)\s*\{') {
+        $memberName = $Matches[1]
+    } elseif ($line -match '^\s*(\w+)\s*=\s*') {
+        # enum member
+        $memberName = $Matches[1]
+    }
+
+    if ($memberName) {
+        foreach ($acr in $acronymPatterns) {
+            if ($memberName -cmatch "(?<![A-Z])$($acr.AllCaps)(?![a-z])") {
+                $violations.Add([NamingViolation]::new(
+                    'ACRONYM001', 'Error', 'Acronym Casing',
+                    $currentTypeName, $memberName,
+                    "Member '$memberName' contains '$($acr.AllCaps)' in all-caps. Use PascalCase '$($acr.PascalCase)'.",
+                    "Rename '$($acr.AllCaps)' to '$($acr.PascalCase)' in the member name.",
+                    $i + 1
+                ))
+            }
+        }
+    }
+}
+
+# =====================================================
+# RULE: CONTEXT - Ambiguous/generic type names without service prefix
+# =====================================================
+# These are known generic names that should be prefixed with service/resource context.
+$ambiguousPatterns = @(
+    'ProvisioningState'
+    'EncryptionStatus'
+    'EncryptionState'
+    'PublicNetworkAccess'
+    'PrivateEndpointConnection'
+    'PrivateEndpointConnectionData'
+    'PrivateLinkResource'
+    'PrivateLinkResourceData'
+    'PrivateLinkServiceConnectionState'
+    'ConnectionState'
+    'AccessLevel'
+    'CreatedByType'
+    'ManagedServiceIdentity'
+    'UserAssignedIdentity'
+    'EncryptionProperties'
+    'NetworkRuleSet'
+    'Sku'
+    'SkuName'
+    'SkuTier'
+    'Kind'
+    'Plan'
+    'Usage'
+    'UsageName'
+    'Capability'
+    'CheckNameAvailabilityResult'
+    'CheckNameAvailabilityRequest'
+    'NameAvailabilityReason'
+)
+
+foreach ($typeName in $typeInfos.Keys) {
+    $info = $typeInfos[$typeName]
+    if ($info.Kind -eq 'interface') { continue }
+    if ($ExcludeRules -contains 'CONTEXT001') { continue }
+
+    # Skip types in .Models namespace that start with the RP prefix (already qualified)
+    $rpPrefix = Get-RpPrefix $info.Namespace
+
+    if ($typeName -in $ambiguousPatterns) {
+        # Check if the type name is exactly one of the ambiguous patterns
+        # (not prefixed with the RP name)
+        $violations.Add([NamingViolation]::new(
+            'CONTEXT001', 'Warning', 'Contextual Naming',
+            $typeName, '',
+            "Type '$typeName' is a generic/ambiguous name. It should include a service or resource prefix for clarity.",
+            "Rename to '${rpPrefix}${typeName}' or similar qualified name.",
+            $info.Line
+        ))
+    }
+}
+
+# =====================================================
+# RULE: ENUM - Plural enum names should be singular
+# =====================================================
+foreach ($typeName in $typeInfos.Keys) {
+    $info = $typeInfos[$typeName]
+    if ($info.Kind -ne 'enum') { continue }
+    if ($ExcludeRules -contains 'ENUM001') { continue }
+
+    # Check for Flags attribute - we'd need to look at the line before, but in API surface files
+    # [Flags] appears on the line before the enum declaration
+    $lineIdx = $info.Line - 1  # 0-based
+    $hasFlagsAttr = $false
+    if ($lineIdx -gt 0 -and $lines[$lineIdx - 1] -match '\[System\.Flags\]|\[Flags\]') {
+        $hasFlagsAttr = $true
+    }
+
+    if (-not $hasFlagsAttr -and $typeName -match 's$' -and $typeName -notmatch '(ss|us|is|Status|Access|Address)$') {
+        $violations.Add([NamingViolation]::new(
+            'ENUM001', 'Warning', 'Enum Naming',
+            $typeName, '',
+            "Enum '$typeName' has a plural name. Non-[Flags] enums should use singular names.",
+            "Rename to singular form.",
+            $info.Line
+        ))
+    }
+}
+
+# =====================================================
+# RULE: METHOD - ListOperations methods should be removed
+# =====================================================
+$currentTypeName = ''
+for ($i = 0; $i -lt $totalLines; $i++) {
+    $line = $lines[$i]
+
+    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?:class|struct)\s+(\w+)') {
+        $currentTypeName = $Matches[1]
+        continue
+    }
+
+    if ($currentTypeName -and $ExcludeRules -notcontains 'METHOD001' -and
+        $line -match '\s+(ListOperations|ListOperationsAsync)\s*\(') {
+        $methodName = $Matches[1]
+        $violations.Add([NamingViolation]::new(
+            'METHOD001', 'Error', 'Method',
+            $currentTypeName, $methodName,
+            "Method '$methodName' should be removed. SDK exposes operations via public APIs.",
+            "Remove this method.",
+            $i + 1
+        ))
+    }
+}
+
+# =====================================================
+# RULE: TTL - TTL properties should be TimeToLiveIn<Unit>
+# =====================================================
+$currentTypeName = ''
+for ($i = 0; $i -lt $totalLines; $i++) {
+    $line = $lines[$i]
+
+    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?:class|struct)\s+(\w+)') {
+        $currentTypeName = $Matches[1]
+        continue
+    }
+
+    if ($currentTypeName -and $ExcludeRules -notcontains 'TTL001' -and
+        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*\S+\s+(\w*(?:(?<=\b|[a-z])Ttl|TTL)\w*)\s*\{') {
+        $propName = $Matches[1]
+        # Exclude false positives like "Throttle" containing "ttl"
+        if ($propName -notmatch 'Throttle|Bottl|Settle|Little|Battle|Cattle|Subtle' -and
+            $propName -notmatch 'TimeToLiveIn') {
+            $violations.Add([NamingViolation]::new(
+                'TTL001', 'Warning', 'Property Naming',
+                $currentTypeName, $propName,
+                "TTL property '$propName' should follow the 'TimeToLiveIn<Unit>' naming pattern.",
+                "Rename to 'TimeToLiveInSeconds' or similar.",
+                $i + 1
+            ))
+        }
+    }
+}
+
+#endregion
+
+#region --- Output ---
+
+if ($violations.Count -eq 0) {
+    Write-Host "`n✅ No naming violations found." -ForegroundColor Green
+    return
+}
+
+# Group by category
+$grouped = $violations | Group-Object Category | Sort-Object Name
+
+$errorCount   = @($violations | Where-Object { $_.Severity -eq 'Error' }).Count
+$warningCount = @($violations | Where-Object { $_.Severity -eq 'Warning' }).Count
+
+Write-Host "`n========================================" -ForegroundColor Yellow
+Write-Host " Naming Rule Violations Report" -ForegroundColor Yellow
+Write-Host "========================================" -ForegroundColor Yellow
+Write-Host " File: $(Split-Path $ApiFilePath -Leaf)"
+Write-Host " Errors:   $errorCount" -ForegroundColor Red
+Write-Host " Warnings: $warningCount" -ForegroundColor DarkYellow
+Write-Host "========================================`n" -ForegroundColor Yellow
+
+foreach ($group in $grouped) {
+    Write-Host "── $($group.Name) ($($group.Count) issues) ──" -ForegroundColor Magenta
+    foreach ($v in $group.Group) {
+        $color = if ($v.Severity -eq 'Error') { 'Red' } else { 'DarkYellow' }
+        $icon  = if ($v.Severity -eq 'Error') { '❌' } else { '⚠️' }
+
+        $member = if ($v.MemberName) { ".$($v.MemberName)" } else { '' }
+        Write-Host "  $icon [$($v.RuleId)] Line $($v.Line): $($v.TypeName)$member" -ForegroundColor $color
+        Write-Host "     $($v.Message)" -ForegroundColor Gray
+        Write-Host "     💡 $($v.Suggestion)" -ForegroundColor DarkCyan
+        Write-Host ""
+    }
+}
+
+Write-Host "----------------------------------------"
+Write-Host "Total: $($violations.Count) violations ($errorCount errors, $warningCount warnings)"
+Write-Host "----------------------------------------"
+
+# Return violations for programmatic use (pipe to Out-Null if you only want console output)
+Write-Output $violations
+
+#endregion

--- a/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
+++ b/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
@@ -158,11 +158,11 @@ for ($i = 0; $i -lt $totalLines; $i++) {
     }
 }
 
-# Helper: check if a type inherits from a given base (simple string search in bases)
+# Helper: check if a type inherits from a given base (word-boundary match in bases)
 function Test-InheritsFrom([string]$typeName, [string]$baseName) {
     $info = $typeInfos[$typeName]
     if (-not $info) { return $false }
-    return $info.Bases -match [regex]::Escape($baseName)
+    return $info.Bases -match "\b$([regex]::Escape($baseName))\b"
 }
 
 # Derive RP prefix from namespace for contextual naming checks
@@ -432,7 +432,7 @@ foreach ($typeName in $typeInfos.Keys) {
     foreach ($acr in $acronymPatterns) {
         # Check if the ALL-CAPS version appears as a substring in the type name
         # but not as the PascalCase version
-        if ($typeName -cmatch "(?<![A-Z])$($acr.AllCaps)(?![a-z])") {
+        if ($typeName -cmatch "(?<![A-Z])$($acr.AllCaps)(?=[A-Z][a-z]|[^a-zA-Z]|$)") {
             $violations.Add([NamingViolation]::new(
                 $acr.Id, 'Error', 'Acronym Casing',
                 $typeName, '',
@@ -467,7 +467,7 @@ for ($i = 0; $i -lt $totalLines; $i++) {
 
     if ($memberName) {
         foreach ($acr in $acronymPatterns) {
-            if ($memberName -cmatch "(?<![A-Z])$($acr.AllCaps)(?![a-z])") {
+            if ($memberName -cmatch "(?<![A-Z])$($acr.AllCaps)(?=[A-Z][a-z]|[^a-zA-Z]|$)") {
                 $violations.Add([NamingViolation]::new(
                     'ACRONYM001', 'Error', 'Acronym Casing',
                     $currentTypeName, $memberName,
@@ -551,7 +551,7 @@ foreach ($typeName in $typeInfos.Keys) {
         $hasFlagsAttr = $true
     }
 
-    if (-not $hasFlagsAttr -and $typeName -match 's$' -and $typeName -notmatch '(ss|us|is|Status|Access|Address)$') {
+    if (-not $hasFlagsAttr -and $typeName -match 's$' -and $typeName -notmatch '(ss|us|is|as|os|Status|Access|Address|Series|Alias|Atlas|Chaos|Canvas)$') {
         $violations.Add([NamingViolation]::new(
             'ENUM001', 'Warning', 'Enum Naming',
             $typeName, '',

--- a/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
+++ b/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
@@ -18,12 +18,18 @@
 .PARAMETER ApiFilePath
     Direct path to an API surface file. Overrides PackagePath-based discovery.
 
+.PARAMETER BaselineApiFilePath
+    Path to the baseline (previously released) API surface file. When provided, only violations
+    on types/members that are new or changed compared to the baseline will be reported.
+    This enables deterministic filtering without relying on LLM judgment.
+
 .PARAMETER ExcludeRules
     Array of rule IDs to skip (e.g., 'SUFFIX001', 'BOOL001').
 
 .EXAMPLE
     .\Check-MgmtNamingRules.ps1 -PackagePath sdk/compute/Azure.ResourceManager.Compute
     .\Check-MgmtNamingRules.ps1 -ApiFilePath sdk/compute/Azure.ResourceManager.Compute/api/Azure.ResourceManager.Compute.net10.0.cs
+    .\Check-MgmtNamingRules.ps1 -ApiFilePath current-api.cs -BaselineApiFilePath baseline-api.cs
 #>
 [CmdletBinding()]
 param(
@@ -32,6 +38,9 @@ param(
 
     [Parameter(Mandatory = $false)]
     [string]$ApiFilePath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$BaselineApiFilePath,
 
     [Parameter(Mandatory = $false)]
     [string[]]$ExcludeRules = @()
@@ -66,29 +75,19 @@ class NamingViolation {
     }
 }
 
-function Get-ShortTypeName([string]$fullName) {
-    # Azure.ResourceManager.Compute.Models.Foo  ->  Foo
-    if ($fullName.Contains('.')) {
-        return $fullName.Split('.')[-1]
-    }
-    return $fullName
-}
-
 #endregion
 
 #region --- Resolve API file ---
 
 if (-not $ApiFilePath -and -not $PackagePath) {
-    Write-Error "Specify either -PackagePath or -ApiFilePath."
-    return
+    throw "Specify either -PackagePath or -ApiFilePath."
 }
 
 if (-not $ApiFilePath) {
     # Prefer net10.0, then net8.0, then netstandard2.0
     $apiDir = Join-Path $PackagePath 'api'
     if (-not (Test-Path $apiDir)) {
-        Write-Error "API directory not found: $apiDir"
-        return
+        throw "API directory not found: $apiDir"
     }
     $candidates = @('net10.0', 'net8.0', 'netstandard2.0')
     foreach ($tfm in $candidates) {
@@ -103,20 +102,34 @@ if (-not $ApiFilePath) {
         if ($allCs.Count -gt 0) {
             $ApiFilePath = $allCs[0].FullName
         } else {
-            Write-Error "No API surface files found in $apiDir"
-            return
+            throw "No API surface files found in $apiDir"
         }
     }
 }
 
 if (-not (Test-Path $ApiFilePath)) {
-    Write-Error "API file not found: $ApiFilePath"
-    return
+    throw "API file not found: $ApiFilePath"
 }
 
 Write-Host "Scanning: $ApiFilePath" -ForegroundColor Cyan
 $lines = Get-Content $ApiFilePath
 $totalLines = $lines.Count
+
+# Load baseline API file for filtering (if provided)
+$baselineLines = @{}
+if ($BaselineApiFilePath) {
+    if (-not (Test-Path $BaselineApiFilePath)) {
+        throw "Baseline API file not found: $BaselineApiFilePath"
+    }
+    Write-Host "Baseline: $BaselineApiFilePath" -ForegroundColor Cyan
+    # Store each non-empty trimmed line in a HashSet for fast lookup
+    foreach ($bline in (Get-Content $BaselineApiFilePath)) {
+        $trimmed = $bline.Trim()
+        if ($trimmed) {
+            $baselineLines[$trimmed] = $true
+        }
+    }
+}
 
 #endregion
 
@@ -292,8 +305,8 @@ for ($i = 0; $i -lt $totalLines; $i++) {
             $violations.Add([NamingViolation]::new(
                 'BOOL001', 'Error', 'Property Naming',
                 $currentTypeName, $propName,
-                "Boolean property '$propName' does not start with a verb prefix (Is, Can, Has).",
-                "Rename to 'Is$propName', 'Can$propName', or 'Has$propName'.",
+                "Boolean property '$propName' does not start with a verb prefix (Is, Can, Has, Does, Should, Allow, Enable, Disable, Use, Support).",
+                "Rename to 'Is$propName', 'Can$propName', 'Has$propName', or another accepted verb prefix.",
                 $i + 1
             ))
         }
@@ -379,16 +392,21 @@ for ($i = 0; $i -lt $totalLines; $i++) {
     }
 
     # string location/Location property -> should consider AzureLocation
+    # Only match 'Location' as a PascalCase word (capital L), not as a suffix of words like
+    # Allocation, Deallocation, Collocation, Relocation where 'location' is lowercase.
     if ($ExcludeRules -notcontains 'TYPE003' -and
-        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*string\s+(\w*[Ll]ocation)\s*\{') {
+        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*string\s+(\w*Location)\s*\{') {
         $propName = $Matches[1]
-        $violations.Add([NamingViolation]::new(
-            'TYPE003', 'Warning', 'Type Formatting',
-            $currentTypeName, $propName,
-            "String property '$propName' may represent an Azure location and should use AzureLocation type.",
-            "Change type to Azure.Core.AzureLocation.",
-            $i + 1
-        ))
+        # Exclude words where "location" is part of a different English word (lowercase 'l')
+        if ($propName -cnotmatch '[a-z]location') {
+            $violations.Add([NamingViolation]::new(
+                'TYPE003', 'Warning', 'Type Formatting',
+                $currentTypeName, $propName,
+                "String property '$propName' may represent an Azure location and should use AzureLocation type.",
+                "Change type to Azure.Core.AzureLocation.",
+                $i + 1
+            ))
+        }
     }
 }
 
@@ -422,8 +440,8 @@ $acronymPatterns = @(
     @{ AllCaps = 'AAD';   PascalCase = 'Aad';   Id = 'ACRONYM001' }
 )
 
-# Also check: "ID" should be "Id" (except when standalone or after a lowercase letter)
-# And "VM" should be "Vm"
+# NOTE: Potential future enhancement: consider enforcing "ID" -> "Id" and "VM" -> "Vm"
+#       with appropriate exceptions (e.g., when standalone or after a lowercase letter).
 
 foreach ($typeName in $typeInfos.Keys) {
     $info = $typeInfos[$typeName]
@@ -431,7 +449,10 @@ foreach ($typeName in $typeInfos.Keys) {
 
     foreach ($acr in $acronymPatterns) {
         # Check if the ALL-CAPS version appears as a substring in the type name
-        # but not as the PascalCase version
+        # but not as the PascalCase version.
+        # The lookahead ensures we match the end of the all-caps run: next char must be
+        # uppercase-then-lowercase (new PascalCase word), non-letter, or end-of-string.
+        # This prevents "HTTP" from matching inside "HTTPS".
         if ($typeName -cmatch "(?<![A-Z])$($acr.AllCaps)(?=[A-Z][a-z]|[^a-zA-Z]|$)") {
             $violations.Add([NamingViolation]::new(
                 $acr.Id, 'Error', 'Acronym Casing',
@@ -445,6 +466,9 @@ foreach ($typeName in $typeInfos.Keys) {
 }
 
 # Also scan property names and enum members for acronym issues
+# NOTE: The acronym regex may produce rare false positives on names that coincidentally
+# contain the letter sequence (e.g., NIC check could flag "UnicodeProperty"). These cases
+# are unlikely in Azure SDK naming but worth being aware of.
 $currentTypeName = ''
 for ($i = 0; $i -lt $totalLines; $i++) {
     $line = $lines[$i]
@@ -525,11 +549,17 @@ foreach ($typeName in $typeInfos.Keys) {
     if ($typeName -in $ambiguousPatterns) {
         # Check if the type name is exactly one of the ambiguous patterns
         # (not prefixed with the RP name)
+        if ([string]::IsNullOrEmpty($rpPrefix)) {
+            $suggestion = "Type '$typeName' is a generic/ambiguous name. Consider adding a service or resource prefix for clarity."
+        }
+        else {
+            $suggestion = "Rename to '${rpPrefix}${typeName}' or similar qualified name."
+        }
         $violations.Add([NamingViolation]::new(
             'CONTEXT001', 'Warning', 'Contextual Naming',
             $typeName, '',
             "Type '$typeName' is a generic/ambiguous name. It should include a service or resource prefix for clarity.",
-            "Rename to '${rpPrefix}${typeName}' or similar qualified name.",
+            $suggestion,
             $info.Line
         ))
     }
@@ -543,12 +573,35 @@ foreach ($typeName in $typeInfos.Keys) {
     if ($info.Kind -ne 'enum') { continue }
     if ($ExcludeRules -contains 'ENUM001') { continue }
 
-    # Check for Flags attribute - we'd need to look at the line before, but in API surface files
-    # [Flags] appears on the line before the enum declaration
+    # Detect Flags enums heuristically: API surface files (api/*.cs) do not include
+    # attribute annotations like [Flags], so we cannot check for the attribute directly.
+    # Instead, check if the enum member values are powers of 2 (0, 1, 2, 4, 8, ...),
+    # which strongly indicates a flags enum.
     $lineIdx = $info.Line - 1  # 0-based
     $hasFlagsAttr = $false
-    if ($lineIdx -gt 0 -and $lines[$lineIdx - 1] -match '\[System\.Flags\]|\[Flags\]') {
-        $hasFlagsAttr = $true
+
+    # Scan forward from the enum declaration to collect member values
+    $enumValues = @()
+    for ($j = $lineIdx + 1; $j -lt $totalLines; $j++) {
+        $eline = $lines[$j]
+        if ($eline -match '^\s*\}') { break }
+        if ($eline -match '^\s*\w+\s*=\s*(-?\d+)') {
+            $enumValues += [long]$Matches[1]
+        }
+    }
+    # A flags enum typically has at least 2 members with values that are all powers of 2 (or 0)
+    if ($enumValues.Count -ge 2) {
+        $allPowersOfTwo = $true
+        foreach ($val in $enumValues) {
+            if ($val -lt 0) { $allPowersOfTwo = $false; break }
+            if ($val -ne 0 -and ($val -band ($val - 1)) -ne 0) {
+                $allPowersOfTwo = $false
+                break
+            }
+        }
+        if ($allPowersOfTwo) {
+            $hasFlagsAttr = $true
+        }
     }
 
     if (-not $hasFlagsAttr -and $typeName -match 's$' -and $typeName -notmatch '(ss|us|is|as|os|Status|Access|Address|Series|Alias|Atlas|Chaos|Canvas)$') {
@@ -600,7 +653,7 @@ for ($i = 0; $i -lt $totalLines; $i++) {
     }
 
     if ($currentTypeName -and $ExcludeRules -notcontains 'TTL001' -and
-        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*\S+\s+(\w*(?:(?<=\b|[a-z])Ttl|TTL)\w*)\s*\{') {
+        $line -match '^\s*public\s+(?:(?:new|override|virtual|abstract|static|sealed)\s+)*\S+\s+(\w*(?:Ttl|TTL)\w*)\s*\{') {
         $propName = $Matches[1]
         # Exclude false positives like "Throttle" containing "ttl"
         if ($propName -notmatch 'Throttle|Bottl|Settle|Little|Battle|Cattle|Subtle' -and
@@ -614,6 +667,29 @@ for ($i = 0; $i -lt $totalLines; $i++) {
             ))
         }
     }
+}
+
+#endregion
+
+#region --- Baseline Filtering ---
+
+# If a baseline API file was provided, filter out violations for types/members that
+# existed unchanged in the baseline. This ensures only new or changed API surface is reported.
+if ($BaselineApiFilePath -and $baselineLines.Count -gt 0) {
+    $filteredViolations = [System.Collections.Generic.List[NamingViolation]]::new()
+    foreach ($v in $violations) {
+        # For type-level violations, check if the type declaration line exists in baseline
+        # For member-level violations, check if the member line exists in baseline
+        $violationLine = $lines[$v.Line - 1].Trim()
+        if (-not $baselineLines.ContainsKey($violationLine)) {
+            $filteredViolations.Add($v)
+        }
+    }
+    $removedCount = $violations.Count - $filteredViolations.Count
+    if ($removedCount -gt 0) {
+        Write-Host "Filtered out $removedCount violation(s) present in baseline." -ForegroundColor DarkGray
+    }
+    $violations = $filteredViolations
 }
 
 #endregion
@@ -656,8 +732,5 @@ foreach ($group in $grouped) {
 Write-Host "----------------------------------------"
 Write-Host "Total: $($violations.Count) violations ($errorCount errors, $warningCount warnings)"
 Write-Host "----------------------------------------"
-
-# Return violations for programmatic use (pipe to Out-Null if you only want console output)
-Write-Output $violations
 
 #endregion

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -42,10 +42,16 @@ To determine the review scope:
 ### Instructions
 
 1. Determine review scope per the "Scope of Review" section above.
-2. Examine API surface files (api/*.cs) for public API, focusing on new/changed surface.
-3. Check Generated models and resources in src/Generated/.
-4. Review TypeSpec customizations (e.g., `client.tsp`, `tspconfig.yaml`).
-5. For each issue found, record the exact file path, line number, and comment body to include as an inline review comment.
+2. **Run the automated naming rule scanner** to find all deterministic naming violations:
+   ```powershell
+   pwsh .github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1 -PackagePath <package-path>
+   ```
+   The script checks all rules in the "API Review Checklist" below and outputs violations with rule IDs, line numbers, and suggested fixes. Include every violation from the script output as an inline review comment.
+   If `ApiCompatVersion` is present (i.e., a prior stable version exists), filter the script output to only report violations on **new or changed** API surface (per the "Scope of Review" section). Violations on types/members that existed unchanged in the prior stable release should be ignored.
+3. Examine API surface files (api/*.cs) for public API, focusing on new/changed surface. Check for any additional issues not covered by the script (e.g., contextual judgment calls, domain-specific naming).
+4. Check Generated models and resources in src/Generated/.
+5. Review TypeSpec customizations (e.g., `client.tsp`, `tspconfig.yaml`).
+6. For each issue found, record the exact file path, line number, and comment body to include as an inline review comment.
 
 ### API Review Checklist
 

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -77,8 +77,8 @@ To determine the review scope:
 - **PUT/POST operation body:** Must be named `[Model]Content` or `[Model]Data`
 
 #### Property Naming
-- **Boolean properties:** Must start with verb prefix: `Is`, `Can`, `Has`
-- **DateTimeOffset properties:** Should end with `On` (e.g., `CreatedOn`, `StartOn`, `EndOn`)
+- **Boolean properties:** Must start with verb prefix: `Is`, `Can`, `Has`, `Does`, `Should`, `Allow`, `Enable`, `Disable`, `Use`, `Support`
+- **DateTimeOffset properties:** Should end with `On` or `At` (e.g., `CreatedOn`, `StartOn`, `ExpiresAt`)
 - **Interval/Duration (integer):** Include units in name (e.g., `MonitoringIntervalInSeconds`)
 - **TTL properties:** Rename to `TimeToLiveIn<Unit>`
 

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -47,7 +47,11 @@ To determine the review scope:
    pwsh .github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1 -PackagePath <package-path>
    ```
    The script checks all rules in the "API Review Checklist" below and outputs violations with rule IDs, line numbers, and suggested fixes. Include every violation from the script output as an inline review comment.
-   If `ApiCompatVersion` is present (i.e., a prior stable version exists), filter the script output to only report violations on **new or changed** API surface (per the "Scope of Review" section). Violations on types/members that existed unchanged in the prior stable release should be ignored.
+   If `ApiCompatVersion` is present (i.e., a prior stable version exists), pass the baseline API surface file to the script using `-BaselineApiFilePath` so it can deterministically filter out violations on unchanged API surface:
+   ```powershell
+   pwsh .github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1 -ApiFilePath <current-api-file> -BaselineApiFilePath <baseline-api-file>
+   ```
+   When `-BaselineApiFilePath` is provided, the script automatically excludes violations on types/members that existed unchanged in the prior stable release.
 3. Examine API surface files (api/*.cs) for public API, focusing on new/changed surface. Check for any additional issues not covered by the script (e.g., contextual judgment calls, domain-specific naming).
 4. Check Generated models and resources in src/Generated/.
 5. Review TypeSpec customizations (e.g., `client.tsp`, `tspconfig.yaml`).


### PR DESCRIPTION
## What
Add `Check-MgmtNamingRules.ps1` to the `azure-sdk-mgmt-pr-review` skill folder and integrate it into the Phase 2 review workflow.

## Why
The PR review skill relies on Copilot to catch naming violations, but LLM output is non-deterministic — some violations get missed across reviews. This script provides a deterministic baseline that catches **all** rule-based naming violations consistently.

## What the script checks (12 rule categories)
| Rule ID | Category | Check |
|---------|----------|-------|
| SUFFIX001-009 | Type Suffix | Parameter(s), Request, Options, Response, Data, Definition, Operation, Collection |
| BOOL001 | Property Naming | Boolean properties must start with Is/Can/Has |
| DATE001 | Property Naming | DateTimeOffset properties should end with "On" |
| TTL001 | Property Naming | TTL properties should follow TimeToLiveIn\<Unit\> |
| TYPE001-003 | Type Formatting | string ResourceIds → ResourceIdentifier, string etag → ETag, string location → AzureLocation |
| ACRONYM001 | Acronym Casing | 23 common acronyms must use PascalCase |
| CONTEXT001 | Contextual Naming | Flags generic/ambiguous type names lacking service prefix |
| ENUM001 | Enum Naming | Plural enum names should be singular |
| METHOD001 | Method | ListOperations methods should be removed |

## Usage
```powershell
pwsh .github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1 -PackagePath sdk/compute/Azure.ResourceManager.Compute
```

## SKILL.md change
Updated Phase 2 instructions to run the script as step 2 (before manual review), so Copilot uses it to find all deterministic violations first, then does manual review for contextual issues.