### PR TITLE
[MySql] Temporarily ignore tests incompatible with TypeSpec-migrated Storage client

### DIFF
--- a/sdk/mysql/Azure.ResourceManager.MySql/tests/Scenario/MySqlFlexibleServerBackupTests.cs
+++ b/sdk/mysql/Azure.ResourceManager.MySql/tests/Scenario/MySqlFlexibleServerBackupTests.cs
@@ -23,6 +23,7 @@ using NUnit.Framework;
 
 namespace Azure.ResourceManager.MySql.Tests
 {
+    [Ignore("Recordings incompatible with TypeSpec-migrated Storage client. https://github.com/Azure/azure-sdk-for-net/issues/57679")]
     public class MySqlFlexibleServerBackupTests : MySqlManagementTestBase
     {
         public MySqlFlexibleServerBackupTests(bool isAsync)


### PR DESCRIPTION
## Changes

Temporarily ignores `MySqlFlexibleServerBackupTests` whose recordings are incompatible with the TypeSpec-migrated Storage client.

Tracking issue: https://github.com/Azure/azure-sdk-for-net/issues/57679

Split from #57668 to unblock CI pipeline timeouts.

---
*This PR was created using the GitHub Copilot CLI.*