### PR TITLE
Update npm feed URL in Build-Emitter.ps1

### DIFF
--- a/eng/scripts/typespec/Build-Emitter.ps1
+++ b/eng/scripts/typespec/Build-Emitter.ps1
@@ -45,7 +45,7 @@ function Build-Emitter {
         Copy-Item $file -Destination $outputPath
 
         if (!$TargetNpmJsFeed) {
-            $feedUrl = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js-test-autorest/npm/registry"
+            $feedUrl = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry"
 
             $packageJson = Get-Content -Path "./package.json" | ConvertFrom-Json
             $packageVersion = $packageJson.version


### PR DESCRIPTION
Stop using the deprecated test feed

From https://github.com/Azure/azure-sdk-tools/issues/14590