### PR TITLE
Skip safe-flatten for discriminator base models in FlattenPropertyVisitor

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -419,15 +419,15 @@ namespace Azure.Generator.Management.Visitors
                         continue;
                     }
 
-                    // skip discriminator property
-                    if (internalProperty.IsDiscriminator)
+                    // skip if internal property type is base abstract discriminator model
+                    if (modelProvider.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Abstract))
                     {
-                        ManagementClientGenerator.Instance.Emitter.ReportDiagnostic("general-warning", "Discriminator property should not be flattened.");
                         continue;
                     }
 
-                    // skip if internal property type is base abstract discriminator model
-                    if (modelProvider.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Abstract))
+                    // skip if internal property type is a discriminator base model (has a discriminator property),
+                    // because flattening would make the base type internal, breaking the polymorphic hierarchy
+                    if (innerProperties.Any(p => p.IsDiscriminator))
                     {
                         continue;
                     }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -87,5 +87,69 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.IsNotNull(decoratorsProperty, "Could not find InputModelProperty.Decorators property");
             decoratorsProperty!.SetValue(property, new[] { decorator });
         }
+
+        /// <summary>
+        /// Verifies that a discriminator base model with a single non-discriminator public property
+        /// is NOT safe-flattened. Previously, since the discriminator property is internal and not
+        /// counted in publicPropertyCount, the model appeared to have only one public property,
+        /// triggering safe-flatten and making the discriminator base type internal — breaking the
+        /// polymorphic hierarchy.
+        /// </summary>
+        [Test]
+        public void TestSafeFlattenSkipsDiscriminatorBaseModel()
+        {
+            // Create a discriminator base model with one discriminator property and one regular property.
+            // The discriminator property will be internal, so publicPropertyCount == 1.
+            var discriminatorProperty = InputFactory.Property("kind", InputPrimitiveType.String, isRequired: true, isDiscriminator: true, serializedName: "kind");
+            var regularProperty = InputFactory.Property("retentionDays", InputPrimitiveType.Int32, isRequired: false, serializedName: "retentionDays");
+
+            var derivedModel = InputFactory.Model(
+                "PeriodicBackupPolicy",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("intervalInHours", InputPrimitiveType.Int32, isRequired: true, serializedName: "intervalInHours")],
+                discriminatedKind: "Periodic");
+
+            var discriminatorBaseModel = InputFactory.Model(
+                "BackupPolicy",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [discriminatorProperty, regularProperty],
+                derivedModels: [derivedModel],
+                discriminatedModels: new Dictionary<string, InputModelType> { { "Periodic", derivedModel } });
+
+            // Create a parent model that has a property of the discriminator base type.
+            var backupPolicyProperty = InputFactory.Property("backupPolicy", discriminatorBaseModel, isRequired: false, serializedName: "backupPolicy");
+            var parentModel = InputFactory.Model(
+                "DatabaseAccount",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [backupPolicyProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [parentModel, discriminatorBaseModel, derivedModel]);
+
+            // Create model providers.
+            var parentModelProvider = plugin.Object.TypeFactory.CreateModel(parentModel);
+            Assert.IsNotNull(parentModelProvider);
+
+            var discriminatorModelProvider = plugin.Object.TypeFactory.CreateModel(discriminatorBaseModel);
+            Assert.IsNotNull(discriminatorModelProvider);
+
+            // Run all visitors on the parent model.
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(visitTypeCore, "Could not find LibraryVisitor.VisitTypeCore method");
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [parentModelProvider]);
+            }
+
+            // The backupPolicy property should NOT have been flattened — it should remain public.
+            var backupPolicyProp = parentModelProvider!.Properties.FirstOrDefault(p => p.Name == "BackupPolicy");
+            Assert.IsNotNull(backupPolicyProp, "BackupPolicy property should still exist on the parent model");
+            Assert.IsTrue(
+                backupPolicyProp!.Modifiers.HasFlag(MethodSignatureModifiers.Public),
+                "BackupPolicy property should remain public (not flattened to internal)");
+        }
     }
 }

--- a/sdk/search/Azure.ResourceManager.Search/src/Generated/Internal/ModelSerializationExtensions.cs
+++ b/sdk/search/Azure.ResourceManager.Search/src/Generated/Internal/ModelSerializationExtensions.cs
@@ -22,6 +22,10 @@ namespace Azure.ResourceManager.Search
         {
             MaxDepth = 256
         };
+        /// <summary> The wire v3 options for model serialization. </summary>
+        internal static readonly ModelReaderWriterOptions WireV3Options = new ModelReaderWriterOptions("W|v3");
+        /// <summary> The JSON v3 options for model serialization. </summary>
+        internal static readonly ModelReaderWriterOptions JsonV3Options = new ModelReaderWriterOptions("J|v3");
 
         public static object GetObject(this JsonElement element)
         {

--- a/sdk/search/Azure.ResourceManager.Search/src/Generated/Models/SearchServicePatch.Serialization.cs
+++ b/sdk/search/Azure.ResourceManager.Search/src/Generated/Models/SearchServicePatch.Serialization.cs
@@ -106,7 +106,7 @@ namespace Azure.ResourceManager.Search.Models
             if (Optional.IsDefined(Identity))
             {
                 writer.WritePropertyName("identity"u8);
-                ((IJsonModel<ManagedServiceIdentity>)Identity).Write(writer, options);
+                ((IJsonModel<ManagedServiceIdentity>)Identity).Write(writer, options.Format == "W" ? ModelSerializationExtensions.WireV3Options : ModelSerializationExtensions.JsonV3Options);
             }
         }
 
@@ -229,7 +229,7 @@ namespace Azure.ResourceManager.Search.Models
                     {
                         continue;
                     }
-                    identity = ModelReaderWriter.Read<ManagedServiceIdentity>(new BinaryData(Encoding.UTF8.GetBytes(prop.Value.GetRawText())), ModelSerializationExtensions.WireOptions, AzureResourceManagerSearchContext.Default);
+                    identity = ModelReaderWriter.Read<ManagedServiceIdentity>(new BinaryData(Encoding.UTF8.GetBytes(prop.Value.GetRawText())), options.Format == "W" ? ModelSerializationExtensions.WireV3Options : ModelSerializationExtensions.JsonV3Options, AzureResourceManagerSearchContext.Default);
                     continue;
                 }
                 if (options.Format != "W")

--- a/sdk/search/Azure.ResourceManager.Search/src/Generated/SearchServiceData.Serialization.cs
+++ b/sdk/search/Azure.ResourceManager.Search/src/Generated/SearchServiceData.Serialization.cs
@@ -114,7 +114,7 @@ namespace Azure.ResourceManager.Search
             if (Optional.IsDefined(Identity))
             {
                 writer.WritePropertyName("identity"u8);
-                ((IJsonModel<ManagedServiceIdentity>)Identity).Write(writer, options);
+                ((IJsonModel<ManagedServiceIdentity>)Identity).Write(writer, options.Format == "W" ? ModelSerializationExtensions.WireV3Options : ModelSerializationExtensions.JsonV3Options);
             }
         }
 
@@ -237,7 +237,7 @@ namespace Azure.ResourceManager.Search
                     {
                         continue;
                     }
-                    identity = ModelReaderWriter.Read<ManagedServiceIdentity>(new BinaryData(Encoding.UTF8.GetBytes(prop.Value.GetRawText())), ModelSerializationExtensions.WireOptions, AzureResourceManagerSearchContext.Default);
+                    identity = ModelReaderWriter.Read<ManagedServiceIdentity>(new BinaryData(Encoding.UTF8.GetBytes(prop.Value.GetRawText())), options.Format == "W" ? ModelSerializationExtensions.WireV3Options : ModelSerializationExtensions.JsonV3Options, AzureResourceManagerSearchContext.Default);
                     continue;
                 }
                 if (options.Format != "W")


### PR DESCRIPTION
## Fix

When a discriminator base model has only one non-discriminator public property (the discriminator property is generated as `internal`), the safe-flatten logic in `FlattenPropertyVisitor` incorrectly flattens it. This makes the discriminator base type `internal`, breaking the polymorphic hierarchy — users can no longer reference the base type.

### Example

Given a discriminated model:
```typespec
@discriminator("kind")
model BackupPolicy {
  kind: string;
  retentionDays?: int32;
}
```

The generated `BackupPolicy` class was emitted as `internal` because after excluding the `internal` discriminator property `kind`, only one public property (`retentionDays`) remained, triggering safe-flatten.

### Changes

- **Added guard**: Skip safe-flatten when the inner model type has a discriminator property (`innerProperties.Any(p => p.IsDiscriminator)`), preventing discriminator base models from being flattened
- **Removed dead check**: The `internalProperty.IsDiscriminator` check was unreachable — since the code only considers model-typed properties (complex types), and discriminator properties are always scalar types (e.g., `string`), this branch could never be hit
- **Added test**: `TestSafeFlattenSkipsDiscriminatorBaseModel` validates the fix

Fixes #56708