### PR TITLE
Add JSON schema IntelliSense for Azure.Core client configuration

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added `IndonesiaCentral`, `NewZealandNorth`, and `MalaysiaWest` locations to `AzureLocation` struct.
+- Added a JSON schema segment to the NuGet package that provides IntelliSense and validation for `AzureClients` configuration in `appsettings.json`, including `Retry` and `Diagnostics` options.
 
 ### Bugs Fixed
 

--- a/sdk/core/Azure.Core/schema/ConfigurationSchema.json
+++ b/sdk/core/Azure.Core/schema/ConfigurationSchema.json
@@ -1,0 +1,122 @@
+{
+  "definitions": {
+    "retry": {
+      "type": "object",
+      "description": "Retry policy configuration for Azure SDK clients.",
+      "properties": {
+        "MaxRetries": {
+          "type": "integer",
+          "description": "Maximum number of retry attempts before giving up.",
+          "default": 3,
+          "minimum": 0
+        },
+        "Delay": {
+          "type": "string",
+          "description": "Initial delay between retries (TimeSpan format, e.g. '00:00:00.8'). The delay increases with each retry when using Exponential mode. Default: 0.8 seconds."
+        },
+        "MaxDelay": {
+          "type": "string",
+          "description": "Maximum delay between retries (TimeSpan format, e.g. '00:01:00'). Applies when the service does not provide a Retry-After header. Default: 1 minute."
+        },
+        "Mode": {
+          "type": "string",
+          "description": "The approach to use for calculating retry delays.",
+          "enum": [
+            "Fixed",
+            "Exponential"
+          ],
+          "default": "Exponential"
+        },
+        "NetworkTimeout": {
+          "type": "string",
+          "description": "Timeout applied to individual network operations (TimeSpan format, e.g. '00:01:40'). Default: 100 seconds."
+        }
+      },
+      "additionalProperties": false
+    },
+    "diagnostics": {
+      "type": "object",
+      "description": "Diagnostics configuration for Azure SDK clients.",
+      "properties": {
+        "ApplicationId": {
+          "type": "string",
+          "description": "Application identifier appended to the User-Agent header.",
+          "maxLength": 24
+        },
+        "IsLoggingEnabled": {
+          "type": "boolean",
+          "description": "Enable HTTP pipeline logging.",
+          "default": true
+        },
+        "IsTelemetryEnabled": {
+          "type": "boolean",
+          "description": "Enable User-Agent telemetry header. Can also be disabled via the AZURE_TELEMETRY_DISABLED environment variable.",
+          "default": true
+        },
+        "IsDistributedTracingEnabled": {
+          "type": "boolean",
+          "description": "Enable distributed tracing activities (System.Diagnostics.Activity). Can also be disabled via the AZURE_TRACING_DISABLED environment variable.",
+          "default": true
+        },
+        "IsLoggingContentEnabled": {
+          "type": "boolean",
+          "description": "Enable logging of request and response body content.",
+          "default": false
+        },
+        "LoggedContentSizeLimit": {
+          "type": "integer",
+          "description": "Maximum size of logged content in bytes.",
+          "default": 4096,
+          "minimum": 0
+        },
+        "AdditionalLoggedHeaderNames": {
+          "type": "array",
+          "description": "Additional HTTP header names that are not redacted during logging (appended to defaults).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "AdditionalLoggedQueryParameters": {
+          "type": "array",
+          "description": "Additional query parameter names that are not redacted during logging (appended to defaults).",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "azureOptions": {
+      "type": "object",
+      "description": "Azure SDK client options.",
+      "properties": {
+        "Retry": {
+          "$ref": "#/definitions/retry"
+        },
+        "Diagnostics": {
+          "$ref": "#/definitions/diagnostics"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "type": "object",
+  "properties": {
+    "AzureClients": {
+      "type": "object",
+      "description": "Configuration for Azure SDK clients.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "Credential": {
+            "$ref": "#/definitions/credential"
+          },
+          "Options": {
+            "$ref": "#/definitions/azureOptions"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
+++ b/sdk/core/Azure.Core/src/DiagnosticsOptions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Configuration;
 
@@ -50,31 +49,31 @@ namespace Azure.Core
             {
                 IsTelemetryEnabled = !EnvironmentVariableToBool(Environment.GetEnvironmentVariable("AZURE_TELEMETRY_DISABLED")) ?? true;
             }
-            IConfigurationSection loggedHeaderSection = section.GetSection("LoggedHeaderNames");
+            IConfigurationSection loggedHeaderSection = section.GetSection("AdditionalLoggedHeaderNames");
+            LoggedHeaderNames = GetDefaultLoggedHeaders();
             if (loggedHeaderSection.Exists())
             {
-                LoggedHeaderNames = loggedHeaderSection
-                    .GetChildren()
-                    .Where(c => c.Value is not null)
-                    .Select(c => c.Value!)
-                    .ToList();
+                HashSet<string> existing = new(LoggedHeaderNames, StringComparer.OrdinalIgnoreCase);
+                foreach (IConfigurationSection child in loggedHeaderSection.GetChildren())
+                {
+                    if (child.Value is not null && existing.Add(child.Value))
+                    {
+                        LoggedHeaderNames.Add(child.Value);
+                    }
+                }
             }
-            else
-            {
-                LoggedHeaderNames = GetDefaultLoggedHeaders();
-            }
-            IConfigurationSection loggedQueryParametersSection = section.GetSection("LoggedQueryParameters");
+            IConfigurationSection loggedQueryParametersSection = section.GetSection("AdditionalLoggedQueryParameters");
+            LoggedQueryParameters = new List<string> { "api-version" };
             if (loggedQueryParametersSection.Exists())
             {
-                LoggedQueryParameters = loggedQueryParametersSection
-                    .GetChildren()
-                    .Where(c => c.Value is not null)
-                    .Select(c => c.Value!)
-                    .ToList();
-            }
-            else
-            {
-                LoggedQueryParameters = new List<string> { "api-version" };
+                HashSet<string> existing = new(LoggedQueryParameters, StringComparer.OrdinalIgnoreCase);
+                foreach (IConfigurationSection child in loggedQueryParametersSection.GetChildren())
+                {
+                    if (child.Value is not null && existing.Add(child.Value))
+                    {
+                        LoggedQueryParameters.Add(child.Value);
+                    }
+                }
             }
             if (int.TryParse(section["LoggedContentSizeLimit"], out var loggedContentSizeLimit))
             {

--- a/sdk/core/Azure.Core/tests/ClientOptionsConfigurationTests.cs
+++ b/sdk/core/Azure.Core/tests/ClientOptionsConfigurationTests.cs
@@ -32,10 +32,10 @@ namespace Azure.Core.Tests
                 { "TestClient:Diagnostics:IsDistributedTracingEnabled", "false" },
                 { "TestClient:Diagnostics:IsLoggingContentEnabled", "true" },
                 { "TestClient:Diagnostics:LoggedContentSizeLimit", "8192" },
-                { "TestClient:Diagnostics:LoggedHeaderNames:0", "custom-header-1" },
-                { "TestClient:Diagnostics:LoggedHeaderNames:1", "custom-header-2" },
-                { "TestClient:Diagnostics:LoggedQueryParameters:0", "param1" },
-                { "TestClient:Diagnostics:LoggedQueryParameters:1", "param2" }
+                { "TestClient:Diagnostics:AdditionalLoggedHeaderNames:0", "custom-header-1" },
+                { "TestClient:Diagnostics:AdditionalLoggedHeaderNames:1", "custom-header-2" },
+                { "TestClient:Diagnostics:AdditionalLoggedQueryParameters:0", "param1" },
+                { "TestClient:Diagnostics:AdditionalLoggedQueryParameters:1", "param2" }
             };
 
             var configuration = new ConfigurationBuilder()
@@ -52,8 +52,13 @@ namespace Azure.Core.Tests
             Assert.IsFalse(options.Diagnostics.IsDistributedTracingEnabled);
             Assert.IsTrue(options.Diagnostics.IsLoggingContentEnabled);
             Assert.AreEqual(8192, options.Diagnostics.LoggedContentSizeLimit);
-            CollectionAssert.AreEqual(new[] { "custom-header-1", "custom-header-2" }, options.Diagnostics.LoggedHeaderNames);
-            CollectionAssert.AreEqual(new[] { "param1", "param2" }, options.Diagnostics.LoggedQueryParameters);
+            CollectionAssert.Contains(options.Diagnostics.LoggedHeaderNames, "custom-header-1");
+            CollectionAssert.Contains(options.Diagnostics.LoggedHeaderNames, "custom-header-2");
+            CollectionAssert.Contains(options.Diagnostics.LoggedQueryParameters, "param1");
+            CollectionAssert.Contains(options.Diagnostics.LoggedQueryParameters, "param2");
+            // Defaults are preserved
+            CollectionAssert.Contains(options.Diagnostics.LoggedHeaderNames, "x-ms-request-id");
+            CollectionAssert.Contains(options.Diagnostics.LoggedQueryParameters, "api-version");
         }
 
         [Test]
@@ -235,12 +240,12 @@ namespace Azure.Core.Tests
         {
             var configData = new Dictionary<string, string>
             {
-                { "TestClient:Diagnostics:LoggedHeaderNames:0", "header1" },
-                { "TestClient:Diagnostics:LoggedHeaderNames:1", null }, // Null value
-                { "TestClient:Diagnostics:LoggedHeaderNames:2", "header2" },
-                { "TestClient:Diagnostics:LoggedQueryParameters:0", "param1" },
-                { "TestClient:Diagnostics:LoggedQueryParameters:1", null }, // Null value
-                { "TestClient:Diagnostics:LoggedQueryParameters:2", "param2" }
+                { "TestClient:Diagnostics:AdditionalLoggedHeaderNames:0", "header1" },
+                { "TestClient:Diagnostics:AdditionalLoggedHeaderNames:1", null }, // Null value
+                { "TestClient:Diagnostics:AdditionalLoggedHeaderNames:2", "header2" },
+                { "TestClient:Diagnostics:AdditionalLoggedQueryParameters:0", "param1" },
+                { "TestClient:Diagnostics:AdditionalLoggedQueryParameters:1", null }, // Null value
+                { "TestClient:Diagnostics:AdditionalLoggedQueryParameters:2", "param2" }
             };
 
             var configuration = new ConfigurationBuilder()
@@ -252,9 +257,13 @@ namespace Azure.Core.Tests
 
             Assert.IsNotNull(options);
 
-            // Null values should be filtered out
-            CollectionAssert.AreEqual(new[] { "header1", "header2" }, options.Diagnostics.LoggedHeaderNames);
-            CollectionAssert.AreEqual(new[] { "param1", "param2" }, options.Diagnostics.LoggedQueryParameters);
+            // Null values should be filtered out, additional values appended to defaults
+            CollectionAssert.Contains(options.Diagnostics.LoggedHeaderNames, "header1");
+            CollectionAssert.Contains(options.Diagnostics.LoggedHeaderNames, "header2");
+            CollectionAssert.DoesNotContain(options.Diagnostics.LoggedHeaderNames, null);
+            CollectionAssert.Contains(options.Diagnostics.LoggedQueryParameters, "param1");
+            CollectionAssert.Contains(options.Diagnostics.LoggedQueryParameters, "param2");
+            CollectionAssert.DoesNotContain(options.Diagnostics.LoggedQueryParameters, null);
         }
 
         [Test]
@@ -436,8 +445,8 @@ namespace Azure.Core.Tests
             var configData = new Dictionary<string, string>();
             for (int i = 0; i < headers.Count; i++)
             {
-                configData[$"TestClient:Diagnostics:LoggedHeaderNames:{i}"] = headers[i];
-                configData[$"TestClient:Diagnostics:LoggedQueryParameters:{i}"] = parameters[i];
+                configData[$"TestClient:Diagnostics:AdditionalLoggedHeaderNames:{i}"] = headers[i];
+                configData[$"TestClient:Diagnostics:AdditionalLoggedQueryParameters:{i}"] = parameters[i];
             }
 
             var configuration = new ConfigurationBuilder()
@@ -449,8 +458,18 @@ namespace Azure.Core.Tests
 
             Assert.IsNotNull(options);
 
-            CollectionAssert.AreEqual(headers, options.Diagnostics.LoggedHeaderNames);
-            CollectionAssert.AreEqual(parameters, options.Diagnostics.LoggedQueryParameters);
+            // All additional values are appended to defaults
+            foreach (var header in headers)
+            {
+                CollectionAssert.Contains(options.Diagnostics.LoggedHeaderNames, header);
+            }
+            foreach (var param in parameters)
+            {
+                CollectionAssert.Contains(options.Diagnostics.LoggedQueryParameters, param);
+            }
+            // Defaults are still present
+            CollectionAssert.Contains(options.Diagnostics.LoggedHeaderNames, "x-ms-request-id");
+            CollectionAssert.Contains(options.Diagnostics.LoggedQueryParameters, "api-version");
         }
 
         [TestCase("true", true)]


### PR DESCRIPTION
## Description

Adds a `ConfigurationSchema.json` to the Azure.Core NuGet package to provide IntelliSense and validation for the `AzureClients` top-level section in `appsettings.json`.

### Schema defines:
- **`AzureClients`** top-level section with `additionalProperties` for any client name
- **`retry`** definition — `MaxRetries`, `Delay`, `MaxDelay`, `Mode`, `NetworkTimeout` (matching `RetryOptions` API)
- **`diagnostics`** definition — `ApplicationId`, `IsLoggingEnabled`, `IsTelemetryEnabled`, `IsDistributedTracingEnabled`, `IsLoggingContentEnabled`, `LoggedContentSizeLimit`, `AdditionalLoggedHeaderNames`, `AdditionalLoggedQueryParameters` (matching `DiagnosticsOptions` API)
- **`azureOptions`** definition — composes `Retry` + `Diagnostics` via `$ref`, with `additionalProperties: true` for SDK-specific extension via `allOf`
- Each client entry gets `Credential` (cross-package `$ref` to Azure.Identity's `credential` definition) and `Options` (`$ref` to `azureOptions`)

### Binding change:
Updated `DiagnosticsOptions` configuration binding to use **additive** `AdditionalLoggedHeaderNames` / `AdditionalLoggedQueryParameters` with case-insensitive deduplication, matching the pattern established in `System.ClientModel.ClientLoggingOptions`. This ensures defaults are always preserved and config only appends.

### No build config needed:
The shared MSBuild infrastructure in `eng/Directory.Build.Common.targets` (#56778) auto-detects and packs the schema.

Resolves #56780