### PR TITLE
Bump mgmt generator dependency in provisioning generator to 20260322.1

### DIFF
--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -18,7 +18,7 @@
 |---|---|---|---|---|
 | `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [efe6d40](https://github.com/microsoft/typespec/commit/efe6d40ce13ff67fcb272b1d5ee468820d514f5e) |
 | `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1312b44](https://github.com/Azure/azure-sdk-for-net/commit/1312b44074cae7a101ad057106714ed614e08429) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260322.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260322.1) | [1.0.0-alpha.20260322.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260322.1) | [46c72fa](https://github.com/Azure/azure-sdk-for-net/commit/46c72fadd820d9d3e8422d9d963f51abb3800e87) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260322.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260322.2) | [1.0.0-alpha.20260322.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260322.2) | [46c72fa](https://github.com/Azure/azure-sdk-for-net/commit/46c72fadd820d9d3e8422d9d963f51abb3800e87) |
 
 ## Source Files
 

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -18,7 +18,7 @@
 |---|---|---|---|---|
 | `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [efe6d40](https://github.com/microsoft/typespec/commit/efe6d40ce13ff67fcb272b1d5ee468820d514f5e) |
 | `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1.0.0-alpha.20260320.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260320.2) | [1312b44](https://github.com/Azure/azure-sdk-for-net/commit/1312b44074cae7a101ad057106714ed614e08429) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260314.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260314.2) | [1.0.0-alpha.20260319.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260319.1) | [46c72fa](https://github.com/Azure/azure-sdk-for-net/commit/46c72fadd820d9d3e8422d9d963f51abb3800e87) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260322.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260322.1) | [1.0.0-alpha.20260322.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260322.1) | [46c72fa](https://github.com/Azure/azure-sdk-for-net/commit/46c72fadd820d9d3e8422d9d963f51abb3800e87) |
 
 ## Source Files
 

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260320.2</UnbrandedGeneratorVersion>
     <AzureGeneratorVersion>1.0.0-alpha.20260320.2</AzureGeneratorVersion>
-    <AzureManagementGeneratorVersion>1.0.0-alpha.20260314.2</AzureManagementGeneratorVersion>
+    <AzureManagementGeneratorVersion>1.0.0-alpha.20260322.1</AzureManagementGeneratorVersion>
   </PropertyGroup>
 
   <!-- Packages used by the TypeSpec generators -->

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260320.2</UnbrandedGeneratorVersion>
     <AzureGeneratorVersion>1.0.0-alpha.20260320.2</AzureGeneratorVersion>
-    <AzureManagementGeneratorVersion>1.0.0-alpha.20260322.1</AzureManagementGeneratorVersion>
+    <AzureManagementGeneratorVersion>1.0.0-alpha.20260322.2</AzureManagementGeneratorVersion>
   </PropertyGroup>
 
   <!-- Packages used by the TypeSpec generators -->

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
@@ -3879,7 +3879,8 @@
                   "2024-01-01-preview",
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "ProvisioningTypeSpec.KeyValue",
@@ -3929,7 +3930,8 @@
                   "2024-01-01-preview",
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               },
               {
                 "resourceModelId": "ProvisioningTypeSpec.Item",
@@ -3971,7 +3973,8 @@
                   "2024-01-01-preview",
                   "2024-04-01",
                   "2024-05-01"
-                ]
+                ],
+                "rbacRoles": []
               }
             ],
             "nonResourceMethods": [

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260314.2"
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260322.1"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.66.0",
@@ -164,33 +164,33 @@
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260312.1",
-      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
-      "integrity": "sha512-haufuXCdGZNzQ1Ak0kyNAVIOtbWQzqJf4KChjgz98IDIHFyg4KD1prCNatFhrzcG/kLbrNEFLNgeCCHxUxMtrA==",
+      "version": "1.0.0-alpha.20260320.2",
+      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260320.2.tgz",
+      "integrity": "sha512-lez1VwPCiROBUK6pQq4i9ktM+WK0kw63FTlvlx5TYioqOB9ZmioNoYwk79rUuPs6wxoXBWSmCoglN1ODH7Nsrg==",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260320.2"
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260314.2",
-      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260314.2.tgz",
-      "integrity": "sha512-MOus4ENSIJuEE+mp7uGwy0b9/+4duxGgJ44NBZNaMI/u3ESLpL4dZ0W7azUvT2tTRgIEB6Sio09l+i51uxigyg==",
+      "version": "1.0.0-alpha.20260322.1",
+      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260322.1.tgz",
+      "integrity": "sha512-WkGm5mPLPdEEzPEZZdXiSiEsL3cmt12zt/DUh77By957bXLuMZbJwL9GBqV8GSHDKVRe3++k3jWo0HAB3Gl8Pg==",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260312.1"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260320.2"
       },
       "peerDependencies": {
         "@typespec/http-client-csharp": "^1.0.0-alpha"
       }
     },
     "node_modules/@azure-typespec/http-client-csharp/node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260312.1",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260312.1.tgz",
-      "integrity": "sha512-pFCH82WUR+PdupXuQVRLhKqzbiBHzuS6VbRw3NROPyGXqzNIiN6byVq3/cAEHNhDrMQJseH2n+ISjuamLEv0AQ==",
+      "version": "1.0.0-alpha.20260320.2",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260320.2.tgz",
+      "integrity": "sha512-kE823ktgXmgWZukX/iOl0CEE5m8dN2Efv8+xnzbW9pYr1tz9I3E6wSy5uD099L7/vgM8jdLH+E/V5/BYedW8pw==",
       "license": "MIT",
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.66.0 <0.67.0 || ~0.67.0-0",
+        "@azure-tools/typespec-client-generator-core": ">=0.66.3 <0.67.0 || ~0.67.0-0",
         "@typespec/compiler": "^1.10.0",
         "@typespec/http": "^1.10.0",
         "@typespec/openapi": "^1.10.0",

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260322.1"
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260322.2"
       },
       "devDependencies": {
         "@azure-tools/typespec-autorest": "0.66.0",
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260322.1",
-      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260322.1.tgz",
-      "integrity": "sha512-WkGm5mPLPdEEzPEZZdXiSiEsL3cmt12zt/DUh77By957bXLuMZbJwL9GBqV8GSHDKVRe3++k3jWo0HAB3Gl8Pg==",
+      "version": "1.0.0-alpha.20260322.2",
+      "resolved": "https://registry.npmjs.org/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260322.2.tgz",
+      "integrity": "sha512-7HnHP7AronTAS6wUoBlMEOoGP03GaDGDxUE4/q4N6QtlGgSCx1MdIvU6K5G8Krp2oDwaiy4kHEWDFpvabKQv8A==",
       "license": "MIT",
       "dependencies": {
         "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260320.2"

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -16,7 +16,7 @@
         "@azure-tools/typespec-azure-core": "0.66.0",
         "@azure-tools/typespec-azure-resource-manager": "0.66.0",
         "@azure-tools/typespec-azure-rulesets": "0.66.0",
-        "@azure-tools/typespec-client-generator-core": "0.66.2",
+        "@azure-tools/typespec-client-generator-core": "0.66.3",
         "@azure-tools/typespec-liftr-base": "0.12.0",
         "@eslint/js": "^9.2.0",
         "@types/node": "~22.12.0",
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.66.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.2.tgz",
-      "integrity": "sha512-Qr5fstJ0yQiTYNvp/EuY3+mUBue2ri9qNZkT6aC+CsfBt5yjfdjo++3SuEsDQtELyS8pBoDOT3weLiB0N+/fSw==",
+      "version": "0.66.3",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.3.tgz",
+      "integrity": "sha512-sNetQ6igxAp/vL6X2kEIy715ToDTqoJeb+OL59GEUtOW/3KBSi5tsxvDdCwSfEoaNEmv/FYjh/gJDwAWCJdFJg==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -36,7 +36,7 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260314.2"
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260322.1"
   },
   "peerDependencies": {
     "@azure-typespec/http-client-csharp": "^1.0.0-alpha",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -47,7 +47,7 @@
     "@azure-tools/typespec-azure-core": "0.66.0",
     "@azure-tools/typespec-azure-resource-manager": "0.66.0",
     "@azure-tools/typespec-azure-rulesets": "0.66.0",
-    "@azure-tools/typespec-client-generator-core": "0.66.2",
+    "@azure-tools/typespec-client-generator-core": "0.66.3",
     "@azure-tools/typespec-liftr-base": "0.12.0",
     "@eslint/js": "^9.2.0",
     "@types/node": "~22.12.0",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -36,7 +36,7 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260322.1"
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260322.2"
   },
   "peerDependencies": {
     "@azure-typespec/http-client-csharp": "^1.0.0-alpha",


### PR DESCRIPTION
## Changes

Bumps `@azure-typespec/http-client-csharp-mgmt` from `1.0.0-alpha.20260314.2` to `1.0.0-alpha.20260322.1` in the provisioning generator.

### Updated files
- **`eng/packages/http-client-csharp-provisioning/package.json`** — npm dependency version
- **`eng/packages/http-client-csharp-provisioning/package-lock.json`** — lockfile with updated integrity hashes and transitive deps
- **`eng/centralpackagemanagement/Directory.Generation.Packages.props`** — `AzureManagementGeneratorVersion` NuGet property
- **`doc/GeneratorVersions/Emitter_Version_Dashboard.md`** — dashboard row for provisioning emitter

### Transitive dependency updates
The new mgmt generator `20260322.1` depends on:
- `@azure-typespec/http-client-csharp` `1.0.0-alpha.20260320.2` (was `20260312.1`)
- `@typespec/http-client-csharp` `1.0.0-alpha.20260320.2` (was `20260312.1`)

### Note
The `eng/azure-typespec-http-client-csharp-provisioning-emitter-package*.json` files still reference the published provisioning emitter `1.0.0-alpha.20260316.3` which depends on the old mgmt version. These will be updated after a new provisioning emitter publish.