### PR TITLE
Fix KeyNotFoundException in FlattenPropertyVisitor.BuildConstructorParameters

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -184,7 +184,7 @@ namespace Azure.Generator.Management.Visitors
             }
             // handle the case where the return type is a derived type of a flattened model type
             // we only deal with single level inheritance here to avoid complexity
-            else if (ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(returnType, out var typeProvider) && typeProvider is ModelProvider model && model.BaseType is not null && _flattenedModelTypes.TryGetValue(model.BaseType, out value))
+            else if (TryGetModelProvider(returnType, out var model) && model.BaseType is not null && _flattenedModelTypes.TryGetValue(model.BaseType, out value))
             {
                 propertyNameMap = value;
                 return true;
@@ -255,11 +255,20 @@ namespace Azure.Generator.Management.Visitors
                                     // Flatten the property to the new instance parameters
                                     // If the property is null, we need to ensure that we create a new instance of the model type.
                                     // If the property is not null, we can use the existing value.
-                                    updatedInstanceParameters.Add(
-                                    new TernaryConditionalExpression(
-                                        BuildConditionExpression(value, parameterMap)!,
-                                        Default,
-                                        New.Instance(variable.Type, BuildConstructorParameters(variable.Type, value, parameterMap))));
+                                    var ctorParams = BuildConstructorParameters(variable.Type, value, parameterMap);
+                                    if (ctorParams is not null)
+                                    {
+                                        updatedInstanceParameters.Add(
+                                        new TernaryConditionalExpression(
+                                            BuildConditionExpression(value, parameterMap)!,
+                                            Default,
+                                            New.Instance(variable.Type, ctorParams)));
+                                    }
+                                    else
+                                    {
+                                        // Type not found in CSharpTypeMap, fall back to default to avoid referencing a removed parameter
+                                        updatedInstanceParameters.Add(Default);
+                                    }
                                 }
                                 else
                                 {
@@ -315,12 +324,15 @@ namespace Azure.Generator.Management.Visitors
         }
 
         // Use the flattened property as the parameter, if it is an overridden value type, we need to use the Value property.
-        private ValueExpression[] BuildConstructorParameters(CSharpType propertyType, List<FlattenPropertyInfo> flattenedProperties, IReadOnlyDictionary<ParameterProvider, ParameterProvider>? parameterMap = null, bool publicConstructor = false)
+        private ValueExpression[]? BuildConstructorParameters(CSharpType propertyType, List<FlattenPropertyInfo> flattenedProperties, IReadOnlyDictionary<ParameterProvider, ParameterProvider>? parameterMap = null, bool publicConstructor = false)
         {
-            var propertyModelType = ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap[propertyType] as ModelProvider;
+            if (!TryGetModelProvider(propertyType, out var propertyModelType))
+            {
+                return null;
+            }
             var constructorParameters = publicConstructor
-                ? propertyModelType!.Constructors.First(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)).Signature.Parameters
-                : propertyModelType!.FullConstructor.Signature.Parameters;
+                ? propertyModelType.Constructors.First(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)).Signature.Parameters
+                : propertyModelType.FullConstructor.Signature.Parameters;
 
             var parameters = new List<ValueExpression>();
             var additionalPropertyIndex = GetAdditionalPropertyIndex();
@@ -422,7 +434,14 @@ namespace Azure.Generator.Management.Visitors
                                 if (innerFlattenedProperties.Count > 0)
                                 {
                                     var innerParameters = BuildConstructorParameters(constructorParameterType, innerFlattenedProperties, parameterMap);
-                                    parameters.Add(New.Instance(constructorParameterType, innerParameters));
+                                    if (innerParameters is not null)
+                                    {
+                                        parameters.Add(New.Instance(constructorParameterType, innerParameters));
+                                    }
+                                    else
+                                    {
+                                        parameters.Add(Default.CastTo(constructorParameterType));
+                                    }
                                 }
                                 else
                                 {
@@ -507,7 +526,7 @@ namespace Azure.Generator.Management.Visitors
             {
                 // only flatten complex type properties
                 var propertyType = internalProperty.Type;
-                if (!(ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(propertyType, out var typeProvider) && typeProvider is ModelProvider modelProvider))
+                if (!TryGetModelProvider(propertyType, out var modelProvider))
                 {
                     continue;
                 }
@@ -847,19 +866,31 @@ namespace Azure.Generator.Management.Visitors
                             if (currentInternalProperty is not null)
                             {
                                 var properties = value.Where(x => flattenedProperties.Contains(x.FlattenedProperty)).ToList();
-                                var nestedModelType = ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap[variable.Type] as ModelProvider;
-                                bool nestedHasPublicCtor = nestedModelType?.Constructors.Any(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public)) == true;
+                                bool nestedHasPublicCtor = false;
+                                if (TryGetModelProvider(variable.Type, out var nestedModelType))
+                                {
+                                    nestedHasPublicCtor = nestedModelType.Constructors.Any(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+                                }
                                 var conditionExpression = BuildConditionExpression(properties, publicConstructor: nestedHasPublicCtor);
-                                var instanceExpression = New.Instance(variable.Type, BuildConstructorParameters(variable.Type, properties, publicConstructor: nestedHasPublicCtor));
-                                var assignmentExpression =
-                                    conditionExpression is null
-                                    ? instanceExpression
-                                    : new TernaryConditionalExpression(
-                                    conditionExpression,
-                                    Default,
-                                    instanceExpression
-                                    );
-                                updatedBodyStatements.Add(((MemberExpression)currentInternalProperty).Assign(assignmentExpression).Terminate());
+                                var ctorParams = BuildConstructorParameters(variable.Type, properties, publicConstructor: nestedHasPublicCtor);
+                                if (ctorParams is not null)
+                                {
+                                    var instanceExpression = New.Instance(variable.Type, ctorParams);
+                                    var assignmentExpression =
+                                        conditionExpression is null
+                                        ? instanceExpression
+                                        : new TernaryConditionalExpression(
+                                        conditionExpression,
+                                        Default,
+                                        instanceExpression
+                                        );
+                                    updatedBodyStatements.Add(((MemberExpression)currentInternalProperty).Assign(assignmentExpression).Terminate());
+                                }
+                                else
+                                {
+                                    // Type not found in CSharpTypeMap; emit a safe assignment that does not reference the original parameter
+                                    updatedBodyStatements.Add(((MemberExpression)currentInternalProperty).Assign(Default).Terminate());
+                                }
                             }
                         }
                         else
@@ -874,6 +905,17 @@ namespace Azure.Generator.Management.Visitors
                 }
                 publicConstructor.Update(signature: publicConstructor.Signature, bodyStatements: updatedBodyStatements);
             }
+        }
+
+        private static bool TryGetModelProvider(CSharpType type, [NotNullWhen(true)] out ModelProvider? modelProvider)
+        {
+            if (ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(type, out var typeProvider) && typeProvider is ModelProvider model)
+            {
+                modelProvider = model;
+                return true;
+            }
+            modelProvider = null;
+            return false;
         }
 
         private class CSharpTypeNameComparer : IEqualityComparer<CSharpType>
@@ -916,8 +958,7 @@ namespace Azure.Generator.Management.Visitors
                 return true;
             }
             // Check base types for inherited flattened properties
-            if (ManagementClientGenerator.Instance.TypeFactory.CSharpTypeMap.TryGetValue(type, out var typeProvider)
-                && typeProvider is ModelProvider model)
+            if (TryGetModelProvider(type, out var model))
             {
                 var baseModel = model.BaseModelProvider;
                 while (baseModel is not null)


### PR DESCRIPTION
## Fix KeyNotFoundException in FlattenPropertyVisitor.BuildConstructorParameters

### Problem
SDK generation for Storage (and potentially other services) fails with:
```
The given key 'global::.DeletedAccountProperties' was not present in the dictionary.
```
The crash occurs in `FlattenPropertyVisitor.BuildConstructorParameters` when looking up a `CSharpType` in `CSharpTypeMap` using the unsafe dictionary indexer `[]`.

### Root Cause
Two locations in `FlattenPropertyVisitor.cs` use `CSharpTypeMap[type]` (lines 320 and 850), which throws `KeyNotFoundException` when a type isn't registered in the map. Other usages in the same file already use `TryGetValue` safely.

### Fix
- Changed `BuildConstructorParameters` return type to `ValueExpression[]?`
- Replaced unsafe `CSharpTypeMap[propertyType]` indexer with `TryGetValue` 
- Updated all 3 call sites to handle `null` gracefully (fall back to original parameter/default)
- Applied the same `TryGetValue` fix in `UpdatePublicConstructorBody`

### Validation
- Generator builds successfully with 0 warnings/errors
- All 7 Storage-related SDKs regenerate successfully (previously crashed)
