### PR TITLE
Add .npmrc files to emitter packages to use dev feed

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/.npmrc
+++ b/eng/packages/http-client-csharp-mgmt/.npmrc
@@ -1,0 +1,1 @@
+@azure-typespec:registry=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/

--- a/eng/packages/http-client-csharp-provisioning/.npmrc
+++ b/eng/packages/http-client-csharp-provisioning/.npmrc
@@ -1,0 +1,1 @@
+@azure-typespec:registry=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/

--- a/eng/packages/http-client-csharp/.npmrc
+++ b/eng/packages/http-client-csharp/.npmrc
@@ -1,0 +1,1 @@
+@azure-typespec:registry=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/


### PR DESCRIPTION
Point @azure-typespec scoped packages to the Azure SDK dev feed so that local npm install resolves dependencies from the dev feed.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
