### PR TITLE
Documentation updates for ClientCertificateCredential Platform Certificate Store support

### DIFF
--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -231,7 +231,7 @@ Not all credentials require this configuration. Credentials that authenticate th
 |-|-
 |`AZURE_CLIENT_ID`|ID of a Microsoft Entra application
 |`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
-|`AZURE_CLIENT_CERTIFICATE_PATH`|path to a PFX or PEM-encoded certificate file including private key
+|`AZURE_CLIENT_CERTIFICATE_PATH`|Path to the client certificate, including the private key. The path must be to either a "pfx"- or "pem"-encoded certificate on disk, or a certifcate in the platform certificate store by thumbprint.<br>For example:<ul><li>`c:\data\certificate.pfx`</li><li>`/etc/app/cert.pem`</li><li>`cert:/CurrentUser/My/E661583E8FABEF4C0BEF694CBC41C28FB81CD870`</li></ul>
 |`AZURE_CLIENT_CERTIFICATE_PASSWORD`|(optional) the password protecting the certificate file (currently only supported for PFX (PKCS12) certificates)
 |`AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`|(optional) send certificate chain in x5c header to support subject name / issuer based authentication
 

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -231,7 +231,7 @@ Not all credentials require this configuration. Credentials that authenticate th
 |-|-
 |`AZURE_CLIENT_ID`|ID of a Microsoft Entra application
 |`AZURE_TENANT_ID`|ID of the application's Microsoft Entra tenant
-|`AZURE_CLIENT_CERTIFICATE_PATH`|Path to the client certificate, including the private key. The path must be to either a "pfx"- or "pem"-encoded certificate on disk, or a certifcate in the platform certificate store by thumbprint.<br>For example:<ul><li>`c:\data\certificate.pfx`</li><li>`/etc/app/cert.pem`</li><li>`cert:/CurrentUser/My/E661583E8FABEF4C0BEF694CBC41C28FB81CD870`</li></ul>
+|`AZURE_CLIENT_CERTIFICATE_PATH`|Path to the client certificate, including the private key. The path must be to either a "pfx"- or "pem"-encoded certificate on disk, or a certificate in the platform certificate store by thumbprint.<br>For example:<ul><li>`c:\data\certificate.pfx`</li><li>`/etc/app/cert.pem`</li><li>`cert:/CurrentUser/My/E661583E8FABEF4C0BEF694CBC41C28FB81CD870`</li></ul>
 |`AZURE_CLIENT_CERTIFICATE_PASSWORD`|(optional) the password protecting the certificate file (currently only supported for PFX (PKCS12) certificates)
 |`AZURE_CLIENT_SEND_CERTIFICATE_CHAIN`|(optional) send certificate chain in x5c header to support subject name / issuer based authentication
 

--- a/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
+++ b/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
@@ -22,7 +22,7 @@ var credential = new ClientCertificateCredential(tenantId, clientId, certificate
 
 ## Loading certificates from an X509Store
 
-Applications running on platforms which provide a secure certificate store, such as the Windows Certificate Store on Windows, and the KeyChain on MacOS, might prefer to store and retrieve certificates from there.
+Applications running on platforms which provide a secure certificate store, such as the Windows Certificate Store on Windows, and the KeyChain on macOS, might prefer to store and retrieve certificates from there.
 
 `ClientCertificateCredential` supports locating certificates by thumbrprint via a certificate path:
 ```C# Snippet:Identity_CertificateCredential_CreateWithPath_Store

--- a/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
+++ b/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
@@ -1,18 +1,20 @@
 # Using the ClientCertificateCredential
 
-Applications which execute in a protected environment can authenticate using a client assertion signed by a private key whose public key or root certificate is registered with Microsoft Entra ID. The Azure.Identity library provides the `ClientCertificateCredential` for applications choosing to authenticate this way. Below are some examples of how applications can utilize the `ClientCertificateCredential` to authenticate clients.
+Applications which execute in a protected environment can authenticate using a client assertion signed by a private key whose public key or root certificate is registered with Microsoft Entra ID. The Azure.Identity library provides the [`ClientCertificateCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.clientcertificatecredential) for applications choosing to authenticate this way. Below are some examples of how applications can utilize `ClientCertificateCredential` to authenticate clients.
 
+`ClientCertificateCredential` can also be used via [`EnvironmentCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.environmentcredential), or [`DefaultAzureCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) - see [README#credential-classes](../README.md#credential-classes).
 
 ## Loading certificates from disk
 
-Applications commonly need to load a client certificate from disk. One approach is for the application to construct the `ClientCertificateCredential` by specifying the applications tenant id, client id, and the path to the certificate.
+Applications commonly need to load a client certificate from disk. One approach is for the application to construct the `ClientCertificateCredential` by specifying the applications tenant id, client id, and filesystem path to the certificate.
 
-```C# Snippet:Identity_CertificateCredenetial_CreateWithPath
+```C# Snippet:Identity_CertificateCredential_CreateWithPath_File
 var credential = new ClientCertificateCredential(tenantId, clientId, "./certs/cert.pfx");
 ```
-Alternatively, the application can construct the `X509Certificate2` themselves, such as in the following example, where the certificate key is password protected.
 
-```C# Snippet:Identity_CertificateCredenetial_CreateWithX509Cert
+Alternatively, the application can construct the [`X509Certificate2`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.x509certificate2) themselves, such as in the following example, where the certificate key is password protected.
+
+```C# Snippet:Identity_CertificateCredential_CreateWithX509Cert
 var certificate = new X509Certificate2("./certs/cert-password-protected.pfx", "password");
 
 var credential = new ClientCertificateCredential(tenantId, clientId, certificate);
@@ -20,19 +22,33 @@ var credential = new ClientCertificateCredential(tenantId, clientId, certificate
 
 ## Loading certificates from an X509Store
 
-Applications running on platforms which provide a secure certificate store might prefer to store and retrieve certificates from there. While the `ClientCertificateCredential` doesn't directly provide a mechanism for this, the application can retrieve the appropriate certificate from the store and use it to construct the `ClientCertificateCredential`.
+Applications running on platforms which provide a secure certificate store, such as the Windows Certificate Store on Windows, and the KeyChain on MacOS, might prefer to store and retrieve certificates from there.
 
-Consider the scenario where a pinned certificate used for development authentication is stored in the Personal certificate store. Since the certificate is pinned it can be identified by its thumbprint, which the application might read from configuration or the environment.
+`ClientCertificateCredential` supports locating certificates by thumbrprint via a certificate path:
+```C# Snippet:Identity_CertificateCredential_CreateWithPath_Store
+var credential = new ClientCertificateCredential(tenantId, clientId, "cert:/CurrentUser/My/E661583E8FABEF4C0BEF694CBC41C28FB81CD870");
+```
 
-```C# Snippet:Identity_CertificateCredenetial_CreateFromStore
+Alternatively, the application can retrieve the certificate from the store itself and use it to construct the `ClientCertificateCredential`.
+
+For example, loading the newest certificate with a certain friendly name from Local Computer\Personal certificate store (`certlm.msc` on Windows):
+
+```C# Snippet:Identity_CertificateCredential_CreateFromStore
 using var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
 
-store.Open(OpenFlags.ReadOnly);
+store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
 
-var certificate = store.Certificates.Cast<X509Certificate2>().FirstOrDefault(cert => cert.Thumbprint == thumbprint);
+var certificate = store.Certificates
+    .OfType<X509Certificate2>()
+    .Where(static cert => DateTime.UtcNow > cert.NotBefore && DateTime.UtcNow < cert.NotAfter)
+    .OrderByDescending(static cert => cert.NotAfter)
+    .FirstOrDefault(cert => cert.FriendlyName == friendlyName)
+    ?? throw new CertificateNotFoundException($"Valid certificate with friendly name '{friendlyName}' could not be found in the local machine personal certificate store");
 
 var credential = new ClientCertificateCredential(tenantId, clientId, certificate);
 ```
+
+See the [X509Store section in Cross-platform cryptography in .NET](https://learn.microsoft.com/dotnet/standard/security/cross-platform-cryptography#x509store]).
 
 ## Rolling Certificates
 
@@ -44,7 +60,7 @@ However, if an application wants to roll this certificate without creating new s
 
 If the application get's notified of certificate rotations and it can directly respond, it might choose to wrap the `ClientCertificateCredential` in a custom credential which provides a means for rotating the certificate.
 
-```C# Snippet:Identity_CertificateCredenetial_RotatableCredential
+```C# Snippet:Identity_CertificateCredential_RotatableCredential
 public class RotatableCertificateCredential : TokenCredential
 {
     private readonly string _tenantId;
@@ -80,7 +96,7 @@ The above example shows a custom credential type `RotatableCertificateCredential
 ### Implicit rotation
 Some applications might want to respond to certificate rotations which are external to the application, for instance a separate process rotates the certificate by updating it on disk. Here the application create a custom credential which checks for certificate updates when tokens are requested.
 
-```C# Snippet:Identity_CertificateCredenetial_RotatingCredential
+```C# Snippet:Identity_CertificateCredential_RotatingCredential
 public class RotatingCertificateCredential : TokenCredential
 {
     private readonly string _tenantId;

--- a/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
+++ b/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
@@ -2,7 +2,7 @@
 
 Applications which execute in a protected environment can authenticate using a client assertion signed by a private key whose public key or root certificate is registered with Microsoft Entra ID. The Azure.Identity library provides the [`ClientCertificateCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.clientcertificatecredential) for applications choosing to authenticate this way. Below are some examples of how applications can utilize `ClientCertificateCredential` to authenticate clients.
 
-`ClientCertificateCredential` can also be used via [`EnvironmentCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.environmentcredential), or [`DefaultAzureCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) - see [README#credential-classes]([../README.md#credential-classe](https://github.com/azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md#credential-classes)).
+`ClientCertificateCredential` can also be used via [`EnvironmentCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.environmentcredential), or [`DefaultAzureCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) - see [README#credential-classes](https://github.com/azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md#credential-classes).
 
 ## Loading certificates from disk
 

--- a/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
+++ b/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
@@ -31,7 +31,7 @@ var credential = new ClientCertificateCredential(tenantId, clientId, "cert:/Curr
 
 Alternatively, the application can retrieve the certificate from the store itself and use it to construct the `ClientCertificateCredential`.
 
-For example, loading the newest certificate with a certain friendly name from Local Computer\Personal certificate store (`certlm.msc` on Windows):
+For example, loading the newest certificate with a certain friendly name from **Local Computer > Personal > Certificates** store (`certlm.msc` on Windows):
 
 ```C# Snippet:Identity_CertificateCredential_CreateFromStore
 using var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);

--- a/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
+++ b/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
@@ -2,7 +2,7 @@
 
 Applications which execute in a protected environment can authenticate using a client assertion signed by a private key whose public key or root certificate is registered with Microsoft Entra ID. The Azure.Identity library provides the [`ClientCertificateCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.clientcertificatecredential) for applications choosing to authenticate this way. Below are some examples of how applications can utilize `ClientCertificateCredential` to authenticate clients.
 
-`ClientCertificateCredential` can also be used via [`EnvironmentCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.environmentcredential), or [`DefaultAzureCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) - see [README#credential-classes](../README.md#credential-classes).
+`ClientCertificateCredential` can also be used via [`EnvironmentCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.environmentcredential), or [`DefaultAzureCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) - see [README#credential-classes]([../README.md#credential-classe](https://github.com/azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/README.md#credential-classes)).
 
 ## Loading certificates from disk
 

--- a/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
+++ b/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
@@ -24,7 +24,7 @@ var credential = new ClientCertificateCredential(tenantId, clientId, certificate
 
 Applications running on platforms which provide a secure certificate store, such as the Windows Certificate Store on Windows, and the KeyChain on macOS, might prefer to store and retrieve certificates from there.
 
-`ClientCertificateCredential` supports locating certificates by thumbrprint via a certificate path:
+`ClientCertificateCredential` supports locating certificates by thumbprint via a certificate path:
 ```C# Snippet:Identity_CertificateCredential_CreateWithPath_Store
 var credential = new ClientCertificateCredential(tenantId, clientId, "cert:/CurrentUser/My/E661583E8FABEF4C0BEF694CBC41C28FB81CD870");
 ```

--- a/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
+++ b/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
@@ -48,7 +48,7 @@ var certificate = store.Certificates
 var credential = new ClientCertificateCredential(tenantId, clientId, certificate);
 ```
 
-See the [X509Store section in Cross-platform cryptography in .NET](https://learn.microsoft.com/dotnet/standard/security/cross-platform-cryptography#x509store]).
+See the [X509Store section in Cross-platform cryptography in .NET](https://learn.microsoft.com/dotnet/standard/security/cross-platform-cryptography#x509store).
 
 ## Rolling Certificates
 

--- a/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
+++ b/sdk/identity/Azure.Identity/samples/ClientCertificateCredentialSamples.md
@@ -6,7 +6,7 @@ Applications which execute in a protected environment can authenticate using a c
 
 ## Loading certificates from disk
 
-Applications commonly need to load a client certificate from disk. One approach is for the application to construct the `ClientCertificateCredential` by specifying the applications tenant id, client id, and filesystem path to the certificate.
+Applications commonly need to load a client certificate from disk. One approach is for the application to construct the `ClientCertificateCredential` by specifying the application's tenant ID, client ID, and filesystem path to the certificate.
 
 ```C# Snippet:Identity_CertificateCredential_CreateWithPath_File
 var credential = new ClientCertificateCredential(tenantId, clientId, "./certs/cert.pfx");

--- a/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
@@ -29,7 +29,13 @@ namespace Azure.Identity
     /// <listheader><term>Variable</term><description>Description</description></listheader>
     /// <item><term>AZURE_TENANT_ID</term><description>The Microsoft Entra tenant (directory) ID.</description></item>
     /// <item><term>AZURE_CLIENT_ID</term><description>The client (application) ID of an App Registration in the tenant.</description></item>
-    /// <item><term>AZURE_CLIENT_CERTIFICATE_PATH</term><description>A path to certificate and private key pair in PEM or PFX format, which can authenticate the App Registration.</description></item>
+    /// <item><term>AZURE_CLIENT_CERTIFICATE_PATH</term><description>Path to the client certificate and the private key. The path must be to either a "pfx"- or "pem"-encoded certificate on disk, or a certifcate in the platform certificate store by thumbprint.
+    /// For example:
+    /// <list type="bullet">
+    ///   <item><description><c>c:\data\certificate.pfx</c></description></item>
+    ///   <item><description><c>/etc/app/cert.pem</c></description></item>
+    ///   <item><description><c>cert:/CurrentUser/My/E661583E8FABEF4C0BEF694CBC41C28FB81CD870</c></description></item>
+    /// </list></description></item>
     /// <item><term>AZURE_CLIENT_CERTIFICATE_PASSWORD</term><description>(Optional) The password protecting the certificate file (currently only supported for PFX (PKCS12) certificates).</description></item>
     /// <item><term>AZURE_CLIENT_SEND_CERTIFICATE_CHAIN</term><description>(Optional) Specifies whether an authentication request will include an x5c header to support subject name / issuer based authentication. When set to `true` or `1`, authentication requests include the x5c header.</description></item>
     /// </list>

--- a/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
+++ b/sdk/identity/Azure.Identity/src/Credentials/EnvironmentCredential.cs
@@ -29,7 +29,7 @@ namespace Azure.Identity
     /// <listheader><term>Variable</term><description>Description</description></listheader>
     /// <item><term>AZURE_TENANT_ID</term><description>The Microsoft Entra tenant (directory) ID.</description></item>
     /// <item><term>AZURE_CLIENT_ID</term><description>The client (application) ID of an App Registration in the tenant.</description></item>
-    /// <item><term>AZURE_CLIENT_CERTIFICATE_PATH</term><description>Path to the client certificate and the private key. The path must be to either a "pfx"- or "pem"-encoded certificate on disk, or a certifcate in the platform certificate store by thumbprint.
+    /// <item><term>AZURE_CLIENT_CERTIFICATE_PATH</term><description>Path to the client certificate and the private key. The path must be to either a "pfx"- or "pem"-encoded certificate on disk, or a certificate in the platform certificate store by thumbprint.
     /// For example:
     /// <list type="bullet">
     ///   <item><description><c>c:\data\certificate.pfx</c></description></item>

--- a/sdk/identity/Azure.Identity/tests/samples/CertificateCredentialSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/CertificateCredentialSnippets.cs
@@ -50,12 +50,14 @@ namespace Azure.Identity.Tests.samples
             #endregion
         }
 
+        public sealed class CertificateNotFoundException(string message) : Exception(message) { }
+
         public void CreateFromStore()
         {
             string tenantId = "00000000-0000-0000-0000-00000000";
             string clientId = "00000000-0000-0000-0000-00000000";
             string friendlyName = "";
-            
+
             #region Snippet:Identity_CertificateCredential_CreateFromStore
             using var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
 

--- a/sdk/identity/Azure.Identity/tests/samples/CertificateCredentialSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/CertificateCredentialSnippets.cs
@@ -14,13 +14,23 @@ namespace Azure.Identity.Tests.samples
 {
     public class CertificateCredentialSnippets
     {
-        public void CreateWithPath()
+        public void CreateWithPath_File()
         {
             string tenantId = "00000000-0000-0000-0000-00000000";
             string clientId = "00000000-0000-0000-0000-00000000";
 
-            #region Snippet:Identity_CertificateCredenetial_CreateWithPath
+            #region Snippet:Identity_CertificateCredential_CreateWithPath_File
             var credential = new ClientCertificateCredential(tenantId, clientId, "./certs/cert.pfx");
+            #endregion
+        }
+
+        public void CreateWithPath_Store()
+        {
+            string tenantId = "00000000-0000-0000-0000-00000000";
+            string clientId = "00000000-0000-0000-0000-00000000";
+
+            ```C# Snippet:Identity_CertificateCredential_CreateWithPath_Store
+            var credential = new ClientCertificateCredential(tenantId, clientId, "cert:/CurrentUser/My/E661583E8FABEF4C0BEF694CBC41C28FB81CD870");
             #endregion
         }
 
@@ -29,7 +39,7 @@ namespace Azure.Identity.Tests.samples
             string tenantId = "00000000-0000-0000-0000-00000000";
             string clientId = "00000000-0000-0000-0000-00000000";
 
-            #region Snippet:Identity_CertificateCredenetial_CreateWithX509Cert
+            #region Snippet:Identity_CertificateCredential_CreateWithX509Cert
 #if NET9_0_OR_GREATER
             var certificate = X509CertificateLoader.LoadPkcs12FromFile("./certs/cert-password-protected.pfx", "password");
 #else
@@ -44,19 +54,25 @@ namespace Azure.Identity.Tests.samples
         {
             string tenantId = "00000000-0000-0000-0000-00000000";
             string clientId = "00000000-0000-0000-0000-00000000";
-            string thumbprint = "";
-            #region Snippet:Identity_CertificateCredenetial_CreateFromStore
+            string friendlyName = "";
+            
+            #region Snippet:Identity_CertificateCredential_CreateFromStore
             using var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
 
-            store.Open(OpenFlags.ReadOnly);
+            store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
 
-            var certificate = store.Certificates.Cast<X509Certificate2>().FirstOrDefault(cert => cert.Thumbprint == thumbprint);
+            var certificate = store.Certificates
+                .OfType<X509Certificate2>()
+                .Where(static cert => DateTime.UtcNow > cert.NotBefore && DateTime.UtcNow < cert.NotAfter)
+                .OrderByDescending(static cert => cert.NotAfter)
+                .FirstOrDefault(cert => cert.FriendlyName == friendlyName)
+                ?? throw new CertificateNotFoundException($"Valid certificate with friendly name '{friendlyName}' could not be found in the local machine personal certificate store");
 
             var credential = new ClientCertificateCredential(tenantId, clientId, certificate);
             #endregion
         }
 
-        #region Snippet:Identity_CertificateCredenetial_RotatableCredential
+        #region Snippet:Identity_CertificateCredential_RotatableCredential
         public class RotatableCertificateCredential : TokenCredential
         {
             private readonly string _tenantId;
@@ -87,7 +103,7 @@ namespace Azure.Identity.Tests.samples
         }
         #endregion
 
-        #region Snippet:Identity_CertificateCredenetial_RotatingCredential
+        #region Snippet:Identity_CertificateCredential_RotatingCredential
         public class RotatingCertificateCredential : TokenCredential
         {
             private readonly string _tenantId;

--- a/sdk/identity/Azure.Identity/tests/samples/CertificateCredentialSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/CertificateCredentialSnippets.cs
@@ -29,7 +29,7 @@ namespace Azure.Identity.Tests.samples
             string tenantId = "00000000-0000-0000-0000-00000000";
             string clientId = "00000000-0000-0000-0000-00000000";
 
-            ```C# Snippet:Identity_CertificateCredential_CreateWithPath_Store
+            C# Snippet:Identity_CertificateCredential_CreateWithPath_Store
             var credential = new ClientCertificateCredential(tenantId, clientId, "cert:/CurrentUser/My/E661583E8FABEF4C0BEF694CBC41C28FB81CD870");
             #endregion
         }

--- a/sdk/identity/Azure.Identity/tests/samples/CertificateCredentialSnippets.cs
+++ b/sdk/identity/Azure.Identity/tests/samples/CertificateCredentialSnippets.cs
@@ -29,7 +29,7 @@ namespace Azure.Identity.Tests.samples
             string tenantId = "00000000-0000-0000-0000-00000000";
             string clientId = "00000000-0000-0000-0000-00000000";
 
-            C# Snippet:Identity_CertificateCredential_CreateWithPath_Store
+            #region Snippet:Identity_CertificateCredential_CreateWithPath_Store
             var credential = new ClientCertificateCredential(tenantId, clientId, "cert:/CurrentUser/My/E661583E8FABEF4C0BEF694CBC41C28FB81CD870");
             #endregion
         }


### PR DESCRIPTION
Update readme, code doc, and examples following up https://github.com/Azure/azure-sdk-for-net/pull/56312.

(should be squashed)