### PR TITLE
Fix missing AddJsonFile call in SecureCredentialHandling doc snippet

### DIFF
--- a/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
+++ b/sdk/core/Azure.Core/src/docs/SecureCredentialHandling.md
@@ -148,6 +148,7 @@ This maps the Key Vault secret to the configuration path `Clients:MyClient:Crede
 ```csharp
 HostApplicationBuilder builder = Host.CreateApplicationBuilder();
 
+builder.Configuration.AddJsonFile("appsettings.json");
 builder.Configuration.AddKeyVaultSecrets("AzureClients:KeyVault");
 
 builder.AddClient<MyClient, MyClientSettings>("Clients:MyClient");


### PR DESCRIPTION
The Key Vault production example in `SecureCredentialHandling.md` was missing the `AddJsonFile("appsettings.json")` call needed to load the JSON configuration source before adding Key Vault secrets on top.

### Changes
- Added `builder.Configuration.AddJsonFile("appsettings.json");` before the `AddKeyVaultSecrets` call in the "Azure Key Vault (Production)" code snippet.