### PR TITLE
[Identity] Upgrade Microsoft.Identity.Client.Broker version to 4.83.3

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -185,7 +185,7 @@
     <PackageVersion Include="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.1" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.1" />
-    <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.83.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.83.3" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.15.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Updated `Microsoft.Identity.Client.Broker` dependency to version 4.83.1.
+- Updated `Microsoft.Identity.Client.Broker` dependency to version 4.83.3.
 
 ## 1.4.0 (2026-02-26)
 


### PR DESCRIPTION
This pull request updates the `Microsoft.Identity.Client.Broker` dependency to a newer patch version. This ensures that the latest bug fixes and improvements from the dependency are included in the project.

Dependency update:

* Bumped `Microsoft.Identity.Client.Broker` version from `4.83.1` to `4.83.3` in `Directory.Packages.props` and updated the changelog to reflect this change. [[1]](diffhunk://#diff-34722ab18b971a624aed915bdd01fb067592af249ead3acf5123b5247e67b2cfL188-R188) [[2]](diffhunk://#diff-9c764404f1ff19317e5eb5e0f70b1cc842f9d2a77a9a70418c09e93d7b877e9bL13-R13)

----
 _🤖AI Generated PR description_