### PR TITLE
Add JSON schema IntelliSense for Azure.Security.KeyVault.Secrets client configuration

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/schema/ConfigurationSchema.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/schema/ConfigurationSchema.json
@@ -1,0 +1,39 @@
+{
+  "type": "object",
+  "properties": {
+    "AzureClients": {
+      "type": "object",
+      "properties": {
+        "SecretClient": {
+          "type": "object",
+          "description": "Configuration for Azure Key Vault Secrets client.",
+          "properties": {
+            "VaultUri": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URI to the vault on which the client operates. Appears as \"DNS Name\" in the Azure portal."
+            },
+            "Credential": {
+              "$ref": "#/definitions/credential"
+            },
+            "Options": {
+              "allOf": [
+                { "$ref": "#/definitions/azureOptions" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "DisableChallengeResourceVerification": {
+                      "type": "boolean",
+                      "description": "Disable verification that the authentication challenge resource matches the Key Vault domain."
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a `ConfigurationSchema.json` to `Azure.Security.KeyVault.Secrets` to provide IntelliSense for `SecretClient` in `appsettings.json`.

The schema defines:
- `SecretClient` well-known name under the `AzureClients` section
- `VaultUri` property (URI to the vault)
- `Credential` reference (shared definition from Azure.Identity/System.ClientModel)
- `Options` extending `azureOptions` (from Azure.Core) with the KeyVault-specific `DisableChallengeResourceVerification` option

The shared build infrastructure auto-detects `schema/ConfigurationSchema.json` and packs it into the NuGet package with the appropriate `.targets` file — no `.csproj` changes needed.

Fixes #56783