### PR TITLE
Add ConfigurationSchema.json for Azure.Identity.Broker

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/schema/ConfigurationSchema.json
+++ b/sdk/identity/Azure.Identity.Broker/schema/ConfigurationSchema.json
@@ -1,0 +1,314 @@
+{
+  "definitions": {
+    "credential": {
+      "type": "object",
+      "description": "Credential configuration. Available properties depend on the selected CredentialSource.",
+      "properties": {
+        "CredentialSource": {
+          "type": "string",
+          "description": "The credential type to use for authentication.",
+          "enum": [
+            "BrokerCredential",
+            "VisualStudioCodeCredential"
+          ]
+        }
+      },
+      "required": [
+        "CredentialSource"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "ClientSecret"
+            ]
+          },
+          "then": {
+            "title": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "ClientSecret": {
+                "not": {},
+                "description": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "ClientCertificatePassword"
+            ]
+          },
+          "then": {
+            "title": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "ClientCertificatePassword": {
+                "not": {},
+                "description": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "BrokerCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "DisableAutomaticAuthentication": {
+                "type": "boolean",
+                "description": "Prevent automatic interactive authentication prompts."
+              },
+              "LoginHint": {
+                "type": "string",
+                "description": "Pre-populate the username/email in the login prompt."
+              },
+              "RedirectUri": {
+                "type": "string",
+                "description": "The redirect URI for the OAuth callback.",
+                "format": "uri"
+              },
+              "UseDefaultBrokerAccount": {
+                "type": "boolean",
+                "description": "Authenticate with the default broker account instead of prompting the user with a login dialog."
+              },
+              "IsLegacyMsaPassthroughEnabled": {
+                "type": "boolean",
+                "description": "Enable Microsoft Account (MSA) passthrough."
+              },
+              "TokenCachePersistenceOptions": {
+                "$ref": "#/definitions/tokenCachePersistenceOptions"
+              },
+              "AuthenticationRecord": {
+                "$ref": "#/definitions/authenticationRecord"
+              },
+              "BrowserCustomization": {
+                "$ref": "#/definitions/browserCustomizationOptions"
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "VisualStudioCodeCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Retry": {
+                "$ref": "#/definitions/retry"
+              },
+              "Diagnostics": {
+                "$ref": "#/definitions/diagnostics"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": true
+    },
+    "chainableCredential": {
+      "type": "object",
+      "description": "A credential source in a chain. ApiKeyCredential and ChainedTokenCredential cannot be used.",
+      "properties": {
+        "CredentialSource": {
+          "type": "string",
+          "description": "The token credential type. ApiKeyCredential and ChainedTokenCredential are not allowed in a chain.",
+          "enum": [
+            "BrokerCredential",
+            "VisualStudioCodeCredential"
+          ]
+        },
+        "Retry": {
+          "$ref": "#/definitions/retry"
+        },
+        "Diagnostics": {
+          "$ref": "#/definitions/diagnostics"
+        }
+      },
+      "required": [
+        "CredentialSource"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "ClientSecret"
+            ]
+          },
+          "then": {
+            "title": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "ClientSecret": {
+                "not": {},
+                "description": "⚠️ Do NOT put client secrets in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "ClientCertificatePassword"
+            ]
+          },
+          "then": {
+            "title": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "description": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets",
+            "properties": {
+              "ClientCertificatePassword": {
+                "not": {},
+                "description": "⚠️ Do NOT put certificate passwords in appsettings.json. Use environment variables or Key Vault secrets instead. See https://aka.ms/azsdk/config/secrets"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "BrokerCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "ClientId": {
+                "type": "string",
+                "description": "The client (application) ID."
+              },
+              "DisableInstanceDiscovery": {
+                "type": "boolean",
+                "description": "Skip Microsoft Entra instance discovery and validation."
+              },
+              "DisableAutomaticAuthentication": {
+                "type": "boolean",
+                "description": "Prevent automatic interactive authentication prompts."
+              },
+              "LoginHint": {
+                "type": "string",
+                "description": "Pre-populate the username/email in the login prompt."
+              },
+              "RedirectUri": {
+                "type": "string",
+                "description": "The redirect URI for the OAuth callback.",
+                "format": "uri"
+              },
+              "UseDefaultBrokerAccount": {
+                "type": "boolean",
+                "description": "Authenticate with the default broker account instead of prompting the user with a login dialog."
+              },
+              "IsLegacyMsaPassthroughEnabled": {
+                "type": "boolean",
+                "description": "Enable Microsoft Account (MSA) passthrough."
+              },
+              "TokenCachePersistenceOptions": {
+                "$ref": "#/definitions/tokenCachePersistenceOptions"
+              },
+              "AuthenticationRecord": {
+                "$ref": "#/definitions/authenticationRecord"
+              },
+              "BrowserCustomization": {
+                "$ref": "#/definitions/browserCustomizationOptions"
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "CredentialSource": {
+                "const": "VisualStudioCodeCredential"
+              }
+            },
+            "required": [
+              "CredentialSource"
+            ]
+          },
+          "then": {
+            "properties": {
+              "TenantId": {
+                "type": "string",
+                "description": "The Microsoft Entra tenant (directory) ID."
+              },
+              "AdditionallyAllowedTenants": {
+                "type": "array",
+                "description": "Additional tenant IDs allowed for token acquisition. Use '*' for any tenant.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `ConfigurationSchema.json` to `sdk/identity/Azure.Identity.Broker/schema/` to provide JSON IntelliSense for credential configuration in `appsettings.json` files when the Broker package is referenced.

## Schema Content

- **`credential` definition** with 2 Broker-specific credential sources: `BrokerCredential`, `VisualStudioCodeCredential`
- **Conditional properties per credential type** using draft-07 `if/then` patterns (e.g., `UseDefaultBrokerAccount` and `IsLegacyMsaPassthroughEnabled` only for `BrokerCredential`)
- **`chainableCredential` definition** for `ChainedTokenCredential` sources
- **Secret-blocking patterns** for `ClientSecret` and `ClientCertificatePassword` - prevents secrets from being placed in config files
- References `#/definitions/retry` and `#/definitions/diagnostics` (resolved from Azure.Core during schema merge)
- References `#/definitions/tokenCachePersistenceOptions`, `#/definitions/authenticationRecord`, and `#/definitions/browserCustomizationOptions` (resolved from Azure.Identity during schema merge)

## Why

These credential sources were removed from Azure.Identity's schema in #57483 since they require installation of the `Azure.Identity.Broker` package to function. Defining them in the Broker package's own schema ensures IntelliSense only surfaces them when the Broker package is referenced.

## Testing

Verified IntelliSense works in VS 18.6 Preview with a test console app referencing locally packed schema-only packages for Azure.Core, Azure.Identity, and Azure.Identity.Broker. Confirmed:
- `BrokerCredential` and `VisualStudioCodeCredential` appear in `CredentialSource` completions only when the Broker package is referenced
- Chained composition works: both credentials appear in `ChainedTokenCredential` `Sources` array items
- Per-credential properties activate correctly (`UseDefaultBrokerAccount`, `IsLegacyMsaPassthroughEnabled` for Broker; `TenantId`, `AdditionallyAllowedTenants` for both)

Closes #57521