### PR TITLE
Export emitAzureCodeModel for downstream emitters

### DIFF
--- a/eng/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/eng/packages/http-client-csharp/emitter/src/emitter.ts
@@ -1,14 +1,46 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { EmitContext, NoTarget, resolvePath } from "@typespec/compiler";
+import {
+  Diagnostic,
+  EmitContext,
+  NoTarget,
+  resolvePath
+} from "@typespec/compiler";
 import { createSdkContext } from "@azure-tools/typespec-client-generator-core";
 
-import { emitCodeModel } from "@typespec/http-client-csharp";
+import {
+  CodeModel,
+  CSharpEmitterContext,
+  emitCodeModel
+} from "@typespec/http-client-csharp";
 import { AzureEmitterOptions } from "./options.js";
 import { $lib } from "./lib/lib.js";
 
 export async function $onEmit(context: EmitContext<AzureEmitterOptions>) {
+  const [, diagnostics] = await emitAzureCodeModel(context);
+  context.program.reportDiagnostics(diagnostics);
+}
+
+/**
+ * Emits Azure-flavored code model with optional customization callback.
+ *
+ * This function applies Azure-specific defaults (generator name, license, decorators, etc.),
+ * generates the metadata.json file, and delegates to the base emitter's `emitCodeModel`.
+ * Downstream emitters (e.g., management plane) can call this instead of `$onEmit` to pass
+ * an `updateCodeModel` callback for additional code model transformations.
+ *
+ * @param context - The emit context
+ * @param updateCodeModel - Optional callback to modify the code model before emission
+ * @returns A tuple containing void and any diagnostics generated during emission
+ */
+export async function emitAzureCodeModel(
+  context: EmitContext<AzureEmitterOptions>,
+  updateCodeModel?: (
+    model: CodeModel,
+    context: CSharpEmitterContext
+  ) => CodeModel
+): Promise<[void, readonly Diagnostic[]]> {
   context.options["generator-name"] ??= "AzureClientGenerator";
   context.options["emitter-extension-path"] ??= import.meta.url;
   context.options["license"] ??= {
@@ -38,8 +70,7 @@ export async function $onEmit(context: EmitContext<AzureEmitterOptions>) {
   // Generate metadata.json file
   await generateMetadataFile(context);
 
-  const [, diagnostics] = await emitCodeModel(context);
-  context.program.reportDiagnostics(diagnostics);
+  return await emitCodeModel(context, updateCodeModel);
 }
 
 /**

--- a/eng/packages/http-client-csharp/emitter/src/emitter.ts
+++ b/eng/packages/http-client-csharp/emitter/src/emitter.ts
@@ -23,7 +23,7 @@ export async function $onEmit(context: EmitContext<AzureEmitterOptions>) {
 }
 
 /**
- * Emits Azure-flavored code model with optional customization callback.
+ * Emits Azure code model with optional customization callback.
  *
  * This function applies Azure-specific defaults (generator name, license, decorators, etc.),
  * generates the metadata.json file, and delegates to the base emitter's `emitCodeModel`.

--- a/eng/packages/http-client-csharp/emitter/src/index.ts
+++ b/eng/packages/http-client-csharp/emitter/src/index.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-export { $onEmit } from "./emitter.js";
+export { $onEmit, emitAzureCodeModel } from "./emitter.js";
 export { AzureEmitterOptions, AzureEmitterOptionsSchema } from "./options.js";
 export { $lib } from "./lib/lib.js";


### PR DESCRIPTION
## What

Export a new `emitAzureCodeModel` function from `@azure-typespec/http-client-csharp` that enables downstream emitters (e.g., management plane) to pass an `updateCodeModel` callback while reusing all Azure-specific setup logic.

## Why

The base `@typespec/http-client-csharp` emitter moved `update-code-model` from an option property to a parameter on `emitCodeModel()`. The Azure emitter currently only exports ``, which doesn't allow downstream emitters to pass this callback. The mgmt generator needs to pass its own code model customizations (resource detection, subscription ID transformation, API version fixing, etc.).

## Changes

- **`emitter/src/emitter.ts`**: Extract Azure setup logic into a new `emitAzureCodeModel(context, updateCodeModel?)` function. Refactor `` to delegate to it.
- **`emitter/src/index.ts`**: Export `emitAzureCodeModel` alongside ``.