### PR TITLE
DO NOT MERGE: Storage baseline comparison for weighted batching

### DIFF
--- a/sdk/storage/Azure.ResourceManager.Storage/src/Azure.ResourceManager.Storage.csproj
+++ b/sdk/storage/Azure.ResourceManager.Storage/src/Azure.ResourceManager.Storage.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Storage baseline comparison for weighted batching analysis -->
     <Version>1.7.0-beta.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.6.2</ApiCompatVersion>


### PR DESCRIPTION
Comment-only change to Azure.ResourceManager.Storage to trigger CI with current BatchSize=10 and TestDependsOnDependency. Used to measure baseline for weighted batching comparison.