### PR TITLE
[KeyVault] Fix CHANGELOG for Azure.Security.KeyVault.Secrets 4.10.0-beta.1 release

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Release History
 
-## 4.10.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+## 4.10.0-beta.1 (2026-04-07)
 
 ## 4.9.0 (2026-02-25)
 


### PR DESCRIPTION
## Summary

Fixes the `4.10.0-beta.1` CHANGELOG entry for `Azure.Security.KeyVault.Secrets` which was blocking the release pipeline with two errors:

1. **"Entry has no release date set"** — Added release date `2026-04-07`.
2. **"Sections with no content"** — Removed empty `Features Added`, `Breaking Changes`, `Bugs Fixed`, and `Other Changes` sections.

## Related

Unblocks: `Verify ChangeLogEntry for Azure.Security.KeyVault.Secrets` step in the release pipeline.