### PR TITLE
Fix ObjectDisposedException in TableClient.GetEntityAsync (#57079)

### DIFF
--- a/sdk/tables/Azure.Data.Tables/src/TableRestClient.cs
+++ b/sdk/tables/Azure.Data.Tables/src/TableRestClient.cs
@@ -151,7 +151,11 @@ namespace Azure.Data.Tables
             scope.Start();
             try
             {
-                using HttpMessage message = CreateQueryEntityWithPartitionAndRowKeyRequest(table, partitionKey, rowKey, timeout, format, select, filter, context);
+                // Do not dispose the HttpMessage here; the caller needs the Response's ContentStream
+                // to remain readable for deserialization (e.g., in GetEntityInternalAsync).
+                // Disposing the message would dispose the response, which on some runtimes disposes
+                // seekable non-MemoryStream content streams, causing ObjectDisposedException.
+                HttpMessage message = CreateQueryEntityWithPartitionAndRowKeyRequest(table, partitionKey, rowKey, timeout, format, select, filter, context);
                 return _pipeline.ProcessMessage(message, context);
             }
             catch (Exception e)
@@ -184,7 +188,9 @@ namespace Azure.Data.Tables
             scope.Start();
             try
             {
-                using HttpMessage message = CreateQueryEntityWithPartitionAndRowKeyRequest(table, partitionKey, rowKey, timeout, format, select, filter, context);
+                // Do not dispose the HttpMessage here; the caller needs the Response's ContentStream
+                // to remain readable for deserialization (e.g., in GetEntityInternalAsync).
+                HttpMessage message = CreateQueryEntityWithPartitionAndRowKeyRequest(table, partitionKey, rowKey, timeout, format, select, filter, context);
                 return await _pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
             }
             catch (Exception e)

--- a/sdk/tables/Azure.Data.Tables/tests/TableClientTests.cs
+++ b/sdk/tables/Azure.Data.Tables/tests/TableClientTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -736,6 +737,68 @@ namespace Azure.Data.Tables.Tests
   }}
 }}");
             return new(_ => conflictResponse);
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/Azure/azure-sdk-for-net/issues/57079.
+        /// Verifies that GetEntityAsync correctly deserializes the response even when the
+        /// transport response disposes its content stream on Dispose() (as the real HTTP
+        /// transport does for non-MemoryStream seekable streams).
+        /// </summary>
+        [Test]
+        public async Task GetEntityAsyncDoesNotThrowObjectDisposedException()
+        {
+            string entityJson =
+                "{\"odata.etag\": \"W/\\\"datetime'2021-03-23T18%3A28%3A39.9160983Z'\\\"\", \"PartitionKey\": \"pk\", \"RowKey\": \"rk-1\", \"Timestamp\": \"2021-03-23T18:28:39.9160983Z\", \"Value\": \"hello\"}";
+            var response = new StreamDisposingMockResponse(200);
+            response.SetContent(entityJson);
+            var transport = new MockTransport(_ => response);
+            var tableClient = new TableClient(_url, TableName, new MockCredential(), new TableClientOptions { Transport = transport });
+
+            Response<TableEntity> result = await tableClient.GetEntityAsync<TableEntity>("pk", "rk-1");
+
+            Assert.AreEqual("pk", result.Value.PartitionKey);
+            Assert.AreEqual("rk-1", result.Value.RowKey);
+            Assert.AreEqual("hello", result.Value.GetString("Value"));
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/Azure/azure-sdk-for-net/issues/57079.
+        /// Verifies that GetEntityIfExistsAsync correctly deserializes the response even
+        /// when the transport response disposes its content stream on Dispose().
+        /// </summary>
+        [Test]
+        public async Task GetEntityIfExistsAsyncDoesNotThrowObjectDisposedException()
+        {
+            string entityJson =
+                "{\"odata.etag\": \"W/\\\"datetime'2021-03-23T18%3A28%3A39.9160983Z'\\\"\", \"PartitionKey\": \"pk\", \"RowKey\": \"rk-1\", \"Timestamp\": \"2021-03-23T18:28:39.9160983Z\", \"Value\": \"world\"}";
+            var response = new StreamDisposingMockResponse(200);
+            response.SetContent(entityJson);
+            var transport = new MockTransport(_ => response);
+            var tableClient = new TableClient(_url, TableName, new MockCredential(), new TableClientOptions { Transport = transport });
+
+            NullableResponse<TableEntity> result = await tableClient.GetEntityIfExistsAsync<TableEntity>("pk", "rk-1");
+
+            Assert.IsTrue(result.HasValue);
+            Assert.AreEqual("pk", result.Value.PartitionKey);
+            Assert.AreEqual("rk-1", result.Value.RowKey);
+            Assert.AreEqual("world", result.Value.GetString("Value"));
+        }
+
+        /// <summary>
+        /// A mock response that disposes its ContentStream on Dispose(), simulating the
+        /// behavior of the real HttpClientTransportResponse for non-MemoryStream seekable
+        /// streams. Used by regression tests for issue #57079.
+        /// </summary>
+        private class StreamDisposingMockResponse : MockResponse
+        {
+            public StreamDisposingMockResponse(int status) : base(status) { }
+
+            public override void Dispose()
+            {
+                ContentStream?.Dispose();
+                base.Dispose();
+            }
         }
 
         public class EnumEntity : ITableEntity


### PR DESCRIPTION
Remove `using` from HttpMessage in QueryEntityWithPartitionAndRowKey protocol methods to prevent premature disposal of the response content stream. When the HttpMessage was disposed at the end of the method scope, it also disposed the Response, which could dispose the underlying content stream before the caller (GetEntityInternalAsync) had a chance to deserialize it via SerializationHelpers.ResponseToDictionary.

Added regression tests using a StreamDisposingMockResponse that simulates real transport behavior (disposing the content stream on Response.Dispose()) to verify the fix for both GetEntityAsync and GetEntityIfExistsAsync.

Fixes #57079

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
