### PR TITLE
Make dependency calculation dynamic for all changed packages

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -94,20 +94,17 @@ function Get-dotnet-AdditionalValidationPackagesFromPackageSet($LocatedPackages,
 {
   $additionalValidationPackages = @()
 
-  $DependencyCalculationPackages = @(
-    "Azure.Core",
-    "Azure.ResourceManager",
-    "System.ClientModel"
-  )
-
-  $TestDependsOnDependencySet = $LocatedPackages | Where-Object { $_.Name -in $DependencyCalculationPackages }
-  $TestDependsOnDependency = $TestDependsOnDependencySet.Name -join " "
+  # Use all directly changed packages for dependency calculation. This ensures that
+  # when any package changes, all cross-service packages that depend on it are included
+  # as indirect packages for validation testing.
+  $TestDependsOnDependencySet = $LocatedPackages | Where-Object { $_.IncludedForValidation -eq $false }
+  $TestDependsOnDependency = ($TestDependsOnDependencySet | ForEach-Object { $_.Name }) -join " "
 
   if (!$TestDependsOnDependency) {
     return $additionalValidationPackages
   }
 
-  Write-Host "Calculating dependencies for $($pkgProp.Name)"
+  Write-Host "Calculating dependencies for: $TestDependsOnDependency"
 
   $outputFilePath = Join-Path $RepoRoot "_dependencylist.txt"
 


### PR DESCRIPTION
## Problem

When a PR changes a package like \Azure.ResourceManager.Storage\, the \
et - pullrequest\ pipeline only tests Storage itself. It does NOT test the 19 cross-service test projects that depend on Storage (Batch, DataFactory, Network, etc.).

## Root Cause

The \Get-dotnet-AdditionalValidationPackagesFromPackageSet\ function in \Language-Settings.ps1\ was hardcoded to only calculate dependencies for three packages: \Azure.Core\, \Azure.ResourceManager\, and \System.ClientModel\. Other packages like \Azure.ResourceManager.Storage\ were not included, so their dependents were never discovered during PR builds.

## Fix

Make the dependency calculation dynamic — use ALL directly changed packages instead of a hardcoded list. When any package changes, the MSBuild \ProjectDependsOn\ target discovers all cross-service packages that depend on it and includes them as indirect validation packages.

This is a one-line logical change that removes the hardcoded filter and replaces it with \IncludedForValidation -eq \False\ (i.e., all direct packages).

## Testing

Retargeting PR #57823 (storage-only change) to this branch to verify that indirect dependent packages now appear in the build.