### PR TITLE
[Mgmt Generator] Fix covariant return type in serialization overrides

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/InheritableSystemObjectModelVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/InheritableSystemObjectModelVisitor.cs
@@ -82,6 +82,14 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
         {
             UpdateSerialization(pendingModel);
         }
+
+        // Fix serialization override return types deferred from UpdateRegularModelInheritance.
+        // Must run in VisitType (not PreVisitModel) because accessing serialization Methods
+        // triggers lazy method building which can cause infinite recursion for discriminated models.
+        if (type is ModelProvider pendingReturnTypeFix && _pendingSerializationReturnTypeFix.Remove(pendingReturnTypeFix))
+        {
+            FixSerializationReturnTypes(pendingReturnTypeFix);
+        }
         return type;
     }
 
@@ -109,6 +117,7 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
     private HashSet<ModelProvider> _updated = new();
     private HashSet<ModelProvider> _regularUpdated = new();
     private HashSet<ModelProvider> _pendingSerialization = new();
+    private HashSet<ModelProvider> _pendingSerializationReturnTypeFix = new();
     private void Update(InheritableSystemObjectModelProvider baseSystemType, ModelProvider model, bool deferSerialization = false)
     {
         // Add cache to avoid duplicated update of PreVisitModel and VisitType
@@ -176,6 +185,11 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
         // additionalBinaryDataProperties). To fix, update the constructor parameter to reference
         // the same field the serialization code will find.
         FixRawDataFieldReference(model);
+
+        // Defer serialization return type fixes to VisitType to avoid triggering lazy
+        // serialization method building during PreVisitModel (which can cause infinite
+        // recursion for discriminated models).
+        _pendingSerializationReturnTypeFix.Add(model);
 
         _regularUpdated.Add(model);
     }
@@ -251,6 +265,7 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
     }
 
     private static readonly HashSet<string> _methodNamesToUpdate = new(){ "JsonModelCreateCore", "PersistableModelCreateCore", "PersistableModelWriteCore" };
+    private static readonly HashSet<string> _methodNamesToFixReturnType = new(){ "JsonModelCreateCore", "PersistableModelCreateCore" };
     private static void UpdateSerialization(ModelProvider model)
     {
         var serializationProvider = model.SerializationProviders;
@@ -266,6 +281,59 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Fixes the return type of serialization override methods (PersistableModelCreateCore,
+    /// JsonModelCreateCore) to match the base virtual method's declared return type.
+    /// Without this, the framework generates overrides with model.Type.BaseType as the return
+    /// type, which can be a covariant return type (e.g., returning CustomPatchBase instead of
+    /// ResourceData). Covariant returns are not supported on .NET Framework.
+    /// </summary>
+    private static void FixSerializationReturnTypes(ModelProvider model)
+    {
+        // The base virtual serialization methods always use the system type (ResourceData)
+        // as their return type. Walk up the hierarchy to find it.
+        var systemBaseType = FindSystemBaseType(model);
+        if (systemBaseType is null)
+        {
+            return;
+        }
+
+        foreach (var provider in model.SerializationProviders)
+        {
+            if (provider is MrwSerializationTypeDefinition serializationTypeDefinition)
+            {
+                foreach (var method in serializationTypeDefinition.Methods.Where(
+                    m => _methodNamesToFixReturnType.Contains(m.Signature.Name)
+                         && m.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Override)))
+                {
+                    var currentReturnType = method.Signature.ReturnType;
+                    if (currentReturnType is not null && !currentReturnType.Equals(systemBaseType))
+                    {
+                        method.Signature.Update(returnType: systemBaseType);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walks up the model hierarchy to find the system base type (e.g., ResourceData)
+    /// that the virtual serialization methods use as their return type.
+    /// </summary>
+    private static CSharpType? FindSystemBaseType(ModelProvider model)
+    {
+        var current = model.BaseModelProvider;
+        while (current is not null)
+        {
+            if (current is InheritableSystemObjectModelProvider { IsSystemBase: true } systemModel)
+            {
+                return systemModel.Type;
+            }
+            current = current.BaseModelProvider;
+        }
+        return null;
     }
 
     private static void UpdateFullConstructor(ModelProvider model, FieldProvider rawDataField)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/InheritableSystemObjectModelVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/InheritableSystemObjectModelVisitor.cs
@@ -264,8 +264,23 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
         model.FullConstructor.Update(signature: updatedSignature);
     }
 
-    private static readonly HashSet<string> _methodNamesToUpdate = new(){ "JsonModelCreateCore", "PersistableModelCreateCore", "PersistableModelWriteCore" };
-    private static readonly HashSet<string> _methodNamesToFixReturnType = new(){ "JsonModelCreateCore", "PersistableModelCreateCore" };
+    private const string JsonModelCreateCoreMethodName = "JsonModelCreateCore";
+    private const string PersistableModelCreateCoreMethodName = "PersistableModelCreateCore";
+    private const string PersistableModelWriteCoreMethodName = "PersistableModelWriteCore";
+
+    private static readonly HashSet<string> _methodNamesToUpdate = new()
+    {
+        JsonModelCreateCoreMethodName,
+        PersistableModelCreateCoreMethodName,
+        PersistableModelWriteCoreMethodName
+    };
+
+    private static readonly HashSet<string> _methodNamesToFixReturnType = new()
+    {
+        JsonModelCreateCoreMethodName,
+        PersistableModelCreateCoreMethodName
+    };
+
     private static void UpdateSerialization(ModelProvider model)
     {
         var serializationProvider = model.SerializationProviders;
@@ -285,15 +300,14 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
 
     /// <summary>
     /// Fixes the return type of serialization override methods (PersistableModelCreateCore,
-    /// JsonModelCreateCore) to match the base virtual method's declared return type.
-    /// Without this, the framework generates overrides with model.Type.BaseType as the return
-    /// type, which can be a covariant return type (e.g., returning CustomPatchBase instead of
-    /// ResourceData). Covariant returns are not supported on .NET Framework.
+    /// JsonModelCreateCore) to use the system base type (e.g., ResourceData) instead of the
+    /// immediate parent type. Without this, the framework generates overrides with
+    /// model.Type.BaseType as the return type, which can produce a covariant return type
+    /// (e.g., returning CustomPatchBase instead of ResourceData). Covariant returns are not
+    /// supported on .NET Framework.
     /// </summary>
-    private static void FixSerializationReturnTypes(ModelProvider model)
+    private void FixSerializationReturnTypes(ModelProvider model)
     {
-        // The base virtual serialization methods always use the system type (ResourceData)
-        // as their return type. Walk up the hierarchy to find it.
         var systemBaseType = FindSystemBaseType(model);
         if (systemBaseType is null)
         {
@@ -318,21 +332,30 @@ internal class InheritableSystemObjectModelVisitor : ScmLibraryVisitor
         }
     }
 
+    private readonly Dictionary<ModelProvider, CSharpType?> _systemBaseTypeCache = new();
+
     /// <summary>
     /// Walks up the model hierarchy to find the system base type (e.g., ResourceData)
     /// that the virtual serialization methods use as their return type.
     /// </summary>
-    private static CSharpType? FindSystemBaseType(ModelProvider model)
+    private CSharpType? FindSystemBaseType(ModelProvider model)
     {
+        if (_systemBaseTypeCache.TryGetValue(model, out var cached))
+        {
+            return cached;
+        }
+
         var current = model.BaseModelProvider;
         while (current is not null)
         {
             if (current is InheritableSystemObjectModelProvider { IsSystemBase: true } systemModel)
             {
+                _systemBaseTypeCache[model] = systemModel.Type;
                 return systemModel.Type;
             }
             current = current.BaseModelProvider;
         }
+        _systemBaseTypeCache[model] = null;
         return null;
     }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/ContainerItemLike.Serialization.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/ContainerItemLike.Serialization.cs
@@ -21,7 +21,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
     {
         /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        protected override EntityResourceLike PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
+        protected override ResourceData PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
         {
             string format = options.Format == "W" ? ((IPersistableModel<ContainerItemLike>)this).GetFormatFromOptions(options) : options.Format;
             switch (format)
@@ -91,7 +91,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
 
         /// <param name="reader"> The JSON reader. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        protected override EntityResourceLike JsonModelCreateCore(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+        protected override ResourceData JsonModelCreateCore(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             string format = options.Format == "W" ? ((IPersistableModel<ContainerItemLike>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/DerivedPatch.Serialization.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/DerivedPatch.Serialization.cs
@@ -21,7 +21,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
     {
         /// <param name="data"> The data to parse. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        protected override CustomPatchBase PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
+        protected override ResourceData PersistableModelCreateCore(BinaryData data, ModelReaderWriterOptions options)
         {
             string format = options.Format == "W" ? ((IPersistableModel<DerivedPatch>)this).GetFormatFromOptions(options) : options.Format;
             switch (format)
@@ -91,7 +91,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
 
         /// <param name="reader"> The JSON reader. </param>
         /// <param name="options"> The client options for reading and writing models. </param>
-        protected override CustomPatchBase JsonModelCreateCore(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
+        protected override ResourceData JsonModelCreateCore(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
         {
             string format = options.Format == "W" ? ((IPersistableModel<DerivedPatch>)this).GetFormatFromOptions(options) : options.Format;
             if (format != "J")


### PR DESCRIPTION
## Description

Fix CS8830 compilation error on .NET Framework caused by covariant return types in serialization method overrides (`PersistableModelCreateCore`, `JsonModelCreateCore`).

This is a follow-up to #57569 which introduced the issue.

### Root Cause

The previous base type resolution fix (#57569) correctly changed derived models' `BuildBaseType()` to return the immediate parent type. However, the framework uses this base type as the override return type for serialization methods. When the immediate parent declares virtual methods with `ResourceData` as the return type, overriding with a more derived return type is a covariant return — **unsupported on .NET Framework 4.6.2**.

```
HybridConnectivityTrackedResourcePatch : ResourceData
  → virtual ResourceData PersistableModelCreateCore(...)

PublicCloudConnectorPatch : HybridConnectivityTrackedResourcePatch
  → override HybridConnectivityTrackedResourcePatch PersistableModelCreateCore(...)  // ❌ CS8830
```

### Fix

Add `FixSerializationReturnTypes()` in `UpdateRegularModelInheritance` that walks up the model hierarchy to find the `InheritableSystemObjectModelProvider` (system base type) and uses its `CSharpType` as the return type for override serialization methods.

The fix is deferred to `VisitType` (not `PreVisitModel`) to avoid triggering lazy serialization method building during model creation, which causes infinite recursion for discriminated models.

### Validation

- All 145 unit tests pass
- `Generate.ps1` passes for both `Mgmt-TypeSpec` and `Mgmt-TypeSpec-MultiService` test projects
- Generated test project serialization overrides now use `ResourceData` return type consistently
