### PR TITLE
[Hosted Agents] chore: bump Microsoft.Agents.AI* to 1.0.0 and version to beta.12

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -213,8 +213,8 @@
     <PackageReference Update="Azure.AI.Projects" Version="1.1.0" />
     <PackageReference Update="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0"/>
     <PackageReference Update="ModelContextProtocol" Version="0.4.0-preview.3" />
-    <PackageReference Update="Microsoft.Agents.AI" Version="1.0.0-rc3" />
-    <PackageReference Update="Microsoft.Agents.AI.Workflows" Version="1.0.0-rc3" />
+    <PackageReference Update="Microsoft.Agents.AI" Version="1.0.0" />
+    <PackageReference Update="Microsoft.Agents.AI.Workflows" Version="1.0.0" />
     <PackageReference Update="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0"/>
   </ItemGroup>
 
@@ -372,8 +372,8 @@
     <PackageReference Update="CommandLineParser" Version="2.8.0" />
     <PackageReference Update="FluentAssertions" Version="5.10.3" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />
-    <PackageReference Update="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc3" />
-    <PackageReference Update="Microsoft.Agents.AI.Workflows" Version="1.0.0-rc3" />
+    <PackageReference Update="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
+    <PackageReference Update="Microsoft.Agents.AI.Workflows" Version="1.0.0" />
     <PackageReference Update="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Update="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Update="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.12 (Unreleased)
+
+### Other Changes
+
+- Update Microsoft.Agents.AI, Microsoft.Agents.AI.Workflows, Microsoft.Agents.AI.OpenAI packages to 1.0.0
+
 ## 1.0.0-beta.11 (2026-03-13)
 
 ### Bugs Fixed

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/AIAgentInvocation.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/AIAgentInvocation.cs
@@ -139,21 +139,21 @@ public class AIAgentInvocation(
         return Task.FromResult<IReadOnlyCollection<ChatMessage>>(request.GetInputMessages());
     }
 
-    private static Dictionary<string, UserInputRequestContent> GetPendingUserInputRequestContents(
+    private static Dictionary<string, ToolApprovalRequestContent> GetPendingUserInputRequestContents(
         IEnumerable<ChatMessage> messages)
     {
-        var res = new Dictionary<string, UserInputRequestContent>();
+        var res = new Dictionary<string, ToolApprovalRequestContent>();
         foreach (var message in messages)
         {
             foreach (var content in message.Contents)
             {
-                if (content is UserInputRequestContent userRequestContent)
+                if (content is ToolApprovalRequestContent userRequestContent)
                 {
-                    res[userRequestContent.Id] = userRequestContent;
+                    res[userRequestContent.RequestId] = userRequestContent;
                 }
-                else if (content is UserInputResponseContent userInputResponseContent)
+                else if (content is ToolApprovalResponseContent userInputResponseContent)
                 {
-                    res.Remove(userInputResponseContent.Id);
+                    res.Remove(userInputResponseContent.RequestId);
                 }
             }
         }

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Azure.AI.AgentServer.AgentFramework.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Azure.AI.AgentServer.AgentFramework.csproj
@@ -3,7 +3,7 @@
     <!-- Approved override -->
     <RequiredTargetFrameworks>net9.0;$(LtsTargetFramework);</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <Version>1.0.0-beta.11</Version>
+    <Version>1.0.0-beta.12</Version>
 
     <PackageTags>Azure.AI.AgentServer.AgentFramework</PackageTags>
   </PropertyGroup>

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Converters/HumanInTheLoopExtentions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Converters/HumanInTheLoopExtentions.cs
@@ -55,12 +55,12 @@ namespace Azure.AI.AgentServer.AgentFramework.Converters
         /// <summary>
         /// Convert a HITL request to an ItemResource
         /// </summary>
-        /// <param name="content">The FunctionApprovalRequestContent to convert.</param>
+        /// <param name="content">The ToolApprovalRequestContent to convert.</param>
         /// <param name="id">The ID for the resource.</param>
         /// <param name="createdBy">Optional information about the creator of the item.</param>
         /// <returns>An ItemResource representing the HITL request.</returns>
         public static FunctionToolCallItemResource ToHumanInTheLoopFunctionCallItemResource(
-            this FunctionApprovalRequestContent content,
+            this ToolApprovalRequestContent content,
             string id,
             CreatedBy? createdBy = null)
         {
@@ -70,47 +70,23 @@ namespace Azure.AI.AgentServer.AgentFramework.Converters
                 createdBy: createdBy,
                 serializedAdditionalRawData: null,
                 status: FunctionToolCallItemResourceStatus.InProgress,
-                callId: content.Id,
-                name: ResponsesExtensions.HumanInTheLoopFunctionName,
-                arguments: JsonSerializer.Serialize(content.FunctionCall, Json)
-                );
-        }
-
-        /// <summary>
-        /// Convert a MCP HITL request to an ItemResource
-        /// </summary>
-        /// <param name="content">MCP Tool approval request</param>
-        /// <param name="id">The ID for the resource.</param>
-        /// <param name="createdBy">Optional information about the creator of the item.</param>
-        /// <returns>An ItemResource representing the HITL request.</returns>
-        public static FunctionToolCallItemResource ToHumanInTheLoopFunctionCallItemResource(
-            this McpServerToolApprovalRequestContent content,
-            string id,
-            CreatedBy? createdBy = null)
-        {
-            return new FunctionToolCallItemResource(
-                type: ItemType.FunctionCall,
-                id: id,
-                createdBy: createdBy,
-                serializedAdditionalRawData: null,
-                status: FunctionToolCallItemResourceStatus.InProgress,
-                callId: content.Id,
+                callId: content.RequestId,
                 name: ResponsesExtensions.HumanInTheLoopFunctionName,
                 arguments: JsonSerializer.Serialize(content.ToolCall, Json)
                 );
         }
 
         /// <summary>
-        /// Filter FunctionApprovalRequestContents from an agent's session messages.
+        /// Filter ToolApprovalRequestContents from an agent's session messages.
         /// </summary>
         /// <param name="agent">The AI agent.</param>
         /// <param name="session">The agent session.</param>
-        /// <returns>A dictionary with function call_id and FunctionApprovalRequests that are pending for approval.</returns>
-        public static Dictionary<string, UserInputRequestContent> GetPendingUserInputRequestContents(
+        /// <returns>A dictionary with function call_id and ToolApprovalRequests that are pending for approval.</returns>
+        public static Dictionary<string, ToolApprovalRequestContent> GetPendingUserInputRequestContents(
             AIAgent agent,
             AgentSession? session)
         {
-            var res = new Dictionary<string, UserInputRequestContent>();
+            var res = new Dictionary<string, ToolApprovalRequestContent>();
             if (session == null)
             {
                 return res;
@@ -132,14 +108,14 @@ namespace Azure.AI.AgentServer.AgentFramework.Converters
             {
                 foreach (var content in message.Contents)
                 {
-                    if (content is UserInputRequestContent userRequestContent)
+                    if (content is ToolApprovalRequestContent userRequestContent)
                     {
-                        res[userRequestContent.Id] = userRequestContent;
+                        res[userRequestContent.RequestId] = userRequestContent;
                     }
-                    else if (content is UserInputResponseContent userInputResponseContent)
+                    else if (content is ToolApprovalResponseContent userInputResponseContent)
                     {
-                        // Remove the UserInputRequestContent that has been responded to
-                        res.Remove(userInputResponseContent.Id);
+                        // Remove the ToolApprovalRequestContent that has been responded to
+                        res.Remove(userInputResponseContent.RequestId);
                     }
                 }
             }
@@ -150,11 +126,11 @@ namespace Azure.AI.AgentServer.AgentFramework.Converters
         /// Validate a HITL response and convert it to a ChatMessage
         /// </summary>
         /// <param name="request">CreateResponse request payload</param>
-        /// <param name="pendingRequests">Dictionary of pending function approval requests</param>
+        /// <param name="pendingRequests">Dictionary of pending tool approval requests</param>
         /// <returns>A ChatMessage representing the validated HITL response.</returns>
         public static List<ChatMessage>? ValidateAndConvertResponse(
             this CreateResponseRequest request,
-            Dictionary<string, UserInputRequestContent>? pendingRequests)
+            Dictionary<string, ToolApprovalRequestContent>? pendingRequests)
         {
             if (pendingRequests == null || pendingRequests.Count == 0)
             {
@@ -171,28 +147,16 @@ namespace Azure.AI.AgentServer.AgentFramework.Converters
                 if (item is FunctionToolCallOutputItemParam funcCallOutputItem)
                 {
                     if (funcCallOutputItem.CallId != null &&
-                        pendingRequests.TryGetValue(funcCallOutputItem.CallId, out var userInputRequest))
+                        pendingRequests.TryGetValue(funcCallOutputItem.CallId, out var approvalRequest))
                     {
-                        if (userInputRequest is FunctionApprovalRequestContent functionApprovalRequest)
+                        var response = funcCallOutputItem.ConvertToolApprovalResponse(approvalRequest);
+                        if (response != null)
                         {
-                            var response = funcCallOutputItem.ConvertFunctionCallApprovalResponse(functionApprovalRequest);
-                            if (response != null)
-                            {
-                                content.Add(response);
-                                continue;
-                            }
+                            content.Add(response);
+                            continue;
                         }
-                        else if (userInputRequest is McpServerToolApprovalRequestContent mcpToolApprovalRequest)
-                        {
-                            var response = funcCallOutputItem.ConvertMcpToolApprovalResponse(mcpToolApprovalRequest);
-                            if (response != null)
-                            {
-                                content.Add(response);
-                                continue;
-                            }
-                        }
-                        // It is not a FunctionApprovalRequestContent or parsing result failed
-                        var functionCallOutput = new FunctionResultContent(userInputRequest.Id, funcCallOutputItem.Output);
+                        // Parsing result failed, fall back to FunctionResultContent
+                        var functionCallOutput = new FunctionResultContent(approvalRequest.RequestId, funcCallOutputItem.Output);
                         content.Add(functionCallOutput);
                     }
                 }
@@ -209,28 +173,10 @@ namespace Azure.AI.AgentServer.AgentFramework.Converters
         /// is successful; otherwise, returns null.
         /// </summary>
         /// <param name="funcCallOutputItem">function call output item parameter from user</param>
-        /// <param name="requestContent">FunctionApprovalRequestContent that requesting input</param>
-        /// <returns>FunctionApprovalResponseContent if the user input is parsed successfully. otherwise, null</returns>
-        private static FunctionApprovalResponseContent? ConvertFunctionCallApprovalResponse(
-                 this FunctionToolCallOutputItemParam funcCallOutputItem, FunctionApprovalRequestContent requestContent)
-        {
-            var parsed = TryParseApprovalResponse(funcCallOutputItem?.Output, out var approvalResult);
-            if (parsed)
-            {
-                return requestContent.CreateResponse(approvalResult);
-            }
-            return null;
-        }
-
-        /// <summary>
-        /// Converts a function tool call output item and request content into an approval response content if parsing
-        /// is successful; otherwise, returns null.
-        /// </summary>
-        /// <param name="funcCallOutputItem">The function tool call output item to parse.</param>
-        /// <param name="requestContent">The original approval request content.</param>
-        /// <returns>An approval response content if parsing succeeds; otherwise, null.</returns>
-        private static McpServerToolApprovalResponseContent? ConvertMcpToolApprovalResponse(
-            this FunctionToolCallOutputItemParam funcCallOutputItem, McpServerToolApprovalRequestContent requestContent)
+        /// <param name="requestContent">ToolApprovalRequestContent that requesting input</param>
+        /// <returns>ToolApprovalResponseContent if the user input is parsed successfully. otherwise, null</returns>
+        private static ToolApprovalResponseContent? ConvertToolApprovalResponse(
+                 this FunctionToolCallOutputItemParam funcCallOutputItem, ToolApprovalRequestContent requestContent)
         {
             var parsed = TryParseApprovalResponse(funcCallOutputItem?.Output, out var approvalResult);
             if (parsed)

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Converters/ItemResourceGenerator.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Converters/ItemResourceGenerator.cs
@@ -90,8 +90,7 @@ public class ItemResourceGenerator
         {
             FunctionCallContent => GenerateFunctionCallEvents(p.Source, onItemResource),
             FunctionResultContent => GenerateFunctionCallOutputEvents(p.Source, onItemResource),
-            FunctionApprovalRequestContent => GenerateHumanInTheLoopEvents(p.Source, onItemResource),
-            McpServerToolApprovalRequestContent => GenerateHumanInTheLoopEvents(p.Source, onItemResource),
+            ToolApprovalRequestContent => GenerateHumanInTheLoopEvents(p.Source, onItemResource),
             TextContent => GenerateAssistantMessageEvents(p.Source, onItemResource),
             _ => null!
         };
@@ -118,7 +117,7 @@ public class ItemResourceGenerator
                             NotifyOnUsageUpdate(usageContent.Details.ToResponseUsage()!);
                         }
                         continue;
-                    case FunctionCallContent or FunctionResultContent or TextContent or FunctionApprovalRequestContent:
+                    case FunctionCallContent or FunctionResultContent or TextContent or ToolApprovalRequestContent:
                         yield return (update, content);
                         break;
                 }
@@ -179,8 +178,7 @@ public class ItemResourceGenerator
         string? authorName = null;
         await foreach (var (update, content) in source.WithCancellation(CancellationToken).ConfigureAwait(false))
         {
-            if (content is not FunctionApprovalRequestContent functionCallContent ||
-                content is not McpServerToolApprovalRequestContent mcpServerToolApprovalRequestContent)
+            if (content is not ToolApprovalRequestContent approvalRequestContent)
             {
                 continue;
             }
@@ -190,11 +188,7 @@ public class ItemResourceGenerator
 
             var groupSeq = GroupSeq.Next();
             var createdBy = CreateCreatedBy(authorName);
-            var item = functionCallContent != null
-                            ? functionCallContent.ToHumanInTheLoopFunctionCallItemResource(
-                                Context.IdGenerator.GenerateFunctionCallId(),
-                                createdBy)
-                            : mcpServerToolApprovalRequestContent.ToHumanInTheLoopFunctionCallItemResource(
+            var item = approvalRequestContent.ToHumanInTheLoopFunctionCallItemResource(
                                 Context.IdGenerator.GenerateFunctionCallId(),
                                 createdBy);
             onItemResource(item);

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Converters/ResponseConverterExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/Converters/ResponseConverterExtensions.cs
@@ -74,15 +74,9 @@ public static class ResponseConverterExtensions
                         idGenerator.GenerateFunctionOutputId(),
                         createdBy);
                     break;
-                case FunctionApprovalRequestContent functionApprovalRequestContent:
+                case ToolApprovalRequestContent toolApprovalRequestContent:
                     // human-in-the-loop approval request
-                    yield return functionApprovalRequestContent.ToHumanInTheLoopFunctionCallItemResource(
-                        idGenerator.GenerateMessageId(),
-                        createdBy);
-                    break;
-                case McpServerToolApprovalRequestContent mcpServerToolApprovalRequestContent:
-                    // human-in-the-loop
-                    yield return mcpServerToolApprovalRequestContent.ToHumanInTheLoopFunctionCallItemResource(
+                    yield return toolApprovalRequestContent.ToHumanInTheLoopFunctionCallItemResource(
                         idGenerator.GenerateMessageId(),
                         createdBy);
                     break;

--- a/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/WorkflowAgentInvocation.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.AgentFramework/src/WorkflowAgentInvocation.cs
@@ -144,21 +144,21 @@ public class WorkflowAgentInvocation(
         return Task.FromResult<IReadOnlyCollection<ChatMessage>>(request.GetInputMessages());
     }
 
-    private static Dictionary<string, UserInputRequestContent> GetPendingUserInputRequestContents(
+    private static Dictionary<string, ToolApprovalRequestContent> GetPendingUserInputRequestContents(
         IEnumerable<ChatMessage> messages)
     {
-        var res = new Dictionary<string, UserInputRequestContent>();
+        var res = new Dictionary<string, ToolApprovalRequestContent>();
         foreach (var message in messages)
         {
             foreach (var content in message.Contents)
             {
-                if (content is UserInputRequestContent userRequestContent)
+                if (content is ToolApprovalRequestContent userRequestContent)
                 {
-                    res[userRequestContent.Id] = userRequestContent;
+                    res[userRequestContent.RequestId] = userRequestContent;
                 }
-                else if (content is UserInputResponseContent userInputResponseContent)
+                else if (content is ToolApprovalResponseContent userInputResponseContent)
                 {
-                    res.Remove(userInputResponseContent.Id);
+                    res.Remove(userInputResponseContent.RequestId);
                 }
             }
         }

--- a/sdk/agentserver/Azure.AI.AgentServer.Contracts/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Contracts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.12 (Unreleased)
+
+### Other Changes
+
+- Package version alignment only. No functional changes.
+
 ## 1.0.0-beta.11 (2026-03-13)
 
 ### Other Changes

--- a/sdk/agentserver/Azure.AI.AgentServer.Contracts/src/Azure.AI.AgentServer.Contracts.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.Contracts/src/Azure.AI.AgentServer.Contracts.csproj
@@ -17,7 +17,7 @@
     </NoWarn>
 
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <Version>1.0.0-beta.11</Version>
+    <Version>1.0.0-beta.12</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.12 (Unreleased)
+
+### Other Changes
+
+- Update Microsoft.Agents.AI, Microsoft.Agents.AI.Workflows, Microsoft.Agents.AI.OpenAI packages to 1.0.0
+
 ## 1.0.0-beta.11 (2026-03-13)
 
 ### Bugs Fixed

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
@@ -3,7 +3,7 @@
     <!-- Approved override -->
     <RequiredTargetFrameworks>net9.0;$(LtsTargetFramework);</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <Version>1.0.0-beta.11</Version>
+    <Version>1.0.0-beta.12</Version>
 
     <PackageTags>Azure.AI.AgentServer.Core</PackageTags>
   </PropertyGroup>

--- a/sdk/agentserver/samples/AgentFramework/AgentThreadAndHITL/AgentThreadAndHITL.csproj
+++ b/sdk/agentserver/samples/AgentFramework/AgentThreadAndHITL/AgentThreadAndHITL.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc3" />
+    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseProjectReference)'=='true'">

--- a/sdk/agentserver/samples/AgentFramework/MinimalConsole/MinimalConsole.csproj
+++ b/sdk/agentserver/samples/AgentFramework/MinimalConsole/MinimalConsole.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc3" />
+        <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseProjectReference)'=='true'">

--- a/sdk/agentserver/samples/AgentFramework/ToolClientCase/ToolClient.csproj
+++ b/sdk/agentserver/samples/AgentFramework/ToolClientCase/ToolClient.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc3" />
+        <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseProjectReference)'=='true'">

--- a/sdk/agentserver/samples/AgentFramework/Workflow/AgentsInWorkflows/AgentsInWorkflows.csproj
+++ b/sdk/agentserver/samples/AgentFramework/Workflow/AgentsInWorkflows/AgentsInWorkflows.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.0.0-rc3" />
-    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc3" />
+    <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseProjectReference)'=='true'">

--- a/sdk/agentserver/samples/AgentFramework/Workflow/BasicWorkflow/BasicWorkflow.csproj
+++ b/sdk/agentserver/samples/AgentFramework/Workflow/BasicWorkflow/BasicWorkflow.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.0.0-rc3" />
-        <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc3" />
+        <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.0.0" />
+        <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseProjectReference)'=='true'">

--- a/sdk/agentserver/samples/AgentFramework/Workflow/ToolWorkflow/ToolWorkflow.csproj
+++ b/sdk/agentserver/samples/AgentFramework/Workflow/ToolWorkflow/ToolWorkflow.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.0.0-rc3" />
-        <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc3" />
+        <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.0.0" />
+        <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(UseProjectReference)'=='true'">

--- a/sdk/agentserver/samples/AgentFramework/Workflow/WorkflowAgentResume/WorkflowAgentResume.csproj
+++ b/sdk/agentserver/samples/AgentFramework/Workflow/WorkflowAgentResume/WorkflowAgentResume.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.0.0-rc3" />
-    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc3" />
+    <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseProjectReference)'=='true'">

--- a/sdk/agentserver/samples/Directory.Packages.props
+++ b/sdk/agentserver/samples/Directory.Packages.props
@@ -8,9 +8,9 @@
         <PackageVersion Include="Azure.AI.OpenAI" Version="2.5.0-beta.1"/>
         <PackageVersion Include="Azure.AI.AgentServer.AgentFramework" Version="*-*" />
         <PackageVersion Include="Azure.AI.AgentServer.Core" Version="*-*" />
-        <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.0.0-rc3" />
-        <PackageVersion Include="Microsoft.Agents.AI" Version="1.0.0-rc3" />
-        <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-rc3" />
+        <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.0.0" />
+        <PackageVersion Include="Microsoft.Agents.AI" Version="1.0.0" />
+        <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
         <PackageVersion Include="OpenAI" Version="2.5.0"/>
         <PackageVersion Include="ModelContextProtocol" Version="*-*" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="*-*" />


### PR DESCRIPTION
### Summary

Updates Microsoft.Agents.AI packages from `1.0.0-rc3` to `1.0.0` (GA) and bumps AgentServer package versions to `1.0.0-beta.12`.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/57776
Related: microsoft/agent-framework#5076

### Changes

**Version bumps (rc3 → 1.0.0):** 9 files, 18 package references
- `eng/Packages.Data.props`
- `sdk/agentserver/samples/Directory.Packages.props`
- 7 sample `.csproj` files

**MEAI breaking change fixes (type unification in 1.0.0):**

| Old type | New type |
|---|---|
| `FunctionApprovalRequestContent` | `ToolApprovalRequestContent` |
| `FunctionApprovalResponseContent` | `ToolApprovalResponseContent` |
| `McpServerToolApprovalRequestContent` | `ToolApprovalRequestContent` |
| `McpServerToolApprovalResponseContent` | `ToolApprovalResponseContent` |
| `UserInputRequestContent` | `ToolApprovalRequestContent` |
| `UserInputResponseContent` | `ToolApprovalResponseContent` |
| `.Id` | `.RequestId` |
| `.FunctionCall` | `.ToolCall` |

**Files updated for API changes:**
- `HumanInTheLoopExtentions.cs` — merged 2 overloads into 1, unified types
- `ItemResourceGenerator.cs` — unified switch cases
- `ResponseConverterExtensions.cs` — merged 2 cases into 1
- `AIAgentInvocation.cs` / `WorkflowAgentInvocation.cs` — updated type references

**Package version bump:** `1.0.0-beta.11` → `1.0.0-beta.12`