### PR TITLE
Add unit tests and fix OpenAPI tool handling in Otel scopes

### DIFF
--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs
@@ -1179,6 +1179,19 @@ namespace Azure.AI.Agents.Persistent.Telemetry
                             );
                             break;
 
+                        case RunStepOpenAPIToolCall openAPIToolCall:
+                            toolCallObj = ToJsonElement(
+                                JsonSerializer.Serialize(
+                                    new GenericToolCallEvent(
+                                        id: toolCall.Id,
+                                        type: toolCall.Type,
+                                        details: openAPIToolCall.OpenAPI
+                                    ),
+                                    EventsContext.Default.GenericToolCallEvent
+                                )
+                            );
+                            break;
+
                         default:
                             IReadOnlyDictionary<string, string> toolCallAttributeDetails = GetToolCallAttributes(toolCall);
                             toolCallObj = ToJsonElement(
@@ -1271,14 +1284,23 @@ namespace Azure.AI.Agents.Persistent.Telemetry
 
             // We cannot get the properties of an object, because Dynamic types are not AOT compatible.
             // Convert the call to JSON and get properties from it.
+            Dictionary<string, string> toolDetails = [];
             using var memStream = new MemoryStream();
-            toolCall.ToRequestContent().WriteTo(memStream, default);
+            try
+            {
+                toolCall.ToRequestContent().WriteTo(memStream, default);
+            }
+            catch (NullReferenceException)
+            {
+                // Some tool call types may have null properties when partially deserialized
+                // during streaming. Return empty details rather than crashing telemetry.
+                return toolDetails;
+            }
             // Reset stream position to the beginning.
             memStream.Position = 0;
             using var tempDoc = JsonDocument.Parse(memStream);
             // Try to find a property with the parsed name
             var toolCallKind = tempDoc.RootElement.ValueKind;
-            Dictionary<string, string> toolDetails = [];
             foreach (JsonProperty elem in tempDoc.RootElement.EnumerateObject())
             {
                 if (string.Equals(toCamelCase(elem.Name), attributeName) && elem.Value.ValueKind == JsonValueKind.Object)

--- a/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/src/Telemetry/OpenTelemetryScope.cs
@@ -1290,12 +1290,13 @@ namespace Azure.AI.Agents.Persistent.Telemetry
             {
                 toolCall.ToRequestContent().WriteTo(memStream, default);
             }
-            catch (NullReferenceException)
+            catch (NullReferenceException) when (toolCall is RunStepOpenAPIToolCall c && c.OpenAPI is null)
             {
                 // Some tool call types may have null properties when partially deserialized
                 // during streaming. Return empty details rather than crashing telemetry.
                 return toolDetails;
             }
+
             // Reset stream position to the beginning.
             memStream.Position = 0;
             using var tempDoc = JsonDocument.Parse(memStream);

--- a/sdk/ai/Azure.AI.Agents.Persistent/tests/PersistentAgentsTelemetryTests.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/tests/PersistentAgentsTelemetryTests.cs
@@ -1291,6 +1291,43 @@ public partial class PersistentAgentTelemetryTests : RecordedTestBase<AIAgentsTe
         );
     }
 
+    [Test]
+    public void GetToolCallAttributes_WithNullOpenAPI_ReturnsEmptyDictionary()
+    {
+        // Simulate a partially deserialized RunStepOpenAPIToolCall where the "openapi" key
+        // was missing from the JSON, leaving OpenAPI as null. This is the scenario reported
+        // in issue #57183.
+        string json = """{"type":"openapi","id":"call_123"}""";
+        using var doc = JsonDocument.Parse(json);
+        var toolCall = RunStepOpenAPIToolCall.DeserializeRunStepOpenAPIToolCall(doc.RootElement);
+
+        Assert.IsNull(toolCall.OpenAPI);
+
+        // GetToolCallAttributes should not throw; it should return an empty dictionary.
+        var result = Telemetry.OpenTelemetryScope.GetToolCallAttributes(toolCall);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Count);
+    }
+
+    [Test]
+    public void GetToolCallAttributes_WithValidOpenAPI_DoesNotThrow()
+    {
+        // Even with a fully populated OpenAPI tool call, GetToolCallAttributes returns an
+        // empty dictionary because the camelCase conversion of "openapi" yields "Openapi",
+        // which does not match the class-derived attribute name "OpenAPI". This is fine
+        // because ProcessToolCalls handles RunStepOpenAPIToolCall via an explicit case
+        // branch and never reaches GetToolCallAttributes for this type.
+        string json = """{"type":"openapi","id":"call_456","openapi":{"url":"https://example.com","method":"GET"}}""";
+        using var doc = JsonDocument.Parse(json);
+        var toolCall = RunStepOpenAPIToolCall.DeserializeRunStepOpenAPIToolCall(doc.RootElement);
+
+        Assert.IsNotNull(toolCall.OpenAPI);
+
+        var result = Telemetry.OpenTelemetryScope.GetToolCallAttributes(toolCall);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Count);
+    }
+
     #region Helpers
     private void CheckCreateAgentEvent(Activity createAgentSpan, string modelName, string agentName, string content)
     {

--- a/sdk/ai/Azure.AI.Agents.Persistent/tests/PersistentAgentsTelemetryTests.cs
+++ b/sdk/ai/Azure.AI.Agents.Persistent/tests/PersistentAgentsTelemetryTests.cs
@@ -1312,11 +1312,8 @@ public partial class PersistentAgentTelemetryTests : RecordedTestBase<AIAgentsTe
     [Test]
     public void GetToolCallAttributes_WithValidOpenAPI_DoesNotThrow()
     {
-        // Even with a fully populated OpenAPI tool call, GetToolCallAttributes returns an
-        // empty dictionary because the camelCase conversion of "openapi" yields "Openapi",
-        // which does not match the class-derived attribute name "OpenAPI". This is fine
-        // because ProcessToolCalls handles RunStepOpenAPIToolCall via an explicit case
-        // branch and never reaches GetToolCallAttributes for this type.
+        // With a fully populated OpenAPI tool call, GetToolCallAttributes should handle
+        // the input without throwing and return a non-null attribute collection.
         string json = """{"type":"openapi","id":"call_456","openapi":{"url":"https://example.com","method":"GET"}}""";
         using var doc = JsonDocument.Parse(json);
         var toolCall = RunStepOpenAPIToolCall.DeserializeRunStepOpenAPIToolCall(doc.RootElement);
@@ -1325,7 +1322,6 @@ public partial class PersistentAgentTelemetryTests : RecordedTestBase<AIAgentsTe
 
         var result = Telemetry.OpenTelemetryScope.GetToolCallAttributes(toolCall);
         Assert.IsNotNull(result);
-        Assert.AreEqual(0, result.Count);
     }
 
     #region Helpers


### PR DESCRIPTION
This pull request addresses improved handling and telemetry for OpenAPI tool calls, particularly focusing on robustness when deserializing tool call details and ensuring telemetry does not fail on partial data. The main changes include adding explicit handling for `RunStepOpenAPIToolCall` in telemetry processing, improving error handling when tool call properties are missing, and adding tests to verify these behaviors.

Improvements to telemetry handling for OpenAPI tool calls:

* Added a dedicated case for `RunStepOpenAPIToolCall` in `ProcessToolCalls`, ensuring OpenAPI tool call details are serialized and processed correctly for telemetry events.
* Improved error handling in `GetToolCallAttributes` by catching `NullReferenceException` when tool call properties are missing, returning an empty dictionary instead of crashing telemetry.

Testing and validation:

* Added tests in `PersistentAgentsTelemetryTests.cs` to verify that `GetToolCallAttributes` returns an empty dictionary for partially deserialized OpenAPI tool calls and does not throw for valid OpenAPI tool calls.# Contributing to the Azure SDK

Fixes #57183 