### PR TITLE
[CODEOWNERS] Fix linter failure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1072,10 +1072,10 @@
 # ServiceOwners:                                                   @tundwed @anamikanupur
 
 # PRLabel: %Network - DNS Private Resolver
-/sdk/dnsresolver/Azure.ResourceManager.*/                          @jamesvoongms @jotrivet
+/sdk/dnsresolver/Azure.ResourceManager.*/                          @ArcturusZhang @ArthurMa1978 @jotrivet
 
 # ServiceLabel: %Network - DNS Private Resolver %Mgmt
-# ServiceOwners:                                                   @jamesvoongms @jotrivet
+# ServiceOwners:                                                   @jotrivet
 
 # PRLabel: %Network - Front Door
 /sdk/frontdoor/Azure.ResourceManager.*/                            @ArcturusZhang @ArthurMa1978


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner that the linter has begun flagging as invalid.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6055020&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_
