### PR TITLE
Add emitter version dashboard and auto-generated banner to Library In…

### DIFF
--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -1,5 +1,8 @@
 # Azure SDK for .NET Libraries Inventory
 
+> **Auto-generated** by `Library_Inventory` on 2026-03-21 17:47:46 UTC.
+> Run that script to refresh this file.
+
 ## Table of Contents
 
 - [Summary](#summary)
@@ -13,10 +16,10 @@
 
 ## Summary
 
-- Total libraries: 410
-- Management Plane (MPG): 231
-  - Autorest/Swagger: 119
-  - New Emitter (TypeSpec): 112
+- Total libraries: 411
+- Management Plane (MPG): 232
+  - Autorest/Swagger: 118
+  - New Emitter (TypeSpec): 114
   - Old TypeSpec: 0
 - Data Plane (DPG): 145
   - Autorest/Swagger: 53
@@ -147,7 +150,7 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 53
 
 Libraries that provide resource management APIs for Azure services and have been migrated to the new TypeSpec emitter.
 
-**Migration Status**: 112 / 112 (100%)
+**Migration Status**: 114 / 114 (100%)
 
 | Service | Library | New Emitter |
 | ------- | ------- | ----------- |
@@ -243,6 +246,7 @@ Libraries that provide resource management APIs for Azure services and have been
 | resourceconnector | Azure.ResourceManager.ResourceConnector | ✅ |
 | resources | Azure.ResourceManager.Resources.Bicep | ✅ |
 | resources | Azure.ResourceManager.Resources.DeploymentStacks | ✅ |
+| resources | Azure.ResourceManager.Resources.Policy | ✅ |
 | secretsstoreextension | Azure.ResourceManager.SecretsStoreExtension | ✅ |
 | selfhelp | Azure.ResourceManager.SelfHelp | ✅ |
 | servicefabricmanagedclusters | Azure.ResourceManager.ServiceFabricManagedClusters | ✅ |
@@ -260,6 +264,7 @@ Libraries that provide resource management APIs for Azure services and have been
 | trafficmanager | Azure.ResourceManager.TrafficManager | ✅ |
 | trustedsigning | Azure.ResourceManager.TrustedSigning | ✅ |
 | virtualenclaves | Azure.ResourceManager.VirtualEnclaves | ✅ |
+| webpubsub | Azure.ResourceManager.WebPubSub | ✅ |
 | weightsandbiases | Azure.ResourceManager.WeightsAndBiases | ✅ |
 | workloadorchestration | Azure.ResourceManager.WorkloadOrchestration | ✅ |
 | workloadssapvirtualinstance | Azure.ResourceManager.WorkloadsSapVirtualInstance | ✅ |
@@ -267,7 +272,7 @@ Libraries that provide resource management APIs for Azure services and have been
 
 ## Management Plane Libraries (MPG) - Still on Swagger
 
-Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 119
+Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 118
 
 | Service | Library |
 | ------- | ------- |
@@ -386,7 +391,6 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 11
 | support | Azure.ResourceManager.Support |
 | synapse | Azure.ResourceManager.Synapse |
 | voiceservices | Azure.ResourceManager.VoiceServices |
-| webpubsub | Azure.ResourceManager.WebPubSub |
 | websites | Azure.ResourceManager.AppService |
 | workloadmonitor | Azure.ResourceManager.WorkloadMonitor |
 | workloads | Azure.ResourceManager.Workloads |
@@ -415,16 +419,16 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 | eventgrid | Azure.Provisioning.EventGrid | Azure.ResourceManager.EventGrid | Reflection |
 | eventhub | Azure.Provisioning.EventHubs | Azure.ResourceManager.EventHubs ✅ | Reflection |
 | frontdoor | Azure.Provisioning.FrontDoor | Azure.ResourceManager.FrontDoor | Reflection |
+| hybridkubernetes | Azure.Provisioning.Kubernetes | Azure.ResourceManager.Kubernetes ✅ | Reflection |
 | keyvault | Azure.Provisioning.KeyVault | Azure.ResourceManager.KeyVault ✅ | Reflection |
+| kubernetesconfiguration | Azure.Provisioning.KubernetesConfiguration | Azure.ResourceManager.KubernetesConfiguration | Reflection |
 | kusto | Azure.Provisioning.Kusto | Azure.ResourceManager.Kusto | Reflection |
+| network | Azure.Provisioning.Network | Azure.ResourceManager.Network | Reflection |
 | operationalinsights | Azure.Provisioning.OperationalInsights | Azure.ResourceManager.OperationalInsights | Reflection |
 | postgresql | Azure.Provisioning.PostgreSql | Azure.ResourceManager.PostgreSql | Reflection |
+| privatedns | Azure.Provisioning.PrivateDns | Azure.ResourceManager.PrivateDns | Reflection |
 | provisioning | Azure.Provisioning | Azure.ResourceManager<br>Azure.ResourceManager.Resources<br>Azure.ResourceManager.Authorization<br>Azure.ResourceManager.ManagedServiceIdentities | Reflection |
 | provisioning | Azure.Provisioning.Deployment | Azure.ResourceManager<br>Azure.ResourceManager.Resources | None |
-| provisioning | Azure.Provisioning.Kubernetes | Azure.ResourceManager.Kubernetes ✅ | Reflection |
-| provisioning | Azure.Provisioning.KubernetesConfiguration | Azure.ResourceManager.KubernetesConfiguration | Reflection |
-| provisioning | Azure.Provisioning.Network | Azure.ResourceManager.Network | Reflection |
-| provisioning | Azure.Provisioning.PrivateDns | Azure.ResourceManager.PrivateDns | Reflection |
 | redis | Azure.Provisioning.Redis | Azure.ResourceManager.Redis | Reflection |
 | redisenterprise | Azure.Provisioning.RedisEnterprise | Azure.ResourceManager.RedisEnterprise ✅ | Reflection |
 | search | Azure.Provisioning.Search | Azure.ResourceManager.Search | Reflection |
@@ -432,7 +436,7 @@ Libraries that provide infrastructure-as-code capabilities for Azure services. T
 | signalr | Azure.Provisioning.SignalR | Azure.ResourceManager.SignalR ✅ | Reflection |
 | sqlmanagement | Azure.Provisioning.Sql | Azure.ResourceManager.Sql | Reflection |
 | storage | Azure.Provisioning.Storage | Azure.ResourceManager.Storage | Reflection |
-| webpubsub | Azure.Provisioning.WebPubSub | Azure.ResourceManager.WebPubSub | Reflection |
+| webpubsub | Azure.Provisioning.WebPubSub | Azure.ResourceManager.WebPubSub ✅ | Reflection |
 | websites | Azure.Provisioning.AppService | Azure.ResourceManager.AppService | Reflection |
 
 

--- a/doc/GeneratorMigration/Library_Inventory.ps1
+++ b/doc/GeneratorMigration/Library_Inventory.ps1
@@ -261,7 +261,10 @@ function New-MarkdownReport {
     $dataPercentage = if ($dataTypeSpecTotal -gt 0) { [math]::Round(($dataMigrated / $dataTypeSpecTotal) * 100, 1) } else { 0 }
 
     $report = @()
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss UTC" -AsUTC
     $report += "# Azure SDK for .NET Libraries Inventory`n"
+    $report += "> **Auto-generated** by ``Library_Inventory`` on $timestamp."
+    $report += "> Run that script to refresh this file.`n"
 
     # Table of Contents
     $report += "## Table of Contents`n"

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,6 +1,6 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-03-21 17:47:33 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-03-21 17:49:33 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Dependency Chain
@@ -17,8 +17,8 @@
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
 | `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [efe6d40](https://github.com/microsoft/typespec/commit/efe6d40ce13ff67fcb272b1d5ee468820d514f5e) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260312.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260312.1) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [3090295](https://github.com/JoshLove-msft/azure-sdk-for-net/commit/3090295108267069a777177be33ddf196b1f33cf) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260314.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260314.2) | [1.0.0-alpha.20260319.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260319.1) | [46c72fa](https://github.com/JoshLove-msft/azure-sdk-for-net/commit/46c72fadd820d9d3e8422d9d963f51abb3800e87) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260312.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260312.1) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [3090295](https://github.com/Azure/azure-sdk-for-net/commit/3090295108267069a777177be33ddf196b1f33cf) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260314.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260314.2) | [1.0.0-alpha.20260319.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260319.1) | [46c72fa](https://github.com/Azure/azure-sdk-for-net/commit/46c72fadd820d9d3e8422d9d963f51abb3800e87) |
 
 ## Source Files
 

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,0 +1,32 @@
+# Emitter Version Dashboard
+
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-03-21 17:47:33 UTC.
+> Run that script to refresh this file after dependency version changes.
+
+## Dependency Chain
+
+```
+@typespec/http-client-csharp (alpha.20260320.2)
+  └─ @azure-typespec/http-client-csharp (alpha.20260320.2)
+       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260319.1)
+            └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260319.2)
+```
+
+## Emitter Versions
+
+| Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
+|---|---|---|---|---|
+| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [efe6d40](https://github.com/microsoft/typespec/commit/efe6d40ce13ff67fcb272b1d5ee468820d514f5e) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260312.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260312.1) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [3090295](https://github.com/JoshLove-msft/azure-sdk-for-net/commit/3090295108267069a777177be33ddf196b1f33cf) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260314.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260314.2) | [1.0.0-alpha.20260319.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260319.1) | [46c72fa](https://github.com/JoshLove-msft/azure-sdk-for-net/commit/46c72fadd820d9d3e8422d9d963f51abb3800e87) |
+
+## Source Files
+
+These are the files where versions are defined:
+
+| File | What it controls |
+|---|---|
+| [eng/packages/http-client-csharp/package.json](../../eng/packages/http-client-csharp/package.json) | Azure emitter's dependency on `@typespec/http-client-csharp` |
+| [eng/packages/http-client-csharp-mgmt/package.json](../../eng/packages/http-client-csharp-mgmt/package.json) | Mgmt emitter's dependency on `@azure-typespec/http-client-csharp` |
+| [eng/packages/http-client-csharp-provisioning/package.json](../../eng/packages/http-client-csharp-provisioning/package.json) | Provisioning emitter's dependency on `@azure-typespec/http-client-csharp-mgmt` |
+| [eng/centralpackagemanagement/Directory.Generation.Packages.props](../../eng/centralpackagemanagement/Directory.Generation.Packages.props) | NuGet versions for generator packages |

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,6 +1,6 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-03-21 17:49:33 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-03-22 01:27:52 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Dependency Chain
@@ -26,7 +26,7 @@ These are the files where versions are defined:
 
 | File | What it controls |
 |---|---|
-| [eng/packages/http-client-csharp/package.json](../../eng/packages/http-client-csharp/package.json) | Azure emitter's dependency on `@typespec/http-client-csharp` |
-| [eng/packages/http-client-csharp-mgmt/package.json](../../eng/packages/http-client-csharp-mgmt/package.json) | Mgmt emitter's dependency on `@azure-typespec/http-client-csharp` |
-| [eng/packages/http-client-csharp-provisioning/package.json](../../eng/packages/http-client-csharp-provisioning/package.json) | Provisioning emitter's dependency on `@azure-typespec/http-client-csharp-mgmt` |
-| [eng/centralpackagemanagement/Directory.Generation.Packages.props](../../eng/centralpackagemanagement/Directory.Generation.Packages.props) | NuGet versions for generator packages |
+| [eng/packages/http-client-csharp/package.json](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/packages/http-client-csharp/package.json) | Azure emitter's dependency on `@typespec/http-client-csharp` |
+| [eng/packages/http-client-csharp-mgmt/package.json](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/packages/http-client-csharp-mgmt/package.json) | Mgmt emitter's dependency on `@azure-typespec/http-client-csharp` |
+| [eng/packages/http-client-csharp-provisioning/package.json](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/packages/http-client-csharp-provisioning/package.json) | Provisioning emitter's dependency on `@azure-typespec/http-client-csharp-mgmt` |
+| [eng/centralpackagemanagement/Directory.Generation.Packages.props](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/centralpackagemanagement/Directory.Generation.Packages.props) | NuGet versions for generator packages |

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
@@ -1,0 +1,190 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Generates the emitter version dependency dashboard (doc/GeneratorVersions/EMITTER_VERSION_DASHBOARD.md).
+
+.DESCRIPTION
+    Reads version information from the emitter package.json files and central NuGet
+    package management props, and queries the npm registry for the latest published
+    versions, to produce a checked-in Markdown dashboard showing the dependency chain
+    across all C# TypeSpec emitters.
+
+    Run this script whenever emitter dependency versions change to keep the dashboard
+    up to date. Requires network access to query the npm registry.
+
+.EXAMPLE
+    ./doc/GeneratorVersions/Generate-EmitterVersionDashboard.ps1
+#>
+
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot ".." "..")).Path,
+    [string]$OutputPath
+)
+
+if (-not $OutputPath) {
+    $OutputPath = Join-Path $RepoRoot "doc" "GeneratorVersions" "Emitter_Version_Dashboard.md"
+}
+
+# --- Helpers ---
+
+function Get-NpmDependencyVersion([string]$PackageJsonPath, [string]$PackageName) {
+    $json = Get-Content $PackageJsonPath -Raw | ConvertFrom-Json
+    $version = $json.dependencies.$PackageName
+    if (-not $version) {
+        $version = $json.peerDependencies.$PackageName
+    }
+    return $version
+}
+
+function Get-PackageJsonVersion([string]$PackageJsonPath) {
+    $json = Get-Content $PackageJsonPath -Raw | ConvertFrom-Json
+    return $json.version
+}
+
+function Get-NpmLatestVersion([string]$PackageName) {
+    try {
+        $result = npm view $PackageName dist-tags.latest 2>&1
+        if ($LASTEXITCODE -eq 0 -and $result) {
+            return ($result | Out-String).Trim()
+        }
+    } catch {}
+    return "unavailable"
+}
+
+function Get-NpmVersionLink([string]$PackageName, [string]$Version) {
+    $encodedName = $PackageName -replace '/', '%2F'
+    return "https://www.npmjs.com/package/$PackageName/v/$Version"
+}
+
+function Get-ShortVersion([string]$Version) {
+    if ($Version -match 'alpha\.(\d{4})(\d{2})(\d{2})\.(\d+)$') {
+        return "alpha.$($Matches[1])$($Matches[2])$($Matches[3]).$($Matches[4])"
+    }
+    return $Version
+}
+
+# --- Gather emitter (npm) versions ---
+
+$azureEmitterPkg   = Join-Path $RepoRoot "eng" "packages" "http-client-csharp" "package.json"
+$mgmtEmitterPkg    = Join-Path $RepoRoot "eng" "packages" "http-client-csharp-mgmt" "package.json"
+$provEmitterPkg    = Join-Path $RepoRoot "eng" "packages" "http-client-csharp-provisioning" "package.json"
+
+$azureEmitterVersion   = Get-PackageJsonVersion $azureEmitterPkg
+$mgmtEmitterVersion    = Get-PackageJsonVersion $mgmtEmitterPkg
+$provEmitterVersion    = Get-PackageJsonVersion $provEmitterPkg
+
+$baseDep_azure   = Get-NpmDependencyVersion $azureEmitterPkg "@typespec/http-client-csharp"
+$azureDep_mgmt   = Get-NpmDependencyVersion $mgmtEmitterPkg "@azure-typespec/http-client-csharp"
+$mgmtDep_prov    = Get-NpmDependencyVersion $provEmitterPkg "@azure-typespec/http-client-csharp-mgmt"
+
+# --- Query npm registry for latest published versions ---
+
+Write-Host "Querying npm registry for latest published versions..."
+$latestBase  = Get-NpmLatestVersion "@typespec/http-client-csharp"
+$latestAzure = Get-NpmLatestVersion "@azure-typespec/http-client-csharp"
+$latestMgmt  = Get-NpmLatestVersion "@azure-typespec/http-client-csharp-mgmt"
+$latestProv  = Get-NpmLatestVersion "@azure-typespec/http-client-csharp-provisioning"
+
+# --- Build version links ---
+
+$linkBaseDep    = Get-NpmVersionLink "@typespec/http-client-csharp" $baseDep_azure
+$linkAzureDep   = Get-NpmVersionLink "@azure-typespec/http-client-csharp" $azureDep_mgmt
+$linkMgmtDep    = Get-NpmVersionLink "@azure-typespec/http-client-csharp-mgmt" $mgmtDep_prov
+
+$linkLatestBase  = Get-NpmVersionLink "@typespec/http-client-csharp" $latestBase
+$linkLatestAzure = Get-NpmVersionLink "@azure-typespec/http-client-csharp" $latestAzure
+$linkLatestMgmt  = Get-NpmVersionLink "@azure-typespec/http-client-csharp-mgmt" $latestMgmt
+$linkLatestProv  = Get-NpmVersionLink "@azure-typespec/http-client-csharp-provisioning" $latestProv
+
+# --- Resolve the git commit that corresponds to each dependency version ---
+# Version format: 1.0.0-alpha.YYYYMMDD.N — extract the date and find the last
+# commit to the dependency's source directory on or before that date.
+
+Write-Host "Resolving git commits for dependency versions..."
+
+function Get-DateFromVersion([string]$Version) {
+    if ($Version -match '(\d{4})(\d{2})(\d{2})\.\d+$') {
+        return "$($Matches[1])-$($Matches[2])-$($Matches[3])"
+    }
+    return $null
+}
+
+function Get-CommitForVersion([string]$RepoRoot, [string]$RelativePath, [string]$Version) {
+    $date = Get-DateFromVersion $Version
+    if (-not $date) { return @{ Hash = $null; Short = "unknown" } }
+    $hash = git -C $RepoRoot log --until="${date}T23:59:59" -1 --format="%H" -- $RelativePath 2>$null
+    $shortHash = if ($hash) { $hash.Substring(0, 7) } else { "unknown" }
+    return @{ Hash = $hash; Short = $shortHash }
+}
+
+function Get-CommitForVersionGitHub([string]$Owner, [string]$Repo, [string]$Path, [string]$Version) {
+    $date = Get-DateFromVersion $Version
+    if (-not $date) { return @{ Hash = $null; Short = "unknown" } }
+    try {
+        $hash = gh api "repos/$Owner/$Repo/commits?path=$Path&until=${date}T23:59:59Z&per_page=1" --jq ".[0].sha" 2>$null
+        $shortHash = if ($hash) { $hash.Substring(0, 7) } else { "unknown" }
+        return @{ Hash = $hash; Short = $shortHash }
+    } catch {
+        return @{ Hash = $null; Short = "unknown" }
+    }
+}
+
+# @typespec/http-client-csharp is from microsoft/typespec
+$commitBase = Get-CommitForVersionGitHub "microsoft" "typespec" "packages/http-client-csharp" $baseDep_azure
+$commitBaseLink = "https://github.com/microsoft/typespec/commit/$($commitBase.Hash)"
+
+# Azure packages are from this repo
+$commitAzure = Get-CommitForVersion $RepoRoot "eng/packages/http-client-csharp" $azureDep_mgmt
+$commitMgmt  = Get-CommitForVersion $RepoRoot "eng/packages/http-client-csharp-mgmt" $mgmtDep_prov
+
+$gitBaseUrl = git -C $RepoRoot remote get-url origin 2>$null
+if ($gitBaseUrl -match 'github\.com[:/](.+?)(?:\.git)?$') {
+    $gitBaseUrl = "https://github.com/$($Matches[1])"
+} else {
+    $gitBaseUrl = "https://github.com/Azure/azure-sdk-for-net"
+}
+
+$commitLinkAzure = "$gitBaseUrl/commit/$($commitAzure.Hash)"
+$commitLinkMgmt  = "$gitBaseUrl/commit/$($commitMgmt.Hash)"
+
+# --- Build Markdown ---
+
+$timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss UTC" -AsUTC
+
+$md = @"
+# Emitter Version Dashboard
+
+> **Auto-generated** by ``Emitter_Version_Dashboard`` on $timestamp.
+> Run that script to refresh this file after dependency version changes.
+
+## Dependency Chain
+
+``````
+@typespec/http-client-csharp ($(Get-ShortVersion $latestBase))
+  └─ @azure-typespec/http-client-csharp ($(Get-ShortVersion $latestAzure))
+       └─ @azure-typespec/http-client-csharp-mgmt ($(Get-ShortVersion $latestMgmt))
+            └─ @azure-typespec/http-client-csharp-provisioning ($(Get-ShortVersion $latestProv))
+``````
+
+## Emitter Versions
+
+| Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
+|---|---|---|---|---|
+| ``@azure-typespec/http-client-csharp`` | ``@typespec/http-client-csharp`` | [$baseDep_azure]($linkBaseDep) | [$latestBase]($linkLatestBase) | [$($commitBase.Short)]($commitBaseLink) |
+| ``@azure-typespec/http-client-csharp-mgmt`` | ``@azure-typespec/http-client-csharp`` | [$azureDep_mgmt]($linkAzureDep) | [$latestAzure]($linkLatestAzure) | [$($commitAzure.Short)]($commitLinkAzure) |
+| ``@azure-typespec/http-client-csharp-provisioning`` | ``@azure-typespec/http-client-csharp-mgmt`` | [$mgmtDep_prov]($linkMgmtDep) | [$latestMgmt]($linkLatestMgmt) | [$($commitMgmt.Short)]($commitLinkMgmt) |
+
+## Source Files
+
+These are the files where versions are defined:
+
+| File | What it controls |
+|---|---|
+| [eng/packages/http-client-csharp/package.json](../../eng/packages/http-client-csharp/package.json) | Azure emitter's dependency on ``@typespec/http-client-csharp`` |
+| [eng/packages/http-client-csharp-mgmt/package.json](../../eng/packages/http-client-csharp-mgmt/package.json) | Mgmt emitter's dependency on ``@azure-typespec/http-client-csharp`` |
+| [eng/packages/http-client-csharp-provisioning/package.json](../../eng/packages/http-client-csharp-provisioning/package.json) | Provisioning emitter's dependency on ``@azure-typespec/http-client-csharp-mgmt`` |
+| [eng/centralpackagemanagement/Directory.Generation.Packages.props](../../eng/centralpackagemanagement/Directory.Generation.Packages.props) | NuGet versions for generator packages |
+"@
+
+$md | Out-File -FilePath $OutputPath -Encoding utf8NoBOM -Force
+Write-Host "Dashboard written to: $OutputPath"

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
@@ -1,19 +1,18 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-    Generates the emitter version dependency dashboard (doc/GeneratorVersions/EMITTER_VERSION_DASHBOARD.md).
+    Generates the emitter version dependency dashboard (doc/GeneratorVersions/Emitter_Version_Dashboard.md).
 
 .DESCRIPTION
-    Reads version information from the emitter package.json files and central NuGet
-    package management props, and queries the npm registry for the latest published
-    versions, to produce a checked-in Markdown dashboard showing the dependency chain
-    across all C# TypeSpec emitters.
+    Reads version information from the emitter package.json files and queries the npm
+    registry for the latest published versions, to produce a checked-in Markdown
+    dashboard showing the dependency chain across all C# TypeSpec emitters.
 
     Run this script whenever emitter dependency versions change to keep the dashboard
     up to date. Requires network access to query the npm registry.
 
 .EXAMPLE
-    ./doc/GeneratorVersions/Generate-EmitterVersionDashboard.ps1
+    ./doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
 #>
 
 param(
@@ -52,7 +51,6 @@ function Get-NpmLatestVersion([string]$PackageName) {
 }
 
 function Get-NpmVersionLink([string]$PackageName, [string]$Version) {
-    $encodedName = $PackageName -replace '/', '%2F'
     return "https://www.npmjs.com/package/$PackageName/v/$Version"
 }
 
@@ -131,21 +129,17 @@ function Get-CommitForVersionGitHub([string]$Owner, [string]$Repo, [string]$Path
 
 # @typespec/http-client-csharp is from microsoft/typespec
 $commitBase = Get-CommitForVersionGitHub "microsoft" "typespec" "packages/http-client-csharp" $baseDep_azure
-$commitBaseLink = "https://github.com/microsoft/typespec/commit/$($commitBase.Hash)"
+$commitBaseLink = if ($commitBase.Hash) { "https://github.com/microsoft/typespec/commit/$($commitBase.Hash)" } else { $null }
 
 # Azure packages are from this repo
 $commitAzure = Get-CommitForVersion $RepoRoot "eng/packages/http-client-csharp" $azureDep_mgmt
 $commitMgmt  = Get-CommitForVersion $RepoRoot "eng/packages/http-client-csharp-mgmt" $mgmtDep_prov
 
-$gitBaseUrl = git -C $RepoRoot remote get-url origin 2>$null
-if ($gitBaseUrl -match 'github\.com[:/](.+?)(?:\.git)?$') {
-    $gitBaseUrl = "https://github.com/$($Matches[1])"
-} else {
-    $gitBaseUrl = "https://github.com/Azure/azure-sdk-for-net"
-}
+# Always link to the canonical Azure SDK for .NET repository
+$gitBaseUrl = "https://github.com/Azure/azure-sdk-for-net"
 
-$commitLinkAzure = "$gitBaseUrl/commit/$($commitAzure.Hash)"
-$commitLinkMgmt  = "$gitBaseUrl/commit/$($commitMgmt.Hash)"
+$commitLinkAzure = if ($commitAzure.Hash) { "$gitBaseUrl/commit/$($commitAzure.Hash)" } else { $null }
+$commitLinkMgmt  = if ($commitMgmt.Hash)  { "$gitBaseUrl/commit/$($commitMgmt.Hash)" } else { $null }
 
 # --- Build Markdown ---
 
@@ -170,9 +164,9 @@ $md = @"
 
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
-| ``@azure-typespec/http-client-csharp`` | ``@typespec/http-client-csharp`` | [$baseDep_azure]($linkBaseDep) | [$latestBase]($linkLatestBase) | [$($commitBase.Short)]($commitBaseLink) |
-| ``@azure-typespec/http-client-csharp-mgmt`` | ``@azure-typespec/http-client-csharp`` | [$azureDep_mgmt]($linkAzureDep) | [$latestAzure]($linkLatestAzure) | [$($commitAzure.Short)]($commitLinkAzure) |
-| ``@azure-typespec/http-client-csharp-provisioning`` | ``@azure-typespec/http-client-csharp-mgmt`` | [$mgmtDep_prov]($linkMgmtDep) | [$latestMgmt]($linkLatestMgmt) | [$($commitMgmt.Short)]($commitLinkMgmt) |
+| ``@azure-typespec/http-client-csharp`` | ``@typespec/http-client-csharp`` | [$baseDep_azure]($linkBaseDep) | [$latestBase]($linkLatestBase) | $(if ($commitBaseLink) { "[$($commitBase.Short)]($commitBaseLink)" } else { $commitBase.Short }) |
+| ``@azure-typespec/http-client-csharp-mgmt`` | ``@azure-typespec/http-client-csharp`` | [$azureDep_mgmt]($linkAzureDep) | [$latestAzure]($linkLatestAzure) | $(if ($commitLinkAzure) { "[$($commitAzure.Short)]($commitLinkAzure)" } else { $commitAzure.Short }) |
+| ``@azure-typespec/http-client-csharp-provisioning`` | ``@azure-typespec/http-client-csharp-mgmt`` | [$mgmtDep_prov]($linkMgmtDep) | [$latestMgmt]($linkLatestMgmt) | $(if ($commitLinkMgmt) { "[$($commitMgmt.Short)]($commitLinkMgmt)" } else { $commitMgmt.Short }) |
 
 ## Source Files
 

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
@@ -174,10 +174,10 @@ These are the files where versions are defined:
 
 | File | What it controls |
 |---|---|
-| [eng/packages/http-client-csharp/package.json](../../eng/packages/http-client-csharp/package.json) | Azure emitter's dependency on ``@typespec/http-client-csharp`` |
-| [eng/packages/http-client-csharp-mgmt/package.json](../../eng/packages/http-client-csharp-mgmt/package.json) | Mgmt emitter's dependency on ``@azure-typespec/http-client-csharp`` |
-| [eng/packages/http-client-csharp-provisioning/package.json](../../eng/packages/http-client-csharp-provisioning/package.json) | Provisioning emitter's dependency on ``@azure-typespec/http-client-csharp-mgmt`` |
-| [eng/centralpackagemanagement/Directory.Generation.Packages.props](../../eng/centralpackagemanagement/Directory.Generation.Packages.props) | NuGet versions for generator packages |
+| [eng/packages/http-client-csharp/package.json](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/packages/http-client-csharp/package.json) | Azure emitter's dependency on ``@typespec/http-client-csharp`` |
+| [eng/packages/http-client-csharp-mgmt/package.json](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/packages/http-client-csharp-mgmt/package.json) | Mgmt emitter's dependency on ``@azure-typespec/http-client-csharp`` |
+| [eng/packages/http-client-csharp-provisioning/package.json](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/packages/http-client-csharp-provisioning/package.json) | Provisioning emitter's dependency on ``@azure-typespec/http-client-csharp-mgmt`` |
+| [eng/centralpackagemanagement/Directory.Generation.Packages.props](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/centralpackagemanagement/Directory.Generation.Packages.props) | NuGet versions for generator packages |
 "@
 
 $md | Out-File -FilePath $OutputPath -Encoding utf8NoBOM -Force


### PR DESCRIPTION
…ventory

- Add doc/GeneratorVersions/Emitter_Version_Dashboard.ps1 script that queries npm registry and git history to produce a version dashboard
- Add doc/GeneratorVersions/Emitter_Version_Dashboard.md showing dependency chain, dependency versions, latest npm versions, and commit links
- Add auto-generated banner to Library_Inventory output

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
