### PR TITLE
Add scaffolding automation for new mgmt TypeSpec SDK packages

### DIFF
--- a/eng/scripts/Invoke-GenerateAndBuildV2.ps1
+++ b/eng/scripts/Invoke-GenerateAndBuildV2.ps1
@@ -262,8 +262,14 @@ if ($relatedTypeSpecProjectFolder) {
         }
         $serviceType = "data-plane"
         $packageName = Split-Path $sdkProjectFolder -Leaf
+        $isNewMgmtPackage = $false
         if ($packageName.StartsWith("Azure.ResourceManager.")) {
             $serviceType = "resource-manager"
+            # Detect whether this is a brand new package (folder doesn't exist yet)
+            if (!(Test-Path -Path $sdkProjectFolder)) {
+                $isNewMgmtPackage = $true
+                Write-Host "Detected new management SDK package: $packageName"
+            }
         }
         $repo = $repoHttpsUrl -replace "https://github.com/", ""
         Write-Host "Start to call tsp-client to generate package: $packageName, serviceType: $serviceType, sdkProjectFolder: $sdkProjectFolder"
@@ -303,6 +309,15 @@ if ($relatedTypeSpecProjectFolder) {
           })
           $exitCode = $LASTEXITCODE
         } else {
+            # For new management SDK packages, create scaffolding files
+            # that the emitter doesn't generate (README, CHANGELOG, ci.mgmt.yml, etc.)
+            if ($isNewMgmtPackage) {
+                New-MgmtPackageScaffolding `
+                    -sdkProjectFolder $sdkProjectFolder `
+                    -packageName $packageName `
+                    -sdkRootPath $sdkPath
+            }
+
             # Update package version suffix based on sdkReleaseType
             if ($sdkReleaseType) {
                 $csprojPath = Join-Path $sdkProjectFolder "src" "$packageName.csproj"

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -749,7 +749,11 @@ function New-MgmtPackageScaffolding()
         $providerSuffix = $providerShortName
     }
     $providerFullName = "Microsoft.$providerSuffix"
-    $lowercaseProviderShortName = $providerShortName.ToLower()
+    # LowercaseProviderShortName in templates maps to the service directory name
+    # (e.g. sdk/compute/Azure.ResourceManager.Compute.Bulkactions => "compute"),
+    # not the package's last segment. Otherwise multi-segment packages would write
+    # an incorrect ServiceDirectory into ci.mgmt.yml.
+    $lowercaseProviderShortName = (Split-Path $serviceDirectory -Leaf).ToLower()
 
     # Locate the mgmt template directory
     $templateDir = Join-Path $sdkRootPath "eng" "templates" "Azure.ResourceManager.Template"

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -718,6 +718,189 @@ function New-ChangeLogIfNotExists()
     }
 }
 
+# Creates scaffolding files for a new management-plane TypeSpec SDK package.
+# This is a temporary bridge until the emitter itself creates all required files.
+# Reads file content from eng/templates/Azure.ResourceManager.Template/ and applies
+# the same placeholder substitutions that `dotnet new azuremgmt` would.
+function New-MgmtPackageScaffolding()
+{
+    param(
+        [string]$sdkProjectFolder,
+        [string]$packageName,
+        [string]$sdkRootPath
+    )
+
+    Write-Host "Creating management SDK scaffolding for $packageName in $sdkProjectFolder"
+
+    # The service directory is the parent of the package folder (sdk/{service}/{package})
+    $serviceDirectory = Split-Path $sdkProjectFolder -Parent
+
+    # Derive naming components from the package name
+    # e.g. Azure.ResourceManager.HorizonDb => providerShortName = HorizonDb, safeName = AzureResourceManagerHorizonDb
+    $nameParts = $packageName.Split(".")
+    $providerShortName = $nameParts[-1]
+    $safeName = $packageName.Replace(".", "")
+
+    # Infer the resource provider name (e.g. Microsoft.HorizonDb) from the package name
+    # Azure.ResourceManager.Foo => Microsoft.Foo, Azure.ResourceManager.Compute.Bulkactions => Microsoft.Compute.Bulkactions
+    if ($nameParts.Count -gt 3) {
+        $providerSuffix = ($nameParts[2..($nameParts.Count - 1)] -join ".")
+    } else {
+        $providerSuffix = $providerShortName
+    }
+    $providerFullName = "Microsoft.$providerSuffix"
+    $lowercaseProviderShortName = $providerShortName.ToLower()
+
+    # Locate the mgmt template directory
+    $templateDir = Join-Path $sdkRootPath "eng" "templates" "Azure.ResourceManager.Template"
+    if (!(Test-Path $templateDir)) {
+        Write-Warning "Management template not found at $templateDir. Skipping scaffolding."
+        return
+    }
+
+    # Helper: read a template file and apply placeholder substitutions matching dotnet new azuremgmt
+    function Read-MgmtTemplate([string]$relativePath) {
+        $templateFile = Join-Path $templateDir $relativePath
+        if (!(Test-Path $templateFile)) {
+            Write-Warning "Template file not found: $templateFile"
+            return $null
+        }
+        $content = Get-Content -Path $templateFile -Raw
+        # Apply substitutions in order: longer/more-specific tokens first to avoid
+        # partial matches (e.g. ProviderShortName inside LowercaseProviderShortName)
+        $content = $content.Replace("Azure.ResourceManager.Template", $packageName)
+        $content = $content.Replace("AzureManagementTemplateSafeName", $safeName)
+        $content = $content.Replace("LowercaseProviderShortName", $lowercaseProviderShortName)
+        $content = $content.Replace("ProviderFullName", $providerFullName)
+        $content = $content.Replace("ProviderShortName", $providerShortName)
+        # Trim trailing whitespace to prevent Set-Content from adding extra newlines (SA1518)
+        return $content.TrimEnd()
+    }
+
+    # --- ci.mgmt.yml (in service directory, not package directory) ---
+    $ciMgmtPath = Join-Path $serviceDirectory "ci.mgmt.yml"
+    if (!(Test-Path $ciMgmtPath)) {
+        Write-Host "Creating ci.mgmt.yml at $ciMgmtPath"
+        $ciContent = Read-MgmtTemplate "content/ci.mgmt.yml"
+        if ($ciContent) {
+            Set-Content -Path $ciMgmtPath -Value $ciContent
+        }
+    } else {
+        Write-Host "ci.mgmt.yml already exists, updating to include $packageName"
+        Update-CIYmlFile -ciFilePath $ciMgmtPath -artifact $packageName
+    }
+
+    # --- Directory.Build.props ---
+    $dirBuildPropsPath = Join-Path $sdkProjectFolder "Directory.Build.props"
+    if (!(Test-Path $dirBuildPropsPath)) {
+        Write-Host "Creating Directory.Build.props"
+        $propsContent = Read-MgmtTemplate "Directory.Build.props"
+        if ($propsContent) {
+            Set-Content -Path $dirBuildPropsPath -Value $propsContent
+        }
+    }
+
+    # --- README.md ---
+    $readmePath = Join-Path $sdkProjectFolder "README.md"
+    if (!(Test-Path $readmePath)) {
+        Write-Host "Creating README.md"
+        $readmeContent = Read-MgmtTemplate "README.md"
+        if ($readmeContent) {
+            Set-Content -Path $readmePath -Value $readmeContent
+        }
+    }
+
+    # --- CHANGELOG.md ---
+    $changelogPath = Join-Path $sdkProjectFolder "CHANGELOG.md"
+    if (!(Test-Path $changelogPath)) {
+        # Try to read version from csproj, fall back to 1.0.0-beta.1
+        $version = "1.0.0-beta.1"
+        $csprojPath = Join-Path $sdkProjectFolder "src" "$packageName.csproj"
+        if (Test-Path $csprojPath) {
+            try {
+                $csproj = New-Object xml
+                $csproj.PreserveWhitespace = $true
+                $csproj.Load($csprojPath)
+                $versionNode = ($csproj | Select-Xml "Project/PropertyGroup/Version").Node
+                if ($versionNode -and ![string]::IsNullOrWhiteSpace($versionNode.InnerText)) {
+                    $version = $versionNode.InnerText
+                }
+            } catch {
+                Write-Warning "Could not read version from csproj, using default: $version"
+            }
+        }
+        New-ChangeLogIfNotExists -projectFolder $sdkProjectFolder -version $version
+    }
+
+    # --- src/Properties/AssemblyInfo.cs ---
+    $propertiesDir = Join-Path $sdkProjectFolder "src" "Properties"
+    $assemblyInfoPath = Join-Path $propertiesDir "AssemblyInfo.cs"
+    if (!(Test-Path $assemblyInfoPath)) {
+        Write-Host "Creating AssemblyInfo.cs"
+        if (!(Test-Path $propertiesDir)) {
+            New-Item -ItemType Directory -Path $propertiesDir -Force | Out-Null
+        }
+        $asmContent = Read-MgmtTemplate "src/Properties/AssemblyInfo.cs"
+        if ($asmContent) {
+            Set-Content -Path $assemblyInfoPath -Value $asmContent
+        }
+    }
+
+    # --- tests/<Package>.Tests.csproj ---
+    $testsDir = Join-Path $sdkProjectFolder "tests"
+    $testCsprojPath = Join-Path $testsDir "$packageName.Tests.csproj"
+    if (!(Test-Path $testCsprojPath)) {
+        Write-Host "Creating test project"
+        if (!(Test-Path $testsDir)) {
+            New-Item -ItemType Directory -Path $testsDir -Force | Out-Null
+        }
+        $testCsprojContent = Read-MgmtTemplate "tests/Azure.ResourceManager.Template.Tests.csproj"
+        if ($testCsprojContent) {
+            Set-Content -Path $testCsprojPath -Value $testCsprojContent
+        }
+    }
+
+    # --- tests/<ProviderShortName>ManagementTestBase.cs ---
+    $testBasePath = Join-Path $testsDir "${providerShortName}ManagementTestBase.cs"
+    if (!(Test-Path $testBasePath)) {
+        Write-Host "Creating test base class"
+        $testBaseContent = Read-MgmtTemplate "tests/ProviderShortNameManagementTestBase.cs"
+        if ($testBaseContent) {
+            Set-Content -Path $testBasePath -Value $testBaseContent
+        }
+    }
+
+    # --- tests/<ProviderShortName>ManagementTestEnvironment.cs ---
+    $testEnvPath = Join-Path $testsDir "${providerShortName}ManagementTestEnvironment.cs"
+    if (!(Test-Path $testEnvPath)) {
+        Write-Host "Creating test environment class"
+        $testEnvContent = Read-MgmtTemplate "tests/ProviderShortNameManagementTestEnvironment.cs"
+        if ($testEnvContent) {
+            Set-Content -Path $testEnvPath -Value $testEnvContent
+        }
+    }
+
+    # --- Fix .sln to include test project ---
+    $slnPath = Join-Path $sdkProjectFolder "$packageName.sln"
+    if (Test-Path $slnPath) {
+        $slnContent = Get-Content $slnPath -Raw
+        if ($slnContent -notmatch [regex]::Escape("$packageName.Tests")) {
+            Write-Host "Adding test project to solution"
+            Push-Location $sdkProjectFolder
+            try {
+                dotnet sln "$packageName.sln" add "tests/$packageName.Tests.csproj" 2>&1 | Out-Null
+                if (!$?) {
+                    Write-Warning "Failed to add test project to solution via dotnet sln. The test project may need to be added manually."
+                }
+            } finally {
+                Pop-Location
+            }
+        }
+    }
+
+    Write-Host "Management SDK scaffolding complete for $packageName"
+}
+
 function GeneratePackage()
 {
     param(
@@ -762,7 +945,7 @@ function GeneratePackage()
         }
     }
 
-    if ($isGenerateSuccess -and $serviceType -eq "data-plane") {
+    if ($isGenerateSuccess) {
         # Get the version from csproj before building
         $projectFile = Join-Path $srcPath "$packageName.csproj"
         $csproj = new-object xml
@@ -881,6 +1064,12 @@ function GeneratePackage()
     $ciFilePath = "sdk/$service/ci.yml"
     if ( $serviceType -eq "resource-manager" ) {
         $ciFilePath = "sdk/$service/ci.mgmt.yml"
+    }
+
+    # For management plane, result is purely based on generation success — no "warning" option.
+    # Build/pack/Export-API failures should not downgrade a successful generation to "warning".
+    if ($serviceType -eq "resource-manager" -and $isGenerateSuccess) {
+        $result = "succeeded"
     }
 
     $packageDetails = @{

--- a/eng/scripts/automation/GenerateAndBuildLib.ps1
+++ b/eng/scripts/automation/GenerateAndBuildLib.ps1
@@ -880,15 +880,15 @@ function New-MgmtPackageScaffolding()
         }
     }
 
-    # --- Fix .sln to include test project ---
-    $slnPath = Join-Path $sdkProjectFolder "$packageName.sln"
-    if (Test-Path $slnPath) {
-        $slnContent = Get-Content $slnPath -Raw
+    # --- Fix .sln/.slnx to include test project ---
+    $slnFile = Get-ChildItem -Path $sdkProjectFolder -Filter "$packageName.sln*" -File | Where-Object { $_.Extension -in '.sln', '.slnx' } | Select-Object -First 1
+    if ($slnFile) {
+        $slnContent = Get-Content $slnFile.FullName -Raw
         if ($slnContent -notmatch [regex]::Escape("$packageName.Tests")) {
-            Write-Host "Adding test project to solution"
+            Write-Host "Adding test project to solution ($($slnFile.Name))"
             Push-Location $sdkProjectFolder
             try {
-                dotnet sln "$packageName.sln" add "tests/$packageName.Tests.csproj" 2>&1 | Out-Null
+                dotnet sln $slnFile.Name add "tests/$packageName.Tests.csproj" 2>&1 | Out-Null
                 if (!$?) {
                     Write-Warning "Failed to add test project to solution via dotnet sln. The test project may need to be added manually."
                 }

--- a/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
+++ b/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
@@ -743,3 +743,55 @@ EndGlobal
         $content | Should -Match "Azure\.ResourceManager\.HorizonDb\.SecondPkg"
     }
 }
+
+Describe "New-MgmtPackageScaffolding multi-segment package" -Tag "UnitTest" {
+    # Regression test: for multi-segment packages like Azure.ResourceManager.Compute.Bulkactions
+    # placed under sdk/compute/, the ci.mgmt.yml ServiceDirectory must be the actual service
+    # directory leaf ("compute"), not the package's last segment ("bulkactions").
+    BeforeAll {
+        $script:msTestRootDir = Join-Path ([System.IO.Path]::GetTempPath()) "mgmt-scaffold-ms-test-$(Get-Random)"
+        New-Item -ItemType Directory -Path $script:msTestRootDir -Force | Out-Null
+
+        $script:msService = "compute"
+        $script:msPackageName = "Azure.ResourceManager.Compute.Bulkactions"
+        $script:msSdkRoot = Join-Path $script:msTestRootDir "sdk-root"
+        $script:msServiceDir = Join-Path $script:msSdkRoot "sdk" $script:msService
+        $script:msProjectDir = Join-Path $script:msServiceDir $script:msPackageName
+        $script:msSrcDir = Join-Path $script:msProjectDir "src"
+
+        New-Item -ItemType Directory -Path $script:msSrcDir -Force | Out-Null
+
+        $realTemplateDir = Join-Path $PSScriptRoot ".." ".." ".." ".." "eng" "templates" "Azure.ResourceManager.Template"
+        $realTemplateDir = Resolve-Path $realTemplateDir
+        $mockTemplateDir = Join-Path $script:msSdkRoot "eng" "templates" "Azure.ResourceManager.Template"
+        Copy-Item -Path $realTemplateDir -Destination $mockTemplateDir -Recurse -Force
+
+        $csprojContent = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.0.0-beta.1</Version>
+  </PropertyGroup>
+</Project>
+"@
+        Set-Content -Path (Join-Path $script:msSrcDir "$($script:msPackageName).csproj") -Value $csprojContent
+    }
+
+    AfterAll {
+        if (Test-Path $script:msTestRootDir) {
+            Remove-Item -Recurse -Force $script:msTestRootDir
+        }
+    }
+
+    It "should derive ServiceDirectory from the service folder, not the package's last segment" {
+        New-MgmtPackageScaffolding `
+            -sdkProjectFolder $script:msProjectDir `
+            -packageName $script:msPackageName `
+            -sdkRootPath $script:msSdkRoot
+
+        $ciPath = Join-Path $script:msSdkRoot "sdk" $script:msService "ci.mgmt.yml"
+        $content = Get-Content $ciPath -Raw
+        $content | Should -Match "ServiceDirectory: compute"
+        $content | Should -Not -Match "ServiceDirectory: bulkactions"
+        $content | Should -Match "name: Azure.ResourceManager.Compute.Bulkactions"
+    }
+}

--- a/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
+++ b/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
@@ -492,3 +492,220 @@ Describe "New-ChangeLogIfNotExists function" -Tag "UnitTest" {
         $content | Should -Match "2\.0\.0"
     }
 }
+
+Describe "New-MgmtPackageScaffolding function" -Tag "UnitTest" {
+    BeforeAll {
+        $script:testRootDir = Join-Path ([System.IO.Path]::GetTempPath()) "mgmt-scaffold-test-$(Get-Random)"
+        New-Item -ItemType Directory -Path $script:testRootDir -Force | Out-Null
+
+        # Set up a mock SDK structure: sdk/<service>/<package>/
+        $script:testService = "horizondb"
+        $script:testPackageName = "Azure.ResourceManager.HorizonDb"
+        $script:testSdkRoot = Join-Path $script:testRootDir "sdk-root"
+        $script:testServiceDir = Join-Path $script:testSdkRoot "sdk" $script:testService
+        $script:testProjectDir = Join-Path $script:testServiceDir $script:testPackageName
+        $script:testSrcDir = Join-Path $script:testProjectDir "src"
+
+        New-Item -ItemType Directory -Path $script:testSrcDir -Force | Out-Null
+
+        # Copy the real mgmt template into the mock SDK root so Read-MgmtTemplate can find it
+        $realTemplateDir = Join-Path $PSScriptRoot ".." ".." ".." ".." "eng" "templates" "Azure.ResourceManager.Template"
+        $realTemplateDir = Resolve-Path $realTemplateDir
+        $mockTemplateDir = Join-Path $script:testSdkRoot "eng" "templates" "Azure.ResourceManager.Template"
+        Copy-Item -Path $realTemplateDir -Destination $mockTemplateDir -Recurse -Force
+
+        # Create a minimal .csproj (simulating emitter output)
+        $csprojContent = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.0.0-beta.1</Version>
+  </PropertyGroup>
+</Project>
+"@
+        Set-Content -Path (Join-Path $script:testSrcDir "$($script:testPackageName).csproj") -Value $csprojContent
+
+        # Create a minimal .sln (simulating emitter output)
+        $slnContent = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "$($script:testPackageName)", "src\$($script:testPackageName).csproj", "{00000000-0000-0000-0000-000000000001}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{00000000-0000-0000-0000-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00000000-0000-0000-0000-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00000000-0000-0000-0000-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00000000-0000-0000-0000-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal
+"@
+        Set-Content -Path (Join-Path $script:testProjectDir "$($script:testPackageName).sln") -Value $slnContent
+    }
+
+    AfterAll {
+        if (Test-Path $script:testRootDir) {
+            Remove-Item -Recurse -Force $script:testRootDir
+        }
+    }
+
+    It "should create ci.mgmt.yml in the service directory" {
+        New-MgmtPackageScaffolding `
+            -sdkProjectFolder $script:testProjectDir `
+            -packageName $script:testPackageName `
+            -sdkRootPath $script:testSdkRoot
+
+        $ciPath = Join-Path $script:testSdkRoot "sdk" $script:testService "ci.mgmt.yml"
+        Test-Path $ciPath | Should -Be $true
+    }
+
+    It "should create ci.mgmt.yml with correct service directory and artifact" {
+        $ciPath = Join-Path $script:testSdkRoot "sdk" $script:testService "ci.mgmt.yml"
+        $content = Get-Content $ciPath -Raw
+        $content | Should -Match "ServiceDirectory: horizondb"
+        $content | Should -Match "name: Azure.ResourceManager.HorizonDb"
+        $content | Should -Match "safeName: AzureResourceManagerHorizonDb"
+    }
+
+    It "should create Directory.Build.props" {
+        $propsPath = Join-Path $script:testProjectDir "Directory.Build.props"
+        Test-Path $propsPath | Should -Be $true
+        $content = Get-Content $propsPath -Raw
+        $content | Should -Match "Directory\.Build\.props"
+    }
+
+    It "should create README.md with package name" {
+        $readmePath = Join-Path $script:testProjectDir "README.md"
+        Test-Path $readmePath | Should -Be $true
+        $content = Get-Content $readmePath -Raw
+        $content | Should -Match "Azure\.ResourceManager\.HorizonDb"
+        $content | Should -Match "dotnet add package"
+    }
+
+    It "should create CHANGELOG.md" {
+        $changelogPath = Join-Path $script:testProjectDir "CHANGELOG.md"
+        Test-Path $changelogPath | Should -Be $true
+        $content = Get-Content $changelogPath -Raw
+        $content | Should -Match "Release History"
+    }
+
+    It "should create AssemblyInfo.cs with correct provider namespace" {
+        $asmInfoPath = Join-Path $script:testProjectDir "src" "Properties" "AssemblyInfo.cs"
+        Test-Path $asmInfoPath | Should -Be $true
+        $content = Get-Content $asmInfoPath -Raw
+        $content | Should -Match 'AzureResourceProviderNamespace\("Microsoft\.HorizonDb"\)'
+        $content | Should -Match "InternalsVisibleTo.*Azure\.ResourceManager\.HorizonDb\.Tests"
+    }
+
+    It "should create test project csproj" {
+        $testCsprojPath = Join-Path $script:testProjectDir "tests" "$($script:testPackageName).Tests.csproj"
+        Test-Path $testCsprojPath | Should -Be $true
+        $content = Get-Content $testCsprojPath -Raw
+        $content | Should -Match "ProjectReference.*src.*$([regex]::Escape($script:testPackageName))\.csproj"
+    }
+
+    It "should create test base class" {
+        $testBasePath = Join-Path $script:testProjectDir "tests" "HorizonDbManagementTestBase.cs"
+        Test-Path $testBasePath | Should -Be $true
+        $content = Get-Content $testBasePath -Raw
+        $content | Should -Match "class HorizonDbManagementTestBase"
+        $content | Should -Match "ManagementRecordedTestBase<HorizonDbManagementTestEnvironment>"
+    }
+
+    It "should create test environment class" {
+        $testEnvPath = Join-Path $script:testProjectDir "tests" "HorizonDbManagementTestEnvironment.cs"
+        Test-Path $testEnvPath | Should -Be $true
+        $content = Get-Content $testEnvPath -Raw
+        $content | Should -Match "class HorizonDbManagementTestEnvironment"
+        $content | Should -Match "TestEnvironment"
+    }
+
+    It "should not overwrite existing files when called again" {
+        # Modify README to have custom content
+        $readmePath = Join-Path $script:testProjectDir "README.md"
+        $customContent = "# Custom README content"
+        Set-Content -Path $readmePath -Value $customContent
+
+        # Call scaffolding again
+        New-MgmtPackageScaffolding `
+            -sdkProjectFolder $script:testProjectDir `
+            -packageName $script:testPackageName `
+            -sdkRootPath $script:testSdkRoot
+
+        # Verify README was not overwritten
+        $content = Get-Content $readmePath -Raw
+        $content.Trim() | Should -Be $customContent
+    }
+
+    It "should handle multi-segment provider names correctly" {
+        $multiSegDir = Join-Path $script:testRootDir "multi-seg"
+        $multiSegService = "compute"
+        $multiSegPkg = "Azure.ResourceManager.Compute.Bulkactions"
+        $multiSegSdkRoot = Join-Path $multiSegDir "sdk-root"
+        $multiSegProjectDir = Join-Path $multiSegSdkRoot "sdk" $multiSegService $multiSegPkg
+        $multiSegSrcDir = Join-Path $multiSegProjectDir "src"
+        New-Item -ItemType Directory -Path $multiSegSrcDir -Force | Out-Null
+
+        # Copy template into this mock SDK root too
+        $realTemplateDir = Join-Path $PSScriptRoot ".." ".." ".." ".." "eng" "templates" "Azure.ResourceManager.Template"
+        $realTemplateDir = Resolve-Path $realTemplateDir
+        $mockTemplateDir = Join-Path $multiSegSdkRoot "eng" "templates" "Azure.ResourceManager.Template"
+        Copy-Item -Path $realTemplateDir -Destination $mockTemplateDir -Recurse -Force
+
+        $csprojContent = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.0.0-beta.1</Version>
+  </PropertyGroup>
+</Project>
+"@
+        Set-Content -Path (Join-Path $multiSegSrcDir "$multiSegPkg.csproj") -Value $csprojContent
+
+        New-MgmtPackageScaffolding `
+            -sdkProjectFolder $multiSegProjectDir `
+            -packageName $multiSegPkg `
+            -sdkRootPath $multiSegSdkRoot
+
+        # Provider should be Microsoft.Compute.Bulkactions
+        $asmInfoPath = Join-Path $multiSegProjectDir "src" "Properties" "AssemblyInfo.cs"
+        $content = Get-Content $asmInfoPath -Raw
+        $content | Should -Match 'AzureResourceProviderNamespace\("Microsoft\.Compute\.Bulkactions"\)'
+
+        # Test class names should use last segment
+        $testBasePath = Join-Path $multiSegProjectDir "tests" "BulkactionsManagementTestBase.cs"
+        Test-Path $testBasePath | Should -Be $true
+    }
+
+    It "should update existing ci.mgmt.yml when it already exists" {
+        # Create a second package in same service directory to test ci.mgmt.yml update path
+        $secondPkg = "Azure.ResourceManager.HorizonDb.SecondPkg"
+        $secondProjectDir = Join-Path $script:testServiceDir $secondPkg
+        $secondSrcDir = Join-Path $secondProjectDir "src"
+        New-Item -ItemType Directory -Path $secondSrcDir -Force | Out-Null
+
+        $csprojContent = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.0.0-beta.1</Version>
+  </PropertyGroup>
+</Project>
+"@
+        Set-Content -Path (Join-Path $secondSrcDir "$secondPkg.csproj") -Value $csprojContent
+
+        New-MgmtPackageScaffolding `
+            -sdkProjectFolder $secondProjectDir `
+            -packageName $secondPkg `
+            -sdkRootPath $script:testSdkRoot
+
+        # ci.mgmt.yml should contain both packages
+        $ciPath = Join-Path $script:testSdkRoot "sdk" $script:testService "ci.mgmt.yml"
+        $content = Get-Content $ciPath -Raw
+        $content | Should -Match "Azure\.ResourceManager\.HorizonDb"
+        $content | Should -Match "Azure\.ResourceManager\.HorizonDb\.SecondPkg"
+    }
+}

--- a/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
+++ b/eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1
@@ -681,6 +681,40 @@ EndGlobal
         Test-Path $testBasePath | Should -Be $true
     }
 
+    It "should find .slnx solution file when .sln does not exist" {
+        # Remove the .sln and create a .slnx instead
+        $slnPath = Join-Path $script:testProjectDir "$($script:testPackageName).sln"
+        $slnxPath = Join-Path $script:testProjectDir "$($script:testPackageName).slnx"
+        if (Test-Path $slnPath) { Remove-Item $slnPath }
+        # Create a minimal .slnx (XML-based solution format)
+        $slnxContent = @"
+<Solution>
+  <Project Path="src\$($script:testPackageName).csproj" />
+</Solution>
+"@
+        Set-Content -Path $slnxPath -Value $slnxContent
+
+        New-MgmtPackageScaffolding `
+            -sdkProjectFolder $script:testProjectDir `
+            -packageName $script:testPackageName `
+            -sdkRootPath $script:testSdkRoot
+
+        # Verify the .slnx still exists (wasn't replaced with .sln)
+        Test-Path $slnxPath | Should -Be $true
+        Test-Path $slnPath | Should -Be $false
+
+        # Restore the .sln for other tests
+        Remove-Item $slnxPath
+        $slnContent = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "$($script:testPackageName)", "src\$($script:testPackageName).csproj", "{00000000-0000-0000-0000-000000000001}"
+EndProject
+Global
+EndGlobal
+"@
+        Set-Content -Path $slnPath -Value $slnContent
+    }
+
     It "should update existing ci.mgmt.yml when it already exists" {
         # Create a second package in same service directory to test ci.mgmt.yml update path
         $secondPkg = "Azure.ResourceManager.HorizonDb.SecondPkg"


### PR DESCRIPTION
## Add scaffolding automation for new management-plane TypeSpec SDK packages

### Problem

When the AutoPR pipeline generates a brand-new management-plane TypeSpec SDK, the emitter (`@azure-typespec/http-client-csharp-mgmt`) only creates `src/Generated/` code and project files. The PR is missing required CI files (`ci.mgmt.yml`, `Directory.Build.props`, `README.md`, `CHANGELOG.md`, `AssemblyInfo.cs`, test project, API listings), causing all CI checks to fail. Today, a human must manually add these files in a second commit ([example: PR #57579](https://github.com/Azure/azure-sdk-for-net/pull/57579)).

### Solution

Add `New-MgmtPackageScaffolding()` to `GenerateAndBuildLib.ps1`, called from `Invoke-GenerateAndBuildV2.ps1` after `tsp-client init` succeeds for a new mgmt package. It creates all required files by reading templates from `eng/templates/Azure.ResourceManager.Template/` and applying placeholder substitution — the same content that `dotnet new azuremgmt` would produce.

### Changes

| File | Change |
|------|--------|
| `eng/scripts/automation/GenerateAndBuildLib.ps1` | Added `New-MgmtPackageScaffolding()` function (~180 lines). Removed data-plane gate in `GeneratePackage()` so build/pack/Export-API runs for mgmt packages. Added mgmt result override (succeed or fail, no warning). |
| `eng/scripts/Invoke-GenerateAndBuildV2.ps1` | Added new-package detection (checks if project folder exists before `tsp-client init`) and scaffolding call after successful generation. |
| `eng/scripts/automation/test/GenerateAndBuildLib-functions.tests.ps1` | Added 12 Pester unit tests for scaffolding function. |

### Files created by scaffolding

| File | Source template |
|------|----------------|
| `sdk/{service}/ci.mgmt.yml` | `content/ci.mgmt.yml` |
| `Directory.Build.props` | `Directory.Build.props` |
| `README.md` | `README.md` |
| `CHANGELOG.md` | Generated via `New-ChangeLogIfNotExists` |
| `src/Properties/AssemblyInfo.cs` | `src/Properties/AssemblyInfo.cs` |
| `tests/{Package}.Tests.csproj` | `tests/Azure.ResourceManager.Template.Tests.csproj` |
| `tests/{Provider}ManagementTestBase.cs` | `tests/ProviderShortNameManagementTestBase.cs` |
| `tests/{Provider}ManagementTestEnvironment.cs` | `tests/ProviderShortNameManagementTestEnvironment.cs` |

### Validation

- ✅ 36 Pester unit tests pass (12 new + 24 existing)
- ✅ Local end-to-end test: ran `Invoke-GenerateAndBuildV2.ps1` against real TypeSpec specs — scaffolding created, build succeeded, NuGet artifact produced, API files exported

**Test PRs** — each uses the same spec commit as its corresponding AutoPR, proving the scaffolding produces CI-ready packages:

| Test PR | Package | AutoPR | Local Build |
|---------|---------|--------|-------------|
| [#57873](https://github.com/Azure/azure-sdk-for-net/pull/57873) | `Azure.ResourceManager.HorizonDb` | [#57579](https://github.com/Azure/azure-sdk-for-net/pull/57579) | ✅ Succeeded |
| [#57915](https://github.com/Azure/azure-sdk-for-net/pull/57915) | `Azure.ResourceManager.Contoso` | [#57746](https://github.com/Azure/azure-sdk-for-net/pull/57746) | ✅ Succeeded |
| [#57916](https://github.com/Azure/azure-sdk-for-net/pull/57916) | `Azure.ResourceManager.AppLink` | [#57404](https://github.com/Azure/azure-sdk-for-net/pull/57404) | ⚠️ CS0102 in generated code (emitter bug) |
| [#57917](https://github.com/Azure/azure-sdk-for-net/pull/57917) | `Azure.ResourceManager.Discovery` | [#56854](https://github.com/Azure/azure-sdk-for-net/pull/56854) | ✅ Succeeded |

### Context

This is a temporary bridge until the emitter itself creates all required files. The scaffolding function is designed to be idempotent — it won't overwrite existing files, making it safe for re-generation scenarios.