### PR TITLE
Bump typespec-client-generator-core to 0.66.2 in provisioning emitter

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -16,7 +16,7 @@
         "@azure-tools/typespec-azure-core": "0.66.0",
         "@azure-tools/typespec-azure-resource-manager": "0.66.0",
         "@azure-tools/typespec-azure-rulesets": "0.66.0",
-        "@azure-tools/typespec-client-generator-core": "0.66.1",
+        "@azure-tools/typespec-client-generator-core": "0.66.2",
         "@azure-tools/typespec-liftr-base": "0.12.0",
         "@eslint/js": "^9.2.0",
         "@types/node": "~22.12.0",
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.1.tgz",
-      "integrity": "sha512-aGxEeuk5fqeb9YfalNWTQtAVLIzPkbxObcmCH02XtHvd4Vd2u1hy4l714OB3rz0V+xR30IOSRGLfFnbEv3c1oA==",
+      "version": "0.66.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.2.tgz",
+      "integrity": "sha512-Qr5fstJ0yQiTYNvp/EuY3+mUBue2ri9qNZkT6aC+CsfBt5yjfdjo++3SuEsDQtELyS8pBoDOT3weLiB0N+/fSw==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -47,7 +47,7 @@
     "@azure-tools/typespec-azure-core": "0.66.0",
     "@azure-tools/typespec-azure-resource-manager": "0.66.0",
     "@azure-tools/typespec-azure-rulesets": "0.66.0",
-    "@azure-tools/typespec-client-generator-core": "0.66.1",
+    "@azure-tools/typespec-client-generator-core": "0.66.2",
     "@azure-tools/typespec-liftr-base": "0.12.0",
     "@eslint/js": "^9.2.0",
     "@types/node": "~22.12.0",


### PR DESCRIPTION
The base emitter (http-client-csharp) uses typespec-client-generator-core 0.66.2, but provisioning was still on 0.66.1. This caused ERESOLVE failures when generating the emitter-package-lock.json in CI because @typespec/http-client-csharp requires >=0.66.2 as a peer dependency.