### PR TITLE
Skip required SDK validation for migration PRs

### DIFF
--- a/eng/scripts/Invoke-GenerateAndBuildV2.ps1
+++ b/eng/scripts/Invoke-GenerateAndBuildV2.ps1
@@ -62,6 +62,14 @@ function Test-MgmtSdkUsingNewGenerator {
         return $false
     }
 
+    # Skip if tsp-location.yaml is untracked (i.e. newly created by tsp-client init
+    # during this CI run, not yet committed). This avoids marking SDK validation as
+    # required for migration PRs where the SDK hasn't been fully migrated yet.
+    $untrackedFiles = git -C $sdkProjectFolder ls-files --others --exclude-standard "tsp-location.yaml"
+    if ($untrackedFiles) {
+        return $false
+    }
+
     $tspConfigContent = Get-Content $tspConfigFile -Raw
     $isNewMgmtEmitter = $tspConfigContent -match '@azure-typespec/http-client-csharp-mgmt'
     $tspLocationContent = Get-Content $tspLocationFile -Raw


### PR DESCRIPTION
## Problem

When a migration PR (e.g. [Azure/azure-rest-api-specs#40067](https://github.com/Azure/azure-rest-api-specs/pull/40067)) adds `@azure-typespec/http-client-csharp-mgmt` to a spec's `tspconfig.yaml`, the .NET SDK validation is incorrectly marked as **required** (blocking), even though the SDK hasn't been fully migrated yet.

## Root Cause

During CI, `tsp-client init` creates `tsp-location.yaml` in the SDK project folder **before** `Test-MgmtSdkUsingNewGenerator` runs. The `tsp-client-config.yaml` global config causes the created file to include `emitterPackageJsonPath: eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json`. When `Test-MgmtSdkUsingNewGenerator` then checks for this file, it finds it (just created moments ago) and incorrectly concludes the SDK is already using the new generator, setting `isSpecGenSdkCheckRequired = true`.

## Fix

In `Test-MgmtSdkUsingNewGenerator`, check if `tsp-location.yaml` is an **untracked** git file (i.e. newly created by `tsp-client init` during this CI run, not yet committed to the repo). If untracked, return false — the SDK hasn't been migrated yet.

This fix is self-contained in the function, making it easy to remove entirely once all management SDK migrations are complete.