### PR TITLE
Remove unnecessary ModelReaderWriterBuildable for OracleDBVersionCollectionGetAllOptions

### DIFF
--- a/sdk/oracle/Azure.ResourceManager.OracleDatabase/src/Custom/Models/AzureResourceManagerOracleDatabaseContext.cs
+++ b/sdk/oracle/Azure.ResourceManager.OracleDatabase/src/Custom/Models/AzureResourceManagerOracleDatabaseContext.cs
@@ -5,13 +5,11 @@
 
 using System.ClientModel.Primitives;
 using Azure.ResourceManager.Models;
-using Azure.ResourceManager.OracleDatabase.Models;
 
 namespace Azure.ResourceManager.OracleDatabase
 {
-    // These 2 types are missing ModelReaderWriterBuildable attribute when migrating to new codegen, will be fixed in future codegen release.
+    // ArmPlan is missing ModelReaderWriterBuildable attribute when migrating to new codegen, will be fixed in future codegen release.
     [ModelReaderWriterBuildable(typeof(ArmPlan))]
-    [ModelReaderWriterBuildable(typeof(OracleDBVersionCollectionGetAllOptions))]
     public partial class AzureResourceManagerOracleDatabaseContext : ModelReaderWriterContext
     {
     }


### PR DESCRIPTION
## Fix SCM0006 build error in Oracle SDK ProjectRef CI

### Problem
The \MustImplementIPersistableModelAnalyzer\ (introduced in #51166, Feb 2026) now reports SCM0006 for types registered via \[ModelReaderWriterBuildable]\ that don't implement \IPersistableModel<T>\. Combined with \TreatWarningsAsErrors=true\, this breaks the Oracle SDK build in ProjectRef mode.

\OracleDBVersionCollectionGetAllOptions\ was registered in \AzureResourceManagerOracleDatabaseContext\ during the new MPG migration (#54702), but it is a pure parameter bag — it is never serialized/deserialized via \ModelReaderWriter\ and doesn't implement \IPersistableModel<T>\.

### Fix
Remove the \[ModelReaderWriterBuildable(typeof(OracleDBVersionCollectionGetAllOptions))]\ attribute. The \ArmPlan\ registration is kept because it **is** used by \ModelReaderWriter.Read<ArmPlan>\ in \OracleSubscriptionData.cs\.

### Validation
- \OracleDBVersionCollectionGetAllOptions\ is only used as an argument to \GetAll()\/\GetAllAsync()\ on \OracleDBVersionCollection\ — never serialized
- It is already excluded from \ModelReaderWriterImplementationValidation.Exceptions.cs\
- \ArmPlan\ implements \IPersistableModel<ArmPlan>\ so its registration does not trigger SCM0006