### PR TITLE
Fix backward-compat model factory overloads passing arguments in wron…

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -65,11 +65,12 @@ namespace Azure.Generator.Management.Visitors
         /// <summary>
         /// Fixes backward-compat overload methods that call primary model factory methods.
         /// After flattening reorders the primary method's parameters, the positional arguments
-        /// in these overloads may be in the wrong order. This method converts them to named arguments.
+        /// in these overloads may be in the wrong order. This method rebuilds the argument list
+        /// to match the primary method's current parameter order.
         /// </summary>
         internal static void FixBackwardCompatOverloads(IReadOnlyList<MethodProvider> methods)
         {
-            // Build a lookup of primary method signatures by name
+            // Build a lookup of primary methods by name
             var primaryMethods = new Dictionary<string, MethodProvider>();
             foreach (var method in methods)
             {
@@ -86,12 +87,7 @@ namespace Azure.Generator.Management.Visitors
 
             foreach (var method in methods)
             {
-                if (!IsBackwardCompatMethod(method))
-                {
-                    continue;
-                }
-
-                if (method.BodyStatements is null)
+                if (!IsBackwardCompatMethod(method) || method.BodyStatements is null)
                 {
                     continue;
                 }
@@ -108,16 +104,8 @@ namespace Azure.Generator.Management.Visitors
                     {
                         var primaryParams = primaryMethod.Signature.Parameters;
                         var invokeArgs = invokeExpression.Arguments;
-
-                        // Build a lookup: paramName -> argument expression from the invoke call
-                        // The invoke was built by the base generator to match the PRIMARY method's
-                        // parameter order BEFORE flattening. After flattening, the order changed.
-                        // We need to rebuild arguments using named references to the PRIMARY method's
-                        // CURRENT parameter order.
-
-                        // The invoke's MethodSignature still references the pre-flatten signature.
-                        // We need to match arguments to the updated primary method's parameters.
                         var invokeSignatureParams = invokeExpression.MethodSignature?.Parameters;
+
                         if (invokeSignatureParams is null || invokeSignatureParams.Count != invokeArgs.Count)
                         {
                             updatedBodyStatements.Add(statement);
@@ -131,40 +119,31 @@ namespace Azure.Generator.Management.Visitors
                             argsByName[invokeSignatureParams[i].Name] = invokeArgs[i];
                         }
 
-                        // Rebuild arguments in the current primary method's parameter order
+                        // Rebuild arguments in the current primary method's parameter order,
+                        // tracking whether any reordering actually occurred.
                         var newArgs = new List<ValueExpression>(primaryParams.Count);
-                        var needsUpdate = false;
-                        foreach (var primaryParam in primaryParams)
+                        var changed = false;
+                        for (int i = 0; i < primaryParams.Count; i++)
                         {
-                            if (argsByName.TryGetValue(primaryParam.Name, out var arg))
+                            if (argsByName.TryGetValue(primaryParams[i].Name, out var arg))
                             {
                                 newArgs.Add(arg);
+                                if (!changed && (i >= invokeArgs.Count || !ReferenceEquals(arg, invokeArgs[i])))
+                                {
+                                    changed = true;
+                                }
                             }
                             else
                             {
                                 // Parameter not in old call, use named default
-                                newArgs.Add(Snippet.PositionalReference(primaryParam, primaryParam.DefaultValue ?? Default));
-                                needsUpdate = true;
+                                newArgs.Add(Snippet.PositionalReference(primaryParams[i], primaryParams[i].DefaultValue ?? Default));
+                                changed = true;
                             }
                         }
 
-                        // Check if argument order actually changed
-                        if (!needsUpdate)
+                        if (changed)
                         {
-                            for (int i = 0; i < Math.Min(invokeArgs.Count, newArgs.Count); i++)
-                            {
-                                if (!ReferenceEquals(invokeArgs[i], newArgs[i]))
-                                {
-                                    needsUpdate = true;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (needsUpdate)
-                        {
-                            var newInvoke = new InvokeMethodExpression(null, primaryMethod.Signature, newArgs);
-                            updatedBodyStatements.Add(Return(newInvoke));
+                            updatedBodyStatements.Add(Return(new InvokeMethodExpression(null, primaryMethod.Signature, newArgs)));
                             bodyUpdated = true;
                         }
                         else

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -59,7 +59,7 @@ namespace Azure.Generator.Management.Visitors
             // Second pass: fix backward-compat overloads whose bodies call primary methods
             // via InvokeMethodExpression. The primary methods' parameter order may have changed
             // after flattening, so positional arguments in overloads can be wrong.
-            FixBackwardCompatOverloads(modelFactory);
+            FixBackwardCompatOverloads(modelFactory.Methods);
         }
 
         /// <summary>
@@ -67,14 +67,13 @@ namespace Azure.Generator.Management.Visitors
         /// After flattening reorders the primary method's parameters, the positional arguments
         /// in these overloads may be in the wrong order. This method converts them to named arguments.
         /// </summary>
-        private static void FixBackwardCompatOverloads(ModelFactoryProvider modelFactory)
+        internal static void FixBackwardCompatOverloads(IReadOnlyList<MethodProvider> methods)
         {
-            // Build a lookup of primary method signatures by name+returnType
+            // Build a lookup of primary method signatures by name
             var primaryMethods = new Dictionary<string, MethodProvider>();
-            foreach (var method in modelFactory.Methods)
+            foreach (var method in methods)
             {
-                // Primary methods have default parameter values; backward-compat ones don't
-                if (method.Signature.Parameters.Count > 0 && method.Signature.Parameters[0].DefaultValue is not null)
+                if (!IsBackwardCompatMethod(method))
                 {
                     var key = method.Signature.Name;
                     // Use the one with the most parameters as the primary (latest) method
@@ -85,10 +84,9 @@ namespace Azure.Generator.Management.Visitors
                 }
             }
 
-            foreach (var method in modelFactory.Methods)
+            foreach (var method in methods)
             {
-                // Skip primary methods (they have default values on parameters)
-                if (method.Signature.Parameters.Count > 0 && method.Signature.Parameters[0].DefaultValue is not null)
+                if (!IsBackwardCompatMethod(method))
                 {
                     continue;
                 }
@@ -185,6 +183,16 @@ namespace Azure.Generator.Management.Visitors
                     method.Update(signature: method.Signature, bodyStatements: updatedBodyStatements);
                 }
             }
+        }
+
+        /// <summary>
+        /// Checks if a method is a backward-compatibility overload by looking for the
+        /// [EditorBrowsable(EditorBrowsableState.Never)] attribute on its signature.
+        /// </summary>
+        internal static bool IsBackwardCompatMethod(MethodProvider method)
+        {
+            return method.Signature.Attributes.Any(a =>
+                a.Type?.FrameworkType == typeof(System.ComponentModel.EditorBrowsableAttribute));
         }
 
         private bool TryGetFlattenPropertyInfo(CSharpType returnType, [NotNullWhen(true)] out Dictionary<string, List<FlattenPropertyInfo>>? propertyNameMap)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -46,12 +46,143 @@ namespace Azure.Generator.Management.Visitors
 
         private void UpdateModelFactory(ModelFactoryProvider modelFactory)
         {
+            // First pass: update primary methods (replace 'properties' param with flattened params, fix body)
             foreach (var method in modelFactory.Methods)
             {
                 var returnType = method.Signature.ReturnType;
                 if (returnType is not null && TryGetFlattenPropertyInfo(returnType, out var propertyNameMap))
                 {
                     UpdateModelFactoryMethod(method, propertyNameMap);
+                }
+            }
+
+            // Second pass: fix backward-compat overloads whose bodies call primary methods
+            // via InvokeMethodExpression. The primary methods' parameter order may have changed
+            // after flattening, so positional arguments in overloads can be wrong.
+            FixBackwardCompatOverloads(modelFactory);
+        }
+
+        /// <summary>
+        /// Fixes backward-compat overload methods that call primary model factory methods.
+        /// After flattening reorders the primary method's parameters, the positional arguments
+        /// in these overloads may be in the wrong order. This method converts them to named arguments.
+        /// </summary>
+        private static void FixBackwardCompatOverloads(ModelFactoryProvider modelFactory)
+        {
+            // Build a lookup of primary method signatures by name+returnType
+            var primaryMethods = new Dictionary<string, MethodProvider>();
+            foreach (var method in modelFactory.Methods)
+            {
+                // Primary methods have default parameter values; backward-compat ones don't
+                if (method.Signature.Parameters.Count > 0 && method.Signature.Parameters[0].DefaultValue is not null)
+                {
+                    var key = method.Signature.Name;
+                    // Use the one with the most parameters as the primary (latest) method
+                    if (!primaryMethods.TryGetValue(key, out var existing) || method.Signature.Parameters.Count > existing.Signature.Parameters.Count)
+                    {
+                        primaryMethods[key] = method;
+                    }
+                }
+            }
+
+            foreach (var method in modelFactory.Methods)
+            {
+                // Skip primary methods (they have default values on parameters)
+                if (method.Signature.Parameters.Count > 0 && method.Signature.Parameters[0].DefaultValue is not null)
+                {
+                    continue;
+                }
+
+                if (method.BodyStatements is null)
+                {
+                    continue;
+                }
+
+                // Look for backward-compat overloads that call another method via InvokeMethodExpression
+                var updatedBodyStatements = new List<MethodBodyStatement>();
+                var bodyUpdated = false;
+                foreach (var statement in method.BodyStatements)
+                {
+                    if (statement is ExpressionStatement expressionStatement
+                        && (expressionStatement.Expression as KeywordExpression)?.Expression is InvokeMethodExpression invokeExpression
+                        && (invokeExpression.MethodName ?? invokeExpression.MethodSignature?.Name) is string calledMethodName
+                        && primaryMethods.TryGetValue(calledMethodName, out var primaryMethod))
+                    {
+                        var primaryParams = primaryMethod.Signature.Parameters;
+                        var invokeArgs = invokeExpression.Arguments;
+
+                        // Build a lookup: paramName -> argument expression from the invoke call
+                        // The invoke was built by the base generator to match the PRIMARY method's
+                        // parameter order BEFORE flattening. After flattening, the order changed.
+                        // We need to rebuild arguments using named references to the PRIMARY method's
+                        // CURRENT parameter order.
+
+                        // The invoke's MethodSignature still references the pre-flatten signature.
+                        // We need to match arguments to the updated primary method's parameters.
+                        var invokeSignatureParams = invokeExpression.MethodSignature?.Parameters;
+                        if (invokeSignatureParams is null || invokeSignatureParams.Count != invokeArgs.Count)
+                        {
+                            updatedBodyStatements.Add(statement);
+                            continue;
+                        }
+
+                        // Map: old param name -> argument expression
+                        var argsByName = new Dictionary<string, ValueExpression>(StringComparer.OrdinalIgnoreCase);
+                        for (int i = 0; i < invokeSignatureParams.Count; i++)
+                        {
+                            argsByName[invokeSignatureParams[i].Name] = invokeArgs[i];
+                        }
+
+                        // Rebuild arguments in the current primary method's parameter order
+                        var newArgs = new List<ValueExpression>(primaryParams.Count);
+                        var needsUpdate = false;
+                        foreach (var primaryParam in primaryParams)
+                        {
+                            if (argsByName.TryGetValue(primaryParam.Name, out var arg))
+                            {
+                                newArgs.Add(arg);
+                            }
+                            else
+                            {
+                                // Parameter not in old call, use named default
+                                newArgs.Add(Snippet.PositionalReference(primaryParam, primaryParam.DefaultValue ?? Default));
+                                needsUpdate = true;
+                            }
+                        }
+
+                        // Check if argument order actually changed
+                        if (!needsUpdate)
+                        {
+                            for (int i = 0; i < Math.Min(invokeArgs.Count, newArgs.Count); i++)
+                            {
+                                if (!ReferenceEquals(invokeArgs[i], newArgs[i]))
+                                {
+                                    needsUpdate = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (needsUpdate)
+                        {
+                            var newInvoke = new InvokeMethodExpression(null, primaryMethod.Signature, newArgs);
+                            updatedBodyStatements.Add(Return(newInvoke));
+                            bodyUpdated = true;
+                        }
+                        else
+                        {
+                            updatedBodyStatements.Add(statement);
+                        }
+                    }
+                    else
+                    {
+                        updatedBodyStatements.Add(statement);
+                    }
+                }
+
+                if (bodyUpdated)
+                {
+                    method.Update(signature: method.Signature, bodyStatements: updatedBodyStatements);
                 }
             }
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -4,11 +4,19 @@
 using Azure.Generator.Management;
 using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
+using Azure.Generator.Management.Visitors;
 using Microsoft.TypeSpec.Generator;
+using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Snippets;
+using Microsoft.TypeSpec.Generator.Statements;
+using Moq;
 using NUnit.Framework;
+using System.ComponentModel;
 using System.Reflection;
+using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Mgmt.Tests
 {
@@ -74,6 +82,147 @@ namespace Azure.Generator.Mgmt.Tests
                     visitTypeCore!.Invoke(visitor, [model]);
                 }
             });
+        }
+
+        /// <summary>
+        /// Verifies that IsBackwardCompatMethod correctly identifies methods with the
+        /// [EditorBrowsable(EditorBrowsableState.Never)] attribute.
+        /// </summary>
+        [Test]
+        public void TestIsBackwardCompatMethod()
+        {
+            // Set up the mock plugin (required for ManagementClientGenerator.Instance)
+            var propertiesModel = InputFactory.Model(
+                "TestProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("displayName", InputPrimitiveType.String, serializedName: "displayName")]);
+            ManagementMockHelpers.LoadMockPlugin(inputModels: () => [propertiesModel]);
+
+            var enclosingType = ManagementClientGenerator.Instance.TypeFactory.CreateModel(propertiesModel)!;
+
+            // Create a method WITHOUT the EditorBrowsable attribute
+            var primarySignature = new MethodSignature(
+                "TestMethod",
+                null,
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                null,
+                null,
+                []);
+            var primaryMethod = new MethodProvider(primarySignature, MethodBodyStatement.Empty, enclosingType);
+            Assert.IsFalse(FlattenPropertyVisitor.IsBackwardCompatMethod(primaryMethod));
+
+            // Create a method WITH the EditorBrowsable(Never) attribute
+            var backCompatSignature = new MethodSignature(
+                "TestMethod",
+                null,
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                null,
+                null,
+                [],
+                Attributes: [new AttributeStatement(typeof(EditorBrowsableAttribute), Snippet.FrameworkEnumValue(EditorBrowsableState.Never))]);
+            var backCompatMethod = new MethodProvider(backCompatSignature, MethodBodyStatement.Empty, enclosingType);
+            Assert.IsTrue(FlattenPropertyVisitor.IsBackwardCompatMethod(backCompatMethod));
+        }
+
+        /// <summary>
+        /// Verifies that FixBackwardCompatOverloads correctly reorders arguments in
+        /// backward-compat overloads when the primary method's parameter order has changed
+        /// after property flattening.
+        /// </summary>
+        [Test]
+        public void TestFixBackwardCompatOverloadsReordersArguments()
+        {
+            // Set up the mock plugin (required for ManagementClientGenerator.Instance)
+            var propertiesModel = InputFactory.Model(
+                "TestProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [InputFactory.Property("displayName", InputPrimitiveType.String, serializedName: "displayName")]);
+            ManagementMockHelpers.LoadMockPlugin(inputModels: () => [propertiesModel]);
+
+            var enclosingType = ManagementClientGenerator.Instance.TypeFactory.CreateModel(propertiesModel)!;
+
+            // Create the primary method signature with params in the FLATTENED order:
+            // (id, name, displayName, provisioningState, etag)
+            var paramId = new ParameterProvider("id", $"", typeof(string)) { DefaultValue = Default };
+            var paramName = new ParameterProvider("name", $"", typeof(string)) { DefaultValue = Default };
+            var paramDisplayName = new ParameterProvider("displayName", $"", typeof(string)) { DefaultValue = Default };
+            var paramProvState = new ParameterProvider("provisioningState", $"", typeof(string)) { DefaultValue = Default };
+            var paramEtag = new ParameterProvider("etag", $"", typeof(string)) { DefaultValue = Default };
+
+            var primarySignature = new MethodSignature(
+                "TestData",
+                null,
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                typeof(object),
+                null,
+                [paramId, paramName, paramDisplayName, paramProvState, paramEtag]);
+            var primaryMethod = new MethodProvider(primarySignature, MethodBodyStatement.Empty, enclosingType);
+
+            // Create the backward-compat overload that calls the primary method.
+            // The OLD param order was: (id, name, etag, displayName, provisioningState)
+            var oldParamId = new ParameterProvider("id", $"", typeof(string));
+            var oldParamName = new ParameterProvider("name", $"", typeof(string));
+            var oldParamEtag = new ParameterProvider("etag", $"", typeof(string));
+            var oldParamDisplayName = new ParameterProvider("displayName", $"", typeof(string));
+            var oldParamProvState = new ParameterProvider("provisioningState", $"", typeof(string));
+
+            var oldSignature = new MethodSignature(
+                "TestData",
+                null,
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                typeof(object),
+                null,
+                [oldParamId, oldParamName, oldParamEtag, oldParamDisplayName, oldParamProvState],
+                Attributes: [new AttributeStatement(typeof(EditorBrowsableAttribute), Snippet.FrameworkEnumValue(EditorBrowsableState.Never))]);
+
+            // The old invoke signature (what the base generator used to build the call)
+            // has params in the PRE-FLATTEN order: (id, name, etag, displayName, provisioningState)
+            var preFlattenSignature = new MethodSignature(
+                "TestData",
+                null,
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                typeof(object),
+                null,
+                [paramId, paramName, paramEtag, paramDisplayName, paramProvState]);
+
+            // Build the invoke call with positional args in the OLD (pre-flatten) order
+            var invokeExpression = new InvokeMethodExpression(null, preFlattenSignature,
+                [oldParamId, oldParamName, oldParamEtag, oldParamDisplayName, oldParamProvState]);
+
+            var backCompatBody = Return(invokeExpression);
+            var backCompatMethod = new MethodProvider(oldSignature, backCompatBody, enclosingType);
+
+            // Act: Run the fix
+            FlattenPropertyVisitor.FixBackwardCompatOverloads([primaryMethod, backCompatMethod]);
+
+            // Assert: The backward-compat overload's body should now have arguments
+            // in the PRIMARY method's current parameter order
+            Assert.IsNotNull(backCompatMethod.BodyStatements);
+            var statements = backCompatMethod.BodyStatements!.ToArray();
+            Assert.AreEqual(1, statements.Length);
+
+            var returnStatement = statements[0] as ExpressionStatement;
+            Assert.IsNotNull(returnStatement);
+            var keywordExpr = returnStatement!.Expression as KeywordExpression;
+            Assert.IsNotNull(keywordExpr);
+            var newInvoke = keywordExpr!.Expression as InvokeMethodExpression;
+            Assert.IsNotNull(newInvoke);
+
+            // The arguments should now be in the PRIMARY method's order:
+            // (id, name, displayName, provisioningState, etag)
+            var args = newInvoke!.Arguments;
+            Assert.AreEqual(5, args.Count);
+            AssertArgIsParameter(args[0], "id", "position 0");
+            AssertArgIsParameter(args[1], "name", "position 1");
+            AssertArgIsParameter(args[2], "displayName", "position 2");
+            AssertArgIsParameter(args[3], "provisioningState", "position 3");
+            AssertArgIsParameter(args[4], "etag", "position 4");
+        }
+
+        private static void AssertArgIsParameter(ValueExpression arg, string expectedName, string context)
+        {
+            string? actualName = arg is VariableExpression v ? v.Declaration.RequestedName : null;
+            Assert.AreEqual(expectedName, actualName, $"Expected parameter '{expectedName}' at {context}, but got '{actualName ?? arg.GetType().Name}'");
         }
 
         private static void ApplyFlattenDecorator(InputModelProperty property)


### PR DESCRIPTION
…g order

When FlattenPropertyVisitor reorders the primary model factory method's parameters (input properties first, read-only properties after), the backward-compat overloads generated by the base TypeSpec generator's BuildMethodsForBackCompatibility still pass arguments positionally in the old order. This causes arguments to be placed at wrong positions in the call to the primary method.

Add FixBackwardCompatOverloads to FlattenPropertyVisitor.UpdateModelFactory that runs after the primary methods are updated. It finds backward-compat overloads with InvokeMethodExpression bodies, maps their arguments by parameter name from the old signature, and rebuilds the argument list in the current primary method's parameter order.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
