### PR TITLE
[CODEOWNERS] Fix linter failures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -278,7 +278,7 @@
 /sdk/confidentialledger/                                           @andpiccione @Azure/azure-sdk-write-acl @christothes @ivarprudnikov @msftsettiy @musabbir @PallabPaul @ryazhang-microsoft @weirenlai
 
 # ServiceLabel: %Confidential Ledger
-# ServiceOwners:                                                   @andpiccione @Azure/azure-sdk-write-acl @ivarprudnikov @msftsettiy @musabbir @PallabPaulf @ryazhang-microsoft @weirenlai
+# ServiceOwners:                                                   @andpiccione @Azure/azure-sdk-write-acl @ivarprudnikov @msftsettiy @musabbir @PallabPaul @ryazhang-microsoft @weirenlai
 
 # PRLabel: %Container Registry
 /sdk/containerregistry/                                            @Azure/azure-sdk-write-acr

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -275,10 +275,10 @@
 # ServiceOwners:                                                   @Drewm3 @hilaryw29 @MsGabsta @nikhilpatel909 @sandeepraichura @TravisCragg-MSFT @ushnaarshadkhan
 
 # PRLabel: %Confidential Ledger
-/sdk/confidentialledger/                                           @andpiccione @Azure/azure-sdk-write-acl @christothes @ivarprudnikov @msftsettiy @musabbir @PallabPaul @prathod09 @ryazhang-microsoft @weirenlai
+/sdk/confidentialledger/                                           @andpiccione @Azure/azure-sdk-write-acl @christothes @ivarprudnikov @msftsettiy @musabbir @PallabPaul @ryazhang-microsoft @weirenlai
 
 # ServiceLabel: %Confidential Ledger
-# ServiceOwners:                                                   @andpiccione @Azure/azure-sdk-write-acl @ivarprudnikov @msftsettiy @musabbir @PallabPaul @prathod09 @ryazhang-microsoft @weirenlai
+# ServiceOwners:                                                   @andpiccione @Azure/azure-sdk-write-acl @ivarprudnikov @msftsettiy @musabbir @PallabPaulf @ryazhang-microsoft @weirenlai
 
 # PRLabel: %Container Registry
 /sdk/containerregistry/                                            @Azure/azure-sdk-write-acr


### PR DESCRIPTION
# Summary

The focus of these changes is to remove an owner that the linter is flagging as no longer valid.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6077715&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4) _(Microsoft internal)_