### PR TITLE
Fixed `HttpClientTransport` to correctly set the `Host` header on outgoing requests when explicitly specified

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed implicit conversion operators to not throw exceptions on null inputs per Framework Design Guidelines. Operators now return safe defaults: `null` for reference types, `default` for value types.
 - Fixed `RequestContent.Dispose()` to be idempotent and thread-safe, preventing `ArrayPool` buffers from being returned multiple times when disposed concurrently or repeatedly.
+- Fixed `HttpClientTransport` to correctly set the `Host` header on outgoing requests when explicitly specified, rather than falling through to `TryAddWithoutValidation`.
 
 ### Other Changes
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
@@ -127,6 +127,14 @@ namespace Azure.Core.Pipeline
                             {
                                 currentRequest.Headers.Authorization = authHeader;
                             }
+                            else if (headerName == HttpHeader.Names.Host)
+                            {
+                                currentRequest.Headers.Host = stringValue;
+                            }
+                            else if (headerName == HttpHeader.Names.UserAgent)
+                            {
+                                currentRequest.Headers.UserAgent.ParseAdd(stringValue);
+                            }
                             else if (!currentRequest.Headers.TryAddWithoutValidation(headerName, stringValue))
                             {
                                 if (currentContent != null && !currentContent.Headers.TryAddWithoutValidation(headerName, stringValue))

--- a/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpClientTransport.Request.cs
@@ -131,10 +131,6 @@ namespace Azure.Core.Pipeline
                             {
                                 currentRequest.Headers.Host = stringValue;
                             }
-                            else if (headerName == HttpHeader.Names.UserAgent)
-                            {
-                                currentRequest.Headers.UserAgent.ParseAdd(stringValue);
-                            }
                             else if (!currentRequest.Headers.TryAddWithoutValidation(headerName, stringValue))
                             {
                                 if (currentContent != null && !currentContent.Headers.TryAddWithoutValidation(headerName, stringValue))

--- a/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
+++ b/sdk/core/Azure.Core/tests/TransportFunctionalTests.cs
@@ -169,6 +169,27 @@ namespace Azure.Core.Tests
             Assert.AreEqual("example.org", host.ToString());
         }
 
+        [Test]
+        public async Task SettingHostHeaderWithSetValueIsReflectedOnServer()
+        {
+            HostString? host = null;
+            using TestServer testServer = new TestServer(
+                context =>
+                {
+                    host = context.Request.GetTypedHeaders().Host;
+                });
+
+            var transport = GetTransport();
+            Request request = transport.CreateRequest();
+            request.Method = RequestMethod.Get;
+            request.Uri.Reset(testServer.Address);
+            request.Headers.SetValue("Host", "custom.example.com");
+
+            await ExecuteRequest(request, transport);
+
+            Assert.AreEqual("custom.example.com", host.ToString());
+        }
+
         [Theory]
         [TestCase(200)]
         [TestCase(300)]


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
