### PR TITLE
Release System.ClientModel 1.10.0

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `IsReadOnly` property to `ClientPipelineOptions` and `ClientLoggingOptions` so callers can check whether options can still be modified without catching an exception.
 - Added `Clone()` method to `ClientPipelineOptions` and `ClientLoggingOptions` that creates a new mutable instance from an existing instance that may be read-only.
 - Added `ConfigurationSchema.json` to the NuGet package via the MSBuild `JsonSchemaSegment` feature, enabling automatic JSON IntelliSense and validation for `appsettings.json` when configuring System.ClientModel-based clients.
+- Updated BCL dependencies to 10.x.
 
 ### Bugs Fixed
 

--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.10.0-beta.1 (Unreleased)
+## 1.10.0 (2026-03-16)
 
 ### Features Added
 
@@ -8,12 +8,11 @@
 - Added `CollectionResult<T>.FromPages` and `AsyncCollectionResult<T>.FromPages` static factory methods that create collection result instances from pre-existing pages of values for testing. 
 - Added `IsReadOnly` property to `ClientPipelineOptions` and `ClientLoggingOptions` so callers can check whether options can still be modified without catching an exception.
 - Added `Clone()` method to `ClientPipelineOptions` and `ClientLoggingOptions` that creates a new mutable instance from an existing instance that may be read-only.
+- Added `ConfigurationSchema.json` to the NuGet package via the MSBuild `JsonSchemaSegment` feature, enabling automatic JSON IntelliSense and validation for `appsettings.json` when configuring System.ClientModel-based clients.
 
 ### Bugs Fixed
 
 - Fixed implicit conversion operator for `ClientResult<T>` to not throw exceptions on null inputs per Framework Design Guidelines. Null inputs now return `default`.
-
-### Other Changes
 
 ### Breaking Changes
 

--- a/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
+++ b/sdk/core/System.ClientModel/schema/ConfigurationSchema.json
@@ -1,6 +1,6 @@
 {
   "definitions": {
-    "scmCredential": {
+    "credential": {
       "type": "object",
       "description": "Credential configuration for System.ClientModel clients.",
       "properties": {
@@ -102,7 +102,7 @@
         "type": "object",
         "properties": {
           "Credential": {
-            "$ref": "#/definitions/scmCredential"
+            "$ref": "#/definitions/credential"
           },
           "Options": {
             "$ref": "#/definitions/options"

--- a/sdk/core/System.ClientModel/src/System.ClientModel.csproj
+++ b/sdk/core/System.ClientModel/src/System.ClientModel.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Contains building blocks for clients that call cloud services.</Description>
-    <Version>1.10.0-beta.1</Version>
+    <Version>1.10.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.9.0</ApiCompatVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Changes

### System.ClientModel 1.10.0

**CHANGELOG.md**
- Set version to 1.10.0 with release date 2026-03-16
- Added changelog entry for `ConfigurationSchema.json` shipped via the MSBuild `JsonSchemaSegment` feature, enabling automatic JSON IntelliSense for `appsettings.json`
- Removed empty "Other Changes" section

**System.ClientModel.csproj**
- Version bumped from `1.10.0-beta.1` to `1.10.0`

**ConfigurationSchema.json**
- Renamed `scmCredential` definition to `credential` to facilitate merging with credential definitions from other packages (e.g., Azure.Identity)
- Updated internal `$ref` to match the renamed definition