### PR TITLE
[Release] Azure.Provisioning.PrivateDns 1.0.0

### DIFF
--- a/sdk/provisioning/Azure.Provisioning.PrivateDns/CHANGELOG.md
+++ b/sdk/provisioning/Azure.Provisioning.PrivateDns/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0 (2026-03-19)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+- Promoted to stable release (GA).
 
 ## 1.0.0-beta.1 (2026-01-08)
 

--- a/sdk/provisioning/Azure.Provisioning.PrivateDns/README.md
+++ b/sdk/provisioning/Azure.Provisioning.PrivateDns/README.md
@@ -9,7 +9,7 @@ Azure.Provisioning.PrivateDns simplifies declarative resource provisioning in .N
 Install the client library for .NET with [NuGet](https://www.nuget.org/ ):
 
 ```dotnetcli
-dotnet add package Azure.Provisioning.PrivateDns --prerelease
+dotnet add package Azure.Provisioning.PrivateDns
 ```
 
 ### Prerequisites

--- a/sdk/provisioning/Azure.Provisioning.PrivateDns/src/Azure.Provisioning.PrivateDns.csproj
+++ b/sdk/provisioning/Azure.Provisioning.PrivateDns/src/Azure.Provisioning.PrivateDns.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Azure.Provisioning.PrivateDns simplifies declarative resource provisioning in .NET.</Description>
-    <Version>1.0.0-beta.2</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
 
     <!-- Disable warning CS1591: Missing XML comment for publicly visible type or member -->


### PR DESCRIPTION
## Azure.Provisioning.PrivateDns 1.0.0 Stable Release

Promotes `Azure.Provisioning.PrivateDns` from `1.0.0-beta.2` to `1.0.0` (GA).

### Changes
- Bumped version from `1.0.0-beta.2` to `1.0.0`
- Updated CHANGELOG.md with release date `2026-03-19`

### Validation
- API surface validated against the [official ARM template reference (2024-06-01)](https://learn.microsoft.com/en-us/azure/templates/microsoft.network/2024-06-01/privatednszones?pivots=deployment-language-bicep)
- All 10 resource types, all deployable properties, all enums, and all 4 API versions confirmed to match