### PR TITLE
Add service.projects for agentserver CI pipeline

### DIFF
--- a/sdk/agentserver/service.projects
+++ b/sdk/agentserver/service.projects
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup Condition="'$(SDKType)' == 'client'">
+    <ProjectsToIncludeBySDKType Include="$(MSBuildThisFileDirectory)Azure.AI.AgentServer.*\**\*.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Fix agentserver CI pipeline failure (build 6087796)

### Root Cause
The `net - agentserver` CI pipeline uses `SDKType: client` in `ci.yml`, which triggers the SDKType filter in `eng/service.proj`. This filter uses `ProjectsToIncludeBySDKType` items defined in a `service.projects` file to determine which projects to include. 

Without a `service.projects` file, the filter removes **all** projects, causing:
- `No Projects found with pattern [..\sdk\agentserver\**\*.csproj]` across all Build & Test jobs (all TFMs, all platforms)
- `Build snippets` failure
- `Save package properties` failure (`Package properties are not available for service directory agentserver`)
- `Create API Review` failure (no PackageInfo json files)

### Fix
Add `sdk/agentserver/service.projects` that maps `SDKType=client` to the three agentserver packages:
- `Azure.AI.AgentServer.Core`
- `Azure.AI.AgentServer.Responses`
- `Azure.AI.AgentServer.Invocations`

### Validation
- `dotnet build eng/service.proj /p:ServiceDirectory=agentserver /p:SDKType=client` succeeds locally (0 errors)