### PR TITLE
Add ConfigurationSchema.json for Azure.ResourceManager

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager/schema/ConfigurationSchema.json
+++ b/sdk/resourcemanager/Azure.ResourceManager/schema/ConfigurationSchema.json
@@ -1,0 +1,56 @@
+{
+  "definitions": {
+    "armEnvironment": {
+      "type": "object",
+      "description": "Azure cloud environment for ARM operations. Defaults to Azure Public Cloud (https://management.azure.com).",
+      "properties": {
+        "Endpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "Management API endpoint base URI (e.g. 'https://management.azure.com')."
+        },
+        "Audience": {
+          "type": "string",
+          "description": "Authentication audience (e.g. 'https://management.azure.com/')."
+        }
+      },
+      "required": ["Endpoint", "Audience"],
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "properties": {
+    "AzureClients": {
+      "type": "object",
+      "properties": {
+        "ArmClient": {
+          "type": "object",
+          "description": "Configuration for ArmClient (Azure Resource Manager).",
+          "properties": {
+            "DefaultSubscriptionId": {
+              "type": "string",
+              "description": "The default Azure subscription ID."
+            },
+            "Credential": {
+              "$ref": "#/definitions/credential"
+            },
+            "Options": {
+              "allOf": [
+                { "$ref": "#/definitions/azureOptions" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Environment": {
+                      "$ref": "#/definitions/armEnvironment"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a `ConfigurationSchema.json` to the `Azure.ResourceManager` NuGet package to provide JSON schema IntelliSense for `ArmClient` configuration in `appsettings.json`.

### What's included

- **`ArmClient` well-known name** under the `AzureClients` section
- **`DefaultSubscriptionId`** property (from `ArmClientSettings`)
- **`Credential`** reference to the shared credential definition
- **ARM-specific options** extending `azureOptions` via `allOf`:
  - `Environment` (`armEnvironment` definition) with `Endpoint` (URI) and `Audience` (string), matching `ArmClientOptions.Environment` / `ArmEnvironment`

### How it works

The shared build infrastructure (#56778) auto-detects `schema/ConfigurationSchema.json` and packs it into the NuGet package with the appropriate `.targets` file for `JsonSchemaSegment` registration. No changes to the `.csproj` are needed.

### Verification

- Schema properties verified against current `ArmClientSettings` and `ArmClientOptions` API
- Build succeeds with 0 warnings/errors
- NuGet pack confirmed: `ConfigurationSchema.json` at package root + `Azure.ResourceManager.targets` in `buildTransitive/` for all TFMs

Resolves #56784