### PR TITLE
Fix flaky HttpClientTransportReferenceCountingTests under coverage

### DIFF
--- a/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
@@ -170,18 +170,23 @@ namespace Azure.Core.Tests
                 }));
             }
 
-            // Wait until all requests are in the handler (past TryAddRef, holding refs)
-            for (int i = 0; i < 5; i++)
+            try
             {
-                Assert.IsTrue(await requestsInHandler.WaitAsync(TimeSpan.FromSeconds(10)),
-                    "Timed out waiting for requests to enter handler");
+                // Wait until all requests are in the handler (past TryAddRef, holding refs)
+                for (int i = 0; i < 5; i++)
+                {
+                    Assert.IsTrue(await requestsInHandler.WaitAsync(TimeSpan.FromSeconds(10)),
+                        "Timed out waiting for requests to enter handler");
+                }
+
+                // Update transport while requests are definitely in-flight
+                transport.Update(new HttpPipelineTransportOptions());
             }
-
-            // Update transport while requests are definitely in-flight
-            transport.Update(new HttpPipelineTransportOptions());
-
-            // Allow all requests to complete
-            releaseRequests.Set();
+            finally
+            {
+                // Always unblock handler threads to prevent test hangs on failure
+                releaseRequests.Set();
+            }
 
             // Wait for all requests to complete
             await Task.WhenAll(tasks);
@@ -273,21 +278,26 @@ namespace Azure.Core.Tests
                 }));
             }
 
-            // Wait until all requests are in the handler (past TryAddRef, holding refs)
-            for (int i = 0; i < requestCount; i++)
+            try
             {
-                Assert.IsTrue(await requestsInHandler.WaitAsync(TimeSpan.FromSeconds(10)),
-                    "Timed out waiting for requests to enter handler");
-            }
+                // Wait until all requests are in the handler (past TryAddRef, holding refs)
+                for (int i = 0; i < requestCount; i++)
+                {
+                    Assert.IsTrue(await requestsInHandler.WaitAsync(TimeSpan.FromSeconds(10)),
+                        "Timed out waiting for requests to enter handler");
+                }
 
-            // Perform multiple updates while requests hold refs to the old wrapper
-            for (int i = 0; i < 3; i++)
+                // Perform multiple updates while requests hold refs to the old wrapper
+                for (int i = 0; i < 3; i++)
+                {
+                    transport.Update(new HttpPipelineTransportOptions());
+                }
+            }
+            finally
             {
-                transport.Update(new HttpPipelineTransportOptions());
+                // Always unblock handler threads to prevent test hangs on failure
+                releaseRequests.Set();
             }
-
-            // Allow all blocked requests to complete
-            releaseRequests.Set();
 
             // Wait for all requests to complete - they should succeed despite updates
             await Task.WhenAll(tasks);

--- a/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
@@ -138,13 +138,16 @@ namespace Azure.Core.Tests
             // Arrange
             var requestCount = 0;
             var responseCount = 0;
+            var requestsInHandler = new SemaphoreSlim(0);
+            var releaseRequests = new ManualResetEventSlim(false);
+
             Func<HttpPipelineTransportOptions, HttpClient> clientFactory = _ =>
             {
                 var handler = new MockHttpHandler(req =>
                 {
                     Interlocked.Increment(ref requestCount);
-                    // Simulate some processing time
-                    Thread.Sleep(10);
+                    requestsInHandler.Release();
+                    releaseRequests.Wait();
                     Interlocked.Increment(ref responseCount);
                     return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
                 });
@@ -153,10 +156,8 @@ namespace Azure.Core.Tests
 
             using var transport = new HttpClientTransport(clientFactory);
 
-            // Act - Start multiple concurrent requests and update transport during processing
+            // Act - Start multiple concurrent requests
             var tasks = new List<Task>();
-
-            // Start several requests
             for (int i = 0; i < 5; i++)
             {
                 tasks.Add(Task.Run(async () =>
@@ -169,9 +170,18 @@ namespace Azure.Core.Tests
                 }));
             }
 
-            // Update transport while requests are in flight
-            await Task.Delay(5); // Let some requests start
+            // Wait until all requests are in the handler (past TryAddRef, holding refs)
+            for (int i = 0; i < 5; i++)
+            {
+                Assert.IsTrue(await requestsInHandler.WaitAsync(TimeSpan.FromSeconds(10)),
+                    "Timed out waiting for requests to enter handler");
+            }
+
+            // Update transport while requests are definitely in-flight
             transport.Update(new HttpPipelineTransportOptions());
+
+            // Allow all requests to complete
+            releaseRequests.Set();
 
             // Wait for all requests to complete
             await Task.WhenAll(tasks);
@@ -231,46 +241,58 @@ namespace Azure.Core.Tests
         {
             // Arrange
             var updateCount = 0;
+            var requestsInHandler = new SemaphoreSlim(0);
+            var releaseRequests = new ManualResetEventSlim(false);
+
             Func<HttpPipelineTransportOptions, HttpClient> clientFactory = _ =>
             {
                 Interlocked.Increment(ref updateCount);
-                var handler = new MockHttpHandler(req => new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+                var handler = new MockHttpHandler(req =>
+                {
+                    requestsInHandler.Release();
+                    releaseRequests.Wait();
+                    return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+                });
                 return new HttpClient(handler);
             };
 
             using var transport = new HttpClientTransport(clientFactory);
 
-            // Act - Multiple updates and concurrent requests
+            // Act - Start concurrent requests that will block in the handler
+            const int requestCount = 10;
             var tasks = new List<Task>();
-
-            // Start continuous requests
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < requestCount; i++)
             {
                 tasks.Add(Task.Run(async () =>
                 {
-                    for (int j = 0; j < 5; j++)
-                    {
-                        var request = transport.CreateRequest();
-                        request.Uri.Reset(new Uri("https://example.com"));
-                        var message = new HttpMessage(request, ResponseClassifier.Shared);
-                        await ProcessSyncOrAsync(transport, message);
-                        Assert.AreEqual(200, message.Response.Status);
-                        await Task.Delay(1); // Small delay between requests
-                    }
+                    var request = transport.CreateRequest();
+                    request.Uri.Reset(new Uri("https://example.com"));
+                    var message = new HttpMessage(request, ResponseClassifier.Shared);
+                    await ProcessSyncOrAsync(transport, message);
+                    Assert.AreEqual(200, message.Response.Status);
                 }));
             }
 
-            // Perform updates while requests are running
+            // Wait until all requests are in the handler (past TryAddRef, holding refs)
+            for (int i = 0; i < requestCount; i++)
+            {
+                Assert.IsTrue(await requestsInHandler.WaitAsync(TimeSpan.FromSeconds(10)),
+                    "Timed out waiting for requests to enter handler");
+            }
+
+            // Perform multiple updates while requests hold refs to the old wrapper
             for (int i = 0; i < 3; i++)
             {
-                await Task.Delay(5);
                 transport.Update(new HttpPipelineTransportOptions());
             }
 
-            // Wait for all requests to complete
+            // Allow all blocked requests to complete
+            releaseRequests.Set();
+
+            // Wait for all requests to complete - they should succeed despite updates
             await Task.WhenAll(tasks);
 
-            // Assert - Should have created multiple clients due to updates
+            // Assert - Should have created initial client + 3 update clients
             Assert.GreaterOrEqual(updateCount, 4, "Should have created multiple clients due to updates");
         }
 

--- a/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
@@ -173,10 +173,17 @@ namespace Azure.Core.Tests
             try
             {
                 // Wait until all requests are in the handler (past TryAddRef, holding refs)
-                for (int i = 0; i < 5; i++)
+                using var waitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                try
                 {
-                    Assert.IsTrue(await requestsInHandler.WaitAsync(TimeSpan.FromSeconds(10)),
-                        "Timed out waiting for requests to enter handler");
+                    for (int i = 0; i < 5; i++)
+                    {
+                        await requestsInHandler.WaitAsync(waitTimeout.Token);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    Assert.Fail("Timed out waiting for requests to enter handler");
                 }
 
                 // Update transport while requests are definitely in-flight
@@ -281,10 +288,17 @@ namespace Azure.Core.Tests
             try
             {
                 // Wait until all requests are in the handler (past TryAddRef, holding refs)
-                for (int i = 0; i < requestCount; i++)
+                using var waitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                try
                 {
-                    Assert.IsTrue(await requestsInHandler.WaitAsync(TimeSpan.FromSeconds(10)),
-                        "Timed out waiting for requests to enter handler");
+                    for (int i = 0; i < requestCount; i++)
+                    {
+                        await requestsInHandler.WaitAsync(waitTimeout.Token);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    Assert.Fail("Timed out waiting for requests to enter handler");
                 }
 
                 // Perform multiple updates while requests hold refs to the old wrapper

--- a/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
@@ -140,7 +140,7 @@ namespace Azure.Core.Tests
             var responseCount = 0;
             var requestsInHandler = new SemaphoreSlim(0);
             var releaseRequests = new ManualResetEventSlim(false);
-            using var overallTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var overallTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
             Func<HttpPipelineTransportOptions, HttpClient> clientFactory = _ =>
             {
@@ -157,18 +157,18 @@ namespace Azure.Core.Tests
 
             using var transport = new HttpClientTransport(clientFactory);
 
-            // Act - Start multiple concurrent requests
+            // Act - Start multiple concurrent requests on dedicated threads to avoid thread pool starvation
             var tasks = new List<Task>();
             for (int i = 0; i < 5; i++)
             {
-                tasks.Add(Task.Run(async () =>
+                tasks.Add(Task.Factory.StartNew(async () =>
                 {
                     var request = transport.CreateRequest();
                     request.Uri.Reset(new Uri("https://example.com"));
                     var message = new HttpMessage(request, ResponseClassifier.Shared);
                     await ProcessSyncOrAsync(transport, message);
                     Assert.AreEqual(200, message.Response.Status);
-                }));
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap());
             }
 
             try
@@ -255,7 +255,7 @@ namespace Azure.Core.Tests
             var updateCount = 0;
             var requestsInHandler = new SemaphoreSlim(0);
             var releaseRequests = new ManualResetEventSlim(false);
-            using var overallTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var overallTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
             Func<HttpPipelineTransportOptions, HttpClient> clientFactory = _ =>
             {
@@ -271,19 +271,19 @@ namespace Azure.Core.Tests
 
             using var transport = new HttpClientTransport(clientFactory);
 
-            // Act - Start concurrent requests that will block in the handler
+            // Act - Start concurrent requests on dedicated threads to avoid thread pool starvation
             const int requestCount = 10;
             var tasks = new List<Task>();
             for (int i = 0; i < requestCount; i++)
             {
-                tasks.Add(Task.Run(async () =>
+                tasks.Add(Task.Factory.StartNew(async () =>
                 {
                     var request = transport.CreateRequest();
                     request.Uri.Reset(new Uri("https://example.com"));
                     var message = new HttpMessage(request, ResponseClassifier.Shared);
                     await ProcessSyncOrAsync(transport, message);
                     Assert.AreEqual(200, message.Response.Status);
-                }));
+                }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap());
             }
 
             try

--- a/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpClientTransportReferenceCountingTests.cs
@@ -140,6 +140,7 @@ namespace Azure.Core.Tests
             var responseCount = 0;
             var requestsInHandler = new SemaphoreSlim(0);
             var releaseRequests = new ManualResetEventSlim(false);
+            using var overallTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             Func<HttpPipelineTransportOptions, HttpClient> clientFactory = _ =>
             {
@@ -147,7 +148,7 @@ namespace Azure.Core.Tests
                 {
                     Interlocked.Increment(ref requestCount);
                     requestsInHandler.Release();
-                    releaseRequests.Wait();
+                    releaseRequests.Wait(overallTimeout.Token);
                     Interlocked.Increment(ref responseCount);
                     return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
                 });
@@ -173,12 +174,11 @@ namespace Azure.Core.Tests
             try
             {
                 // Wait until all requests are in the handler (past TryAddRef, holding refs)
-                using var waitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
                 try
                 {
                     for (int i = 0; i < 5; i++)
                     {
-                        await requestsInHandler.WaitAsync(waitTimeout.Token);
+                        await requestsInHandler.WaitAsync(overallTimeout.Token);
                     }
                 }
                 catch (OperationCanceledException)
@@ -255,6 +255,7 @@ namespace Azure.Core.Tests
             var updateCount = 0;
             var requestsInHandler = new SemaphoreSlim(0);
             var releaseRequests = new ManualResetEventSlim(false);
+            using var overallTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
 
             Func<HttpPipelineTransportOptions, HttpClient> clientFactory = _ =>
             {
@@ -262,7 +263,7 @@ namespace Azure.Core.Tests
                 var handler = new MockHttpHandler(req =>
                 {
                     requestsInHandler.Release();
-                    releaseRequests.Wait();
+                    releaseRequests.Wait(overallTimeout.Token);
                     return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
                 });
                 return new HttpClient(handler);
@@ -288,12 +289,11 @@ namespace Azure.Core.Tests
             try
             {
                 // Wait until all requests are in the handler (past TryAddRef, holding refs)
-                using var waitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
                 try
                 {
                     for (int i = 0; i < requestCount; i++)
                     {
-                        await requestsInHandler.WaitAsync(waitTimeout.Token);
+                        await requestsInHandler.WaitAsync(overallTimeout.Token);
                     }
                 }
                 catch (OperationCanceledException)


### PR DESCRIPTION
## Summary

Fixes #57789

The test `MultipleUpdatesWithConcurrentRequests_HandlesSafeDisposal` and `ConcurrentRequestsWithUpdate_RefCountingEnabled_SafeDisposal` in `HttpClientTransportReferenceCountingTests` intermittently fail with `ObjectDisposedException` when run under code coverage instrumentation due to non-deterministic `Task.Delay` timing.

## Changes

Replaced timing-dependent synchronization with deterministic primitives:

- **`SemaphoreSlim`** signals when requests have entered the mock handler (past `TryAddRef`, actively holding refs to the client wrapper)
- **`ManualResetEventSlim`** blocks requests in the handler until `Update()` has been called, guaranteeing overlap between in-flight requests and transport updates

This preserves the original test intent (validating that ref-counting prevents `ObjectDisposedException` during concurrent `Update()` + request processing) while eliminating timing-dependent flakiness.

## Validation

All 24 `HttpClientTransportReferenceCountingTests` pass consistently across 10 consecutive runs.