### PR TITLE
Relax exact version pins for in-repo generator packages

### DIFF
--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -7,8 +7,8 @@
 
   <!-- Packages used by the TypeSpec generators -->
   <ItemGroup Condition="'$(IsGeneratorLibrary)' == 'true'">
-    <PackageVersion Include="Azure.Generator" Version="[$(AzureGeneratorVersion)]" />
-    <PackageVersion Include="Azure.Generator.Management" Version="[$(AzureManagementGeneratorVersion)]" />
+    <PackageVersion Include="Azure.Generator" Version="$(AzureGeneratorVersion)" />
+    <PackageVersion Include="Azure.Generator.Management" Version="$(AzureManagementGeneratorVersion)" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.1" />
     <PackageVersion Include="Microsoft.TypeSpec.Generator.ClientModel" Version="[$(UnbrandedGeneratorVersion)]" />
     <PackageVersion Include="Microsoft.TypeSpec.Generator.Input" Version="[$(UnbrandedGeneratorVersion)]" />


### PR DESCRIPTION
## Problem

The provisioning generator build fails with **NU1608** when in-repo generator packages (\Azure.Generator\, \Azure.Generator.Management\) are published on different schedules. The exact version pins (\[version]\) baked into published NuGet packages conflict when CPM resolves a newer version:

\\\
Azure.Generator.Management 1.0.0-alpha.20260313.1 requires Azure.Generator (= 1.0.0-alpha.20260310.3)
but version Azure.Generator 1.0.0-alpha.20260312.1 was resolved.
\\\

Example build failure: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6012047&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=352c26c2-0ff9-5c2d-4ae8-5acc0e1d472e

## Fix

Change the CPM version constraints for \Azure.Generator\ and \Azure.Generator.Management\ from exact \[version]\ to minimum \ersion\ (i.e., \>= version\). This allows a newer resolved version to satisfy the dependency without triggering NU1608.

External typespec packages (\Microsoft.TypeSpec.Generator.ClientModel\, \Microsoft.TypeSpec.Generator.Input\) retain their exact pins since cross-repo version drift is riskier.