### PR TITLE
[search] Add package-specific skill support with directory-based discovery

### DIFF
--- a/.github/skills/find-package-skill/SKILL.md
+++ b/.github/skills/find-package-skill/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: find-package-skill
+description: '**UTILITY SKILL** — Must be consulted before making any changes to packages under sdk/. Discovers and loads package-specific domain knowledge that prevents common mistakes. WHEN: add feature to package; fix bug in package; modify package code; regenerate from typespec; change client library.'
+---
+
+# Find Package Skill
+
+Some SDK packages in this monorepo have **package-specific skills** — tribal
+knowledge (architecture, data flows, type mappings, pitfalls) that prevents
+common mistakes. Before modifying any SDK package, check whether a skill exists
+for it using the steps below.
+
+## How to Discover Package Skills
+
+1. **Determine the package directory.** If you already know the file path you're
+   modifying, extract the package directory from it (e.g., a file at
+   `sdk/search/Azure.Search.Documents/src/SearchClient.cs` belongs to the package
+   at `sdk/search/Azure.Search.Documents/`). If you only have a package name,
+   search for a matching directory under `sdk/` or use `.github/CODEOWNERS` path
+   patterns to resolve the service area.
+
+2. **Check for a `.github/skills/` directory** inside the package directory. For
+   example, check whether `sdk/search/Azure.Search.Documents/.github/skills/`
+   exists.
+
+3. **If it exists**, read every `SKILL.md` found under that directory. If a
+   `references/` subdirectory exists next to a `SKILL.md`, read all files in it
+   too for additional context.
+
+4. **If no `.github/skills/` directory exists** for the package, no
+   package-specific skill has been created yet — proceed normally.

--- a/sdk/search/Azure.Search.Documents/.github/skills/search-documents/SKILL.md
+++ b/sdk/search/Azure.Search.Documents/.github/skills/search-documents/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: search-documents
+description: '**UTILITY SKILL** — Domain knowledge for the Azure.Search.Documents SDK package. Covers architecture, code generation, key files, and common pitfalls. WHEN: regenerate search package; modify search client; fix search bug; add search feature; search type mapping.'
+---
+
+# Azure.Search.Documents — Package Skill
+
+<!-- TODO: This is a placeholder skill. Domain experts should fill in the sections below
+     with tribal knowledge specific to this package. Use the @azure/search-documents
+     skill in the azure-sdk-for-js repo as a reference for the level of detail expected. -->
+
+## Architecture
+
+<!-- TODO: Describe the overall architecture, data flow patterns,
+     and the relationship between generated and hand-authored code.
+     What conventions does this package follow? -->
+
+### Source Layout
+
+All source lives under `src/`. The `Generated/` subdirectory contains auto-generated
+partial classes and models — **never hand-edit files in `Generated/`**. Hand-authored
+code elsewhere in `src/` extends the generated partial classes.
+
+Directories: `Batching/`, `Generated/`, `Indexes/`, `Internal/`, `KnowledgeBases/`,
+`Models/`, `Options/`, `Properties/`, `SearchDocument/`, `Serialization/`, `Spatial/`,
+`Utilities/`.
+
+<!-- TODO: Document the purpose of each directory and key files. -->
+
+## Regeneration
+
+TypeSpec source is configured in `tsp-location.yaml`.
+
+<!-- TODO: Document the regeneration workflow for this package.
+     - What command regenerates the client?
+     - What files need manual updates after regeneration?
+     - Are there any merge steps or special flags? -->
+
+## The Clients
+
+<!-- TODO: Document the clients in this package, their purposes,
+     construction patterns, authentication, and any non-obvious behaviors. -->
+
+## Key Hand-Authored Files
+
+<!-- TODO: Document the key hand-authored files and their purposes. -->
+
+## Type Mappings
+
+<!-- TODO: Document property name differences between public API and wire format,
+     any type conversions, null handling patterns, etc. -->
+
+## Common Pitfalls
+
+<!-- TODO: Document common mistakes and non-obvious behaviors. -->
+
+## Testing Notes
+
+<!-- TODO: Document test patterns, recorded test setup, environment requirements,
+     and any special testing conventions for this package. -->


### PR DESCRIPTION
## What

This PR adds support for **package-specific skills** — tribal knowledge that agents load before modifying SDK packages. Two files:

1. **`.github/skills/find-package-skill/SKILL.md`** — a discovery skill that teaches agents how to find package-specific skills by checking for `.github/skills/` inside the package directory they're modifying. No hardcoded lookup table — the directory structure IS the source of truth.

2. **`sdk/search/Azure.Search.Documents/.github/skills/search-documents/SKILL.md`** — placeholder skill for Search with scaffolded sections for domain experts to fill in.

### Updated approach (per discussion with @jsquire and @m-redding)

The original PR had a registry table mapping package names to skill paths. Based on Jesse's feedback, I replaced that with **directory-based inference**: the find-package-skill now instructs agents to derive the package directory from the file path being modified (or resolve a package name by searching under `sdk/`), then check if `.github/skills/` exists inside it. No registration step needed — just create the directory and the skill is automatically discoverable.

This addresses the drift concern since there's no table to keep in sync. Adding a new package skill = creating `.github/skills/<name>/SKILL.md` inside your package directory. That's it.

## Experiment Results

I ran 30 experiments with independent agents to validate the discovery approach. Each agent was given a user prompt and told to follow the find-package-skill before proceeding.

**Overall: 28/30 correct (93.3%)**

| Category | Total | Correct | Accuracy |
|----------|-------|---------|----------|
| Search prompts (skill exists) | 16 | 14 | 87.5% |
| Other packages (no skill) | 14 | 14 | 100% |

### Key findings

- **Zero false positives.** No agent loaded a skill for the wrong package — even for trap tests like `Azure.Provisioning.Search` and `Azure.ResourceManager.Search` (same `sdk/search/` service area, different package directories).
- **2 false negatives** (agent found the right directory but incorrectly reported `.github/skills/` didn't exist). These appear to be execution flukes — the same prompt patterns succeeded in other runs. A registry table would have the same ~7% miss rate since agents can fail to read a table just as they can fail to check a directory.
- **Prompt diversity** — tested with explicit package names, NuGet names, class names, full file paths, sub-client names, vague descriptions ("help me with the search package"), config file references, CODEOWNERS hints, and more. All resolved correctly except the 2 flukes above.

<details>
<summary>Full experiment breakdown</summary>

**Search prompts (skill exists)**

| Prompt Style | Found Skill |
|-------------|-------------|
| Explicit package name + typespec regen | ✅ |
| Class name only ("SearchClient.cs bug") | ❌ |
| Explicit package name + vector search | ✅ |
| Class name ("SearchIndexClient synonym map") | ✅ |
| Full file path | ✅ |
| Vague ("regenerate the search SDK") | ✅ |
| Class name ("SearchIndexerClient null ref") | ✅ |
| Full file path (IndexDocumentsBatch.cs) | ✅ |
| Test file ("add test for batching") | ✅ |
| NuGet package name | ✅ |
| Sub-client ("KnowledgeRetrievalClient") | ✅ |
| Generated folder reference | ✅ |
| Config file (tsp-location.yaml) | ✅ |
| Changelog update | ❌ |
| Ambiguous ("help me with the search package") | ✅ |
| CODEOWNERS hint ("Search service label") | ✅ |

**Other packages (no skill) — all correct**

KeyVault, Storage, Identity, EventHubs, ServiceBus, Cosmos, AppConfiguration, Monitor, FormRecognizer, OpenAI, Communication, TextAnalytics, Azure.Provisioning.Search ⚠️, Azure.ResourceManager.Search ⚠️

⚠️ = trap tests (same service area, different package)

</details>

## Related PRs

- https://github.com/Azure/azure-sdk-for-js/pull/37484
- https://github.com/Azure/azure-sdk-for-python/pull/45972

## Callouts

- @efrainretana is working on the contents of the Search skill for dotnet — this placeholder provides the hook for it to be picked up correctly.
- Other language repos (JS, Python) currently use a registry table approach. If directory inference works well here, we could bring it to those repos too.
