### PR TITLE
Block edits to CODEOWNERS' "Client Libraries" section and redirect the contributor to use the agent flow instead

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,6 +81,8 @@
 # Client Libraries
 ####################
 
+# Test unacceptable edit
+
 # PRLabel: %AI Agents
 /sdk/agentserver/    @ankitbko @RaviPidaparthi
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,13 +75,9 @@
 # ServiceLabel: %Extensions
 # AzureSdkOwners:                                                  @jsquire
 
-# Test acceptable edit
-
 ####################
 # Client Libraries
 ####################
-
-# Test unacceptable edit
 
 # PRLabel: %AI Agents
 /sdk/agentserver/    @ankitbko @RaviPidaparthi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -75,6 +75,8 @@
 # ServiceLabel: %Extensions
 # AzureSdkOwners:                                                  @jsquire
 
+# Test acceptable edit
+
 ####################
 # Client Libraries
 ####################

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -168,6 +168,11 @@ jobs:
           parameters:
             SourceDirectory: $(Build.SourcesDirectory)
 
+        - template: /eng/common/pipelines/templates/steps/verify-codeowners-sections.yml
+          parameters:
+            Sections:
+              - 'Client Libraries'
+
         - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
 
     - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml


### PR DESCRIPTION
Edits to other sections: 

<img width="1031" height="598" alt="image" src="https://github.com/user-attachments/assets/096eca7d-2f0e-4582-ac8c-07fa695de6f1" />


Edits to Client Libraries section rejected: 

<img width="1172" height="1025" alt="image" src="https://github.com/user-attachments/assets/a8dbd1b2-8bd0-4e73-bed8-e2aae84c0d88" />

