### PR TITLE
Add Invocations protocol samples for AgentServer

### DIFF
--- a/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/.dockerignore
+++ b/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/.dockerignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+.vs/
+*.user
+*.suo

--- a/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/AgentWithLongRunningTask.csproj
+++ b/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/AgentWithLongRunningTask.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);AZC0100;AZC0004</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Azure.AI.AgentServer.Invocations\src\Azure.AI.AgentServer.Invocations.csproj" />
+    <ProjectReference Include="..\..\..\Azure.AI.AgentServer.Hosting\src\Azure.AI.AgentServer.Hosting.csproj" />
+  </ItemGroup>
+</Project>

--- a/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/AgentWithLongRunningTask.csproj
+++ b/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/AgentWithLongRunningTask.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/Dockerfile
+++ b/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore
+RUN dotnet build -c Release --no-restore
+RUN dotnet publish -c Release --no-build -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 8088
+ENTRYPOINT ["dotnet", "AgentWithLongRunningTask.dll"]

--- a/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/Program.cs
+++ b/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/Program.cs
@@ -1,0 +1,106 @@
+// Document Analysis Agent — Demonstrates the long-running operations (LRO) pattern
+// with the Invocations protocol. Submit a document for analysis, poll for progress,
+// and retrieve results when the analysis is complete.
+
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Azure.AI.AgentServer.Hosting;
+using Azure.AI.AgentServer.Invocations;
+using Microsoft.AspNetCore.Http;
+
+var handler = new DocumentAnalysisHandler();
+var builder = AgentHost.CreateBuilder(args);
+builder.AddInvocations(handler);
+builder.Build().Run();
+
+public class DocumentAnalysisHandler : InvocationHandler
+{
+    private readonly ConcurrentDictionary<string, JobState> _jobs = new();
+
+    // POST /invocations — accept a document and start background analysis
+    public override async Task HandleAsync(
+        HttpRequest request, HttpResponse response,
+        InvocationContext context, CancellationToken cancellationToken)
+    {
+        var body = await new StreamReader(request.Body).ReadToEndAsync(cancellationToken);
+        var invocationId = Guid.NewGuid().ToString();
+
+        _jobs[invocationId] = new JobState
+        {
+            Status = "running",
+            Input = body,
+            StartedAt = DateTime.UtcNow
+        };
+
+        // Simulate background work completing after 3 seconds
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(3000, CancellationToken.None);
+            if (_jobs.TryGetValue(invocationId, out var job) && job.Status == "running")
+            {
+                job.Status = "completed";
+                job.Result = $"Analysis complete: '{body}' contains {body.Split(' ').Length} words";
+            }
+        });
+
+        response.StatusCode = 202;
+        response.Headers["Location"] = $"/invocations/{invocationId}";
+        await response.WriteAsync(
+            JsonSerializer.Serialize(new { invocationId, status = "running" }),
+            cancellationToken);
+    }
+
+    // GET /invocations/{invocationId} — poll for status
+    public override async Task GetAsync(
+        string invocationId, HttpRequest request, HttpResponse response,
+        CancellationToken cancellationToken)
+    {
+        if (!_jobs.TryGetValue(invocationId, out var job))
+        {
+            response.StatusCode = 404;
+            return;
+        }
+
+        if (job.Status == "running")
+        {
+            response.StatusCode = 202;
+            await response.WriteAsync(
+                JsonSerializer.Serialize(new { invocationId, status = "running" }),
+                cancellationToken);
+            return;
+        }
+
+        response.StatusCode = 200;
+        response.ContentType = "application/json";
+        await response.WriteAsync(
+            JsonSerializer.Serialize(new { invocationId, status = job.Status, result = job.Result }),
+            cancellationToken);
+    }
+
+    // POST /invocations/{invocationId}/cancel — cancel a running analysis
+    public override async Task CancelAsync(
+        string invocationId, HttpRequest request, HttpResponse response,
+        CancellationToken cancellationToken)
+    {
+        if (_jobs.TryGetValue(invocationId, out var job))
+        {
+            job.Status = "cancelled";
+            response.StatusCode = 200;
+            await response.WriteAsync(
+                JsonSerializer.Serialize(new { invocationId, status = "cancelled" }),
+                cancellationToken);
+        }
+        else
+        {
+            response.StatusCode = 404;
+        }
+    }
+
+    private class JobState
+    {
+        public string Status { get; set; } = "pending";
+        public string Input { get; set; } = "";
+        public string? Result { get; set; }
+        public DateTime StartedAt { get; set; }
+    }
+}

--- a/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/README.md
+++ b/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/README.md
@@ -1,0 +1,95 @@
+<!-- Begin standard disclaimer — do not modify -->
+**IMPORTANT!** All samples and other resources made available in this GitHub repository ("samples") are designed to assist in accelerating development of agents, solutions, and agent workflows for various scenarios. Review all provided resources and carefully test output behavior in the context of your use case. AI responses may be inaccurate and AI actions should be monitored with human oversight. Learn more in the transparency documents for [Agent Service](https://learn.microsoft.com/en-us/azure/ai-foundry/responsible-ai/agents/transparency-note) and [Agent Framework](https://github.com/microsoft/agent-framework/blob/main/TRANSPARENCY_FAQ.md).
+
+Agents, solutions, or other output you create may be subject to legal and regulatory requirements, may require licenses, or may not be suitable for all industries, scenarios, or use cases. By using any sample, you are acknowledging that any output created using those samples are solely your responsibility, and that you will comply with all applicable laws, regulations, and relevant safety standards, terms of service, and codes of conduct.
+
+Third-party samples contained in this folder are subject to their own designated terms, and they have not been tested or verified by Microsoft or its affiliates.
+
+Microsoft has no responsibility to you or others with respect to any of these samples or any resulting output.
+<!-- End standard disclaimer -->
+
+# What this sample demonstrates
+
+Demonstrates the **long-running operations (LRO)** pattern with the Invocations protocol. The handler accepts a document submission, simulates background processing, and supports polling for status and cancellation. This is the standard pattern for operations that take more than a few seconds to complete.
+
+## How It Works
+
+### LRO Lifecycle
+
+1. **Submit** (`POST /invocations`) — Accepts the document and returns `202 Accepted` with an invocation ID
+2. **Poll** (`GET /invocations/{id}`) — Returns `running` (202) or `completed` (200) with results
+3. **Cancel** (`DELETE /invocations/{id}`) — Cancels the running operation
+
+### Agent Hosting
+
+The agent is hosted using the [Azure AI AgentServer SDK](https://www.nuget.org/packages/Azure.AI.AgentServer.Invocations). Note that the handler is registered as a **singleton** to preserve job state across requests. See [Program.cs](Program.cs) for the full implementation.
+
+### Agent Deployment
+
+The hosted agent can be deployed to Microsoft Foundry using the Azure Developer CLI [ai agent](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/concepts/hosted-agents?view=foundry&tabs=cli#create-a-hosted-agent) extension.
+
+## Running the Agent Locally
+
+### Prerequisites
+
+1. **Azure AI Foundry Project**
+   - Project created in [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/what-is-foundry?view=foundry#microsoft-foundry-portals)
+   - Note your project endpoint URL
+
+2. **Azure CLI** — `az login`
+
+3. **.NET 10.0 SDK or later** — `dotnet --version`
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AZURE_AI_PROJECT_ENDPOINT` | Yes | Your Azure AI Foundry project endpoint URL |
+
+### Running the Sample
+
+```bash
+dotnet run
+```
+
+### Interacting with the Agent
+
+**Step 1 — Submit a document:**
+
+```bash
+curl -X POST http://localhost:8088/invocations \
+  -H "Content-Type: text/plain" \
+  -d "The quick brown fox jumps over the lazy dog"
+```
+
+Response: `202 Accepted` with `Location` header containing the invocation ID.
+
+**Step 2 — Poll for status:**
+
+```bash
+curl http://localhost:8088/invocations/{invocation-id}
+```
+
+Returns `202` while processing, then `200` with results when complete.
+
+**Step 3 — (Optional) Cancel:**
+
+```bash
+curl -X DELETE http://localhost:8088/invocations/{invocation-id}
+```
+
+### Deploying the Agent to Microsoft Foundry
+
+To deploy your agent to Microsoft Foundry, follow the comprehensive deployment guide at https://aka.ms/azdaiagent/docs
+
+## Troubleshooting
+
+### Images built on Apple Silicon or other ARM64 machines do not work on our service
+
+We **recommend using `azd` cloud build**, which always builds images with the correct architecture.
+
+If you choose to **build locally**, use:
+
+```shell
+docker build --platform=linux/amd64 -t image .
+```

--- a/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/agent.yaml
+++ b/sdk/agentserver/samples/invocations/AgentWithLongRunningTask/agent.yaml
@@ -1,0 +1,22 @@
+name: agent-with-long-running-task
+description: >
+  Demonstrates the long-running operations (LRO) pattern with the Invocations protocol.
+  Submit a document for analysis, poll for progress, and retrieve results when the analysis
+  is complete. Shows Submit → Poll → Complete/Cancel lifecycle.
+metadata:
+  tags:
+    - AI Agent Hosting
+    - Azure AI AgentServer
+    - Invocations Protocol
+    - Long Running Operations
+    - LRO
+template:
+  name: agent-with-long-running-task
+  kind: hosted
+  protocols:
+    - protocol: invocations
+      version: v1
+  environment_variables:
+    - name: AZURE_AI_PROJECT_ENDPOINT
+      value: ${AZURE_AI_PROJECT_ENDPOINT}
+resources: []

--- a/sdk/agentserver/samples/invocations/AgentWithMultiTurn/.dockerignore
+++ b/sdk/agentserver/samples/invocations/AgentWithMultiTurn/.dockerignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+.vs/
+*.user
+*.suo

--- a/sdk/agentserver/samples/invocations/AgentWithMultiTurn/AgentWithMultiTurn.csproj
+++ b/sdk/agentserver/samples/invocations/AgentWithMultiTurn/AgentWithMultiTurn.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);AZC0100;AZC0004</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Azure.AI.AgentServer.Invocations\src\Azure.AI.AgentServer.Invocations.csproj" />
+    <ProjectReference Include="..\..\..\Azure.AI.AgentServer.Hosting\src\Azure.AI.AgentServer.Hosting.csproj" />
+  </ItemGroup>
+</Project>

--- a/sdk/agentserver/samples/invocations/AgentWithMultiTurn/AgentWithMultiTurn.csproj
+++ b/sdk/agentserver/samples/invocations/AgentWithMultiTurn/AgentWithMultiTurn.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/sdk/agentserver/samples/invocations/AgentWithMultiTurn/Dockerfile
+++ b/sdk/agentserver/samples/invocations/AgentWithMultiTurn/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore
+RUN dotnet build -c Release --no-restore
+RUN dotnet publish -c Release --no-build -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 8088
+ENTRYPOINT ["dotnet", "AgentWithMultiTurn.dll"]

--- a/sdk/agentserver/samples/invocations/AgentWithMultiTurn/Program.cs
+++ b/sdk/agentserver/samples/invocations/AgentWithMultiTurn/Program.cs
@@ -1,0 +1,51 @@
+// Travel Planner Agent — Demonstrates multi-turn conversation with the Invocations
+// protocol. Each request carries a session_id query parameter so the handler can
+// accumulate conversation history across turns.
+
+using System.Collections.Concurrent;
+using Azure.AI.AgentServer.Hosting;
+using Azure.AI.AgentServer.Invocations;
+using Microsoft.AspNetCore.Http;
+
+var handler = new TravelPlannerHandler();
+var builder = AgentHost.CreateBuilder(args);
+builder.AddInvocations(handler);
+builder.Build().Run();
+
+public class TravelPlannerHandler : InvocationHandler
+{
+    private readonly ConcurrentDictionary<string, List<string>> _sessions = new();
+
+    public override async Task HandleAsync(
+        HttpRequest request, HttpResponse response,
+        InvocationContext context, CancellationToken cancellationToken)
+    {
+        var sessionId = request.Query["session_id"].FirstOrDefault() ?? "default";
+        var input = await new StreamReader(request.Body).ReadToEndAsync(cancellationToken);
+
+        var history = _sessions.GetOrAdd(sessionId, _ => new List<string>());
+
+        lock (history)
+        {
+            history.Add($"User: {input}");
+        }
+
+        string reply;
+        lock (history)
+        {
+            reply = history.Count switch
+            {
+                1 => $"Welcome to Travel Planner! You said: \"{input}\". Where would you like to go?",
+                2 => $"Great choice! How many days do you plan to stay? (History: {history.Count} turns)",
+                3 => $"Here's a suggested itinerary based on our {history.Count}-turn conversation:\n" +
+                     string.Join("\n", history.Select((h, i) => $"  Turn {i + 1}: {h}")),
+                _ => $"Turn {history.Count}: Got it! Anything else you'd like to plan?\n" +
+                     $"Full conversation so far:\n" +
+                     string.Join("\n", history.Select((h, i) => $"  {i + 1}. {h}"))
+            };
+            history.Add($"Agent: {reply}");
+        }
+
+        await response.WriteAsync(reply, cancellationToken);
+    }
+}

--- a/sdk/agentserver/samples/invocations/AgentWithMultiTurn/README.md
+++ b/sdk/agentserver/samples/invocations/AgentWithMultiTurn/README.md
@@ -1,0 +1,93 @@
+<!-- Begin standard disclaimer — do not modify -->
+**IMPORTANT!** All samples and other resources made available in this GitHub repository ("samples") are designed to assist in accelerating development of agents, solutions, and agent workflows for various scenarios. Review all provided resources and carefully test output behavior in the context of your use case. AI responses may be inaccurate and AI actions should be monitored with human oversight. Learn more in the transparency documents for [Agent Service](https://learn.microsoft.com/en-us/azure/ai-foundry/responsible-ai/agents/transparency-note) and [Agent Framework](https://github.com/microsoft/agent-framework/blob/main/TRANSPARENCY_FAQ.md).
+
+Agents, solutions, or other output you create may be subject to legal and regulatory requirements, may require licenses, or may not be suitable for all industries, scenarios, or use cases. By using any sample, you are acknowledging that any output created using those samples are solely your responsibility, and that you will comply with all applicable laws, regulations, and relevant safety standards, terms of service, and codes of conduct.
+
+Third-party samples contained in this folder are subject to their own designated terms, and they have not been tested or verified by Microsoft or its affiliates.
+
+Microsoft has no responsibility to you or others with respect to any of these samples or any resulting output.
+<!-- End standard disclaimer -->
+
+# What this sample demonstrates
+
+Demonstrates **multi-turn conversation** with the Invocations protocol. The handler uses a `session_id` query parameter to maintain conversation history across multiple requests, enabling stateful dialog patterns like travel planning, booking flows, or any step-by-step interaction.
+
+## How It Works
+
+### Session Management
+
+Each request includes a `?session_id=<id>` query parameter. The handler stores conversation history in a `ConcurrentDictionary` keyed by session ID. Successive turns build on previous context.
+
+**Important:** The handler is registered as a **singleton** (not scoped) so that session state persists across HTTP requests.
+
+See [Program.cs](Program.cs) for the full implementation.
+
+### Agent Deployment
+
+The hosted agent can be deployed to Microsoft Foundry using the Azure Developer CLI [ai agent](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/concepts/hosted-agents?view=foundry&tabs=cli#create-a-hosted-agent) extension.
+
+## Running the Agent Locally
+
+### Prerequisites
+
+1. **Azure AI Foundry Project**
+   - Project created in [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/what-is-foundry?view=foundry#microsoft-foundry-portals)
+   - Note your project endpoint URL
+
+2. **Azure CLI** — `az login`
+
+3. **.NET 10.0 SDK or later** — `dotnet --version`
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AZURE_AI_PROJECT_ENDPOINT` | Yes | Your Azure AI Foundry project endpoint URL |
+
+### Running the Sample
+
+```bash
+dotnet run
+```
+
+### Interacting with the Agent
+
+**Turn 1:**
+
+```bash
+curl -X POST "http://localhost:8088/invocations?session_id=trip-001" \
+  -H "Content-Type: text/plain" \
+  -d "I want to plan a trip to Paris"
+```
+
+**Turn 2:**
+
+```bash
+curl -X POST "http://localhost:8088/invocations?session_id=trip-001" \
+  -H "Content-Type: text/plain" \
+  -d "5 days"
+```
+
+**Turn 3:**
+
+```bash
+curl -X POST "http://localhost:8088/invocations?session_id=trip-001" \
+  -H "Content-Type: text/plain" \
+  -d "I like museums and food tours"
+```
+
+Each response references previous turns to demonstrate accumulated context.
+
+### Deploying the Agent to Microsoft Foundry
+
+To deploy your agent to Microsoft Foundry, follow the comprehensive deployment guide at https://aka.ms/azdaiagent/docs
+
+## Troubleshooting
+
+### Images built on Apple Silicon or other ARM64 machines do not work on our service
+
+Use `azd` cloud build, or build locally with:
+
+```shell
+docker build --platform=linux/amd64 -t image .
+```

--- a/sdk/agentserver/samples/invocations/AgentWithMultiTurn/agent.yaml
+++ b/sdk/agentserver/samples/invocations/AgentWithMultiTurn/agent.yaml
@@ -1,0 +1,22 @@
+name: agent-with-multi-turn
+description: >
+  Demonstrates multi-turn conversation with the Invocations protocol.
+  Each request carries a session_id query parameter so the handler can
+  accumulate conversation history across turns.
+metadata:
+  tags:
+    - AI Agent Hosting
+    - Azure AI AgentServer
+    - Invocations Protocol
+    - Multi-turn Conversation
+    - Session Management
+template:
+  name: agent-with-multi-turn
+  kind: hosted
+  protocols:
+    - protocol: invocations
+      version: v1
+  environment_variables:
+    - name: AZURE_AI_PROJECT_ENDPOINT
+      value: ${AZURE_AI_PROJECT_ENDPOINT}
+resources: []

--- a/sdk/agentserver/samples/invocations/AgentWithStreaming/.dockerignore
+++ b/sdk/agentserver/samples/invocations/AgentWithStreaming/.dockerignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+.vs/
+*.user
+*.suo

--- a/sdk/agentserver/samples/invocations/AgentWithStreaming/AgentWithStreaming.csproj
+++ b/sdk/agentserver/samples/invocations/AgentWithStreaming/AgentWithStreaming.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);AZC0100;AZC0004</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Azure.AI.AgentServer.Invocations\src\Azure.AI.AgentServer.Invocations.csproj" />
+    <ProjectReference Include="..\..\..\Azure.AI.AgentServer.Hosting\src\Azure.AI.AgentServer.Hosting.csproj" />
+  </ItemGroup>
+</Project>

--- a/sdk/agentserver/samples/invocations/AgentWithStreaming/AgentWithStreaming.csproj
+++ b/sdk/agentserver/samples/invocations/AgentWithStreaming/AgentWithStreaming.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/sdk/agentserver/samples/invocations/AgentWithStreaming/Dockerfile
+++ b/sdk/agentserver/samples/invocations/AgentWithStreaming/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore
+RUN dotnet build -c Release --no-restore
+RUN dotnet publish -c Release --no-build -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 8088
+ENTRYPOINT ["dotnet", "AgentWithStreaming.dll"]

--- a/sdk/agentserver/samples/invocations/AgentWithStreaming/Program.cs
+++ b/sdk/agentserver/samples/invocations/AgentWithStreaming/Program.cs
@@ -1,0 +1,43 @@
+// Code Gen Agent — Demonstrates server-sent events (SSE) streaming with the
+// Invocations protocol. The handler streams generated code tokens one at a time,
+// producing a real-time "typing" effect for the caller.
+
+using Azure.AI.AgentServer.Hosting;
+using Azure.AI.AgentServer.Invocations;
+using Microsoft.AspNetCore.Http;
+
+var builder = AgentHost.CreateBuilder(args);
+builder.AddInvocations<CodeGenHandler>();
+builder.Build().Run();
+
+public class CodeGenHandler : InvocationHandler
+{
+    public override async Task HandleAsync(
+        HttpRequest request, HttpResponse response,
+        InvocationContext context, CancellationToken cancellationToken)
+    {
+        var prompt = await new StreamReader(request.Body).ReadToEndAsync(cancellationToken);
+
+        response.ContentType = "text/event-stream";
+        response.Headers["Cache-Control"] = "no-cache";
+
+        var tokens = new[]
+        {
+            "public ", "class ", "Hello", "World ", "{\n",
+            "  public ", "static ", "void ", "Main() ", "{\n",
+            "    Console", ".WriteLine", "(\"Hello!", "\");\n",
+            "  }\n",
+            "}\n"
+        };
+
+        foreach (var token in tokens)
+        {
+            await response.WriteAsync($"data: {token}\n\n", cancellationToken);
+            await response.Body.FlushAsync(cancellationToken);
+            await Task.Delay(100, cancellationToken);
+        }
+
+        await response.WriteAsync("data: [DONE]\n\n", cancellationToken);
+        await response.Body.FlushAsync(cancellationToken);
+    }
+}

--- a/sdk/agentserver/samples/invocations/AgentWithStreaming/README.md
+++ b/sdk/agentserver/samples/invocations/AgentWithStreaming/README.md
@@ -1,0 +1,81 @@
+<!-- Begin standard disclaimer — do not modify -->
+**IMPORTANT!** All samples and other resources made available in this GitHub repository ("samples") are designed to assist in accelerating development of agents, solutions, and agent workflows for various scenarios. Review all provided resources and carefully test output behavior in the context of your use case. AI responses may be inaccurate and AI actions should be monitored with human oversight. Learn more in the transparency documents for [Agent Service](https://learn.microsoft.com/en-us/azure/ai-foundry/responsible-ai/agents/transparency-note) and [Agent Framework](https://github.com/microsoft/agent-framework/blob/main/TRANSPARENCY_FAQ.md).
+
+Agents, solutions, or other output you create may be subject to legal and regulatory requirements, may require licenses, or may not be suitable for all industries, scenarios, or use cases. By using any sample, you are acknowledging that any output created using those samples are solely your responsibility, and that you will comply with all applicable laws, regulations, and relevant safety standards, terms of service, and codes of conduct.
+
+Third-party samples contained in this folder are subject to their own designated terms, and they have not been tested or verified by Microsoft or its affiliates.
+
+Microsoft has no responsibility to you or others with respect to any of these samples or any resulting output.
+<!-- End standard disclaimer -->
+
+# What this sample demonstrates
+
+Demonstrates **SSE (Server-Sent Events) streaming** with the Invocations protocol. The handler streams generated code tokens one at a time over the HTTP connection, producing a real-time "typing" effect. This is the standard pattern for streaming responses such as code generation, chat completions, or any incremental output.
+
+## How It Works
+
+### SSE Streaming
+
+The handler sets `Content-Type: text/event-stream` and writes `data:` frames at a throttled rate. The caller receives each token as it's produced, rather than waiting for the full response. A final `[DONE]` event signals completion.
+
+See [Program.cs](Program.cs) for the full implementation.
+
+### Agent Deployment
+
+The hosted agent can be deployed to Microsoft Foundry using the Azure Developer CLI [ai agent](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/concepts/hosted-agents?view=foundry&tabs=cli#create-a-hosted-agent) extension.
+
+## Running the Agent Locally
+
+### Prerequisites
+
+1. **Azure AI Foundry Project**
+   - Project created in [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/what-is-foundry?view=foundry#microsoft-foundry-portals)
+   - Note your project endpoint URL
+
+2. **Azure CLI** — `az login`
+
+3. **.NET 10.0 SDK or later** — `dotnet --version`
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AZURE_AI_PROJECT_ENDPOINT` | Yes | Your Azure AI Foundry project endpoint URL |
+
+### Running the Sample
+
+```bash
+dotnet run
+```
+
+### Interacting with the Agent
+
+```bash
+curl -N -X POST http://localhost:8088/invocations \
+  -H "Content-Type: text/plain" \
+  -d "Generate a hello world program"
+```
+
+You'll see tokens stream in real time:
+
+```
+data: public
+data: class
+data: HelloWorld {
+...
+data: [DONE]
+```
+
+### Deploying the Agent to Microsoft Foundry
+
+To deploy your agent to Microsoft Foundry, follow the comprehensive deployment guide at https://aka.ms/azdaiagent/docs
+
+## Troubleshooting
+
+### Images built on Apple Silicon or other ARM64 machines do not work on our service
+
+Use `azd` cloud build, or build locally with:
+
+```shell
+docker build --platform=linux/amd64 -t image .
+```

--- a/sdk/agentserver/samples/invocations/AgentWithStreaming/agent.yaml
+++ b/sdk/agentserver/samples/invocations/AgentWithStreaming/agent.yaml
@@ -1,0 +1,22 @@
+name: agent-with-streaming
+description: >
+  Demonstrates server-sent events (SSE) streaming with the Invocations protocol.
+  The handler streams generated code tokens one at a time, producing a real-time
+  typing effect for the caller.
+metadata:
+  tags:
+    - AI Agent Hosting
+    - Azure AI AgentServer
+    - Invocations Protocol
+    - Server-Sent Events
+    - Streaming
+template:
+  name: agent-with-streaming
+  kind: hosted
+  protocols:
+    - protocol: invocations
+      version: v1
+  environment_variables:
+    - name: AZURE_AI_PROJECT_ENDPOINT
+      value: ${AZURE_AI_PROJECT_ENDPOINT}
+resources: []

--- a/sdk/agentserver/samples/invocations/EchoAgent/.dockerignore
+++ b/sdk/agentserver/samples/invocations/EchoAgent/.dockerignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+.vs/
+*.user
+*.suo

--- a/sdk/agentserver/samples/invocations/EchoAgent/Dockerfile
+++ b/sdk/agentserver/samples/invocations/EchoAgent/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore
+RUN dotnet build -c Release --no-restore
+RUN dotnet publish -c Release --no-build -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine AS final
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 8088
+ENTRYPOINT ["dotnet", "EchoAgent.dll"]

--- a/sdk/agentserver/samples/invocations/EchoAgent/EchoAgent.csproj
+++ b/sdk/agentserver/samples/invocations/EchoAgent/EchoAgent.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>$(NoWarn);AZC0100;AZC0004</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Azure.AI.AgentServer.Invocations\src\Azure.AI.AgentServer.Invocations.csproj" />
+    <ProjectReference Include="..\..\..\Azure.AI.AgentServer.Hosting\src\Azure.AI.AgentServer.Hosting.csproj" />
+  </ItemGroup>
+</Project>

--- a/sdk/agentserver/samples/invocations/EchoAgent/EchoAgent.csproj
+++ b/sdk/agentserver/samples/invocations/EchoAgent/EchoAgent.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/sdk/agentserver/samples/invocations/EchoAgent/Program.cs
+++ b/sdk/agentserver/samples/invocations/EchoAgent/Program.cs
@@ -1,0 +1,20 @@
+// Echo Agent — The simplest possible invocation handler: read plain text in, write plain text out.
+
+using Azure.AI.AgentServer.Hosting;
+using Azure.AI.AgentServer.Invocations;
+using Microsoft.AspNetCore.Http;
+
+var builder = AgentHost.CreateBuilder(args);
+builder.AddInvocations<EchoHandler>();
+builder.Build().Run();
+
+public class EchoHandler : InvocationHandler
+{
+    public override async Task HandleAsync(
+        HttpRequest request, HttpResponse response,
+        InvocationContext context, CancellationToken cancellationToken)
+    {
+        var input = await new StreamReader(request.Body).ReadToEndAsync(cancellationToken);
+        await response.WriteAsync($"You said: {input}", cancellationToken);
+    }
+}

--- a/sdk/agentserver/samples/invocations/EchoAgent/README.md
+++ b/sdk/agentserver/samples/invocations/EchoAgent/README.md
@@ -1,0 +1,102 @@
+<!-- Begin standard disclaimer — do not modify -->
+**IMPORTANT!** All samples and other resources made available in this GitHub repository ("samples") are designed to assist in accelerating development of agents, solutions, and agent workflows for various scenarios. Review all provided resources and carefully test output behavior in the context of your use case. AI responses may be inaccurate and AI actions should be monitored with human oversight. Learn more in the transparency documents for [Agent Service](https://learn.microsoft.com/en-us/azure/ai-foundry/responsible-ai/agents/transparency-note) and [Agent Framework](https://github.com/microsoft/agent-framework/blob/main/TRANSPARENCY_FAQ.md).
+
+Agents, solutions, or other output you create may be subject to legal and regulatory requirements, may require licenses, or may not be suitable for all industries, scenarios, or use cases. By using any sample, you are acknowledging that any output created using those samples are solely your responsibility, and that you will comply with all applicable laws, regulations, and relevant safety standards, terms of service, and codes of conduct.
+
+Third-party samples contained in this folder are subject to their own designated terms, and they have not been tested or verified by Microsoft or its affiliates.
+
+Microsoft has no responsibility to you or others with respect to any of these samples or any resulting output.
+<!-- End standard disclaimer -->
+
+# What this sample demonstrates
+
+A minimal "Hello World" for the Invocations protocol. The `EchoHandler` reads plain text from the request body and echoes it back, demonstrating the simplest possible `InvocationHandler` implementation with the [Azure.AI.AgentServer.Invocations](https://www.nuget.org/packages/Azure.AI.AgentServer.Invocations) SDK.
+
+## How It Works
+
+### Echo Handler
+
+The agent is a single class that extends `InvocationHandler` and overrides `HandleAsync`. It reads the raw request body and writes it back as the response. See [Program.cs](Program.cs) for the full implementation.
+
+### Agent Hosting
+
+The agent is hosted using the [Azure AI AgentServer SDK](https://www.nuget.org/packages/Azure.AI.AgentServer.Invocations),
+which provisions a REST API endpoint compatible with the Invocations protocol.
+
+### Agent Deployment
+
+The hosted agent can be deployed to Microsoft Foundry using the Azure Developer CLI [ai agent](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/concepts/hosted-agents?view=foundry&tabs=cli#create-a-hosted-agent) extension.
+
+## Running the Agent Locally
+
+### Prerequisites
+
+Before running this sample, ensure you have:
+
+1. **Azure AI Foundry Project**
+   - Project created in [Azure AI Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/what-is-foundry?view=foundry#microsoft-foundry-portals)
+   - Note your project endpoint URL
+
+2. **Azure CLI**
+   - Installed and authenticated
+   - Run `az login` and verify with `az account show`
+
+3. **.NET 10.0 SDK or later**
+   - Verify your version: `dotnet --version`
+   - Download from [https://dotnet.microsoft.com/download](https://dotnet.microsoft.com/download)
+
+### Environment Variables
+
+Set the following environment variables (must match `agent.yaml`):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AZURE_AI_PROJECT_ENDPOINT` | Yes | Your Azure AI Foundry project endpoint URL |
+
+**Bash:**
+
+```bash
+export AZURE_AI_PROJECT_ENDPOINT="https://<your-resource>.services.ai.azure.com/api/projects/<your-project>"
+```
+
+### Running the Sample
+
+Dependencies are restored automatically when building the project.
+
+```bash
+dotnet run
+```
+
+This will start the hosted agent locally on `http://localhost:8088/`.
+
+### Interacting with the Agent
+
+```bash
+curl -X POST http://localhost:8088/invocations \
+  -H "Content-Type: text/plain" \
+  -d "Hello, agent!"
+```
+
+Response: `You said: Hello, agent!`
+
+### Deploying the Agent to Microsoft Foundry
+
+To deploy your agent to Microsoft Foundry, follow the comprehensive deployment guide at https://aka.ms/azdaiagent/docs
+
+## Troubleshooting
+
+### Images built on Apple Silicon or other ARM64 machines do not work on our service
+
+We **recommend using `azd` cloud build**, which always builds images with the correct architecture.
+
+If you choose to **build locally**, and your machine is **not `linux/amd64`** (for example, an Apple Silicon Mac), the image will **not be compatible with our service**, causing runtime failures.
+
+**Fix for local builds**
+
+Use this command to build the image locally:
+
+```shell
+docker build --platform=linux/amd64 -t image .
+```
+
+This forces the image to be built for the required `amd64` architecture.

--- a/sdk/agentserver/samples/invocations/EchoAgent/agent.yaml
+++ b/sdk/agentserver/samples/invocations/EchoAgent/agent.yaml
@@ -1,0 +1,23 @@
+# Unique identifier/name for this agent
+name: echo-agent
+# Brief description of what this agent does
+description: >
+  The simplest possible invocation handler: reads plain text input and echoes it back.
+  Demonstrates basic InvocationHandler usage with the Azure AI AgentServer SDK.
+metadata:
+  tags:
+    - AI Agent Hosting
+    - Azure AI AgentServer
+    - Invocations Protocol
+    - Echo
+    - Getting Started
+template:
+  name: echo-agent
+  kind: hosted
+  protocols:
+    - protocol: invocations
+      version: v1
+  environment_variables:
+    - name: AZURE_AI_PROJECT_ENDPOINT
+      value: ${AZURE_AI_PROJECT_ENDPOINT}
+resources: []


### PR DESCRIPTION
## Invocations protocol samples for Azure.AI.AgentServer

Adds 4 runnable samples demonstrating the Invocations protocol patterns:

| Sample | Pattern |
|--------|---------|
| **EchoAgent** | Basic request/response |
| **AgentWithLongRunningTask** | LRO (submit  poll  complete/cancel) |
| **AgentWithStreaming** | SSE streaming |
| **AgentWithMultiTurn** | Multi-turn conversation with session state |

Each sample follows the [foundry sample guidelines](https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/1998917?_a=files) and includes: `Program.cs`, `.csproj`, `agent.yaml`, `Dockerfile`, `.dockerignore`, and `README.md`.

### Note on package references

Since `Azure.AI.AgentServer.Invocations` and `Azure.AI.AgentServer.Hosting` are not yet published to NuGet, the `.csproj` files use `ProjectReference` to the local source projects. When the packages are published, swap to `PackageReference`:

```xml
<!-- Current (local development) -->
<ProjectReference Include="..\..\..\Azure.AI.AgentServer.Invocations\src\Azure.AI.AgentServer.Invocations.csproj" />

<!-- After NuGet publish -->
<PackageReference Include="Azure.AI.AgentServer.Invocations" Version="1.0.0-beta.1" />
```

The `Dockerfile` is already written for the NuGet scenario (`COPY . .` + `dotnet restore`), so it will work as-is once packages are on the feed.