### PR TITLE
Ignore flaky ConcurrentGET snapshot consistency test

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SnapshotConsistencyTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SnapshotConsistencyTests.cs
@@ -23,6 +23,7 @@ public class SnapshotConsistencyTests : ProtocolTestBase
     /// never completed with fewer items than final count).
     /// </summary>
     [Test]
+    [Ignore("Flaky due to race condition — https://github.com/Azure/azure-sdk-for-net/issues/57815")]
     public async Task ConcurrentGET_DuringEmission_ReturnsConsistentSnapshots()
     {
         var handlerStarted = new TaskCompletionSource();


### PR DESCRIPTION
## Description

Ignores the flaky test `ConcurrentGET_DuringEmission_ReturnsConsistentSnapshots` in `Azure.AI.AgentServer.Responses` pending investigation and fix.

## Details

The test intermittently fails with a `KeyNotFoundException` at `JsonElement.GetProperty("status")` (line 72 of `SnapshotConsistencyTests.cs`). This is a race condition: concurrent GET requests during SSE event emission occasionally receive a snapshot JSON object missing the `status` property.

**Tracking issue:** #57815
**Build failure:** https://dev.azure.com/azure-sdk/29ec6040-b234-4e31-b139-33dc4287b756/_apis/build/builds/6109110/logs/1263
