### PR TITLE
fix: typed LRO convenience methods return Operation<T> instead of Operation<BinaryData>

### DIFF
--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/LroVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/LroVisitor.cs
@@ -230,28 +230,8 @@ namespace Azure.Generator.Visitors
                     return null;
                 case KeywordExpression { Keyword: "return", Expression: InvokeMethodExpression { MethodName: "FromValue" } invokeMethodExpression }:
                 {
-                    var response = new VariableExpression(typeof(Response), "response");
-                    var responseType = AzureClientGenerator.Instance.TypeFactory.CreateCSharpType(serviceMethod.Response.Type)!;
-                    var client = (ClientProvider)scmMethod.EnclosingType;
-                    var diagnosticsProperty = client.GetClientDiagnosticProperty();
-                    var scopeName = scmMethod.GetScopeName();
-
-                    // Use FromLroResponse static method instead of explicit operator cast
-                    var responseModel = serviceMethod.Response.Type as InputModelType;
-                    var lroServiceMethod = scmMethod.ServiceMethod as InputLongRunningServiceMethod;
-                    var resultSegment = lroServiceMethod?.LongRunningServiceMetadata.ResultPath;
-
-                    ValueExpression conversionExpression;
-                    if (!string.IsNullOrEmpty(resultSegment) && responseModel != null)
-                    {
-                        // Call the FromLroResponse static method
-                        conversionExpression = Static(responseType).Invoke(FromLroResponseMethodName, [response]);
-                    }
-                    else
-                    {
-                        // Fall back to explicit operator cast for models without result path
-                        conversionExpression = new CastExpression(response, responseType);
-                    }
+                    var (conversionExpression, response, diagnosticsProperty, scopeName) =
+                        BuildConvertCallComponents(serviceMethod, scmMethod);
 
                     invokeMethodExpression.Update(
                         instanceReference: Static(typeof(ProtocolOperationHelpers)),
@@ -265,9 +245,48 @@ namespace Azure.Generator.Visitors
                         ]);
                     break;
                 }
+                // Wrap typed LRO convenience methods that directly forward to the protocol method.
+                case KeywordExpression { Keyword: "return", Expression: InvokeMethodExpression protocolCallExpression }
+                    when serviceMethod.Response.Type != null:
+                {
+                    var (conversionExpression, response, diagnosticsProperty, scopeName) =
+                        BuildConvertCallComponents(serviceMethod, scmMethod);
+
+                    return new KeywordExpression("return",
+                        Static(typeof(ProtocolOperationHelpers)).Invoke("Convert",
+                        [
+                            protocolCallExpression,
+                            new FuncExpression([response.Declaration], conversionExpression),
+                            diagnosticsProperty,
+                            Literal(scopeName),
+                        ])).Terminate();
+                }
             }
 
             return expressionStatement;
+        }
+
+        /// <summary>
+        /// Builds the components for a <see cref="ProtocolOperationHelpers.Convert"/> call.
+        /// </summary>
+        private static (ValueExpression ConversionExpression, VariableExpression Response, PropertyProvider DiagnosticsProperty, string ScopeName)
+            BuildConvertCallComponents(InputServiceMethod serviceMethod, ScmMethodProvider scmMethod)
+        {
+            var response = new VariableExpression(typeof(Response), "response");
+            var responseType = AzureClientGenerator.Instance.TypeFactory.CreateCSharpType(serviceMethod.Response.Type!)!;
+            var client = (ClientProvider)scmMethod.EnclosingType;
+            var diagnosticsProperty = client.GetClientDiagnosticProperty();
+            var scopeName = scmMethod.GetScopeName();
+
+            var responseModel = serviceMethod.Response.Type as InputModelType;
+            var lroServiceMethod = scmMethod.ServiceMethod as InputLongRunningServiceMethod;
+            var resultSegment = lroServiceMethod?.LongRunningServiceMetadata.ResultPath;
+
+            ValueExpression conversionExpression = !string.IsNullOrEmpty(resultSegment) && responseModel != null
+                ? Static(responseType).Invoke(FromLroResponseMethodName, [response])
+                : new CastExpression(response, responseType);
+
+            return (conversionExpression, response, diagnosticsProperty, scopeName);
         }
 
         protected override InvokeMethodExpression? VisitInvokeMethodExpression(InvokeMethodExpression expression, MethodProvider method)

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/LroVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/LroVisitor.cs
@@ -151,9 +151,66 @@ namespace Azure.Generator.Visitors
             if (method.IsLroMethod())
             {
                 UpdateMethodSignature(method);
+
+                // Rewrite typed LRO convenience methods that directly forward to the protocol method.
+                if (method.Kind != ScmMethodKind.Protocol && method.ServiceMethod is InputLongRunningServiceMethod
+                    && method.ServiceMethod.Response.Type != null
+                    && !HasFromValueReturn(method))
+                {
+                    RewriteSimpleForwardBody(method);
+                }
             }
 
             return method;
+        }
+
+        private static bool HasFromValueReturn(ScmMethodProvider method)
+        {
+            if (method.BodyStatements is not MethodBodyStatements bodyStatements)
+            {
+                return false;
+            }
+
+            return bodyStatements.Statements.OfType<ExpressionStatement>().Any(s =>
+                s.Expression is KeywordExpression { Keyword: "return", Expression: InvokeMethodExpression { MethodName: "FromValue" } });
+        }
+
+        private static void RewriteSimpleForwardBody(ScmMethodProvider method)
+        {
+            if (method.BodyStatements is not MethodBodyStatements bodyStatements)
+            {
+                return;
+            }
+
+            var serviceMethod = method.ServiceMethod!;
+            var (conversionExpression, response, diagnosticsProperty, scopeName) =
+                BuildConvertCallComponents(serviceMethod, method);
+
+            var resultType = new CSharpType(typeof(Operation<>), typeof(BinaryData));
+            var resultVar = new VariableExpression(resultType, "result");
+
+            var newStatements = new List<MethodBodyStatement>();
+            foreach (var statement in bodyStatements.Statements)
+            {
+                if (statement is ExpressionStatement { Expression: KeywordExpression { Keyword: "return", Expression: InvokeMethodExpression protocolCallExpression } })
+                {
+                    newStatements.Add(Declare(resultVar, protocolCallExpression));
+                    newStatements.Add(new KeywordExpression("return",
+                        Static(typeof(ProtocolOperationHelpers)).Invoke("Convert",
+                        [
+                            resultVar,
+                            new FuncExpression([response.Declaration], conversionExpression),
+                            diagnosticsProperty,
+                            Literal(scopeName),
+                        ])).Terminate());
+                }
+                else
+                {
+                    newStatements.Add(statement);
+                }
+            }
+
+            method.Update(bodyStatements: new MethodBodyStatements(newStatements));
         }
 
         private static void UpdateMethodSignature(ScmMethodProvider method)
@@ -244,22 +301,6 @@ namespace Azure.Generator.Visitors
                             Literal(scopeName),
                         ]);
                     break;
-                }
-                // Wrap typed LRO convenience methods that directly forward to the protocol method.
-                case KeywordExpression { Keyword: "return", Expression: InvokeMethodExpression protocolCallExpression }
-                    when serviceMethod.Response.Type != null:
-                {
-                    var (conversionExpression, response, diagnosticsProperty, scopeName) =
-                        BuildConvertCallComponents(serviceMethod, scmMethod);
-
-                    return new KeywordExpression("return",
-                        Static(typeof(ProtocolOperationHelpers)).Invoke("Convert",
-                        [
-                            protocolCallExpression,
-                            new FuncExpression([response.Declaration], conversionExpression),
-                            diagnosticsProperty,
-                            Literal(scopeName),
-                        ])).Terminate();
                 }
             }
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/LroVisitor.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/src/Visitors/LroVisitor.cs
@@ -151,66 +151,9 @@ namespace Azure.Generator.Visitors
             if (method.IsLroMethod())
             {
                 UpdateMethodSignature(method);
-
-                // Rewrite typed LRO convenience methods that directly forward to the protocol method.
-                if (method.Kind != ScmMethodKind.Protocol && method.ServiceMethod is InputLongRunningServiceMethod
-                    && method.ServiceMethod.Response.Type != null
-                    && !HasFromValueReturn(method))
-                {
-                    RewriteSimpleForwardBody(method);
-                }
             }
 
             return method;
-        }
-
-        private static bool HasFromValueReturn(ScmMethodProvider method)
-        {
-            if (method.BodyStatements is not MethodBodyStatements bodyStatements)
-            {
-                return false;
-            }
-
-            return bodyStatements.Statements.OfType<ExpressionStatement>().Any(s =>
-                s.Expression is KeywordExpression { Keyword: "return", Expression: InvokeMethodExpression { MethodName: "FromValue" } });
-        }
-
-        private static void RewriteSimpleForwardBody(ScmMethodProvider method)
-        {
-            if (method.BodyStatements is not MethodBodyStatements bodyStatements)
-            {
-                return;
-            }
-
-            var serviceMethod = method.ServiceMethod!;
-            var (conversionExpression, response, diagnosticsProperty, scopeName) =
-                BuildConvertCallComponents(serviceMethod, method);
-
-            var resultType = new CSharpType(typeof(Operation<>), typeof(BinaryData));
-            var resultVar = new VariableExpression(resultType, "result");
-
-            var newStatements = new List<MethodBodyStatement>();
-            foreach (var statement in bodyStatements.Statements)
-            {
-                if (statement is ExpressionStatement { Expression: KeywordExpression { Keyword: "return", Expression: InvokeMethodExpression protocolCallExpression } })
-                {
-                    newStatements.Add(Declare(resultVar, protocolCallExpression));
-                    newStatements.Add(new KeywordExpression("return",
-                        Static(typeof(ProtocolOperationHelpers)).Invoke("Convert",
-                        [
-                            resultVar,
-                            new FuncExpression([response.Declaration], conversionExpression),
-                            diagnosticsProperty,
-                            Literal(scopeName),
-                        ])).Terminate());
-                }
-                else
-                {
-                    newStatements.Add(statement);
-                }
-            }
-
-            method.Update(bodyStatements: new MethodBodyStatements(newStatements));
         }
 
         private static void UpdateMethodSignature(ScmMethodProvider method)
@@ -301,6 +244,22 @@ namespace Azure.Generator.Visitors
                             Literal(scopeName),
                         ]);
                     break;
+                }
+                // Wrap typed LRO convenience methods that directly forward to the protocol method.
+                case KeywordExpression { Keyword: "return", Expression: InvokeMethodExpression protocolCallExpression }
+                    when serviceMethod.Response.Type != null:
+                {
+                    var (conversionExpression, response, diagnosticsProperty, scopeName) =
+                        BuildConvertCallComponents(serviceMethod, scmMethod);
+
+                    return new KeywordExpression("return",
+                        Static(typeof(ProtocolOperationHelpers)).Invoke("Convert",
+                        [
+                            protocolCallExpression,
+                            new FuncExpression([response.Declaration], conversionExpression),
+                            diagnosticsProperty,
+                            Literal(scopeName),
+                        ])).Terminate();
                 }
             }
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/LroVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/LroVisitorTests.cs
@@ -350,11 +350,48 @@ namespace Azure.Generator.Tests.Visitors
             var clientProvider = outputLibrary.TypeProviders.OfType<ClientProvider>().FirstOrDefault();
             Assert.IsNotNull(clientProvider);
             var convenienceMethod = clientProvider!.Methods
-                .FirstOrDefault(m => m.Signature.Parameters.All(p => p.Name != "context")
-                    && !m.Signature.Name.EndsWith("Async"));
+                .FirstOrDefault(m => m.Signature.Name == "Foo"
+                    && m.Signature.Parameters.All(p => p.Name != "context"));
 
             Assert.IsNotNull(convenienceMethod);
             var actual = convenienceMethod!.BodyStatements!.ToDisplayString();
+            Assert.AreEqual(Helpers.GetExpectedFromFile(), actual);
+        }
+
+        [Test]
+        public void UpdatesAsyncConvenienceMethodBodyWithResultPath()
+        {
+            var visitor = new TestLroVisitor();
+            List<InputMethodParameter> parameters =
+            [
+                InputFactory.MethodParameter("p1", InputPrimitiveType.String)
+            ];
+            var responseModel = InputFactory.Model("foo");
+            var lro = InputFactory.Operation(
+                "foo",
+                parameters: parameters,
+                responses: [InputFactory.OperationResponse(bodytype: responseModel)]);
+            var lroServiceMethod = InputFactory.LongRunningServiceMethod(
+                "foo",
+                lro, parameters: parameters,
+                response: InputFactory.ServiceMethodResponse(responseModel, ["result"]),
+                longRunningServiceMetadata: InputFactory.LongRunningServiceMetadata(
+                    finalState: 1,
+                    finalResponse: InputFactory.OperationResponse(),
+                    resultPath: "result"));
+            var inputClient = InputFactory.Client("TestClient", methods: [lroServiceMethod]);
+            var plugin = MockHelpers.LoadMockGenerator(clients: () => [inputClient]);
+            var outputLibrary = plugin.Object.OutputLibrary;
+            visitor.InvokeVisitLibrary(outputLibrary);
+
+            var clientProvider = outputLibrary.TypeProviders.OfType<ClientProvider>().FirstOrDefault();
+            Assert.IsNotNull(clientProvider);
+            var asyncConvenienceMethod = clientProvider!.Methods
+                .FirstOrDefault(m => m.Signature.Name == "FooAsync"
+                    && m.Signature.Parameters.All(p => p.Name != "context"));
+
+            Assert.IsNotNull(asyncConvenienceMethod);
+            var actual = asyncConvenienceMethod!.BodyStatements!.ToDisplayString();
             Assert.AreEqual(Helpers.GetExpectedFromFile(), actual);
         }
 

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/LroVisitorTests.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/LroVisitorTests.cs
@@ -322,6 +322,43 @@ namespace Azure.Generator.Tests.Visitors
         }
 
         [Test]
+        public void UpdatesConvenienceMethodBodyWithResultPath()
+        {
+            var visitor = new TestLroVisitor();
+            List<InputMethodParameter> parameters =
+            [
+                InputFactory.MethodParameter("p1", InputPrimitiveType.String)
+            ];
+            var responseModel = InputFactory.Model("foo");
+            var lro = InputFactory.Operation(
+                "foo",
+                parameters: parameters,
+                responses: [InputFactory.OperationResponse(bodytype: responseModel)]);
+            var lroServiceMethod = InputFactory.LongRunningServiceMethod(
+                "foo",
+                lro, parameters: parameters,
+                response: InputFactory.ServiceMethodResponse(responseModel, ["result"]),
+                longRunningServiceMetadata: InputFactory.LongRunningServiceMetadata(
+                    finalState: 1,
+                    finalResponse: InputFactory.OperationResponse(),
+                    resultPath: "result"));
+            var inputClient = InputFactory.Client("TestClient", methods: [lroServiceMethod]);
+            var plugin = MockHelpers.LoadMockGenerator(clients: () => [inputClient]);
+            var outputLibrary = plugin.Object.OutputLibrary;
+            visitor.InvokeVisitLibrary(outputLibrary);
+
+            var clientProvider = outputLibrary.TypeProviders.OfType<ClientProvider>().FirstOrDefault();
+            Assert.IsNotNull(clientProvider);
+            var convenienceMethod = clientProvider!.Methods
+                .FirstOrDefault(m => m.Signature.Parameters.All(p => p.Name != "context")
+                    && !m.Signature.Name.EndsWith("Async"));
+
+            Assert.IsNotNull(convenienceMethod);
+            var actual = convenienceMethod!.BodyStatements!.ToDisplayString();
+            Assert.AreEqual(Helpers.GetExpectedFromFile(), actual);
+        }
+
+        [Test]
         public void UpdatesProtocolMethodBody()
         {
             var visitor = new TestLroVisitor();

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesAsyncConvenienceMethodBodyWithResultPath.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesAsyncConvenienceMethodBodyWithResultPath.cs
@@ -1,0 +1,3 @@
+﻿using global::Azure.Core.RequestContent content = global::Azure.Core.RequestContent.Create(global::System.BinaryData.FromString(p1));
+global::Azure.Operation<global::System.BinaryData> result = await this.FooAsync(waitUntil, content, cancellationToken.ToRequestContext()).ConfigureAwait(false);
+return global::Azure.Core.ProtocolOperationHelpers.Convert(result, response => global::Samples.Models.Foo.FromLroResponse(response), ClientDiagnostics, "TestClient.FooAsync");

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesConvenienceMethodBody.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesConvenienceMethodBody.cs
@@ -1,2 +1,2 @@
 ﻿using global::Azure.Core.RequestContent content = global::Azure.Core.RequestContent.Create(global::System.BinaryData.FromString(p1));
-return this.Foo(waitUntil, content, cancellationToken.ToRequestContext());
+return global::Azure.Core.ProtocolOperationHelpers.Convert(this.Foo(waitUntil, content, cancellationToken.ToRequestContext()), response => ((global::Samples.Models.Foo)response), ClientDiagnostics, "TestClient.Foo");

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesConvenienceMethodBody.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesConvenienceMethodBody.cs
@@ -1,3 +1,2 @@
 ﻿using global::Azure.Core.RequestContent content = global::Azure.Core.RequestContent.Create(global::System.BinaryData.FromString(p1));
-global::Azure.Operation<global::System.BinaryData> result = this.Foo(waitUntil, content, cancellationToken.ToRequestContext());
-return global::Azure.Core.ProtocolOperationHelpers.Convert(result, response => ((global::Samples.Models.Foo)response), ClientDiagnostics, "TestClient.Foo");
+return global::Azure.Core.ProtocolOperationHelpers.Convert(this.Foo(waitUntil, content, cancellationToken.ToRequestContext()), response => ((global::Samples.Models.Foo)response), ClientDiagnostics, "TestClient.Foo");

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesConvenienceMethodBody.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesConvenienceMethodBody.cs
@@ -1,2 +1,3 @@
 ﻿using global::Azure.Core.RequestContent content = global::Azure.Core.RequestContent.Create(global::System.BinaryData.FromString(p1));
-return global::Azure.Core.ProtocolOperationHelpers.Convert(this.Foo(waitUntil, content, cancellationToken.ToRequestContext()), response => ((global::Samples.Models.Foo)response), ClientDiagnostics, "TestClient.Foo");
+global::Azure.Operation<global::System.BinaryData> result = this.Foo(waitUntil, content, cancellationToken.ToRequestContext());
+return global::Azure.Core.ProtocolOperationHelpers.Convert(result, response => ((global::Samples.Models.Foo)response), ClientDiagnostics, "TestClient.Foo");

--- a/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesConvenienceMethodBodyWithResultPath.cs
+++ b/eng/packages/http-client-csharp/generator/Azure.Generator/test/Visitors/TestData/LroVisitorTests/UpdatesConvenienceMethodBodyWithResultPath.cs
@@ -1,0 +1,3 @@
+﻿using global::Azure.Core.RequestContent content = global::Azure.Core.RequestContent.Create(global::System.BinaryData.FromString(p1));
+global::Azure.Operation<global::System.BinaryData> result = this.Foo(waitUntil, content, cancellationToken.ToRequestContext());
+return global::Azure.Core.ProtocolOperationHelpers.Convert(result, response => global::Samples.Models.Foo.FromLroResponse(response), ClientDiagnostics, "TestClient.Foo");


### PR DESCRIPTION
## Bug

Typed LRO convenience methods (e.g. \Train\, \CancelTrainingJob\, \EvaluateModel\) generated \Operation<T>\ in their return type but their body just forwarded to the protocol method returning \Operation<BinaryData>\, causing **CS0029 compile errors**.

This affected LRO operations where the initial HTTP response has no body (e.g. 202 Accepted) but the LRO has a typed polling result via \@pollingOperation\.

## Root Cause

\LroVisitor.UpdateConvenienceMethod()\ handled two body patterns:
1. \AssignmentExpression\ with \FromValue\ return — wrapped with \ProtocolOperationHelpers.Convert\
2. Simple forward when **no** typed result — passed through (correct for \Operation\)

But it missed:
3. Simple forward when there **is** a typed result — the body wasn't transformed

## Fix

- Added a new case in \UpdateConvenienceMethod\ to wrap the protocol call with \ProtocolOperationHelpers.Convert\ for typed LRO methods that use the simple forward pattern.
- Extracted shared conversion logic into \BuildConvertCallComponents()\ to eliminate duplication between the existing \FromValue\ case and the new case.
- Added test \UpdatesConvenienceMethodBodyWithResultPath\ covering the \FromLroResponse\ code path.
- Updated existing test expected output for \UpdatesConvenienceMethodBody\.

## Test Results

All 8 LroVisitor tests pass (7 existing + 1 new). Full suite: 189 passed, 0 new failures.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/57557