### PR TITLE
[MPG Generator] Fix paging action operations to not resource-wrap return types

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableResourceProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableResourceProvider.cs
@@ -313,15 +313,17 @@ namespace Azure.Generator.Management.Providers
                 methodName = isAsync ? $"{baseName}Async" : baseName;
             }
 
-            return BuildServiceMethod(resourceMethod.InputMethod, resourceMethod.InputClient, isAsync, methodName, resource);
+            // Action operations should not resource-wrap paging results
+            var skipResourceWrapping = resourceMethod.Kind == ResourceOperationKind.Action;
+            return BuildServiceMethod(resourceMethod.InputMethod, resourceMethod.InputClient, isAsync, methodName, resource, skipResourceWrapping);
         }
 
-        protected MethodProvider BuildServiceMethod(InputServiceMethod method, InputClient inputClient, bool isAsync, string? methodName = null, ResourceClientProvider? explicitResourceClient = null)
+        protected MethodProvider BuildServiceMethod(InputServiceMethod method, InputClient inputClient, bool isAsync, string? methodName = null, ResourceClientProvider? explicitResourceClient = null, bool skipResourceWrapping = false)
         {
             var clientInfo = _clientInfos[inputClient];
             return method switch
             {
-                InputPagingServiceMethod pagingMethod => new PageableOperationMethodProvider(this, _operationContext, clientInfo, pagingMethod, isAsync, methodName, explicitResourceClient),
+                InputPagingServiceMethod pagingMethod => new PageableOperationMethodProvider(this, _operationContext, clientInfo, pagingMethod, isAsync, methodName, explicitResourceClient, skipResourceWrapping),
                 _ => BuildNonPagingServiceMethod(method, clientInfo, isAsync, methodName, explicitResourceClient)
             };
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableResourceProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableResourceProvider.cs
@@ -314,16 +314,16 @@ namespace Azure.Generator.Management.Providers
             }
 
             // Action operations should not resource-wrap paging results
-            var skipResourceWrapping = resourceMethod.Kind == ResourceOperationKind.Action;
-            return BuildServiceMethod(resourceMethod.InputMethod, resourceMethod.InputClient, isAsync, methodName, resource, skipResourceWrapping);
+            var isResourceAction = resourceMethod.Kind == ResourceOperationKind.Action;
+            return BuildServiceMethod(resourceMethod.InputMethod, resourceMethod.InputClient, isAsync, methodName, resource, isResourceAction);
         }
 
-        protected MethodProvider BuildServiceMethod(InputServiceMethod method, InputClient inputClient, bool isAsync, string? methodName = null, ResourceClientProvider? explicitResourceClient = null, bool skipResourceWrapping = false)
+        protected MethodProvider BuildServiceMethod(InputServiceMethod method, InputClient inputClient, bool isAsync, string? methodName = null, ResourceClientProvider? explicitResourceClient = null, bool isResourceAction = false)
         {
             var clientInfo = _clientInfos[inputClient];
             return method switch
             {
-                InputPagingServiceMethod pagingMethod => new PageableOperationMethodProvider(this, _operationContext, clientInfo, pagingMethod, isAsync, methodName, explicitResourceClient, skipResourceWrapping),
+                InputPagingServiceMethod pagingMethod => new PageableOperationMethodProvider(this, _operationContext, clientInfo, pagingMethod, isAsync, methodName, explicitResourceClient, isResourceAction),
                 _ => BuildNonPagingServiceMethod(method, clientInfo, isAsync, methodName, explicitResourceClient)
             };
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/PageableOperationMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/PageableOperationMethodProvider.cs
@@ -42,7 +42,7 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             bool isAsync,
             string? methodName = null,
             ResourceClientProvider? explicitResourceClient = null,
-            bool skipResourceWrapping = false)
+            bool isResourceAction = false)
         {
             _enclosingType = enclosingType;
             _operationContext = operationContext;
@@ -57,7 +57,7 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
                 ref _actualItemType!,
                 ref _itemResourceClient,
                 explicitResourceClient,
-                skipResourceWrapping
+                isResourceAction
             );
             _methodName = methodName ?? _convenienceMethod.Signature.Name;
             _signature = CreateSignature();
@@ -69,11 +69,11 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             ref CSharpType actualItemType,
             ref ResourceClientProvider? resourceClient,
             ResourceClientProvider? explicitResourceClient = null,
-            bool skipResourceWrapping = false
+            bool isResourceAction = false
             )
         {
             actualItemType = itemType;
-            if (skipResourceWrapping)
+            if (isResourceAction)
             {
                 return;
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/PageableOperationMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/PageableOperationMethodProvider.cs
@@ -41,7 +41,8 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             InputPagingServiceMethod method,
             bool isAsync,
             string? methodName = null,
-            ResourceClientProvider? explicitResourceClient = null)
+            ResourceClientProvider? explicitResourceClient = null,
+            bool skipResourceWrapping = false)
         {
             _enclosingType = enclosingType;
             _operationContext = operationContext;
@@ -55,7 +56,8 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
                 _itemType,
                 ref _actualItemType!,
                 ref _itemResourceClient,
-                explicitResourceClient
+                explicitResourceClient,
+                skipResourceWrapping
             );
             _methodName = methodName ?? _convenienceMethod.Signature.Name;
             _signature = CreateSignature();
@@ -66,10 +68,15 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             CSharpType itemType,
             ref CSharpType actualItemType,
             ref ResourceClientProvider? resourceClient,
-            ResourceClientProvider? explicitResourceClient = null
+            ResourceClientProvider? explicitResourceClient = null,
+            bool skipResourceWrapping = false
             )
         {
             actualItemType = itemType;
+            if (skipResourceWrapping)
+            {
+                return;
+            }
             // If explicit resource client is provided, use it to avoid incorrect lookup when multiple resources share same model
             if (explicitResourceClient != null && explicitResourceClient.ResourceData.Type.Equals(itemType))
             {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -372,10 +372,10 @@ namespace Azure.Generator.Management.Providers
                 if (method is InputPagingServiceMethod pagingMethod)
                 {
                     // Action operations should not resource-wrap paging results
-                    var isAction = methodKind == ResourceOperationKind.Action;
+                    var isResourceAction = methodKind == ResourceOperationKind.Action;
                     // Use PageableOperationMethodProvider for InputPagingServiceMethod
-                    operationMethods.Add(new PageableOperationMethodProvider(this, _operationContext, restClientInfo, pagingMethod, true, methodName: ResourceHelpers.GetOperationMethodName(methodKind, true, false), skipResourceWrapping: isAction));
-                    operationMethods.Add(new PageableOperationMethodProvider(this, _operationContext, restClientInfo, pagingMethod, false, methodName: ResourceHelpers.GetOperationMethodName(methodKind, false, false), skipResourceWrapping: isAction));
+                    operationMethods.Add(new PageableOperationMethodProvider(this, _operationContext, restClientInfo, pagingMethod, true, methodName: ResourceHelpers.GetOperationMethodName(methodKind, true, false), isResourceAction: isResourceAction));
+                    operationMethods.Add(new PageableOperationMethodProvider(this, _operationContext, restClientInfo, pagingMethod, false, methodName: ResourceHelpers.GetOperationMethodName(methodKind, false, false), isResourceAction: isResourceAction));
 
                     continue;
                 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -371,9 +371,11 @@ namespace Azure.Generator.Management.Providers
 
                 if (method is InputPagingServiceMethod pagingMethod)
                 {
+                    // Action operations should not resource-wrap paging results
+                    var isAction = methodKind == ResourceOperationKind.Action;
                     // Use PageableOperationMethodProvider for InputPagingServiceMethod
-                    operationMethods.Add(new PageableOperationMethodProvider(this, _operationContext, restClientInfo, pagingMethod, true, methodName: ResourceHelpers.GetOperationMethodName(methodKind, true, false)));
-                    operationMethods.Add(new PageableOperationMethodProvider(this, _operationContext, restClientInfo, pagingMethod, false, methodName: ResourceHelpers.GetOperationMethodName(methodKind, false, false)));
+                    operationMethods.Add(new PageableOperationMethodProvider(this, _operationContext, restClientInfo, pagingMethod, true, methodName: ResourceHelpers.GetOperationMethodName(methodKind, true, false), skipResourceWrapping: isAction));
+                    operationMethods.Add(new PageableOperationMethodProvider(this, _operationContext, restClientInfo, pagingMethod, false, methodName: ResourceHelpers.GetOperationMethodName(methodKind, false, false), skipResourceWrapping: isAction));
 
                     continue;
                 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
@@ -493,6 +493,7 @@ namespace Azure.Generator.Management.Tests.Common
         /// <param name="response"></param>
         /// <param name="exception"></param>
         /// <param name="pagingMetadata"></param>
+        /// <param name="crossLanguageDefinitionId"></param>
         /// <returns></returns>
         public static InputPagingServiceMethod PagingServiceMethod(
            string name,
@@ -501,7 +502,8 @@ namespace Azure.Generator.Management.Tests.Common
            IReadOnlyList<InputMethodParameter>? parameters = null,
            InputServiceMethodResponse? response = null,
            InputServiceMethodResponse? exception = null,
-           InputPagingServiceMetadata? pagingMetadata = null)
+           InputPagingServiceMetadata? pagingMetadata = null,
+           string? crossLanguageDefinitionId = null)
         {
             return new InputPagingServiceMethod(
                 name,
@@ -516,7 +518,7 @@ namespace Azure.Generator.Management.Tests.Common
                 false,
                 true,
                 true,
-                string.Empty,
+                crossLanguageDefinitionId ?? Guid.NewGuid().ToString(),
                 pagingMetadata ?? PagingMetadata([], null, null));
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Common/InputFactory.cs
@@ -493,7 +493,6 @@ namespace Azure.Generator.Management.Tests.Common
         /// <param name="response"></param>
         /// <param name="exception"></param>
         /// <param name="pagingMetadata"></param>
-        /// <param name="crossLanguageDefinitionId"></param>
         /// <returns></returns>
         public static InputPagingServiceMethod PagingServiceMethod(
            string name,
@@ -502,8 +501,7 @@ namespace Azure.Generator.Management.Tests.Common
            IReadOnlyList<InputMethodParameter>? parameters = null,
            InputServiceMethodResponse? response = null,
            InputServiceMethodResponse? exception = null,
-           InputPagingServiceMetadata? pagingMetadata = null,
-           string? crossLanguageDefinitionId = null)
+           InputPagingServiceMetadata? pagingMetadata = null)
         {
             return new InputPagingServiceMethod(
                 name,
@@ -518,7 +516,7 @@ namespace Azure.Generator.Management.Tests.Common
                 false,
                 true,
                 true,
-                crossLanguageDefinitionId ?? Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 pagingMetadata ?? PagingMetadata([], null, null));
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/PageableOperationMethodProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/PageableOperationMethodProviderTests.cs
@@ -197,8 +197,7 @@ namespace Azure.Generator.Management.Tests.Providers
                 "listConfigurations",
                 listConfigsOp,
                 parameters: [serverNameMethodParam, subsIdMethodParam, rgMethodParam],
-                pagingMetadata: pagingMetadata,
-                crossLanguageDefinitionId: "Microsoft.Test.Servers.listConfigurations");
+                pagingMetadata: pagingMetadata);
 
             // ===== Build ARM provider schema =====
             var serverResourceIdPattern = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/servers/{serverName}";

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/PageableOperationMethodProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/PageableOperationMethodProviderTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Generator.Management.Tests.Providers
         [TestCase]
         public void PagingAction_DoesNotResourceWrap_ReturnType()
         {
-            var (ServerModel, ConfigModel) = SetupPagingActionScenario(out var plugin);
+            SetupPagingActionScenario(out var plugin);
             var outputLibrary = plugin.Object.OutputLibrary as ManagementOutputLibrary;
             Assert.NotNull(outputLibrary);
 
@@ -33,11 +33,12 @@ namespace Azure.Generator.Management.Tests.Providers
                 .FirstOrDefault(p => p.Name == "ServerResource");
             Assert.NotNull(serverResourceProvider, "ServerResource provider should exist");
 
-            // Find the paging action method (listConfigurations / listConfigurationsAsync)
+            // Find the sync paging action method, explicitly excluding Async variants
             var listConfigMethod = serverResourceProvider!.Methods
-                .FirstOrDefault(m => m.Signature.Name.StartsWith("GetConfigurations", StringComparison.OrdinalIgnoreCase)
-                    || m.Signature.Name.StartsWith("listConfigurations", StringComparison.OrdinalIgnoreCase));
-            Assert.NotNull(listConfigMethod, "Paging action method should exist on ServerResource");
+                .FirstOrDefault(m => !m.Signature.Name.EndsWith("Async", StringComparison.OrdinalIgnoreCase)
+                    && (m.Signature.Name.StartsWith("GetConfigurations", StringComparison.OrdinalIgnoreCase)
+                        || m.Signature.Name.StartsWith("listConfigurations", StringComparison.OrdinalIgnoreCase)));
+            Assert.NotNull(listConfigMethod, "Sync paging action method should exist on ServerResource");
 
             var returnType = listConfigMethod!.Signature.ReturnType;
             Assert.NotNull(returnType);
@@ -61,7 +62,7 @@ namespace Azure.Generator.Management.Tests.Providers
         [TestCase]
         public void PagingAction_DoesNotResourceWrap_AsyncReturnType()
         {
-            var (ServerModel, ConfigModel) = SetupPagingActionScenario(out var plugin);
+            SetupPagingActionScenario(out var plugin);
             var outputLibrary = plugin.Object.OutputLibrary as ManagementOutputLibrary;
             Assert.NotNull(outputLibrary);
 
@@ -97,7 +98,7 @@ namespace Azure.Generator.Management.Tests.Providers
         /// This models the real-world case from the issue: listByServer is an action on ClusterServer
         /// that returns ServerConfiguration items.
         /// </summary>
-        private static (InputModelType ServerModel, InputModelType ConfigModel) SetupPagingActionScenario(
+        private static void SetupPagingActionScenario(
             out Moq.Mock<ManagementClientGenerator> plugin)
         {
             // Create the child resource model (Configuration) - this is what the paging action returns
@@ -236,8 +237,6 @@ namespace Azure.Generator.Management.Tests.Providers
             plugin = ManagementMockHelpers.LoadMockPlugin(
                 inputModels: () => [serverModel, configModel, pageModel],
                 clients: () => [client]);
-
-            return (serverModel, configModel);
         }
 
         private static InputDecoratorInfo BuildArmProviderSchema(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/PageableOperationMethodProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/PageableOperationMethodProviderTests.cs
@@ -1,0 +1,294 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Management.Models;
+using Azure.Generator.Management.Providers;
+using Azure.Generator.Management.Tests.Common;
+using Azure.Generator.Management.Tests.TestHelpers;
+using Azure.ResourceManager;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Providers;
+using NUnit.Framework;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Azure.Generator.Management.Tests.Providers
+{
+    internal class PageableOperationMethodProviderTests
+    {
+        /// <summary>
+        /// Verifies that a paging action operation on a resource does NOT resource-wrap the return type.
+        /// The return type should be Pageable{ConfigurationData}, not Pageable{ConfigurationResource}.
+        /// </summary>
+        [TestCase]
+        public void PagingAction_DoesNotResourceWrap_ReturnType()
+        {
+            var (ServerModel, ConfigModel) = SetupPagingActionScenario(out var plugin);
+            var outputLibrary = plugin.Object.OutputLibrary as ManagementOutputLibrary;
+            Assert.NotNull(outputLibrary);
+
+            // Find the parent resource (Server) - it should have the paging action method
+            var serverResourceProvider = outputLibrary!.TypeProviders
+                .OfType<ResourceClientProvider>()
+                .FirstOrDefault(p => p.Name == "ServerResource");
+            Assert.NotNull(serverResourceProvider, "ServerResource provider should exist");
+
+            // Find the paging action method (listConfigurations / listConfigurationsAsync)
+            var listConfigMethod = serverResourceProvider!.Methods
+                .FirstOrDefault(m => m.Signature.Name.StartsWith("GetConfigurations", StringComparison.OrdinalIgnoreCase)
+                    || m.Signature.Name.StartsWith("listConfigurations", StringComparison.OrdinalIgnoreCase));
+            Assert.NotNull(listConfigMethod, "Paging action method should exist on ServerResource");
+
+            var returnType = listConfigMethod!.Signature.ReturnType;
+            Assert.NotNull(returnType);
+
+            // The return type should be Pageable<T> or AsyncPageable<T>
+            Assert.IsTrue(
+                returnType!.FrameworkType == typeof(Pageable<>) || returnType.FrameworkType == typeof(AsyncPageable<>),
+                $"Return type should be Pageable<> or AsyncPageable<>, but was {returnType}");
+
+            // The generic argument should be the data model type, NOT the resource type
+            var itemType = returnType.Arguments[0];
+            Assert.AreNotEqual("ConfigurationResource", itemType.Name,
+                "Paging action should NOT resource-wrap the return type to ConfigurationResource");
+            Assert.AreEqual("ConfigurationData", itemType.Name,
+                "Paging action should return the raw data type ConfigurationData");
+        }
+
+        /// <summary>
+        /// Verifies the same for the async variant.
+        /// </summary>
+        [TestCase]
+        public void PagingAction_DoesNotResourceWrap_AsyncReturnType()
+        {
+            var (ServerModel, ConfigModel) = SetupPagingActionScenario(out var plugin);
+            var outputLibrary = plugin.Object.OutputLibrary as ManagementOutputLibrary;
+            Assert.NotNull(outputLibrary);
+
+            var serverResourceProvider = outputLibrary!.TypeProviders
+                .OfType<ResourceClientProvider>()
+                .FirstOrDefault(p => p.Name == "ServerResource");
+            Assert.NotNull(serverResourceProvider);
+
+            // Find async variant
+            var asyncMethod = serverResourceProvider!.Methods
+                .FirstOrDefault(m => m.Signature.Name.EndsWith("Async", StringComparison.OrdinalIgnoreCase)
+                    && (m.Signature.Name.Contains("GetConfigurations", StringComparison.OrdinalIgnoreCase)
+                        || m.Signature.Name.Contains("listConfigurations", StringComparison.OrdinalIgnoreCase)));
+            Assert.NotNull(asyncMethod, "Async paging action method should exist on ServerResource");
+
+            var returnType = asyncMethod!.Signature.ReturnType;
+            Assert.NotNull(returnType);
+
+            Assert.AreEqual(typeof(AsyncPageable<>), returnType!.FrameworkType,
+                "Async return type should be AsyncPageable<>");
+
+            var itemType = returnType.Arguments[0];
+            Assert.AreNotEqual("ConfigurationResource", itemType.Name,
+                "Async paging action should NOT resource-wrap the return type");
+            Assert.AreEqual("ConfigurationData", itemType.Name,
+                "Async paging action should return the raw data type ConfigurationData");
+        }
+
+        /// <summary>
+        /// Sets up a scenario with two resources:
+        /// - ServerResource (parent) with a Read operation and a paging Action that returns ConfigurationData
+        /// - ConfigurationResource (child) with a Read operation
+        /// This models the real-world case from the issue: listByServer is an action on ClusterServer
+        /// that returns ServerConfiguration items.
+        /// </summary>
+        private static (InputModelType ServerModel, InputModelType ConfigModel) SetupPagingActionScenario(
+            out Moq.Mock<ManagementClientGenerator> plugin)
+        {
+            // Create the child resource model (Configuration) - this is what the paging action returns
+            var configModel = InputFactory.Model("ConfigurationData",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("value", InputPrimitiveType.String, isReadOnly: false),
+                ],
+                decorators: []);
+
+            // Create the parent resource model (Server)
+            var serverModel = InputFactory.Model("ServerData",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("location", InputPrimitiveType.String, isReadOnly: false),
+                ],
+                decorators: []);
+
+            // Create the page wrapper model for the paging response
+            var pageModel = InputFactory.Model("ConfigurationListResult",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties:
+                [
+                    InputFactory.Property("value", InputFactory.Array(configModel)),
+                    InputFactory.Property("nextLink", InputPrimitiveType.Url),
+                ]);
+
+            var uuidType = new InputPrimitiveType(InputPrimitiveTypeKind.String, "uuid", "Azure.Core.uuid");
+
+            // Common path parameters
+            var subsIdParam = InputFactory.PathParameter("subscriptionId", uuidType, isRequired: true);
+            var rgParam = InputFactory.PathParameter("resourceGroupName", InputPrimitiveType.String, isRequired: true);
+            var serverNameParam = InputFactory.PathParameter("serverName", InputPrimitiveType.String, isRequired: true);
+            var configNameParam = InputFactory.PathParameter("configurationName", InputPrimitiveType.String, isRequired: true);
+
+            // Method parameters
+            var subsIdMethodParam = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
+            var rgMethodParam = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var serverNameMethodParam = InputFactory.MethodParameter("serverName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var configNameMethodParam = InputFactory.MethodParameter("configurationName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+
+            // ===== Server resource operations =====
+            var serverPath = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/servers/{serverName}";
+            var serverResponse = InputFactory.OperationResponse(statusCodes: [200], bodytype: serverModel);
+
+            var getServerOp = InputFactory.Operation(
+                name: "getServer",
+                responses: [serverResponse],
+                parameters: [subsIdParam, rgParam, serverNameParam],
+                path: serverPath);
+
+            var getServerMethod = InputFactory.BasicServiceMethod(
+                "getServer",
+                getServerOp,
+                parameters: [serverNameMethodParam, subsIdMethodParam, rgMethodParam],
+                crossLanguageDefinitionId: "Microsoft.Test.Servers.get");
+
+            // ===== Configuration resource operations =====
+            var configPath = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/servers/{serverName}/configurations/{configurationName}";
+            var configResponse = InputFactory.OperationResponse(statusCodes: [200], bodytype: configModel);
+
+            var getConfigOp = InputFactory.Operation(
+                name: "getConfiguration",
+                responses: [configResponse],
+                parameters: [subsIdParam, rgParam, serverNameParam, configNameParam],
+                path: configPath);
+
+            var getConfigMethod = InputFactory.BasicServiceMethod(
+                "getConfiguration",
+                getConfigOp,
+                parameters: [configNameMethodParam, serverNameMethodParam, subsIdMethodParam, rgMethodParam],
+                crossLanguageDefinitionId: "Microsoft.Test.Configurations.get");
+
+            // ===== Paging action on Server that returns Configuration items =====
+            var listConfigsPath = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/servers/{serverName}/configurations";
+            var listConfigsResponse = InputFactory.OperationResponse(statusCodes: [200], bodytype: pageModel);
+
+            var listConfigsOp = InputFactory.Operation(
+                name: "listConfigurations",
+                responses: [listConfigsResponse],
+                parameters: [subsIdParam, rgParam, serverNameParam],
+                path: listConfigsPath,
+                httpMethod: "POST");
+
+            var pagingMetadata = InputFactory.NextLinkPagingMetadata("value", "nextLink", InputResponseLocation.Body);
+
+            var listConfigsMethod = InputFactory.PagingServiceMethod(
+                "listConfigurations",
+                listConfigsOp,
+                parameters: [serverNameMethodParam, subsIdMethodParam, rgMethodParam],
+                pagingMetadata: pagingMetadata,
+                crossLanguageDefinitionId: "Microsoft.Test.Servers.listConfigurations");
+
+            // ===== Build ARM provider schema =====
+            var serverResourceIdPattern = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/servers/{serverName}";
+            var configResourceIdPattern = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/servers/{serverName}/configurations/{configurationName}";
+
+            var serverDecorator = BuildArmProviderSchema(
+                serverModel,
+                [
+                    new ResourceMethod(ResourceOperationKind.Read, getServerMethod, getServerOp.Path, ResourceScope.ResourceGroup, serverResourceIdPattern, null!),
+                    // This is the key: listConfigurations is an Action on Server, not a List
+                    new ResourceMethod(ResourceOperationKind.Action, listConfigsMethod, listConfigsOp.Path, ResourceScope.ResourceGroup, serverResourceIdPattern, null!),
+                ],
+                serverResourceIdPattern,
+                "Microsoft.Test/servers",
+                null,
+                ResourceScope.ResourceGroup,
+                "Server");
+
+            var configDecorator = BuildArmProviderSchema(
+                configModel,
+                [
+                    new ResourceMethod(ResourceOperationKind.Read, getConfigMethod, getConfigOp.Path, ResourceScope.ResourceGroup, configResourceIdPattern, null!),
+                ],
+                configResourceIdPattern,
+                "Microsoft.Test/servers/configurations",
+                null,
+                ResourceScope.ResourceGroup,
+                "Configuration");
+
+            var client = InputFactory.Client(
+                "TestClient",
+                methods: [getServerMethod, getConfigMethod, listConfigsMethod],
+                decorators: [serverDecorator, configDecorator],
+                crossLanguageDefinitionId: "Test.TestClient");
+
+            plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [serverModel, configModel, pageModel],
+                clients: () => [client]);
+
+            return (serverModel, configModel);
+        }
+
+        private static InputDecoratorInfo BuildArmProviderSchema(
+            InputModelType resourceModel,
+            IReadOnlyList<ResourceMethod> methods,
+            string resourceIdPattern,
+            string resourceType,
+            string? singletonResourceName,
+            ResourceScope resourceScope,
+            string? resourceName)
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+            };
+
+            var resourceSchema = new Dictionary<string, object?>
+            {
+                ["resourceModelId"] = resourceModel.CrossLanguageDefinitionId,
+                ["resourceIdPattern"] = resourceIdPattern,
+                ["resourceType"] = resourceType,
+                ["resourceScope"] = resourceScope.ToString(),
+                ["methods"] = methods.Select(SerializeResourceMethod).ToList(),
+                ["singletonResourceName"] = singletonResourceName,
+                ["resourceName"] = resourceName,
+            };
+
+            var arguments = new Dictionary<string, BinaryData>
+            {
+                ["resources"] = BinaryData.FromObjectAsJson(new[] { resourceSchema }, options),
+                ["nonResourceMethods"] = BinaryData.FromObjectAsJson(Array.Empty<object>(), options)
+            };
+
+            return new InputDecoratorInfo("Azure.ClientGenerator.Core.@armProviderSchema", arguments);
+
+            static Dictionary<string, string> SerializeResourceMethod(ResourceMethod m)
+            {
+                var result = new Dictionary<string, string>
+                {
+                    ["methodId"] = m.InputMethod.CrossLanguageDefinitionId,
+                    ["kind"] = m.Kind.ToString(),
+                    ["operationPath"] = m.OperationPath,
+                    ["operationScope"] = m.OperationScope.ToString()
+                };
+                if (m.ResourceScopeIdPattern != null)
+                {
+                    result["resourceScope"] = m.ResourceScopeIdPattern;
+                }
+                return result;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes #57110 - paging action operations were incorrectly having their return types resource-wrapped.

When a paging operation is an ARM **action** (e.g., `ArmResourceActionSync`), not a **list**, the generator should return the raw data type (`Pageable<ConfigurationData>`), not the resource-wrapped type (`Pageable<ConfigurationResource>`).

### Root cause

`PageableOperationMethodProvider.InitializeTypeInfo()` performs a fallback lookup via `TryGetResourceClientProvider` to find a matching resource for the paged item's data type. This lookup doesn't distinguish between Action and List operation kinds - it always wraps if a matching resource exists.

### Fix

Added a `skipResourceWrapping` parameter to `PageableOperationMethodProvider` that bypasses the resource data type to resource type lookup. This flag is set to `true` when the ARM operation kind is `ResourceOperationKind.Action` in both:
- `ResourceClientProvider.BuildMethods()`
- `MockableResourceProvider.BuildResourceServiceMethod()`

### Changes

| File | Change |
|------|--------|
| `PageableOperationMethodProvider.cs` | Added `skipResourceWrapping` parameter to constructor and `InitializeTypeInfo` |
| `ResourceClientProvider.cs` | Pass `skipResourceWrapping: true` for Action operations |
| `MockableResourceProvider.cs` | Thread `skipResourceWrapping` through for Action operations |
| `PageableOperationMethodProviderTests.cs` | **New** - 2 tests verifying paging actions don't resource-wrap |
| `InputFactory.cs` | Added `crossLanguageDefinitionId` param to `PagingServiceMethod` helper |

### Testing

- 2 new unit tests for sync/async paging action return types
- All 121 existing tests pass

Fixes #57110

> **Note:** This PR was authored by GitHub Copilot.