### PR TITLE
Add JSON schema IntelliSense for Azure.Data.AppConfiguration

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/schema/ConfigurationSchema.json
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/schema/ConfigurationSchema.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "properties": {
+    "AzureClients": {
+      "type": "object",
+      "properties": {
+        "ConfigurationClient": {
+          "type": "object",
+          "description": "Configuration for Azure App Configuration client.",
+          "properties": {
+            "Endpoint": {
+              "type": "string",
+              "format": "uri",
+              "description": "The URI of the App Configuration store (e.g. 'https://{name}.azconfig.io')."
+            },
+            "Credential": {
+              "$ref": "#/definitions/credential"
+            },
+            "Options": {
+              "allOf": [
+                { "$ref": "#/definitions/azureOptions" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Audience": {
+                      "description": "The audience to use for authentication with Microsoft Entra. Not used when authenticating with a connection string.",
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "https://appconfig.azure.com",
+                            "https://appconfig.azure.us",
+                            "https://appconfig.azure.cn"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
Add `ConfigurationSchema.json` to `Azure.Data.AppConfiguration` to provide `appsettings.json` IntelliSense for `ConfigurationClient` via the `JsonSchemaSegment` mechanism.

## Why
Customers configuring `ConfigurationClient` via `appsettings.json` currently get no IntelliSense or validation. This adds schema-driven IntelliSense that Visual Studio merges automatically from NuGet package segments.

## Schema defines
- `ConfigurationClient` well-known name under `AzureClients`
- `Endpoint` property (URI)
- `Credential` reference (resolved from Azure.Identity/System.ClientModel segments)
- `Options` extending `azureOptions` via `allOf` with the `Audience` property (extensible enum with 3 well-known values: `https://appconfig.azure.com`, `https://appconfig.azure.us`, `https://appconfig.azure.cn`)

## How tested
- Packed NuGet locally, created test ASP.NET project referencing the local package
- Verified `JsonSchemaSegment` items resolve (System.ClientModel + Azure.Core + Azure.Data.AppConfiguration)
- Verified IntelliSense in VS Preview for `appsettings.json`

Closes #56782