### PR TITLE
Update Library Inventory and Emitter Version Dashboard

### DIFF
--- a/doc/GeneratorMigration/Library_Inventory.md
+++ b/doc/GeneratorMigration/Library_Inventory.md
@@ -1,6 +1,6 @@
 # Azure SDK for .NET Libraries Inventory
 
-> **Auto-generated** by `Library_Inventory` on 2026-04-03 19:07:48 UTC.
+> **Auto-generated** by `Library_Inventory` on 2026-04-07 06:52:44 UTC.
 > Run that script to refresh this file.
 
 ## Table of Contents
@@ -18,8 +18,8 @@
 
 - Total libraries: 398
 - Management Plane (MPG): 232
-  - Autorest/Swagger: 102
-  - New Emitter (TypeSpec): 130
+  - Autorest/Swagger: 101
+  - New Emitter (TypeSpec): 131
   - Old TypeSpec: 0
 - Data Plane (DPG): 128
   - Autorest/Swagger: 37
@@ -134,7 +134,7 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 37
 
 Libraries that provide resource management APIs for Azure services and have been migrated to the new TypeSpec emitter.
 
-**Migration Status**: 130 / 130 (100%)
+**Migration Status**: 131 / 131 (100%)
 
 | Service | Library | New Emitter |
 | ------- | ------- | ----------- |
@@ -169,6 +169,7 @@ Libraries that provide resource management APIs for Azure services and have been
 | containerregistry | Azure.ResourceManager.ContainerRegistry | ✅ |
 | containerregistry | Azure.ResourceManager.ContainerRegistry.Tasks | ✅ |
 | containerservice | Azure.ResourceManager.ContainerService | ✅ |
+| cosmosdbforpostgresql | Azure.ResourceManager.CosmosDBForPostgreSql | ✅ |
 | databasewatcher | Azure.ResourceManager.DatabaseWatcher | ✅ |
 | databox | Azure.ResourceManager.DataBox | ✅ |
 | datadog | Azure.ResourceManager.Datadog | ✅ |
@@ -272,7 +273,7 @@ Libraries that provide resource management APIs for Azure services and have been
 
 ## Management Plane Libraries (MPG) - Still on Swagger
 
-Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 102
+Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 101
 
 | Service | Library |
 | ------- | ------- |
@@ -298,7 +299,6 @@ Libraries that have not yet been migrated to the new TypeSpec emitter. Total: 10
 | containerapps | Azure.ResourceManager.AppContainers |
 | containerinstance | Azure.ResourceManager.ContainerInstance |
 | cosmosdb | Azure.ResourceManager.CosmosDB |
-| cosmosdbforpostgresql | Azure.ResourceManager.CosmosDBForPostgreSql |
 | costmanagement | Azure.ResourceManager.CostManagement |
 | customer-insights | Azure.ResourceManager.CustomerInsights |
 | databoxedge | Azure.ResourceManager.DataBoxEdge |

--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,14 +1,14 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-04-04 01:49:57 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-04-07 06:52:45 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Dependency Chain
 
 ```
-@typespec/http-client-csharp (alpha.20260403.13)
-  └─ @azure-typespec/http-client-csharp (alpha.20260403.2)
-       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260403.1)
+@typespec/http-client-csharp (alpha.20260406.20)
+  └─ @azure-typespec/http-client-csharp (alpha.20260403.3)
+       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260406.1)
             └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260327.1)
 ```
 
@@ -16,9 +16,9 @@
 
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
-| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260403.13](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260403.13) | [1.0.0-alpha.20260403.13](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260403.13) | [051d4b8](https://github.com/microsoft/typespec/commit/051d4b89dafbaeaadf4e968f67d2e23ef3f46135) |
-| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260331.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260331.4) | [1.0.0-alpha.20260403.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260403.2) | [97c14b2](https://github.com/Azure/azure-sdk-for-net/commit/97c14b2679e311a9485d2a477b54813048c4d0d6) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260322.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260322.2) | [1.0.0-alpha.20260403.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260403.1) | [e413cb9](https://github.com/Azure/azure-sdk-for-net/commit/e413cb9dfdf6460c14915fe09126ca3b39f050e2) |
+| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260403.13](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260403.13) | [1.0.0-alpha.20260406.20](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260406.20) | [051d4b8](https://github.com/microsoft/typespec/commit/051d4b89dafbaeaadf4e968f67d2e23ef3f46135) |
+| `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260331.4](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260331.4) | [1.0.0-alpha.20260403.3](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260403.3) | [97c14b2](https://github.com/Azure/azure-sdk-for-net/commit/97c14b2679e311a9485d2a477b54813048c4d0d6) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260322.2](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260322.2) | [1.0.0-alpha.20260406.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260406.1) | [e413cb9](https://github.com/Azure/azure-sdk-for-net/commit/e413cb9dfdf6460c14915fe09126ca3b39f050e2) |
 
 ## Source Files
 


### PR DESCRIPTION
## Description

Regenerated the Library Inventory and Emitter Version Dashboard markdown files with the latest data.

### Changes

**Library Inventory** (`doc/GeneratorMigration/Library_Inventory.md`):
- `Azure.ResourceManager.CosmosDBForPostgreSql` migrated from Swagger to New Emitter (MPG Swagger 102→101, New Emitter 130→131)
- Timestamp refreshed

**Emitter Version Dashboard** (`doc/GeneratorVersions/Emitter_Version_Dashboard.md`):
- Updated latest npm versions for all emitters (e.g., `@typespec/http-client-csharp` → `alpha.20260406.20`, `@azure-typespec/http-client-csharp-mgmt` → `alpha.20260406.1`)
- Dependency chain versions refreshed
- Timestamp refreshed
