### PR TITLE
Fix template changelog formatting

### DIFF
--- a/sdk/template/Azure.Template/CHANGELOG.md
+++ b/sdk/template/Azure.Template/CHANGELOG.md
@@ -6,18 +6,12 @@
 
 - Added `WidgetAnalyticsClientSettings` to support creating a `WidgetAnalyticsClient` from `IConfiguration`, including configuration-based credential resolution and dependency injection registration.
 
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.0.3-beta.20 (2022-04-26)
 
 ### Other Changes
 - Release DPG library
 - Add Grow-up story
-  
+
 ## 1.0.3-beta.19 (2020-09-24)
 - Test Submit-PR
 


### PR DESCRIPTION
Breaking template PR CI which is breaking canary builds run by 1es template validation.