### PR TITLE
Move FoundryEnrichmentProcessor agent tags to OnEnd

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/FoundryEnrichmentProcessor.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/FoundryEnrichmentProcessor.cs
@@ -39,6 +39,20 @@ internal sealed class FoundryEnrichmentProcessor : BaseProcessor<Activity>
     /// <inheritdoc/>
     public override void OnStart(Activity activity)
     {
+        if (_projectId is not null)
+        {
+            activity.SetTag("microsoft.foundry.project.id", _projectId);
+        }
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Agent identity tags are set in <c>OnEnd</c> rather than <c>OnStart</c>
+    /// so that they take precedence over any values an underlying framework
+    /// (e.g. the OpenAI SDK) may have stamped during the span's lifetime.
+    /// </remarks>
+    public override void OnEnd(Activity activity)
+    {
         if (_agentName is not null)
         {
             activity.SetTag("gen_ai.agent.name", _agentName);
@@ -52,11 +66,6 @@ internal sealed class FoundryEnrichmentProcessor : BaseProcessor<Activity>
         if (_agentId is not null)
         {
             activity.SetTag("gen_ai.agent.id", _agentId);
-        }
-
-        if (_projectId is not null)
-        {
-            activity.SetTag("microsoft.foundry.project.id", _projectId);
         }
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnrichmentProcessorTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnrichmentProcessorTests.cs
@@ -4,33 +4,52 @@
 using System.Diagnostics;
 using Azure.AI.AgentServer.Core.Internal;
 using NUnit.Framework;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 namespace Azure.AI.AgentServer.Core.Tests;
 
 [TestFixture]
 public class FoundryEnrichmentProcessorTests
 {
+    private string _sourceName = null!;
+    private ActivitySource _activitySource = null!;
+    private TracerProvider _tracerProvider = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _sourceName = $"Test.Foundry.{Guid.NewGuid():N}";
+        _activitySource = new ActivitySource(_sourceName);
+    }
+
     [TearDown]
     public void TearDown()
     {
+        _tracerProvider?.Dispose();
+        _activitySource?.Dispose();
         Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", null);
         Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", null);
         Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ARM_ID", null);
         FoundryEnvironment.Reload();
     }
 
-    [Test]
-    public void OnStart_SetsAllTags_WhenAllEnvVarsPresent()
+    private void BuildProvider()
     {
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", "2.0");
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ARM_ID", "/subscriptions/sub1/resourceGroups/rg1");
-        FoundryEnvironment.Reload();
+        _tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(_sourceName)
+            .AddProcessor(new FoundryEnrichmentProcessor())
+            .Build()!;
+    }
 
-        var processor = new FoundryEnrichmentProcessor();
-        using var activity = new Activity("test");
+    [Test]
+    public void SetsAllTags_WhenAllEnvVarsPresent()
+    {
+        SetEnv("my-agent", "2.0", "/subscriptions/sub1/resourceGroups/rg1");
+        BuildProvider();
 
-        processor.OnStart(activity);
+        using var activity = _activitySource.StartActivity("test")!;
+        activity.Stop();
 
         Assert.That(activity.GetTagItem("gen_ai.agent.name"), Is.EqualTo("my-agent"));
         Assert.That(activity.GetTagItem("gen_ai.agent.version"), Is.EqualTo("2.0"));
@@ -39,15 +58,13 @@ public class FoundryEnrichmentProcessorTests
     }
 
     [Test]
-    public void OnStart_SetsAgentId_WithNameOnly_WhenVersionMissing()
+    public void SetsAgentId_WithNameOnly_WhenVersionMissing()
     {
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        FoundryEnvironment.Reload();
+        SetEnv("my-agent");
+        BuildProvider();
 
-        var processor = new FoundryEnrichmentProcessor();
-        using var activity = new Activity("test");
-
-        processor.OnStart(activity);
+        using var activity = _activitySource.StartActivity("test")!;
+        activity.Stop();
 
         Assert.That(activity.GetTagItem("gen_ai.agent.name"), Is.EqualTo("my-agent"));
         Assert.That(activity.GetTagItem("gen_ai.agent.version"), Is.Null);
@@ -55,14 +72,13 @@ public class FoundryEnrichmentProcessorTests
     }
 
     [Test]
-    public void OnStart_DoesNotSetTags_WhenEnvVarsAbsent()
+    public void DoesNotSetTags_WhenEnvVarsAbsent()
     {
         FoundryEnvironment.Reload();
+        BuildProvider();
 
-        var processor = new FoundryEnrichmentProcessor();
-        using var activity = new Activity("test");
-
-        processor.OnStart(activity);
+        using var activity = _activitySource.StartActivity("test")!;
+        activity.Stop();
 
         Assert.That(activity.GetTagItem("gen_ai.agent.name"), Is.Null);
         Assert.That(activity.GetTagItem("gen_ai.agent.version"), Is.Null);
@@ -71,16 +87,60 @@ public class FoundryEnrichmentProcessorTests
     }
 
     [Test]
-    public void OnStart_SetsProjectId_WhenArmIdPresent()
+    public void SetsProjectId_WhenArmIdPresent()
     {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ARM_ID", "/subscriptions/sub1/projects/proj1");
-        FoundryEnvironment.Reload();
+        SetEnv(projectArmId: "/subscriptions/sub1/projects/proj1");
+        BuildProvider();
 
-        var processor = new FoundryEnrichmentProcessor();
-        using var activity = new Activity("test");
-
-        processor.OnStart(activity);
+        using var activity = _activitySource.StartActivity("test")!;
+        activity.Stop();
 
         Assert.That(activity.GetTagItem("microsoft.foundry.project.id"), Is.EqualTo("/subscriptions/sub1/projects/proj1"));
+    }
+
+    [Test]
+    public void AgentTags_SurviveOverwrite_ByUnderlyingFramework()
+    {
+        SetEnv("my-agent", "2.0");
+        BuildProvider();
+
+        using var activity = _activitySource.StartActivity("test")!;
+
+        // Simulate an underlying framework (e.g. OpenAI SDK) overwriting tags mid-span.
+        activity.SetTag("gen_ai.agent.name", "framework-agent");
+        activity.SetTag("gen_ai.agent.version", "9.9");
+        activity.SetTag("gen_ai.agent.id", "framework-agent:9.9");
+
+        activity.Stop();
+
+        Assert.That(activity.GetTagItem("gen_ai.agent.name"), Is.EqualTo("my-agent"));
+        Assert.That(activity.GetTagItem("gen_ai.agent.version"), Is.EqualTo("2.0"));
+        Assert.That(activity.GetTagItem("gen_ai.agent.id"), Is.EqualTo("my-agent:2.0"));
+    }
+
+    [Test]
+    public void AgentTags_SurvivePartialOverwrite()
+    {
+        SetEnv("my-agent", "1.0");
+        BuildProvider();
+
+        using var activity = _activitySource.StartActivity("test")!;
+
+        // Framework only overwrites the name.
+        activity.SetTag("gen_ai.agent.name", "other-agent");
+
+        activity.Stop();
+
+        Assert.That(activity.GetTagItem("gen_ai.agent.name"), Is.EqualTo("my-agent"));
+        Assert.That(activity.GetTagItem("gen_ai.agent.version"), Is.EqualTo("1.0"));
+        Assert.That(activity.GetTagItem("gen_ai.agent.id"), Is.EqualTo("my-agent:1.0"));
+    }
+
+    private static void SetEnv(string? agentName = null, string? agentVersion = null, string? projectArmId = null)
+    {
+        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", agentName);
+        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", agentVersion);
+        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ARM_ID", projectArmId);
+        FoundryEnvironment.Reload();
     }
 }


### PR DESCRIPTION
## Problem

`FoundryEnrichmentProcessor` sets `gen_ai.agent.name`, `gen_ai.agent.version`, and `gen_ai.agent.id` in `OnStart`. If an underlying framework (e.g. the OpenAI SDK) overwrites these tags during the span's lifetime, the Foundry values are lost.

## Solution

Move the three `gen_ai.agent.*` tags from `OnStart` to `OnEnd`, so they are stamped last and cannot be overwritten by downstream frameworks. `microsoft.foundry.project.id` remains in `OnStart` since it is not subject to framework overwrites.

## Tests

Rewrote tests to use a real `TracerProvider` + `ActivitySource` pipeline. Added two overwrite-resistance tests:
- **`AgentTags_SurviveOverwrite_ByUnderlyingFramework`** — all 3 tags overwritten mid-span, restored on end
- **`AgentTags_SurvivePartialOverwrite`** — only name overwritten, all tags correct on end