### PR TITLE
[Network] Temporarily ignore tests incompatible with TypeSpec-migrated Storage client

### DIFF
--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/FirewallTests.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/FirewallTests.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 
 namespace Azure.ResourceManager.Network.Tests
 {
+    [Ignore("Recordings incompatible with TypeSpec-migrated Storage client. https://github.com/Azure/azure-sdk-for-net/issues/57679")]
     public class FirewallTests : NetworkServiceClientTestBase
     {
         private ResourceGroupResource _resourceGroup;

--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/IPGroupTests.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/IPGroupTests.cs
@@ -14,6 +14,7 @@ using NUnit.Framework;
 
 namespace Azure.ResourceManager.Network.Tests
 {
+    [Ignore("Recordings incompatible with TypeSpec-migrated Storage client. https://github.com/Azure/azure-sdk-for-net/issues/57679")]
     public class IpGroupTests : NetworkServiceClientTestBase
     {
         private ResourceGroupResource _resourceGroup;

--- a/sdk/network/Azure.ResourceManager.Network/tests/Tests/NetworkSecurityPerimeterTests.cs
+++ b/sdk/network/Azure.ResourceManager.Network/tests/Tests/NetworkSecurityPerimeterTests.cs
@@ -15,6 +15,7 @@ using NUnit.Framework;
 
 namespace Azure.ResourceManager.Network.Tests
 {
+    [Ignore("Recordings incompatible with TypeSpec-migrated Storage client. https://github.com/Azure/azure-sdk-for-net/issues/57679")]
     public class NetworkSecurityPerimeterTests : NetworkServiceClientTestBase
     {
         private string _rgNamePrefix = "rg-nsp-dot-net-sdk-test-";


### PR DESCRIPTION
## Changes

Temporarily ignores `FirewallTests`, `IpGroupTests`, and `NetworkSecurityPerimeterTests` whose recordings are incompatible with the TypeSpec-migrated Storage client.

Tracking issue: https://github.com/Azure/azure-sdk-for-net/issues/57679

Split from #57668 to unblock CI pipeline timeouts.

---
*This PR was created using the GitHub Copilot CLI.*