### PR TITLE
Release: Azure.Identity.Broker 1.5.0

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.5.0 (2026-04-01)
 
+### Features Added
+
+- Added a JSON schema segment to the NuGet package that provides IntelliSense and validation for Azure.Identity.Broker credential configuration in `appsettings.json`.
+
 ### Other Changes
 
 - Updated `Microsoft.Identity.Client.Broker` dependency to version 4.83.1.

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.5.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.5.0 (2026-04-01)
 
 ### Other Changes
 

--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides authentication broker APIs for authenticating to Microsoft Entra ID</Description>
     <AssemblyTitle>Microsoft Azure.Identity.Broker Component</AssemblyTitle>
-    <Version>1.5.0-beta.1</Version>
+    <Version>1.5.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.4.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity Broker;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
## Release: Azure.Identity.Broker 1.5.0

### Changes
- Version bumped from 1.5.0-beta.1 to 1.5.0
- Release date set to 04/01/2026
- Added JSON schema segment changelog entry
- Updated `Microsoft.Identity.Client.Broker` dependency to version 4.83.1