### PR TITLE
[Mgmt Generator] Fix ResourceData base type resolution

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
@@ -326,7 +326,7 @@ namespace Azure.Generator.Management
             var arrayResponseCollectionResults = ExtractArrayResponseCollectionResults();
 
             return [
-                .. base.BuildTypeProviders().Where(t => t is not InheritableSystemObjectModelProvider),
+                .. base.BuildTypeProviders().Where(t => t is not InheritableSystemObjectModelProvider { IsSystemBase: true }),
                 WirePathAttributeDefinition,
                 ArmOperation,
                 ArmOperationOfT,

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementTypeFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementTypeFactory.cs
@@ -117,21 +117,22 @@ namespace Azure.Generator.Management
             // First check for standard ARM types that map to system types
             if (KnownManagementTypes.TryGetInheritableSystemType(model.CrossLanguageDefinitionId, out var replacedType))
             {
-                return new InheritableSystemObjectModelProvider(replacedType.FrameworkType, model);
+                return InheritableSystemObjectModelProvider.CreateSystemBase(replacedType.FrameworkType, model);
             }
             if (KnownManagementTypes.TryGetSystemType(model.CrossLanguageDefinitionId, out _))
             {
                 return null;
             }
 
-            // Ensure base models that map to inheritable system types (e.g., TrackedResource → TrackedResourceData)
-            // are created BEFORE derived models. The framework caches the CSharpType (including BaseType) eagerly
-            // during model construction. If the base model hasn't been created yet when BuildBaseType() runs,
-            // it returns a stale/incorrect value that gets permanently cached.
+            // For models whose base is an inheritable system type (e.g., TrackedResource → TrackedResourceData),
+            // use a derived InheritableSystemObjectModelProvider which overrides BuildBaseType() to return the
+            // correct framework CSharpType. The default ModelProvider.BuildBaseType() returns
+            // BaseModelProvider.Type, which produces a non-framework CSharpType that gets eagerly cached.
             if (model.BaseModel is { } baseModel &&
-                KnownManagementTypes.TryGetInheritableSystemType(baseModel.CrossLanguageDefinitionId, out _))
+                KnownManagementTypes.TryGetInheritableSystemType(baseModel.CrossLanguageDefinitionId, out var inheritableType))
             {
                 CreateModel(baseModel);
+                return InheritableSystemObjectModelProvider.CreateDerived(model, inheritableType);
             }
 
             // For custom Azure resource models (root, intermediate, and resource data models),

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/InheritableSystemObjectModelProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/InheritableSystemObjectModelProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using System;
 
@@ -13,21 +14,74 @@ namespace Azure.Generator.Management.Providers
     internal class InheritableSystemObjectModelProvider : ModelProvider
     {
         internal readonly Type _type;
-        public InheritableSystemObjectModelProvider(Type type, InputModelType inputModel) : base(inputModel)
+        private readonly CSharpType? _frameworkBaseType;
+
+        // WORKAROUND: Static field to pass the framework base type to BuildBaseType() during
+        // base constructor execution. In C#, virtual methods called from a base constructor
+        // dispatch to the derived override, but instance fields are not yet assigned at that
+        // point. Since BuildBaseType() is called (and cached) during base(inputModel),
+        // _frameworkBaseType is still null. We use this static to bridge the gap.
+        // This is safe because SDK generation is single-threaded, and CreateDerived() scopes
+        // the value tightly with try/finally.
+        // TODO: Remove this workaround when InheritableSystemObjectModelProvider is refactored
+        // or replaced by SystemObjectModelProvider from MTG.
+        private static CSharpType? s_pendingBaseType;
+
+        /// <summary>
+        /// True when this provider represents the system base type itself (e.g., TrackedResourceData).
+        /// False when it represents a derived model whose base type is a system type.
+        /// </summary>
+        internal bool IsSystemBase { get; }
+
+        private InheritableSystemObjectModelProvider(Type type, InputModelType inputModel, bool isSystemBase, CSharpType? frameworkBaseType = null) : base(inputModel)
         {
             _type = type;
-            CrossLanguageDefinitionId = inputModel.CrossLanguageDefinitionId;
+            _frameworkBaseType = frameworkBaseType;
+            IsSystemBase = isSystemBase;
+            if (isSystemBase)
+            {
+                CrossLanguageDefinitionId = inputModel.CrossLanguageDefinitionId;
+            }
         }
 
-        internal string CrossLanguageDefinitionId { get; }
+        /// <summary>
+        /// Creates a provider representing the system base type itself (e.g., TrackedResource → TrackedResourceData).
+        /// </summary>
+        internal static InheritableSystemObjectModelProvider CreateSystemBase(Type type, InputModelType inputModel)
+            => new(type, inputModel, isSystemBase: true);
 
-        protected override string BuildName() => _type?.Name ?? string.Empty;
+        /// <summary>
+        /// Creates a provider for a model that extends an inheritable system type.
+        /// Overrides BuildBaseType() to return the correct framework CSharpType.
+        /// </summary>
+        internal static InheritableSystemObjectModelProvider CreateDerived(InputModelType inputModel, CSharpType frameworkBaseType)
+        {
+            s_pendingBaseType = frameworkBaseType;
+            try
+            {
+                return new InheritableSystemObjectModelProvider(
+                    frameworkBaseType.FrameworkType, inputModel, isSystemBase: false, frameworkBaseType);
+            }
+            finally
+            {
+                s_pendingBaseType = null;
+            }
+        }
+
+        internal string? CrossLanguageDefinitionId { get; }
+
+        protected override string BuildName() => IsSystemBase ? (_type?.Name ?? string.Empty) : base.BuildName();
 
         protected override string BuildRelativeFilePath()
-            => throw new InvalidOperationException("This type should not be writing in generation");
+            => IsSystemBase
+                ? throw new InvalidOperationException("This type should not be writing in generation")
+                : base.BuildRelativeFilePath();
 
         // _type may be null when called from base constructor before field assignment.
         // The visitor's UpdateNamespace corrects this to _type.Namespace after construction.
-        protected override string BuildNamespace() => _type?.Namespace ?? string.Empty;
+        protected override string BuildNamespace() => IsSystemBase ? (_type?.Namespace ?? string.Empty) : base.BuildNamespace();
+
+        protected override CSharpType? BuildBaseType()
+            => IsSystemBase ? base.BuildBaseType() : (_frameworkBaseType ?? s_pendingBaseType);
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/InheritableSystemObjectModelVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/InheritableSystemObjectModelVisitor.cs
@@ -25,12 +25,12 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
 {
     protected override ModelProvider? PreVisitModel(InputModelType model, ModelProvider? type)
     {
-        if (type is InheritableSystemObjectModelProvider systemType)
+        if (type is InheritableSystemObjectModelProvider { IsSystemBase: true } systemType)
         {
             UpdateNamespace(systemType);
         }
 
-        if (type is not InheritableSystemObjectModelProvider && type?.BaseModelProvider is InheritableSystemObjectModelProvider baseSystemType)
+        if (type is not InheritableSystemObjectModelProvider { IsSystemBase: true } && type?.BaseModelProvider is InheritableSystemObjectModelProvider { IsSystemBase: true } baseSystemType)
         {
             // Defer serialization update for discriminated models to avoid infinite recursion.
             // Accessing serializationTypeDefinition.Methods triggers building DerivedModels ->
@@ -40,7 +40,7 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
             // (before properties and fields are modified later in Update).
             Update(baseSystemType, type, deferSerialization: model.DiscriminatorProperty != null);
         }
-        else if (type?.BaseModelProvider is not null && type is not InheritableSystemObjectModelProvider)
+        else if (type?.BaseModelProvider is not null && type is not InheritableSystemObjectModelProvider { IsSystemBase: true })
         {
             // Handle regular model inheritance where a non-system model extends another non-system model.
             // This fixes duplicate property generation when TypeSpec models redefine base model properties
@@ -58,16 +58,16 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
             UpdateModelFactory(modelFactory);
         }
 
-        if (type is InheritableSystemObjectModelProvider systemType)
+        if (type is InheritableSystemObjectModelProvider { IsSystemBase: true } systemType)
         {
             UpdateNamespace(systemType);
         }
 
-        if (type is ModelProvider model && model is not InheritableSystemObjectModelProvider && model.BaseModelProvider is InheritableSystemObjectModelProvider baseSystemType)
+        if (type is ModelProvider model && model is not InheritableSystemObjectModelProvider { IsSystemBase: true } && model.BaseModelProvider is InheritableSystemObjectModelProvider { IsSystemBase: true } baseSystemType)
         {
             Update(baseSystemType, model);
         }
-        else if (type is ModelProvider model2 && model2.BaseModelProvider is not null && model2 is not InheritableSystemObjectModelProvider)
+        else if (type is ModelProvider model2 && model2.BaseModelProvider is not null && model2 is not InheritableSystemObjectModelProvider { IsSystemBase: true })
         {
             // Handle regular model inheritance where a non-system model extends another non-system model.
             // This fixes duplicate property generation when TypeSpec models redefine base model properties

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/NameVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/NameVisitor.cs
@@ -103,7 +103,7 @@ internal class NameVisitor : ScmLibraryVisitor
         }
         var enclosingType = propertyProvider.EnclosingType;
         if (enclosingType is not InheritableSystemObjectModelProvider modelProvider
-            || !modelProvider.CrossLanguageDefinitionId.Equals(KnownManagementTypes.ArmResourceId))
+            || modelProvider.CrossLanguageDefinitionId?.Equals(KnownManagementTypes.ArmResourceId) != true)
         {
             return;
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InheritableSystemObjectModelVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InheritableSystemObjectModelVisitorTests.cs
@@ -14,6 +14,85 @@ namespace Azure.Generator.Mgmt.Tests
     internal class InheritableSystemObjectModelVisitorTests
     {
         /// <summary>
+        /// Verifies that a model extending TrackedResource resolves to TrackedResourceData
+        /// as its base type, not ArmResource or any other incorrect type.
+        /// This reproduces the bug where the framework eagerly caches CSharpType.BaseType
+        /// during model construction. When model processing order causes the derived model
+        /// to be constructed before the base model's InheritableSystemObjectModelProvider,
+        /// the cached BaseType gets permanently set to the wrong value.
+        /// </summary>
+        [TestCase("Azure.ResourceManager.CommonTypes.TrackedResource", typeof(Azure.ResourceManager.Models.TrackedResourceData))]
+        [TestCase("Azure.ResourceManager.CommonTypes.ProxyResource", typeof(Azure.ResourceManager.Models.ResourceData))]
+        [TestCase("Azure.ResourceManager.CommonTypes.ExtensionResource", typeof(Azure.ResourceManager.Models.ResourceData))]
+        public void ResourceDataModelInheritsCorrectBaseType(string baseModelCrossLanguageId, System.Type expectedBaseType)
+        {
+            // Arrange: Create a base model (TrackedResource/ProxyResource) and a derived model
+            var baseModel = new InputModelType(
+                "TrackedResource",
+                "Azure.ResourceManager.CommonTypes",
+                baseModelCrossLanguageId,
+                "public",
+                null,
+                null,
+                "ARM Tracked Resource",
+                InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                [
+                    InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                    InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                ],
+                null,
+                [],
+                null,
+                null,
+                new Dictionary<string, InputModelType>(),
+                null,
+                false,
+                new InputSerializationOptions(),
+                false);
+
+            var derivedModel = new InputModelType(
+                "MonitorResource",
+                "Samples.Models",
+                "MonitorResource",
+                "public",
+                null,
+                null,
+                "Monitor Resource extending tracked resource",
+                InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                [InputFactory.Property("monitorName", InputPrimitiveType.String)],
+                baseModel,
+                [],
+                null,
+                null,
+                new Dictionary<string, InputModelType>(),
+                null,
+                false,
+                new InputSerializationOptions(),
+                false);
+
+            // Load with derived model FIRST to stress model ordering
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [derivedModel, baseModel]);
+
+            // Act - create the derived model
+            var derivedType = plugin.Object.TypeFactory.CreateModel(derivedModel);
+
+            // Assert
+            Assert.IsNotNull(derivedType, "Derived model should be created");
+            Assert.IsNotNull(derivedType!.BaseModelProvider, "Derived model should have a base model provider");
+
+            // The critical assertion: the derived model's CSharpType.BaseType should be the
+            // correct framework type (TrackedResourceData/ResourceData), not ArmResource.
+            var actualBaseType = derivedType.Type.BaseType;
+            Assert.IsNotNull(actualBaseType, "Derived model's CSharpType.BaseType should not be null");
+            Assert.IsTrue(actualBaseType!.IsFrameworkType,
+                $"Expected framework type {expectedBaseType.Name} but got non-framework type: {actualBaseType.Name} ({actualBaseType.Namespace})");
+            Assert.AreEqual(expectedBaseType, actualBaseType.FrameworkType,
+                $"Derived model should inherit from {expectedBaseType.Name}");
+        }
+
+        /// <summary>
         /// Verifies that creating a discriminated model extending ARM Resource does not cause
         /// a stack overflow. Before the fix, UpdateSerialization accessed Methods during
         /// PreVisitModel which triggered building DerivedModels -> CreateModel for derived types

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ManagementTypeFactoryTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ManagementTypeFactoryTests.cs
@@ -8,7 +8,6 @@ using Azure.ResourceManager.Resources.Models;
 using Microsoft.TypeSpec.Generator.Input;
 using NUnit.Framework;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Azure.Generator.Mgmt.Tests
 {
@@ -128,47 +127,6 @@ namespace Azure.Generator.Mgmt.Tests
             // No ManagedServiceIdentityType enum at all
             var plugin = ManagementMockHelpers.LoadMockPlugin(inputEnums: () => []);
             Assert.IsFalse(plugin.Object.TypeFactory.UseManagedServiceIdentityV3);
-        }
-
-        [TestCase("Azure.ResourceManager.CommonTypes.TrackedResource", typeof(Azure.ResourceManager.Models.TrackedResourceData))]
-        [TestCase("Azure.ResourceManager.CommonTypes.ProxyResource", typeof(Azure.ResourceManager.Models.ResourceData))]
-        [TestCase("Azure.ResourceManager.CommonTypes.ExtensionResource", typeof(Azure.ResourceManager.Models.ResourceData))]
-        public void CreateCSharpTypeReturnsCorrectTypeForInheritableSystemModel(string crossLanguageDefinitionId, System.Type expectedType)
-        {
-            // When CreateCSharpType is called for an inheritable system model (TrackedResource,
-            // ProxyResource, etc.), it should return the corresponding system type
-            // (TrackedResourceData, ResourceData). Without this, derived models that reference
-            // the base model during type resolution can get the wrong cached BaseType.
-            var model = new InputModelType(
-                "TestResource",
-                "Azure.ResourceManager.CommonTypes",
-                crossLanguageDefinitionId,
-                "public",
-                null,
-                null,
-                "ARM resource",
-                InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
-                [
-                    InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
-                ],
-                null,
-                [],
-                null,
-                null,
-                new Dictionary<string, InputModelType>(),
-                null,
-                false,
-                new InputSerializationOptions(),
-                false);
-
-            var plugin = ManagementMockHelpers.LoadMockPlugin(
-                inputModels: () => [model]);
-
-            var result = plugin.Object.TypeFactory.CreateCSharpType(model);
-            Assert.IsNotNull(result);
-            Assert.IsTrue(result!.IsFrameworkType,
-                $"Expected framework type {expectedType.Name} but got non-framework type: {result}");
-            Assert.AreEqual(expectedType, result.FrameworkType);
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/ContainerItemLike.Serialization.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/ContainerItemLike.Serialization.cs
@@ -21,7 +21,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
     {
         /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        protected override ResourceData PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
+        protected override EntityResourceLike PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
         {
             string format = options.Format == "W" ? ((IPersistableModel<ContainerItemLike>)this).GetFormatFromOptions(options) : options.Format;
             switch (format)
@@ -91,7 +91,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
 
         /// <param name="reader"> The JSON reader. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        protected override ResourceData JsonModelCreateCore(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+        protected override EntityResourceLike JsonModelCreateCore(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             string format = options.Format == "W" ? ((IPersistableModel<ContainerItemLike>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/DerivedPatch.Serialization.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/DerivedPatch.Serialization.cs
@@ -21,7 +21,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
     {
         /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        protected override ResourceData PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
+        protected override CustomPatchBase PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
         {
             string format = options.Format == "W" ? ((IPersistableModel<DerivedPatch>)this).GetFormatFromOptions(options) : options.Format;
             switch (format)
@@ -91,7 +91,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
 
         /// <param name="reader"> The JSON reader. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        protected override ResourceData JsonModelCreateCore(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+        protected override CustomPatchBase JsonModelCreateCore(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             string format = options.Format == "W" ? ((IPersistableModel<DerivedPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")


### PR DESCRIPTION
## Description

Fix a bug where ResourceData models (e.g., `NewRelicMonitorResourceData`) incorrectly inherit from a non-framework CSharpType instead of the correct framework type (`TrackedResourceData`, `ResourceData`) when extending inheritable system types (`TrackedResource`, `ProxyResource`, `ExtensionResource`).

This is a follow-up to #57529 which partially fixed the issue but missed the core problem.

### Root Cause

`ModelProvider.BuildBaseType()` returns `BaseModelProvider.Type`, which for `InheritableSystemObjectModelProvider` produces a **non-framework CSharpType** (constructed internally by `TypeProvider.Type` from `BuildName()`/`BuildNamespace()`) rather than the framework CSharpType (from `typeof(TrackedResourceData)`). This non-framework type gets eagerly cached in the `CSharpType` during base constructor execution and cannot be corrected afterward since `CSharpType.BaseType` is init-only.

### Why PR #57529's fix was insufficient

1. The `CreateCSharpTypeCore` and `CreateModelCore` preemptive ordering fixes didn't address the fundamental issue: `InheritableSystemObjectModelProvider.Type` always produces a non-framework CSharpType, which is what `BuildBaseType()` returns via `BaseModelProvider.Type`
2. The test (`CreateCSharpTypeReturnsCorrectTypeForInheritableSystemModel`) only tested `CreateCSharpType()` on the **base model itself** — it never created a derived model or verified its `BaseType`

### Fix

Extend `InheritableSystemObjectModelProvider` to handle both system base types and derived models:

- **`CreateSystemBase()`** — creates a provider representing the system base type itself (existing behavior, e.g., TrackedResource → TrackedResourceData)
- **`CreateDerived()`** — creates a provider for a model that extends a system type, overriding `BuildBaseType()` to return the correct framework CSharpType directly
- **`IsSystemBase` flag** — distinguishes the two roles so the visitor, output library, and other checks route them through the correct processing paths

A static `s_pendingBaseType` field is used as a workaround for C#'s virtual dispatch during base constructor — `BuildBaseType()` is called and cached during `base(inputModel)` before instance fields are assigned. This is safe since SDK generation is single-threaded. A TODO is added to remove this workaround during future refactoring.

### Test

Replaced the ineffective `CreateCSharpTypeReturnsCorrectTypeForInheritableSystemModel` test with `ResourceDataModelInheritsCorrectBaseType` which:
- Creates both a base model (TrackedResource/ProxyResource/ExtensionResource) AND a derived model
- Verifies the derived model's `CSharpType.BaseType` is the correct **framework** type
- Confirms the test **fails on main** without the fix

### Validation

- All 143 unit tests pass
- `Generate.ps1` passes for both `Mgmt-TypeSpec` and `Mgmt-TypeSpec-MultiService` test projects
- `RegenSdkLocal.ps1 -Services "NewRelicObservability"` produces correct `NewRelicMonitorResourceData : TrackedResourceData` (was `ArmResource`)
