### PR TITLE
Add treeless checkout to Compliance job to avoid 4 GB fetch

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -140,6 +140,19 @@ jobs:
         image: $(WINDOWSVMIMAGE)
         os: windows
       steps:
+        - checkout: self
+          fetchDepth: 1
+          fetchTags: false
+
+        - pwsh: |
+            $targetBranch = "${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/"
+            if (-not $targetBranch) {
+              $targetBranch = "main"
+            }
+            Write-Host "Fetching origin/$targetBranch for diff comparison"
+            git fetch --depth=1 origin "${targetBranch}:refs/remotes/origin/${targetBranch}"
+          displayName: Fetch target branch for diff comparison
+
         - task: UsePythonVersion@0
           displayName: "Use Python 3.11"
           inputs:

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -149,8 +149,10 @@ jobs:
             if (-not $targetBranch) {
               $targetBranch = "main"
             }
-            Write-Host "Fetching origin/$targetBranch for diff comparison"
+            Write-Host "Fetching origin/$targetBranch at depth=1"
             git fetch --depth=1 origin "${targetBranch}:refs/remotes/origin/${targetBranch}"
+            Write-Host "Deepening by 1 commit to resolve merge base for three-dot diff"
+            git fetch --deepen=1 origin
           displayName: Fetch target branch for diff comparison
 
         - task: UsePythonVersion@0

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -141,19 +141,8 @@ jobs:
         os: windows
       steps:
         - checkout: self
-          fetchDepth: 1
+          fetchFilter: tree:0
           fetchTags: false
-
-        - pwsh: |
-            $targetBranch = "${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/"
-            if (-not $targetBranch) {
-              $targetBranch = "main"
-            }
-            Write-Host "Fetching origin/$targetBranch at depth=1"
-            git fetch --depth=1 origin "${targetBranch}:refs/remotes/origin/${targetBranch}"
-            Write-Host "Deepening by 1 commit to resolve merge base for three-dot diff"
-            git fetch --deepen=1 origin
-          displayName: Fetch target branch for diff comparison
 
         - task: UsePythonVersion@0
           displayName: "Use Python 3.11"


### PR DESCRIPTION
## Problem

The \Compliance\ job in \ci.yml\ had no explicit \checkout:\ step, so Azure DevOps performed a default full \git fetch\ on every run — downloading **4.17 GB** and **1,748,456 objects** just to run spelling, link, path length, and filename validation checks. This took ~7 minutes per run.

## Fix

Add an explicit \checkout: self\ with \fetchFilter: tree:0\ and \fetchTags: false\ as the first step in the Compliance job. The treeless clone downloads all commit metadata (~171 MB) but skips tree/blob objects until checkout needs them. This preserves the full commit graph so \git merge-base\ and three-dot diffs (used by \ng-common-workflow-enforcer\ and \get-changedfiles.ps1\) work correctly. This is the same pattern used by \codeowners-linter.yml\.

We initially tried \fetchDepth: 1\ (shallow clone) but it broke the three-dot diff (\origin/main...HEAD\) because the merge base couldn't be resolved without commit history.

## Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| **Data fetched** | 4.17 GB | ~171 MB | **96% smaller** |
| **Objects** | 1,748,456 | ~155K | **91% fewer** |
| **Checkout time** | ~7 min | ~2 min | **~5 min saved** |
