### PR TITLE
Fix provisioning generator property ordering and child resource location

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningPropertyInfo.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Primitives/ProvisioningPropertyInfo.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.TypeSpec.Generator.Primitives;
+
 namespace Azure.Generator.Provisioning.Primitives
 {
     /// <summary>
@@ -11,5 +13,6 @@ namespace Azure.Generator.Provisioning.Primitives
         bool IsOutput,
         bool IsRequired,
         string[] BicepPath,
-        string? DefaultValue = null);
+        string? DefaultValue = null,
+        CSharpType? TypeOverride = null);
 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -40,7 +40,7 @@ namespace Azure.Generator.Provisioning.Providers
             "id", "systemData", "type"
         };
 
-        // System properties that should always be required
+        // System properties that should always be required, even when marked readOnly (path parameters)
         private static readonly HashSet<string> RequiredInputProperties = new(StringComparer.OrdinalIgnoreCase)
         {
             "name", "location"
@@ -371,15 +371,24 @@ namespace Azure.Generator.Provisioning.Providers
             var result = new List<ResourcePropertyInfo>();
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            // Collect from the resource model and its base chain
-            CollectPropertiesFromModel(_inputModel, result, seen, basePath: null);
-
+            // Collect from the base chain first (top-most ancestor → immediate base),
+            // then from the resource model itself. This ensures inherited ARM common
+            // properties (name, location, tags) appear before leaf-defined properties
+            // (e.g., the "properties" bag), which controls the Bicep emission order.
+            var chain = new List<InputModelType>();
             var baseModel = _inputModel.BaseModel;
             while (baseModel != null)
             {
-                CollectPropertiesFromModel(baseModel, result, seen, basePath: null);
+                chain.Add(baseModel);
                 baseModel = baseModel.BaseModel;
             }
+            chain.Reverse();
+
+            foreach (var model in chain)
+            {
+                CollectPropertiesFromModel(model, result, seen, basePath: null);
+            }
+            CollectPropertiesFromModel(_inputModel, result, seen, basePath: null);
 
             return result;
         }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -389,11 +389,6 @@ namespace Azure.Generator.Provisioning.Providers
                 CollectPropertiesFromModel(model, result, seen, basePath: null);
             }
 
-            foreach (var model in chain)
-            {
-                CollectPropertiesFromModel(model, result, seen, basePath: null);
-            }
-
             return result;
         }
 

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -439,7 +439,8 @@ namespace Azure.Generator.Provisioning.Providers
                 // Ensure "location" at the resource level always uses AzureLocation,
                 // even when the TypeSpec defines it as plain string.
                 CSharpType? typeOverride = null;
-                if (string.Equals(serializedName, "location", StringComparison.OrdinalIgnoreCase))
+                if (basePath is null
+                    && string.Equals(serializedName, "location", StringComparison.OrdinalIgnoreCase))
                 {
                     typeOverride = new CSharpType(typeof(BicepValue<>), typeof(Azure.Core.AzureLocation));
                 }

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -375,29 +375,19 @@ namespace Azure.Generator.Provisioning.Providers
             // then from the resource model itself. This ensures inherited ARM common
             // properties (name, location, tags) appear before leaf-defined properties
             // (e.g., the "properties" bag), which controls the Bicep emission order.
-<<<<<<< HEAD
             var chain = new Stack<InputModelType>();
             chain.Push(_inputModel);
             var baseModel = _inputModel.BaseModel;
             while (baseModel != null)
             {
                 chain.Push(baseModel);
-=======
-            var chain = new List<InputModelType>();
-            var baseModel = _inputModel.BaseModel;
-            while (baseModel != null)
-            {
-                chain.Add(baseModel);
->>>>>>> 2b590f8031332ec769dc77adfd3219fa9b6ee476
                 baseModel = baseModel.BaseModel;
             }
-            chain.Reverse();
 
             foreach (var model in chain)
             {
                 CollectPropertiesFromModel(model, result, seen, basePath: null);
             }
-            CollectPropertiesFromModel(_inputModel, result, seen, basePath: null);
 
             foreach (var model in chain)
             {

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -97,7 +97,8 @@ namespace Azure.Generator.Provisioning.Providers
                 propInfo.IsOutput,
                 propInfo.IsRequired,
                 propInfo.BicepPath,
-                propInfo.DefaultValue);
+                propInfo.DefaultValue,
+                propInfo.TypeOverride);
         }
 
         /// <summary>
@@ -428,7 +429,15 @@ namespace Azure.Generator.Provisioning.Providers
                     defaultValue = _resourceMetadata.SingletonResourceName;
                     isOutput = true;
                 }
-                result.Add(new ResourcePropertyInfo(prop, propertyName, bicepPath, isOutput, isRequired, defaultValue));
+                // Ensure "location" at the resource level always uses AzureLocation,
+                // even when the TypeSpec defines it as plain string.
+                CSharpType? typeOverride = null;
+                if (string.Equals(serializedName, "location", StringComparison.OrdinalIgnoreCase))
+                {
+                    typeOverride = new CSharpType(typeof(BicepValue<>), typeof(Azure.Core.AzureLocation));
+                }
+
+                result.Add(new ResourcePropertyInfo(prop, propertyName, bicepPath, isOutput, isRequired, defaultValue, typeOverride));
             }
         }
 
@@ -842,7 +851,8 @@ namespace Azure.Generator.Provisioning.Providers
             string[] BicepPath,
             bool IsOutput,
             bool IsRequired,
-            string? DefaultValue = null);
+            string? DefaultValue = null,
+            CSharpType? TypeOverride = null);
 
         // ── ResourceVersions nested class ────────────────────────────
 

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -62,6 +62,11 @@ namespace Azure.Generator.Provisioning.Providers
         /// </summary>
         private readonly List<ResourcePropertyInfo> _allProperties;
         /// <summary>
+        /// Lookup from InputModelProperty to ResourcePropertyInfo for O(1) access in
+        /// <see cref="IProvisioningPropertyInfo.GetProvisioningPropertyInfo"/>.
+        /// </summary>
+        private readonly Dictionary<InputModelProperty, ResourcePropertyInfo> _propertyLookup;
+        /// <summary>
         /// Serialized property names that are writable in the create/update request body model.
         /// When the resource model is output-only (e.g., a ProxyResource with a separate create body),
         /// its properties may be marked readOnly even though the create body accepts them as input.
@@ -90,8 +95,8 @@ namespace Azure.Generator.Provisioning.Providers
         /// <inheritdoc/>
         ProvisioningPropertyInfo? IProvisioningPropertyInfo.GetProvisioningPropertyInfo(InputModelProperty inputProp)
         {
-            var propInfo = _allProperties.FirstOrDefault(p => p.Property == inputProp);
-            if (propInfo == null) return null;
+            if (!_propertyLookup.TryGetValue(inputProp, out var propInfo))
+                return null;
             return new ProvisioningPropertyInfo(
                 propInfo.PropertyName,
                 propInfo.IsOutput,
@@ -114,6 +119,7 @@ namespace Azure.Generator.Provisioning.Providers
                 : null;
             _createBodyWritableProperties = BuildCreateBodyWritableProperties();
             _allProperties = CollectAllProperties();
+            _propertyLookup = _allProperties.ToDictionary(p => p.Property);
         }
 
         /// <summary>
@@ -127,6 +133,7 @@ namespace Azure.Generator.Provisioning.Providers
             _defaultApiVersion = null;
             _createBodyWritableProperties = [];
             _allProperties = CollectAllProperties();
+            _propertyLookup = _allProperties.ToDictionary(p => p.Property);
         }
 
         public override void Reset()

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -40,7 +40,7 @@ namespace Azure.Generator.Provisioning.Providers
             "id", "systemData", "type"
         };
 
-        // System properties that should always be required
+        // System properties that should always be required, even when marked readOnly (path parameters)
         private static readonly HashSet<string> RequiredInputProperties = new(StringComparer.OrdinalIgnoreCase)
         {
             "name", "location"
@@ -371,14 +371,22 @@ namespace Azure.Generator.Provisioning.Providers
             var result = new List<ResourcePropertyInfo>();
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            // Collect from the resource model and its base chain
-            CollectPropertiesFromModel(_inputModel, result, seen, basePath: null);
-
+            // Collect from the base chain first (top-most ancestor → immediate base),
+            // then from the resource model itself. This ensures inherited ARM common
+            // properties (name, location, tags) appear before leaf-defined properties
+            // (e.g., the "properties" bag), which controls the Bicep emission order.
+            var chain = new Stack<InputModelType>();
+            chain.Push(_inputModel);
             var baseModel = _inputModel.BaseModel;
             while (baseModel != null)
             {
-                CollectPropertiesFromModel(baseModel, result, seen, basePath: null);
+                chain.Push(baseModel);
                 baseModel = baseModel.BaseModel;
+            }
+
+            foreach (var model in chain)
+            {
+                CollectPropertiesFromModel(model, result, seen, basePath: null);
             }
 
             return result;

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -438,6 +438,7 @@ namespace Azure.Generator.Provisioning.Providers
                 }
                 // Ensure "location" at the resource level always uses AzureLocation,
                 // even when the TypeSpec defines it as plain string.
+                // TODO - this is currently a workaround until we have a more reliable way to detect such violations from the spec level.
                 CSharpType? typeOverride = null;
                 if (basePath is null
                     && string.Equals(serializedName, "location", StringComparison.OrdinalIgnoreCase))

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/Providers/ProvisioningResourceProvider.cs
@@ -43,7 +43,7 @@ namespace Azure.Generator.Provisioning.Providers
         // System properties that should always be required, even when marked readOnly (path parameters)
         private static readonly HashSet<string> RequiredInputProperties = new(StringComparer.OrdinalIgnoreCase)
         {
-            "name", "location"
+            "name"
         };
 
         // Properties to skip entirely (type is implied by the resource type)

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
@@ -218,6 +218,16 @@ namespace Azure.Generator.Provisioning
                 var resolvedName = baseProperty?.Name ?? info.PropertyName;
                 var bicepType = CreateCSharpType(inputModelProperty.Type);
                 if (bicepType == null) return null;
+
+                // Ensure "location" properties always use BicepValue<AzureLocation>,
+                // even when the TypeSpec defines them as plain string.
+                var serializedName = inputModelProperty.SerializedName ?? inputModelProperty.Name;
+                if (string.Equals(serializedName, "location", StringComparison.OrdinalIgnoreCase)
+                    && bicepType.Equals(new CSharpType(typeof(BicepValue<>), typeof(string))))
+                {
+                    bicepType = new CSharpType(typeof(BicepValue<>), typeof(Azure.Core.AzureLocation));
+                }
+
                 return ProvisioningPropertyProvider.Create(
                     resolvedName, bicepType,
                     info.IsOutput, info.IsRequired, info.BicepPath, info.DefaultValue,

--- a/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/Azure.Generator.Provisioning/src/ProvisioningTypeFactory.cs
@@ -216,17 +216,8 @@ namespace Azure.Generator.Provisioning
                 var info = infoProvider.GetProvisioningPropertyInfo(inputModelProperty);
                 if (info == null) return null;
                 var resolvedName = baseProperty?.Name ?? info.PropertyName;
-                var bicepType = CreateCSharpType(inputModelProperty.Type);
+                var bicepType = info.TypeOverride ?? CreateCSharpType(inputModelProperty.Type);
                 if (bicepType == null) return null;
-
-                // Ensure "location" properties always use BicepValue<AzureLocation>,
-                // even when the TypeSpec defines them as plain string.
-                var serializedName = inputModelProperty.SerializedName ?? inputModelProperty.Name;
-                if (string.Equals(serializedName, "location", StringComparison.OrdinalIgnoreCase)
-                    && bicepType.Equals(new CSharpType(typeof(BicepValue<>), typeof(string))))
-                {
-                    bicepType = new CSharpType(typeof(BicepValue<>), typeof(Azure.Core.AzureLocation));
-                }
 
                 return ProvisioningPropertyProvider.Create(
                     resolvedName, bicepType,

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/ConfigurationStore.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/ConfigurationStore.cs
@@ -21,13 +21,13 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
     /// <summary> A configuration store. </summary>
     public partial class ConfigurationStore : ProvisionableResource
     {
-        private ConfigurationStoreProperties _properties;
+        private BicepValue<ResourceIdentifier> _id;
         private BicepValue<string> _name;
-        private BicepValue<string> _eTag;
+        private SystemData _systemData;
         private BicepDictionary<string> _tags;
         private BicepValue<AzureLocation> _location;
-        private BicepValue<ResourceIdentifier> _id;
-        private SystemData _systemData;
+        private ConfigurationStoreProperties _properties;
+        private BicepValue<string> _eTag;
 
         /// <summary> Creates a new ConfigurationStore. </summary>
         /// <param name="bicepIdentifier"> The bicep identifier name. </param>
@@ -36,18 +36,13 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         {
         }
 
-        /// <summary> Gets or sets the Properties. </summary>
-        public ConfigurationStoreProperties Properties
+        /// <summary> Gets the Id. </summary>
+        public BicepValue<ResourceIdentifier> Id
         {
             get
             {
                 Initialize();
-                return _properties;
-            }
-            set
-            {
-                Initialize();
-                AssignOrReplace(ref _properties, value);
+                return _id;
             }
         }
 
@@ -66,13 +61,13 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             }
         }
 
-        /// <summary> Gets the ETag. </summary>
-        public BicepValue<string> ETag
+        /// <summary> Gets the SystemData. </summary>
+        public SystemData SystemData
         {
             get
             {
                 Initialize();
-                return _eTag;
+                return _systemData;
             }
         }
 
@@ -106,23 +101,28 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             }
         }
 
-        /// <summary> Gets the Id. </summary>
-        public BicepValue<ResourceIdentifier> Id
+        /// <summary> Gets or sets the Properties. </summary>
+        public ConfigurationStoreProperties Properties
         {
             get
             {
                 Initialize();
-                return _id;
+                return _properties;
+            }
+            set
+            {
+                Initialize();
+                AssignOrReplace(ref _properties, value);
             }
         }
 
-        /// <summary> Gets the SystemData. </summary>
-        public SystemData SystemData
+        /// <summary> Gets the ETag. </summary>
+        public BicepValue<string> ETag
         {
             get
             {
                 Initialize();
-                return _systemData;
+                return _eTag;
             }
         }
 
@@ -130,13 +130,13 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         protected override void DefineProvisionableProperties()
         {
             base.DefineProvisionableProperties();
-            _properties = DefineModelProperty<ConfigurationStoreProperties>(nameof(Properties), new string[] { "properties" });
+            _id = DefineProperty<ResourceIdentifier>(nameof(Id), new string[] { "id" }, isOutput: true);
             _name = DefineProperty<string>(nameof(Name), new string[] { "name" }, isRequired: true);
-            _eTag = DefineProperty<string>(nameof(ETag), new string[] { "eTag" }, isOutput: true);
+            _systemData = DefineModelProperty<SystemData>(nameof(SystemData), new string[] { "systemData" }, isOutput: true);
             _tags = DefineDictionaryProperty<string>(nameof(Tags), new string[] { "tags" });
             _location = DefineProperty<AzureLocation>(nameof(Location), new string[] { "location" }, isRequired: true);
-            _id = DefineProperty<ResourceIdentifier>(nameof(Id), new string[] { "id" }, isOutput: true);
-            _systemData = DefineModelProperty<SystemData>(nameof(SystemData), new string[] { "systemData" }, isOutput: true);
+            _properties = DefineModelProperty<ConfigurationStoreProperties>(nameof(Properties), new string[] { "properties" });
+            _eTag = DefineProperty<string>(nameof(ETag), new string[] { "eTag" }, isOutput: true);
             DefineAdditionalProperties();
         }
 

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Item.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/Item.cs
@@ -17,11 +17,11 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
     /// <summary> An item in a configuration store. </summary>
     public partial class Item : ProvisionableResource
     {
-        private ItemProperties _properties;
-        private BicepValue<string> _name;
-        private BicepDictionary<string> _tags;
         private BicepValue<ResourceIdentifier> _id;
+        private BicepValue<string> _name;
         private SystemData _systemData;
+        private ItemProperties _properties;
+        private BicepDictionary<string> _tags;
         private ResourceReference<ConfigurationStore> _parent;
 
         /// <summary> Creates a new Item. </summary>
@@ -31,18 +31,13 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         {
         }
 
-        /// <summary> Gets or sets the Properties. </summary>
-        internal ItemProperties Properties
+        /// <summary> Gets the Id. </summary>
+        public BicepValue<ResourceIdentifier> Id
         {
             get
             {
                 Initialize();
-                return _properties;
-            }
-            set
-            {
-                Initialize();
-                AssignOrReplace(ref _properties, value);
+                return _id;
             }
         }
 
@@ -61,6 +56,31 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             }
         }
 
+        /// <summary> Gets the SystemData. </summary>
+        public SystemData SystemData
+        {
+            get
+            {
+                Initialize();
+                return _systemData;
+            }
+        }
+
+        /// <summary> Gets or sets the Properties. </summary>
+        internal ItemProperties Properties
+        {
+            get
+            {
+                Initialize();
+                return _properties;
+            }
+            set
+            {
+                Initialize();
+                AssignOrReplace(ref _properties, value);
+            }
+        }
+
         /// <summary> Gets or sets the Tags. </summary>
         public BicepDictionary<string> Tags
         {
@@ -73,26 +93,6 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             {
                 Initialize();
                 _tags.Assign(value);
-            }
-        }
-
-        /// <summary> Gets the Id. </summary>
-        public BicepValue<ResourceIdentifier> Id
-        {
-            get
-            {
-                Initialize();
-                return _id;
-            }
-        }
-
-        /// <summary> Gets the SystemData. </summary>
-        public SystemData SystemData
-        {
-            get
-            {
-                Initialize();
-                return _systemData;
             }
         }
 
@@ -166,11 +166,11 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         protected override void DefineProvisionableProperties()
         {
             base.DefineProvisionableProperties();
-            _properties = DefineModelProperty<ItemProperties>(nameof(Properties), new string[] { "properties" });
-            _name = DefineProperty<string>(nameof(Name), new string[] { "name" }, isRequired: true);
-            _tags = DefineDictionaryProperty<string>(nameof(Tags), new string[] { "tags" });
             _id = DefineProperty<ResourceIdentifier>(nameof(Id), new string[] { "id" }, isOutput: true);
+            _name = DefineProperty<string>(nameof(Name), new string[] { "name" }, isRequired: true);
             _systemData = DefineModelProperty<SystemData>(nameof(SystemData), new string[] { "systemData" }, isOutput: true);
+            _properties = DefineModelProperty<ItemProperties>(nameof(Properties), new string[] { "properties" });
+            _tags = DefineDictionaryProperty<string>(nameof(Tags), new string[] { "tags" });
             _parent = DefineResource<ConfigurationStore>("Parent", new string[] { "parent" }, isRequired: true);
             DefineAdditionalProperties();
         }

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/KeyValue.cs
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/src/Generated/KeyValue.cs
@@ -17,10 +17,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
     /// <summary> A key-value pair in a configuration store. </summary>
     public partial class KeyValue : ProvisionableResource
     {
-        private KeyValueProperties _properties;
-        private BicepValue<string> _name;
         private BicepValue<ResourceIdentifier> _id;
+        private BicepValue<string> _name;
         private SystemData _systemData;
+        private KeyValueProperties _properties;
         private ResourceReference<ConfigurationStore> _parent;
 
         /// <summary> Creates a new KeyValue. </summary>
@@ -30,18 +30,13 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         {
         }
 
-        /// <summary> Gets or sets the Properties. </summary>
-        public KeyValueProperties Properties
+        /// <summary> Gets the Id. </summary>
+        public BicepValue<ResourceIdentifier> Id
         {
             get
             {
                 Initialize();
-                return _properties;
-            }
-            set
-            {
-                Initialize();
-                AssignOrReplace(ref _properties, value);
+                return _id;
             }
         }
 
@@ -60,16 +55,6 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             }
         }
 
-        /// <summary> Gets the Id. </summary>
-        public BicepValue<ResourceIdentifier> Id
-        {
-            get
-            {
-                Initialize();
-                return _id;
-            }
-        }
-
         /// <summary> Gets the SystemData. </summary>
         public SystemData SystemData
         {
@@ -77,6 +62,21 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
             {
                 Initialize();
                 return _systemData;
+            }
+        }
+
+        /// <summary> Gets or sets the Properties. </summary>
+        public KeyValueProperties Properties
+        {
+            get
+            {
+                Initialize();
+                return _properties;
+            }
+            set
+            {
+                Initialize();
+                AssignOrReplace(ref _properties, value);
             }
         }
 
@@ -99,10 +99,10 @@ namespace Azure.Provisioning.ProvisioningTypeSpec
         protected override void DefineProvisionableProperties()
         {
             base.DefineProvisionableProperties();
-            _properties = DefineModelProperty<KeyValueProperties>(nameof(Properties), new string[] { "properties" });
-            _name = DefineProperty<string>(nameof(Name), new string[] { "name" }, isRequired: true);
             _id = DefineProperty<ResourceIdentifier>(nameof(Id), new string[] { "id" }, isOutput: true);
+            _name = DefineProperty<string>(nameof(Name), new string[] { "name" }, isRequired: true);
             _systemData = DefineModelProperty<SystemData>(nameof(SystemData), new string[] { "systemData" }, isOutput: true);
+            _properties = DefineModelProperty<KeyValueProperties>(nameof(Properties), new string[] { "properties" });
             _parent = DefineResource<ConfigurationStore>("Parent", new string[] { "parent" }, isRequired: true);
             DefineAdditionalProperties();
         }


### PR DESCRIPTION
## Description

Fixes #57489 and #57488

### Property ordering (#57489)

The provisioning generator was collecting properties from the leaf model first, then walking up the base chain. This caused the `properties` bag to appear before `name`/`location` in the generated `DefineProvisionableProperties()` method, which in turn caused Bicep output to emit `properties:` before `name:` — breaking conventional ARM Bicep ordering.

**Fix:** Reversed the property collection order in `CollectAllProperties()` using a `Stack` so that base model properties (`name`, `location`, `tags` from `TrackedResource`/`Resource`) are collected before leaf-defined properties (e.g., the `properties` bag).

### Child resource location (#57488)

The `location` property was unconditionally forced as required via `RequiredInputProperties`, even for child/proxy resources where the TypeSpec marks it as `@visibility(Lifecycle.Read)` (read-only). This caused spurious `location: location` to appear in Bicep output for child resources like `KeyVaultSecret`.

**Fix:** Removed `location` from `RequiredInputProperties`. For tracked resources, `location` is already `optional=false`/`readOnly=false` in the TypeSpec model, so it remains required naturally. For child resources with read-only location, it now correctly becomes output-only.

Also added a `TypeOverride` mechanism in `ProvisioningPropertyInfo` to ensure resource-level `location` properties always use `BicepValue<AzureLocation>` even when the TypeSpec defines them as plain `string`.

### Minor improvements

- Used `Dictionary<InputModelProperty, ResourcePropertyInfo>` for O(1) property lookup in `GetProvisioningPropertyInfo` instead of linear scan.