### PR TITLE
Support IJsonModel<T> types in BicepValue<T> via JSON-to-Bicep conversion

### DIFF
--- a/sdk/datafactory/Azure.Provisioning.DataFactory/tests/Azure.Provisioning.DataFactory.Tests.csproj
+++ b/sdk/datafactory/Azure.Provisioning.DataFactory/tests/Azure.Provisioning.DataFactory.Tests.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />
+    <ProjectReference Include="..\..\..\core\Azure.Core.Expressions.DataFactory\src\Azure.Core.Expressions.DataFactory.csproj" />
     <ProjectReference Include="..\..\..\provisioning\Azure.Provisioning\src\Azure.Provisioning.csproj" />
     <ProjectReference Include="..\src\Azure.Provisioning.DataFactory.csproj" />
     <ProjectReference Include="..\..\..\provisioning\Azure.Provisioning.Deployment\src\Azure.Provisioning.Deployment.csproj" />

--- a/sdk/datafactory/Azure.Provisioning.DataFactory/tests/DataFactoryElementBicepValueTests.cs
+++ b/sdk/datafactory/Azure.Provisioning.DataFactory/tests/DataFactoryElementBicepValueTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core.Expressions.DataFactory;
+using NUnit.Framework;
+
+namespace Azure.Provisioning.DataFactory.Tests;
+
+/// <summary>
+/// Tests that BicepValue can handle DataFactoryElement types via
+/// the IPersistableModel JSON serialization fallback.
+/// </summary>
+public class DataFactoryElementBicepValueTests
+{
+    [Test]
+    public void BicepValue_WithDataFactoryElementString_CompilesSuccessfully()
+    {
+        DataFactoryElement<string> element = DataFactoryElement<string>.FromLiteral("hello");
+        var bicepValue = new BicepValue<DataFactoryElement<string>>(element);
+
+        Assert.AreEqual("'hello'", bicepValue.Compile().ToString());
+    }
+
+    [Test]
+    public void BicepValue_WithDataFactoryElementBool_CompilesSuccessfully()
+    {
+        DataFactoryElement<bool> element = DataFactoryElement<bool>.FromLiteral(true);
+        var bicepValue = new BicepValue<DataFactoryElement<bool>>(element);
+
+        Assert.AreEqual("true", bicepValue.Compile().ToString());
+    }
+
+    [Test]
+    public void BicepValue_WithDataFactoryElementInt_CompilesSuccessfully()
+    {
+        DataFactoryElement<int> element = DataFactoryElement<int>.FromLiteral(42);
+        var bicepValue = new BicepValue<DataFactoryElement<int>>(element);
+
+        Assert.AreEqual("42", bicepValue.Compile().ToString());
+    }
+
+    [Test]
+    public void BicepValue_WithDataFactoryElementExpression_CompilesSuccessfully()
+    {
+        DataFactoryElement<string> element = DataFactoryElement<string>.FromExpression("@pipeline().parameters.myParam");
+        var bicepValue = new BicepValue<DataFactoryElement<string>>(element);
+
+        // Expression-type DataFactoryElements serialize as {"type":"Expression","value":"..."}
+        string result = bicepValue.Compile().ToString();
+        Assert.That(result, Does.Contain("type: 'Expression'"));
+        Assert.That(result, Does.Contain("value: '@pipeline().parameters.myParam'"));
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning/src/BicepValueOfT.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/BicepValueOfT.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ClientModel.Primitives;
 using System.ComponentModel;
 using System.Net;
 using Azure.Core;
@@ -186,6 +187,7 @@ public class BicepValue<T> : BicepValue
         Enum e => BicepSyntax.Value(BicepTypeMapping.ToLiteralString(e, Format)),
         // Other extensible enums like AzureLocation (AzureLocation has been handled above)
         ValueType ee => BicepSyntax.Value(BicepTypeMapping.ToLiteralString(ee, Format)),
+        IJsonModel<T> model => BicepValueJsonConverter.ConvertFromJsonModel(model),
         _ => throw new InvalidOperationException($"Cannot convert {Value} to a Bicep expression.")
     };
 }

--- a/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepValueJsonConverter.cs
+++ b/sdk/provisioning/Azure.Provisioning/src/Expressions/BicepValueJsonConverter.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Azure.Provisioning.Expressions;
+
+/// <summary>
+/// Converts JSON elements into Bicep expressions.
+/// </summary>
+internal static class BicepValueJsonConverter
+{
+    /// <summary>
+    /// Converts an <see cref="IJsonModel{T}"/> into a <see cref="BicepExpression"/>
+    /// by serializing to JSON and then converting the JSON to Bicep.
+    /// </summary>
+    public static BicepExpression ConvertFromJsonModel<T>(IJsonModel<T> model)
+    {
+        using MemoryStream stream = new();
+        using (Utf8JsonWriter writer = new(stream))
+        {
+            model.Write(writer, ModelReaderWriterOptions.Json);
+        }
+        using JsonDocument doc = JsonDocument.Parse(stream.ToArray());
+        return ConvertFromJson(doc.RootElement);
+    }
+
+    /// <summary>
+    /// Converts a <see cref="JsonElement"/> into a <see cref="BicepExpression"/>.
+    /// </summary>
+    /// <param name="element">The JSON element to convert.</param>
+    /// <returns>A Bicep expression representing the JSON value.</returns>
+    public static BicepExpression ConvertFromJson(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.String => BicepSyntax.Value(element.GetString()!),
+        JsonValueKind.Number when element.TryGetInt32(out int i) => BicepSyntax.Value(i),
+        JsonValueKind.Number => BicepSyntax.Value(element.GetDouble()),
+        JsonValueKind.True => BicepSyntax.Value(true),
+        JsonValueKind.False => BicepSyntax.Value(false),
+        JsonValueKind.Null => BicepSyntax.Null(),
+        JsonValueKind.Object => ConvertObject(element),
+        JsonValueKind.Array => ConvertArray(element),
+        _ => throw new InvalidOperationException($"Unsupported JSON value kind: {element.ValueKind}")
+    };
+
+    private static BicepExpression ConvertObject(JsonElement element)
+    {
+        List<PropertyExpression> properties = [];
+        foreach (JsonProperty prop in element.EnumerateObject())
+        {
+            properties.Add(new PropertyExpression(prop.Name, ConvertFromJson(prop.Value)));
+        }
+        return new ObjectExpression([.. properties]);
+    }
+
+    private static BicepExpression ConvertArray(JsonElement element)
+    {
+        List<BicepExpression> values = [];
+        foreach (JsonElement item in element.EnumerateArray())
+        {
+            values.Add(ConvertFromJson(item));
+        }
+        return new ArrayExpression([.. values]);
+    }
+}

--- a/sdk/provisioning/Azure.Provisioning/tests/Expressions/BicepValueJsonConverterTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/Expressions/BicepValueJsonConverterTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace Azure.Provisioning.Tests.Expressions
+{
+    /// <summary>
+    /// Tests that BicepValue handles IPersistableModel types by converting
+    /// their JSON serialization into Bicep expressions.
+    /// </summary>
+    public class BicepValueJsonConverterTests
+    {
+        /// <summary>
+        /// A simple IJsonModel that serializes to a given JSON string.
+        /// Used to test the JSON → Bicep conversion for various shapes.
+        /// </summary>
+        private class FakeModel : IJsonModel<FakeModel>
+        {
+            private readonly string _json;
+            public FakeModel(string json) => _json = json;
+            public void Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+            {
+                using JsonDocument doc = JsonDocument.Parse(_json);
+                doc.RootElement.WriteTo(writer);
+            }
+            public FakeModel Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options) => throw new NotImplementedException();
+            public BinaryData Write(ModelReaderWriterOptions options) => BinaryData.FromString(_json);
+            public FakeModel Create(BinaryData data, ModelReaderWriterOptions options) => throw new NotImplementedException();
+            public string GetFormatFromOptions(ModelReaderWriterOptions options) => "J";
+        }
+
+        private static string CompileModel(string json)
+        {
+            var model = new FakeModel(json);
+            var bicepValue = new BicepValue<FakeModel>(model);
+            return bicepValue.Compile().ToString();
+        }
+
+        [Test]
+        public void ConvertStringValue()
+        {
+            Assert.AreEqual("'hello'", CompileModel("\"hello\""));
+        }
+
+        [Test]
+        public void ConvertIntValue()
+        {
+            Assert.AreEqual("42", CompileModel("42"));
+        }
+
+        [Test]
+        public void ConvertNegativeIntValue()
+        {
+            Assert.AreEqual("-7", CompileModel("-7"));
+        }
+
+        [Test]
+        public void ConvertBoolTrue()
+        {
+            Assert.AreEqual("true", CompileModel("true"));
+        }
+
+        [Test]
+        public void ConvertBoolFalse()
+        {
+            Assert.AreEqual("false", CompileModel("false"));
+        }
+
+        [Test]
+        public void ConvertNullValue()
+        {
+            Assert.AreEqual("null", CompileModel("null"));
+        }
+
+        [Test]
+        public void ConvertSimpleObject()
+        {
+            string result = CompileModel("{\"name\":\"test\",\"count\":5}");
+            Assert.That(result, Does.Contain("name: 'test'"));
+            Assert.That(result, Does.Contain("count: 5"));
+        }
+
+        [Test]
+        public void ConvertEmptyArray()
+        {
+            string result = CompileModel("[]");
+            Assert.AreEqual("[]", result);
+        }
+
+        [Test]
+        public void ConvertSimpleArray()
+        {
+            string result = CompileModel("[1,2,3]");
+            Assert.That(result, Does.Contain("1"));
+            Assert.That(result, Does.Contain("2"));
+            Assert.That(result, Does.Contain("3"));
+        }
+
+        [Test]
+        public void ConvertNestedObject()
+        {
+            string result = CompileModel("{\"outer\":{\"inner\":\"value\"}}");
+            Assert.That(result, Does.Contain("outer:"));
+            Assert.That(result, Does.Contain("inner: 'value'"));
+        }
+
+        [Test]
+        public void ConvertMixedArray()
+        {
+            string result = CompileModel("[\"a\",1,true,null]");
+            Assert.That(result, Does.Contain("'a'"));
+            Assert.That(result, Does.Contain("1"));
+            Assert.That(result, Does.Contain("true"));
+            Assert.That(result, Does.Contain("null"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for `IJsonModel<T>` types (e.g. `DataFactoryElement<T>`) in `BicepValue<T>` by serializing them to JSON and converting to Bicep expressions.

### Changes

- **`BicepValueJsonConverter`** (new): Utility that converts `JsonElement` → `BicepExpression` recursively (objects, arrays, primitives). Includes `ConvertFromJsonModel<T>()` that writes via `IJsonModel<T>.Write(Utf8JsonWriter, ...)` — AOT-safe, no reflection.
- **`BicepValue<T>.CompileLiteralValue()`**: Added `IJsonModel<T>` fallback before the default `InvalidOperationException` throw. Any type implementing `IJsonModel<T>` now automatically works with `BicepValue<T>`.
- **Tests**: 11 converter tests (string, int, bool, null, objects, arrays, nested, mixed) + 4 `DataFactoryElement<T>` integration tests.

### Motivation

`DataFactoryElement<T>` from `Azure.Core.Expressions.DataFactory` is extensively used in Azure.ResourceManager.DataFactory models but was not supported by `BicepValue<T>.CompileLiteralValue()`, which only handled known primitives and `IBicepValue` types. This blocked `Azure.Provisioning.DataFactory` from using properties of type `BicepValue<DataFactoryElement<T>>`.