### PR TITLE
Rename EnablePerfCounters to EnablePerformanceCounters per API review

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-* Add ability to specify EnableStandardMetrics and EnablePerfCounters
+* Add ability to specify EnableStandardMetrics and EnablePerformanceCounters
   ([#56438](https://github.com/Azure/azure-sdk-for-net/pull/56438))
 
 ### Breaking Changes

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net10.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net10.0.cs
@@ -7,7 +7,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
-        public bool EnablePerfCounters { get { throw null; } set { } }
+        public bool EnablePerformanceCounters { get { throw null; } set { } }
         public bool EnableStandardMetrics { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net8.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.net8.0.cs
@@ -7,7 +7,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
-        public bool EnablePerfCounters { get { throw null; } set { } }
+        public bool EnablePerformanceCounters { get { throw null; } set { } }
         public bool EnableStandardMetrics { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/api/Azure.Monitor.OpenTelemetry.AspNetCore.netstandard2.0.cs
@@ -7,7 +7,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
-        public bool EnablePerfCounters { get { throw null; } set { } }
+        public bool EnablePerformanceCounters { get { throw null; } set { } }
         public bool EnableStandardMetrics { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/src/AzureMonitorOptions.cs
@@ -58,7 +58,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
         /// Gets or sets a value indicating whether performance counters should be collected.
         /// Default is true.
         /// </summary>
-        public bool EnablePerfCounters { get; set; } = true;
+        public bool EnablePerformanceCounters { get; set; } = true;
 
         /// <summary>
         /// Enables or disables filtering logs based on trace sampling decisions.
@@ -108,7 +108,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore
             exporterOptions.StorageDirectory = StorageDirectory;
             exporterOptions.EnableLiveMetrics = EnableLiveMetrics;
             exporterOptions.EnableStandardMetrics = EnableStandardMetrics;
-            exporterOptions.EnablePerfCounters = EnablePerfCounters;
+            exporterOptions.EnablePerformanceCounters = EnablePerformanceCounters;
             exporterOptions.EnableTraceBasedLogsSampler = EnableTraceBasedLogsSampler;
             if (Transport != null)
             {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureMonitorOptionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.AspNetCore/tests/Azure.Monitor.OpenTelemetry.AspNetCore.Tests/AzureMonitorOptionsTests.cs
@@ -270,36 +270,36 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
         }
 
         [Fact]
-        public void AzureMonitorOptions_EnablePerfCounters_DefaultValue_IsTrue()
+        public void AzureMonitorOptions_EnablePerformanceCounters_DefaultValue_IsTrue()
         {
             // Arrange & Act
             var options = new AzureMonitorOptions();
 
             // Assert
-            Assert.True(options.EnablePerfCounters);
+            Assert.True(options.EnablePerformanceCounters);
         }
 
         [Fact]
-        public void AzureMonitorOptions_EnablePerfCounters_CanBeDisabled()
+        public void AzureMonitorOptions_EnablePerformanceCounters_CanBeDisabled()
         {
             // Arrange & Act
             var options = new AzureMonitorOptions
             {
-                EnablePerfCounters = false
+                EnablePerformanceCounters = false
             };
 
             // Assert
-            Assert.False(options.EnablePerfCounters);
+            Assert.False(options.EnablePerformanceCounters);
         }
 
         [Fact]
-        public void AzureMonitorOptions_SetValueToExporterOptions_CopiesEnablePerfCounters()
+        public void AzureMonitorOptions_SetValueToExporterOptions_CopiesEnablePerformanceCounters()
         {
             // Arrange
             var azureMonitorOptions = new AzureMonitorOptions
             {
                 ConnectionString = TestConnectionString,
-                EnablePerfCounters = false
+                EnablePerformanceCounters = false
             };
 
             var exporterOptions = new AzureMonitorExporterOptions();
@@ -308,12 +308,12 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             azureMonitorOptions.SetValueToExporterOptions(exporterOptions);
 
             // Assert
-            Assert.False(exporterOptions.EnablePerfCounters);
+            Assert.False(exporterOptions.EnablePerformanceCounters);
             Assert.Equal(TestConnectionString, exporterOptions.ConnectionString);
         }
 
         [Fact]
-        public void UseAzureMonitor_DefaultEnablePerfCounters()
+        public void UseAzureMonitor_DefaultEnablePerformanceCounters()
         {
             // Arrange
             var serviceCollection = new ServiceCollection();
@@ -332,16 +332,16 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             var azureMonitorOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorOptions>>()
                 .Get(Options.DefaultName);
 
-            Assert.True(azureMonitorOptions.EnablePerfCounters);
+            Assert.True(azureMonitorOptions.EnablePerformanceCounters);
 
             var exporterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>()
                 .Get(Options.DefaultName);
 
-            Assert.True(exporterOptions.EnablePerfCounters);
+            Assert.True(exporterOptions.EnablePerformanceCounters);
         }
 
         [Fact]
-        public void UseAzureMonitor_CanDisablePerfCounters()
+        public void UseAzureMonitor_CanDisablePerformanceCounters()
         {
             // Arrange
             var serviceCollection = new ServiceCollection();
@@ -351,7 +351,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
                 .UseAzureMonitor(options =>
                 {
                     options.ConnectionString = TestConnectionString;
-                    options.EnablePerfCounters = false;
+                    options.EnablePerformanceCounters = false;
                     options.DisableOfflineStorage = true;
                 });
 
@@ -361,16 +361,16 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             var azureMonitorOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorOptions>>()
                 .Get(Options.DefaultName);
 
-            Assert.False(azureMonitorOptions.EnablePerfCounters);
+            Assert.False(azureMonitorOptions.EnablePerformanceCounters);
 
             var exporterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>()
                 .Get(Options.DefaultName);
 
-            Assert.False(exporterOptions.EnablePerfCounters);
+            Assert.False(exporterOptions.EnablePerformanceCounters);
         }
 
         [Fact]
-        public void UseAzureMonitor_EnablePerfCounters_PropagatesCorrectly()
+        public void UseAzureMonitor_EnablePerformanceCounters_PropagatesCorrectly()
         {
             // Arrange
             var serviceCollection = new ServiceCollection();
@@ -380,7 +380,7 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
                 .UseAzureMonitor(options =>
                 {
                     options.ConnectionString = TestConnectionString;
-                    options.EnablePerfCounters = true;
+                    options.EnablePerformanceCounters = true;
                     options.DisableOfflineStorage = true;
                 });
 
@@ -393,8 +393,8 @@ namespace Azure.Monitor.OpenTelemetry.AspNetCore.Tests
             var exporterOptions = serviceProvider.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>()
                 .Get(Options.DefaultName);
 
-            Assert.Equal(azureMonitorOptions.EnablePerfCounters, exporterOptions.EnablePerfCounters);
-            Assert.True(exporterOptions.EnablePerfCounters);
+            Assert.Equal(azureMonitorOptions.EnablePerformanceCounters, exporterOptions.EnablePerformanceCounters);
+            Assert.True(exporterOptions.EnablePerformanceCounters);
         }
 
         [Fact]

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/CHANGELOG.md
@@ -21,7 +21,7 @@
   ([#57549](https://github.com/Azure/azure-sdk-for-net/pull/57549))
 * Made `AzureMonitorLogExporter`, `AzureMonitorMetricExporter`, and `AzureMonitorTraceExporter` public for direct use when configuring OpenTelemetry.
    ([#56344](https://github.com/Azure/azure-sdk-for-net/pull/56344))
-* Made options `EnablePerfCounters` and `EnableStandardMetrics` public in `AzureMonitorExporterOptions`.
+* Made options `EnablePerformanceCounters` and `EnableStandardMetrics` public in `AzureMonitorExporterOptions`.
    ([#56344](https://github.com/Azure/azure-sdk-for-net/pull/56344))
 
 ## 1.6.0 (2026-01-28)

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net10.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net10.0.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
-        public bool EnablePerfCounters { get { throw null; } set { } }
+        public bool EnablePerformanceCounters { get { throw null; } set { } }
         public bool EnableStandardMetrics { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net8.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.net8.0.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
-        public bool EnablePerfCounters { get { throw null; } set { } }
+        public bool EnablePerformanceCounters { get { throw null; } set { } }
         public bool EnableStandardMetrics { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/api/Azure.Monitor.OpenTelemetry.Exporter.netstandard2.0.cs
@@ -15,7 +15,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         public Azure.Core.TokenCredential Credential { get { throw null; } set { } }
         public bool DisableOfflineStorage { get { throw null; } set { } }
         public bool EnableLiveMetrics { get { throw null; } set { } }
-        public bool EnablePerfCounters { get { throw null; } set { } }
+        public bool EnablePerformanceCounters { get { throw null; } set { } }
         public bool EnableStandardMetrics { get { throw null; } set { } }
         public bool EnableTraceBasedLogsSampler { get { throw null; } set { } }
         public float SamplingRatio { get { throw null; } set { } }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/AzureMonitorExporterOptions.cs
@@ -130,7 +130,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter
         /// Gets or sets a value indicating whether performance counters should be collected.
         /// Default is true.
         /// </summary>
-        public bool EnablePerfCounters { get; set; } = true;
+        public bool EnablePerformanceCounters { get; set; } = true;
 
         internal void SetValueToLiveMetricsOptions(AzureMonitorLiveMetricsOptions liveMetricsOptions)
         {

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/StandardMetricsExtractionProcessor.cs
@@ -21,7 +21,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         private AzureMonitorResource? _resource;
 
         private readonly bool _enableStandardMetrics;
-        private readonly bool _enablePerfCounters;
+        private readonly bool _enablePerformanceCounters;
 
         internal readonly Lazy<MeterProvider?> _meterProvider;
         private readonly Meter? _standardMetricMeter;
@@ -73,12 +73,12 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         internal StandardMetricsExtractionProcessor(AzureMonitorMetricExporter metricExporter, AzureMonitorExporterOptions options)
         {
             _enableStandardMetrics = options.EnableStandardMetrics;
-            _enablePerfCounters = options.EnablePerfCounters;
+            _enablePerformanceCounters = options.EnablePerformanceCounters;
 
             // Initialize Lazy<T> for thread-safe lazy initialization of MeterProvider
             _meterProvider = new Lazy<MeterProvider?>(() =>
             {
-                if (!_enableStandardMetrics && !_enablePerfCounters)
+                if (!_enableStandardMetrics && !_enablePerformanceCounters)
                 {
                     return null;
                 }
@@ -90,7 +90,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     meterProviderBuilder.AddMeter(StandardMetricConstants.StandardMetricMeterName);
                 }
 
-                if (_enablePerfCounters)
+                if (_enablePerformanceCounters)
                 {
                     meterProviderBuilder.AddMeter(PerfCounterConstants.PerfCounterMeterName);
                 }
@@ -115,7 +115,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 _dependencyDuration = _standardMetricMeter.CreateHistogram<double>(StandardMetricConstants.DependencyDurationInstrumentName);
             }
 
-            if (_enablePerfCounters)
+            if (_enablePerformanceCounters)
             {
                 _process = Process.GetCurrentProcess();
                 _perfCounterMeter = new Meter(PerfCounterConstants.PerfCounterMeterName);
@@ -157,7 +157,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                 }
 
                 // Increment request count for rate calculation
-                if (_enablePerfCounters)
+                if (_enablePerformanceCounters)
                 {
                     Interlocked.Increment(ref _requestCount);
                 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StandardMetricTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/StandardMetricTests.cs
@@ -632,7 +632,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var traceTelemetryItems = new List<TelemetryItem>();
             var metricTelemetryItems = new List<TelemetryItem>();
 
-            var options = new AzureMonitorExporterOptions { EnablePerfCounters = false };
+            var options = new AzureMonitorExporterOptions { EnablePerformanceCounters = false };
             var standardMetricCustomProcessor = new StandardMetricsExtractionProcessor(new AzureMonitorMetricExporter(new MockTransmitter(metricTelemetryItems)), options);
 
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
@@ -687,7 +687,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var options = new AzureMonitorExporterOptions
             {
                 EnableStandardMetrics = false,
-                EnablePerfCounters = false
+                EnablePerformanceCounters = false
             };
             var standardMetricCustomProcessor = new StandardMetricsExtractionProcessor(new AzureMonitorMetricExporter(new MockTransmitter(metricTelemetryItems)), options);
 
@@ -724,7 +724,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void ValidateEnablePropertiesConfiguration(bool enableStandardMetrics, bool enablePerfCounters)
+        public void ValidateEnablePropertiesConfiguration(bool enableStandardMetrics, bool enablePerformanceCounters)
         {
             var activitySource = new ActivitySource(nameof(StandardMetricTests.ValidateEnablePropertiesConfiguration));
             var traceTelemetryItems = new List<TelemetryItem>();
@@ -733,7 +733,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var options = new AzureMonitorExporterOptions
             {
                 EnableStandardMetrics = enableStandardMetrics,
-                EnablePerfCounters = enablePerfCounters
+                EnablePerformanceCounters = enablePerformanceCounters
             };
             var standardMetricCustomProcessor = new StandardMetricsExtractionProcessor(new AzureMonitorMetricExporter(new MockTransmitter(metricTelemetryItems)), options);
 
@@ -785,7 +785,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests
             var requestRate = FindMetric(PerfCounterConstants.RequestRateMetricIdValue);
             var privateBytes = FindMetric(PerfCounterConstants.ProcessPrivateBytesMetricIdValue);
 
-            if (enablePerfCounters)
+            if (enablePerformanceCounters)
             {
                 // At least some perf counter metrics should be present
                 Assert.True(requestRate != null || privateBytes != null, "Expected at least one performance counter metric when enabled");


### PR DESCRIPTION
Renamed across Exporter and AspNetCore source, tests, API listings, and changelogs.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
