### PR TITLE
Bump http-client-csharp-mgmt base dependency to 1.0.0-alpha.20260318.2

### DIFF
--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260316.1</UnbrandedGeneratorVersion>
-    <AzureGeneratorVersion>1.0.0-alpha.20260312.1</AzureGeneratorVersion>
+    <AzureGeneratorVersion>1.0.0-alpha.20260318.2</AzureGeneratorVersion>
     <AzureManagementGeneratorVersion>1.0.0-alpha.20260314.2</AzureManagementGeneratorVersion>
   </PropertyGroup>
 

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260318.2"
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.38",
@@ -17,7 +17,7 @@
         "@azure-tools/typespec-azure-core": "0.66.0",
         "@azure-tools/typespec-azure-resource-manager": "0.66.0",
         "@azure-tools/typespec-azure-rulesets": "0.66.0",
-        "@azure-tools/typespec-client-generator-core": "0.66.1",
+        "@azure-tools/typespec-client-generator-core": "0.66.2",
         "@azure-tools/typespec-liftr-base": "0.12.0",
         "@eslint/js": "^9.2.0",
         "@types/node": "~22.12.0",
@@ -26,7 +26,7 @@
         "@typespec/compiler": "1.10.0",
         "@typespec/events": "0.80.0",
         "@typespec/http": "1.10.0",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260312.1",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260316.1",
         "@typespec/http-specs": "0.1.0-alpha.34",
         "@typespec/openapi": "1.10.0",
         "@typespec/rest": "0.80.0",
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.1.tgz",
-      "integrity": "sha512-aGxEeuk5fqeb9YfalNWTQtAVLIzPkbxObcmCH02XtHvd4Vd2u1hy4l714OB3rz0V+xR30IOSRGLfFnbEv3c1oA==",
+      "version": "0.66.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.2.tgz",
+      "integrity": "sha512-Qr5fstJ0yQiTYNvp/EuY3+mUBue2ri9qNZkT6aC+CsfBt5yjfdjo++3SuEsDQtELyS8pBoDOT3weLiB0N+/fSw==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -252,12 +252,12 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260312.1",
-      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
-      "integrity": "sha512-haufuXCdGZNzQ1Ak0kyNAVIOtbWQzqJf4KChjgz98IDIHFyg4KD1prCNatFhrzcG/kLbrNEFLNgeCCHxUxMtrA==",
+      "version": "1.0.0-alpha.20260318.2",
+      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260318.2.tgz",
+      "integrity": "sha512-eYFgkCCvYWwWa41IyXZbDNrHqqLq2XkXGH2SqNFISW+jlfgyaNoODfrIt+/vkdA5hFnESwJP+qJBe8NTwLHLLw==",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260316.1"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -2779,12 +2779,12 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260312.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
-      "integrity": "sha512-pFCH82WUR+PdupXuQVRLhKqzbiBHzuS6VbRw3NROPyGXqzNIiN6byVq3/cAEHNhDrMQJseH2n+ISjuamLEv0AQ==",
+      "version": "1.0.0-alpha.20260316.1",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260316.1.tgz",
+      "integrity": "sha512-9M1GNEbjPm+GxGb12NhqtIbHazqXrk2QY54SxSrpkxhu1NTNyEZinTn7wXiaGwmRt8kjoyUjN7rg67iFJ9KxbA==",
       "license": "MIT",
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.66.0 <0.67.0 || ~0.67.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.66.2 <0.67.0 || ~0.67.0-0",
         "@typespec/compiler": "^1.10.0",
         "@typespec/http": "^1.10.0",
         "@typespec/openapi": "^1.10.0",

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -37,7 +37,7 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260318.2"
   },
   "peerDependencies": {
     "@typespec/http-client-csharp": "^1.0.0-alpha"
@@ -48,7 +48,7 @@
     "@azure-tools/typespec-azure-core": "0.66.0",
     "@azure-tools/typespec-azure-resource-manager": "0.66.0",
     "@azure-tools/typespec-azure-rulesets": "0.66.0",
-    "@azure-tools/typespec-client-generator-core": "0.66.1",
+    "@azure-tools/typespec-client-generator-core": "0.66.2",
     "@azure-tools/typespec-liftr-base": "0.12.0",
     "@eslint/js": "^9.2.0",
     "@types/node": "~22.12.0",
@@ -57,7 +57,7 @@
     "@typespec/compiler": "1.10.0",
     "@typespec/events": "0.80.0",
     "@typespec/http": "1.10.0",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260312.1",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260316.1",
     "@typespec/http-specs": "0.1.0-alpha.34",
     "@typespec/openapi": "1.10.0",
     "@typespec/rest": "0.80.0",


### PR DESCRIPTION
Updates the mgmt generator's base dependency versions to match PR #57224:

- `@azure-typespec/http-client-csharp`: `1.0.0-alpha.20260312.1` → `1.0.0-alpha.20260318.2`
- `@typespec/http-client-csharp` (devDep): `1.0.0-alpha.20260312.1` → `1.0.0-alpha.20260316.1`
- `@azure-tools/typespec-client-generator-core` (devDep): `0.66.1` → `0.66.2`
- `AzureGeneratorVersion` in `Directory.Generation.Packages.props`: `1.0.0-alpha.20260312.1` → `1.0.0-alpha.20260318.2`

Emitter build, lint, prettier, generator build, and test project regeneration all pass with no changes.