### PR TITLE
[SRP] add E2E test to cover none GUID format domainGUID value

### DIFF
--- a/sdk/storage/Azure.ResourceManager.Storage/assets.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.ResourceManager.Storage",
-  "Tag": "net/storage/Azure.ResourceManager.Storage_f51ce6ec32"
+  "Tag": "net/storage/Azure.ResourceManager.Storage_42c580a933"
 }

--- a/sdk/storage/Azure.ResourceManager.Storage/assets.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.ResourceManager.Storage",
-  "Tag": "net/storage/Azure.ResourceManager.Storage_ea3be373ba"
+  "Tag": "net/storage/Azure.ResourceManager.Storage_82e8fb541b"
 }

--- a/sdk/storage/Azure.ResourceManager.Storage/assets.json
+++ b/sdk/storage/Azure.ResourceManager.Storage/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/storage/Azure.ResourceManager.Storage",
-  "Tag": "net/storage/Azure.ResourceManager.Storage_82e8fb541b"
+  "Tag": "net/storage/Azure.ResourceManager.Storage_f51ce6ec32"
 }

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/Tests/StorageAccountTests.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/Tests/StorageAccountTests.cs
@@ -2547,17 +2547,16 @@ namespace Azure.ResourceManager.Storage.Tests
 
         [Test]
         [RecordedTest]
-        public async Task StorageAccountNoneGuidFormatDomainGuid()
+        public async Task StorageAccountNonGuidFormatDomainGuid()
         {
+            // E2E test for issue https://github.com/Azure/azure-sdk-for-net/issues/56903
             //create storage account
             _resourceGroup = await CreateResourceGroupAsync();
             string accountName = await CreateValidAccountNameAsync(namePrefix);
 
-
-            // This E2E test for issue https://github.com/Azure/azure-sdk-for-net/issues/56903
             // With domainName = " ", domainId = Guid.Empty, can create a storage account which server returns domainId as " ".
             // If re-record this case, need check the record file to make sure server still return domainId as " ".
-            // We still don't find a way to set domainId to other none GUID value on server with .net SDK, but has unit test to cover other value in test class StorageActiveDirectoryPropertiesSerializationTests.
+            // We still don't find a way to set domainId to other non-GUID value on server with .net SDK, but has unit test to cover other value in test class StorageActiveDirectoryPropertiesSerializationTests.
             string domainName = " ";
             var domainId = Guid.Empty;
             var data = new FilesIdentityBasedAuthentication(DirectoryServiceOption.Aadkerb)
@@ -2577,12 +2576,14 @@ namespace Azure.ResourceManager.Storage.Tests
             Assert.AreEqual(DirectoryServiceOption.Aadkerb, account.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions);
             Assert.AreEqual(domainName, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainName);
             Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);
+            Assert.IsNull(account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.ActiveDirectoryDomainGuid);
 
             // Get  storage account
             account = (await storageAccountCollection.GetAsync(accountName)).Value;
             Assert.AreEqual(DirectoryServiceOption.Aadkerb, account.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions);
             Assert.AreEqual(domainName, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainName);
             Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);
+            Assert.IsNull(account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.ActiveDirectoryDomainGuid);
 
             // Update storage account
             var updateParameters = new StorageAccountPatch
@@ -2593,12 +2594,14 @@ namespace Azure.ResourceManager.Storage.Tests
             Assert.AreEqual(DirectoryServiceOption.Aadkerb, account.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions);
             Assert.AreEqual(domainName, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainName);
             Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);
+            Assert.IsNull(account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.ActiveDirectoryDomainGuid);
 
             // Get  storage account again
             account = (await storageAccountCollection.GetAsync(accountName)).Value;
             Assert.AreEqual(DirectoryServiceOption.Aadkerb, account.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions);
             Assert.AreEqual(domainName, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainName);
             Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);
+            Assert.IsNull(account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.ActiveDirectoryDomainGuid);
         }
 
         [Test]

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/Tests/StorageAccountTests.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/Tests/StorageAccountTests.cs
@@ -2547,6 +2547,62 @@ namespace Azure.ResourceManager.Storage.Tests
 
         [Test]
         [RecordedTest]
+        public async Task StorageAccountNoneGuidFormatDomainGuid()
+        {
+            //create storage account
+            _resourceGroup = await CreateResourceGroupAsync();
+            string accountName = await CreateValidAccountNameAsync(namePrefix);
+
+
+            // This E2E test for issue https://github.com/Azure/azure-sdk-for-net/issues/56903
+            // With domainName = " ", domainId = Guid.Empty, can create a storage account which server returns domainId as " ".
+            // If re-record this case, need check the record file to make sure server still return domainId as " ".
+            // We still don't find a way to set domainId to other none GUID value on server with .net SDK, but has unit test to cover other value in test class StorageActiveDirectoryPropertiesSerializationTests.
+            string domainName = " ";
+            var domainId = Guid.Empty;
+            var data = new FilesIdentityBasedAuthentication(DirectoryServiceOption.Aadkerb)
+            {
+                ActiveDirectoryProperties = new StorageActiveDirectoryProperties(domainName, domainId)
+            };
+            var parameters = new StorageAccountCreateOrUpdateContent(
+                new StorageSku(StorageSkuName.StandardLrs),
+                StorageKind.StorageV2,
+                DefaultLocation
+                )
+            {
+                AzureFilesIdentityBasedAuthentication = data
+            };
+            StorageAccountCollection storageAccountCollection = _resourceGroup.GetStorageAccounts();
+            StorageAccountResource account = (await storageAccountCollection.CreateOrUpdateAsync(WaitUntil.Completed, accountName, parameters)).Value;
+            Assert.AreEqual(DirectoryServiceOption.Aadkerb, account.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions);
+            Assert.AreEqual(domainName, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainName);
+            Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);
+
+            // Get  storage account
+            account = (await storageAccountCollection.GetAsync(accountName)).Value;
+            Assert.AreEqual(DirectoryServiceOption.Aadkerb, account.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions);
+            Assert.AreEqual(domainName, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainName);
+            Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);
+
+            // Update storage account
+            var updateParameters = new StorageAccountPatch
+            {
+                AzureFilesIdentityBasedAuthentication = data
+            };
+            account = (await account.UpdateAsync(updateParameters)).Value;
+            Assert.AreEqual(DirectoryServiceOption.Aadkerb, account.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions);
+            Assert.AreEqual(domainName, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainName);
+            Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);
+
+            // Get  storage account again
+            account = (await storageAccountCollection.GetAsync(accountName)).Value;
+            Assert.AreEqual(DirectoryServiceOption.Aadkerb, account.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions);
+            Assert.AreEqual(domainName, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainName);
+            Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);
+        }
+
+        [Test]
+        [RecordedTest]
         public async Task StorageAccountCreateSetGetFileSmbOauth()
         {
             //create storage account

--- a/sdk/storage/Azure.ResourceManager.Storage/tests/Tests/StorageAccountTests.cs
+++ b/sdk/storage/Azure.ResourceManager.Storage/tests/Tests/StorageAccountTests.cs
@@ -2596,8 +2596,16 @@ namespace Azure.ResourceManager.Storage.Tests
             Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);
             Assert.IsNull(account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.ActiveDirectoryDomainGuid);
 
-            // Get  storage account again
-            account = (await storageAccountCollection.GetAsync(accountName)).Value;
+            // List storage account
+            account = null;
+            await foreach (StorageAccountResource account1 in _resourceGroup.GetStorageAccounts().GetAllAsync())
+            {
+                if (account1.Id.Name == accountName)
+                {
+                    account = account1;
+                }
+            }
+            Assert.IsNotNull(account);
             Assert.AreEqual(DirectoryServiceOption.Aadkerb, account.Data.AzureFilesIdentityBasedAuthentication.DirectoryServiceOptions);
             Assert.AreEqual(domainName, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainName);
             Assert.AreEqual(domainId, account.Data.AzureFilesIdentityBasedAuthentication.ActiveDirectoryProperties.DomainGuid);


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
