### PR TITLE
Generate GetResourceNameRequirements() override in provisioning resources

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Statements;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
@@ -253,9 +254,12 @@ namespace Azure.Generator.Provisioning.Providers
             // DefineAdditionalProperties() partial method for customization
             methods.Add(BuildDefineAdditionalPropertiesMethod());
 
-            // TODO(https://github.com/Azure/azure-sdk-for-net/issues/56743): Generate
-            // `GetResourceNameRequirements()` override with min/max length and valid characters
-            // parsed from the ARM spec's @pattern/@minLength/@maxLength decorators.
+            // GetResourceNameRequirements() override — only for base resource types
+            var nameRequirementsMethod = BuildGetResourceNameRequirementsMethod(_resourceMetadata, this);
+            if (nameRequirementsMethod != null)
+            {
+                methods.Add(nameRequirementsMethod);
+            }
 
             return [.. methods];
         }
@@ -495,6 +499,75 @@ namespace Azure.Generator.Provisioning.Providers
                 []);
 
             return new MethodProvider(sig, this);
+        }
+
+        private static MethodProvider? BuildGetResourceNameRequirementsMethod(ArmResourceMetadata? resourceMetadata, TypeProvider enclosingType)
+        {
+            if (resourceMetadata is null)
+            {
+                return null;
+            }
+
+            var constraints = resourceMetadata.NameConstraints;
+            int minLength = constraints.MinLength ?? 1;
+            int maxLength = constraints.MaxLength ?? 24;
+
+            // Parse valid characters from pattern, or use conservative default
+            var validCharacters = constraints.Pattern != null
+                ? constraints.Pattern.ParsePatternToResourceNameCharacters()
+                : ResourceNameCharacters.LowercaseLetters;
+
+            // If parsing produced no characters, fall back to conservative default
+            if (validCharacters == (ResourceNameCharacters)0)
+            {
+                validCharacters = ResourceNameCharacters.LowercaseLetters;
+            }
+
+            // Build the flags expression by OR-ing the individual flag values
+            ValueExpression flagsExpression = BuildResourceNameCharactersExpression(validCharacters);
+
+            var sig = new MethodSignature(
+                "GetResourceNameRequirements",
+                $"Get the requirements for naming this resource.",
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Override,
+                typeof(ResourceNameRequirements),
+                $"Naming requirements.",
+                [],
+                Attributes: [new AttributeStatement(typeof(EditorBrowsableAttribute), [new MemberExpression(typeof(EditorBrowsableState), nameof(EditorBrowsableState.Never))])]);
+
+            var body = New.Instance(
+                typeof(ResourceNameRequirements),
+                [Literal(minLength), Literal(maxLength), flagsExpression]);
+
+            return new MethodProvider(sig, body, enclosingType);
+        }
+
+        private static ValueExpression BuildResourceNameCharactersExpression(ResourceNameCharacters characters)
+        {
+            var flags = new List<ValueExpression>();
+
+            if (characters.HasFlag(ResourceNameCharacters.LowercaseLetters))
+                flags.Add(FrameworkEnumValue(ResourceNameCharacters.LowercaseLetters));
+            if (characters.HasFlag(ResourceNameCharacters.UppercaseLetters))
+                flags.Add(FrameworkEnumValue(ResourceNameCharacters.UppercaseLetters));
+            if (characters.HasFlag(ResourceNameCharacters.Numbers))
+                flags.Add(FrameworkEnumValue(ResourceNameCharacters.Numbers));
+            if (characters.HasFlag(ResourceNameCharacters.Hyphen))
+                flags.Add(FrameworkEnumValue(ResourceNameCharacters.Hyphen));
+            if (characters.HasFlag(ResourceNameCharacters.Underscore))
+                flags.Add(FrameworkEnumValue(ResourceNameCharacters.Underscore));
+            if (characters.HasFlag(ResourceNameCharacters.Period))
+                flags.Add(FrameworkEnumValue(ResourceNameCharacters.Period));
+            if (characters.HasFlag(ResourceNameCharacters.Parentheses))
+                flags.Add(FrameworkEnumValue(ResourceNameCharacters.Parentheses));
+
+            // OR them together
+            var result = flags[0];
+            for (int i = 1; i < flags.Count; i++)
+            {
+                result = new BinaryOperatorExpression("|", result, flags[i]);
+            }
+            return result;
         }
 
         // ── Type resolution helpers ──────────────────────────────────

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -509,6 +509,13 @@ namespace Azure.Generator.Provisioning.Providers
             }
 
             var constraints = resourceMetadata.NameConstraints;
+
+            // Only generate the override when the spec actually specifies name constraints
+            if (constraints.Pattern is null && constraints.MinLength is null && constraints.MaxLength is null)
+            {
+                return null;
+            }
+
             int minLength = constraints.MinLength ?? 1;
             int maxLength = constraints.MaxLength ?? 24;
 

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/ResourceNameConstraintsHelper.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Utilities/ResourceNameConstraintsHelper.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Provisioning.Primitives;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Azure.Generator.Provisioning.Utilities;
+
+/// <summary>
+/// Helper to convert regex patterns from ARM spec into <see cref="ResourceNameCharacters"/> flags.
+/// </summary>
+internal static class ResourceNameConstraintsHelper
+{
+    /// <summary>
+    /// Representative test strings for each <see cref="ResourceNameCharacters"/> flag.
+    /// If any character in the test string matches the pattern, the flag is included.
+    /// </summary>
+    private static readonly (string TestChars, ResourceNameCharacters Flag)[] CharacterTests =
+    [
+        ("abcxyz", ResourceNameCharacters.LowercaseLetters),
+        ("ABCXYZ", ResourceNameCharacters.UppercaseLetters),
+        ("0123456789", ResourceNameCharacters.Numbers),
+        ("-", ResourceNameCharacters.Hyphen),
+        ("_", ResourceNameCharacters.Underscore),
+        (".", ResourceNameCharacters.Period),
+        ("()", ResourceNameCharacters.Parentheses),
+    ];
+
+    extension(string pattern)
+    {
+        /// <summary>
+        /// Converts a regex pattern string into <see cref="ResourceNameCharacters"/> flags
+        /// by extracting all character classes from the pattern and testing representative
+        /// characters against them.
+        /// </summary>
+        internal ResourceNameCharacters ParsePatternToResourceNameCharacters()
+        {
+            // Extract all [...] character class groups from the pattern and combine them
+            // so we can test if any position in the pattern accepts each character.
+            var charClasses = Regex.Matches(pattern, @"\[(?:[^\]]|\\.)+\]");
+            if (charClasses.Count == 0)
+            {
+                return (ResourceNameCharacters)0;
+            }
+
+            var combined = string.Join("|", charClasses.Cast<Match>().Select(m => m.Value));
+            var regex = new Regex("^(?:" + combined + ")$");
+
+            var result = (ResourceNameCharacters)0;
+
+            foreach (var (testChars, flag) in CharacterTests)
+            {
+                foreach (char c in testChars)
+                {
+                    if (regex.IsMatch(c.ToString()))
+                    {
+                        result |= flag;
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/ConfigurationStore.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/ConfigurationStore.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System.ComponentModel;
 using Azure.Core;
 using Azure.Provisioning;
 using Azure.Provisioning.Primitives;
@@ -146,6 +147,11 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
 
         /// <summary> Define additional provisionable properties for ConfigurationStore that are not part of the generated code. </summary>
         partial void DefineAdditionalProperties();
+
+        /// <summary> Get the requirements for naming this resource. </summary>
+        /// <returns> Naming requirements. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override ResourceNameRequirements GetResourceNameRequirements() => new ResourceNameRequirements(1, 24, ResourceNameCharacters.LowercaseLetters | ResourceNameCharacters.UppercaseLetters | ResourceNameCharacters.Numbers | ResourceNameCharacters.Hyphen);
 
         /// <summary></summary>
         public static partial class ResourceVersions

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/KeyValue.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/KeyValue.cs
@@ -5,6 +5,7 @@
 
 #nullable disable
 
+using System.ComponentModel;
 using Azure.Core;
 using Azure.Provisioning;
 using Azure.Provisioning.Primitives;
@@ -117,6 +118,11 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
 
         /// <summary> Define additional provisionable properties for KeyValue that are not part of the generated code. </summary>
         partial void DefineAdditionalProperties();
+
+        /// <summary> Get the requirements for naming this resource. </summary>
+        /// <returns> Naming requirements. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override ResourceNameRequirements GetResourceNameRequirements() => new ResourceNameRequirements(1, 24, ResourceNameCharacters.LowercaseLetters | ResourceNameCharacters.UppercaseLetters | ResourceNameCharacters.Numbers | ResourceNameCharacters.Hyphen);
 
         /// <summary></summary>
         public static partial class ResourceVersions

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -90,7 +90,6 @@
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.1.tgz",
       "integrity": "sha512-aGxEeuk5fqeb9YfalNWTQtAVLIzPkbxObcmCH02XtHvd4Vd2u1hy4l714OB3rz0V+xR30IOSRGLfFnbEv3c1oA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0",
@@ -117,6 +116,7 @@
       "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
       "integrity": "sha512-haufuXCdGZNzQ1Ak0kyNAVIOtbWQzqJf4KChjgz98IDIHFyg4KD1prCNatFhrzcG/kLbrNEFLNgeCCHxUxMtrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
       }
@@ -163,6 +163,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
       "integrity": "sha512-pFCH82WUR+PdupXuQVRLhKqzbiBHzuS6VbRw3NROPyGXqzNIiN6byVq3/cAEHNhDrMQJseH2n+ISjuamLEv0AQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@azure-tools/typespec-client-generator-core": ">=0.66.0 <0.67.0 || ~0.67.0-0",
         "@typespec/compiler": "^1.10.0",
@@ -1662,7 +1663,6 @@
       "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1707,7 +1707,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1923,7 +1922,6 @@
       "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.10.0.tgz",
       "integrity": "sha512-R6BATDkughntPpaxeESJF+wxma5PEjgmnnKvH0/ByqUH8VyhIckQWE9kkP0Uc/EJ0o0VYhe8qCwWQvV70k5lTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "~7.29.0",
         "@inquirer/prompts": "^8.0.1",
@@ -1971,6 +1969,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.80.0.tgz",
       "integrity": "sha512-FrWEUwxhDNbE2YN4fyqV5Qrz9qFJbvPoiKrJM7dexkb7eyhepq3dbc5zZgAm/qFBQ+XxGQQVJ4swXxKT+338fw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1983,7 +1982,6 @@
       "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.10.0.tgz",
       "integrity": "sha512-/fj55fmUj4m/FmNdfH0V52menVrmS2r5Xj9d1H+pnjQbxvvaxS906RSRcoF8kbg3PvlibP/Py5u82TAk53AyqA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2033,7 +2031,6 @@
       "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.80.0.tgz",
       "integrity": "sha512-xczXLoB2akSIDner41gQYTS9CG6TdCN0QHYvXBT6ZrYEnBh+pMvdymW//5CSOTamZLOGo9AOJVJaFfwbFA4vQQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2076,7 +2073,6 @@
       "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.80.0.tgz",
       "integrity": "sha512-WQCT0jN2lSRfwOy+Cd1KUYzenpKR5TdoX0uW6zQdvxQ9nQZIXoaSaReh9/ldhmSV4xv3p2dqF9oq1cdbVGfJTg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2089,6 +2085,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.80.0.tgz",
       "integrity": "sha512-Qfy5eyCcOF3xYOU/dejhpmmeY75U1Q9C8XBE+GvSZ3lakRfKBIpT+X6Q07qmKSAbGYJZKYLWCIAy/dgCuu/OAA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2243,7 +2240,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -2281,7 +2277,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2761,7 +2756,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4845,7 +4839,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4950,7 +4943,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5021,7 +5013,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5138,7 +5129,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5152,7 +5142,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -90,6 +90,7 @@
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.1.tgz",
       "integrity": "sha512-aGxEeuk5fqeb9YfalNWTQtAVLIzPkbxObcmCH02XtHvd4Vd2u1hy4l714OB3rz0V+xR30IOSRGLfFnbEv3c1oA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0",
@@ -116,7 +117,6 @@
       "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
       "integrity": "sha512-haufuXCdGZNzQ1Ak0kyNAVIOtbWQzqJf4KChjgz98IDIHFyg4KD1prCNatFhrzcG/kLbrNEFLNgeCCHxUxMtrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
       }
@@ -163,7 +163,6 @@
       "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
       "integrity": "sha512-pFCH82WUR+PdupXuQVRLhKqzbiBHzuS6VbRw3NROPyGXqzNIiN6byVq3/cAEHNhDrMQJseH2n+ISjuamLEv0AQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@azure-tools/typespec-client-generator-core": ">=0.66.0 <0.67.0 || ~0.67.0-0",
         "@typespec/compiler": "^1.10.0",
@@ -1663,6 +1662,7 @@
       "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -1707,6 +1707,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1922,6 +1923,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.10.0.tgz",
       "integrity": "sha512-R6BATDkughntPpaxeESJF+wxma5PEjgmnnKvH0/ByqUH8VyhIckQWE9kkP0Uc/EJ0o0VYhe8qCwWQvV70k5lTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "~7.29.0",
         "@inquirer/prompts": "^8.0.1",
@@ -1969,7 +1971,6 @@
       "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.80.0.tgz",
       "integrity": "sha512-FrWEUwxhDNbE2YN4fyqV5Qrz9qFJbvPoiKrJM7dexkb7eyhepq3dbc5zZgAm/qFBQ+XxGQQVJ4swXxKT+338fw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -1982,6 +1983,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.10.0.tgz",
       "integrity": "sha512-/fj55fmUj4m/FmNdfH0V52menVrmS2r5Xj9d1H+pnjQbxvvaxS906RSRcoF8kbg3PvlibP/Py5u82TAk53AyqA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2031,6 +2033,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.80.0.tgz",
       "integrity": "sha512-xczXLoB2akSIDner41gQYTS9CG6TdCN0QHYvXBT6ZrYEnBh+pMvdymW//5CSOTamZLOGo9AOJVJaFfwbFA4vQQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2073,6 +2076,7 @@
       "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.80.0.tgz",
       "integrity": "sha512-WQCT0jN2lSRfwOy+Cd1KUYzenpKR5TdoX0uW6zQdvxQ9nQZIXoaSaReh9/ldhmSV4xv3p2dqF9oq1cdbVGfJTg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2085,7 +2089,6 @@
       "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.80.0.tgz",
       "integrity": "sha512-Qfy5eyCcOF3xYOU/dejhpmmeY75U1Q9C8XBE+GvSZ3lakRfKBIpT+X6Q07qmKSAbGYJZKYLWCIAy/dgCuu/OAA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
@@ -2240,6 +2243,7 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -2277,6 +2281,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2756,6 +2761,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4839,6 +4845,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4943,6 +4950,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5013,6 +5021,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5129,6 +5138,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5142,6 +5152,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",


### PR DESCRIPTION
## Summary

Implements the provisioning generator side of #56743: generates `GetResourceNameRequirements()` overrides on provisioning resource classes using ARM spec name constraints (`@pattern`, `@minLength`, `@maxLength`).

### Changes

- **`ProvisioningResourceProvider.cs`**: Added `BuildGetResourceNameRequirementsMethod()` that reads `NameConstraints` from `ArmProviderSchema` and emits a `GetResourceNameRequirements()` override returning the appropriate `ResourceNameRequirements` with parsed `ResourceNameCharacters` flags.
- **`ResourceNameConstraintsHelper.cs`** (new): Regex-based pattern-to-`ResourceNameCharacters` converter using C# 14 extension syntax. Compiles the ARM `@pattern` decorator value as a `Regex` and tests representative characters to determine which `ResourceNameCharacters` flags to set.
- **Regenerated test projects**: `ConfigurationStore.cs` and `KeyValue.cs` now include `GetResourceNameRequirements()` overrides.

### Approach

Instead of manually parsing regex character classes, the pattern string is compiled as a `Regex` and representative characters from each `ResourceNameCharacters` flag (lowercase letters, uppercase letters, numbers, hyphen, underscore, period, parentheses) are tested with `Regex.IsMatch`. This is simpler, more maintainable, and correctly handles any valid regex pattern.

Fixes #56743