### PR TITLE
Add ConfigurationSchema.json for Azure.Identity credential IntelliSense

### DIFF
--- a/sdk/core/Azure.Core/src/docs/ConfigurationAndDependencyInjection.md
+++ b/sdk/core/Azure.Core/src/docs/ConfigurationAndDependencyInjection.md
@@ -253,7 +253,7 @@ the `Credential` section as well.
     "CredentialSource": "AzureCliCredential",
     "TenantId": "00000000-0000-0000-0000-000000000000",
     "Subscription": "my-subscription-name",
-    "CredentialProcessTimeout": "00:00:30"
+    "ProcessTimeout": "00:00:30"
   }
 }
 ```
@@ -264,7 +264,7 @@ the `Credential` section as well.
   "Credential": {
     "CredentialSource": "AzureDeveloperCliCredential",
     "TenantId": "00000000-0000-0000-0000-000000000000",
-    "CredentialProcessTimeout": "00:00:30"
+    "ProcessTimeout": "00:00:30"
   }
 }
 ```
@@ -276,8 +276,8 @@ the `Credential` section as well.
     "CredentialSource": "AzurePipelinesCredential",
     "TenantId": "00000000-0000-0000-0000-000000000000",
     "ClientId": "00000000-0000-0000-0000-000000000000",
-    "AzurePipelinesServiceConnectionId": "00000000-0000-0000-0000-000000000000",
-    "AzurePipelinesSystemAccessToken": "$(System.AccessToken)",
+    "ServiceConnectionId": "00000000-0000-0000-0000-000000000000",
+    "SystemAccessToken": "$(System.AccessToken)",
     "DisableInstanceDiscovery": false,
     "TokenCachePersistenceOptions": {
       "Name": "my-app-cache",
@@ -293,7 +293,7 @@ the `Credential` section as well.
   "Credential": {
     "CredentialSource": "AzurePowerShellCredential",
     "TenantId": "00000000-0000-0000-0000-000000000000",
-    "CredentialProcessTimeout": "00:00:30"
+    "ProcessTimeout": "00:00:30"
   }
 }
 ```
@@ -316,6 +316,8 @@ the `Credential` section as well.
 }
 ```
 
+> `BrokerCredential` requires the `Azure.Identity.Broker` package.
+
 **EnvironmentCredential:**
 ```json
 {
@@ -327,15 +329,14 @@ the `Credential` section as well.
     "ClientCertificatePath": "/path/to/cert.pem",
     "ClientCertificatePassword": "...",
     "SendCertificateChain": false,
-    "Username": "...",
-    "Password": "...",
     "DisableInstanceDiscovery": false
   }
 }
 ```
 
 > `EnvironmentCredential` resolves authentication in priority order: client secret → client
-> certificate → username/password. Only one set of auth properties needs to be configured.
+> certificate. Only one set of auth properties needs to be configured.
+> Username/password (ROPC) authentication is not supported via configuration.
 
 **InteractiveBrowserCredential:**
 ```json
@@ -404,13 +405,15 @@ the `Credential` section as well.
 }
 ```
 
+> `VisualStudioCodeCredential` requires the `Azure.Identity.Broker` package.
+
 **VisualStudioCredential:**
 ```json
 {
   "Credential": {
     "CredentialSource": "VisualStudioCredential",
     "TenantId": "00000000-0000-0000-0000-000000000000",
-    "CredentialProcessTimeout": "00:00:30"
+    "ProcessTimeout": "00:00:30"
   }
 }
 ```

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -398,6 +398,9 @@
               "AuthenticationRecord": {
                 "$ref": "#/definitions/authenticationRecord"
               },
+              "BrowserCustomization": {
+                "$ref": "#/definitions/browserCustomizationOptions"
+              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
@@ -1050,6 +1053,9 @@
               "AuthenticationRecord": {
                 "$ref": "#/definitions/authenticationRecord"
               },
+              "BrowserCustomization": {
+                "$ref": "#/definitions/browserCustomizationOptions"
+              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
@@ -1307,6 +1313,21 @@
         "ClientId": {
           "type": "string",
           "description": "The client application ID used for authentication."
+        }
+      },
+      "additionalProperties": false
+    },
+    "browserCustomizationOptions": {
+      "type": "object",
+      "description": "Options for customizing the interactive browser authentication experience.",
+      "properties": {
+        "SuccessMessage": {
+          "type": "string",
+          "description": "The HTML content shown in the browser after successful authentication."
+        },
+        "ErrorMessage": {
+          "type": "string",
+          "description": "The HTML content shown in the browser after failed authentication."
         }
       },
       "additionalProperties": false

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -330,7 +330,7 @@
                   "properties": {
                     "ManagedIdentityId": {
                       "type": "string",
-                      "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
+                      "description": "The user-assigned managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
                     }
                   }
                 }
@@ -966,7 +966,7 @@
                   "properties": {
                     "ManagedIdentityId": {
                       "type": "string",
-                      "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
+                      "description": "The user-assigned managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
                     }
                   }
                 }

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -102,7 +102,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",
@@ -139,7 +139,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",
@@ -176,7 +176,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",
@@ -417,7 +417,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",
@@ -774,7 +774,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",
@@ -805,7 +805,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",
@@ -836,7 +836,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",
@@ -1047,7 +1047,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -599,7 +599,7 @@
               },
               "ManagedIdentityIdKind": {
                 "type": "string",
-                "description": "The type of managed identity to use as the federated identity. SystemAssigned is not supported.",
+                "description": "The type of user-assigned managed identity to use as the federated identity. SystemAssigned is not supported.",
                 "enum": [
                   "ClientId",
                   "ResourceId",
@@ -1205,7 +1205,7 @@
               },
               "ManagedIdentityIdKind": {
                 "type": "string",
-                "description": "The type of managed identity to use as the federated identity. SystemAssigned is not supported.",
+                "description": "The type of user-assigned managed identity to use as the federated identity. SystemAssigned is not supported.",
                 "enum": [
                   "ClientId",
                   "ResourceId",

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -1,0 +1,1268 @@
+{
+  "definitions": {
+    "credential": {
+      "type": "object",
+      "description": "Credential configuration. Available properties depend on the selected CredentialSource.",
+      "properties": {
+        "CredentialSource": {
+          "description": "The credential type to use for authentication.",
+          "enum": [
+            "AzureCliCredential",
+            "AzurePowerShellCredential",
+            "AzureDeveloperCliCredential",
+            "EnvironmentCredential",
+            "WorkloadIdentityCredential",
+            "ManagedIdentityCredential",
+            "InteractiveBrowserCredential",
+            "VisualStudioCredential",
+            "VisualStudioCodeCredential",
+            "BrokerCredential",
+            "AzurePipelinesCredential",
+            "ManagedIdentityAsFederatedIdentityCredential",
+            "ChainedTokenCredential"
+          ]
+        }
+      },
+      "required": [
+        "CredentialSource"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "ClientSecret"
+            ]
+          },
+          "then": {
+            "title": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "ClientSecret": {
+                "not": {},
+                "description": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "ClientCertificatePassword"
+            ]
+          },
+          "then": {
+            "title": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "ClientCertificatePassword": {
+                "not": {},
+                "description": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "Password"
+            ]
+          },
+          "then": {
+            "title": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "Password": {
+                "not": {},
+                "description": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "AzureCliCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "Subscription": {
+                "type": "string",
+                "description": "The Azure subscription name or ID for Azure CLI."
+              },
+              "CredentialProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "AzurePowerShellCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "CredentialProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "AzureDeveloperCliCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "CredentialProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "EnvironmentCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "WorkloadIdentityCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "IsAzureProxyEnabled": {
+                "type": "boolean",
+                "description": "Enable Azure Kubernetes Service (AKS) proxy mode."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "ManagedIdentityCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "ManagedIdentityIdKind": {
+                "type": "string",
+                "description": "The type of managed identity to use.",
+                "enum": [
+                  "SystemAssigned",
+                  "ClientId",
+                  "ResourceId",
+                  "ObjectId"
+                ]
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "ManagedIdentityIdKind": {
+                      "enum": [
+                        "ClientId",
+                        "ResourceId",
+                        "ObjectId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ManagedIdentityIdKind"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "ManagedIdentityId": {
+                      "type": "string",
+                      "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "InteractiveBrowserCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "DisableAutomaticAuthentication": {
+                "type": "boolean",
+                "description": "Prevent automatic interactive authentication prompts."
+              },
+              "LoginHint": {
+                "type": "string",
+                "description": "Pre-populate the username/email in the login prompt."
+              },
+              "RedirectUri": {
+                "type": "string",
+                "description": "The redirect URI for the OAuth callback.",
+                "format": "uri"
+              },
+              "TokenCachePersistenceOptions": {
+                "$ref": "#/definitions/tokenCachePersistenceOptions"
+              },
+              "AuthenticationRecord": {
+                "$ref": "#/definitions/authenticationRecord"
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "VisualStudioCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "CredentialProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "VisualStudioCodeCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "BrokerCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "UseDefaultBrokerAccount": {
+                "type": "boolean",
+                "description": "Use the default broker account for authentication."
+              },
+              "IsLegacyMsaPassthroughEnabled": {
+                "type": "boolean",
+                "description": "Enable legacy Microsoft Account (MSA) passthrough."
+              },
+              "LoginHint": {
+                "type": "string",
+                "description": "Pre-populate the username/email in the login prompt."
+              },
+              "TokenCachePersistenceOptions": {
+                "$ref": "#/definitions/tokenCachePersistenceOptions"
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "AzurePipelinesCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "AzurePipelinesServiceConnectionId": {
+                "type": "string",
+                "description": "The Azure Pipelines service connection ID."
+              },
+              "AzurePipelinesSystemAccessToken": {
+                "type": "string",
+                "description": "The System.AccessToken value from the Azure Pipelines build."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "TokenCachePersistenceOptions": {
+                "$ref": "#/definitions/tokenCachePersistenceOptions"
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "ManagedIdentityAsFederatedIdentityCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "ManagedIdentityIdKind": {
+                "type": "string",
+                "description": "The type of managed identity to use as the federated identity.",
+                "enum": [
+                  "SystemAssigned",
+                  "ClientId",
+                  "ResourceId",
+                  "ObjectId"
+                ]
+              },
+              "AzureCloud": {
+                "description": "The Azure cloud environment.",
+                "anyOf": [
+                  {
+                    "enum": [
+                      "public",
+                      "usgov",
+                      "china"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "ManagedIdentityIdKind": {
+                      "enum": [
+                        "ClientId",
+                        "ResourceId",
+                        "ObjectId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ManagedIdentityIdKind"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "ManagedIdentityId": {
+                      "type": "string",
+                      "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "ChainedTokenCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "Sources": {
+                "type": "array",
+                "description": "Ordered list of credential configurations to chain.",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/definitions/chainableCredential"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": true
+    },
+    "chainableCredential": {
+      "type": "object",
+      "description": "A credential source in a chain. ApiKeyCredential and ChainedTokenCredential cannot be used.",
+      "properties": {
+        "CredentialSource": {
+          "description": "The token credential type. ApiKeyCredential and ChainedTokenCredential are not allowed in a chain.",
+          "enum": [
+            "AzureCliCredential",
+            "AzurePowerShellCredential",
+            "AzureDeveloperCliCredential",
+            "EnvironmentCredential",
+            "WorkloadIdentityCredential",
+            "ManagedIdentityCredential",
+            "InteractiveBrowserCredential",
+            "VisualStudioCredential",
+            "VisualStudioCodeCredential",
+            "BrokerCredential",
+            "AzurePipelinesCredential",
+            "ManagedIdentityAsFederatedIdentityCredential"
+          ]
+        },
+        "Retry": {
+          "$ref": "#/definitions/retry"
+        },
+        "Diagnostics": {
+          "$ref": "#/definitions/diagnostics"
+        }
+      },
+      "required": [
+        "CredentialSource"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "AzureCliCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "Subscription": {
+                "type": "string",
+                "description": "The Azure subscription name or ID for Azure CLI."
+              },
+              "CredentialProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "AzurePowerShellCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "CredentialProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "AzureDeveloperCliCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "CredentialProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "EnvironmentCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "WorkloadIdentityCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "IsAzureProxyEnabled": {
+                "type": "boolean",
+                "description": "Enable Azure Kubernetes Service (AKS) proxy mode."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "ManagedIdentityCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "ManagedIdentityIdKind": {
+                "type": "string",
+                "description": "The type of managed identity to use.",
+                "enum": [
+                  "SystemAssigned",
+                  "ClientId",
+                  "ResourceId",
+                  "ObjectId"
+                ]
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "ManagedIdentityIdKind": {
+                      "enum": [
+                        "ClientId",
+                        "ResourceId",
+                        "ObjectId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ManagedIdentityIdKind"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "ManagedIdentityId": {
+                      "type": "string",
+                      "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "InteractiveBrowserCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "DisableAutomaticAuthentication": {
+                "type": "boolean",
+                "description": "Prevent automatic interactive authentication prompts."
+              },
+              "LoginHint": {
+                "type": "string",
+                "description": "Pre-populate the username/email in the login prompt."
+              },
+              "RedirectUri": {
+                "type": "string",
+                "description": "The redirect URI for the OAuth callback.",
+                "format": "uri"
+              },
+              "TokenCachePersistenceOptions": {
+                "$ref": "#/definitions/tokenCachePersistenceOptions"
+              },
+              "AuthenticationRecord": {
+                "$ref": "#/definitions/authenticationRecord"
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "VisualStudioCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "CredentialProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format). Default: 30 seconds."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "VisualStudioCodeCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "BrokerCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "UseDefaultBrokerAccount": {
+                "type": "boolean",
+                "description": "Use the default broker account for authentication."
+              },
+              "IsLegacyMsaPassthroughEnabled": {
+                "type": "boolean",
+                "description": "Enable legacy Microsoft Account (MSA) passthrough."
+              },
+              "LoginHint": {
+                "type": "string",
+                "description": "Pre-populate the username/email in the login prompt."
+              },
+              "TokenCachePersistenceOptions": {
+                "$ref": "#/definitions/tokenCachePersistenceOptions"
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "AzurePipelinesCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "AzurePipelinesServiceConnectionId": {
+                "type": "string",
+                "description": "The Azure Pipelines service connection ID."
+              },
+              "AzurePipelinesSystemAccessToken": {
+                "type": "string",
+                "description": "The System.AccessToken value from the Azure Pipelines build."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "TokenCachePersistenceOptions": {
+                "$ref": "#/definitions/tokenCachePersistenceOptions"
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "ManagedIdentityAsFederatedIdentityCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "ManagedIdentityIdKind": {
+                "type": "string",
+                "description": "The type of managed identity to use as the federated identity.",
+                "enum": [
+                  "SystemAssigned",
+                  "ClientId",
+                  "ResourceId",
+                  "ObjectId"
+                ]
+              },
+              "AzureCloud": {
+                "description": "The Azure cloud environment.",
+                "anyOf": [
+                  {
+                    "enum": [
+                      "public",
+                      "usgov",
+                      "china"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "ManagedIdentityIdKind": {
+                      "enum": [
+                        "ClientId",
+                        "ResourceId",
+                        "ObjectId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ManagedIdentityIdKind"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "ManagedIdentityId": {
+                      "type": "string",
+                      "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "additionalProperties": true
+    },
+    "tokenCachePersistenceOptions": {
+      "type": "object",
+      "description": "Options for persistent token caching.",
+      "properties": {
+        "Name": {
+          "type": "string",
+          "description": "Name uniquely identifying the token cache to avoid conflicts."
+        },
+        "UnsafeAllowUnencryptedStorage": {
+          "type": "boolean",
+          "description": "Allow unencrypted storage when OS-level encryption is unavailable."
+        }
+      },
+      "additionalProperties": false
+    },
+    "authenticationRecord": {
+      "type": "object",
+      "description": "A record of a previous authentication. Enables silently authenticating a previously logged-in account.",
+      "properties": {
+        "Username": {
+          "type": "string",
+          "description": "The user principal or service principal name."
+        },
+        "Authority": {
+          "type": "string",
+          "description": "The authority host used for authentication."
+        },
+        "HomeAccountId": {
+          "type": "string",
+          "description": "The unique account identifier."
+        },
+        "TenantId": {
+          "type": "string",
+          "description": "The tenant used for authentication."
+        },
+        "ClientId": {
+          "type": "string",
+          "description": "The client application ID used for authentication."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -100,10 +100,6 @@
                 "type": "string",
                 "description": "The Azure subscription name or ID for Azure CLI."
               },
-              "CredentialProcessTimeout": {
-                "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
-              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
@@ -116,6 +112,10 @@
               },
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
+              },
+              "ProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               }
             }
           }
@@ -137,10 +137,6 @@
                 "type": "string",
                 "description": "The Microsoft Entra tenant (directory) ID."
               },
-              "CredentialProcessTimeout": {
-                "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 10 seconds."
-              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
@@ -153,6 +149,10 @@
               },
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
+              },
+              "ProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 10 seconds."
               }
             }
           }
@@ -174,10 +174,6 @@
                 "type": "string",
                 "description": "The Microsoft Entra tenant (directory) ID."
               },
-              "CredentialProcessTimeout": {
-                "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
-              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
@@ -190,6 +186,10 @@
               },
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
+              },
+              "ProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               }
             }
           }
@@ -415,10 +415,6 @@
                 "type": "string",
                 "description": "The Microsoft Entra tenant (directory) ID."
               },
-              "CredentialProcessTimeout": {
-                "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
-              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
@@ -431,6 +427,10 @@
               },
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
+              },
+              "ProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               }
             }
           }
@@ -772,16 +772,16 @@
                 "type": "string",
                 "description": "The Azure subscription name or ID for Azure CLI."
               },
-              "CredentialProcessTimeout": {
-                "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
-              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
                 "items": {
                   "type": "string"
                 }
+              },
+              "ProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               }
             }
           }
@@ -803,16 +803,16 @@
                 "type": "string",
                 "description": "The Microsoft Entra tenant (directory) ID."
               },
-              "CredentialProcessTimeout": {
-                "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 10 seconds."
-              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
                 "items": {
                   "type": "string"
                 }
+              },
+              "ProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 10 seconds."
               }
             }
           }
@@ -834,16 +834,16 @@
                 "type": "string",
                 "description": "The Microsoft Entra tenant (directory) ID."
               },
-              "CredentialProcessTimeout": {
-                "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
-              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
                 "items": {
                   "type": "string"
                 }
+              },
+              "ProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               }
             }
           }
@@ -1045,16 +1045,16 @@
                 "type": "string",
                 "description": "The Microsoft Entra tenant (directory) ID."
               },
-              "CredentialProcessTimeout": {
-                "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
-              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
                 "items": {
                   "type": "string"
                 }
+              },
+              "ProcessTimeout": {
+                "type": "string",
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
               }
             }
           }

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -211,6 +211,22 @@
                 "type": "string",
                 "description": "The Microsoft Entra tenant (directory) ID."
               },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "ClientCertificatePath": {
+                "type": "string",
+                "description": "The file path to a client certificate for authentication."
+              },
+              "SendCertificateChain": {
+                "type": "boolean",
+                "description": "Include the x5c header in client claims when using certificate authentication."
+              },
+              "Username": {
+                "type": "string",
+                "description": "The username for username/password authentication."
+              },
               "DisableInstanceDiscovery": {
                 "type": "boolean",
                 "description": "Skip Microsoft Entra instance discovery and validation."
@@ -864,6 +880,22 @@
               "TenantId": {
                 "type": "string",
                 "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "ClientCertificatePath": {
+                "type": "string",
+                "description": "The file path to a client certificate for authentication."
+              },
+              "SendCertificateChain": {
+                "type": "boolean",
+                "description": "Include the x5c header in client claims when using certificate authentication."
+              },
+              "Username": {
+                "type": "string",
+                "description": "The username for username/password authentication."
               },
               "DisableInstanceDiscovery": {
                 "type": "boolean",

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -62,23 +62,6 @@
         },
         {
           "if": {
-            "required": [
-              "Password"
-            ]
-          },
-          "then": {
-            "title": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
-            "description": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
-            "properties": {
-              "Password": {
-                "not": {},
-                "description": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
-              }
-            }
-          }
-        },
-        {
-          "if": {
             "properties": {
               "CredentialSource": {
                 "const": "AzureCliCredential"
@@ -652,23 +635,6 @@
               "ClientCertificatePassword": {
                 "not": {},
                 "description": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "required": [
-              "Password"
-            ]
-          },
-          "then": {
-            "title": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
-            "description": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
-            "properties": {
-              "Password": {
-                "not": {},
-                "description": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
               }
             }
           }

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -572,7 +572,13 @@
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
               }
-            }
+            },
+            "required": [
+              "TenantId",
+              "ClientId",
+              "AzurePipelinesServiceConnectionId",
+              "AzurePipelinesSystemAccessToken"
+            ]
           }
         },
         {
@@ -1181,7 +1187,13 @@
                   "type": "string"
                 }
               }
-            }
+            },
+            "required": [
+              "TenantId",
+              "ClientId",
+              "AzurePipelinesServiceConnectionId",
+              "AzurePipelinesSystemAccessToken"
+            ]
           }
         },
         {

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -518,7 +518,7 @@
                 "description": "The user-assigned managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
               },
               "AzureCloud": {
-                "description": "The Azure cloud environment.",
+                "description": "The name of the Azure cloud where the managed identity is configured.",
                 "anyOf": [
                   {
                     "enum": [
@@ -1043,7 +1043,7 @@
                 "description": "The user-assigned managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
               },
               "AzureCloud": {
-                "description": "The Azure cloud environment.",
+                "description": "The name of the Azure cloud where the managed identity is configured.",
                 "anyOf": [
                   {
                     "enum": [

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -139,7 +139,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 10 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",
@@ -805,7 +805,7 @@
               },
               "CredentialProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 10 seconds."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -671,7 +671,10 @@
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
               }
-            }
+            },
+            "required": [
+              "Sources"
+            ]
           }
         }
       ],

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -598,13 +598,16 @@
               },
               "ManagedIdentityIdKind": {
                 "type": "string",
-                "description": "The type of managed identity to use as the federated identity.",
+                "description": "The type of managed identity to use as the federated identity. SystemAssigned is not supported.",
                 "enum": [
-                  "SystemAssigned",
                   "ClientId",
                   "ResourceId",
                   "ObjectId"
                 ]
+              },
+              "ManagedIdentityId": {
+                "type": "string",
+                "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
               },
               "AzureCloud": {
                 "description": "The Azure cloud environment.",
@@ -628,31 +631,9 @@
                 "$ref": "#/definitions/diagnostics"
               }
             },
-            "allOf": [
-              {
-                "if": {
-                  "properties": {
-                    "ManagedIdentityIdKind": {
-                      "enum": [
-                        "ClientId",
-                        "ResourceId",
-                        "ObjectId"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "ManagedIdentityIdKind"
-                  ]
-                },
-                "then": {
-                  "properties": {
-                    "ManagedIdentityId": {
-                      "type": "string",
-                      "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
-                    }
-                  }
-                }
-              }
+            "required": [
+              "ManagedIdentityIdKind",
+              "ManagedIdentityId"
             ]
           }
         },
@@ -1175,13 +1156,16 @@
               },
               "ManagedIdentityIdKind": {
                 "type": "string",
-                "description": "The type of managed identity to use as the federated identity.",
+                "description": "The type of managed identity to use as the federated identity. SystemAssigned is not supported.",
                 "enum": [
-                  "SystemAssigned",
                   "ClientId",
                   "ResourceId",
                   "ObjectId"
                 ]
+              },
+              "ManagedIdentityId": {
+                "type": "string",
+                "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
               },
               "AzureCloud": {
                 "description": "The Azure cloud environment.",
@@ -1199,31 +1183,9 @@
                 ]
               }
             },
-            "allOf": [
-              {
-                "if": {
-                  "properties": {
-                    "ManagedIdentityIdKind": {
-                      "enum": [
-                        "ClientId",
-                        "ResourceId",
-                        "ObjectId"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "ManagedIdentityIdKind"
-                  ]
-                },
-                "then": {
-                  "properties": {
-                    "ManagedIdentityId": {
-                      "type": "string",
-                      "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
-                    }
-                  }
-                }
-              }
+            "required": [
+              "ManagedIdentityIdKind",
+              "ManagedIdentityId"
             ]
           }
         }

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -223,10 +223,6 @@
                 "type": "boolean",
                 "description": "Include the x5c header in client claims when using certificate authentication."
               },
-              "Username": {
-                "type": "string",
-                "description": "The username for username/password authentication."
-              },
               "DisableInstanceDiscovery": {
                 "type": "boolean",
                 "description": "Skip Microsoft Entra instance discovery and validation."
@@ -895,10 +891,6 @@
               "SendCertificateChain": {
                 "type": "boolean",
                 "description": "Include the x5c header in client claims when using certificate authentication."
-              },
-              "Username": {
-                "type": "string",
-                "description": "The username for username/password authentication."
               },
               "DisableInstanceDiscovery": {
                 "type": "boolean",

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -9,18 +9,18 @@
           "description": "The credential type to use for authentication.",
           "enum": [
             "AzureCliCredential",
-            "AzurePowerShellCredential",
             "AzureDeveloperCliCredential",
-            "EnvironmentCredential",
-            "WorkloadIdentityCredential",
-            "ManagedIdentityCredential",
-            "InteractiveBrowserCredential",
-            "VisualStudioCredential",
-            "VisualStudioCodeCredential",
-            "BrokerCredential",
             "AzurePipelinesCredential",
+            "AzurePowerShellCredential",
+            "BrokerCredential",
+            "ChainedTokenCredential",
+            "EnvironmentCredential",
+            "InteractiveBrowserCredential",
             "ManagedIdentityAsFederatedIdentityCredential",
-            "ChainedTokenCredential"
+            "ManagedIdentityCredential",
+            "VisualStudioCodeCredential",
+            "VisualStudioCredential",
+            "WorkloadIdentityCredential"
           ]
         }
       },
@@ -676,17 +676,17 @@
           "description": "The token credential type. ApiKeyCredential and ChainedTokenCredential are not allowed in a chain.",
           "enum": [
             "AzureCliCredential",
-            "AzurePowerShellCredential",
             "AzureDeveloperCliCredential",
-            "EnvironmentCredential",
-            "WorkloadIdentityCredential",
-            "ManagedIdentityCredential",
-            "InteractiveBrowserCredential",
-            "VisualStudioCredential",
-            "VisualStudioCodeCredential",
-            "BrokerCredential",
             "AzurePipelinesCredential",
-            "ManagedIdentityAsFederatedIdentityCredential"
+            "AzurePowerShellCredential",
+            "BrokerCredential",
+            "EnvironmentCredential",
+            "InteractiveBrowserCredential",
+            "ManagedIdentityAsFederatedIdentityCredential",
+            "ManagedIdentityCredential",
+            "VisualStudioCodeCredential",
+            "VisualStudioCredential",
+            "WorkloadIdentityCredential"
           ]
         },
         "Retry": {

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -5,6 +5,7 @@
       "description": "Credential configuration. Available properties depend on the selected CredentialSource.",
       "properties": {
         "CredentialSource": {
+          "type": "string",
           "description": "The credential type to use for authentication.",
           "enum": [
             "AzureCliCredential",
@@ -681,6 +682,7 @@
       "description": "A credential source in a chain. ApiKeyCredential and ChainedTokenCredential cannot be used.",
       "properties": {
         "CredentialSource": {
+          "type": "string",
           "description": "The token credential type. ApiKeyCredential and ChainedTokenCredential are not allowed in a chain.",
           "enum": [
             "AzureCliCredential",

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -469,14 +469,6 @@
                 "type": "string",
                 "description": "The client (application) ID."
               },
-              "AzurePipelinesServiceConnectionId": {
-                "type": "string",
-                "description": "The Azure Pipelines service connection ID."
-              },
-              "AzurePipelinesSystemAccessToken": {
-                "type": "string",
-                "description": "The System.AccessToken value from the Azure Pipelines build."
-              },
               "DisableInstanceDiscovery": {
                 "type": "boolean",
                 "description": "Skip Microsoft Entra instance discovery and validation."
@@ -496,6 +488,14 @@
               },
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
+              },
+              "ServiceConnectionId": {
+                "type": "string",
+                "description": "The Azure Pipelines service connection ID."
+              },
+              "SystemAccessToken": {
+                "type": "string",
+                "description": "The System.AccessToken value from the Azure Pipelines build."
               }
             }
           }
@@ -1017,14 +1017,6 @@
                 "type": "string",
                 "description": "The client (application) ID."
               },
-              "AzurePipelinesServiceConnectionId": {
-                "type": "string",
-                "description": "The Azure Pipelines service connection ID."
-              },
-              "AzurePipelinesSystemAccessToken": {
-                "type": "string",
-                "description": "The System.AccessToken value from the Azure Pipelines build."
-              },
               "DisableInstanceDiscovery": {
                 "type": "boolean",
                 "description": "Skip Microsoft Entra instance discovery and validation."
@@ -1038,6 +1030,14 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "ServiceConnectionId": {
+                "type": "string",
+                "description": "The Azure Pipelines service connection ID."
+              },
+              "SystemAccessToken": {
+                "type": "string",
+                "description": "The System.AccessToken value from the Azure Pipelines build."
               }
             }
           }

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -115,7 +115,7 @@
               },
               "ProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 13 seconds."
               }
             }
           }
@@ -189,7 +189,7 @@
               },
               "ProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 13 seconds."
               }
             }
           }
@@ -800,7 +800,7 @@
               },
               "ProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 13 seconds."
               }
             }
           }
@@ -862,7 +862,7 @@
               },
               "ProcessTimeout": {
                 "type": "string",
-                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
+                "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 13 seconds."
               }
             }
           }

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -573,13 +573,7 @@
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
               }
-            },
-            "required": [
-              "TenantId",
-              "ClientId",
-              "AzurePipelinesServiceConnectionId",
-              "AzurePipelinesSystemAccessToken"
-            ]
+            }
           }
         },
         {
@@ -637,11 +631,7 @@
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
               }
-            },
-            "required": [
-              "ManagedIdentityIdKind",
-              "ManagedIdentityId"
-            ]
+            }
           }
         },
         {
@@ -671,10 +661,7 @@
               "Diagnostics": {
                 "$ref": "#/definitions/diagnostics"
               }
-            },
-            "required": [
-              "Sources"
-            ]
+            }
           }
         }
       ],
@@ -720,12 +707,12 @@
             ]
           },
           "then": {
-            "title": "\u26a0\ufe0f Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
-            "description": "\u26a0\ufe0f Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "title": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
             "properties": {
               "ClientSecret": {
                 "not": {},
-                "description": "\u26a0\ufe0f Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+                "description": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
               }
             }
           }
@@ -737,12 +724,12 @@
             ]
           },
           "then": {
-            "title": "\u26a0\ufe0f Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
-            "description": "\u26a0\ufe0f Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "title": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
             "properties": {
               "ClientCertificatePassword": {
                 "not": {},
-                "description": "\u26a0\ufe0f Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+                "description": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
               }
             }
           }
@@ -754,12 +741,12 @@
             ]
           },
           "then": {
-            "title": "\u26a0\ufe0f Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
-            "description": "\u26a0\ufe0f Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "title": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
             "properties": {
               "Password": {
                 "not": {},
-                "description": "\u26a0\ufe0f Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+                "description": "⚠️ Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
               }
             }
           }
@@ -1192,13 +1179,7 @@
                   "type": "string"
                 }
               }
-            },
-            "required": [
-              "TenantId",
-              "ClientId",
-              "AzurePipelinesServiceConnectionId",
-              "AzurePipelinesSystemAccessToken"
-            ]
+            }
           }
         },
         {
@@ -1250,11 +1231,7 @@
                   }
                 ]
               }
-            },
-            "required": [
-              "ManagedIdentityIdKind",
-              "ManagedIdentityId"
-            ]
+            }
           }
         }
       ],

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -12,13 +12,11 @@
             "AzureDeveloperCliCredential",
             "AzurePipelinesCredential",
             "AzurePowerShellCredential",
-            "BrokerCredential",
             "ChainedTokenCredential",
             "EnvironmentCredential",
             "InteractiveBrowserCredential",
             "ManagedIdentityAsFederatedIdentityCredential",
             "ManagedIdentityCredential",
-            "VisualStudioCodeCredential",
             "VisualStudioCredential",
             "WorkloadIdentityCredential"
           ]
@@ -454,95 +452,6 @@
           "if": {
             "properties": {
               "CredentialSource": {
-                "const": "VisualStudioCodeCredential"
-              }
-            },
-            "required": [
-              "CredentialSource"
-            ]
-          },
-          "then": {
-            "properties": {
-              "TenantId": {
-                "type": "string",
-                "description": "The Microsoft Entra tenant (directory) ID."
-              },
-              "AdditionallyAllowedTenants": {
-                "type": "array",
-                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "Retry": {
-                "$ref": "#/definitions/retry"
-              },
-              "Diagnostics": {
-                "$ref": "#/definitions/diagnostics"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "CredentialSource": {
-                "const": "BrokerCredential"
-              }
-            },
-            "required": [
-              "CredentialSource"
-            ]
-          },
-          "then": {
-            "properties": {
-              "TenantId": {
-                "type": "string",
-                "description": "The Microsoft Entra tenant (directory) ID."
-              },
-              "ClientId": {
-                "type": "string",
-                "description": "The client (application) ID."
-              },
-              "DisableInstanceDiscovery": {
-                "type": "boolean",
-                "description": "Skip Microsoft Entra instance discovery and validation."
-              },
-              "UseDefaultBrokerAccount": {
-                "type": "boolean",
-                "description": "Use the default broker account for authentication."
-              },
-              "IsLegacyMsaPassthroughEnabled": {
-                "type": "boolean",
-                "description": "Enable legacy Microsoft Account (MSA) passthrough."
-              },
-              "LoginHint": {
-                "type": "string",
-                "description": "Pre-populate the username/email in the login prompt."
-              },
-              "TokenCachePersistenceOptions": {
-                "$ref": "#/definitions/tokenCachePersistenceOptions"
-              },
-              "AdditionallyAllowedTenants": {
-                "type": "array",
-                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "Retry": {
-                "$ref": "#/definitions/retry"
-              },
-              "Diagnostics": {
-                "$ref": "#/definitions/diagnostics"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "CredentialSource": {
                 "const": "AzurePipelinesCredential"
               }
             },
@@ -694,12 +603,10 @@
             "AzureDeveloperCliCredential",
             "AzurePipelinesCredential",
             "AzurePowerShellCredential",
-            "BrokerCredential",
             "EnvironmentCredential",
             "InteractiveBrowserCredential",
             "ManagedIdentityAsFederatedIdentityCredential",
             "ManagedIdentityCredential",
-            "VisualStudioCodeCredential",
             "VisualStudioCredential",
             "WorkloadIdentityCredential"
           ]
@@ -1085,83 +992,6 @@
               "ProcessTimeout": {
                 "type": "string",
                 "description": "Timeout for the credential process (TimeSpan format, e.g. '00:00:30'). Default: 30 seconds."
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "CredentialSource": {
-                "const": "VisualStudioCodeCredential"
-              }
-            },
-            "required": [
-              "CredentialSource"
-            ]
-          },
-          "then": {
-            "properties": {
-              "TenantId": {
-                "type": "string",
-                "description": "The Microsoft Entra tenant (directory) ID."
-              },
-              "AdditionallyAllowedTenants": {
-                "type": "array",
-                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "CredentialSource": {
-                "const": "BrokerCredential"
-              }
-            },
-            "required": [
-              "CredentialSource"
-            ]
-          },
-          "then": {
-            "properties": {
-              "TenantId": {
-                "type": "string",
-                "description": "The Microsoft Entra tenant (directory) ID."
-              },
-              "ClientId": {
-                "type": "string",
-                "description": "The client (application) ID."
-              },
-              "DisableInstanceDiscovery": {
-                "type": "boolean",
-                "description": "Skip Microsoft Entra instance discovery and validation."
-              },
-              "UseDefaultBrokerAccount": {
-                "type": "boolean",
-                "description": "Use the default broker account for authentication."
-              },
-              "IsLegacyMsaPassthroughEnabled": {
-                "type": "boolean",
-                "description": "Enable legacy Microsoft Account (MSA) passthrough."
-              },
-              "LoginHint": {
-                "type": "string",
-                "description": "Pre-populate the username/email in the login prompt."
-              },
-              "TokenCachePersistenceOptions": {
-                "$ref": "#/definitions/tokenCachePersistenceOptions"
-              },
-              "AdditionallyAllowedTenants": {
-                "type": "array",
-                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
-                "items": {
-                  "type": "string"
-                }
               }
             }
           }

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -259,6 +259,10 @@
                 "type": "boolean",
                 "description": "Enable Azure Kubernetes Service (AKS) proxy mode."
               },
+              "TokenFilePath": {
+                "type": "string",
+                "description": "The path to the file containing the workload identity token."
+              },
               "AdditionallyAllowedTenants": {
                 "type": "array",
                 "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
@@ -873,6 +877,10 @@
               "IsAzureProxyEnabled": {
                 "type": "boolean",
                 "description": "Enable Azure Kubernetes Service (AKS) proxy mode."
+              },
+              "TokenFilePath": {
+                "type": "string",
+                "description": "The path to the file containing the workload identity token."
               },
               "AdditionallyAllowedTenants": {
                 "type": "array",

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -608,7 +608,7 @@
               },
               "ManagedIdentityId": {
                 "type": "string",
-                "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
+                "description": "The user-assigned managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
               },
               "AzureCloud": {
                 "description": "The Azure cloud environment.",
@@ -1214,7 +1214,7 @@
               },
               "ManagedIdentityId": {
                 "type": "string",
-                "description": "The managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
+                "description": "The user-assigned managed identity identifier (client ID, resource ID, or object ID depending on ManagedIdentityIdKind)."
               },
               "AzureCloud": {
                 "description": "The Azure cloud environment.",

--- a/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity/schema/ConfigurationSchema.json
@@ -704,6 +704,57 @@
       "allOf": [
         {
           "if": {
+            "required": [
+              "ClientSecret"
+            ]
+          },
+          "then": {
+            "title": "\u26a0\ufe0f Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "\u26a0\ufe0f Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "ClientSecret": {
+                "not": {},
+                "description": "\u26a0\ufe0f Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "ClientCertificatePassword"
+            ]
+          },
+          "then": {
+            "title": "\u26a0\ufe0f Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "\u26a0\ufe0f Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "ClientCertificatePassword": {
+                "not": {},
+                "description": "\u26a0\ufe0f Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "Password"
+            ]
+          },
+          "then": {
+            "title": "\u26a0\ufe0f Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "\u26a0\ufe0f Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "Password": {
+                "not": {},
+                "description": "\u26a0\ufe0f Do NOT put passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
             "properties": {
               "CredentialSource": {
                 "const": "AzureCliCredential"

--- a/sdk/identity/Azure.Identity/src/ChainedTokenCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/ChainedTokenCredentialFactory.cs
@@ -175,11 +175,6 @@ namespace Azure.Identity
                 options.SendCertificateChain = source.EnvironmentSendCertificateChain.Value;
             }
 
-            if (!string.IsNullOrEmpty(source.EnvironmentUsername))
-            {
-                options.Username = source.EnvironmentUsername;
-            }
-
             if (!string.IsNullOrEmpty(source.EnvironmentPassword))
             {
                 options.Password = source.EnvironmentPassword;

--- a/sdk/identity/Azure.Identity/src/ChainedTokenCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/ChainedTokenCredentialFactory.cs
@@ -175,12 +175,7 @@ namespace Azure.Identity
                 options.SendCertificateChain = source.EnvironmentSendCertificateChain.Value;
             }
 
-            if (!string.IsNullOrEmpty(source.EnvironmentPassword))
-            {
-                options.Password = source.EnvironmentPassword;
-            }
-
-            return new EnvironmentCredential(options);
+return new EnvironmentCredential(options);
         }
 
         private static TokenCredential CreateWorkloadIdentityCredential(DefaultAzureCredentialOptions source)

--- a/sdk/identity/Azure.Identity/src/ChainedTokenCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/ChainedTokenCredentialFactory.cs
@@ -175,7 +175,7 @@ namespace Azure.Identity
                 options.SendCertificateChain = source.EnvironmentSendCertificateChain.Value;
             }
 
-return new EnvironmentCredential(options);
+            return new EnvironmentCredential(options);
         }
 
         private static TokenCredential CreateWorkloadIdentityCredential(DefaultAzureCredentialOptions source)

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -150,12 +150,12 @@ namespace Azure.Identity
                 WorkloadTokenFilePath = tokenFilePath;
             }
 
-            if (section[nameof(AzurePipelinesServiceConnectionId)] is string azurePipelinesServiceConnectionId)
+            if (section[nameof(AzurePipelinesCredential.ServiceConnectionId)] is string azurePipelinesServiceConnectionId)
             {
                 AzurePipelinesServiceConnectionId = azurePipelinesServiceConnectionId;
             }
 
-            if (section[nameof(AzurePipelinesSystemAccessToken)] is string azurePipelinesSystemAccessToken)
+            if (section[nameof(AzurePipelinesCredential.SystemAccessToken)] is string azurePipelinesSystemAccessToken)
             {
                 AzurePipelinesSystemAccessToken = azurePipelinesSystemAccessToken;
             }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -100,7 +100,7 @@ namespace Azure.Identity
                 ManagedIdentityId = managedIdentityId;
             }
 
-            if (TimeSpan.TryParse(section[nameof(CredentialProcessTimeout)], out TimeSpan credentialProcessTimeout))
+            if (TimeSpan.TryParse(section[nameof(VisualStudioCredentialOptions.ProcessTimeout)], out TimeSpan credentialProcessTimeout))
             {
                 CredentialProcessTimeout = credentialProcessTimeout;
             }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -140,11 +140,6 @@ namespace Azure.Identity
                 EnvironmentSendCertificateChain = sendCertificateChain;
             }
 
-            if (section[nameof(EnvironmentCredentialOptions.Username)] is string username)
-            {
-                EnvironmentUsername = username;
-            }
-
             if (section[nameof(EnvironmentCredentialOptions.Password)] is string password)
             {
                 EnvironmentPassword = password;
@@ -627,11 +622,6 @@ namespace Azure.Identity
         internal bool? EnvironmentSendCertificateChain { get; set; }
 
         /// <summary>
-        /// Specifies the username for the EnvironmentCredential.
-        /// </summary>
-        internal string EnvironmentUsername { get; set; }
-
-        /// <summary>
         /// Specifies the password for the EnvironmentCredential.
         /// </summary>
         internal string EnvironmentPassword { get; set; }
@@ -722,7 +712,6 @@ namespace Azure.Identity
                 dacClone.EnvironmentClientCertificatePath = EnvironmentClientCertificatePath;
                 dacClone.EnvironmentClientCertificatePassword = EnvironmentClientCertificatePassword;
                 dacClone.EnvironmentSendCertificateChain = EnvironmentSendCertificateChain;
-                dacClone.EnvironmentUsername = EnvironmentUsername;
                 dacClone.EnvironmentPassword = EnvironmentPassword;
                 dacClone.WorkloadTokenFilePath = WorkloadTokenFilePath;
             }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -140,7 +140,7 @@ namespace Azure.Identity
                 EnvironmentSendCertificateChain = sendCertificateChain;
             }
 
-if (section[nameof(WorkloadIdentityCredentialOptions.TokenFilePath)] is string tokenFilePath)
+            if (section[nameof(WorkloadIdentityCredentialOptions.TokenFilePath)] is string tokenFilePath)
             {
                 WorkloadTokenFilePath = tokenFilePath;
             }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -140,12 +140,7 @@ namespace Azure.Identity
                 EnvironmentSendCertificateChain = sendCertificateChain;
             }
 
-            if (section[nameof(EnvironmentCredentialOptions.Password)] is string password)
-            {
-                EnvironmentPassword = password;
-            }
-
-            if (section[nameof(WorkloadIdentityCredentialOptions.TokenFilePath)] is string tokenFilePath)
+if (section[nameof(WorkloadIdentityCredentialOptions.TokenFilePath)] is string tokenFilePath)
             {
                 WorkloadTokenFilePath = tokenFilePath;
             }
@@ -621,12 +616,7 @@ namespace Azure.Identity
         /// </summary>
         internal bool? EnvironmentSendCertificateChain { get; set; }
 
-        /// <summary>
-        /// Specifies the password for the EnvironmentCredential.
-        /// </summary>
-        internal string EnvironmentPassword { get; set; }
-
-        /// <summary>
+/// <summary>
         /// Specifies the token file path for the WorkloadIdentityCredential.
         /// </summary>
         internal string WorkloadTokenFilePath { get; set; }
@@ -712,8 +702,7 @@ namespace Azure.Identity
                 dacClone.EnvironmentClientCertificatePath = EnvironmentClientCertificatePath;
                 dacClone.EnvironmentClientCertificatePassword = EnvironmentClientCertificatePassword;
                 dacClone.EnvironmentSendCertificateChain = EnvironmentSendCertificateChain;
-                dacClone.EnvironmentPassword = EnvironmentPassword;
-                dacClone.WorkloadTokenFilePath = WorkloadTokenFilePath;
+dacClone.WorkloadTokenFilePath = WorkloadTokenFilePath;
             }
             else if (clone is InteractiveBrowserCredentialOptions ibcClone)
             {

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -616,7 +616,7 @@ if (section[nameof(WorkloadIdentityCredentialOptions.TokenFilePath)] is string t
         /// </summary>
         internal bool? EnvironmentSendCertificateChain { get; set; }
 
-/// <summary>
+        /// <summary>
         /// Specifies the token file path for the WorkloadIdentityCredential.
         /// </summary>
         internal string WorkloadTokenFilePath { get; set; }

--- a/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/DefaultAzureCredentialOptions.cs
@@ -702,7 +702,7 @@ namespace Azure.Identity
                 dacClone.EnvironmentClientCertificatePath = EnvironmentClientCertificatePath;
                 dacClone.EnvironmentClientCertificatePassword = EnvironmentClientCertificatePassword;
                 dacClone.EnvironmentSendCertificateChain = EnvironmentSendCertificateChain;
-dacClone.WorkloadTokenFilePath = WorkloadTokenFilePath;
+                dacClone.WorkloadTokenFilePath = WorkloadTokenFilePath;
             }
             else if (clone is InteractiveBrowserCredentialOptions ibcClone)
             {

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -322,11 +322,6 @@ namespace Azure.Identity
                 options.SendCertificateChain = Options.EnvironmentSendCertificateChain.Value;
             }
 
-            if (!string.IsNullOrEmpty(Options.EnvironmentUsername))
-            {
-                options.Username = Options.EnvironmentUsername;
-            }
-
             if (!string.IsNullOrEmpty(Options.EnvironmentPassword))
             {
                 options.Password = Options.EnvironmentPassword;

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -322,7 +322,7 @@ namespace Azure.Identity
                 options.SendCertificateChain = Options.EnvironmentSendCertificateChain.Value;
             }
 
-return new EnvironmentCredential(Pipeline, options);
+            return new EnvironmentCredential(Pipeline, options);
         }
 
         public virtual TokenCredential CreateWorkloadIdentityCredential()

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredentialFactory.cs
@@ -322,12 +322,7 @@ namespace Azure.Identity
                 options.SendCertificateChain = Options.EnvironmentSendCertificateChain.Value;
             }
 
-            if (!string.IsNullOrEmpty(Options.EnvironmentPassword))
-            {
-                options.Password = Options.EnvironmentPassword;
-            }
-
-            return new EnvironmentCredential(Pipeline, options);
+return new EnvironmentCredential(Pipeline, options);
         }
 
         public virtual TokenCredential CreateWorkloadIdentityCredential()

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialCreationTests.cs
@@ -139,7 +139,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureCli
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:CredentialProcessTimeout"] = "00:00:45";
+                config["MyClient:Credential:ProcessTimeout"] = "00:00:45";
 
                 var cli = GetUnderlying(CreateFromConfig(config));
                 Assert.AreEqual(TimeSpan.FromSeconds(45), ReadProperty<TimeSpan>(cli, "ProcessTimeout"));
@@ -202,7 +202,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureCli
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:TenantId"] = configTenant;
                 config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
-                config["MyClient:Credential:CredentialProcessTimeout"] = "00:01:00";
+                config["MyClient:Credential:ProcessTimeout"] = "00:01:00";
                 config["MyClient:Credential:Subscription"] = "config-sub";
 
                 var cli = GetUnderlying(CreateFromConfig(config));

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureCliCredentialTests.cs
@@ -50,7 +50,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureCli
             }
             if (timeout != null)
             {
-                config[$"{prefix}:CredentialProcessTimeout"] = timeout.Value.ToString();
+                config[$"{prefix}:ProcessTimeout"] = timeout.Value.ToString();
             }
 
             ConfigurableCredential credential;

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialCreationTests.cs
@@ -139,7 +139,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureDeveloperCli
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:CredentialProcessTimeout"] = "00:00:45";
+                config["MyClient:Credential:ProcessTimeout"] = "00:00:45";
 
                 var azd = GetUnderlying(CreateFromConfig(config));
                 Assert.AreEqual(TimeSpan.FromSeconds(45), ReadProperty<TimeSpan>(azd, "ProcessTimeout"));
@@ -175,7 +175,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureDeveloperCli
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:TenantId"] = configTenant;
                 config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
-                config["MyClient:Credential:CredentialProcessTimeout"] = "00:01:00";
+                config["MyClient:Credential:ProcessTimeout"] = "00:01:00";
 
                 var azd = GetUnderlying(CreateFromConfig(config));
 

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzureDeveloperCliCredentialTests.cs
@@ -44,7 +44,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzureDeveloperCli
             }
             if (timeout != null)
             {
-                config[$"{prefix}:CredentialProcessTimeout"] = timeout.Value.ToString();
+                config[$"{prefix}:ProcessTimeout"] = timeout.Value.ToString();
             }
 
             ConfigurableCredential credential;

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePipelinesCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePipelinesCredentialCreationTests.cs
@@ -24,8 +24,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
         {
             { "TenantId", "test-tenant" },
             { "ClientId", "test-client" },
-            { "AzurePipelinesServiceConnectionId", "test-connection" },
-            { "AzurePipelinesSystemAccessToken", "test-token" },
+            { "ServiceConnectionId", "test-connection" },
+            { "SystemAccessToken", "test-token" },
         };
 
         protected override Dictionary<string, string> GetRequiredEnvVars() => new()
@@ -66,8 +66,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
         {
             config["MyClient:Credential:TenantId"] = tenantId;
             config["MyClient:Credential:ClientId"] = clientId;
-            config["MyClient:Credential:AzurePipelinesServiceConnectionId"] = serviceConnectionId;
-            config["MyClient:Credential:AzurePipelinesSystemAccessToken"] = systemAccessToken;
+            config["MyClient:Credential:ServiceConnectionId"] = serviceConnectionId;
+            config["MyClient:Credential:SystemAccessToken"] = systemAccessToken;
         }
 
         [Test]
@@ -103,8 +103,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
                 IConfiguration config = Helper.GetConfiguration();
                 // TenantId intentionally not set in config — should fall back to env var.
                 config["MyClient:Credential:ClientId"] = "test-client";
-                config["MyClient:Credential:AzurePipelinesServiceConnectionId"] = "test-connection";
-                config["MyClient:Credential:AzurePipelinesSystemAccessToken"] = "test-token";
+                config["MyClient:Credential:ServiceConnectionId"] = "test-connection";
+                config["MyClient:Credential:SystemAccessToken"] = "test-token";
 
                 var cred = GetUnderlying(CreateFromConfig(config));
 
@@ -160,8 +160,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
                 IConfiguration config = Helper.GetConfiguration();
                 // TenantId not set in config and env var is null.
                 config["MyClient:Credential:ClientId"] = "test-client";
-                config["MyClient:Credential:AzurePipelinesServiceConnectionId"] = "test-connection";
-                config["MyClient:Credential:AzurePipelinesSystemAccessToken"] = "test-token";
+                config["MyClient:Credential:ServiceConnectionId"] = "test-connection";
+                config["MyClient:Credential:SystemAccessToken"] = "test-token";
 
                 Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
             }
@@ -177,8 +177,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:TenantId"] = "test-tenant";
                 // ClientId not set.
-                config["MyClient:Credential:AzurePipelinesServiceConnectionId"] = "test-connection";
-                config["MyClient:Credential:AzurePipelinesSystemAccessToken"] = "test-token";
+                config["MyClient:Credential:ServiceConnectionId"] = "test-connection";
+                config["MyClient:Credential:SystemAccessToken"] = "test-token";
 
                 Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
             }
@@ -194,8 +194,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:TenantId"] = "test-tenant";
                 config["MyClient:Credential:ClientId"] = "test-client";
-                // AzurePipelinesServiceConnectionId not set.
-                config["MyClient:Credential:AzurePipelinesSystemAccessToken"] = "test-token";
+                // ServiceConnectionId not set.
+                config["MyClient:Credential:SystemAccessToken"] = "test-token";
 
                 Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
             }
@@ -211,8 +211,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:TenantId"] = "test-tenant";
                 config["MyClient:Credential:ClientId"] = "test-client";
-                config["MyClient:Credential:AzurePipelinesServiceConnectionId"] = "test-connection";
-                // AzurePipelinesSystemAccessToken not set.
+                config["MyClient:Credential:ServiceConnectionId"] = "test-connection";
+                // SystemAccessToken not set.
 
                 Assert.That(() => CreateFromConfig(config), Throws.InstanceOf<ArgumentException>());
             }
@@ -404,8 +404,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:TenantId"] = configTenant;
                 config["MyClient:Credential:ClientId"] = configClient;
-                config["MyClient:Credential:AzurePipelinesServiceConnectionId"] = configConnectionId;
-                config["MyClient:Credential:AzurePipelinesSystemAccessToken"] = "config-token";
+                config["MyClient:Credential:ServiceConnectionId"] = configConnectionId;
+                config["MyClient:Credential:SystemAccessToken"] = "config-token";
                 config["MyClient:Credential:AuthorityHost"] = configAuthority.ToString();
                 config["MyClient:Credential:DisableInstanceDiscovery"] = "true";
                 config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePipelinesCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePipelinesCredentialTests.cs
@@ -34,8 +34,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
                 config["MyClient:Credential:TenantId"] = tenantId;
             }
             config["MyClient:Credential:ClientId"] = ClientId;
-            config["MyClient:Credential:AzurePipelinesServiceConnectionId"] = Guid.NewGuid().ToString();
-            config["MyClient:Credential:AzurePipelinesSystemAccessToken"] = "mytoken";
+            config["MyClient:Credential:ServiceConnectionId"] = Guid.NewGuid().ToString();
+            config["MyClient:Credential:SystemAccessToken"] = "mytoken";
             configureExtra?.Invoke(config);
 
             ConfigurableCredential credential;
@@ -89,8 +89,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
 
             IConfiguration configuration = _helper.GetConfigurationFromCommonCredentialTestConfig<AzurePipelinesCredentialOptions>(config);
             configuration["MyClient:Credential:ClientId"] = ClientId;
-            configuration["MyClient:Credential:AzurePipelinesServiceConnectionId"] = "myConnectionId";
-            configuration["MyClient:Credential:AzurePipelinesSystemAccessToken"] = "mytoken";
+            configuration["MyClient:Credential:ServiceConnectionId"] = "myConnectionId";
+            configuration["MyClient:Credential:SystemAccessToken"] = "mytoken";
 
             ConfigurableCredential credential;
             using (new TestEnvVar(new Dictionary<string, string>
@@ -145,8 +145,8 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePipelines
             IConfiguration config = _helper.GetConfiguration();
             config["MyClient:Credential:TenantId"] = tenantId;
             config["MyClient:Credential:ClientId"] = clientId;
-            config["MyClient:Credential:AzurePipelinesServiceConnectionId"] = serviceConnectionId;
-            config["MyClient:Credential:AzurePipelinesSystemAccessToken"] = systemAccessToken;
+            config["MyClient:Credential:ServiceConnectionId"] = serviceConnectionId;
+            config["MyClient:Credential:SystemAccessToken"] = systemAccessToken;
 
             IConfigurationSection credentialSection = config.GetSection("MyClient:Credential");
             var dacOptions = new DefaultAzureCredentialOptions(new CredentialSettings(credentialSection), credentialSection);

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialCreationTests.cs
@@ -139,7 +139,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePowerShell
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:CredentialProcessTimeout"] = "00:00:45";
+                config["MyClient:Credential:ProcessTimeout"] = "00:00:45";
 
                 var ps = GetUnderlying(CreateFromConfig(config));
                 Assert.AreEqual(TimeSpan.FromSeconds(45), ReadProperty<TimeSpan>(ps, "ProcessTimeout"));
@@ -175,7 +175,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePowerShell
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:TenantId"] = configTenant;
                 config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
-                config["MyClient:Credential:CredentialProcessTimeout"] = "00:01:00";
+                config["MyClient:Credential:ProcessTimeout"] = "00:01:00";
 
                 var ps = GetUnderlying(CreateFromConfig(config));
 

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/AzurePowerShellCredentialTests.cs
@@ -44,7 +44,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.AzurePowerShell
             }
             if (timeout != null)
             {
-                config[$"{prefix}:CredentialProcessTimeout"] = timeout.Value.ToString();
+                config[$"{prefix}:ProcessTimeout"] = timeout.Value.ToString();
             }
 
             ConfigurableCredential credential;

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/ConfigurableCredentialTests.cs
@@ -433,14 +433,14 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
                     // Source 0: AzureCliCredential with all settable properties
                     ["Credential:Sources:0:CredentialSource"] = "AzureCliCredential",
                     ["Credential:Sources:0:TenantId"] = "cli-tenant",
-                    ["Credential:Sources:0:CredentialProcessTimeout"] = "00:00:45",
+                    ["Credential:Sources:0:ProcessTimeout"] = "00:00:45",
                     ["Credential:Sources:0:Subscription"] = "cli-sub-id",
                     ["Credential:Sources:0:AdditionallyAllowedTenants:0"] = "cli-extra-tenant",
 
                     // Source 1: AzurePowerShellCredential with properties
                     ["Credential:Sources:1:CredentialSource"] = "AzurePowerShellCredential",
                     ["Credential:Sources:1:TenantId"] = "ps-tenant",
-                    ["Credential:Sources:1:CredentialProcessTimeout"] = "00:01:00",
+                    ["Credential:Sources:1:ProcessTimeout"] = "00:01:00",
                     ["Credential:Sources:1:AdditionallyAllowedTenants:0"] = "ps-extra-tenant",
 
                     // Source 2: ManagedIdentityCredential with user-assigned client ID
@@ -451,14 +451,14 @@ namespace Azure.Identity.Tests.ConfigurableCredentials
                     // Source 3: AzureDeveloperCliCredential with properties
                     ["Credential:Sources:3:CredentialSource"] = "AzureDeveloperCliCredential",
                     ["Credential:Sources:3:TenantId"] = "azd-tenant",
-                    ["Credential:Sources:3:CredentialProcessTimeout"] = "00:00:30",
+                    ["Credential:Sources:3:ProcessTimeout"] = "00:00:30",
                     ["Credential:Sources:3:AdditionallyAllowedTenants:0"] = "azd-extra-tenant-a",
                     ["Credential:Sources:3:AdditionallyAllowedTenants:1"] = "azd-extra-tenant-b",
 
                     // Source 4: VisualStudioCredential with properties
                     ["Credential:Sources:4:CredentialSource"] = "VisualStudioCredential",
                     ["Credential:Sources:4:TenantId"] = "vs-tenant",
-                    ["Credential:Sources:4:CredentialProcessTimeout"] = "00:02:00",
+                    ["Credential:Sources:4:ProcessTimeout"] = "00:02:00",
                     ["Credential:Sources:4:AdditionallyAllowedTenants:0"] = "*",
                 })
                 .Build();

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
@@ -280,26 +280,6 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Environment
 
         [Test]
         [NonParallelizable]
-        public void Password_ConfigWinsOverEnvVar()
-        {
-            var env = BaseEnvVars(clientSecret: null);
-            env["AZURE_USERNAME"] = "env-user";
-            env["AZURE_PASSWORD"] = "env-pass";
-            using (new TestEnvVar(env))
-            {
-                IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:Password"] = "config-pass";
-
-                var envCred = GetUnderlying(CreateFromConfig(config));
-                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as UsernamePasswordCredential;
-                Assert.IsNotNull(inner, "Should create a UsernamePasswordCredential");
-
-                Assert.AreEqual("config-pass", ReadField<string>(inner, "_password"));
-            }
-        }
-
-        [Test]
-        [NonParallelizable]
         public void Password_FallsBackToEnvVar()
         {
             var env = BaseEnvVars(clientSecret: null);

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
@@ -261,26 +261,6 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Environment
 
         [Test]
         [NonParallelizable]
-        public void Username_ConfigWinsOverEnvVar()
-        {
-            var env = BaseEnvVars(clientSecret: null);
-            env["AZURE_USERNAME"] = "env-user";
-            env["AZURE_PASSWORD"] = "env-pass";
-            using (new TestEnvVar(env))
-            {
-                IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:Username"] = "config-user";
-
-                var envCred = GetUnderlying(CreateFromConfig(config));
-                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as UsernamePasswordCredential;
-                Assert.IsNotNull(inner, "Should create a UsernamePasswordCredential");
-
-                Assert.AreEqual("config-user", ReadField<string>(inner, "_username"));
-            }
-        }
-
-        [Test]
-        [NonParallelizable]
         public void Username_FallsBackToEnvVar()
         {
             var env = BaseEnvVars(clientSecret: null);

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/EnvironmentCredentialCreationTests.cs
@@ -261,44 +261,6 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.Environment
 
         [Test]
         [NonParallelizable]
-        public void Username_FallsBackToEnvVar()
-        {
-            var env = BaseEnvVars(clientSecret: null);
-            env["AZURE_USERNAME"] = "env-user";
-            env["AZURE_PASSWORD"] = "env-pass";
-            using (new TestEnvVar(env))
-            {
-                IConfiguration config = Helper.GetConfiguration();
-
-                var envCred = GetUnderlying(CreateFromConfig(config));
-                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as UsernamePasswordCredential;
-                Assert.IsNotNull(inner, "Should create a UsernamePasswordCredential");
-
-                Assert.AreEqual("env-user", ReadField<string>(inner, "_username"));
-            }
-        }
-
-        [Test]
-        [NonParallelizable]
-        public void Password_FallsBackToEnvVar()
-        {
-            var env = BaseEnvVars(clientSecret: null);
-            env["AZURE_USERNAME"] = "env-user";
-            env["AZURE_PASSWORD"] = "env-pass";
-            using (new TestEnvVar(env))
-            {
-                IConfiguration config = Helper.GetConfiguration();
-
-                var envCred = GetUnderlying(CreateFromConfig(config));
-                var inner = ReadProperty<Azure.Core.TokenCredential>(envCred, "Credential") as UsernamePasswordCredential;
-                Assert.IsNotNull(inner, "Should create a UsernamePasswordCredential");
-
-                Assert.AreEqual("env-pass", ReadField<string>(inner, "_password"));
-            }
-        }
-
-        [Test]
-        [NonParallelizable]
         public void NoCredential_WhenRequiredEnvVarsMissing()
         {
             var env = BaseEnvVars(tenantId: null, clientId: null, clientSecret: null);

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialCreationTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialCreationTests.cs
@@ -139,7 +139,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudio
             using (new TestEnvVar(AllNulledEnvVars()))
             {
                 IConfiguration config = Helper.GetConfiguration();
-                config["MyClient:Credential:CredentialProcessTimeout"] = "00:00:45";
+                config["MyClient:Credential:ProcessTimeout"] = "00:00:45";
 
                 var vs = GetUnderlying(CreateFromConfig(config));
                 Assert.AreEqual(TimeSpan.FromSeconds(45), ReadProperty<TimeSpan>(vs, "ProcessTimeout"));
@@ -175,7 +175,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudio
                 IConfiguration config = Helper.GetConfiguration();
                 config["MyClient:Credential:TenantId"] = configTenant;
                 config["MyClient:Credential:AdditionallyAllowedTenants:0"] = "*";
-                config["MyClient:Credential:CredentialProcessTimeout"] = "00:01:00";
+                config["MyClient:Credential:ProcessTimeout"] = "00:01:00";
 
                 var vs = GetUnderlying(CreateFromConfig(config));
 

--- a/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ConfigurableCredentials/VisualStudioCredentialTests.cs
@@ -62,7 +62,7 @@ namespace Azure.Identity.Tests.ConfigurableCredentials.VisualStudio
         protected override TokenCredential CreateCredentialWithTimeout(IProcessService processService, IFileSystemService fileSystem, TimeSpan timeout)
         {
             IConfiguration config = _helper.GetConfiguration();
-            config["MyClient:Credential:CredentialProcessTimeout"] = timeout.ToString();
+            config["MyClient:Credential:ProcessTimeout"] = timeout.ToString();
 
             ConfigurableCredential credential;
             using (new TestEnvVar("AZURE_TENANT_ID", null))


### PR DESCRIPTION
## What

Adds `ConfigurationSchema.json` to `sdk/identity/Azure.Identity/schema/` to provide JSON IntelliSense for credential configuration in `appsettings.json` files.

## Schema Content

- **`credential` definition** with 13 Azure-specific credential sources: AzureCliCredential, AzurePowerShellCredential, AzureDeveloperCliCredential, EnvironmentCredential, WorkloadIdentityCredential, ManagedIdentityCredential, InteractiveBrowserCredential, VisualStudioCredential, VisualStudioCodeCredential, BrokerCredential, AzurePipelinesCredential, ManagedIdentityAsFederatedIdentityCredential, ChainedTokenCredential
- **Conditional properties per credential type** using draft-07 `if/then` patterns (e.g., `Subscription` only for AzureCliCredential, `ManagedIdentityIdKind`/`ManagedIdentityId` for ManagedIdentityCredential)
- **`chainableCredential` definition** for ChainedTokenCredential sources (excludes ChainedTokenCredential to prevent nesting)
- **Secret-blocking patterns** for `ClientSecret`, `ClientCertificatePassword`, and `Password` - prevents secrets from being placed in config files
- **`tokenCachePersistenceOptions`** and **`authenticationRecord`** reusable definitions
- Does **not** include `ApiKeyCredential` (comes transitively from System.ClientModel)
- References `#/definitions/retry` and `#/definitions/diagnostics` (resolved from Azure.Core during schema merge)

## Testing

Verified IntelliSense works in VS 18.6 IntPreview with a test console app referencing a locally packed version of Azure.Identity containing this schema. The shared build infrastructure auto-detects and packs the schema file.

Closes #56781