### PR TITLE
[CODEOWNERS] Fix linter errors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1053,9 +1053,6 @@
 # ServiceLabel: %Monitor
 # ServiceOwners:                                                   @thomasp98296
 
-# PRLabel: %Neon Postgres
-/sdk/neonpostgres/Azure.ResourceManager.*/                         @ArcturusZhang @ArthurMa1978
-
 # PRLabel: %NetApp Files
 /sdk/netapp/Azure.ResourceManager.*/                               @audunn @Azure/azure-sdk-write-netappfiles
 


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the owner registration for a path that has been retired.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6068628&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_