### PR TITLE
Fix FlattenPropertyVisitor removing public constructor when all flattened properties are optional

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -617,12 +617,19 @@ namespace Azure.Generator.Management.Visitors
 
             if (updated)
             {
-                // if the public constructor became parameterless, we need to remove it
                 if (updateParameters.Count == 0)
                 {
-                    var updatedConstructors = model.Constructors.ToList();
-                    updatedConstructors.Remove(publicConstructor);
-                    model.Update(constructors: updatedConstructors);
+                    // All flattened parameters were optional — the public constructor becomes
+                    // parameterless. This is valid: users create the object and set optional
+                    // properties via setters. Update the signature to remove the old parameters.
+                    publicConstructor.Signature.Update(parameters: updateParameters);
+                    publicConstructor.Update(signature: publicConstructor.Signature);
+
+                    // The serialization type may have already added an internal parameterless
+                    // constructor (for deserialization) before this visitor ran. Now that the
+                    // model has a public parameterless constructor, the internal one is redundant
+                    // and would cause CS0111. Remove it.
+                    RemoveDuplicateSerializationConstructor(model);
                 }
                 else
                 {
@@ -636,6 +643,26 @@ namespace Azure.Generator.Management.Visitors
         {
             // We only include the flattened property in the public constructor if it is required
             return flattenedProperty.WireInfo?.IsRequired == true;
+        }
+
+        /// <summary>
+        /// Removes the internal parameterless constructor from the serialization type if one exists.
+        /// The serialization type adds an internal parameterless constructor for deserialization
+        /// before the flatten visitor runs. When flattening makes the model's public constructor
+        /// parameterless, the serialization constructor becomes a duplicate and must be removed.
+        /// </summary>
+        private static void RemoveDuplicateSerializationConstructor(ModelProvider model)
+        {
+            foreach (var serializationType in model.SerializationProviders)
+            {
+                var ctors = serializationType.Constructors;
+                var parameterlessCtor = ctors.SingleOrDefault(c => !c.Signature.Parameters.Any());
+                if (parameterlessCtor is not null)
+                {
+                    var updatedCtors = ctors.Where(c => c != parameterlessCtor).ToList();
+                    serializationType.Update(constructors: updatedCtors);
+                }
+            }
         }
 
         private void UpdatePublicConstructorBody(ModelProvider model, Dictionary<string, List<FlattenPropertyInfo>> flattenPropertyMap, ConstructorProvider publicConstructor)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -89,6 +89,127 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         /// <summary>
+        /// Verifies that when all flattened sub-properties are optional (non-required),
+        /// the public constructor is kept as a parameterless constructor instead of being removed.
+        /// This is the regression scenario: a model with a "properties" bag where every
+        /// sub-property is optional should still have a public parameterless constructor
+        /// so users can create the object and populate optional properties via setters.
+        /// </summary>
+        [Test]
+        public void TestFlattenKeepsPublicConstructorWhenAllPropertiesAreOptional()
+        {
+            // Create a nested "properties" model with only optional sub-properties.
+            var optionalProp1 = InputFactory.Property("displayName", InputPrimitiveType.String, isRequired: false, serializedName: "displayName");
+            var optionalProp2 = InputFactory.Property("description", InputPrimitiveType.String, isRequired: false, serializedName: "description");
+            var propertiesModel = InputFactory.Model(
+                "TestOptionalProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [optionalProp1, optionalProp2]);
+
+            // Create a required "properties" property with @flattenProperty decorator.
+            var propertiesProperty = InputFactory.Property("properties", propertiesModel, isRequired: true, serializedName: "properties");
+            ApplyFlattenDecorator(propertiesProperty);
+
+            // Create the parent model with Input+Output usage so it gets a public constructor.
+            var parentModel = InputFactory.Model(
+                "TestResource",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [propertiesProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [parentModel, propertiesModel]);
+
+            // Create the model provider.
+            var model = plugin.Object.TypeFactory.CreateModel(parentModel);
+            Assert.IsNotNull(model);
+
+            // Verify precondition: before visitors run, there IS a public constructor.
+            Assert.IsTrue(
+                model!.Constructors.Any(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)),
+                "Precondition: model should have a public constructor before visitors run");
+
+            // Run the VisitType visitors (which triggers FlattenPropertyVisitor).
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(visitTypeCore, "Could not find LibraryVisitor.VisitTypeCore method");
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [model]);
+            }
+
+            // After visitors run, the public constructor should still exist (parameterless).
+            var publicCtor = model.Constructors.SingleOrDefault(
+                c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+            Assert.IsNotNull(publicCtor, "Public constructor should be kept (as parameterless) when all flattened properties are optional");
+            Assert.AreEqual(0, publicCtor!.Signature.Parameters.Count,
+                "Public constructor should be parameterless since all flattened properties are optional");
+
+            // The serialization type should NOT have an internal parameterless constructor
+            // (it would conflict with the public one in the partial class, causing CS0111).
+            foreach (var serializationType in model!.SerializationProviders)
+            {
+                var serializationParameterlessCtor = serializationType.Constructors
+                    .SingleOrDefault(c => !c.Signature.Parameters.Any());
+                Assert.IsNull(serializationParameterlessCtor,
+                    "Serialization type should not have a parameterless constructor when the model already has one");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that when flattened sub-properties contain a mix of required and optional,
+        /// only the required ones appear as constructor parameters.
+        /// </summary>
+        [Test]
+        public void TestFlattenConstructorIncludesOnlyRequiredProperties()
+        {
+            // Create a nested "properties" model with one required and one optional property.
+            var requiredProp = InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, serializedName: "name");
+            var optionalProp = InputFactory.Property("description", InputPrimitiveType.String, isRequired: false, serializedName: "description");
+            var propertiesModel = InputFactory.Model(
+                "TestMixedProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [requiredProp, optionalProp]);
+
+            // Create a required "properties" property with @flattenProperty decorator.
+            var propertiesProperty = InputFactory.Property("properties", propertiesModel, isRequired: true, serializedName: "properties");
+            ApplyFlattenDecorator(propertiesProperty);
+
+            // Create the parent model.
+            var parentModel = InputFactory.Model(
+                "TestResourceMixed",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [propertiesProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [parentModel, propertiesModel]);
+
+            var model = plugin.Object.TypeFactory.CreateModel(parentModel);
+            Assert.IsNotNull(model);
+
+            // Run the VisitType visitors.
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(visitTypeCore);
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [model]);
+            }
+
+            // The public constructor should exist with only the required property as parameter.
+            var publicCtorMixed = model!.Constructors.SingleOrDefault(
+                c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+            Assert.IsNotNull(publicCtorMixed, "Public constructor should exist");
+            Assert.That(publicCtorMixed!.Signature.Parameters, Has.Count.EqualTo(1),
+                "Public constructor should have exactly 1 parameter (the required property)");
+            Assert.AreEqual("name", publicCtorMixed.Signature.Parameters[0].Name,
+                "The constructor parameter should be the required 'name' property");
+        }
+
+        /// <summary>
         /// Verifies that a discriminator base model with a single non-discriminator public property
         /// is NOT safe-flattened. Previously, since the discriminator property is internal and not
         /// counted in publicPropertyCount, the model appeared to have only one public property,


### PR DESCRIPTION
## Problem

When all flattened sub-properties are optional (non-required), `FlattenPropertyVisitor.UpdatePublicConstructor()` was removing the public constructor entirely. This caused models like `DiagnosticRemoteSupportSettingData` (DataBoxEdge) and several others to lose their public constructors, requiring custom workarounds.

## Fix

1. **Keep the parameterless public constructor** — instead of removing the constructor when `updateParameters.Count == 0`, update its signature to be parameterless. Users create the object and set optional properties via setters.

2. **Remove duplicate serialization constructor** — the serialization type (`MrwSerializationTypeDefinition`) adds an internal parameterless constructor before the flatten visitor runs. When flattening makes the model's public constructor parameterless, the serialization one becomes a duplicate causing CS0111. The fix removes it.

## Impact

Verified by regenerating all management SDKs — 6 SDKs gain correct parameterless constructors:
- `HciVmGalleryImageVersionProperties`
- `ConfluentConnectorData`
- `AdhocBasedBackupTriggerContext`
- `AkriConnectorTemplateDiagnostics`
- `RegistryEndpointSystemAssignedIdentityAuthentication`
- `NginxDeploymentPropertiesNginxAppProtect`

No API breaking changes. All 147 existing tests pass + 2 new tests added.

## Tests

- `TestFlattenKeepsPublicConstructorWhenAllPropertiesAreOptional` — verifies the ctor is kept and serialization duplicate is removed
- `TestFlattenConstructorIncludesOnlyRequiredProperties` — verifies mixed required/optional flattened properties
