### PR TITLE
Fix QueueMetricsProvider: preserve ApproximateMessagesCount when PeekMessages fails

### DIFF
--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
@@ -97,14 +97,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
                             queueLength = 0;
                         }
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
                         // If PeekMessages fails (e.g. message encoding mismatch, non-XML-compatible
                         // message body), preserve the ApproximateMessagesCount from GetProperties.
                         // The queue has messages — we just can't peek them. Resetting queueLength
                         // to 0 here would cause the scaler to report no work and prevent scale-out.
-                        _logger.LogFunctionScaleWarning("Error peeking queue messages for scale status. " +
-                            "ApproximateMessagesCount will be used as queue length.", _functionId, ex);
                     }
                 }
             }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
@@ -80,19 +80,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
                 if (queueLength > 0)
                 {
-                    PeekedMessage message = (await _queue.PeekMessagesAsync(1).ConfigureAwait(false)).Value.FirstOrDefault();
-                    if (message != null)
+                    try
                     {
-                        if (message.InsertedOn.HasValue)
+                        PeekedMessage message = (await _queue.PeekMessagesAsync(1).ConfigureAwait(false)).Value.FirstOrDefault();
+                        if (message != null)
                         {
-                            queueTime = DateTime.UtcNow.Subtract(message.InsertedOn.Value.DateTime);
+                            if (message.InsertedOn.HasValue)
+                            {
+                                queueTime = DateTime.UtcNow.Subtract(message.InsertedOn.Value.DateTime);
+                            }
+                        }
+                        else
+                        {
+                            // ApproximateMessageCount often returns a stale value,
+                            // especially when the queue is empty.
+                            queueLength = 0;
                         }
                     }
-                    else
+                    catch (Exception ex)
                     {
-                        // ApproximateMessageCount often returns a stale value,
-                        // especially when the queue is empty.
-                        queueLength = 0;
+                        // If PeekMessages fails (e.g. message encoding mismatch, non-XML-compatible
+                        // message body), preserve the ApproximateMessagesCount from GetProperties.
+                        // The queue has messages — we just can't peek them. Resetting queueLength
+                        // to 0 here would cause the scaler to report no work and prevent scale-out.
+                        _logger.LogFunctionScaleWarning("Error peeking queue messages for scale status. " +
+                            "ApproximateMessagesCount will be used as queue length.", _functionId, ex);
                     }
                 }
             }

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Common/src/Shared/Queues/QueueMetricsProvider.cs
@@ -80,30 +80,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners
 
                 if (queueLength > 0)
                 {
-                    try
+                    PeekedMessage message = (await _queue.PeekMessagesAsync(1).ConfigureAwait(false)).Value.FirstOrDefault();
+                    if (message != null && message.InsertedOn.HasValue)
                     {
-                        PeekedMessage message = (await _queue.PeekMessagesAsync(1).ConfigureAwait(false)).Value.FirstOrDefault();
-                        if (message != null)
-                        {
-                            if (message.InsertedOn.HasValue)
-                            {
-                                queueTime = DateTime.UtcNow.Subtract(message.InsertedOn.Value.DateTime);
-                            }
-                        }
-                        else
-                        {
-                            // ApproximateMessageCount often returns a stale value,
-                            // especially when the queue is empty.
-                            queueLength = 0;
-                        }
+                        queueTime = DateTime.UtcNow.Subtract(message.InsertedOn.Value.DateTime);
                     }
-                    catch (Exception)
-                    {
-                        // If PeekMessages fails (e.g. message encoding mismatch, non-XML-compatible
-                        // message body), preserve the ApproximateMessagesCount from GetProperties.
-                        // The queue has messages — we just can't peek them. Resetting queueLength
-                        // to 0 here would cause the scaler to report no work and prevent scale-out.
-                    }
+                    // If peek returns null (e.g. message encoding mismatch where
+                    // MessageDecodingFailed handler silently filters out un-decodable
+                    // messages), we preserve ApproximateMessagesCount as the queue length.
+                    // Trade-off: ApproximateMessagesCount may briefly be stale after
+                    // a queue is fully drained, causing a transient over-count for one
+                    // poll cycle (~10s). This is preferable to the previous behavior
+                    // which permanently reported QueueLength=0 when messages existed
+                    // but couldn't be peeked.
                 }
             }
             catch (RequestFailedException ex)

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fix QueueMetricsProvider: preserve ApproximateMessagesCount when PeekMessages fails
+
 ### Other Changes
 
 - Replaced scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics.

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Azure;
 using Azure.Core.TestFramework;
 using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Listeners;
 using Microsoft.Azure.WebJobs.Extensions.Storage.Common.Tests;
 using Microsoft.Extensions.DependencyInjection;
@@ -99,6 +100,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
 
             var warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
             Assert.AreEqual("Error querying for queue scale status: Things are very wrong.", warning.FormattedMessage);
+        }
+
+        [Test]
+        public async Task GetMetrics_PeekFailure_PreservesApproximateMessageCount()
+        {
+            // Simulate: GetProperties returns 5 messages, but PeekMessages throws
+            // (e.g. message encoding mismatch, non-XML-compatible body).
+            // The queue length should be preserved as 5, not reset to 0.
+            var queueProperties = new QueueProperties();
+            typeof(QueueProperties).GetProperty(nameof(QueueProperties.ApproximateMessagesCount))
+                .SetValue(queueProperties, 5);
+
+            _mockQueue.Setup(p => p.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Response.FromValue(queueProperties, Mock.Of<Response>())));
+
+            _mockQueue.Setup(p => p.PeekMessagesAsync(
+                It.IsAny<int?>(),
+                It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new FormatException("The input is not a valid Base-64 string"));
+
+            var metrics = await _metricsProvider.GetMetricsAsync();
+
+            Assert.AreEqual(5, metrics.QueueLength);
+            Assert.AreEqual(TimeSpan.Zero, metrics.QueueTime);
+
+            var warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
+            Assert.That(warning.FormattedMessage, Does.Contain("Error peeking queue messages"));
         }
 
         public class TestFixture : IDisposable

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -108,9 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
             // Simulate: GetProperties returns 5 messages, but PeekMessages throws
             // (e.g. message encoding mismatch, non-XML-compatible body).
             // The queue length should be preserved as 5, not reset to 0.
-            var queueProperties = new QueueProperties();
-            typeof(QueueProperties).GetProperty(nameof(QueueProperties.ApproximateMessagesCount))
-                .SetValue(queueProperties, 5);
+            var queueProperties = QueuesModelFactory.QueueProperties(metadata: null, approximateMessagesCount: 5);
 
             _mockQueue.Setup(p => p.GetPropertiesAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response.FromValue(queueProperties, Mock.Of<Response>())));
@@ -124,9 +122,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
 
             Assert.AreEqual(5, metrics.QueueLength);
             Assert.AreEqual(TimeSpan.Zero, metrics.QueueTime);
-
-            var warning = _loggerProvider.GetAllLogMessages().Single(p => p.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
-            Assert.That(warning.FormattedMessage, Does.Contain("Error peeking queue messages"));
         }
 
         public class TestFixture : IDisposable

--- a/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
+++ b/sdk/storage/Microsoft.Azure.WebJobs.Extensions.Storage.Queues/tests/QueueMetricsProviderTests.cs
@@ -105,18 +105,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Storage.Queues.Tests
         [Test]
         public async Task GetMetrics_PeekFailure_PreservesApproximateMessageCount()
         {
-            // Simulate: GetProperties returns 5 messages, but PeekMessages throws
-            // (e.g. message encoding mismatch, non-XML-compatible body).
+            // Simulate: GetProperties returns 5 messages, but PeekMessages returns
+            // an empty array (e.g. MessageDecodingFailed handler silently filtered
+            // out un-decodable messages due to encoding mismatch).
             // The queue length should be preserved as 5, not reset to 0.
             var queueProperties = QueuesModelFactory.QueueProperties(metadata: null, approximateMessagesCount: 5);
 
             _mockQueue.Setup(p => p.GetPropertiesAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Response.FromValue(queueProperties, Mock.Of<Response>())));
 
+            // PeekMessages returns empty array (handler swallowed the decode failure)
             _mockQueue.Setup(p => p.PeekMessagesAsync(
                 It.IsAny<int?>(),
                 It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new FormatException("The input is not a valid Base-64 string"));
+                .Returns(Task.FromResult(Response.FromValue(Array.Empty<PeekedMessage>(), Mock.Of<Response>())));
 
             var metrics = await _metricsProvider.GetMetricsAsync();
 


### PR DESCRIPTION
## Summary

Fix `QueueMetricsProvider.GetMetricsAsync()` to preserve `ApproximateMessagesCount` when `PeekMessagesAsync` returns an empty array, instead of silently resetting `QueueLength` to 0.

## Problem

`QueueMetricsProvider` uses `PeekMessagesAsync` as a staleness check for `ApproximateMessagesCount`. If peek returns no messages, it assumes the count is stale and resets `queueLength = 0`. However, this also triggers when messages *exist* but can't be decoded by the SDK.

### How the bug manifests

`QueueServiceClientProvider.CreateClient()` registers a `MessageDecodingFailed` handler on the `QueueClientOptions`. When peek encounters a message that fails Base64 decoding, the SDK's internal `ToPeekedMessagesWithInvalidMessageHandling` catches the `FormatException` and silently filters the message from the results. Peek returns successfully with an empty array, `FirstOrDefault()` returns null, and the `else { queueLength = 0; }` branch fires.

### Known trigger scenarios

| Scenario | Why peek returns null | Effect |
|---|---|---|
| Message encoding mismatch (e.g. plain text sent, Base64 read) | `MessageDecodingFailed` handler filters the message from peek results | `QueueLength = 0` despite messages present |
| Non-XML-compatible message body (e.g. timestamps with colons) | SDK fails to parse response; handler filters it out | `QueueLength = 0` despite messages present |
| Queue truly empty, stale `ApproximateMessagesCount` | Queue is genuinely empty, peek correctly returns empty | `QueueLength = 0` (correct, but addressed by `ApproximateMessagesCount` converging to 0 within ~10s) |

### Why the stale-count correction is wrong

The `else { queueLength = 0; }` was intended for case 3 (stale count on empty queue). But `ApproximateMessagesCount` is self-correcting — it converges to 0 within one poll cycle (~10s). Meanwhile, cases 1 and 2 cause **permanent** under-scaling because the encoding mismatch doesn't resolve itself.

| | Keep `queueLength = 0` (current) | Remove it (this PR) |
|---|---|---|
| Queue truly empty, stale count | Reports 0 immediately | Over-reports for ~10s, then self-corrects |
| Messages exist but unpeekable | **Reports 0 permanently (BUG)** | Correctly reports message count |

## Fix

Remove the `else { queueLength = 0; }` branch entirely. When peek returns null, preserve the `ApproximateMessagesCount` from `GetPropertiesAsync`. Only `queueTime` (message age) is lost when peek can't return a message.

**Impact on scaling signals:**
- **Target-based scaling** (Flex Consumption): No impact. Uses `QueueLength` only, does not use `queueTime`.
- **Incremental scaling** (Consumption/EP): Loses the `queueTime` secondary signal when peek fails. `QueueLength` (primary signal) still drives ScaleOut/ScaleIn decisions correctly.

This code is only used in the scaling path (`QueueScaleMonitor` and `QueueTargetScaler`), not in the listener/message processing path.

## Changes

- **QueueMetricsProvider.cs:** Removed the `else { queueLength = 0; }` branch and the unnecessary inner try-catch. When peek returns null but `ApproximateMessagesCount > 0`, the queue length is preserved.
- **QueueMetricsProviderTests.cs:** Updated test to mock the actual production path: `PeekMessagesAsync` returns an empty array (simulating `MessageDecodingFailed` handler filtering), and asserts `QueueLength == 5` is preserved.
- **CHANGELOG.md:** Added Bugs Fixed entry.

## Compatibility

This is a behavior fix, not a breaking change. Previously, encoding mismatches caused silent permanent under-scaling (`QueueLength=0`). Now, the authoritative `ApproximateMessagesCount` is preserved. The only behavioral change for correct queues is a potential brief over-count (~10s) when a queue transitions from non-empty to empty, which self-corrects on the next `GetPropertiesAsync` poll.