### PR TITLE
[HDInsight] Temporarily ignore tests incompatible with TypeSpec-migrated Storage client

### DIFF
--- a/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/Scenario/ClusterOperationTests.cs
+++ b/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/Scenario/ClusterOperationTests.cs
@@ -24,6 +24,7 @@ using NUnit.Framework;
 
 namespace Azure.ResourceManager.HDInsight.Tests
 {
+    [Ignore("Recordings incompatible with TypeSpec-migrated Storage client. https://github.com/Azure/azure-sdk-for-net/issues/57679")]
     internal class ClusterOperationTests : HDInsightManagementTestBase
     {
         private ResourceGroupResource _resourceGroup;

--- a/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/Scenario/HDInsightApplicationTests.cs
+++ b/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/Scenario/HDInsightApplicationTests.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 
 namespace Azure.ResourceManager.HDInsight.Tests
 {
+    [Ignore("Recordings incompatible with TypeSpec-migrated Storage client. https://github.com/Azure/azure-sdk-for-net/issues/57679")]
     internal class HDInsightApplicationTests : HDInsightManagementTestBase
     {
         private HDInsightClusterResource _cluster;

--- a/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/Scenario/HDInsightClusterTests.cs
+++ b/sdk/hdinsight/Azure.ResourceManager.HDInsight/tests/Scenario/HDInsightClusterTests.cs
@@ -13,6 +13,7 @@ using NUnit.Framework;
 
 namespace Azure.ResourceManager.HDInsight.Tests
 {
+    [Ignore("Recordings incompatible with TypeSpec-migrated Storage client. https://github.com/Azure/azure-sdk-for-net/issues/57679")]
     internal class HDInsightClusterTests : HDInsightManagementTestBase
     {
         private ResourceGroupResource _resourceGroup;


### PR DESCRIPTION
## Changes

Temporarily ignores `ClusterOperationTests`, `HDInsightApplicationTests`, and `HDInsightClusterTests` whose recordings are incompatible with the TypeSpec-migrated Storage client.

Tracking issue: https://github.com/Azure/azure-sdk-for-net/issues/57679

Split from #57668 to unblock CI pipeline timeouts.

---
*This PR was created using the GitHub Copilot CLI.*