### PR TITLE
Support running release pipeline from release/* branches

### DIFF
--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -276,19 +276,14 @@ stages:
                         EnableNuGetCache: false
                     # When the release pipeline runs from a release/* branch,
                     # sync the csproj and merge changelog entries from the
-                    # release commit into main's versions.
+                    # release commit into main's versions.  Overlay main's
+                    # sdk/ tree while keeping eng/ from the build branch so
+                    # the script and its dependencies remain available.
                     - pwsh: |
-                        # Copy the sync script before switching to main, since
-                        # the script may not yet exist on main.
-                        $tempScript = Join-Path $env:TEMP 'Sync-ReleaseArtifacts.ps1'
-                        Copy-Item 'eng/scripts/Sync-ReleaseArtifacts.ps1' $tempScript
-
-                        # Switch working tree to main so the version-bump PR
-                        # is based on main, then overlay release artifacts.
                         git fetch origin main
-                        git checkout origin/main
-
-                        & $tempScript -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}' -SourceCommit '$(Build.SourceVersion)'
+                        git checkout origin/main -- sdk/
+                        git checkout origin/main -- eng/centralpackagemanagement/
+                        eng/scripts/Sync-ReleaseArtifacts.ps1 -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}' -SourceCommit '$(Build.SourceVersion)'
                       displayName: Sync release artifacts into main
                     - pwsh: |
                         eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -SkipCpmUpdate $false

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -268,23 +268,28 @@ stages:
                   steps:
                     - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
                       parameters:
-                        Repositories:
-                          - Name: $(Build.Repository.Name)
-                            Commitish: refs/heads/main
-                            WorkingDirectory: $(System.DefaultWorkingDirectory)
                         paths:
                           - /sdk
 
                     - template: /eng/pipelines/templates/steps/install-dotnet.yml
                       parameters:
                         EnableNuGetCache: false
-                    # When the release pipeline runs from a release/* branch the
-                    # sparse checkout above lands on main.  Sync the csproj and
-                    # merge changelog entries from the release commit into main.
+                    # When the release pipeline runs from a release/* branch,
+                    # sync the csproj and merge changelog entries from the
+                    # release commit into main's versions.
                     - pwsh: |
-                        eng/scripts/Sync-ReleaseArtifacts.ps1 -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}' -SourceCommit '$(Build.SourceVersion)'
+                        # Copy the sync script before switching to main, since
+                        # the script may not yet exist on main.
+                        $tempScript = Join-Path $env:TEMP 'Sync-ReleaseArtifacts.ps1'
+                        Copy-Item 'eng/scripts/Sync-ReleaseArtifacts.ps1' $tempScript
+
+                        # Switch working tree to main so the version-bump PR
+                        # is based on main, then overlay release artifacts.
+                        git fetch origin main
+                        git checkout origin/main
+
+                        & $tempScript -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}' -SourceCommit '$(Build.SourceVersion)'
                       displayName: Sync release artifacts into main
-                      workingDirectory: $(System.DefaultWorkingDirectory)
                     - pwsh: |
                         eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -SkipCpmUpdate $false
                       displayName: Increment package version

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -276,12 +276,11 @@ stages:
                         EnableNuGetCache: false
                     # When the release pipeline runs from a release/* branch,
                     # sync the csproj and merge changelog entries from the
-                    # release commit into main's versions.  Overlay main's
-                    # sdk/ tree while keeping eng/ from the build branch so
-                    # the script and its dependencies remain available.
+                    # release commit into main's versions.  Only overlay the
+                    # specific package directory and CPM files from main.
                     - pwsh: |
                         git fetch origin main
-                        git checkout origin/main -- sdk/
+                        git checkout origin/main -- "sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/"
                         git checkout origin/main -- eng/centralpackagemanagement/
                         eng/scripts/Sync-ReleaseArtifacts.ps1 -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}' -SourceCommit '$(Build.SourceVersion)'
                       displayName: Sync release artifacts into main

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -274,6 +274,24 @@ stages:
                     - template: /eng/pipelines/templates/steps/install-dotnet.yml
                       parameters:
                         EnableNuGetCache: false
+                    # When the release pipeline runs from a release/* branch, the
+                    # version-bump PR must still target main.  Cherry-pick the
+                    # changelog and csproj from the build source commit so
+                    # Update-PkgVersion sees the released version and dated
+                    # changelog entry.  When the pipeline already runs on main
+                    # this is a no-op (the files are already identical).
+                    - pwsh: |
+                        . eng/common/scripts/common.ps1
+                        $pkgProperties = Get-PkgProperties -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}'
+                        $changelogPath = $pkgProperties.ChangeLogPath
+                        $csprojPath = Join-Path $pkgProperties.DirectoryPath "src" "${{artifact.name}}.csproj"
+
+                        git checkout '$(Build.SourceVersion)' -- $changelogPath
+                        Write-Host "Synced $changelogPath from $(Build.SourceVersion)"
+
+                        git checkout '$(Build.SourceVersion)' -- $csprojPath
+                        Write-Host "Synced $csprojPath from $(Build.SourceVersion)"
+                      displayName: Cherry-pick release artifacts from release commit
                     - pwsh: |
                         eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -SkipCpmUpdate $false
                       displayName: Increment package version
@@ -287,6 +305,7 @@ stages:
                     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
                       parameters:
                         RepoName: azure-sdk-for-net
+                        BaseBranchName: refs/heads/main
                         PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
                         CommitMsg: "Increment package version after release of ${{ artifact.name }}"
                         PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -284,6 +284,7 @@ stages:
                     - pwsh: |
                         eng/scripts/Sync-ReleaseArtifacts.ps1 -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}' -SourceCommit '$(Build.SourceVersion)'
                       displayName: Sync release artifacts into main
+                      workingDirectory: $(System.DefaultWorkingDirectory)
                     - pwsh: |
                         eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -SkipCpmUpdate $false
                       displayName: Increment package version

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -277,11 +277,10 @@ stages:
                     # When the release pipeline runs from a release/* branch,
                     # sync the csproj and merge changelog entries from the
                     # release commit into main's versions.  Only overlay the
-                    # specific package directory and CPM files from main.
+                    # specific package directory from main.
                     - pwsh: |
                         git fetch origin main
                         git checkout origin/main -- "sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/"
-                        git checkout origin/main -- eng/centralpackagemanagement/
                         eng/scripts/Sync-ReleaseArtifacts.ps1 -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}' -SourceCommit '$(Build.SourceVersion)'
                       displayName: Sync release artifacts into main
                     - pwsh: |

--- a/eng/pipelines/templates/stages/archetype-net-release.yml
+++ b/eng/pipelines/templates/stages/archetype-net-release.yml
@@ -268,30 +268,22 @@ stages:
                   steps:
                     - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
                       parameters:
+                        Repositories:
+                          - Name: $(Build.Repository.Name)
+                            Commitish: refs/heads/main
+                            WorkingDirectory: $(System.DefaultWorkingDirectory)
                         paths:
                           - /sdk
 
                     - template: /eng/pipelines/templates/steps/install-dotnet.yml
                       parameters:
                         EnableNuGetCache: false
-                    # When the release pipeline runs from a release/* branch, the
-                    # version-bump PR must still target main.  Cherry-pick the
-                    # changelog and csproj from the build source commit so
-                    # Update-PkgVersion sees the released version and dated
-                    # changelog entry.  When the pipeline already runs on main
-                    # this is a no-op (the files are already identical).
+                    # When the release pipeline runs from a release/* branch the
+                    # sparse checkout above lands on main.  Sync the csproj and
+                    # merge changelog entries from the release commit into main.
                     - pwsh: |
-                        . eng/common/scripts/common.ps1
-                        $pkgProperties = Get-PkgProperties -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}'
-                        $changelogPath = $pkgProperties.ChangeLogPath
-                        $csprojPath = Join-Path $pkgProperties.DirectoryPath "src" "${{artifact.name}}.csproj"
-
-                        git checkout '$(Build.SourceVersion)' -- $changelogPath
-                        Write-Host "Synced $changelogPath from $(Build.SourceVersion)"
-
-                        git checkout '$(Build.SourceVersion)' -- $csprojPath
-                        Write-Host "Synced $csprojPath from $(Build.SourceVersion)"
-                      displayName: Cherry-pick release artifacts from release commit
+                        eng/scripts/Sync-ReleaseArtifacts.ps1 -PackageName '${{artifact.name}}' -ServiceDirectory '${{parameters.ServiceDirectory}}' -SourceCommit '$(Build.SourceVersion)'
+                      displayName: Sync release artifacts into main
                     - pwsh: |
                         eng/scripts/Update-PkgVersion.ps1 -ServiceDirectory '${{parameters.ServiceDirectory}}' -PackageName '${{artifact.name}}' -SkipCpmUpdate $false
                       displayName: Increment package version

--- a/eng/scripts/Sync-ReleaseArtifacts.ps1
+++ b/eng/scripts/Sync-ReleaseArtifacts.ps1
@@ -6,8 +6,8 @@ current working tree which is expected to be on main.
 .DESCRIPTION
 When the release pipeline runs from a release/* branch the sparse checkout
 lands on main.  This script:
-  1. Replaces the csproj with the version from the release commit so
-     Update-PkgVersion sees the released version.
+  1. Syncs the csproj version — takes the higher of main vs release so that
+     hotfix releases (where main has already advanced) do not downgrade.
   2. Merges changelog entries from the release commit into main's changelog
      so new release entries are inserted in the correct version order without
      losing entries that only exist on main.
@@ -79,20 +79,71 @@ function Merge-ChangeLogEntries {
   return $MainEntries
 }
 
+function Resolve-CsprojVersion {
+  <#
+  .SYNOPSIS
+  Returns the higher of two version strings using semver comparison.
+
+  .DESCRIPTION
+  Compares main and release csproj versions and returns the higher one.
+  In a hotfix scenario where main has advanced (e.g. 1.3.0-beta.1) past
+  the release version (e.g. 1.1.1), the main version wins so the
+  version-bump PR does not downgrade.
+  #>
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$MainVersion,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseVersion
+  )
+
+  $mainSemVer = [AzureEngSemanticVersion]::new($MainVersion)
+  $releaseSemVer = [AzureEngSemanticVersion]::new($ReleaseVersion)
+
+  if ($releaseSemVer.CompareTo($mainSemVer) -gt 0) {
+    Write-Host "  Release version $ReleaseVersion > main version $MainVersion — using release"
+    return $ReleaseVersion
+  }
+  else {
+    Write-Host "  Main version $MainVersion >= release version $ReleaseVersion — keeping main"
+    return $MainVersion
+  }
+}
+
 # --- Main ---
 
 $pkgProperties = Get-PkgProperties -PackageName $PackageName -ServiceDirectory $ServiceDirectory
 $changelogPath = $pkgProperties.ChangeLogPath
 $csprojPath = Join-Path $pkgProperties.DirectoryPath "src" "$PackageName.csproj"
 
-# Sync csproj (simple replacement)
+# Sync csproj — take the higher version between main and release
 $csprojGitPath = (Resolve-Path -Relative $csprojPath) -replace '\\', '/'
-git checkout $SourceCommit -- $csprojGitPath
+
+$mainCsproj = [xml](Get-Content -LiteralPath $csprojPath -Raw)
+$mainVersion = ($mainCsproj | Select-Xml "Project/PropertyGroup/Version").Node.InnerText
+
+$releaseCsprojContent = (git show "${SourceCommit}:${csprojGitPath}") -join "`n"
 if ($LASTEXITCODE -ne 0) {
-  Write-Error "Failed to checkout csproj from $SourceCommit"
+  Write-Error "Failed to read csproj from $SourceCommit"
   exit 1
 }
-Write-Host "Synced $csprojGitPath from $SourceCommit"
+$releaseCsproj = [xml]$releaseCsprojContent
+$releaseVersion = ($releaseCsproj | Select-Xml "Project/PropertyGroup/Version").Node.InnerText
+
+$resolvedVersion = Resolve-CsprojVersion -MainVersion $mainVersion -ReleaseVersion $releaseVersion
+
+if ($resolvedVersion -ne $mainVersion) {
+  git checkout $SourceCommit -- $csprojGitPath
+  if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to checkout csproj from $SourceCommit"
+    exit 1
+  }
+  Write-Host "Synced $csprojGitPath from $SourceCommit"
+}
+else {
+  Write-Host "Kept main csproj at $csprojGitPath (version $mainVersion)"
+}
 
 # Merge changelog
 $mainEntries = Get-ChangeLogEntries -ChangeLogLocation $changelogPath

--- a/eng/scripts/Sync-ReleaseArtifacts.ps1
+++ b/eng/scripts/Sync-ReleaseArtifacts.ps1
@@ -1,0 +1,110 @@
+<#
+.SYNOPSIS
+Syncs release artifacts (csproj + changelog) from a release commit into the
+current working tree which is expected to be on main.
+
+.DESCRIPTION
+When the release pipeline runs from a release/* branch the sparse checkout
+lands on main.  This script:
+  1. Replaces the csproj with the version from the release commit so
+     Update-PkgVersion sees the released version.
+  2. Merges changelog entries from the release commit into main's changelog
+     so new release entries are inserted in the correct version order without
+     losing entries that only exist on main.
+
+When the pipeline runs on main both operations are no-ops because the release
+commit IS the current checkout.
+
+.PARAMETER PackageName
+The name of the package (e.g. Azure.Core).
+
+.PARAMETER ServiceDirectory
+The service directory name under sdk/ (e.g. core).
+
+.PARAMETER SourceCommit
+The git commit SHA to sync from (typically $(Build.SourceVersion)).
+
+.EXAMPLE
+eng/scripts/Sync-ReleaseArtifacts.ps1 -PackageName Azure.Core -ServiceDirectory core -SourceCommit abc123
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PackageName,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ServiceDirectory,
+
+  [Parameter(Mandatory = $true)]
+  [string]$SourceCommit
+)
+
+. (Join-Path $PSScriptRoot ".." "common" "scripts" "common.ps1")
+. (Join-Path $PSScriptRoot ".." "common" "scripts" "ChangeLog-Operations.ps1")
+
+function Merge-ChangeLogEntries {
+  <#
+  .SYNOPSIS
+  Merges release changelog entries into main changelog entries.
+
+  .DESCRIPTION
+  For each entry in the release changelog:
+    - If the version does not exist in main, add it.
+    - If main has the version as (Unreleased) but release has a date, replace it.
+    - Otherwise keep main's entry.
+  Returns the merged entries (unordered — Set-ChangeLogContent handles sorting).
+  #>
+  param(
+    [Parameter(Mandatory = $true)]
+    $MainEntries,
+
+    [Parameter(Mandatory = $true)]
+    $ReleaseEntries
+  )
+
+  foreach ($version in $ReleaseEntries.Keys) {
+    $releaseEntry = $ReleaseEntries[$version]
+    if (-not $MainEntries.Contains($version)) {
+      $MainEntries[$version] = $releaseEntry
+      Write-Host "  Added changelog entry for $version from release"
+    }
+    elseif ($MainEntries[$version].ReleaseStatus -eq $CHANGELOG_UNRELEASED_STATUS -and
+            $releaseEntry.ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS) {
+      $MainEntries[$version] = $releaseEntry
+      Write-Host "  Updated changelog entry for $version with release date"
+    }
+  }
+
+  return $MainEntries
+}
+
+# --- Main ---
+
+$pkgProperties = Get-PkgProperties -PackageName $PackageName -ServiceDirectory $ServiceDirectory
+$changelogPath = $pkgProperties.ChangeLogPath
+$csprojPath = Join-Path $pkgProperties.DirectoryPath "src" "$PackageName.csproj"
+
+# Sync csproj (simple replacement)
+$csprojGitPath = (Resolve-Path -Relative $csprojPath) -replace '\\', '/'
+git checkout $SourceCommit -- $csprojGitPath
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "Failed to checkout csproj from $SourceCommit"
+  exit 1
+}
+Write-Host "Synced $csprojGitPath from $SourceCommit"
+
+# Merge changelog
+$mainEntries = Get-ChangeLogEntries -ChangeLogLocation $changelogPath
+$changelogGitPath = (Resolve-Path -Relative $changelogPath) -replace '\\', '/'
+$releaseContent = git show "${SourceCommit}:${changelogGitPath}"
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "Failed to read changelog from $SourceCommit"
+  exit 1
+}
+$releaseEntries = Get-ChangeLogEntriesFromContent $releaseContent
+
+$mergedEntries = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+Set-ChangeLogContent -ChangeLogLocation $changelogPath -ChangeLogEntries $mergedEntries
+Write-Host "Merged changelog at $changelogGitPath"

--- a/eng/scripts/Sync-ReleaseArtifacts.ps1
+++ b/eng/scripts/Sync-ReleaseArtifacts.ps1
@@ -52,6 +52,8 @@ function Merge-ChangeLogEntries {
   For each entry in the release changelog:
     - If the version does not exist in main, add it.
     - If main has the version as (Unreleased) but release has a date, replace it.
+    - If both have a dated entry for the same version, release wins (it has
+      the latest content from prepare-release).
     - Otherwise keep main's entry.
   Returns the merged entries (unordered — Set-ChangeLogContent handles sorting).
   #>
@@ -73,6 +75,11 @@ function Merge-ChangeLogEntries {
             $releaseEntry.ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS) {
       $MainEntries[$version] = $releaseEntry
       Write-Host "  Updated changelog entry for $version with release date"
+    }
+    elseif ($releaseEntry.ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS -and
+            $MainEntries[$version].ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS) {
+      $MainEntries[$version] = $releaseEntry
+      Write-Host "  Replaced changelog entry for $version with release content"
     }
   }
 

--- a/eng/scripts/Update-PkgVersion.ps1
+++ b/eng/scripts/Update-PkgVersion.ps1
@@ -122,6 +122,22 @@ else {
     $versionPattern = '(<Package(?:Version|Reference)\s+(?:Include|Update)="' + $escapedName + '"\s+Version=")(\d[^"]*?)(")'
     $totalUpdates = 0
 
+    # Helper: returns $true if the released version is strictly greater than the
+    # version already present in $Content for this package.  When the existing
+    # version is already >= the released version (e.g. hotfix scenario) the CPM
+    # entry must not be downgraded.
+    function Test-ShouldUpdateCpm([string]$Content, [string]$Pattern, [string]$NewVersion) {
+      $m = [regex]::Match($Content, $Pattern)
+      if (-not $m.Success) { return $true }  # no existing entry — allow insert
+      $existingVer = $m.Groups[2].Value
+      $existingSemVer = [AzureEngSemanticVersion]::ParseVersionString($existingVer)
+      $newSemVer = [AzureEngSemanticVersion]::ParseVersionString($NewVersion)
+      if ($existingSemVer -and $newSemVer -and $newSemVer.CompareTo($existingSemVer) -le 0) {
+        return $false
+      }
+      return $true
+    }
+
     # New CPM structure (post CPM migration): eng/centralpackagemanagement/*.Packages.props
     # Update all occurrences in files directly in this directory — NOT in overrides/ subdirectory.
     $cpmDir = Join-Path $RepoRoot "eng" "centralpackagemanagement"
@@ -130,6 +146,12 @@ else {
       foreach ($file in $cpmFiles) {
         $content = Get-Content -LiteralPath $file.FullName -Raw
         if (-not $content) { continue }
+
+        if (-not (Test-ShouldUpdateCpm $content $versionPattern $releasedVersion)) {
+          Write-Host "Skipping CPM update for '$PackageName' in '$($file.FullName)': existing version >= $releasedVersion"
+          continue
+        }
+
         $newContent = [regex]::Replace($content, $versionPattern, '${1}' + $releasedVersion + '${3}')
 
         if ($newContent -ne $content) {
@@ -148,48 +170,53 @@ else {
     if (Test-Path -LiteralPath $oldFile -PathType Leaf) {
       $content = Get-Content -LiteralPath $oldFile -Raw
 
-      # Walk each ItemGroup block individually. Check the Condition attribute to decide
-      # whether this block is safe to update, then only replace within that block's body.
-      $itemGroupPattern = '<ItemGroup(?<attrs>[^>]*)>(?<body>.*?)</ItemGroup>'
-      $regexOptions = [System.Text.RegularExpressions.RegexOptions]::Singleline
-      $packagePattern = '(<Package(?:Version|Reference)\s+(?:Include|Update)="' + $escapedName + '"\s+Version=")(\d[^"]*?)(")'
+      if (-not (Test-ShouldUpdateCpm $content $versionPattern $releasedVersion)) {
+        Write-Host "Skipping CPM update for '$PackageName' in '$oldFile': existing version >= $releasedVersion"
+      }
+      else {
+        # Walk each ItemGroup block individually. Check the Condition attribute to decide
+        # whether this block is safe to update, then only replace within that block's body.
+        $itemGroupPattern = '<ItemGroup(?<attrs>[^>]*)>(?<body>.*?)</ItemGroup>'
+        $regexOptions = [System.Text.RegularExpressions.RegexOptions]::Singleline
+        $packagePattern = '(<Package(?:Version|Reference)\s+(?:Include|Update)="' + $escapedName + '"\s+Version=")(\d[^"]*?)(")'
 
-      $builder = New-Object System.Text.StringBuilder
-      $lastIndex = 0
-      $oldFileUpdated = $false
+        $builder = New-Object System.Text.StringBuilder
+        $lastIndex = 0
+        $oldFileUpdated = $false
 
-      foreach ($match in [regex]::Matches($content, $itemGroupPattern, $regexOptions)) {
-        # Append content before this ItemGroup unchanged.
-        if ($match.Index -gt $lastIndex) {
-          [void]$builder.Append($content.Substring($lastIndex, $match.Index - $lastIndex))
+        foreach ($match in [regex]::Matches($content, $itemGroupPattern, $regexOptions)) {
+          # Append content before this ItemGroup unchanged.
+          if ($match.Index -gt $lastIndex) {
+            [void]$builder.Append($content.Substring($lastIndex, $match.Index - $lastIndex))
+          }
+
+          $attrs = $match.Groups['attrs'].Value
+          $body = $match.Groups['body'].Value
+
+          # Determine if this ItemGroup is safe to update.
+          $isUnsafe = ($attrs -match 'MSBuildProjectName') -or
+                      ($attrs -match 'TargetFramework') -or
+                      ($attrs -match "IsClientLibrary\)'\s*!=\s*'true'")
+
+          $newBody = $body
+          if (-not $isUnsafe) {
+            $newBody = [regex]::Replace($body, $packagePattern, '${1}' + $releasedVersion + '${3}')
+            if ($newBody -ne $body) { $oldFileUpdated = $true }
+          }
+
+          [void]$builder.Append('<ItemGroup' + $attrs + '>' + $newBody + '</ItemGroup>')
+          $lastIndex = $match.Index + $match.Length
         }
 
-        $attrs = $match.Groups['attrs'].Value
-        $body = $match.Groups['body'].Value
-
-        # Determine if this ItemGroup is safe to update.
-        $isUnsafe = ($attrs -match 'MSBuildProjectName') -or
-                    ($attrs -match 'TargetFramework') -or
-                    ($attrs -match "IsClientLibrary\)'\s*!=\s*'true'")
-
-        $newBody = $body
-        if (-not $isUnsafe) {
-          $newBody = [regex]::Replace($body, $packagePattern, '${1}' + $releasedVersion + '${3}')
-          if ($newBody -ne $body) { $oldFileUpdated = $true }
+        if ($lastIndex -lt $content.Length) {
+          [void]$builder.Append($content.Substring($lastIndex))
         }
 
-        [void]$builder.Append('<ItemGroup' + $attrs + '>' + $newBody + '</ItemGroup>')
-        $lastIndex = $match.Index + $match.Length
-      }
-
-      if ($lastIndex -lt $content.Length) {
-        [void]$builder.Append($content.Substring($lastIndex))
-      }
-
-      if ($oldFileUpdated) {
-        Set-Content -LiteralPath $oldFile -Value $builder.ToString() -NoNewline
-        Write-Host "Updated package '$PackageName' version to '$releasedVersion' in '$oldFile'"
-        $totalUpdates++
+        if ($oldFileUpdated) {
+          Set-Content -LiteralPath $oldFile -Value $builder.ToString() -NoNewline
+          Write-Host "Updated package '$PackageName' version to '$releasedVersion' in '$oldFile'"
+          $totalUpdates++
+        }
       }
     }
 

--- a/eng/scripts/Update-PkgVersion.ps1
+++ b/eng/scripts/Update-PkgVersion.ps1
@@ -128,7 +128,7 @@ else {
     # entry must not be downgraded.
     function Test-ShouldUpdateCpm([string]$Content, [string]$Pattern, [string]$NewVersion) {
       $m = [regex]::Match($Content, $Pattern)
-      if (-not $m.Success) { return $true }  # no existing entry — allow insert
+      if (-not $m.Success) { return $true }  # no existing entry to compare — allow update attempt
       $existingVer = $m.Groups[2].Value
       $existingSemVer = [AzureEngSemanticVersion]::ParseVersionString($existingVer)
       $newSemVer = [AzureEngSemanticVersion]::ParseVersionString($NewVersion)

--- a/eng/scripts/Update-PkgVersion.ps1
+++ b/eng/scripts/Update-PkgVersion.ps1
@@ -127,11 +127,14 @@ else {
     # version is already >= the released version (e.g. hotfix scenario) the CPM
     # entry must not be downgraded.
     function Test-ShouldUpdateCpm([string]$Content, [string]$Pattern, [string]$NewVersion) {
+      $newSemVer = [AzureEngSemanticVersion]::ParseVersionString($NewVersion)
+      if ($newSemVer -and $newSemVer.IsPrerelease) {
+        return $false
+      }
       $m = [regex]::Match($Content, $Pattern)
       if (-not $m.Success) { return $true }  # no existing entry to compare — allow update attempt
       $existingVer = $m.Groups[2].Value
       $existingSemVer = [AzureEngSemanticVersion]::ParseVersionString($existingVer)
-      $newSemVer = [AzureEngSemanticVersion]::ParseVersionString($NewVersion)
       if ($existingSemVer -and $newSemVer -and $newSemVer.CompareTo($existingSemVer) -le 0) {
         return $false
       }

--- a/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
+++ b/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
@@ -228,8 +228,7 @@ Describe "Resolve-CsprojVersion" {
         $result | Should -Be "1.1.0"
     }
 
-    It "Normal GA release: release version is higher than main prerelease" {
-        # Main has 1.1.0-beta.1, releasing GA 1.1.0 bumps minor
+    It "Normal GA release: release version is higher than main" {
         $result = Resolve-CsprojVersion -MainVersion "1.0.0" -ReleaseVersion "1.1.0"
         $result | Should -Be "1.1.0"
     }

--- a/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
+++ b/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
@@ -44,6 +44,11 @@ BeforeAll {
                 $MainEntries[$version] = $releaseEntry
                 Write-Host "  Updated changelog entry for $version with release date"
             }
+            elseif ($releaseEntry.ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS -and
+                    $MainEntries[$version].ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS) {
+                $MainEntries[$version] = $releaseEntry
+                Write-Host "  Replaced changelog entry for $version with release content"
+            }
         }
 
         return $MainEntries
@@ -167,7 +172,7 @@ Describe "Merge-ChangeLogEntries" {
         $result["1.1.1"].ReleaseStatus | Should -Be "(2026-03-17)"
     }
 
-    It "Does not overwrite a dated entry on main with a different dated entry from release" {
+    It "Dated entry on both branches — release content wins" {
         $mainChangelog = Build-Changelog @(
             @{ Version = "1.0.0"; Status = "(2026-01-15)"; Content = @("", "### Features Added", "", "- from main") }
         )
@@ -179,8 +184,40 @@ Describe "Merge-ChangeLogEntries" {
 
         $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
 
-        # Main's entry should be preserved (both have dates — no overwrite)
-        $result["1.0.0"].ReleaseStatus | Should -Be "(2026-01-15)"
+        # Release content wins when both are dated
+        $result["1.0.0"].ReleaseStatus | Should -Be "(2026-01-01)"
+    }
+
+    It "Dated entry with different content — release content replaces main" {
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.1.0"; Status = "(2026-03-17)"; Content = @("", "### Features Added", "", "- old content from main") }
+        )
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.1.0"; Status = "(2026-03-17)"; Content = @("", "### Features Added", "", "- updated content from release", "- extra fix") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        $result["1.1.0"].ReleaseContent | Should -Contain "- updated content from release"
+        $result["1.1.0"].ReleaseContent | Should -Contain "- extra fix"
+    }
+
+    It "Unreleased entry on both branches — main's unreleased content is kept" {
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.2.0"; Status = "(Unreleased)"; Content = @("", "### Features Added", "", "- main work in progress") }
+        )
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.2.0"; Status = "(Unreleased)"; Content = @("", "### Features Added", "", "- release branch wip") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        # Both unreleased — main wins (no overwrite)
+        $result["1.2.0"].ReleaseContent | Should -Contain "- main work in progress"
     }
 
     It "Handles version ordering correctly after merge via Set-ChangeLogContent" {

--- a/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
+++ b/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
@@ -24,8 +24,8 @@ BeforeAll {
     . (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "logging.ps1")
     . (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "ChangeLog-Operations.ps1")
 
-    # Load just the Merge-ChangeLogEntries function from the script under test.
-    # We dot-source a filtered version to avoid the main execution block and its
+    # Load just the testable functions from the script under test.
+    # We define them here to avoid the main execution block and its
     # dependencies (Get-PkgProperties, git, etc.).
     function Merge-ChangeLogEntries {
         param(
@@ -47,6 +47,25 @@ BeforeAll {
         }
 
         return $MainEntries
+    }
+
+    function Resolve-CsprojVersion {
+        param(
+            [Parameter(Mandatory = $true)] [string]$MainVersion,
+            [Parameter(Mandatory = $true)] [string]$ReleaseVersion
+        )
+
+        $mainSemVer = [AzureEngSemanticVersion]::new($MainVersion)
+        $releaseSemVer = [AzureEngSemanticVersion]::new($ReleaseVersion)
+
+        if ($releaseSemVer.CompareTo($mainSemVer) -gt 0) {
+            Write-Host "  Release version $ReleaseVersion > main version $MainVersion — using release"
+            return $ReleaseVersion
+        }
+        else {
+            Write-Host "  Main version $MainVersion >= release version $ReleaseVersion — keeping main"
+            return $MainVersion
+        }
     }
 
     function Build-Changelog {
@@ -199,5 +218,52 @@ Describe "Merge-ChangeLogEntries" {
         finally {
             Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
         }
+    }
+}
+
+Describe "Resolve-CsprojVersion" {
+
+    It "Normal release: release version equals main version" {
+        $result = Resolve-CsprojVersion -MainVersion "1.1.0" -ReleaseVersion "1.1.0"
+        $result | Should -Be "1.1.0"
+    }
+
+    It "Normal GA release: release version is higher than main prerelease" {
+        # Main has 1.1.0-beta.1, releasing GA 1.1.0 bumps minor
+        $result = Resolve-CsprojVersion -MainVersion "1.0.0" -ReleaseVersion "1.1.0"
+        $result | Should -Be "1.1.0"
+    }
+
+    It "Normal beta release: release equals main" {
+        $result = Resolve-CsprojVersion -MainVersion "1.1.0-beta.2" -ReleaseVersion "1.1.0-beta.2"
+        $result | Should -Be "1.1.0-beta.2"
+    }
+
+    It "Hotfix: main has advanced past release — keeps main version" {
+        # Main is at 1.3.0-beta.1, hotfix ships 1.1.1
+        $result = Resolve-CsprojVersion -MainVersion "1.3.0-beta.1" -ReleaseVersion "1.1.1"
+        $result | Should -Be "1.3.0-beta.1"
+    }
+
+    It "Hotfix: main GA is higher than release — keeps main version" {
+        # Main already shipped 1.2.0, hotfix ships 1.1.1
+        $result = Resolve-CsprojVersion -MainVersion "1.2.0" -ReleaseVersion "1.1.1"
+        $result | Should -Be "1.2.0"
+    }
+
+    It "Release version higher than main prerelease" {
+        # Main has old beta, release ships newer GA
+        $result = Resolve-CsprojVersion -MainVersion "1.0.0-beta.3" -ReleaseVersion "1.0.0"
+        $result | Should -Be "1.0.0"
+    }
+
+    It "Prerelease on both — higher prerelease wins" {
+        $result = Resolve-CsprojVersion -MainVersion "1.2.0-beta.1" -ReleaseVersion "1.2.0-beta.3"
+        $result | Should -Be "1.2.0-beta.3"
+    }
+
+    It "Major version difference — higher wins" {
+        $result = Resolve-CsprojVersion -MainVersion "2.0.0-beta.1" -ReleaseVersion "1.5.0"
+        $result | Should -Be "2.0.0-beta.1"
     }
 }

--- a/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
+++ b/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
@@ -1,0 +1,203 @@
+#Requires -Version 7.0
+<#
+.How-To-Run
+This test file uses Pester, a testing framework for PowerShell.
+
+First, ensure you have `pester` installed:
+
+`Install-Module Pester -Force`
+
+Then invoke tests with:
+
+`Invoke-Pester ./Sync-ReleaseArtifacts.tests.ps1`
+
+#>
+
+. (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "Helpers" PSModule-Helpers.ps1)
+Install-ModuleIfNotInstalled "Pester" "5.3.3" | Import-Module
+
+Set-StrictMode -Version 3
+
+BeforeAll {
+    # Load ChangeLog-Operations for parsing helpers and the CHANGELOG_UNRELEASED_STATUS constant.
+    . (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "SemVer.ps1")
+    . (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "logging.ps1")
+    . (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "ChangeLog-Operations.ps1")
+
+    # Load just the Merge-ChangeLogEntries function from the script under test.
+    # We dot-source a filtered version to avoid the main execution block and its
+    # dependencies (Get-PkgProperties, git, etc.).
+    function Merge-ChangeLogEntries {
+        param(
+            [Parameter(Mandatory = $true)] $MainEntries,
+            [Parameter(Mandatory = $true)] $ReleaseEntries
+        )
+
+        foreach ($version in $ReleaseEntries.Keys) {
+            $releaseEntry = $ReleaseEntries[$version]
+            if (-not $MainEntries.Contains($version)) {
+                $MainEntries[$version] = $releaseEntry
+                Write-Host "  Added changelog entry for $version from release"
+            }
+            elseif ($MainEntries[$version].ReleaseStatus -eq $CHANGELOG_UNRELEASED_STATUS -and
+                    $releaseEntry.ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS) {
+                $MainEntries[$version] = $releaseEntry
+                Write-Host "  Updated changelog entry for $version with release date"
+            }
+        }
+
+        return $MainEntries
+    }
+
+    function Build-Changelog {
+        <# Helper to build a changelog string from version specs. Each spec is
+           @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("### Bugs Fixed", "", "- fix1") }
+        #>
+        param([array]$Entries, [string]$Header = "# Release History")
+        $lines = @($Header, "")
+        foreach ($entry in $Entries) {
+            $lines += "## $($entry.Version) $($entry.Status)"
+            if ($entry.Content) { $lines += $entry.Content }
+            else { $lines += @("", "### Features Added", "") }
+            $lines += ""
+        }
+        return $lines -join "`n"
+    }
+}
+
+Describe "Merge-ChangeLogEntries" {
+
+    It "No-op when release and main have identical entries" {
+        $changelog = Build-Changelog @(
+            @{ Version = "1.1.0"; Status = "(2026-03-01)"; Content = @("", "### Features Added", "", "- feature1") },
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- initial") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $changelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $changelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        $result.Count | Should -Be 2
+        $result.Contains("1.1.0") | Should -BeTrue
+        $result.Contains("1.0.0") | Should -BeTrue
+    }
+
+    It "Adds new version from release that is missing in main" {
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.2.0"; Status = "(Unreleased)" },
+            @{ Version = "1.1.0"; Status = "(2026-02-01)"; Content = @("", "### Features Added", "", "- feature1") },
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- initial") }
+        )
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.1.1"; Status = "(2026-03-17)"; Content = @("", "### Bugs Fixed", "", "- hotfix") },
+            @{ Version = "1.1.0"; Status = "(2026-02-01)"; Content = @("", "### Features Added", "", "- feature1") },
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- initial") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        $result.Count | Should -Be 4
+        $result.Contains("1.2.0") | Should -BeTrue
+        $result.Contains("1.1.1") | Should -BeTrue
+        $result.Contains("1.1.0") | Should -BeTrue
+        $result.Contains("1.0.0") | Should -BeTrue
+        $result["1.1.1"].ReleaseStatus | Should -Be "(2026-03-17)"
+    }
+
+    It "Updates unreleased entry with release date" {
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.1.0"; Status = "(Unreleased)"; Content = @("", "### Features Added", "", "- feature1") },
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- initial") }
+        )
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.1.0"; Status = "(2026-03-17)"; Content = @("", "### Features Added", "", "- feature1", "- feature2") },
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- initial") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        $result.Count | Should -Be 2
+        $result["1.1.0"].ReleaseStatus | Should -Be "(2026-03-17)"
+    }
+
+    It "Preserves entries that only exist on main" {
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.2.0"; Status = "(Unreleased)" },
+            @{ Version = "1.1.0"; Status = "(2026-02-01)"; Content = @("", "### Features Added", "", "- feature1") },
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- initial") }
+        )
+        # Release branch was forked before 1.2.0 work started
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.1.1"; Status = "(2026-03-17)"; Content = @("", "### Bugs Fixed", "", "- hotfix") },
+            @{ Version = "1.1.0"; Status = "(2026-02-01)"; Content = @("", "### Features Added", "", "- feature1") },
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- initial") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        $result.Count | Should -Be 4
+        $result.Contains("1.2.0") | Should -BeTrue
+        $result["1.2.0"].ReleaseStatus | Should -Be "(Unreleased)"
+        $result.Contains("1.1.1") | Should -BeTrue
+        $result["1.1.1"].ReleaseStatus | Should -Be "(2026-03-17)"
+    }
+
+    It "Does not overwrite a dated entry on main with a different dated entry from release" {
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.0.0"; Status = "(2026-01-15)"; Content = @("", "### Features Added", "", "- from main") }
+        )
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- from release") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        # Main's entry should be preserved (both have dates — no overwrite)
+        $result["1.0.0"].ReleaseStatus | Should -Be "(2026-01-15)"
+    }
+
+    It "Handles version ordering correctly after merge via Set-ChangeLogContent" {
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.2.0"; Status = "(Unreleased)" },
+            @{ Version = "1.1.0"; Status = "(2026-02-01)"; Content = @("", "### Features Added", "", "- feature1") },
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- initial") }
+        )
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.1.1"; Status = "(2026-03-17)"; Content = @("", "### Bugs Fixed", "", "- hotfix") },
+            @{ Version = "1.1.0"; Status = "(2026-02-01)"; Content = @("", "### Features Added", "", "- feature1") },
+            @{ Version = "1.0.0"; Status = "(2026-01-01)"; Content = @("", "### Features Added", "", "- initial") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $merged = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        # Write to a temp file and read back to verify ordering
+        $tempFile = [System.IO.Path]::GetTempFileName()
+        try {
+            Set-ChangeLogContent -ChangeLogLocation $tempFile -ChangeLogEntries $merged
+            $content = Get-Content $tempFile -Raw
+
+            # Verify version order in the file: 1.2.0 > 1.1.1 > 1.1.0 > 1.0.0
+            $idx_120 = $content.IndexOf("1.2.0")
+            $idx_111 = $content.IndexOf("1.1.1")
+            $idx_110 = $content.IndexOf("1.1.0")
+            $idx_100 = $content.IndexOf("1.0.0")
+
+            $idx_120 | Should -BeLessThan $idx_111
+            $idx_111 | Should -BeLessThan $idx_110
+            $idx_110 | Should -BeLessThan $idx_100
+        }
+        finally {
+            Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/eng/scripts/tests/Update-PkgVersion-CpmUpdate.tests.ps1
+++ b/eng/scripts/tests/Update-PkgVersion-CpmUpdate.tests.ps1
@@ -26,11 +26,14 @@ BeforeAll {
     . (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "SemVer.ps1")
 
     function Test-ShouldUpdateCpm([string]$Content, [string]$Pattern, [string]$NewVersion) {
+        $newSemVer = [AzureEngSemanticVersion]::ParseVersionString($NewVersion)
+        if ($newSemVer -and $newSemVer.IsPrerelease) {
+            return $false
+        }
         $m = [regex]::Match($Content, $Pattern)
         if (-not $m.Success) { return $true }
         $existingVer = $m.Groups[2].Value
         $existingSemVer = [AzureEngSemanticVersion]::ParseVersionString($existingVer)
-        $newSemVer = [AzureEngSemanticVersion]::ParseVersionString($NewVersion)
         if ($existingSemVer -and $newSemVer -and $newSemVer.CompareTo($existingSemVer) -le 0) {
             return $false
         }
@@ -233,7 +236,7 @@ Describe "New CPM version replacement" -Tag "UnitTest" {
     }
 
     Context "with prerelease version" {
-        It "updates prerelease versions" {
+        It "does not update prerelease versions" {
             $root = Join-Path $TestDrive "upd-pre"
             $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
             New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
@@ -241,10 +244,10 @@ Describe "New CPM version replacement" -Tag "UnitTest" {
 
             Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.Generator" -ReleasedVersion "1.0.0-alpha.20260225.1"
 
-            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.0.0-alpha.20260225.1"'
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.0.0-alpha.20260219.1"'
         }
 
-        It "updates beta versions" {
+        It "does not update beta versions" {
             $root = Join-Path $TestDrive "upd-beta"
             $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
             New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
@@ -252,10 +255,10 @@ Describe "New CPM version replacement" -Tag "UnitTest" {
 
             Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.AI.OpenAI" -ReleasedVersion "2.0.0-beta.4"
 
-            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="2.0.0-beta.4"'
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="2.0.0-beta.3"'
         }
 
-        It "updates preview versions" {
+        It "does not update preview versions" {
             $root = Join-Path $TestDrive "upd-preview"
             $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
             New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
@@ -263,7 +266,7 @@ Describe "New CPM version replacement" -Tag "UnitTest" {
 
             Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.Monitor.OpenTelemetry" -ReleasedVersion "1.0.0-preview.6"
 
-            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.0.0-preview.6"'
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.0.0-preview.5"'
         }
     }
 
@@ -281,15 +284,15 @@ Describe "New CPM version replacement" -Tag "UnitTest" {
     }
 
     Context "with PrivateAssets attribute" {
-        It "preserves other attributes" {
+        It "preserves other attributes when updating GA version" {
             $root = Join-Path $TestDrive "upd-pa"
             $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
             New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
-            '<Project><ItemGroup><PackageVersion Include="Azure.ClientSdk.Analyzers" Version="0.1.0" PrivateAssets="All" /></ItemGroup></Project>' | Set-Content (Join-Path $cpmDir "Directory.Packages.props") -NoNewline
+            '<Project><ItemGroup><PackageVersion Include="Azure.Core" Version="1.43.0" PrivateAssets="All" /></ItemGroup></Project>' | Set-Content (Join-Path $cpmDir "Directory.Packages.props") -NoNewline
 
-            Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.ClientSdk.Analyzers" -ReleasedVersion "0.1.1"
+            Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.44.0"
 
-            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="0.1.1" PrivateAssets="All"'
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.44.0" PrivateAssets="All"'
         }
     }
 
@@ -366,15 +369,15 @@ Describe "Old Packages.Data.props scoped update" -Tag "UnitTest" {
             @"
 <Project>
   <ItemGroup>
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.0" PrivateAssets="All" />
+    <PackageReference Update="Azure.Core" Version="1.43.0" />
   </ItemGroup>
 </Project>
 "@ | Set-Content (Join-Path $root "eng" "Packages.Data.props") -NoNewline
 
-            $result = Update-OldCpmFile -RepoRoot $root -PackageName "Azure.ClientSdk.Analyzers" -ReleasedVersion "0.1.1"
+            $result = Update-OldCpmFile -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.44.0"
 
             $result | Should -Be 1
-            (Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw) | Should -Match 'Version="0.1.1"'
+            (Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw) | Should -Match 'Version="1.44.0"'
         }
     }
 
@@ -596,7 +599,7 @@ Describe "Old Packages.Data.props scoped update" -Tag "UnitTest" {
     }
 
     Context "with beta version in old format" {
-        It "updates beta versions in safe group" {
+        It "does not update beta versions in CPM" {
             $root = Join-Path $TestDrive "old-beta"
             New-Item -ItemType Directory -Path (Join-Path $root "eng") -Force | Out-Null
             @"
@@ -609,8 +612,8 @@ Describe "Old Packages.Data.props scoped update" -Tag "UnitTest" {
 
             $result = Update-OldCpmFile -RepoRoot $root -PackageName "Azure.AI.OpenAI" -ReleasedVersion "2.0.0-beta.4"
 
-            $result | Should -Be 1
-            (Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw) | Should -Match 'Version="2.0.0-beta.4"'
+            $result | Should -Be 0
+            (Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw) | Should -Match 'Version="2.0.0-beta.3"'
         }
     }
 
@@ -937,6 +940,51 @@ Describe "CPM version guard — no downgrade" -Tag "UnitTest" {
 
             $result | Should -Be 1
             (Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw) | Should -Match 'Version="1.44.0"'
+        }
+    }
+
+    Context "Beta releases never update CPM" {
+        It "does not update new CPM when released version is beta" {
+            $root = Join-Path $TestDrive "guard-new-beta"
+            $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
+            New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
+            '<Project><ItemGroup><PackageVersion Include="Azure.Core" Version="1.43.0" /></ItemGroup></Project>' |
+                Set-Content (Join-Path $cpmDir "Directory.Packages.props") -NoNewline
+
+            $result = Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.44.0-beta.1"
+
+            $result | Should -Be 0
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.43.0"'
+        }
+
+        It "does not update new CPM when released version is preview" {
+            $root = Join-Path $TestDrive "guard-new-preview"
+            $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
+            New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
+            '<Project><ItemGroup><PackageVersion Include="Azure.AI.OpenAI" Version="2.0.0-beta.3" /></ItemGroup></Project>' |
+                Set-Content (Join-Path $cpmDir "Directory.Packages.props") -NoNewline
+
+            $result = Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.AI.OpenAI" -ReleasedVersion "2.0.0-beta.4"
+
+            $result | Should -Be 0
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="2.0.0-beta.3"'
+        }
+
+        It "does not update old CPM when released version is beta" {
+            $root = Join-Path $TestDrive "guard-old-beta"
+            New-Item -ItemType Directory -Path (Join-Path $root "eng") -Force | Out-Null
+            @"
+<Project>
+  <ItemGroup>
+    <PackageReference Update="Azure.Core" Version="1.43.0" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content (Join-Path $root "eng" "Packages.Data.props") -NoNewline
+
+            $result = Update-OldCpmFile -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.44.0-beta.1"
+
+            $result | Should -Be 0
+            (Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw) | Should -Match 'Version="1.43.0"'
         }
     }
 }

--- a/eng/scripts/tests/Update-PkgVersion-CpmUpdate.tests.ps1
+++ b/eng/scripts/tests/Update-PkgVersion-CpmUpdate.tests.ps1
@@ -23,6 +23,20 @@ BeforeAll {
     # Helper functions that replicate the CPM update logic from Update-PkgVersion.ps1.
     # We test in isolation since Update-PkgVersion.ps1 has heavy dependencies on common.ps1.
 
+    . (Join-Path $PSScriptRoot ".." ".." "common" "scripts" "SemVer.ps1")
+
+    function Test-ShouldUpdateCpm([string]$Content, [string]$Pattern, [string]$NewVersion) {
+        $m = [regex]::Match($Content, $Pattern)
+        if (-not $m.Success) { return $true }
+        $existingVer = $m.Groups[2].Value
+        $existingSemVer = [AzureEngSemanticVersion]::ParseVersionString($existingVer)
+        $newSemVer = [AzureEngSemanticVersion]::ParseVersionString($NewVersion)
+        if ($existingSemVer -and $newSemVer -and $newSemVer.CompareTo($existingSemVer) -le 0) {
+            return $false
+        }
+        return $true
+    }
+
     function Update-NewCpmFiles {
         param (
             [Parameter(Mandatory = $true)] [string]$RepoRoot,
@@ -39,6 +53,11 @@ BeforeAll {
             foreach ($file in $cpmFiles) {
                 $content = Get-Content -LiteralPath $file.FullName -Raw
                 if (-not $content) { continue }
+
+                if (-not (Test-ShouldUpdateCpm $content $versionPattern $ReleasedVersion)) {
+                    continue
+                }
+
                 $newContent = [regex]::Replace($content, $versionPattern, '${1}' + $ReleasedVersion + '${3}')
                 if ($newContent -ne $content) {
                     Set-Content -LiteralPath $file.FullName -Value $newContent -NoNewline
@@ -60,6 +79,12 @@ BeforeAll {
         if (-not (Test-Path -LiteralPath $oldFile -PathType Leaf)) { return 0 }
 
         $content = Get-Content -LiteralPath $oldFile -Raw
+        $versionPattern = '(<Package(?:Version|Reference)\s+(?:Include|Update)="' + $escapedName + '"\s+Version=")(\d[^"]*?)(")'
+
+        if (-not (Test-ShouldUpdateCpm $content $versionPattern $ReleasedVersion)) {
+            return 0
+        }
+
         $itemGroupPattern = '<ItemGroup(?<attrs>[^>]*)>(?<body>.*?)</ItemGroup>'
         $regexOptions = [System.Text.RegularExpressions.RegexOptions]::Singleline
         $packagePattern = '(<Package(?:Version|Reference)\s+(?:Include|Update)="' + $escapedName + '"\s+Version=")(\d[^"]*?)(")'
@@ -801,6 +826,117 @@ Describe "SkipCpmUpdate gating" {
 
             $content = Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw
             $content | Should -BeLike '*Version="1.44.0"*'
+        }
+    }
+}
+
+# --------------------- Version Guard (no downgrade) ---------------------
+Describe "CPM version guard — no downgrade" -Tag "UnitTest" {
+
+    Context "New CPM: released version lower than existing" {
+        It "does not downgrade when CPM has higher GA version" {
+            $root = Join-Path $TestDrive "guard-new-higher"
+            $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
+            New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
+            '<Project><ItemGroup><PackageVersion Include="Azure.Core" Version="1.44.0" /></ItemGroup></Project>' |
+                Set-Content (Join-Path $cpmDir "Directory.Packages.props") -NoNewline
+
+            $result = Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.43.0"
+
+            $result | Should -Be 0
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.44.0"'
+        }
+
+        It "does not downgrade when CPM has higher GA and release is hotfix" {
+            $root = Join-Path $TestDrive "guard-new-hotfix"
+            $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
+            New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
+            '<Project><ItemGroup><PackageVersion Include="Azure.Core" Version="1.44.0" /></ItemGroup></Project>' |
+                Set-Content (Join-Path $cpmDir "Directory.Packages.props") -NoNewline
+
+            $result = Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.43.1"
+
+            $result | Should -Be 0
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.44.0"'
+        }
+
+        It "does not write prerelease over same GA version" {
+            $root = Join-Path $TestDrive "guard-new-prerelease"
+            $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
+            New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
+            '<Project><ItemGroup><PackageVersion Include="Azure.Core" Version="1.44.0" /></ItemGroup></Project>' |
+                Set-Content (Join-Path $cpmDir "Directory.Packages.props") -NoNewline
+
+            $result = Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.44.0-beta.1"
+
+            $result | Should -Be 0
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.44.0"'
+        }
+
+        It "updates when released version is strictly higher" {
+            $root = Join-Path $TestDrive "guard-new-update"
+            $cpmDir = Join-Path $root "eng" "centralpackagemanagement"
+            New-Item -ItemType Directory -Path $cpmDir -Force | Out-Null
+            '<Project><ItemGroup><PackageVersion Include="Azure.Core" Version="1.43.0" /></ItemGroup></Project>' |
+                Set-Content (Join-Path $cpmDir "Directory.Packages.props") -NoNewline
+
+            $result = Update-NewCpmFiles -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.44.0"
+
+            $result | Should -Be 1
+            (Get-Content (Join-Path $cpmDir "Directory.Packages.props") -Raw) | Should -Match 'Version="1.44.0"'
+        }
+    }
+
+    Context "Old CPM: released version lower than existing" {
+        It "does not downgrade old format CPM" {
+            $root = Join-Path $TestDrive "guard-old-higher"
+            New-Item -ItemType Directory -Path (Join-Path $root "eng") -Force | Out-Null
+            @"
+<Project>
+  <ItemGroup>
+    <PackageReference Update="Azure.Core" Version="1.44.0" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content (Join-Path $root "eng" "Packages.Data.props") -NoNewline
+
+            $result = Update-OldCpmFile -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.43.0"
+
+            $result | Should -Be 0
+            (Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw) | Should -Match 'Version="1.44.0"'
+        }
+
+        It "does not downgrade old format CPM in hotfix scenario" {
+            $root = Join-Path $TestDrive "guard-old-hotfix"
+            New-Item -ItemType Directory -Path (Join-Path $root "eng") -Force | Out-Null
+            @"
+<Project>
+  <ItemGroup>
+    <PackageReference Update="Azure.Core" Version="1.44.0" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content (Join-Path $root "eng" "Packages.Data.props") -NoNewline
+
+            $result = Update-OldCpmFile -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.43.1"
+
+            $result | Should -Be 0
+            (Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw) | Should -Match 'Version="1.44.0"'
+        }
+
+        It "updates old format when released version is strictly higher" {
+            $root = Join-Path $TestDrive "guard-old-update"
+            New-Item -ItemType Directory -Path (Join-Path $root "eng") -Force | Out-Null
+            @"
+<Project>
+  <ItemGroup>
+    <PackageReference Update="Azure.Core" Version="1.43.0" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content (Join-Path $root "eng" "Packages.Data.props") -NoNewline
+
+            $result = Update-OldCpmFile -RepoRoot $root -PackageName "Azure.Core" -ReleasedVersion "1.44.0"
+
+            $result | Should -Be 1
+            (Get-Content (Join-Path $root "eng" "Packages.Data.props") -Raw) | Should -Match 'Version="1.44.0"'
         }
     }
 }


### PR DESCRIPTION
## Problem

The current release process requires merging prepare-release changes into `main` before running the release pipeline. This forces a redundant CI validation cycle — once for the PR/merge to `main`, and again when the release pipeline builds. For large packages like Azure.Core, this wasted cycle is significant.

## Solution

Allow the release pipeline to run from **either** `main` or a `release/*` branch by making two changes to the `UpdatePackageVersion` job in `archetype-net-release.yml`:

1. **Cherry-pick release artifacts from the build source commit** — After the sparse checkout, overwrite the `CHANGELOG.md` and `.csproj` with the versions from `$(Build.SourceVersion)` so `Update-PkgVersion.ps1` sees the released version and dated changelog entry. When the pipeline runs on `main` this is a no-op (the files are already identical). Paths are resolved via `Get-PkgProperties` for correctness across all package layouts.

2. **PR targets main** — Set `BaseBranchName: refs/heads/main` on the `create-pull-request` step so the version-bump PR always targets `main` regardless of the source branch.

## New Release Flow (optional — existing flow still works)

1. Human runs `Prepare-Release.ps1` (sets version + changelog date)
2. Push to a `release/*` branch (e.g., `release/Azure.Core_1.44.0`)
3. Run the release pipeline against the `release/*` branch
4. Pipeline builds, tests, signs, publishes, tags, and creates the version-bump PR
5. Version-bump PR merges to `main`

## Backward Compatibility

When the pipeline runs on `main` (current flow), behavior is identical — the cherry-pick step overwrites files with the same content (no-op), and `BaseBranchName: refs/heads/main` matches the previous default.