### PR TITLE
[KeyVault] Add samples for new certificate SANs (IP/URI) and secret outContentType/PreviousVersion features

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample1_HelloWorld.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample1_HelloWorld.md
@@ -16,12 +16,21 @@ CertificateClient client = new CertificateClient(new Uri(keyVaultUrl), new Defau
 
 ## Creating a certificate
 
-Let's create a self-signed certificate using the default policy.
+Let's create a self-signed certificate with Subject Alternative Names (SANs) that include DNS names, IP addresses, and URIs.
 If the certificate already exists in the Azure Key Vault, then a new version of the key is created.
 
 ```C# Snippet:CertificatesSample1CreateCertificate
 string certName = $"defaultCert-{Guid.NewGuid()}";
-CertificateOperation certOp = client.StartCreateCertificate(certName, CertificatePolicy.Default);
+
+// Create Subject Alternative Names (SANs) with DNS names, IP addresses, and URIs.
+var sans = new SubjectAlternativeNames();
+sans.DnsNames.Add("sdk.azure-int.net");
+sans.IpAddresses.Add("10.0.0.1");
+sans.IpAddresses.Add("2001:db8::1");
+sans.UniformResourceIdentifiers.Add("https://mydomain.com");
+
+var policy = new CertificatePolicy(WellKnownIssuerNames.Self, "CN=SelfSignedCert", sans);
+CertificateOperation certOp = client.StartCreateCertificate(certName, policy);
 
 while (!certOp.HasCompleted)
 {

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs
@@ -26,7 +26,16 @@ namespace Azure.Security.KeyVault.Certificates.Samples
 
             #region Snippet:CertificatesSample1CreateCertificate
             string certName = $"defaultCert-{Guid.NewGuid()}";
-            CertificateOperation certOp = client.StartCreateCertificate(certName, CertificatePolicy.Default);
+
+            // Create Subject Alternative Names (SANs) with DNS names, IP addresses, and URIs.
+            var sans = new SubjectAlternativeNames();
+            sans.DnsNames.Add("sdk.azure-int.net");
+            sans.IpAddresses.Add("10.0.0.1");
+            sans.IpAddresses.Add("2001:db8::1");
+            sans.UniformResourceIdentifiers.Add("https://mydomain.com");
+
+            var policy = new CertificatePolicy(WellKnownIssuerNames.Self, "CN=SelfSignedCert", sans);
+            CertificateOperation certOp = client.StartCreateCertificate(certName, policy);
 
             while (!certOp.HasCompleted)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorld.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorld.md
@@ -37,6 +37,14 @@ KeyVaultSecret bankSecret = client.GetSecret(secretName);
 Debug.WriteLine($"Secret is returned with name {bankSecret.Name} and value {bankSecret.Value}");
 ```
 
+### Getting a secret with outContentType
+
+For certificate-backed secrets, you can request the secret value in a different format. For example, to convert a PFX-backed secret to PEM:
+
+```csharp
+KeyVaultSecret pemSecret = client.GetSecret(secretName, version: null, outContentType: SecretContentType.Pem);
+```
+
 ## Updating secret properties
 
 After one year if the bank account is still active, we need to update the expiration time of the secret.
@@ -58,6 +66,18 @@ var secretNewValue = new KeyVaultSecret(secretName, "bhjd4DDgsa");
 secretNewValue.Properties.ExpiresOn = DateTimeOffset.Now.AddYears(1);
 
 client.SetSecret(secretNewValue);
+```
+
+## Checking previous version
+
+For secrets created after June 1, 2025, you can retrieve the previous version identifier, which is useful for tracking version history of certificate-backed secrets.
+
+```csharp
+KeyVaultSecret latestSecret = client.GetSecret(secretName);
+if (latestSecret.Properties.PreviousVersion != null)
+{
+    Debug.WriteLine($"Secret's previous version is {latestSecret.Properties.PreviousVersion}");
+}
 ```
 
 ## Deleting a secret

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorld.cs
@@ -39,6 +39,10 @@ namespace Azure.Security.KeyVault.Secrets.Samples
             Debug.WriteLine($"Secret is returned with name {bankSecret.Name} and value {bankSecret.Value}");
             #endregion
 
+            // For certificate-backed secrets, you can retrieve the value in a different format using outContentType.
+            // For example, to get a PFX-backed secret as PEM:
+            // KeyVaultSecret pemSecret = client.GetSecret(secretName, version: null, outContentType: SecretContentType.Pem);
+
             #region Snippet:SecretsSample1UpdateSecretProperties
             bankSecret.Properties.ExpiresOn = bankSecret.Properties.ExpiresOn.Value.AddYears(1);
             SecretProperties updatedSecret = client.UpdateSecretProperties(bankSecret.Properties);
@@ -51,6 +55,13 @@ namespace Azure.Security.KeyVault.Secrets.Samples
 
             client.SetSecret(secretNewValue);
             #endregion
+
+            // For secrets created after June 1, 2025, PreviousVersion tracks version history.
+            KeyVaultSecret latestSecret = client.GetSecret(secretName);
+            if (latestSecret.Properties.PreviousVersion != null)
+            {
+                Debug.WriteLine($"Secret's previous version is {latestSecret.Properties.PreviousVersion}");
+            }
 
             #region Snippet:SecretsSample1DeleteSecret
             DeleteSecretOperation operation = client.StartDeleteSecret(secretName);


### PR DESCRIPTION
## Description
This PR adds sample code demonstrating new KeyVault features:

### Certificates
- IP addresses in Subject Alternative Names (SANs)
- URIs in Subject Alternative Names (SANs)

### Secrets
- `outContentType` parameter (`SecretContentType.Pem`) for format conversion  
- `PreviousVersion` property on SecretProperties

## Files Changed
- `sdk/keyvault/Azure.Security.KeyVault.Certificates/tests/samples/Sample1_HelloWorld.cs`  
- `sdk/keyvault/Azure.Security.KeyVault.Certificates/samples/Sample1_HelloWorld.md`  
- `sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/samples/Sample1_HelloWorld.cs`  
- `sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorld.md`