### PR TITLE
Cache redirect primary node URL in CodeTransparencyRedirectPolicy

### DIFF
--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bugs Fixed
 
+- Improved redirect performance for write operations by caching the latest primary node URL from redirect responses and reusing it for subsequent non-GET requests. The cache is lazily populated and refreshed whenever the service redirects to a different primary node.
+
 ### Other Changes
 
 ## 1.0.0-beta.8 (2026-03-02)

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/src/CodeTransparencyRedirectPolicy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
@@ -22,6 +23,8 @@ namespace Azure.Security.CodeTransparency
     internal sealed class CodeTransparencyRedirectPolicy : HttpPipelinePolicy
     {
         private const int MaxRedirects = 5;
+        private readonly object _primaryNodeLock = new object();
+        private Uri _primaryNodeBaseUri;
 
         /// <inheritdoc/>
         public override void Process(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
@@ -37,6 +40,8 @@ namespace Azure.Security.CodeTransparency
 
         private async ValueTask ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
+            TryApplyCachedPrimaryNode(message.Request);
+
             if (async)
             {
                 await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
@@ -63,6 +68,8 @@ namespace Azure.Security.CodeTransparency
                 }
 
                 Uri redirectUri = BuildRedirectUri(message.Request.Uri.ToUri(), location);
+
+                CachePrimaryNode(redirectUri);
 
                 // Disallow redirect from HTTPS to HTTP.
                 if (string.Equals(message.Request.Uri.Scheme, "https", StringComparison.OrdinalIgnoreCase) &&
@@ -105,6 +112,58 @@ namespace Azure.Security.CodeTransparency
             }
 
             return redirectUri;
+        }
+
+        private void TryApplyCachedPrimaryNode(Request request)
+        {
+            if (request.Method == RequestMethod.Get)
+            {
+                return;
+            }
+
+            Uri primaryNodeBaseUri = Volatile.Read(ref _primaryNodeBaseUri);
+            if (primaryNodeBaseUri == null)
+            {
+                return;
+            }
+
+            request.Uri.Reset(BuildUriWithPrimaryHost(request.Uri.ToUri(), primaryNodeBaseUri));
+        }
+
+        private void CachePrimaryNode(Uri redirectUri)
+        {
+            Uri candidatePrimary = GetPrimaryNodeBaseUri(redirectUri);
+            if (candidatePrimary == null)
+            {
+                return;
+            }
+
+            lock (_primaryNodeLock)
+            {
+                _primaryNodeBaseUri = candidatePrimary;
+            }
+        }
+
+        private static Uri GetPrimaryNodeBaseUri(Uri uri)
+        {
+            if (uri == null || !uri.IsAbsoluteUri)
+            {
+                return null;
+            }
+
+            return new UriBuilder(uri.Scheme, uri.Host, uri.IsDefaultPort ? -1 : uri.Port).Uri;
+        }
+
+        private static Uri BuildUriWithPrimaryHost(Uri requestUri, Uri primaryNodeBaseUri)
+        {
+            var builder = new UriBuilder(requestUri)
+            {
+                Scheme = primaryNodeBaseUri.Scheme,
+                Host = primaryNodeBaseUri.Host,
+                Port = primaryNodeBaseUri.IsDefaultPort ? -1 : primaryNodeBaseUri.Port
+            };
+
+            return builder.Uri;
         }
     }
 }

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/CodeTransparencyRedirectPolicyTests.cs
@@ -205,5 +205,99 @@ namespace Azure.Security.CodeTransparency.Tests
             Assert.AreEqual(200, response.Status);
             Assert.IsTrue(redirectResponse.IsDisposed);
         }
+
+        [Test]
+        public async Task CachesPrimaryNodeForSubsequentNonGetRequests()
+        {
+            var policy = new CodeTransparencyRedirectPolicy();
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200),
+                new MockResponse(200));
+
+            await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, policy);
+
+            await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, policy);
+
+            Assert.AreEqual(3, mockTransport.Requests.Count);
+            Assert.AreEqual("https://primary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
+        }
+
+        [Test]
+        public async Task UsesCachedPrimaryOnlyForNonGetRequests()
+        {
+            var policy = new CodeTransparencyRedirectPolicy();
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://primary-node.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200),
+                new MockResponse(200));
+
+            await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, policy);
+
+            await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Get;
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, policy);
+
+            Assert.AreEqual(3, mockTransport.Requests.Count);
+            Assert.AreEqual("https://secondary-node.confidential-ledger.azure.com/ledger", mockTransport.Requests[2].Uri.ToString());
+        }
+
+        [Test]
+        public async Task RefreshesCachedPrimaryWhenRedirectTargetChanges()
+        {
+            var policy = new CodeTransparencyRedirectPolicy();
+            var mockTransport = new MockTransport(
+                new MockResponse(307).AddHeader("Location", "https://primary-a.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200),
+                new MockResponse(307).AddHeader("Location", "https://primary-b.confidential-ledger.azure.com/ledger"),
+                new MockResponse(200),
+                new MockResponse(200));
+
+            await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, policy);
+
+            await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, policy);
+
+            await SendRequestAsync(mockTransport, message =>
+            {
+                message.Request.Method = RequestMethod.Post;
+                message.Request.Uri.Reset(new Uri("https://secondary-node.confidential-ledger.azure.com/ledger"));
+            }, policy);
+
+            Assert.AreEqual(5, mockTransport.Requests.Count);
+            bool sawPrimaryA = false;
+            foreach (MockRequest request in mockTransport.Requests)
+            {
+                if (request.Uri.ToString() == "https://primary-a.confidential-ledger.azure.com/ledger")
+                {
+                    sawPrimaryA = true;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(sawPrimaryA, "Expected at least one request to the previously cached primary node.");
+            Assert.AreEqual("https://primary-b.confidential-ledger.azure.com/ledger", mockTransport.Requests[4].Uri.ToString());
+        }
     }
 }


### PR DESCRIPTION
## Description

When a Code Transparency Service node returns a 307/308 redirect (routing a write to the primary node), the redirect target URL is now cached in the `CodeTransparencyRedirectPolicy`. Subsequent non-GET requests reuse the cached primary node URL directly, avoiding the redirect round-trip.

### Changes
- **`CodeTransparencyRedirectPolicy.cs`**: Added lazy cache for primary node base URI. On first redirect, the primary host is stored. Subsequent non-GET requests have their host rewritten to the cached primary. GET requests are unaffected. The cache refreshes if a new redirect target is received.
- **`CodeTransparencyRedirectPolicyTests.cs`**: Added 3 new tests:
  - `CachesPrimaryNodeForSubsequentNonGetRequests`
  - `UsesCachedPrimaryOnlyForNonGetRequests`
  - `RefreshesCachedPrimaryWhenRedirectTargetChanges`
- **`CHANGELOG.md`**: Added entry under Bugs Fixed.

### Performance Impact
Tested against a 3-node ledger:
- **Write  (redirected)**: ~500ms (307 redirect + new TLS connection + 202)
- **Writes (cached)**: ~12ms each (direct to cached primary, no redirect)
- **~35x faster** on subsequent writes" 

<img width="1210" height="500" alt="image" src="https://github.com/user-attachments/assets/b1323a2a-bcab-4c15-b0e5-70d1b7c162c9" />
