### PR TITLE
Fix operation scope detection for multi-provider paths

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -598,7 +598,7 @@ export function getOperationScopeFromPath(
 
 /**
  * Check if a path has multiple /providers/ segments, indicating a cross-RP path
- * that extends another ARM resource.
+ * (e.g. extension resources or cross-RP actions).
  */
 function hasMultipleProviderSegments(path: string): boolean {
   const providerMatches = path.match(/\/providers\//gi);

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resolve-arm-resources-converter.ts
@@ -561,7 +561,10 @@ function convertScopeToResourceScope(
 /**
  * Determine operation scope from path
  */
-export function getOperationScopeFromPath(path: string): ResourceScope {
+export function getOperationScopeFromPath(
+  path: string,
+  isListOperation: boolean = false
+): ResourceScope {
   // Match any path starting with a variable segment followed by /providers/
   // This covers scope-based operations like /{resourceUri}/providers/..., /{scope}/providers/..., /{resourceId}/providers/..., etc.
   if (/^\/\{[^}]+\}\/providers\//.test(path)) {
@@ -579,20 +582,35 @@ export function getOperationScopeFromPath(path: string): ResourceScope {
   ) {
     return ResourceScope.ManagementGroup;
   } else if (hasMultipleProviderSegments(path)) {
-    // Paths with multiple /providers/ segments indicate extension resources
-    // e.g., /providers/Microsoft.Management/serviceGroups/{name}/providers/Microsoft.Edge/sites/{siteName}
+    // Paths with multiple /providers/ segments indicate cross-RP paths.
+    // For non-list operations whose path ends with a constant segment (no {param}),
+    // this is a cross-RP action (e.g., .../providers/Microsoft.CostManagement/generateReport)
+    // and should be Tenant scope.
+    // Otherwise (list operations, or paths ending with {param}), this is a true
+    // extension resource and should be Extension scope.
+    if (!isListOperation && !isVariableSegment(lastSegment(path))) {
+      return ResourceScope.Tenant;
+    }
     return ResourceScope.Extension;
   }
   return ResourceScope.Tenant; // all the templates work as if there is a tenant decorator when there is no such decorator
 }
 
 /**
- * Check if a path has multiple /providers/ segments, indicating an extension resource
+ * Check if a path has multiple /providers/ segments, indicating a cross-RP path
  * that extends another ARM resource.
  */
 function hasMultipleProviderSegments(path: string): boolean {
   const providerMatches = path.match(/\/providers\//gi);
   return providerMatches !== null && providerMatches.length > 1;
+}
+
+/**
+ * Get the last segment of a path.
+ */
+function lastSegment(path: string): string {
+  const segments = path.split("/").filter((s) => s.length > 0);
+  return segments[segments.length - 1];
 }
 
 /**
@@ -777,7 +795,7 @@ function assignListOperationsToResources(
         methodId,
         kind: ResourceOperationKind.List,
         operationPath: listOp.path,
-        operationScope: getOperationScopeFromPath(listOp.path),
+        operationScope: getOperationScopeFromPath(listOp.path, true),
         resourceScope: undefined
       });
     }

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-detection.ts
@@ -307,7 +307,10 @@ export function buildArmProviderSchema(
         methodId: method.crossLanguageDefinitionId,
         kind,
         operationPath: method.operation.path,
-        operationScope: getOperationScopeFromPath(method.operation.path)
+        operationScope: getOperationScopeFromPath(
+          method.operation.path,
+          kind === ResourceOperationKind.List
+        )
       });
       if (!entry.resourceType) {
         entry.resourceType = calculateResourceTypeFromPath(

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-type.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-type.test.ts
@@ -131,6 +131,36 @@ describe("Operation Scope Detection", () => {
     strictEqual(scope, ResourceScope.Extension);
   });
 
+  it("tenant scope for cross-RP action path (no resource instance)", async () => {
+    const path =
+      "/providers/microsoft.Billing/billingAccounts/{billingAccountId}/providers/Microsoft.CostManagement/generateReservationDetailsReport";
+    const scope = getOperationScopeFromPath(path);
+    strictEqual(scope, ResourceScope.Tenant);
+  });
+
+  it("tenant scope for cross-RP list action path", async () => {
+    const path =
+      "/providers/microsoft.Billing/billingAccounts/{billingAccountId}/providers/Microsoft.CostManagement/benefitUtilizationSummaries";
+    const scope = getOperationScopeFromPath(path);
+    strictEqual(scope, ResourceScope.Tenant);
+  });
+
+  it("tenant scope for cross-RP nested action path", async () => {
+    const path =
+      "/providers/microsoft.Billing/billingAccounts/{billingAccountName}/billingProfiles/{billingProfileName}/invoices/{invoiceName}/providers/Microsoft.CostManagement/pricesheets/default/download";
+    const scope = getOperationScopeFromPath(path);
+    strictEqual(scope, ResourceScope.Tenant);
+  });
+
+  it("extension scope for cross-RP list operation (serviceGroups sites)", async () => {
+    const path =
+      "/providers/Microsoft.Management/serviceGroups/{servicegroupName}/providers/Microsoft.Edge/sites";
+    const scope = getOperationScopeFromPath(path, true);
+    strictEqual(scope, ResourceScope.Extension);
+  });
+
+
+
   it("extension scope from generic variable prefix with {resourceId}", async () => {
     const path =
       "/{resourceId}/providers/Microsoft.DataProtection/backupInstances";

--- a/eng/packages/http-client-csharp-mgmt/emitter/test/resource-type.test.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/test/resource-type.test.ts
@@ -159,8 +159,6 @@ describe("Operation Scope Detection", () => {
     strictEqual(scope, ResourceScope.Extension);
   });
 
-
-
   it("extension scope from generic variable prefix with {resourceId}", async () => {
     const path =
       "/{resourceId}/providers/Microsoft.DataProtection/backupInstances";


### PR DESCRIPTION
## Problem

The `hasMultipleProviderSegments` check in `getOperationScopeFromPath` unconditionally classified all cross-RP paths as **Extension** scope. This was incorrect for cross-RP **action** paths (e.g., CostManagement's `/providers/microsoft.Billing/billingAccounts/{id}/providers/Microsoft.CostManagement/generateReservationDetailsReport`), which are not extension resources and should receive **Tenant** scope.

## Fix

Add an `isListOperation` parameter to `getOperationScopeFromPath`. For multi-provider paths (Rule 5):

- **Non-list + constant last segment** -- Tenant (cross-RP actions like `generateReservationDetailsReport`)
- **List operations or paths ending with `{param}`** -- Extension (true extension resources)

A list operation in `assignListOperationsToResources` is always derived from a resource CRUD path by removing the last `{param}` segment, so granting it Extension scope is correct.

## Changes

- `resolve-arm-resources-converter.ts`: Added `isListOperation` branching in Rule 5 to distinguish cross-RP actions (Tenant) from extension resources (Extension); added `lastSegment` helper; updated list operation call site
- `resource-detection.ts`: Updated call site to pass `kind === ResourceOperationKind.List`
- `resource-type.test.ts`: Added tests for cross-RP action scope (Tenant) and cross-RP list operation scope (Extension)

## Real-world example

CostManagement `GenerateReservationDetailsReport_ByBillingAccountId` is a cross-RP action with path `/providers/microsoft.Billing/billingAccounts/{billingAccountId}/providers/Microsoft.CostManagement/generateReservationDetailsReport` (two `/providers/` segments, ends with constant). It should be -- and is -- generated as a `TenantResource` extension method:

- **TypeSpec spec**: [routes.tsp#L855](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/routes.tsp#L855)
- **Generated SDK**: [CostManagementExtensions.cs#L2090](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/costmanagement/Azure.ResourceManager.CostManagement/src/Generated/Extensions/CostManagementExtensions.cs#L2090)

## Validation

- All 71 emitter tests pass (29 scope tests + 42 resource detection tests)
- SiteManager SDK regenerated with zero diff, `ServiceGroupEdgeSiteCollection` retains `GetAll`/`IEnumerable`
- CostManagement cross-RP actions correctly get Tenant scope