### PR TITLE
fix: only classify pageable actions as List when item type is a resource model

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -437,9 +437,8 @@ function convertResolvedResourceToMetadata(
         const responseModelId = methodResponseModelIdMap?.get(methodId);
         const isResourceList =
           sdkMethodKind === "paging" &&
-          !!responseModelId &&
-          !!resourceModelIds &&
-          resourceModelIds.has(responseModelId);
+          resourceModelIds !== undefined &&
+          resourceModelIds.has(responseModelId!);
         methods.push({
           methodId,
           kind: isResourceList

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -56,9 +56,7 @@ import { CSharpEmitterContext } from "@typespec/http-client-csharp";
 import {
   getCrossLanguageDefinitionId,
   getClientType,
-  SdkModelType,
-  SdkPagingServiceMethod,
-  SdkHttpOperation
+  SdkModelType
 } from "@azure-tools/typespec-client-generator-core";
 import {
   isVariableSegment,
@@ -126,22 +124,12 @@ export function resolveArmResources(
         (method.kind === "paging" || method.kind === "lropaging") &&
         !methodResponseModelIdMap.has(method.crossLanguageDefinitionId)
       ) {
-        const pagingMethod =
-          method as SdkPagingServiceMethod<SdkHttpOperation>;
-        const segments = pagingMethod.pagingMetadata?.pageItemsSegments;
-        if (segments && segments.length > 0) {
-          const itemsType = segments[segments.length - 1].type;
-          if (itemsType.kind === "array" && itemsType.valueType.kind === "model") {
-            methodResponseModelIdMap.set(
-              method.crossLanguageDefinitionId,
-              (itemsType.valueType as SdkModelType).crossLanguageDefinitionId
-            );
-          } else if (itemsType.kind === "model") {
-            methodResponseModelIdMap.set(
-              method.crossLanguageDefinitionId,
-              (itemsType as SdkModelType).crossLanguageDefinitionId
-            );
-          }
+        const responseType = method.response?.type;
+        if (responseType?.kind === "array" && responseType.valueType.kind === "model") {
+          methodResponseModelIdMap.set(
+            method.crossLanguageDefinitionId,
+            (responseType.valueType as SdkModelType).crossLanguageDefinitionId
+          );
         }
       }
     }

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -56,7 +56,9 @@ import { CSharpEmitterContext } from "@typespec/http-client-csharp";
 import {
   getCrossLanguageDefinitionId,
   getClientType,
-  SdkModelType
+  SdkModelType,
+  SdkPagingServiceMethod,
+  SdkHttpOperation
 } from "@azure-tools/typespec-client-generator-core";
 import {
   isVariableSegment,
@@ -103,6 +105,9 @@ export function resolveArmResources(
   // Build a lookup map from methodId to SdkMethod kind (basic, paging, lro, lropaging)
   // so that we can detect pageable actions that should be classified as List
   const methodKindMap = new Map<string, string>();
+  // Build a lookup map from methodId to the response item type's crossLanguageDefinitionId
+  // so that we can verify pageable actions return actual resource models
+  const methodResponseModelIdMap = new Map<string, string>();
   for (const client of getAllSdkClients(sdkContext)) {
     for (const method of client.methods) {
       if (!methodApiVersionsMap.has(method.crossLanguageDefinitionId)) {
@@ -116,6 +121,42 @@ export function resolveArmResources(
           method.crossLanguageDefinitionId,
           method.kind
         );
+      }
+      if (
+        (method.kind === "paging" || method.kind === "lropaging") &&
+        !methodResponseModelIdMap.has(method.crossLanguageDefinitionId)
+      ) {
+        const pagingMethod =
+          method as SdkPagingServiceMethod<SdkHttpOperation>;
+        const segments = pagingMethod.pagingMetadata?.pageItemsSegments;
+        if (segments && segments.length > 0) {
+          const itemsType = segments[segments.length - 1].type;
+          if (itemsType.kind === "array" && itemsType.valueType.kind === "model") {
+            methodResponseModelIdMap.set(
+              method.crossLanguageDefinitionId,
+              (itemsType.valueType as SdkModelType).crossLanguageDefinitionId
+            );
+          } else if (itemsType.kind === "model") {
+            methodResponseModelIdMap.set(
+              method.crossLanguageDefinitionId,
+              (itemsType as SdkModelType).crossLanguageDefinitionId
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // Build the set of resource model IDs for validating pageable action responses
+  const resourceModelIds = new Set<string>();
+  if (provider.resources) {
+    for (const resolvedResource of provider.resources) {
+      const modelId = getCrossLanguageDefinitionId(
+        sdkContext,
+        resolvedResource.type
+      );
+      if (modelId) {
+        resourceModelIds.add(modelId);
       }
     }
   }
@@ -143,7 +184,9 @@ export function resolveArmResources(
         program,
         sdkContext,
         resolvedResource,
-        methodKindMap
+        methodKindMap,
+        methodResponseModelIdMap,
+        resourceModelIds
       );
 
       const resource = {
@@ -208,7 +251,8 @@ export function resolveArmResources(
   const filteredResources = postProcessArmResources(
     resources,
     nonResourceMethods,
-    parentLookup
+    parentLookup,
+    methodResponseModelIdMap
   );
 
   // Add provider operations as non-resource methods
@@ -298,7 +342,9 @@ function convertResolvedResourceToMetadata(
   program: Program,
   sdkContext: CSharpEmitterContext,
   resolvedResource: ResolvedResource,
-  methodKindMap?: Map<string, string>
+  methodKindMap?: Map<string, string>,
+  methodResponseModelIdMap?: Map<string, string>,
+  resourceModelIds?: Set<string>
 ): ResourceMetadata {
   const methods: ResourceMethod[] = [];
   const resourceScope = convertScopeToResourceScope(resolvedResource.scope);
@@ -396,15 +442,21 @@ function convertResolvedResourceToMetadata(
     for (const actionOp of resolvedResource.operations.actions) {
       const methodId = getMethodIdFromOperation(sdkContext, actionOp.operation);
       if (methodId) {
-        // If the action is pageable, classify as List instead of Action
-        // (handles ArmResourceActionSync used for list-children operations)
+        // Classify as List only if the action is pageable AND its response item type
+        // is a known resource model. This prevents metadata-returning pageable actions
+        // from being misclassified as List operations.
         const sdkMethodKind = methodKindMap?.get(methodId);
+        const responseModelId = methodResponseModelIdMap?.get(methodId);
+        const isResourceList =
+          sdkMethodKind === "paging" &&
+          !!responseModelId &&
+          !!resourceModelIds &&
+          resourceModelIds.has(responseModelId);
         methods.push({
           methodId,
-          kind:
-            sdkMethodKind === "paging"
-              ? ResourceOperationKind.List
-              : ResourceOperationKind.Action,
+          kind: isResourceList
+            ? ResourceOperationKind.List
+            : ResourceOperationKind.Action,
           operationPath: actionOp.path,
           operationScope: resourceScope,
           resourceScope: calculateResourceScope(actionOp.path, resolvedResource)

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -28,8 +28,7 @@ import {
   getClientType,
   SdkHttpOperation,
   SdkMethod,
-  SdkModelType,
-  SdkPagingServiceMethod
+  SdkModelType
 } from "@azure-tools/typespec-client-generator-core";
 import pluralize from "pluralize";
 import {
@@ -906,24 +905,17 @@ function getResourceModelId(
 }
 
 /**
- * Extracts the page item model's crossLanguageDefinitionId from a paging method.
- * Returns undefined if the item type is not a model (e.g., metadata or scalar types).
+ * Extracts the page item model's crossLanguageDefinitionId from a paging method
+ * using the method's response type (which is an array of the item type).
+ * Returns undefined if the item type is not a model.
  */
 function getPagingItemModelId(
   method: SdkMethod<SdkHttpOperation>
 ): string | undefined {
   if (method.kind !== "paging" && method.kind !== "lropaging") return undefined;
-  const pagingMethod = method as SdkPagingServiceMethod<SdkHttpOperation>;
-  const segments = pagingMethod.pagingMetadata?.pageItemsSegments;
-  if (!segments || segments.length === 0) return undefined;
-  // The last segment's type is the items array; extract the element type
-  const itemsType = segments[segments.length - 1].type;
-  if (itemsType.kind === "array" && itemsType.valueType.kind === "model") {
-    return (itemsType.valueType as SdkModelType).crossLanguageDefinitionId;
-  }
-  // Fallback: the items property might directly be a model (non-array case)
-  if (itemsType.kind === "model") {
-    return (itemsType as SdkModelType).crossLanguageDefinitionId;
+  const responseType = method.response?.type;
+  if (responseType?.kind === "array" && responseType.valueType.kind === "model") {
+    return (responseType.valueType as SdkModelType).crossLanguageDefinitionId;
   }
   return undefined;
 }

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -28,7 +28,8 @@ import {
   getClientType,
   SdkHttpOperation,
   SdkMethod,
-  SdkModelType
+  SdkModelType,
+  SdkPagingServiceMethod
 } from "@azure-tools/typespec-client-generator-core";
 import pluralize from "pluralize";
 import {
@@ -124,6 +125,16 @@ export function buildArmProviderSchema(
     resourceModels.map((m) => m.crossLanguageDefinitionId)
   );
 
+  // Build a lookup map from methodId to the page item type's crossLanguageDefinitionId
+  // so that relocateCrossResourceListActions can verify type compatibility
+  const methodResponseModelIdMap = new Map<string, string>();
+  for (const [methodId, method] of serviceMethods) {
+    const itemModelId = getPagingItemModelId(method);
+    if (itemModelId) {
+      methodResponseModelIdMap.set(methodId, itemModelId);
+    }
+  }
+
   // Track client names associated with each resource path for name derivation
   const resourcePathToClientName = new Map<string, string>();
 
@@ -144,7 +155,8 @@ export function buildArmProviderSchema(
     const serviceMethod = serviceMethods.get(method.crossLanguageDefinitionId);
     const { kind, modelId, explicitResourceName } = parseResourceOperation(
       serviceMethod,
-      sdkContext
+      sdkContext,
+      resourceModelIds
     );
 
     if (modelId && kind && resourceModelIds.has(modelId)) {
@@ -457,7 +469,8 @@ export function buildArmProviderSchema(
   const filteredResources = postProcessArmResources(
     resources,
     nonResourceMethodsArray,
-    parentLookup
+    parentLookup,
+    methodResponseModelIdMap
   );
 
   // Emit diagnostics for resources that were filtered out (non-singleton resources without Read operations)
@@ -575,7 +588,8 @@ function isCRUDKind(kind: ResourceOperationKind): boolean {
 
 function parseResourceOperation(
   serviceMethod: SdkMethod<SdkHttpOperation> | undefined,
-  sdkContext: CSharpEmitterContext
+  sdkContext: CSharpEmitterContext,
+  resourceModelIds?: Set<string>
 ): {
   kind?: ResourceOperationKind;
   modelId?: string;
@@ -624,13 +638,13 @@ function parseResourceOperation(
         };
       case armResourceActionName:
         return {
-          // If the operation is pageable, it's actually a list operation
-          // (e.g., blobContainersList modeled as ArmResourceActionSync
-          // but returning paged results)
-          kind:
-            serviceMethod?.kind === "paging"
-              ? ResourceOperationKind.List
-              : ResourceOperationKind.Action,
+          // If the operation is pageable AND its response item type is a known
+          // resource model, it's a list-children operation (e.g., blobContainersList
+          // modeled as ArmResourceActionSync but returning paged Container resources).
+          // If the item type is NOT a resource model (e.g., metadata), keep it as Action.
+          kind: isPagingActionListingResources(serviceMethod, resourceModelIds)
+            ? ResourceOperationKind.List
+            : ResourceOperationKind.Action,
           modelId: getResourceModelId(sdkContext, decorator),
           explicitResourceName: undefined
         };
@@ -889,6 +903,45 @@ function getResourceModelId(
     decorator.args[0].value as Model,
     decorator.definition?.name
   );
+}
+
+/**
+ * Extracts the page item model's crossLanguageDefinitionId from a paging method.
+ * Returns undefined if the item type is not a model (e.g., metadata or scalar types).
+ */
+function getPagingItemModelId(
+  method: SdkMethod<SdkHttpOperation>
+): string | undefined {
+  if (method.kind !== "paging" && method.kind !== "lropaging") return undefined;
+  const pagingMethod = method as SdkPagingServiceMethod<SdkHttpOperation>;
+  const segments = pagingMethod.pagingMetadata?.pageItemsSegments;
+  if (!segments || segments.length === 0) return undefined;
+  // The last segment's type is the items array; extract the element type
+  const itemsType = segments[segments.length - 1].type;
+  if (itemsType.kind === "array" && itemsType.valueType.kind === "model") {
+    return (itemsType.valueType as SdkModelType).crossLanguageDefinitionId;
+  }
+  // Fallback: the items property might directly be a model (non-array case)
+  if (itemsType.kind === "model") {
+    return (itemsType as SdkModelType).crossLanguageDefinitionId;
+  }
+  return undefined;
+}
+
+/**
+ * Checks whether a pageable action actually lists resource models.
+ * Returns true only if the method is a paging method AND its page item type
+ * matches a known resource model. This prevents metadata-returning pageable actions
+ * (e.g., NginxDeployments_WafPolicyList returning WafPolicyMetadata) from being
+ * misclassified as List operations.
+ */
+function isPagingActionListingResources(
+  serviceMethod: SdkMethod<SdkHttpOperation> | undefined,
+  resourceModelIds?: Set<string>
+): boolean {
+  if (!serviceMethod || !resourceModelIds) return false;
+  const itemModelId = getPagingItemModelId(serviceMethod);
+  return !!itemModelId && resourceModelIds.has(itemModelId);
 }
 
 function getResourceModelIdCore(

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -327,7 +327,8 @@ export interface ParentResourceLookupContext {
 export function postProcessArmResources(
   resources: ArmResourceSchema[],
   nonResourceMethods: NonResourceMethod[],
-  parentLookup: ParentResourceLookupContext
+  parentLookup: ParentResourceLookupContext,
+  methodResponseModelIdMap?: Map<string, string>
 ): ArmResourceSchema[] {
   // Step 1: Separate valid resources (with resourceIdPattern) from incomplete ones (without)
   const validResources = resources.filter(
@@ -412,7 +413,7 @@ export function postProcessArmResources(
   // (e.g., blobContainersList as ArmResourceActionSync on BlobService that lists BlobContainers),
   // detect that the Action's operationPath matches a child resource's collection path
   // and reclassify it as a List on the child resource.
-  relocateCrossResourceListActions(validResources);
+  relocateCrossResourceListActions(validResources, methodResponseModelIdMap);
 
   // Step 4: Populate resourceScope for all resource methods
   // For each method, find the longest matching resource path that is a prefix of the method's operation path
@@ -695,7 +696,8 @@ function canBeListResourceScope(
  *   - Result: List is moved from BlobService to Container
  */
 function relocateCrossResourceListActions(
-  validResources: ArmResourceSchema[]
+  validResources: ArmResourceSchema[],
+  methodResponseModelIdMap?: Map<string, string>
 ): void {
   // Find List methods that are assigned to the wrong resource and should be
   // relocated to a child resource. This handles the case where a pageable
@@ -731,6 +733,15 @@ function relocateCrossResourceListActions(
         // The additional segment must be a variable segment (e.g. `{resourceName}`)
         const lastSegment = resSegments[resSegments.length - 1];
         if (!isVariableSegment(lastSegment)) continue;
+
+        // Verify the response item type matches the target resource's model.
+        // This prevents relocating pageable actions that return metadata models
+        // (not the resource type) to the wrong collection.
+        if (methodResponseModelIdMap) {
+          const responseModelId = methodResponseModelIdMap.get(method.methodId);
+          if (responseModelId && responseModelId !== candidate.resourceModelId)
+            continue;
+        }
 
         relocations.push({
           sourceResource: resource,


### PR DESCRIPTION
## Fix: Pageable action-to-List classification and collection IEnumerable type mismatch

### Problem

When a pageable `ArmResourceAction` returns a non-resource model (e.g., metadata), the emitter incorrectly classifies it as a `List` operation. This causes the generator to:
1. Move the operation to the child resource's collection class
2. Add `IEnumerable<ResourceType>` to the collection, but `GetAll()` returns `Pageable<MetadataModel>` → **CS0266 type mismatch**

This was observed in `Azure.ResourceManager.Nginx` where `NginxDeployments_WafPolicyList` (pageable, returns `WafPolicyMetadata`) was misclassified as a List operation for `NginxDeploymentWafPolicyResource`.

### Root Cause

The emitter classified **any** pageable action as `List` based solely on `serviceMethod.kind === "paging"`, without checking whether the page item type is actually a resource model.

### Fix

**Emitter** (3 files):
- `resource-detection.ts`: Added `getPagingItemModelId()` to extract the page item type from `pagingMetadata.pageItemsSegments`, and `isPagingActionListingResources()` that only classifies an action as List when the item type is a **known resource model**
- `resolve-arm-resources-converter.ts`: Same logic for the legacy detection path via `methodResponseModelIdMap`
- `resource-metadata.ts`: `relocateCrossResourceListActions()` now verifies the response item type matches the target child resource's `resourceModelId` before relocating

### Validation

- ✅ Emitter: all 67 tests pass (including BlobService→Container relocation)
- ✅ Generator: all 140 unit tests pass
- ✅ Lint + Prettier clean
- ✅ Test project regeneration produces no diff

Addresses review feedback from https://github.com/Azure/azure-sdk-for-net/pull/57524#discussion_r2999104403
