### PR TITLE
Remove static .npmrc and exclude package-lock.json from generation diff check

### DIFF
--- a/eng/packages/.npmrc
+++ b/eng/packages/.npmrc
@@ -1,1 +1,0 @@
-registry=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/

--- a/eng/scripts/typespec/Check-CodeGeneration.ps1
+++ b/eng/scripts/typespec/Check-CodeGeneration.ps1
@@ -13,7 +13,7 @@ try {
     & "$EmitterPackagePath/eng/scripts/Generate.ps1"
 
     Write-Host 'Checking generated files difference...'
-    git -c core.safecrlf=false diff --ignore-space-at-eol --exit-code
+    git -c core.safecrlf=false diff --ignore-space-at-eol --exit-code -- ':!package-lock.json'
     if ($LastExitCode -ne 0) {
         Write-Error 'Generated code of Azure generator is not up to date. Please run: /eng/scripts/Generate.ps1'
         exit 1


### PR DESCRIPTION
The static .npmrc at ng/packages/.npmrc is no longer needed — the create-authenticated-npmrc pipeline step in rchetype-typespec-emitter.yml (azure-sdk-tools#14557) now creates the .npmrc dynamically in each emitter package directory before npm commands run.

Additionally, Check-CodeGeneration.ps1 is updated to exclude package-lock.json from the diff check, since the authenticated feed can rewrite resolved URLs which is not a meaningful code generation difference.

## Changes
- Removed ng/packages/.npmrc
- Updated ng/scripts/typespec/Check-CodeGeneration.ps1 to exclude package-lock.json from git diff

Depends on: https://github.com/Azure/azure-sdk-tools/pull/14557