### PR TITLE
Add scriptWarning pattern so data-plane build failures show as warnings

### DIFF
--- a/eng/swagger_to_sdk_config.json
+++ b/eng/swagger_to_sdk_config.json
@@ -5,12 +5,14 @@
       "path": "pwsh ./eng/scripts/Invoke-GenerateAndBuildV2.ps1",
       "logPrefix": ".Net",
       "stderr": {
-        "showInComment": ".*(\\[ERROR\\]|ExternalError).*",
-        "scriptError": "\\[ERROR\\]"
+        "showInComment": ".*(\\[ERROR\\]|\\[WARNING\\]|ExternalError).*",
+        "scriptError": "\\[ERROR\\]",
+        "scriptWarning": "\\[WARNING\\]"
       },
       "stdout": {
-        "showInComment": ".*(Start to|\\[ERROR\\]|: error|(?!0\\b)\\d+ Error\\(s\\)).*",
-        "scriptError": "\\[ERROR\\]"
+        "showInComment": ".*(Start to|\\[ERROR\\]|\\[WARNING\\]|: error|(?!0\\b)\\d+ Error\\(s\\)).*",
+        "scriptError": "\\[ERROR\\]",
+        "scriptWarning": "\\[WARNING\\]"
       }
     }
   },


### PR DESCRIPTION
## Description

Fixes the issue where PR #57430 changed build failure log prefixes from `[ERROR]` to `[WARNING]` but the pipeline still shows green instead of yellow (succeeded with issues).

**Root cause:** The `swagger_to_sdk_config.json` configures the spec-gen-sdk-runner to detect script issues via regex patterns in stdout/stderr. It had `scriptError` matching `[ERROR]` lines, but PR #57430 changed those to `[WARNING]` without adding a corresponding `scriptWarning` pattern. Without it, the runner treats all output as clean.

**Changes:**
- Add `scriptWarning` pattern for `[WARNING]` to both stdout and stderr sections
- Add `[WARNING]` to `showInComment` patterns so warnings appear in spec PR comments

Fixes Azure/azure-sdk-for-net#57405