### PR TITLE
Bump http-client-csharp dependency to 1.0.0-alpha.20260320.2 in mgmt

### DIFF
--- a/.github/skills/bump-mgmt-base-version/SKILL.md
+++ b/.github/skills/bump-mgmt-base-version/SKILL.md
@@ -100,10 +100,18 @@ This script:
 
 If regeneration produces file changes, they must be included in the commit.
 
-### 9. Verify
+### 9. Refresh the Emitter Version Dashboard
+
+```shell
+pwsh doc/GeneratorVersions/Emitter_Version_Dashboard.ps1
+```
+
+This regenerates `doc/GeneratorVersions/Emitter_Version_Dashboard.md` so the documented dependency chain matches the updated package.json versions. The updated dashboard file must be included in the commit.
+
+### 10. Verify
 
 - Run `git status` to see all modified files
-- Ensure `package.json`, `package-lock.json`, `Directory.Generation.Packages.props`, and any regenerated test project files are included
+- Ensure `package.json`, `package-lock.json`, `Directory.Generation.Packages.props`, `Emitter_Version_Dashboard.md`, and any regenerated test project files are included
 - All changes should be committed together
 
 ## Key Files Reference
@@ -117,3 +125,5 @@ If regeneration produces file changes, they must be included in the commit.
 | `eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Azure.Generator.Management.csproj` | Generator project referencing Azure.Generator |
 | `eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1` | Test project regeneration script |
 | `eng/packages/http-client-csharp-mgmt/eng/scripts/Generation.psm1` | Build and generation helper functions |
+| `doc/GeneratorVersions/Emitter_Version_Dashboard.ps1` | Script to regenerate the version dashboard |
+| `doc/GeneratorVersions/Emitter_Version_Dashboard.md` | Emitter dependency version dashboard |

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,6 +1,6 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-03-22 01:27:52 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-03-23 01:09:51 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Dependency Chain
@@ -17,7 +17,7 @@
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
 | `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [efe6d40](https://github.com/microsoft/typespec/commit/efe6d40ce13ff67fcb272b1d5ee468820d514f5e) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260312.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260312.1) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [3090295](https://github.com/Azure/azure-sdk-for-net/commit/3090295108267069a777177be33ddf196b1f33cf) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1312b44](https://github.com/Azure/azure-sdk-for-net/commit/1312b44074cae7a101ad057106714ed614e08429) |
 | `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260314.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260314.2) | [1.0.0-alpha.20260319.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260319.1) | [46c72fa](https://github.com/Azure/azure-sdk-for-net/commit/46c72fadd820d9d3e8422d9d963f51abb3800e87) |
 
 ## Source Files

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260320.2</UnbrandedGeneratorVersion>
-    <AzureGeneratorVersion>1.0.0-alpha.20260312.1</AzureGeneratorVersion>
+    <AzureGeneratorVersion>1.0.0-alpha.20260320.2</AzureGeneratorVersion>
     <AzureManagementGeneratorVersion>1.0.0-alpha.20260314.2</AzureManagementGeneratorVersion>
   </PropertyGroup>
 

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/RestOperations/CheckNameAvailabilityOperationGroupRestOperations.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/RestOperations/CheckNameAvailabilityOperationGroupRestOperations.cs
@@ -56,7 +56,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             Request request = message.Request;
             request.Uri = uri;
             request.Method = RequestMethod.Post;
-            if ("application/json" != null)
+            if (content != null)
             {
                 request.Headers.SetValue("Content-Type", "application/json");
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/RestOperations/GroupQuotaLimitListsRestOperations.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/RestOperations/GroupQuotaLimitListsRestOperations.cs
@@ -85,7 +85,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             Request request = message.Request;
             request.Uri = uri;
             request.Method = RequestMethod.Put;
-            if ("application/json" != null)
+            if (content != null)
             {
                 request.Headers.SetValue("Content-Type", "application/json");
             }
@@ -114,7 +114,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             Request request = message.Request;
             request.Uri = uri;
             request.Method = RequestMethod.Patch;
-            if ("application/json" != null)
+            if (content != null)
             {
                 request.Headers.SetValue("Content-Type", "application/json");
             }

--- a/eng/packages/http-client-csharp-mgmt/package-lock.json
+++ b/eng/packages/http-client-csharp-mgmt/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260320.2"
       },
       "devDependencies": {
         "@azure-tools/azure-http-specs": "0.1.0-alpha.38",
@@ -17,7 +17,7 @@
         "@azure-tools/typespec-azure-core": "0.66.0",
         "@azure-tools/typespec-azure-resource-manager": "0.66.0",
         "@azure-tools/typespec-azure-rulesets": "0.66.0",
-        "@azure-tools/typespec-client-generator-core": "0.66.1",
+        "@azure-tools/typespec-client-generator-core": "0.66.3",
         "@azure-tools/typespec-liftr-base": "0.12.0",
         "@eslint/js": "^9.2.0",
         "@types/node": "~22.12.0",
@@ -26,7 +26,7 @@
         "@typespec/compiler": "1.10.0",
         "@typespec/events": "0.80.0",
         "@typespec/http": "1.10.0",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260312.1",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260320.2",
         "@typespec/http-specs": "0.1.0-alpha.34",
         "@typespec/openapi": "1.10.0",
         "@typespec/rest": "0.80.0",
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.1.tgz",
-      "integrity": "sha512-aGxEeuk5fqeb9YfalNWTQtAVLIzPkbxObcmCH02XtHvd4Vd2u1hy4l714OB3rz0V+xR30IOSRGLfFnbEv3c1oA==",
+      "version": "0.66.3",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.3.tgz",
+      "integrity": "sha512-sNetQ6igxAp/vL6X2kEIy715ToDTqoJeb+OL59GEUtOW/3KBSi5tsxvDdCwSfEoaNEmv/FYjh/gJDwAWCJdFJg==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -252,12 +252,12 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260312.1",
-      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
-      "integrity": "sha512-haufuXCdGZNzQ1Ak0kyNAVIOtbWQzqJf4KChjgz98IDIHFyg4KD1prCNatFhrzcG/kLbrNEFLNgeCCHxUxMtrA==",
+      "version": "1.0.0-alpha.20260320.2",
+      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260320.2.tgz",
+      "integrity": "sha512-lez1VwPCiROBUK6pQq4i9ktM+WK0kw63FTlvlx5TYioqOB9ZmioNoYwk79rUuPs6wxoXBWSmCoglN1ODH7Nsrg==",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260320.2"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -2779,12 +2779,12 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260312.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
-      "integrity": "sha512-pFCH82WUR+PdupXuQVRLhKqzbiBHzuS6VbRw3NROPyGXqzNIiN6byVq3/cAEHNhDrMQJseH2n+ISjuamLEv0AQ==",
+      "version": "1.0.0-alpha.20260320.2",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260320.2.tgz",
+      "integrity": "sha512-kE823ktgXmgWZukX/iOl0CEE5m8dN2Efv8+xnzbW9pYr1tz9I3E6wSy5uD099L7/vgM8jdLH+E/V5/BYedW8pw==",
       "license": "MIT",
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.66.0 <0.67.0 || ~0.67.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.66.3 <0.67.0 || ~0.67.0-0",
         "@typespec/compiler": "^1.10.0",
         "@typespec/http": "^1.10.0",
         "@typespec/openapi": "^1.10.0",

--- a/eng/packages/http-client-csharp-mgmt/package.json
+++ b/eng/packages/http-client-csharp-mgmt/package.json
@@ -37,7 +37,7 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
+    "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260320.2"
   },
   "peerDependencies": {
     "@typespec/http-client-csharp": "^1.0.0-alpha"
@@ -48,7 +48,7 @@
     "@azure-tools/typespec-azure-core": "0.66.0",
     "@azure-tools/typespec-azure-resource-manager": "0.66.0",
     "@azure-tools/typespec-azure-rulesets": "0.66.0",
-    "@azure-tools/typespec-client-generator-core": "0.66.1",
+    "@azure-tools/typespec-client-generator-core": "0.66.3",
     "@azure-tools/typespec-liftr-base": "0.12.0",
     "@eslint/js": "^9.2.0",
     "@types/node": "~22.12.0",
@@ -57,7 +57,7 @@
     "@typespec/compiler": "1.10.0",
     "@typespec/events": "0.80.0",
     "@typespec/http": "1.10.0",
-    "@typespec/http-client-csharp": "1.0.0-alpha.20260312.1",
+    "@typespec/http-client-csharp": "1.0.0-alpha.20260320.2",
     "@typespec/http-specs": "0.1.0-alpha.34",
     "@typespec/openapi": "1.10.0",
     "@typespec/rest": "0.80.0",


### PR DESCRIPTION
## What
Update the `http-client-csharp` base dependency used by the management-plane generator (`http-client-csharp-mgmt`).

## Changes
- **`eng/packages/http-client-csharp-mgmt/package.json`**: Bumped `@azure-typespec/http-client-csharp` from `1.0.0-alpha.20260312.1` to `1.0.0-alpha.20260320.2`
- **`eng/centralpackagemanagement/Directory.Generation.Packages.props`**: Bumped `AzureGeneratorVersion` from `1.0.0-alpha.20260312.1` to `1.0.0-alpha.20260320.2`
- **`eng/packages/http-client-csharp-mgmt/package.json`**: Bumped `@azure-tools/typespec-client-generator-core` from `0.66.1` to `0.66.3` (required by new base version peer dependency)
- **`package-lock.json`**: Updated resolved dependency tree
- Regenerated test projects (minor changes in generated REST operations)
- Refreshed `doc/GeneratorVersions/Emitter_Version_Dashboard.md` to reflect updated versions
- Updated `bump-mgmt-base-version` skill to include Emitter Version Dashboard regeneration step