### PR TITLE
Fix CodeTransparency unit test timeout due to missing mock transport

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
@@ -280,7 +280,7 @@ namespace Azure.Security.CodeTransparency.Tests
                     AuthorizedReceiptBehavior = AuthorizedReceiptBehavior.RequireAll,
                     UnauthorizedReceiptBehavior = UnauthorizedReceiptBehavior.FailIfPresent
                 };
-                CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions);
+                CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
                 Console.WriteLine("Verification succeeded: The statement was registered in the immutable ledger.");
             }
             catch (Exception e)

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/SamplesUnitTests.cs
@@ -280,7 +280,11 @@ namespace Azure.Security.CodeTransparency.Tests
                     AuthorizedReceiptBehavior = AuthorizedReceiptBehavior.RequireAll,
                     UnauthorizedReceiptBehavior = UnauthorizedReceiptBehavior.FailIfPresent
                 };
+#if SNIPPET
+                CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions);
+#else
                 CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
+#endif
                 Console.WriteLine("Verification succeeded: The statement was registered in the immutable ledger.");
             }
             catch (Exception e)


### PR DESCRIPTION
## Problem

The \Snippet_Readme_CodeTransparencyVerification_Test\ in \Azure.Security.CodeTransparency\ was making **real HTTP calls** to \`foo.bar.com\ instead of using the configured \MockTransport\. This caused:

- 4 retries x 1m40s network timeout = ~6m44s per test run
- CI failure due to Azure.Core.TestFramework's 30-second global test timeout
- Blocked unrelated PRs (e.g. [#57185](https://github.com/Azure/azure-sdk-for-net/pull/57185)) that include this test in their batch

## Root Cause

The test creates a \CodeTransparencyClientOptions\ with a \MockTransport\ but never passes it to the static \VerifyTransparentStatement\ method. The method accepts an optional third parameter \clientOptions\ — without it, it creates real HTTP clients for each issuer domain.

## Fix

Pass the mock-configured \options\ as the third argument:

\\\diff
- CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions);
+ CodeTransparencyClient.VerifyTransparentStatement(transparentStatementBytes, verificationOptions, options);
\\\

## Verification

- **Before fix:** Test hangs for 6+ minutes making real HTTP calls, then fails CI timeout
- **After fix:** Both test instances pass in ~134ms using the mock transport