### PR TITLE
[AppConfiguration] Fix build errors from Description property added to spec

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net10.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net10.0.cs
@@ -117,8 +117,10 @@ namespace Azure.Data.AppConfiguration
     public static partial class ConfigurationModelFactory
     {
         public static Azure.Data.AppConfiguration.ConfigurationSetting ConfigurationSetting(string key, string value, string label = null, string contentType = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
+        public static Azure.Data.AppConfiguration.ConfigurationSetting ConfigurationSetting(string key = null, string label = null, string contentType = null, string value = null, System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), System.Collections.Generic.IDictionary<string, string> tags = null, string description = null, bool? isReadOnly = default(bool?), Azure.ETag eTag = default(Azure.ETag)) { throw null; }
         public static Azure.Data.AppConfiguration.ConfigurationSettingsFilter ConfigurationSettingsFilter(string key = null, string label = null, System.Collections.Generic.IEnumerable<string> tags = null) { throw null; }
-        public static Azure.Data.AppConfiguration.ConfigurationSnapshot ConfigurationSnapshot(string name = null, Azure.Data.AppConfiguration.ConfigurationSnapshotStatus? status = default(Azure.Data.AppConfiguration.ConfigurationSnapshotStatus?), System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters = null, Azure.Data.AppConfiguration.SnapshotComposition? snapshotComposition = default(Azure.Data.AppConfiguration.SnapshotComposition?), System.DateTimeOffset? createdOn = default(System.DateTimeOffset?), System.DateTimeOffset? expiresOn = default(System.DateTimeOffset?), System.TimeSpan? retentionPeriod = default(System.TimeSpan?), long? sizeInBytes = default(long?), long? itemCount = default(long?), System.Collections.Generic.IDictionary<string, string> tags = null, Azure.ETag eTag = default(Azure.ETag)) { throw null; }
+        public static Azure.Data.AppConfiguration.ConfigurationSnapshot ConfigurationSnapshot(string name, Azure.Data.AppConfiguration.ConfigurationSnapshotStatus? status, System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters, Azure.Data.AppConfiguration.SnapshotComposition? snapshotComposition, System.DateTimeOffset? createdOn, System.DateTimeOffset? expiresOn, System.TimeSpan? retentionPeriod, long? sizeInBytes, long? itemCount, System.Collections.Generic.IDictionary<string, string> tags, Azure.ETag eTag) { throw null; }
+        public static Azure.Data.AppConfiguration.ConfigurationSnapshot ConfigurationSnapshot(string name = null, Azure.Data.AppConfiguration.ConfigurationSnapshotStatus? status = default(Azure.Data.AppConfiguration.ConfigurationSnapshotStatus?), System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters = null, Azure.Data.AppConfiguration.SnapshotComposition? snapshotComposition = default(Azure.Data.AppConfiguration.SnapshotComposition?), System.DateTimeOffset? createdOn = default(System.DateTimeOffset?), System.DateTimeOffset? expiresOn = default(System.DateTimeOffset?), System.TimeSpan? retentionPeriod = default(System.TimeSpan?), long? sizeInBytes = default(long?), long? itemCount = default(long?), System.Collections.Generic.IDictionary<string, string> tags = null, string description = null, Azure.ETag eTag = default(Azure.ETag)) { throw null; }
         public static Azure.Data.AppConfiguration.FeatureFlagConfigurationSetting FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
         public static Azure.Data.AppConfiguration.SecretReferenceConfigurationSetting SecretReferenceConfigurationSetting(string key, System.Uri secretId, string label = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
         public static Azure.Data.AppConfiguration.SettingLabel SettingLabel(string name = null) { throw null; }
@@ -128,6 +130,7 @@ namespace Azure.Data.AppConfiguration
         public ConfigurationSetting(string key, string value, string label = null) { }
         public ConfigurationSetting(string key, string value, string label, Azure.ETag etag) { }
         public string ContentType { get { throw null; } set { } }
+        public string Description { get { throw null; } set { } }
         public Azure.ETag ETag { get { throw null; } }
         public bool? IsReadOnly { get { throw null; } }
         public string Key { get { throw null; } set { } }
@@ -170,6 +173,7 @@ namespace Azure.Data.AppConfiguration
     {
         public ConfigurationSnapshot(System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters) { }
         public System.DateTimeOffset? CreatedOn { get { throw null; } }
+        public string Description { get { throw null; } set { } }
         public Azure.ETag ETag { get { throw null; } }
         public System.DateTimeOffset? ExpiresOn { get { throw null; } }
         public System.Collections.Generic.IList<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> Filters { get { throw null; } }
@@ -229,7 +233,7 @@ namespace Azure.Data.AppConfiguration
         public FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label = null) : base (default(string), default(string), default(string)) { }
         public FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label, Azure.ETag etag) : base (default(string), default(string), default(string)) { }
         public System.Collections.Generic.IList<Azure.Data.AppConfiguration.FeatureFlagFilter> ClientFilters { get { throw null; } }
-        public string Description { get { throw null; } set { } }
+        public new string Description { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public string FeatureId { get { throw null; } set { } }
         public bool IsEnabled { get { throw null; } set { } }
@@ -259,6 +263,7 @@ namespace Azure.Data.AppConfiguration
         LastModified = (uint)32,
         IsReadOnly = (uint)64,
         Tags = (uint)128,
+        Description = (uint)256,
         All = (uint)4294967295,
     }
     public partial class SettingLabel : System.ClientModel.Primitives.IJsonModel<Azure.Data.AppConfiguration.SettingLabel>, System.ClientModel.Primitives.IPersistableModel<Azure.Data.AppConfiguration.SettingLabel>
@@ -335,6 +340,7 @@ namespace Azure.Data.AppConfiguration
         private readonly int _dummyPrimitive;
         public SnapshotFields(string value) { throw null; }
         public static Azure.Data.AppConfiguration.SnapshotFields CreatedOn { get { throw null; } }
+        public static Azure.Data.AppConfiguration.SnapshotFields Description { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields ETag { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields ExpiresOn { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Filters { get { throw null; } }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net8.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.net8.0.cs
@@ -117,8 +117,10 @@ namespace Azure.Data.AppConfiguration
     public static partial class ConfigurationModelFactory
     {
         public static Azure.Data.AppConfiguration.ConfigurationSetting ConfigurationSetting(string key, string value, string label = null, string contentType = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
+        public static Azure.Data.AppConfiguration.ConfigurationSetting ConfigurationSetting(string key = null, string label = null, string contentType = null, string value = null, System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), System.Collections.Generic.IDictionary<string, string> tags = null, string description = null, bool? isReadOnly = default(bool?), Azure.ETag eTag = default(Azure.ETag)) { throw null; }
         public static Azure.Data.AppConfiguration.ConfigurationSettingsFilter ConfigurationSettingsFilter(string key = null, string label = null, System.Collections.Generic.IEnumerable<string> tags = null) { throw null; }
-        public static Azure.Data.AppConfiguration.ConfigurationSnapshot ConfigurationSnapshot(string name = null, Azure.Data.AppConfiguration.ConfigurationSnapshotStatus? status = default(Azure.Data.AppConfiguration.ConfigurationSnapshotStatus?), System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters = null, Azure.Data.AppConfiguration.SnapshotComposition? snapshotComposition = default(Azure.Data.AppConfiguration.SnapshotComposition?), System.DateTimeOffset? createdOn = default(System.DateTimeOffset?), System.DateTimeOffset? expiresOn = default(System.DateTimeOffset?), System.TimeSpan? retentionPeriod = default(System.TimeSpan?), long? sizeInBytes = default(long?), long? itemCount = default(long?), System.Collections.Generic.IDictionary<string, string> tags = null, Azure.ETag eTag = default(Azure.ETag)) { throw null; }
+        public static Azure.Data.AppConfiguration.ConfigurationSnapshot ConfigurationSnapshot(string name, Azure.Data.AppConfiguration.ConfigurationSnapshotStatus? status, System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters, Azure.Data.AppConfiguration.SnapshotComposition? snapshotComposition, System.DateTimeOffset? createdOn, System.DateTimeOffset? expiresOn, System.TimeSpan? retentionPeriod, long? sizeInBytes, long? itemCount, System.Collections.Generic.IDictionary<string, string> tags, Azure.ETag eTag) { throw null; }
+        public static Azure.Data.AppConfiguration.ConfigurationSnapshot ConfigurationSnapshot(string name = null, Azure.Data.AppConfiguration.ConfigurationSnapshotStatus? status = default(Azure.Data.AppConfiguration.ConfigurationSnapshotStatus?), System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters = null, Azure.Data.AppConfiguration.SnapshotComposition? snapshotComposition = default(Azure.Data.AppConfiguration.SnapshotComposition?), System.DateTimeOffset? createdOn = default(System.DateTimeOffset?), System.DateTimeOffset? expiresOn = default(System.DateTimeOffset?), System.TimeSpan? retentionPeriod = default(System.TimeSpan?), long? sizeInBytes = default(long?), long? itemCount = default(long?), System.Collections.Generic.IDictionary<string, string> tags = null, string description = null, Azure.ETag eTag = default(Azure.ETag)) { throw null; }
         public static Azure.Data.AppConfiguration.FeatureFlagConfigurationSetting FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
         public static Azure.Data.AppConfiguration.SecretReferenceConfigurationSetting SecretReferenceConfigurationSetting(string key, System.Uri secretId, string label = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
         public static Azure.Data.AppConfiguration.SettingLabel SettingLabel(string name = null) { throw null; }
@@ -128,6 +130,7 @@ namespace Azure.Data.AppConfiguration
         public ConfigurationSetting(string key, string value, string label = null) { }
         public ConfigurationSetting(string key, string value, string label, Azure.ETag etag) { }
         public string ContentType { get { throw null; } set { } }
+        public string Description { get { throw null; } set { } }
         public Azure.ETag ETag { get { throw null; } }
         public bool? IsReadOnly { get { throw null; } }
         public string Key { get { throw null; } set { } }
@@ -170,6 +173,7 @@ namespace Azure.Data.AppConfiguration
     {
         public ConfigurationSnapshot(System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters) { }
         public System.DateTimeOffset? CreatedOn { get { throw null; } }
+        public string Description { get { throw null; } set { } }
         public Azure.ETag ETag { get { throw null; } }
         public System.DateTimeOffset? ExpiresOn { get { throw null; } }
         public System.Collections.Generic.IList<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> Filters { get { throw null; } }
@@ -229,7 +233,7 @@ namespace Azure.Data.AppConfiguration
         public FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label = null) : base (default(string), default(string), default(string)) { }
         public FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label, Azure.ETag etag) : base (default(string), default(string), default(string)) { }
         public System.Collections.Generic.IList<Azure.Data.AppConfiguration.FeatureFlagFilter> ClientFilters { get { throw null; } }
-        public string Description { get { throw null; } set { } }
+        public new string Description { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public string FeatureId { get { throw null; } set { } }
         public bool IsEnabled { get { throw null; } set { } }
@@ -259,6 +263,7 @@ namespace Azure.Data.AppConfiguration
         LastModified = (uint)32,
         IsReadOnly = (uint)64,
         Tags = (uint)128,
+        Description = (uint)256,
         All = (uint)4294967295,
     }
     public partial class SettingLabel : System.ClientModel.Primitives.IJsonModel<Azure.Data.AppConfiguration.SettingLabel>, System.ClientModel.Primitives.IPersistableModel<Azure.Data.AppConfiguration.SettingLabel>
@@ -335,6 +340,7 @@ namespace Azure.Data.AppConfiguration
         private readonly int _dummyPrimitive;
         public SnapshotFields(string value) { throw null; }
         public static Azure.Data.AppConfiguration.SnapshotFields CreatedOn { get { throw null; } }
+        public static Azure.Data.AppConfiguration.SnapshotFields Description { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields ETag { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields ExpiresOn { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Filters { get { throw null; } }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/api/Azure.Data.AppConfiguration.netstandard2.0.cs
@@ -115,8 +115,10 @@ namespace Azure.Data.AppConfiguration
     public static partial class ConfigurationModelFactory
     {
         public static Azure.Data.AppConfiguration.ConfigurationSetting ConfigurationSetting(string key, string value, string label = null, string contentType = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
+        public static Azure.Data.AppConfiguration.ConfigurationSetting ConfigurationSetting(string key = null, string label = null, string contentType = null, string value = null, System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), System.Collections.Generic.IDictionary<string, string> tags = null, string description = null, bool? isReadOnly = default(bool?), Azure.ETag eTag = default(Azure.ETag)) { throw null; }
         public static Azure.Data.AppConfiguration.ConfigurationSettingsFilter ConfigurationSettingsFilter(string key = null, string label = null, System.Collections.Generic.IEnumerable<string> tags = null) { throw null; }
-        public static Azure.Data.AppConfiguration.ConfigurationSnapshot ConfigurationSnapshot(string name = null, Azure.Data.AppConfiguration.ConfigurationSnapshotStatus? status = default(Azure.Data.AppConfiguration.ConfigurationSnapshotStatus?), System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters = null, Azure.Data.AppConfiguration.SnapshotComposition? snapshotComposition = default(Azure.Data.AppConfiguration.SnapshotComposition?), System.DateTimeOffset? createdOn = default(System.DateTimeOffset?), System.DateTimeOffset? expiresOn = default(System.DateTimeOffset?), System.TimeSpan? retentionPeriod = default(System.TimeSpan?), long? sizeInBytes = default(long?), long? itemCount = default(long?), System.Collections.Generic.IDictionary<string, string> tags = null, Azure.ETag eTag = default(Azure.ETag)) { throw null; }
+        public static Azure.Data.AppConfiguration.ConfigurationSnapshot ConfigurationSnapshot(string name, Azure.Data.AppConfiguration.ConfigurationSnapshotStatus? status, System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters, Azure.Data.AppConfiguration.SnapshotComposition? snapshotComposition, System.DateTimeOffset? createdOn, System.DateTimeOffset? expiresOn, System.TimeSpan? retentionPeriod, long? sizeInBytes, long? itemCount, System.Collections.Generic.IDictionary<string, string> tags, Azure.ETag eTag) { throw null; }
+        public static Azure.Data.AppConfiguration.ConfigurationSnapshot ConfigurationSnapshot(string name = null, Azure.Data.AppConfiguration.ConfigurationSnapshotStatus? status = default(Azure.Data.AppConfiguration.ConfigurationSnapshotStatus?), System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters = null, Azure.Data.AppConfiguration.SnapshotComposition? snapshotComposition = default(Azure.Data.AppConfiguration.SnapshotComposition?), System.DateTimeOffset? createdOn = default(System.DateTimeOffset?), System.DateTimeOffset? expiresOn = default(System.DateTimeOffset?), System.TimeSpan? retentionPeriod = default(System.TimeSpan?), long? sizeInBytes = default(long?), long? itemCount = default(long?), System.Collections.Generic.IDictionary<string, string> tags = null, string description = null, Azure.ETag eTag = default(Azure.ETag)) { throw null; }
         public static Azure.Data.AppConfiguration.FeatureFlagConfigurationSetting FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
         public static Azure.Data.AppConfiguration.SecretReferenceConfigurationSetting SecretReferenceConfigurationSetting(string key, System.Uri secretId, string label = null, Azure.ETag eTag = default(Azure.ETag), System.DateTimeOffset? lastModified = default(System.DateTimeOffset?), bool? isReadOnly = default(bool?)) { throw null; }
         public static Azure.Data.AppConfiguration.SettingLabel SettingLabel(string name = null) { throw null; }
@@ -126,6 +128,7 @@ namespace Azure.Data.AppConfiguration
         public ConfigurationSetting(string key, string value, string label = null) { }
         public ConfigurationSetting(string key, string value, string label, Azure.ETag etag) { }
         public string ContentType { get { throw null; } set { } }
+        public string Description { get { throw null; } set { } }
         public Azure.ETag ETag { get { throw null; } }
         public bool? IsReadOnly { get { throw null; } }
         public string Key { get { throw null; } set { } }
@@ -168,6 +171,7 @@ namespace Azure.Data.AppConfiguration
     {
         public ConfigurationSnapshot(System.Collections.Generic.IEnumerable<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> filters) { }
         public System.DateTimeOffset? CreatedOn { get { throw null; } }
+        public string Description { get { throw null; } set { } }
         public Azure.ETag ETag { get { throw null; } }
         public System.DateTimeOffset? ExpiresOn { get { throw null; } }
         public System.Collections.Generic.IList<Azure.Data.AppConfiguration.ConfigurationSettingsFilter> Filters { get { throw null; } }
@@ -227,7 +231,7 @@ namespace Azure.Data.AppConfiguration
         public FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label = null) : base (default(string), default(string), default(string)) { }
         public FeatureFlagConfigurationSetting(string featureId, bool isEnabled, string label, Azure.ETag etag) : base (default(string), default(string), default(string)) { }
         public System.Collections.Generic.IList<Azure.Data.AppConfiguration.FeatureFlagFilter> ClientFilters { get { throw null; } }
-        public string Description { get { throw null; } set { } }
+        public new string Description { get { throw null; } set { } }
         public string DisplayName { get { throw null; } set { } }
         public string FeatureId { get { throw null; } set { } }
         public bool IsEnabled { get { throw null; } set { } }
@@ -257,6 +261,7 @@ namespace Azure.Data.AppConfiguration
         LastModified = (uint)32,
         IsReadOnly = (uint)64,
         Tags = (uint)128,
+        Description = (uint)256,
         All = (uint)4294967295,
     }
     public partial class SettingLabel : System.ClientModel.Primitives.IJsonModel<Azure.Data.AppConfiguration.SettingLabel>, System.ClientModel.Primitives.IPersistableModel<Azure.Data.AppConfiguration.SettingLabel>
@@ -333,6 +338,7 @@ namespace Azure.Data.AppConfiguration
         private readonly int _dummyPrimitive;
         public SnapshotFields(string value) { throw null; }
         public static Azure.Data.AppConfiguration.SnapshotFields CreatedOn { get { throw null; } }
+        public static Azure.Data.AppConfiguration.SnapshotFields Description { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields ETag { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields ExpiresOn { get { throw null; } }
         public static Azure.Data.AppConfiguration.SnapshotFields Filters { get { throw null; } }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/metadata.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/metadata.json
@@ -1,5 +1,5 @@
 {
   "apiVersions": {
-    "AzureAppConfiguration": "2024-09-01"
+    "AzureAppConfiguration": "2026-04-01"
   }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/ConfigurationModelFactory.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/ConfigurationModelFactory.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Azure;
 
@@ -15,6 +16,34 @@ namespace Azure.Data.AppConfiguration
     /// <summary> A factory class for creating instances of the models for mocking. </summary>
     public static partial class ConfigurationModelFactory
     {
+
+        /// <summary> A key-value pair representing application settings. </summary>
+        /// <param name="key"> The key of the key-value. </param>
+        /// <param name="label"> The label the key-value belongs to. </param>
+        /// <param name="contentType"> The content type of the value stored within the key-value. </param>
+        /// <param name="value"> The value of the key-value. </param>
+        /// <param name="lastModified"> A date representing the last time the key-value was modified. </param>
+        /// <param name="tags"> The tags of the key-value. </param>
+        /// <param name="description"> The description of the key-value. </param>
+        /// <param name="isReadOnly"> Indicates whether the key-value is locked. </param>
+        /// <param name="eTag"> A value representing the current state of the resource. </param>
+        /// <returns> A new <see cref="AppConfiguration.ConfigurationSetting"/> instance for mocking. </returns>
+        public static ConfigurationSetting ConfigurationSetting(string key = default, string label = default, string contentType = default, string value = default, DateTimeOffset? lastModified = default, IDictionary<string, string> tags = default, string description = default, bool? isReadOnly = default, ETag eTag = default)
+        {
+            tags ??= new ChangeTrackingDictionary<string, string>();
+
+            return new ConfigurationSetting(
+                key,
+                label,
+                contentType,
+                value,
+                lastModified,
+                tags,
+                description,
+                isReadOnly,
+                eTag,
+                additionalBinaryDataProperties: null);
+        }
 
         /// <summary> A snapshot is a named, immutable subset of an App Configuration store's key-values. </summary>
         /// <param name="name"> The name of the snapshot. </param>
@@ -37,9 +66,10 @@ namespace Azure.Data.AppConfiguration
         /// <param name="sizeInBytes"> The size in bytes of the snapshot. </param>
         /// <param name="itemCount"> The amount of key-values in the snapshot. </param>
         /// <param name="tags"> The tags of the snapshot. </param>
+        /// <param name="description"> The description of the snapshot. </param>
         /// <param name="eTag"> A value representing the current state of the snapshot. </param>
         /// <returns> A new <see cref="AppConfiguration.ConfigurationSnapshot"/> instance for mocking. </returns>
-        public static ConfigurationSnapshot ConfigurationSnapshot(string name = default, ConfigurationSnapshotStatus? status = default, IEnumerable<ConfigurationSettingsFilter> filters = default, SnapshotComposition? snapshotComposition = default, DateTimeOffset? createdOn = default, DateTimeOffset? expiresOn = default, TimeSpan? retentionPeriod = default, long? sizeInBytes = default, long? itemCount = default, IDictionary<string, string> tags = default, ETag eTag = default)
+        public static ConfigurationSnapshot ConfigurationSnapshot(string name = default, ConfigurationSnapshotStatus? status = default, IEnumerable<ConfigurationSettingsFilter> filters = default, SnapshotComposition? snapshotComposition = default, DateTimeOffset? createdOn = default, DateTimeOffset? expiresOn = default, TimeSpan? retentionPeriod = default, long? sizeInBytes = default, long? itemCount = default, IDictionary<string, string> tags = default, string description = default, ETag eTag = default)
         {
             filters ??= new ChangeTrackingList<ConfigurationSettingsFilter>();
             tags ??= new ChangeTrackingDictionary<string, string>();
@@ -55,6 +85,7 @@ namespace Azure.Data.AppConfiguration
                 sizeInBytes,
                 itemCount,
                 tags,
+                description,
                 eTag,
                 additionalBinaryDataProperties: null);
         }
@@ -80,6 +111,35 @@ namespace Azure.Data.AppConfiguration
         public static SettingLabel SettingLabel(string name = default)
         {
             return new SettingLabel(name, additionalBinaryDataProperties: null);
+        }
+
+        /// <summary> A snapshot is a named, immutable subset of an App Configuration store's key-values. </summary>
+        /// <param name="name"> The name of the snapshot. </param>
+        /// <param name="status"> The current status of the snapshot. </param>
+        /// <param name="filters"> A list of filters used to filter the key-values included in the snapshot. </param>
+        /// <param name="snapshotComposition">
+        /// The composition type describes how the key-values within the snapshot are
+        ///             composed. The 'key' composition type ensures there are no two key-values
+        ///             containing the same key. The 'key_label' composition type ensures there are no
+        ///             two key-values containing the same key and label.
+        /// </param>
+        /// <param name="createdOn"> The time that the snapshot was created. </param>
+        /// <param name="expiresOn"> The time that the snapshot will expire. </param>
+        /// <param name="retentionPeriod">
+        /// The amount of time, in seconds, that a snapshot will remain in the archived
+        ///             state before expiring. This property is only writable during the creation of a
+        ///             snapshot. If not specified, the default lifetime of key-value revisions will be
+        ///             used.
+        /// </param>
+        /// <param name="sizeInBytes"> The size in bytes of the snapshot. </param>
+        /// <param name="itemCount"> The amount of key-values in the snapshot. </param>
+        /// <param name="tags"> The tags of the snapshot. </param>
+        /// <param name="eTag"> A value representing the current state of the snapshot. </param>
+        /// <returns> A new <see cref="AppConfiguration.ConfigurationSnapshot"/> instance for mocking. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ConfigurationSnapshot ConfigurationSnapshot(string name, ConfigurationSnapshotStatus? status, IEnumerable<ConfigurationSettingsFilter> filters, SnapshotComposition? snapshotComposition, DateTimeOffset? createdOn, DateTimeOffset? expiresOn, TimeSpan? retentionPeriod, long? sizeInBytes, long? itemCount, IDictionary<string, string> tags, ETag eTag)
+        {
+            return ConfigurationSnapshot(name, status, filters, snapshotComposition, createdOn, expiresOn, retentionPeriod, sizeInBytes, itemCount, tags, description: default, eTag);
         }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/ConfigurationSetting.Serialization.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/ConfigurationSetting.Serialization.cs
@@ -133,6 +133,11 @@ namespace Azure.Data.AppConfiguration
                 }
                 writer.WriteEndObject();
             }
+            if (Optional.IsDefined(Description))
+            {
+                writer.WritePropertyName("description"u8);
+                writer.WriteStringValue(Description);
+            }
             if (Optional.IsDefined(IsReadOnly))
             {
                 writer.WritePropertyName("locked"u8);
@@ -188,6 +193,7 @@ namespace Azure.Data.AppConfiguration
             string value = default;
             DateTimeOffset? lastModified = default;
             IDictionary<string, string> tags = default;
+            string description = default;
             bool? isReadOnly = default;
             ETag eTag = default;
             IDictionary<string, BinaryData> additionalBinaryDataProperties = new ChangeTrackingDictionary<string, BinaryData>();
@@ -243,6 +249,11 @@ namespace Azure.Data.AppConfiguration
                     tags = dictionary;
                     continue;
                 }
+                if (prop.NameEquals("description"u8))
+                {
+                    description = prop.Value.GetString();
+                    continue;
+                }
                 if (prop.NameEquals("locked"u8))
                 {
                     if (prop.Value.ValueKind == JsonValueKind.Null)
@@ -269,6 +280,7 @@ namespace Azure.Data.AppConfiguration
                 value,
                 lastModified,
                 tags ?? new ChangeTrackingDictionary<string, string>(),
+                description,
                 isReadOnly,
                 eTag,
                 additionalBinaryDataProperties);

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/ConfigurationSetting.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/ConfigurationSetting.cs
@@ -24,10 +24,11 @@ namespace Azure.Data.AppConfiguration
         /// <param name="value"> The value of the key-value. </param>
         /// <param name="lastModified"> A date representing the last time the key-value was modified. </param>
         /// <param name="tags"> The tags of the key-value. </param>
+        /// <param name="description"> The description of the key-value. </param>
         /// <param name="isReadOnly"> Indicates whether the key-value is locked. </param>
         /// <param name="eTag"> A value representing the current state of the resource. </param>
         /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
-        internal ConfigurationSetting(string key, string label, string contentType, string value, DateTimeOffset? lastModified, IDictionary<string, string> tags, bool? isReadOnly, ETag eTag, IDictionary<string, BinaryData> additionalBinaryDataProperties)
+        internal ConfigurationSetting(string key, string label, string contentType, string value, DateTimeOffset? lastModified, IDictionary<string, string> tags, string description, bool? isReadOnly, ETag eTag, IDictionary<string, BinaryData> additionalBinaryDataProperties)
         {
             Key = key;
             Label = label;
@@ -35,9 +36,13 @@ namespace Azure.Data.AppConfiguration
             Value = value;
             LastModified = lastModified;
             Tags = tags;
+            Description = description;
             IsReadOnly = isReadOnly;
             ETag = eTag;
             _additionalBinaryDataProperties = additionalBinaryDataProperties;
         }
+
+        /// <summary> The description of the key-value. </summary>
+        public string Description { get; set; }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/ConfigurationSnapshot.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/ConfigurationSnapshot.cs
@@ -50,9 +50,10 @@ namespace Azure.Data.AppConfiguration
         /// <param name="sizeInBytes"> The size in bytes of the snapshot. </param>
         /// <param name="itemCount"> The amount of key-values in the snapshot. </param>
         /// <param name="tags"> The tags of the snapshot. </param>
+        /// <param name="description"> The description of the snapshot. </param>
         /// <param name="eTag"> A value representing the current state of the snapshot. </param>
         /// <param name="additionalBinaryDataProperties"> Keeps track of any properties unknown to the library. </param>
-        internal ConfigurationSnapshot(string name, ConfigurationSnapshotStatus? status, IList<ConfigurationSettingsFilter> filters, SnapshotComposition? snapshotComposition, DateTimeOffset? createdOn, DateTimeOffset? expiresOn, TimeSpan? retentionPeriod, long? sizeInBytes, long? itemCount, IDictionary<string, string> tags, ETag eTag, IDictionary<string, BinaryData> additionalBinaryDataProperties)
+        internal ConfigurationSnapshot(string name, ConfigurationSnapshotStatus? status, IList<ConfigurationSettingsFilter> filters, SnapshotComposition? snapshotComposition, DateTimeOffset? createdOn, DateTimeOffset? expiresOn, TimeSpan? retentionPeriod, long? sizeInBytes, long? itemCount, IDictionary<string, string> tags, string description, ETag eTag, IDictionary<string, BinaryData> additionalBinaryDataProperties)
         {
             Name = name;
             Status = status;
@@ -64,8 +65,12 @@ namespace Azure.Data.AppConfiguration
             SizeInBytes = sizeInBytes;
             ItemCount = itemCount;
             Tags = tags;
+            Description = description;
             ETag = eTag;
             _additionalBinaryDataProperties = additionalBinaryDataProperties;
         }
+
+        /// <summary> The description of the snapshot. </summary>
+        public string Description { get; set; }
     }
 }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/SettingFields.Serialization.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/SettingFields.Serialization.cs
@@ -20,6 +20,7 @@ namespace Azure.Data.AppConfiguration
             SettingFields.Value => "value",
             SettingFields.LastModified => "last_modified",
             SettingFields.Tags => "tags",
+            SettingFields.Description => "description",
             SettingFields.IsReadOnly => "locked",
             SettingFields.ETag => "etag",
             _ => throw new ArgumentOutOfRangeException(nameof(value), value, "Unknown SettingFields value.")
@@ -51,6 +52,10 @@ namespace Azure.Data.AppConfiguration
             if (StringComparer.OrdinalIgnoreCase.Equals(value, "tags"))
             {
                 return SettingFields.Tags;
+            }
+            if (StringComparer.OrdinalIgnoreCase.Equals(value, "description"))
+            {
+                return SettingFields.Description;
             }
             if (StringComparer.OrdinalIgnoreCase.Equals(value, "locked"))
             {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/SnapshotFields.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Generated/Models/SnapshotFields.cs
@@ -34,6 +34,8 @@ namespace Azure.Data.AppConfiguration
         private const string ItemsCountValue = "items_count";
         /// <summary> Tags field. </summary>
         private const string TagsValue = "tags";
+        /// <summary> Description field. </summary>
+        private const string DescriptionValue = "description";
         /// <summary> Etag field. </summary>
         private const string EtagValue = "etag";
 
@@ -58,6 +60,9 @@ namespace Azure.Data.AppConfiguration
 
         /// <summary> Tags field. </summary>
         public static SnapshotFields Tags { get; } = new SnapshotFields(TagsValue);
+
+        /// <summary> Description field. </summary>
+        public static SnapshotFields Description { get; } = new SnapshotFields(DescriptionValue);
 
         /// <summary> Determines if two <see cref="SnapshotFields"/> values are the same. </summary>
         /// <param name="left"> The left value to compare. </param>

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/FeatureFlagConfigurationSetting.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/FeatureFlagConfigurationSetting.cs
@@ -117,7 +117,7 @@ namespace Azure.Data.AppConfiguration
         /// <summary>
         /// Gets or sets a description of the feature.
         /// </summary>
-        public string Description
+        public new string Description
         {
             get
             {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingFields.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/Models/SettingFields.cs
@@ -59,6 +59,11 @@ namespace Azure.Data.AppConfiguration
         Tags = 0x0080,
 
         /// <summary>
+        /// The description of the configuration setting.
+        /// </summary>
+        Description = 0x0100,
+
+        /// <summary>
         /// Allows for all the properties of a ConfigurationSetting to be retrieved.
         /// </summary>
         All = uint.MaxValue

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tsp-location.yaml
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tsp-location.yaml
@@ -1,4 +1,4 @@
 repo: Azure/azure-rest-api-specs
 directory: "specification/appconfiguration/data-plane/AppConfiguration"
-commit: 6267b64842af3d744c5b092a3f3beef49729ad6d
+commit: 296cb684e2596ca56e122d3911885994ff33e970
 emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-emitter-package.json"


### PR DESCRIPTION
## Description

Resolves build failures caused by adding a `Description` property to `ConfigurationSetting` and `ConfigurationSnapshot` in the OpenAPI spec.

### Changes

1. **`FeatureFlagConfigurationSetting.Description`** — Added `new` keyword. The handwritten `Description` property on `FeatureFlagConfigurationSetting` (the *feature flag's* description, parsed from the JSON Value) now hides the new base `ConfigurationSetting.Description` (the *key-value resource's* description). These are semantically different.

2. **`SettingFields` enum** — Added `Description = 0x0100` member. The generated `SettingFields.Serialization.cs` references `SettingFields.Description` but the handwritten enum was missing this value.

3. **Regenerated code** from spec commit `296cb684e2596ca56e122d3911885994ff33e970`.
## Release Plan Details
- Release Plan: 
- Work Item Link: https://dev.azure.com/azure-sdk/fe81d705-3c06-41e5-bf7c-5ebea18efe89/_workitems/edit/33586
- Spec Pull Request: https://github.com/Azure/azure-rest-api-specs/pull/41671
- Spec API version: 2026-04-01