### PR TITLE
Update Azure.Provisioning.ApiManagement release date to 2026-03-20

### DIFF
--- a/sdk/apimanagement/Azure.Provisioning.ApiManagement/CHANGELOG.md
+++ b/sdk/apimanagement/Azure.Provisioning.ApiManagement/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (2026-03-19)
+## 1.0.0-beta.1 (2026-03-20)
 
 ### Features Added
 


### PR DESCRIPTION
Updates the CHANGELOG release date for `Azure.Provisioning.ApiManagement` 1.0.0-beta.1 from 2026-03-19 to 2026-03-20 to match the actual merge date.