### PR TITLE
add prepare PR mode to CodeChecks

### DIFF
--- a/.github/skills/pre-commit-checks/SKILL.md
+++ b/.github/skills/pre-commit-checks/SKILL.md
@@ -7,6 +7,8 @@ description: Pre-commit validation checks for azure-sdk-for-net. Use this before
 
 Run these checks after making changes to SDK packages under `sdk/` and **before** staging, committing, or pushing. These steps may produce additional file changes that must be included in the commit.
 
+> **Quick alternative:** Run `eng/scripts/CodeChecks.ps1 -ServiceDirectory <service> -PreparePr` to execute all pre-commit checks at once (format, regenerate code, export API, update snippets). It reports which files were updated so you can commit them. The steps below describe the same checks in detail for when you need more control.
+
 > **General rule:** Steps 3–5 are conditional to save time, but if you are unsure whether a step is needed, **always run it**. It is better to run an unnecessary script than to miss a required regeneration.
 
 ## 1. Determine scope from changed files

--- a/.github/skills/pre-commit-checks/SKILL.md
+++ b/.github/skills/pre-commit-checks/SKILL.md
@@ -7,8 +7,6 @@ description: Pre-commit validation checks for azure-sdk-for-net. Use this before
 
 Run these checks after making changes to SDK packages under `sdk/` and **before** staging, committing, or pushing. These steps may produce additional file changes that must be included in the commit.
 
-> **Quick alternative:** Run `eng/scripts/CodeChecks.ps1 -ServiceDirectory <service> -PreparePr` to execute all pre-commit checks at once (format, regenerate code, export API, update snippets). It reports which files were updated so you can commit them. The steps below describe the same checks in detail for when you need more control.
-
 > **General rule:** Steps 3–5 are conditional to save time, but if you are unsure whether a step is needed, **always run it**. It is better to run an unnecessary script than to miss a required regeneration.
 
 ## 1. Determine scope from changed files

--- a/eng/scripts/CodeChecks.Helpers.ps1
+++ b/eng/scripts/CodeChecks.Helpers.ps1
@@ -1,0 +1,45 @@
+# Helper functions for CodeChecks.ps1
+# Separated so they can be unit-tested without executing the main script.
+
+# Parses a single git status --porcelain line and returns the path(s) it contains.
+# For renames ("old -> new"), returns both paths. Returns an empty array for blank/malformed lines.
+function Get-PorcelainPaths([string]$line) {
+    if ([string]::IsNullOrWhiteSpace($line)) { return @() }
+    if ($line.Length -le 3) { return @() }
+    # The porcelain format is "XY path" where XY are the two status characters.
+    # Skip exactly 3 characters (XY + space) to get the path portion.
+    $pathPart = $line.Substring(3)
+    # Handle renames of the form "oldpath -> newpath".
+    if ($pathPart -match '(.+?)\s->\s(.+)$') {
+        return @($matches[1], $matches[2])
+    }
+    return @($pathPart)
+}
+
+# Given the current git status --porcelain lines and a list of pre-existing changed paths,
+# returns an object describing which status lines are new (produced by code checks) versus
+# which were already present before code checks ran.
+function Get-CodeCheckSummary {
+    param(
+        [string[]]$CurrentStatusLines,
+        [string[]]$PreExistingChanges
+    )
+
+    $newStatusLines = @()
+    foreach ($line in $CurrentStatusLines) {
+        # Wrap in @() to prevent PowerShell from unwrapping single-element arrays
+        # to strings, which would cause $paths[-1] to return a character instead of a path.
+        $paths = @(Get-PorcelainPaths $line)
+        if (-not $paths) { continue }
+        # For renames, check the destination (last) path against pre-existing changes.
+        $checkPath = $paths[-1]
+        if ($checkPath -notin $PreExistingChanges) {
+            $newStatusLines += $line
+        }
+    }
+
+    return @{
+        NewStatusLines   = $newStatusLines
+        PreExistingCount = ($PreExistingChanges | Measure-Object).Count
+    }
+}

--- a/eng/scripts/CodeChecks.Helpers.ps1
+++ b/eng/scripts/CodeChecks.Helpers.ps1
@@ -43,3 +43,41 @@ function Get-CodeCheckSummary {
         PreExistingCount = ($PreExistingChanges | Measure-Object).Count
     }
 }
+
+# Determines the action to take when a git diff is detected after code checks.
+# Returns an object with:
+#   Action       - "none" (no diffs), "error" (fail with message), or "report" (informational summary)
+#   ErrorMessage - the error string (only when Action = "error")
+#   Summary      - the Get-CodeCheckSummary result (only when Action = "report")
+function Get-DiffCheckResult {
+    param(
+        [bool]$HasDiff,
+        [bool]$SkipDiffValidation,
+        [string[]]$CurrentStatusLines = @(),
+        [string[]]$PreExistingChanges = @(),
+        [string]$ServiceDirectory = ""
+    )
+
+    if (-not $HasDiff) {
+        return @{ Action = "none" }
+    }
+
+    if (-not $SkipDiffValidation) {
+        return @{
+            Action       = "error"
+            ErrorMessage = "Generated code is not up to date.`
+    You may need to rebase on the latest main, `
+    run 'eng\scripts\Update-Snippets.ps1 $ServiceDirectory' if you modified sample snippets or other *.md files (https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#updating-sample-snippets), `
+    run 'eng\scripts\Export-API.ps1 $ServiceDirectory' if you changed public APIs (https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#public-api-additions). `
+    run 'dotnet build /t:GenerateCode' to update the generated code and samples.`
+    `
+To fix this locally, run 'eng\scripts\CodeChecks.ps1 -ServiceDirectory $ServiceDirectory -SkipDiffValidation' and commit the resulting changes."
+        }
+    }
+
+    $summary = Get-CodeCheckSummary -CurrentStatusLines $CurrentStatusLines -PreExistingChanges $PreExistingChanges
+    return @{
+        Action  = "report"
+        Summary = $summary
+    }
+}

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -107,11 +107,11 @@ try {
             Write-Host "`nRunning dotnet format"
             Join-Path "$PSScriptRoot/../../sdk" $ServiceDirectory `
                 | Resolve-Path `
-                | % { Get-ChildItem $_ -Filter "Azure.*.sln" -Recurse } `
+                | % { Get-ChildItem $_ -Filter "*.csproj" -Recurse } `
                 | % {
                     Write-Host "Formatting $(Split-Path -Leaf $_)"
                     Invoke-Block {
-                        & dotnet format $_ --verbosity minimal
+                        & dotnet format $_ --verbosity quiet
                     }
                 }
         }

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -255,7 +255,7 @@ try {
                 }
                 if ($preExistingChanges) {
                     Write-Host ""
-                    Write-Host -f Cyan "Note: $($preExistingChanges.Count) pre-existing changed file(s) were ignored (not modified by code checks)."
+                    Write-Host -f Cyan "Note: $($preExistingChanges.Count) file(s) already had changes before code checks ran and were excluded from the list above."
                 }
             }
             else {

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -62,8 +62,27 @@ try {
     # only the files that were changed by the code checks, not pre-existing changes.
     $preExistingChanges = @()
     if ($PreparePr) {
-        $preExistingChanges = @(git diff --name-only)
-        $preExistingChanges += @(git diff --name-only --cached)
+        $statusLines = git status --porcelain
+        foreach ($line in $statusLines) {
+            if ([string]::IsNullOrWhiteSpace($line)) {
+                continue
+            }
+            $trimmed = $line.Trim()
+            if ($trimmed.Length -le 3) {
+                continue
+            }
+            # Skip the two status characters and the following space to get the path portion.
+            $pathPart = $trimmed.Substring(3)
+            # Handle renames of the form "oldpath -> newpath".
+            if ($pathPart -match '(.+?)\s->\s(.+)$') {
+                $preExistingChanges += $matches[1]
+                $preExistingChanges += $matches[2]
+            }
+            else {
+                $preExistingChanges += $pathPart
+            }
+        }
+        $preExistingChanges = $preExistingChanges | Sort-Object -Unique
     }
 
     Write-Host "Restore ./node_modules"

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -15,7 +15,7 @@ param (
     [switch] $SpellCheckPublicApiSurface,
 
     [Parameter()]
-    [switch] $PreparePr
+    [switch] $SkipDiffValidation
 )
 
 Write-Host "Service Directory $ServiceDirectory"
@@ -59,10 +59,10 @@ function Invoke-Block([scriptblock]$cmd) {
 }
 
 try {
-    # In PreparePr mode, snapshot the current git state so we can later report
+    # When SkipDiffValidation is set, snapshot the current git state so we can later report
     # only the files that were changed by the code checks, not pre-existing changes.
     $preExistingChanges = @()
-    if ($PreparePr) {
+    if ($SkipDiffValidation) {
         $statusLines = git status --porcelain
         foreach ($line in $statusLines) {
             $preExistingChanges += Get-PorcelainPaths $line
@@ -110,7 +110,7 @@ try {
                         }
             }
 
-        if ($PreparePr) {
+        if ($SkipDiffValidation) {
             Write-Host "`nRunning dotnet format"
             Join-Path "$PSScriptRoot/../../sdk" $ServiceDirectory `
                 | Resolve-Path `
@@ -222,28 +222,29 @@ try {
         # prevent warning related to EOL differences which triggers an exception for some reason
         & git -c core.safecrlf=false diff --ignore-space-at-eol --exit-code
         if ($LastExitCode -ne 0) {
-            if ($PreparePr) {
-                $summary = Get-CodeCheckSummary -CurrentStatusLines (git status --porcelain) -PreExistingChanges $preExistingChanges
-                if ($summary.NewStatusLines) {
-                    $newStatus = ($summary.NewStatusLines | ForEach-Object { "    $_" }) -join "`n"
-                    Write-Host ""
-                    Write-Host -f Green "The following files were updated by code checks and should be included in your commit:"
-                    Write-Host -f Yellow $newStatus
+            $diffResult = Get-DiffCheckResult `
+                -HasDiff $true `
+                -SkipDiffValidation $SkipDiffValidation `
+                -CurrentStatusLines (git status --porcelain) `
+                -PreExistingChanges $preExistingChanges `
+                -ServiceDirectory $ServiceDirectory
+
+            switch ($diffResult.Action) {
+                "error" {
+                    LogError $diffResult.ErrorMessage
                 }
-                if ($summary.PreExistingCount -gt 0) {
-                    Write-Host ""
-                    Write-Host -f Cyan "Note: $($summary.PreExistingCount) file(s) already had changes before code checks ran and were excluded from the list above."
+                "report" {
+                    if ($diffResult.Summary.NewStatusLines) {
+                        $newStatus = ($diffResult.Summary.NewStatusLines | ForEach-Object { "    $_" }) -join "`n"
+                        Write-Host ""
+                        Write-Host -f Green "The following files were updated by code checks and should be included in your commit:"
+                        Write-Host -f Yellow $newStatus
+                    }
+                    if ($diffResult.Summary.PreExistingCount -gt 0) {
+                        Write-Host ""
+                        Write-Host -f Cyan "Note: $($diffResult.Summary.PreExistingCount) file(s) already had changes before code checks ran and were excluded from the list above."
+                    }
                 }
-            }
-            else {
-                LogError `
-"Generated code is not up to date.`
-    You may need to rebase on the latest main, `
-    run 'eng\scripts\Update-Snippets.ps1 $ServiceDirectory' if you modified sample snippets or other *.md files (https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#updating-sample-snippets), `
-    run 'eng\scripts\Export-API.ps1 $ServiceDirectory' if you changed public APIs (https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#public-api-additions). `
-    run 'dotnet build /t:GenerateCode' to update the generated code and samples.`
-    `
-To fix this locally, run 'eng\scripts\CodeChecks.ps1 -ServiceDirectory $ServiceDirectory -PreparePr' and commit the resulting changes."
             }
         }
     }
@@ -259,7 +260,7 @@ finally {
         Write-Host -f Red "error : $err"
     }
 
-    if ($PreparePr -and $errors) {
+    if ($SkipDiffValidation -and $errors) {
         Write-Host ""
         Write-Host -f Yellow "The above $($errors.Length) issue(s) require manual attention and cannot be auto-fixed."
     }

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -27,6 +27,7 @@ $Env:NODE_OPTIONS = "--max-old-space-size=8192"
 Set-StrictMode -Version 1
 
 . (Join-Path $PSScriptRoot\..\common\scripts common.ps1)
+. (Join-Path $PSScriptRoot CodeChecks.Helpers.ps1)
 
 [string[]] $errors = @()
 
@@ -39,49 +40,6 @@ function LogError([string]$message) {
     }
     Write-Host -f Red "error: $message"
     $script:errors += $message
-}
-
-# Parses a single git status --porcelain line and returns the path(s) it contains.
-# For renames ("old -> new"), returns both paths. Returns an empty array for blank/malformed lines.
-function Get-PorcelainPaths([string]$line) {
-    if ([string]::IsNullOrWhiteSpace($line)) { return @() }
-    if ($line.Length -le 3) { return @() }
-    # The porcelain format is "XY path" where XY are the two status characters.
-    # Skip exactly 3 characters (XY + space) to get the path portion.
-    $pathPart = $line.Substring(3)
-    # Handle renames of the form "oldpath -> newpath".
-    if ($pathPart -match '(.+?)\s->\s(.+)$') {
-        return @($matches[1], $matches[2])
-    }
-    return @($pathPart)
-}
-
-# Given the current git status --porcelain lines and a list of pre-existing changed paths,
-# returns an object describing which status lines are new (produced by code checks) versus
-# which were already present before code checks ran.
-function Get-CodeCheckSummary {
-    param(
-        [string[]]$CurrentStatusLines,
-        [string[]]$PreExistingChanges
-    )
-
-    $newStatusLines = @()
-    foreach ($line in $CurrentStatusLines) {
-        # Wrap in @() to prevent PowerShell from unwrapping single-element arrays
-        # to strings, which would cause $paths[-1] to return a character instead of a path.
-        $paths = @(Get-PorcelainPaths $line)
-        if (-not $paths) { continue }
-        # For renames, check the destination (last) path against pre-existing changes.
-        $checkPath = $paths[-1]
-        if ($checkPath -notin $PreExistingChanges) {
-            $newStatusLines += $line
-        }
-    }
-
-    return @{
-        NewStatusLines   = $newStatusLines
-        PreExistingCount = ($PreExistingChanges | Measure-Object).Count
-    }
 }
 
 function Invoke-Block([scriptblock]$cmd) {

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -41,6 +41,21 @@ function LogError([string]$message) {
     $script:errors += $message
 }
 
+# Parses a single git status --porcelain line and returns the path(s) it contains.
+# For renames ("old -> new"), returns both paths. Returns an empty array for blank/malformed lines.
+function Get-PorcelainPaths([string]$line) {
+    if ([string]::IsNullOrWhiteSpace($line)) { return @() }
+    $trimmed = $line.Trim()
+    if ($trimmed.Length -le 3) { return @() }
+    # Skip the two status characters and the following space to get the path portion.
+    $pathPart = $trimmed.Substring(3)
+    # Handle renames of the form "oldpath -> newpath".
+    if ($pathPart -match '(.+?)\s->\s(.+)$') {
+        return @($matches[1], $matches[2])
+    }
+    return @($pathPart)
+}
+
 function Invoke-Block([scriptblock]$cmd) {
     $cmd | Out-String | Write-Verbose
     & $cmd
@@ -64,23 +79,7 @@ try {
     if ($PreparePr) {
         $statusLines = git status --porcelain
         foreach ($line in $statusLines) {
-            if ([string]::IsNullOrWhiteSpace($line)) {
-                continue
-            }
-            $trimmed = $line.Trim()
-            if ($trimmed.Length -le 3) {
-                continue
-            }
-            # Skip the two status characters and the following space to get the path portion.
-            $pathPart = $trimmed.Substring(3)
-            # Handle renames of the form "oldpath -> newpath".
-            if ($pathPart -match '(.+?)\s->\s(.+)$') {
-                $preExistingChanges += $matches[1]
-                $preExistingChanges += $matches[2]
-            }
-            else {
-                $preExistingChanges += $pathPart
-            }
+            $preExistingChanges += Get-PorcelainPaths $line
         }
         $preExistingChanges = $preExistingChanges | Sort-Object -Unique
     }
@@ -232,15 +231,10 @@ try {
                 $currentStatusLines = git status --porcelain
                 $newStatusLines = @()
                 foreach ($line in $currentStatusLines) {
-                    if ([string]::IsNullOrWhiteSpace($line)) { continue }
-                    $trimmed = $line.Trim()
-                    if ($trimmed.Length -le 3) { continue }
-                    $pathPart = $trimmed.Substring(3)
-                    # For renames, check the destination path against pre-existing changes.
-                    $checkPath = $pathPart
-                    if ($pathPart -match '.+?\s->\s(.+)$') {
-                        $checkPath = $matches[1]
-                    }
+                    $paths = Get-PorcelainPaths $line
+                    if (-not $paths) { continue }
+                    # For renames, check the destination (last) path against pre-existing changes.
+                    $checkPath = $paths[-1]
                     if ($checkPath -notin $preExistingChanges) {
                         $newStatusLines += $line
                     }

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -228,8 +228,6 @@ try {
         # prevent warning related to EOL differences which triggers an exception for some reason
         & git -c core.safecrlf=false diff --ignore-space-at-eol --exit-code
         if ($LastExitCode -ne 0) {
-            $status = git status -s | Out-String
-            $status = $status -replace "`n","`n    "
             if ($PreparePr) {
                 $currentStatusLines = git status --porcelain
                 $newStatusLines = @()

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -58,6 +58,14 @@ function Invoke-Block([scriptblock]$cmd) {
 }
 
 try {
+    # In PreparePr mode, snapshot the current git state so we can later report
+    # only the files that were changed by the code checks, not pre-existing changes.
+    $preExistingChanges = @()
+    if ($PreparePr) {
+        $preExistingChanges = @(git diff --name-only)
+        $preExistingChanges += @(git diff --name-only --cached)
+    }
+
     Write-Host "Restore ./node_modules"
     Invoke-Block {
         & npm ci --prefix $RepoRoot
@@ -204,9 +212,18 @@ try {
             $status = git status -s | Out-String
             $status = $status -replace "`n","`n    "
             if ($PreparePr) {
-                Write-Host ""
-                Write-Host -f Green "The following files were updated by code checks and should be included in your commit:"
-                Write-Host -f Yellow "    $status"
+                $currentChanges = @(git diff --name-only)
+                $newChanges = $currentChanges | Where-Object { $_ -notin $preExistingChanges }
+                if ($newChanges) {
+                    $newStatus = ($newChanges | ForEach-Object { "    M $_" }) -join "`n"
+                    Write-Host ""
+                    Write-Host -f Green "The following files were updated by code checks and should be included in your commit:"
+                    Write-Host -f Yellow $newStatus
+                }
+                if ($preExistingChanges) {
+                    Write-Host ""
+                    Write-Host -f Cyan "Note: $($preExistingChanges.Count) pre-existing changed file(s) were ignored (not modified by code checks)."
+                }
             }
             else {
                 LogError `

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -231,10 +231,24 @@ try {
             $status = git status -s | Out-String
             $status = $status -replace "`n","`n    "
             if ($PreparePr) {
-                $currentChanges = @(git diff --name-only)
-                $newChanges = $currentChanges | Where-Object { $_ -notin $preExistingChanges }
-                if ($newChanges) {
-                    $newStatus = ($newChanges | ForEach-Object { "    M $_" }) -join "`n"
+                $currentStatusLines = git status --porcelain
+                $newStatusLines = @()
+                foreach ($line in $currentStatusLines) {
+                    if ([string]::IsNullOrWhiteSpace($line)) { continue }
+                    $trimmed = $line.Trim()
+                    if ($trimmed.Length -le 3) { continue }
+                    $pathPart = $trimmed.Substring(3)
+                    # For renames, check the destination path against pre-existing changes.
+                    $checkPath = $pathPart
+                    if ($pathPart -match '.+?\s->\s(.+)$') {
+                        $checkPath = $matches[1]
+                    }
+                    if ($checkPath -notin $preExistingChanges) {
+                        $newStatusLines += $line
+                    }
+                }
+                if ($newStatusLines) {
+                    $newStatus = ($newStatusLines | ForEach-Object { "    $_" }) -join "`n"
                     Write-Host ""
                     Write-Host -f Green "The following files were updated by code checks and should be included in your commit:"
                     Write-Host -f Yellow $newStatus

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -102,7 +102,10 @@ try {
                     | % {
                             $proj = Join-Path $slnDir $_
                             if (-not (Test-Path $proj)) {
-                                LogError "Missing project. Solution references a project which does not exist: $proj. [$sln] "
+                                LogError `
+"Missing project. Solution '$sln' references a project which does not exist: $proj.`
+    To remove the stale reference, run: dotnet sln `"$sln`" remove `"$_`"`
+    Or restore the missing project file if it was deleted unintentionally."
                             }
                         }
             }
@@ -155,12 +158,18 @@ try {
 
             if ($readmeContent -Match "Install-Package")
             {
-                LogError "README files should use dotnet CLI for installation instructions. '$readmePath'"
+                LogError `
+"README '$readmePath' uses 'Install-Package' (NuGet Package Manager Console syntax).`
+    Replace with the dotnet CLI equivalent: dotnet add package <PackageName>`
+    See https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md for conventions."
             }
 
             if ($readmeContent -Match "dotnet add .*--version")
             {
-                LogError "Specific versions should not be specified in the installation instructions in '$readmePath'. For beta versions, include the --prerelease flag."
+                LogError `
+"README '$readmePath' pins a specific version with --version.`
+    Remove the --version flag so users always get the latest.`
+    For beta packages, use '--prerelease' instead of '--version <x.y.z-beta.n>'."
             }
 
             if ($readmeContent -Match "dotnet add")
@@ -190,9 +199,9 @@ try {
                     if (-Not ($readmeContent -Match "dotnet add (?!.*--prerelease)"))
                     {
                         LogError `
-"No GA installation instructions found in '$readmePath' but there was a GA entry in the Changelog '$changelogPath'. `
-    Ensure that there are installation instructions that do not contain the --prerelease flag. You may also include `
-    instructions for installing a beta that does include the --prerelease flag."
+"README '$readmePath' is missing GA installation instructions, but the changelog has a GA release.`
+    Add a line like: dotnet add package <PackageName>`
+    You may also include a separate beta install line with --prerelease."
                     }
                 }
                 elseif ($hasRelease)
@@ -200,8 +209,8 @@ try {
                     if (-Not ($readmeContent -Match "dotnet add .*--prerelease$"))
                     {
                         LogError `
-"No beta installation instructions found in '$readmePath' but there was a beta entry in the Changelog '$changelogPath'. `
-    Ensure that there are installation instructions that contain the --prerelease flag."
+"README '$readmePath' is missing beta installation instructions, but the changelog has a beta release.`
+    Add a line like: dotnet add package <PackageName> --prerelease"
                     }
                 }
             }
@@ -248,6 +257,11 @@ finally {
 
     foreach ($err in $errors) {
         Write-Host -f Red "error : $err"
+    }
+
+    if ($PreparePr -and $errors) {
+        Write-Host ""
+        Write-Host -f Yellow "The above $($errors.Length) issue(s) require manual attention and cannot be auto-fixed."
     }
 
     if ($errors) {

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -12,7 +12,10 @@ param (
     [string] $SDKType = "all",
 
     [Parameter()]
-    [switch] $SpellCheckPublicApiSurface
+    [switch] $SpellCheckPublicApiSurface,
+
+    [Parameter()]
+    [switch] $PreparePr
 )
 
 Write-Host "Service Directory $ServiceDirectory"
@@ -91,6 +94,19 @@ try {
                             }
                         }
             }
+
+        if ($PreparePr) {
+            Write-Host "`nRunning dotnet format"
+            Join-Path "$PSScriptRoot/../../sdk" $ServiceDirectory `
+                | Resolve-Path `
+                | % { Get-ChildItem $_ -Filter "Azure.*.sln" -Recurse } `
+                | % {
+                    Write-Host "Formatting $(Split-Path -Leaf $_)"
+                    Invoke-Block {
+                        & dotnet format $_ --verbosity minimal
+                    }
+                }
+        }
 
         $debugLogging = $env:SYSTEM_DEBUG -eq "true"
         $logsFolder = $env:BUILD_ARTIFACTSTAGINGDIRECTORY
@@ -187,14 +203,21 @@ try {
         if ($LastExitCode -ne 0) {
             $status = git status -s | Out-String
             $status = $status -replace "`n","`n    "
-            LogError `
+            if ($PreparePr) {
+                Write-Host ""
+                Write-Host -f Green "The following files were updated by code checks and should be included in your commit:"
+                Write-Host -f Yellow "    $status"
+            }
+            else {
+                LogError `
 "Generated code is not up to date.`
     You may need to rebase on the latest main, `
     run 'eng\scripts\Update-Snippets.ps1 $ServiceDirectory' if you modified sample snippets or other *.md files (https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#updating-sample-snippets), `
     run 'eng\scripts\Export-API.ps1 $ServiceDirectory' if you changed public APIs (https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#public-api-additions). `
     run 'dotnet build /t:GenerateCode' to update the generated code and samples.`
     `
-To reproduce this error locally, run 'eng\scripts\CodeChecks.ps1 -ServiceDirectory $ServiceDirectory'."
+To fix this locally, run 'eng\scripts\CodeChecks.ps1 -ServiceDirectory $ServiceDirectory -PreparePr' and commit the resulting changes."
+            }
         }
     }
 }

--- a/eng/scripts/CodeChecks.ps1
+++ b/eng/scripts/CodeChecks.ps1
@@ -45,15 +45,43 @@ function LogError([string]$message) {
 # For renames ("old -> new"), returns both paths. Returns an empty array for blank/malformed lines.
 function Get-PorcelainPaths([string]$line) {
     if ([string]::IsNullOrWhiteSpace($line)) { return @() }
-    $trimmed = $line.Trim()
-    if ($trimmed.Length -le 3) { return @() }
-    # Skip the two status characters and the following space to get the path portion.
-    $pathPart = $trimmed.Substring(3)
+    if ($line.Length -le 3) { return @() }
+    # The porcelain format is "XY path" where XY are the two status characters.
+    # Skip exactly 3 characters (XY + space) to get the path portion.
+    $pathPart = $line.Substring(3)
     # Handle renames of the form "oldpath -> newpath".
     if ($pathPart -match '(.+?)\s->\s(.+)$') {
         return @($matches[1], $matches[2])
     }
     return @($pathPart)
+}
+
+# Given the current git status --porcelain lines and a list of pre-existing changed paths,
+# returns an object describing which status lines are new (produced by code checks) versus
+# which were already present before code checks ran.
+function Get-CodeCheckSummary {
+    param(
+        [string[]]$CurrentStatusLines,
+        [string[]]$PreExistingChanges
+    )
+
+    $newStatusLines = @()
+    foreach ($line in $CurrentStatusLines) {
+        # Wrap in @() to prevent PowerShell from unwrapping single-element arrays
+        # to strings, which would cause $paths[-1] to return a character instead of a path.
+        $paths = @(Get-PorcelainPaths $line)
+        if (-not $paths) { continue }
+        # For renames, check the destination (last) path against pre-existing changes.
+        $checkPath = $paths[-1]
+        if ($checkPath -notin $PreExistingChanges) {
+            $newStatusLines += $line
+        }
+    }
+
+    return @{
+        NewStatusLines   = $newStatusLines
+        PreExistingCount = ($PreExistingChanges | Measure-Object).Count
+    }
 }
 
 function Invoke-Block([scriptblock]$cmd) {
@@ -228,26 +256,16 @@ try {
         & git -c core.safecrlf=false diff --ignore-space-at-eol --exit-code
         if ($LastExitCode -ne 0) {
             if ($PreparePr) {
-                $currentStatusLines = git status --porcelain
-                $newStatusLines = @()
-                foreach ($line in $currentStatusLines) {
-                    $paths = Get-PorcelainPaths $line
-                    if (-not $paths) { continue }
-                    # For renames, check the destination (last) path against pre-existing changes.
-                    $checkPath = $paths[-1]
-                    if ($checkPath -notin $preExistingChanges) {
-                        $newStatusLines += $line
-                    }
-                }
-                if ($newStatusLines) {
-                    $newStatus = ($newStatusLines | ForEach-Object { "    $_" }) -join "`n"
+                $summary = Get-CodeCheckSummary -CurrentStatusLines (git status --porcelain) -PreExistingChanges $preExistingChanges
+                if ($summary.NewStatusLines) {
+                    $newStatus = ($summary.NewStatusLines | ForEach-Object { "    $_" }) -join "`n"
                     Write-Host ""
                     Write-Host -f Green "The following files were updated by code checks and should be included in your commit:"
                     Write-Host -f Yellow $newStatus
                 }
-                if ($preExistingChanges) {
+                if ($summary.PreExistingCount -gt 0) {
                     Write-Host ""
-                    Write-Host -f Cyan "Note: $($preExistingChanges.Count) file(s) already had changes before code checks ran and were excluded from the list above."
+                    Write-Host -f Cyan "Note: $($summary.PreExistingCount) file(s) already had changes before code checks ran and were excluded from the list above."
                 }
             }
             else {

--- a/eng/scripts/tests/CodeChecks.Tests.ps1
+++ b/eng/scripts/tests/CodeChecks.Tests.ps1
@@ -1,10 +1,11 @@
 <#
 .SYNOPSIS
-    Unit tests for the PreparePr functionality in CodeChecks.ps1.
+    Unit tests for the SkipDiffValidation functionality in CodeChecks.ps1.
 
 .DESCRIPTION
-    Tests the helper functions that parse git porcelain output and produce the
-    "what is new" summary when running CodeChecks with -PreparePr.
+    Tests the helper functions that parse git porcelain output, produce the
+    "what is new" summary, and determine the correct action (error vs. report)
+    when running CodeChecks with or without -SkipDiffValidation.
 
 .How-To-Run
     Install Pester if needed:
@@ -211,6 +212,139 @@ Describe "Get-CodeCheckSummary" -Tag "UnitTest" {
             $result = Get-CodeCheckSummary -CurrentStatusLines $currentLines -PreExistingChanges @()
 
             $result.NewStatusLines.Count | Should -Be 0
+        }
+    }
+}
+
+# ─────────────────────────────────────────────
+# Get-DiffCheckResult
+# ─────────────────────────────────────────────
+Describe "Get-DiffCheckResult" -Tag "UnitTest" {
+
+    Context "no diffs detected" {
+        It "returns 'none' action when there are no diffs and SkipDiffValidation is false" {
+            $result = Get-DiffCheckResult -HasDiff $false -SkipDiffValidation $false
+            $result.Action | Should -Be "none"
+        }
+
+        It "returns 'none' action when there are no diffs and SkipDiffValidation is true" {
+            $result = Get-DiffCheckResult -HasDiff $false -SkipDiffValidation $true
+            $result.Action | Should -Be "none"
+        }
+    }
+
+    Context "default behavior (SkipDiffValidation = false) — validates CI mode" {
+        It "returns 'error' action when diffs exist and SkipDiffValidation is false" {
+            $result = Get-DiffCheckResult -HasDiff $true -SkipDiffValidation $false -ServiceDirectory "foo"
+            $result.Action | Should -Be "error"
+        }
+
+        It "produces an error message mentioning the service directory" {
+            $result = Get-DiffCheckResult -HasDiff $true -SkipDiffValidation $false -ServiceDirectory "storage"
+            $result.ErrorMessage | Should -BeLike "*Generated code is not up to date*"
+            $result.ErrorMessage | Should -BeLike "*storage*"
+        }
+
+        It "error message includes remediation instructions" {
+            $result = Get-DiffCheckResult -HasDiff $true -SkipDiffValidation $false -ServiceDirectory "keyvault"
+            $result.ErrorMessage | Should -BeLike "*Update-Snippets*"
+            $result.ErrorMessage | Should -BeLike "*Export-API*"
+            $result.ErrorMessage | Should -BeLike "*GenerateCode*"
+        }
+
+        It "error message suggests -SkipDiffValidation for local fix" {
+            $result = Get-DiffCheckResult -HasDiff $true -SkipDiffValidation $false -ServiceDirectory "compute"
+            $result.ErrorMessage | Should -BeLike "*-SkipDiffValidation*"
+        }
+
+        It "does not include a Summary in error mode" {
+            $result = Get-DiffCheckResult -HasDiff $true -SkipDiffValidation $false
+            $result.Keys | Should -Not -Contain "Summary"
+        }
+    }
+
+    Context "report mode (SkipDiffValidation = true)" {
+        It "returns 'report' action when diffs exist and SkipDiffValidation is true" {
+            $statusLines = @(" M sdk/foo/Generated/Client.cs")
+            $result = Get-DiffCheckResult -HasDiff $true -SkipDiffValidation $true -CurrentStatusLines $statusLines
+
+            $result.Action | Should -Be "report"
+        }
+
+        It "includes a Summary with new status lines" {
+            $statusLines = @(
+                " M sdk/foo/Generated/Client.cs",
+                " M sdk/foo/api/Foo.netstandard2.0.cs"
+            )
+            $result = Get-DiffCheckResult -HasDiff $true -SkipDiffValidation $true `
+                -CurrentStatusLines $statusLines -PreExistingChanges @()
+
+            $result.Summary | Should -Not -BeNullOrEmpty
+            $result.Summary.NewStatusLines.Count | Should -Be 2
+        }
+
+        It "filters pre-existing changes in the summary" {
+            $statusLines = @(
+                " M sdk/foo/src/MyClient.cs",
+                " M sdk/foo/Generated/Client.cs"
+            )
+            $preExisting = @("sdk/foo/src/MyClient.cs")
+            $result = Get-DiffCheckResult -HasDiff $true -SkipDiffValidation $true `
+                -CurrentStatusLines $statusLines -PreExistingChanges $preExisting
+
+            $result.Summary.NewStatusLines.Count | Should -Be 1
+            $result.Summary.NewStatusLines[0]    | Should -BeLike "*Generated/Client.cs*"
+            $result.Summary.PreExistingCount      | Should -Be 1
+        }
+
+        It "does not include an ErrorMessage in report mode" {
+            $result = Get-DiffCheckResult -HasDiff $true -SkipDiffValidation $true `
+                -CurrentStatusLines @(" M sdk/foo/bar.cs")
+            $result.Keys | Should -Not -Contain "ErrorMessage"
+        }
+    }
+
+    Context "realistic end-to-end scenarios" {
+        It "simulates CI run: diffs found, default mode (no flag), error is raised" {
+            # CI runs without -SkipDiffValidation, so SkipDiffValidation is $false
+            $result = Get-DiffCheckResult `
+                -HasDiff $true `
+                -SkipDiffValidation $false `
+                -CurrentStatusLines @(" M sdk/ai/Generated/FooClient.cs") `
+                -ServiceDirectory "ai"
+
+            $result.Action       | Should -Be "error"
+            $result.ErrorMessage | Should -BeLike "*not up to date*"
+        }
+
+        It "simulates local run: no diffs after code checks, nothing to report" {
+            $result = Get-DiffCheckResult `
+                -HasDiff $false `
+                -SkipDiffValidation $true `
+                -CurrentStatusLines @() `
+                -PreExistingChanges @()
+
+            $result.Action | Should -Be "none"
+        }
+
+        It "simulates local run with pre-existing and new changes" {
+            $statusLines = @(
+                " M sdk/ai/src/HandWritten.cs",
+                " M sdk/ai/Generated/FooClient.cs",
+                "A  sdk/ai/api/Foo.netstandard2.0.cs",
+                "?? sdk/ai/src/Scratch.cs"
+            )
+            $preExisting = @("sdk/ai/src/HandWritten.cs", "sdk/ai/src/Scratch.cs")
+
+            $result = Get-DiffCheckResult `
+                -HasDiff $true `
+                -SkipDiffValidation $true `
+                -CurrentStatusLines $statusLines `
+                -PreExistingChanges $preExisting
+
+            $result.Action                        | Should -Be "report"
+            $result.Summary.NewStatusLines.Count  | Should -Be 2
+            $result.Summary.PreExistingCount       | Should -Be 2
         }
     }
 }

--- a/eng/scripts/tests/CodeChecks.Tests.ps1
+++ b/eng/scripts/tests/CodeChecks.Tests.ps1
@@ -17,15 +17,7 @@
 Import-Module Pester
 
 BeforeAll {
-    # CodeChecks.ps1 is a full script with param() and side effects, so we can't
-    # dot-source it. Instead, use the PowerShell AST to extract just the function
-    # definitions and define them in the test scope without executing anything.
-    $scriptPath = "$PSScriptRoot/../CodeChecks.ps1"
-    $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$null, [ref]$null)
-    $functions = $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $false)
-    foreach ($fn in $functions) {
-        Invoke-Expression $fn.Extent.Text
-    }
+    . "$PSScriptRoot/../CodeChecks.Helpers.ps1"
 }
 
 # ─────────────────────────────────────────────

--- a/eng/scripts/tests/CodeChecks.Tests.ps1
+++ b/eng/scripts/tests/CodeChecks.Tests.ps1
@@ -1,0 +1,224 @@
+<#
+.SYNOPSIS
+    Unit tests for the PreparePr functionality in CodeChecks.ps1.
+
+.DESCRIPTION
+    Tests the helper functions that parse git porcelain output and produce the
+    "what is new" summary when running CodeChecks with -PreparePr.
+
+.How-To-Run
+    Install Pester if needed:
+        Install-Module Pester -Force
+
+    Run these tests:
+        Invoke-Pester -Output Detailed $PSScriptRoot/CodeChecks.Tests.ps1
+#>
+
+Import-Module Pester
+
+BeforeAll {
+    # CodeChecks.ps1 is a full script with param() and side effects, so we can't
+    # dot-source it. Instead, use the PowerShell AST to extract just the function
+    # definitions and define them in the test scope without executing anything.
+    $scriptPath = "$PSScriptRoot/../CodeChecks.ps1"
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$null, [ref]$null)
+    $functions = $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $false)
+    foreach ($fn in $functions) {
+        Invoke-Expression $fn.Extent.Text
+    }
+}
+
+# ─────────────────────────────────────────────
+# Get-PorcelainPaths
+# ─────────────────────────────────────────────
+Describe "Get-PorcelainPaths" -Tag "UnitTest" {
+
+    Context "standard status codes" {
+        It "parses modified file: '<line>'" -TestCases @(
+            @{ line = " M sdk/foo/bar.cs";  expected = @("sdk/foo/bar.cs") }
+            @{ line = "M  sdk/foo/bar.cs";  expected = @("sdk/foo/bar.cs") }
+            @{ line = "MM sdk/foo/bar.cs";  expected = @("sdk/foo/bar.cs") }
+        ) {
+            Get-PorcelainPaths $line | Should -Be $expected
+        }
+
+        It "parses added file" {
+            Get-PorcelainPaths "A  sdk/new/file.cs" | Should -Be @("sdk/new/file.cs")
+        }
+
+        It "parses deleted file" {
+            Get-PorcelainPaths " D sdk/old/file.cs" | Should -Be @("sdk/old/file.cs")
+        }
+
+        It "parses untracked file" {
+            Get-PorcelainPaths "?? sdk/untracked.cs" | Should -Be @("sdk/untracked.cs")
+        }
+    }
+
+    Context "rename handling" {
+        It "returns both old and new paths for a rename" {
+            $result = Get-PorcelainPaths "R  sdk/old.cs -> sdk/new.cs"
+            $result.Count | Should -Be 2
+            $result[0]    | Should -Be "sdk/old.cs"
+            $result[1]    | Should -Be "sdk/new.cs"
+        }
+
+        It "handles rename with spaces in path" {
+            $result = Get-PorcelainPaths "R  sdk/my dir/old.cs -> sdk/my dir/new.cs"
+            $result.Count | Should -Be 2
+            $result[0]    | Should -Be "sdk/my dir/old.cs"
+            $result[1]    | Should -Be "sdk/my dir/new.cs"
+        }
+    }
+
+    Context "edge cases" {
+        It "returns empty for null input" {
+            Get-PorcelainPaths $null | Should -BeNullOrEmpty
+        }
+
+        It "returns empty for empty string" {
+            Get-PorcelainPaths "" | Should -BeNullOrEmpty
+        }
+
+        It "returns empty for whitespace-only string" {
+            Get-PorcelainPaths "   " | Should -BeNullOrEmpty
+        }
+
+        It "returns empty for line too short to contain a path" {
+            Get-PorcelainPaths "M " | Should -BeNullOrEmpty
+        }
+
+        It "returns empty for exactly three characters (status only)" {
+            Get-PorcelainPaths "M  " | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "paths with special characters" {
+        It "handles path with parentheses" {
+            Get-PorcelainPaths " M sdk/foo/bar(v2).cs" | Should -Be @("sdk/foo/bar(v2).cs")
+        }
+
+        It "handles deeply nested path" {
+            $deep = " M sdk/storage/Azure.Storage.Blobs/src/Generated/Models/BlobItem.cs"
+            Get-PorcelainPaths $deep | Should -Be @("sdk/storage/Azure.Storage.Blobs/src/Generated/Models/BlobItem.cs")
+        }
+    }
+}
+
+# ─────────────────────────────────────────────
+# Get-CodeCheckSummary
+# ─────────────────────────────────────────────
+Describe "Get-CodeCheckSummary" -Tag "UnitTest" {
+
+    Context "clean working tree before code checks" {
+        It "reports all changes as new when there were no pre-existing changes" {
+            $currentLines = @(
+                " M sdk/foo/Generated/Client.cs",
+                " M sdk/foo/api/Foo.netstandard2.0.cs"
+            )
+
+            $result = Get-CodeCheckSummary -CurrentStatusLines $currentLines -PreExistingChanges @()
+
+            $result.NewStatusLines.Count | Should -Be 2
+            $result.PreExistingCount      | Should -Be 0
+        }
+    }
+
+    Context "dirty working tree before code checks" {
+        It "filters out pre-existing changes and reports only new ones" {
+            $currentLines = @(
+                " M sdk/foo/src/MyClient.cs",
+                " M sdk/foo/Generated/Client.cs",
+                " M sdk/foo/api/Foo.netstandard2.0.cs"
+            )
+            $preExisting = @("sdk/foo/src/MyClient.cs")
+
+            $result = Get-CodeCheckSummary -CurrentStatusLines $currentLines -PreExistingChanges $preExisting
+
+            $result.NewStatusLines.Count | Should -Be 2
+            $result.NewStatusLines[0]    | Should -BeLike "*Generated/Client.cs*"
+            $result.NewStatusLines[1]    | Should -BeLike "*Foo.netstandard2.0.cs*"
+            $result.PreExistingCount      | Should -Be 1
+        }
+
+        It "returns no new lines when every change was pre-existing" {
+            $currentLines = @(
+                " M sdk/foo/src/MyClient.cs",
+                " M sdk/foo/src/Helper.cs"
+            )
+            $preExisting = @("sdk/foo/src/MyClient.cs", "sdk/foo/src/Helper.cs")
+
+            $result = Get-CodeCheckSummary -CurrentStatusLines $currentLines -PreExistingChanges $preExisting
+
+            $result.NewStatusLines.Count | Should -Be 0
+            $result.PreExistingCount      | Should -Be 2
+        }
+    }
+
+    Context "rename handling" {
+        It "reports rename as new when destination path is not pre-existing" {
+            $currentLines = @(
+                "R  sdk/foo/OldName.cs -> sdk/foo/NewName.cs"
+            )
+            $preExisting = @("sdk/bar/Unrelated.cs")
+
+            $result = Get-CodeCheckSummary -CurrentStatusLines $currentLines -PreExistingChanges $preExisting
+
+            $result.NewStatusLines.Count | Should -Be 1
+        }
+
+        It "filters rename when destination path is pre-existing" {
+            $currentLines = @(
+                "R  sdk/foo/OldName.cs -> sdk/foo/NewName.cs"
+            )
+            $preExisting = @("sdk/foo/NewName.cs")
+
+            $result = Get-CodeCheckSummary -CurrentStatusLines $currentLines -PreExistingChanges $preExisting
+
+            $result.NewStatusLines.Count | Should -Be 0
+        }
+    }
+
+    Context "mixed scenarios" {
+        It "handles a realistic mix of modified, added, deleted, and untracked files" {
+            $currentLines = @(
+                " M sdk/ai/src/HandWritten.cs",     # pre-existing (user edit)
+                " M sdk/ai/Generated/FooClient.cs",  # new (regenerated)
+                "A  sdk/ai/api/Foo.netstandard2.0.cs", # new (Export-API)
+                "?? sdk/ai/src/Scratch.cs"            # pre-existing (untracked user file)
+            )
+            $preExisting = @("sdk/ai/src/HandWritten.cs", "sdk/ai/src/Scratch.cs")
+
+            $result = Get-CodeCheckSummary -CurrentStatusLines $currentLines -PreExistingChanges $preExisting
+
+            $result.NewStatusLines.Count | Should -Be 2
+            $result.NewStatusLines[0]    | Should -BeLike "*FooClient.cs*"
+            $result.NewStatusLines[1]    | Should -BeLike "*Foo.netstandard2.0.cs*"
+            $result.PreExistingCount      | Should -Be 2
+        }
+
+        It "preserves the original porcelain line text in new status lines" {
+            $line = " M sdk/foo/Generated/Client.cs"
+            $result = Get-CodeCheckSummary -CurrentStatusLines @($line) -PreExistingChanges @()
+
+            $result.NewStatusLines[0] | Should -BeExactly $line
+        }
+    }
+
+    Context "empty / no-op inputs" {
+        It "returns empty summary when there are no current changes" {
+            $result = Get-CodeCheckSummary -CurrentStatusLines @() -PreExistingChanges @()
+
+            $result.NewStatusLines.Count | Should -Be 0
+            $result.PreExistingCount      | Should -Be 0
+        }
+
+        It "returns empty summary when current lines are all blank or malformed" {
+            $currentLines = @("", "   ", "M ")
+
+            $result = Get-CodeCheckSummary -CurrentStatusLines $currentLines -PreExistingChanges @()
+
+            $result.NewStatusLines.Count | Should -Be 0
+        }
+    }
+}


### PR DESCRIPTION
 Fixes https://github.com/Azure/azure-sdk-for-net/issues/55594

 # Problem
CodeChecks.ps1 runs scripts that have side effects (GenerateCode, Update-Snippets, Export-API) and then uses git diff to verify no uncommitted changes exist. This is the right behavior in CI — it catches stale generated code. But locally, it's counterproductive: the script fixes the problem for you and then fails because it fixed something.

For example, if your snippets are out of date, CodeChecks runs Update-Snippets.ps1 which updates them, and then immediately fails because there's a diff. The developer has to re-run the individual scripts themselves or just commit and hope CI passes.

# Solution
## Adds a -PreparePr switch that turns CodeChecks into a "fix it for me" tool:

`eng\scripts\CodeChecks.ps1 -ServiceDirectory <service> -PreparePr`

When -PreparePr is set:
- Runs dotnet format on all csproj files in the service directory (not run in CI mode)
- Runs all the same regeneration steps (GenerateCode, Update-Snippets, Export-API)
- Reports changed files as informational output instead of failing
- Filters out pre-existing uncommitted changes so you only see what the script produced

## Default behavior (no flag) is completely unchanged — no CI pipeline modifications needed.

## What it looks like
With pre-existing changes in your working tree:

```
   The following files were updated by code checks and should be included in your commit:
       M sdk/ai/Azure.AI.Foo/src/Generated/FooClient.cs
       M sdk/ai/Azure.AI.Foo/api/Azure.AI.Foo.netstandard2.0.cs
   
   Note: 3 pre-existing changed file(s) were ignored (not modified by code checks).
```