### PR TITLE
Fix FlattenPropertyVisitor name-based matching for custom code overrides

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -521,7 +521,10 @@ namespace Azure.Generator.Management.Visitors
                 var innerProperties = PropertyHelpers.GetAllProperties(modelProvider);
 
                 // handle `@flattenProperty`
-                if (ManagementClientGenerator.Instance.OutputLibrary.OutputFlattenPropertyMap.TryGetValue(model, out var propertiesToFlatten) && propertiesToFlatten.Contains(internalProperty))
+                // Use name-based matching instead of reference equality because custom code
+                // may override the property, creating a different PropertyProvider instance
+                // than the one cached in OutputFlattenPropertyMap.
+                if (ManagementClientGenerator.Instance.OutputLibrary.OutputFlattenPropertyMap.TryGetValue(model, out var propertiesToFlatten) && propertiesToFlatten.Any(p => p.Name == internalProperty.Name))
                 {
                     isFlattenProperty = true;
                     PropertyFlatten(model, modelProvider, innerProperties, propertyMap, internalProperty);


### PR DESCRIPTION
## Fix FlattenPropertyVisitor to use name-based matching for custom code overrides

Fixes #57525

### Problem

When custom code overrides a flattened property (e.g. to add backward-compatible setters), the `PropertyProvider` instance from `CustomCodeView` differs from the one cached in `OutputFlattenPropertyMap`. The `Contains` check at line 524 of `FlattenPropertyVisitor.cs` used **reference equality**, causing flatten detection to fail silently.

This resulted in the generator emitting public factory methods with internal type parameters (`AccountProperties`, `OrganizationProperties`, `PlanDataProperties`), producing **CS0051** compilation errors. SDK authors had to work around this with `CodeGenSuppress` attributes on the model factory.

### Root Cause

`OutputFlattenPropertyMap` is built via `TypeFactory.CreateProperty()`, which caches `PropertyProvider` instances by input property. When custom code overrides the same property in a partial class, the model's `CustomCodeView.Properties` contains a **different object** than the cached one. The `HashSet<PropertyProvider>.Contains()` check (default reference equality) fails, so the property is not recognized as a flatten target.

### Fix

Changed the `Contains` check to **name-based matching**:

`csharp
// Before (reference equality — fails with custom code overrides)
propertiesToFlatten.Contains(internalProperty)

// After (name-based matching — works regardless of property source)
propertiesToFlatten.Any(p => p.Name == internalProperty.Name)
`

### Validation

- Removed the `CodeGenSuppress` workaround from `NewRelicObservability`'s custom model factory
- Regenerated the SDK using `RegenSdkLocal.ps1` with the local generator fix
- Build passes without any CS0051 errors
