### PR TITLE
Bump Azure.Monitor.OpenTelemetry.Exporter dependency to 1.7.0

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -117,7 +117,7 @@
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Azure.Messaging.WebPubSub" Version="1.6.0" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageVersion Include="Azure.Monitor.Query.Logs" Version="1.0.0" />
     <PackageVersion Include="Azure.ResourceManager" Version="1.14.0" />
     <PackageVersion Include="Azure.ResourceManager.ApiManagement" Version="1.3.0" />


### PR DESCRIPTION
Bumping the exporter version to 1.7.0 - with this update rate limited sampling is default in the distro too.
