### PR TITLE
Fix child spans showing as siblings in streaming path

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Responses/Endpoint/AgentRunEndpoints.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Responses/Endpoint/AgentRunEndpoints.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
 using Azure.AI.AgentServer.Contracts.Generated.OpenAI;
 using Azure.AI.AgentServer.Contracts.Generated.Responses;
 using Azure.AI.AgentServer.Core.Common.Http.ServerSentEvent;
@@ -59,7 +62,8 @@ public static class AgentRunEndpoints
 
         UpdateContextBaggage(scopeAttrs);
         await using var _ = AgentInvocationContext.Setup(context).ConfigureAwait(false);
-        using var activity = context.StartActivity(logger, request);
+        IDisposable? activityScope = context.StartActivity(logger, request);
+        var activity = Activity.Current;
         try
         {
             logger.LogInformation($"Processing CreateResponse request: response_id={context.ResponseId}, "
@@ -69,10 +73,16 @@ public static class AgentRunEndpoints
             {
                 logger.LogInformation("Invoking agent to create streaming response.");
                 var updates = agentInvocation.InvokeStreamAsync(request, context, ct);
-                return updates.ToSseResult(
-                    e => SseFrame.Of(name: e.Type.ToString(), data: e),
-                    logger,
-                    ct);
+                // Transfer activity scope ownership to the streaming pipeline so that
+                // Activity.Current is restored during enumeration and child spans are
+                // properly parented under this activity instead of appearing as siblings.
+                var result = WithActivityScope(updates, activity, activityScope, ct)
+                    .ToSseResult(
+                        e => SseFrame.Of(name: e.Type.ToString(), data: e),
+                        logger,
+                        ct);
+                activityScope = null;
+                return result;
             }
 
             logger.LogInformation("Invoking agent to create response.");
@@ -87,6 +97,10 @@ public static class AgentRunEndpoints
             // Exceptions will be export to exceptions table in Application Insights.
             logger.LogError(ex, "Error when processing CreateResponse request.");
             throw;
+        }
+        finally
+        {
+            activityScope?.Dispose();
         }
     }
 
@@ -126,6 +140,33 @@ public static class AgentRunEndpoints
         foreach (var kv in scopeAttrs)
         {
             Baggage.SetBaggage(kv.Key, kv.Value);
+        }
+    }
+
+    /// <summary>
+    /// Wraps an async enumerable to restore the given <see cref="Activity"/> as
+    /// <see cref="Activity.Current"/> during enumeration and dispose the
+    /// <paramref name="scope"/> when enumeration completes. This ensures that
+    /// child spans created during deferred streaming execution are properly
+    /// parented under the original activity.
+    /// </summary>
+    private static async IAsyncEnumerable<T> WithActivityScope<T>(
+        IAsyncEnumerable<T> source,
+        Activity? activity,
+        IDisposable? scope,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        Activity.Current = activity;
+        try
+        {
+            await foreach (var item in source.WithCancellation(ct).ConfigureAwait(false))
+            {
+                yield return item;
+            }
+        }
+        finally
+        {
+            scope?.Dispose();
         }
     }
 }


### PR DESCRIPTION
The HostedAgents activity was created with 'using var' in CreateResponseAsync, which disposed/stopped it when the method returned. For the streaming path, actual enumeration happens later in SseResult.ExecuteAsync, so Activity.Current had already reverted and any child spans started during streaming lost their parent.

Fix: transfer activity scope ownership to the streaming pipeline via WithActivityScope, which restores Activity.Current during enumeration and disposes the scope when streaming completes. Non-streaming path is unaffected (activity disposed in finally as before).

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
