### PR TITLE
Plumb resource RBAC roles through ArmProviderSchema via @@clientOption

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -432,7 +432,7 @@ function convertResolvedResourceToMetadata(
     sdkContext,
     resolvedResource.type
   ) as SdkModelType;
-  const rbacRoles = extractRbacRoles(sdkModel?.decorators);
+  const rbacRoles = extractRbacRoles(sdkModel);
 
   return {
     // we only assign resourceIdPattern when this resource has a read operation, otherwise this is empty

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -49,10 +49,15 @@ import {
   ParentResourceLookupContext,
   assignNonResourceMethodsToResources,
   calculateResourceTypeFromPath,
-  resolveResourceApiVersions
+  resolveResourceApiVersions,
+  extractRbacRoles
 } from "./resource-metadata.js";
 import { CSharpEmitterContext } from "@typespec/http-client-csharp";
-import { getCrossLanguageDefinitionId } from "@azure-tools/typespec-client-generator-core";
+import {
+  getCrossLanguageDefinitionId,
+  getClientType,
+  SdkModelType
+} from "@azure-tools/typespec-client-generator-core";
 import {
   isVariableSegment,
   isPrefix,
@@ -422,6 +427,13 @@ function convertResolvedResourceToMetadata(
   // API versions will be computed after post-processing when methods are finalized
   const apiVersions: string[] = [];
 
+  // Extract RBAC roles from @@clientOption decorator
+  const sdkModel = getClientType(
+    sdkContext,
+    resolvedResource.type
+  ) as SdkModelType;
+  const rbacRoles = extractRbacRoles(sdkModel?.decorators);
+
   return {
     // we only assign resourceIdPattern when this resource has a read operation, otherwise this is empty
     resourceIdPattern: resourceIdPattern,
@@ -437,7 +449,8 @@ function convertResolvedResourceToMetadata(
     ),
     resourceName: resourceName,
     nameConstraints,
-    apiVersions
+    apiVersions,
+    rbacRoles
   };
 }
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -538,7 +538,7 @@ export function buildArmProviderSchema(
     };
 
     // Extract RBAC roles from @@clientOption decorator
-    resource.metadata.rbacRoles = extractRbacRoles(sdkModel?.decorators);
+    resource.metadata.rbacRoles = extractRbacRoles(sdkModel);
   }
 
   // Assign non-resource methods to resources based on operationPath prefix matching.

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -20,7 +20,8 @@ import {
   postProcessArmResources,
   ParentResourceLookupContext,
   assignNonResourceMethodsToResources,
-  resolveResourceApiVersions
+  resolveResourceApiVersions,
+  extractRbacRoles
 } from "./resource-metadata.js";
 import {
   DecoratorInfo,
@@ -285,7 +286,8 @@ export function buildArmProviderSchema(
           // Use model name as default; will be updated later if multiple paths exist
           resourceName: model?.name ?? "Unknown",
           nameConstraints: {},
-          apiVersions: []
+          apiVersions: [],
+          rbacRoles: []
         } as ResourceMetadata;
         resourcePathToMetadataMap.set(metadataKey, entry);
       }
@@ -534,6 +536,9 @@ export function buildArmProviderSchema(
         ? getMaxLength(sdkContext.program, nameProperty)
         : undefined
     };
+
+    // Extract RBAC roles from @@clientOption decorator
+    resource.metadata.rbacRoles = extractRbacRoles(sdkModel?.decorators);
   }
 
   // Assign non-resource methods to resources based on operationPath prefix matching.

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -56,6 +56,16 @@ export interface NameConstraints {
   maxLength?: number;
 }
 
+/**
+ * Represents a single RBAC role definition for a resource.
+ */
+export interface RbacRole {
+  /** The role name (e.g., "KeyVaultContributor") */
+  name: string;
+  /** The role GUID (e.g., "f25e0fa2-a7c8-4377-a976-54943a77a395") */
+  value: string;
+}
+
 export interface ResourceMetadata {
   resourceIdPattern: string;
   resourceType: string;
@@ -69,6 +79,8 @@ export interface ResourceMetadata {
   nameConstraints: NameConstraints;
   /** The API versions that this resource is available in */
   apiVersions: string[];
+  /** The RBAC roles defined for this resource via @@clientOption */
+  rbacRoles: RbacRole[];
 }
 
 export function convertResourceMetadataToArguments(
@@ -83,6 +95,30 @@ export function convertResourceMetadataToArguments(
     singletonResourceName: metadata.singletonResourceName,
     resourceName: metadata.resourceName
   };
+}
+
+const clientOptionDecorator = "Azure.ClientGenerator.Core.@clientOption";
+const rbacRolesKey = "resource-rbac-roles";
+
+/**
+ * Extracts RBAC roles from a model's @@clientOption decorator with key "resource-rbac-roles".
+ * The decorator value is expected to be a record of role name to role GUID.
+ */
+export function extractRbacRoles(
+  decorators: { name: string; arguments: Record<string, any> }[] | undefined
+): RbacRole[] {
+  if (!decorators) return [];
+  const decorator = decorators.find(
+    (d) =>
+      d.name === clientOptionDecorator && d.arguments?.["name"] === rbacRolesKey
+  );
+  if (!decorator) return [];
+  const value = decorator.arguments?.["value"];
+  if (!value || typeof value !== "object") return [];
+  return Object.entries(value).map(([name, guid]) => ({
+    name,
+    value: guid as string
+  }));
 }
 
 export interface NonResourceMethod {
@@ -253,7 +289,8 @@ export function convertArmProviderSchemaToArguments(
       singletonResourceName: r.metadata.singletonResourceName,
       resourceName: r.metadata.resourceName,
       nameConstraints: r.metadata.nameConstraints,
-      apiVersions: r.metadata.apiVersions
+      apiVersions: r.metadata.apiVersions,
+      rbacRoles: r.metadata.rbacRoles
     })),
     nonResourceMethods: schema.nonResourceMethods.map((m) => ({
       methodId: m.methodId,

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -6,6 +6,10 @@ import {
   findLongestPrefixMatch,
   countProviderSegments
 } from "./utils.js";
+import {
+  DecoratedType,
+  getClientOptions
+} from "@azure-tools/typespec-client-generator-core";
 
 const ResourceGroupScopePrefix =
   "/subscriptions/{subscriptionId}/resourceGroups";
@@ -97,28 +101,23 @@ export function convertResourceMetadataToArguments(
   };
 }
 
-const clientOptionDecorator = "Azure.ClientGenerator.Core.@clientOption";
 const rbacRolesKey = "resource-rbac-roles";
 
 /**
  * Extracts RBAC roles from a model's @@clientOption decorator with key "resource-rbac-roles".
- * The decorator value is expected to be a record of role name to role GUID.
+ * Uses TCGC's getClientOptions API which handles scope filtering.
+ * The value is expected to be a record of role name to role GUID.
  */
-export function extractRbacRoles(
-  decorators: { name: string; arguments: Record<string, any> }[] | undefined
-): RbacRole[] {
-  if (!decorators) return [];
-  const decorator = decorators.find(
-    (d) =>
-      d.name === clientOptionDecorator && d.arguments?.["name"] === rbacRolesKey
-  );
-  if (!decorator) return [];
-  const value = decorator.arguments?.["value"];
+export function extractRbacRoles(model: DecoratedType | undefined): RbacRole[] {
+  if (!model) return [];
+  const value = getClientOptions(model, rbacRolesKey);
   if (!value || typeof value !== "object") return [];
-  return Object.entries(value).map(([name, guid]) => ({
-    name,
-    value: guid as string
-  }));
+  return Object.entries(value as Record<string, string>).map(
+    ([name, guid]) => ({
+      name,
+      value: guid
+    })
+  );
 }
 
 export interface NonResourceMethod {

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-detection.test.ts
@@ -3206,4 +3206,107 @@ interface Employees {
     ok(resolvedGadget);
     deepStrictEqual(resolvedGadget.metadata.apiVersions, ["2024-05-01"]);
   });
+
+  it("rbac roles from clientOption decorator", async () => {
+    const program = await typeSpecCompile(
+      `
+/** Widget properties */
+model WidgetProperties {
+  /** Color of widget */
+  color?: string;
+}
+
+/** A Widget resource with RBAC roles */
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles"
+model Widget is TrackedResource<WidgetProperties> {
+  ...ResourceNameParameter<Widget>;
+}
+
+interface Operations extends Azure.ResourceManager.Operations {}
+
+@armResourceOperations
+interface Widgets {
+  get is ArmResourceRead<Widget>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
+}
+
+@@clientOption(Widget, "resource-rbac-roles", #{
+  WidgetContributor: "00000000-0000-0000-0000-000000000001",
+  WidgetReader: "00000000-0000-0000-0000-000000000002",
+}, "csharp");
+`,
+      runner
+    );
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const root = createModel(sdkContext);
+
+    const armProviderSchema = buildArmProviderSchema(sdkContext, root);
+    ok(armProviderSchema);
+    strictEqual(armProviderSchema.resources.length, 1);
+
+    const widgetResource = armProviderSchema.resources[0];
+    ok(widgetResource);
+    deepStrictEqual(widgetResource.metadata.rbacRoles, [
+      {
+        name: "WidgetContributor",
+        value: "00000000-0000-0000-0000-000000000001"
+      },
+      { name: "WidgetReader", value: "00000000-0000-0000-0000-000000000002" }
+    ]);
+
+    // Also validate resolveArmResources produces the same roles
+    const resolvedSchema = resolveArmResources(program, sdkContext);
+    ok(resolvedSchema);
+    const resolvedResource = resolvedSchema.resources[0];
+    ok(resolvedResource);
+    deepStrictEqual(
+      resolvedResource.metadata.rbacRoles,
+      widgetResource.metadata.rbacRoles
+    );
+  });
+
+  it("rbac roles empty when no clientOption decorator", async () => {
+    const program = await typeSpecCompile(
+      `
+/** Gadget properties */
+model GadgetProperties {
+  /** Size of gadget */
+  size?: int32;
+}
+
+/** A Gadget resource without RBAC roles */
+model Gadget is TrackedResource<GadgetProperties> {
+  ...ResourceNameParameter<Gadget>;
+}
+
+interface Operations extends Azure.ResourceManager.Operations {}
+
+@armResourceOperations
+interface Gadgets {
+  get is ArmResourceRead<Gadget>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<Gadget>;
+}
+`,
+      runner
+    );
+    const context = createEmitterContext(program);
+    const sdkContext = await createCSharpSdkContext(context);
+    const root = createModel(sdkContext);
+
+    const armProviderSchema = buildArmProviderSchema(sdkContext, root);
+    ok(armProviderSchema);
+    strictEqual(armProviderSchema.resources.length, 1);
+
+    const gadgetResource = armProviderSchema.resources[0];
+    ok(gadgetResource);
+    deepStrictEqual(gadgetResource.metadata.rbacRoles, []);
+
+    // Also validate resolveArmResources produces empty roles
+    const resolvedSchema = resolveArmResources(program, sdkContext);
+    ok(resolvedSchema);
+    const resolvedResource = resolvedSchema.resources[0];
+    ok(resolvedResource);
+    deepStrictEqual(resolvedResource.metadata.rbacRoles, []);
+  });
 });

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ArmResourceMetadata.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ArmResourceMetadata.cs
@@ -20,6 +20,7 @@ namespace Azure.Generator.Management.Models;
 /// <param name="ChildResourceIds"> The list of child resource ID patterns. </param>
 /// <param name="NameConstraints"> The name constraints for the resource. </param>
 /// <param name="ApiVersions"> The API versions that this resource is available in. </param>
+/// <param name="RbacRoles"> The RBAC roles defined for this resource. </param>
 public record ArmResourceMetadata(
     string ResourceIdPattern,
     string ResourceName,
@@ -31,7 +32,8 @@ public record ArmResourceMetadata(
     string? ParentResourceId,
     IReadOnlyList<string> ChildResourceIds,
     ArmResourceNameConstraints NameConstraints,
-    IReadOnlyList<string> ApiVersions)
+    IReadOnlyList<string> ApiVersions,
+    IReadOnlyList<ArmResourceRbacRole> RbacRoles)
 {
     // ChildResourceIds is currently unpopulated and passed in as an empty array
     internal static ArmResourceMetadata DeserializeResourceMetadata(JsonElement element, InputModelType inputModel, IReadOnlyList<string> childResourceIds)
@@ -105,6 +107,15 @@ public record ArmResourceMetadata(
             }
         }
 
+        var rbacRoles = new List<ArmResourceRbacRole>();
+        if (element.TryGetProperty("rbacRoles", out var rbacRolesElement))
+        {
+            foreach (var item in rbacRolesElement.EnumerateArray())
+            {
+                rbacRoles.Add(ArmResourceRbacRole.DeserializeRbacRole(item));
+            }
+        }
+
         return new(
             resourceIdPattern ?? throw new InvalidOperationException("resourceIdPattern cannot be null"),
             resourceName ?? throw new InvalidOperationException("resourceName cannot be null"),
@@ -116,6 +127,7 @@ public record ArmResourceMetadata(
             parentResource,
             childResourceIds,
             nameConstraints,
-            apiVersions);
+            apiVersions,
+            rbacRoles);
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ArmResourceRbacRole.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/ResourceSchemas/ArmResourceRbacRole.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace Azure.Generator.Management.Models;
+
+/// <summary> Represents an RBAC role definition for a resource. </summary>
+/// <param name="Name"> The role name (e.g., "KeyVaultContributor"). </param>
+/// <param name="Value"> The role GUID (e.g., "f25e0fa2-a7c8-4377-a976-54943a77a395"). </param>
+public record ArmResourceRbacRole(
+    string Name,
+    string Value)
+{
+    internal static ArmResourceRbacRole DeserializeRbacRole(JsonElement element)
+    {
+        string? name = null;
+        string? value = null;
+
+        if (element.TryGetProperty("name", out var nameElement))
+        {
+            name = nameElement.GetString();
+        }
+        if (element.TryGetProperty("value", out var valueElement))
+        {
+            value = valueElement.GetString();
+        }
+
+        return new(
+            name ?? throw new System.InvalidOperationException("RBAC role name cannot be null"),
+            value ?? throw new System.InvalidOperationException("RBAC role value cannot be null"));
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/foo.tsp
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/foo.tsp
@@ -13,6 +13,7 @@ using LiftrBase;
 namespace MgmtTypeSpec;
 
 @resource("foos")
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
 model Foo is TrackedResource<FooProperties, false> {
   ...ResourceNameParameter<Foo, SegmentName = "foos">;
 
@@ -206,3 +207,9 @@ model FooSettingsProperties is BaseResourceProperties {
 model FooSettingsPropertiesMetaData {
   metaDatas?: string[];
 }
+
+@@clientOption(Foo, "resource-rbac-roles", #{
+  FooContributor: "00000000-0000-0000-0000-000000000001",
+  FooReader: "00000000-0000-0000-0000-000000000002",
+  FooDataOperator: "00000000-0000-0000-0000-000000000003",
+}, "csharp");

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/foo.tsp
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/foo.tsp
@@ -13,7 +13,6 @@ using LiftrBase;
 namespace MgmtTypeSpec;
 
 @resource("foos")
-#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
 model Foo is TrackedResource<FooProperties, false> {
   ...ResourceNameParameter<Foo, SegmentName = "foos">;
 
@@ -208,6 +207,7 @@ model FooSettingsPropertiesMetaData {
   metaDatas?: string[];
 }
 
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
 @@clientOption(Foo, "resource-rbac-roles", #{
   FooContributor: "00000000-0000-0000-0000-000000000001",
   FooReader: "00000000-0000-0000-0000-000000000002",

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
@@ -8097,6 +8097,18 @@
         {
           "name": "Azure.ResourceManager.Private.@armResourceInternal",
           "arguments": {}
+        },
+        {
+          "name": "Azure.ClientGenerator.Core.@clientOption",
+          "arguments": {
+            "name": "resource-rbac-roles",
+            "value": {
+              "FooContributor": "00000000-0000-0000-0000-000000000001",
+              "FooReader": "00000000-0000-0000-0000-000000000002",
+              "FooDataOperator": "00000000-0000-0000-0000-000000000003"
+            },
+            "scope": "csharp"
+          }
         }
       ],
       "serializationOptions": {
@@ -21815,7 +21827,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.StorageSyncService",
@@ -21837,7 +21850,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.Foo",
@@ -21915,6 +21929,20 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
+                ],
+                "rbacRoles": [
+                  {
+                    "name": "FooContributor",
+                    "value": "00000000-0000-0000-0000-000000000001"
+                  },
+                  {
+                    "name": "FooReader",
+                    "value": "00000000-0000-0000-0000-000000000002"
+                  },
+                  {
+                    "name": "FooDataOperator",
+                    "value": "00000000-0000-0000-0000-000000000003"
+                  }
                 ]
               },
               {
@@ -21963,7 +21991,8 @@
                 },
                 "apiVersions": [
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.Bar",
@@ -22028,7 +22057,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.BarSettingsResource",
@@ -22062,7 +22092,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.BarQuotaResource",
@@ -22095,7 +22126,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.Baz",
@@ -22157,7 +22189,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.Zoo",
@@ -22235,7 +22268,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.IssueTestResource",
@@ -22282,7 +22316,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.EndpointResource",
@@ -22335,7 +22370,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.SelfHelpResource",
@@ -22357,7 +22393,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.PlaywrightQuota",
@@ -22396,7 +22433,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.JobResource",
@@ -22436,7 +22474,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.HciVmInstance",
@@ -22461,7 +22500,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.GroupQuotaSubscriptionRequestStatus",
@@ -22483,7 +22523,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.GroupQuotaLimitList",
@@ -22521,7 +22562,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.SubscriptionQuotaAllocationsList",
@@ -22543,7 +22585,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.Joo",
@@ -22583,7 +22626,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.SAPVirtualInstance",
@@ -22615,7 +22659,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.BestPractice",
@@ -22668,7 +22713,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.BestPractice",
@@ -22723,7 +22769,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.ResourceTypeTestResource",
@@ -22755,7 +22802,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.SampleData",
@@ -22802,7 +22850,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.WorkloadNetworks",
@@ -22849,7 +22898,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.WorkloadNetworkVmGroup",
@@ -22904,7 +22954,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.WorkloadNetworkSegment",
@@ -22959,7 +23010,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.Target",
@@ -23006,7 +23058,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.Cluster",
@@ -23068,7 +23121,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.DuplicatePropertyTest",
@@ -23115,7 +23169,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.ServiceGroupSite",
@@ -23154,7 +23209,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.TrafficProfile",
@@ -23199,7 +23255,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.TrafficEndpoint",
@@ -23238,7 +23295,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.VmConfigurationAssignment",
@@ -23260,7 +23318,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.HcrpConfigurationAssignment",
@@ -23282,7 +23341,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.MultiFlattenTest",
@@ -23315,7 +23375,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.PolicyAssignment",
@@ -23360,7 +23421,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.PolicyAssignment",
@@ -23405,7 +23467,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.TestCertificate",
@@ -23451,7 +23514,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.SharedConfig",
@@ -23480,7 +23544,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "MgmtTypeSpec.SharedConfig",
@@ -23525,7 +23590,8 @@
                 "apiVersions": [
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               }
             ],
             "nonResourceMethods": [


### PR DESCRIPTION
## Summary

Adds support for plumbing RBAC role definitions through the mgmt generator's ArmProviderSchema, using TCGC's `@@clientOption` decorator with the key `resource-rbac-roles`.

This enables TypeSpec authors to declare RBAC roles on ARM resources:
```typespec
#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles"
@@clientOption(MyResource, "resource-rbac-roles", #{
  MyContributor: "00000000-0000-0000-0000-000000000001",
  MyReader: "00000000-0000-0000-0000-000000000002",
}, "csharp");
```

The roles flow through the emitter into the code model JSON and are deserialized in the C# generator as `ArmResourceRbacRole` records on `ArmResourceMetadata`.

## Changes

**Emitter (TypeScript):**
- Added `RbacRole` interface and `extractRbacRoles()` helper in `resource-metadata.ts`
- Extract RBAC roles from `@@clientOption` decorator in both resource detection paths
- Serialize `rbacRoles` in `convertArmProviderSchemaToArguments`

**Generator (C#):**
- New `ArmResourceRbacRole` record with JSON deserialization
- Added `RbacRoles` parameter to `ArmResourceMetadata`

**Test project:**
- Added `@@clientOption` with 3 test RBAC roles on the Foo resource in `foo.tsp`
- 2 new emitter tests for RBAC roles extraction

Related to #56743