### PR TITLE
[Release] Azure.Identity.Broker 1.5.0

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -185,7 +185,7 @@
     <PackageVersion Include="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.1" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.1" />
-    <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.83.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.83.3" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.15.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -1,16 +1,14 @@
 # Release History
 
-## 1.5.0-beta.1 (Unreleased)
+## 1.5.0 (2026-04-01)
 
 ### Features Added
 
-### Breaking Changes
-
-### Bugs Fixed
+- Added a JSON schema segment to the NuGet package that provides IntelliSense and validation for Azure.Identity.Broker credential configuration in `appsettings.json`.
 
 ### Other Changes
 
-- Updated `Microsoft.Identity.Client.Broker` dependency to version 4.83.1.
+- Updated `Microsoft.Identity.Client.Broker` dependency to version 4.83.3.
 
 ## 1.4.0 (2026-02-26)
 

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 1.5.0 (2026-04-01)
+## 1.5.0 (2026-04-02)
 
 ### Features Added
 
-- Added a JSON schema segment to the NuGet package that provides IntelliSense and validation for Azure.Identity.Broker credential configuration in `appsettings.json`.
+- Added a JSON schema segment to the NuGet package that provides IntelliSense and validation for `Azure.Identity.Broker` credential configuration in `appsettings.json`.
 
 ### Other Changes
 

--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides authentication broker APIs for authenticating to Microsoft Entra ID</Description>
     <AssemblyTitle>Microsoft Azure.Identity.Broker Component</AssemblyTitle>
-    <Version>1.5.0-beta.1</Version>
+    <Version>1.5.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.4.0</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity Broker;$(PackageCommonTags)</PackageTags>


### PR DESCRIPTION
## Release: Azure.Identity.Broker 1.5.0

### Changes
- Version bumped from 1.5.0-beta.1 to 1.5.0
- Release date set to 04/01/2026
- Added JSON schema segment changelog entry
- Updated `Microsoft.Identity.Client.Broker` dependency from 4.83.1 to 4.83.3

### CI Note
The ignored-test changes that were part of the original PR (#57668) have been split into individual PRs to avoid pipeline timeouts. Once these PRs merge, CI will pass for this PR:

- [#57707 — DataFactory](https://github.com/Azure/azure-sdk-for-net/pull/57707)
- [#57708 — HDInsight](https://github.com/Azure/azure-sdk-for-net/pull/57708)
- [#57709 — MySql](https://github.com/Azure/azure-sdk-for-net/pull/57709)
- [#57710 — Network](https://github.com/Azure/azure-sdk-for-net/pull/57710)
- [#57711 — RecoveryServicesBackup](https://github.com/Azure/azure-sdk-for-net/pull/57711)

**This PR should be merged after the above PRs have been merged.**

---
*This PR was created using the GitHub Copilot CLI.*