### PR TITLE
Fix tag method generation for non-singleton resources with bodyless PATCH

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -471,8 +471,11 @@ namespace Azure.Generator.Management.Providers
                 return (false, null);
             }
 
-            // If there is no patch method with a body, fall back to the put method
-            var putMethod = _resourceMetadata.Methods.FirstOrDefault(m => m.Kind == ResourceOperationKind.Create);
+            // If there is no patch method with a body, fall back to the put method.
+            // Search _resourceServiceMethods (the categorized set) instead of _resourceMetadata.Methods
+            // because for non-singleton resources with an Update method, the Create method is only
+            // assigned to the collection, not the resource.
+            var putMethod = _resourceServiceMethods.FirstOrDefault(m => m.Kind == ResourceOperationKind.Create);
             return (false, putMethod);
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/InputResourceData.cs
@@ -162,6 +162,57 @@ namespace Azure.Generator.Management.Tests.Common
         }
 
         /// <summary>
+        /// Creates a non-singleton resource with only GET and PUT (no PATCH at all).
+        /// Since there is no Update method, the Create (PUT) method gets added to the resource's methods
+        /// by the categorization fallback, and tag methods SHOULD be generated using PUT.
+        /// This mirrors real SDK resources like CosmosDB CassandraKeyspaceResource.
+        /// </summary>
+        public static (InputClient InputClient, IReadOnlyList<InputModelType> InputModels) ClientWithResourceNoPatchOnlyPut()
+        {
+            const string TestClientName = "TestClient";
+            const string ResourceModelName = "ResponseType";
+            var responseModel = InputFactory.Model(ResourceModelName,
+                        usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                        properties:
+                        [
+                            InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("tags", new InputDictionaryType("dict", InputPrimitiveType.String, InputPrimitiveType.String), isReadOnly: false),
+                        ],
+                        decorators: []);
+            var responseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: responseModel);
+            var uuidType = new InputPrimitiveType(InputPrimitiveTypeKind.String, "uuid", "Azure.Core.uuid");
+            var subsIdOpParameter = InputFactory.PathParameter("subscriptionId", uuidType, isRequired: true);
+            var rgOpParameter = InputFactory.PathParameter("resourceGroupName", InputPrimitiveType.String, isRequired: true);
+            var testNameOpParameter = InputFactory.PathParameter("testName", InputPrimitiveType.String, isRequired: true);
+            var dataOpParameter = InputFactory.BodyParameter("data", responseModel, isRequired: true);
+            var getOperation = InputFactory.Operation(name: "get", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}");
+            // PUT operation WITH body parameter — no PATCH at all
+            var createOperation = InputFactory.Operation(name: "createTest", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter, dataOpParameter], path: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}", httpMethod: "PUT");
+            var subscriptionIdParameter = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
+            var resourceGroupParameter = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var testNameParameter = InputFactory.MethodParameter("testName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            var dataParameter = InputFactory.MethodParameter("data", responseModel, location: InputRequestLocation.Body, isRequired: true);
+            var getMethod = InputFactory.BasicServiceMethod("get", getOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var createMethod = InputFactory.BasicServiceMethod("createTest", createOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+
+            var resourceIdPattern = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}";
+            var armProviderDecorator = BuildArmProviderSchema(responseModel, [
+                new ResourceMethod(ResourceOperationKind.Read, getMethod, getMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!),
+                new ResourceMethod(ResourceOperationKind.Create, createMethod, createMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!)
+            ], resourceIdPattern, "Microsoft.Tests/tests", null, ResourceScope.ResourceGroup, "ResponseType");
+
+            var client = InputFactory.Client(
+                TestClientName,
+                methods: [getMethod, createMethod],
+                decorators: [armProviderDecorator],
+                crossLanguageDefinitionId: $"Test.{TestClientName}");
+
+            return (client, [responseModel]);
+        }
+
+        /// <summary>
         /// Creates a client with a resource where the PATCH operation has no request body but a PUT operation exists.
         /// Tag methods should still be generated using the PUT operation as fallback.
         /// </summary>
@@ -205,6 +256,63 @@ namespace Azure.Generator.Management.Tests.Common
                 new ResourceMethod(ResourceOperationKind.Create, createMethod, createMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!),
                 new ResourceMethod(ResourceOperationKind.Update, updateMethod, updateMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!)
             ], resourceIdPattern, "Microsoft.Tests/tests", null, ResourceScope.ResourceGroup, "ResponseType");
+
+            var client = InputFactory.Client(
+                TestClientName,
+                methods: [getMethod, createMethod, updateMethod],
+                decorators: [armProviderDecorator],
+                crossLanguageDefinitionId: $"Test.{TestClientName}");
+
+            return (client, [responseModel]);
+        }
+
+        /// <summary>
+        /// Creates a singleton resource where the PATCH operation has no request body but a PUT operation exists.
+        /// For singleton resources, the Create (PUT) method is categorized into the resource (not the collection),
+        /// so tag methods SHOULD be generated using the PUT fallback.
+        /// </summary>
+        public static (InputClient InputClient, IReadOnlyList<InputModelType> InputModels) ClientWithSingletonResourceBodylessPatchAndPut()
+        {
+            const string TestClientName = "TestClient";
+            const string ResourceModelName = "ResponseType";
+            var responseModel = InputFactory.Model(ResourceModelName,
+                        usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                        properties:
+                        [
+                            InputFactory.Property("id", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("type", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("name", InputPrimitiveType.String, isReadOnly: true),
+                            InputFactory.Property("tags", new InputDictionaryType("dict", InputPrimitiveType.String, InputPrimitiveType.String), isReadOnly: false),
+                        ],
+                        decorators: []);
+            var responseType = InputFactory.OperationResponse(statusCodes: [200], bodytype: responseModel);
+            var uuidType = new InputPrimitiveType(InputPrimitiveTypeKind.String, "uuid", "Azure.Core.uuid");
+            var subsIdOpParameter = InputFactory.PathParameter("subscriptionId", uuidType, isRequired: true);
+            var rgOpParameter = InputFactory.PathParameter("resourceGroupName", InputPrimitiveType.String, isRequired: true);
+            var testNameOpParameter = InputFactory.PathParameter("testName", InputPrimitiveType.String, isRequired: true);
+            var dataOpParameter = InputFactory.BodyParameter("data", responseModel, isRequired: true);
+            // Singleton resource path - ends with a fixed name "default"
+            var singletonPath = "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Tests/tests/{testName}/policies/default";
+            var getOperation = InputFactory.Operation(name: "get", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter], path: singletonPath);
+            // PUT operation WITH body parameter
+            var createOperation = InputFactory.Operation(name: "createTest", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter, dataOpParameter], path: singletonPath, httpMethod: "PUT");
+            // PATCH operation with NO body parameter
+            var updateOperation = InputFactory.Operation(name: "update", responses: [responseType], parameters: [subsIdOpParameter, rgOpParameter, testNameOpParameter], path: singletonPath, httpMethod: "PATCH");
+            var subscriptionIdParameter = InputFactory.MethodParameter("subscriptionId", uuidType, location: InputRequestLocation.Path);
+            var resourceGroupParameter = InputFactory.MethodParameter("resourceGroupName", InputPrimitiveType.String, location: InputRequestLocation.Path);
+            var testNameParameter = InputFactory.MethodParameter("testName", InputPrimitiveType.String, location: InputRequestLocation.Path, isRequired: true);
+            var dataParameter = InputFactory.MethodParameter("data", responseModel, location: InputRequestLocation.Body, isRequired: true);
+            var getMethod = InputFactory.BasicServiceMethod("get", getOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            var createMethod = InputFactory.BasicServiceMethod("createTest", createOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter, dataParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+            // Update method has no body parameter
+            var updateMethod = InputFactory.BasicServiceMethod("update", updateOperation, parameters: [testNameParameter, subscriptionIdParameter, resourceGroupParameter], crossLanguageDefinitionId: Guid.NewGuid().ToString());
+
+            var resourceIdPattern = singletonPath;
+            var armProviderDecorator = BuildArmProviderSchema(responseModel, [
+                new ResourceMethod(ResourceOperationKind.Read, getMethod, getMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!),
+                new ResourceMethod(ResourceOperationKind.Create, createMethod, createMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!),
+                new ResourceMethod(ResourceOperationKind.Update, updateMethod, updateMethod.Operation.Path, ResourceScope.ResourceGroup, resourceIdPattern, null!)
+            ], resourceIdPattern, "Microsoft.Tests/tests/policies", "default", ResourceScope.ResourceGroup, "ResponseType");
 
             var client = InputFactory.Client(
                 TestClientName,

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TagMethodProviderTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Providers/TagMethodProviderTests.cs
@@ -162,19 +162,58 @@ namespace Azure.Generator.Management.Tests.Providers
         }
 
         [TestCase]
-        public void Verify_TagMethodsGenerated_WhenPatchHasNoBodyButPutExists()
+        public void Verify_NoTagMethods_WhenNonSingletonHasBodylessPatchAndPut()
         {
             var (client, models) = InputResourceData.ClientWithResourceBodylessPatchAndPut();
             _ = ManagementMockHelpers.LoadMockPlugin(inputModels: () => models, clients: () => [client]);
             var resourceClientProvider = ManagementClientGenerator.Instance.OutputLibrary.TypeProviders.OfType<ResourceClientProvider>().First();
             Assert.IsNotNull(resourceClientProvider);
 
-            // Verify that tag methods ARE generated using the PUT fallback
+            // For a non-singleton resource, the Create (PUT) method is categorized only into the collection,
+            // not the resource. When PATCH has no body, the PUT fallback should not be found in the resource's
+            // methods, so tag methods should NOT be generated.
             var tagMethodNames = new[] { "AddTag", "AddTagAsync", "SetTags", "SetTagsAsync", "RemoveTag", "RemoveTagAsync" };
             foreach (var tagMethodName in tagMethodNames)
             {
                 var method = resourceClientProvider.Methods.SingleOrDefault(m => m.Signature.Name == tagMethodName);
-                Assert.IsNotNull(method, $"Tag method '{tagMethodName}' should be generated using PUT fallback when PATCH has no body.");
+                Assert.IsNull(method, $"Tag method '{tagMethodName}' should not be generated for non-singleton resource when PATCH has no body and PUT is collection-only.");
+            }
+        }
+
+        [TestCase]
+        public void Verify_TagMethodsGenerated_WhenSingletonHasBodylessPatchAndPut()
+        {
+            var (client, models) = InputResourceData.ClientWithSingletonResourceBodylessPatchAndPut();
+            _ = ManagementMockHelpers.LoadMockPlugin(inputModels: () => models, clients: () => [client]);
+            var resourceClientProvider = ManagementClientGenerator.Instance.OutputLibrary.TypeProviders.OfType<ResourceClientProvider>().First();
+            Assert.IsNotNull(resourceClientProvider);
+
+            // For a singleton resource, the Create (PUT) method is categorized into the resource,
+            // so the PUT fallback should be found and tag methods SHOULD be generated.
+            var tagMethodNames = new[] { "AddTag", "AddTagAsync", "SetTags", "SetTagsAsync", "RemoveTag", "RemoveTagAsync" };
+            foreach (var tagMethodName in tagMethodNames)
+            {
+                var method = resourceClientProvider.Methods.SingleOrDefault(m => m.Signature.Name == tagMethodName);
+                Assert.IsNotNull(method, $"Tag method '{tagMethodName}' should be generated for singleton resource using PUT fallback when PATCH has no body.");
+            }
+        }
+
+        [TestCase]
+        public void Verify_TagMethodsGenerated_WhenNonSingletonHasNoPatchOnlyPut()
+        {
+            var (client, models) = InputResourceData.ClientWithResourceNoPatchOnlyPut();
+            _ = ManagementMockHelpers.LoadMockPlugin(inputModels: () => models, clients: () => [client]);
+            var resourceClientProvider = ManagementClientGenerator.Instance.OutputLibrary.TypeProviders.OfType<ResourceClientProvider>().First();
+            Assert.IsNotNull(resourceClientProvider);
+
+            // For a non-singleton resource with no PATCH at all, the Create (PUT) method gets added
+            // to the resource's methods by the categorization fallback (no hasUpdateMethod).
+            // Tag methods SHOULD be generated using PUT.
+            var tagMethodNames = new[] { "AddTag", "AddTagAsync", "SetTags", "SetTagsAsync", "RemoveTag", "RemoveTagAsync" };
+            foreach (var tagMethodName in tagMethodNames)
+            {
+                var method = resourceClientProvider.Methods.SingleOrDefault(m => m.Signature.Name == tagMethodName);
+                Assert.IsNotNull(method, $"Tag method '{tagMethodName}' should be generated for non-singleton resource using PUT when no PATCH exists.");
             }
         }
 


### PR DESCRIPTION
## Problem

`PopulateUpdateMethod` in `ResourceClientProvider` was searching `_resourceMetadata.Methods` (the unfiltered full set of methods) for a PUT fallback when the PATCH method has no body. For **non-singleton** resources with a bodyless PATCH, the Create (PUT) method is categorized **only into the collection**, not the resource (because `hasUpdateMethod` is `true`). This caused tag methods to be incorrectly generated using a collection-only method.

### Real SDK example
`ExtensionResource` in `Azure.ResourceManager.AgFoodPlatform` is a non-singleton resource with a bodyless PATCH — this is the exact scenario where the bug would trigger.

## Fix

Changed the PUT fallback in `PopulateUpdateMethod` to search `_resourceServiceMethods` (the categorized set assigned to the resource) instead of `_resourceMetadata.Methods`. This ensures the PUT method is only used for tag generation when it was actually assigned to the resource class.

### Scenarios covered

| Scenario | Tags generated? | Reason |
|---|---|---|
| Singleton + bodyless PATCH + PUT | Yes | PUT is in the resource for singletons |
| Non-singleton + bodyless PATCH + PUT | No | PUT is collection-only (fix) |
| Non-singleton + no PATCH + PUT only | Yes | PUT added to resource via hasUpdateMethod fallback |
| Non-singleton + PATCH with tags body | Yes | Uses PATCH directly |
| Non-singleton + bodyless PATCH, no PUT | No | Nothing to fall back to |

## Tests

- **Updated**: `Verify_NoTagMethods_WhenNonSingletonHasBodylessPatchAndPut` — asserts tags are NOT generated for non-singleton with bodyless PATCH + collection-only PUT
- **Added**: `Verify_TagMethodsGenerated_WhenSingletonHasBodylessPatchAndPut` — singleton with bodyless PATCH + PUT SHOULD generate tags
- **Added**: `Verify_TagMethodsGenerated_WhenNonSingletonHasNoPatchOnlyPut` — non-singleton with no PATCH, only PUT SHOULD generate tags (CosmosDB pattern)

All 151 tests pass.