### PR TITLE
Fix intermittent CloseRespectsCancellationToken test failure

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -484,10 +484,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
             var mockProcessor = new Mock<ServiceBusProcessor>() { CallBase = true };
             mockProcessor.Setup(
                 p => p.IsProcessing).Returns(true);
+            // A fresh CTS token is distinguishable from CancellationToken.None without
+            // needing CancelAfter, which can cause flaky failures under CI load.
             var cts = new CancellationTokenSource();
-
-            // mutate the cancellation token to distinguish it from CancellationToken.None
-            cts.CancelAfter(500);
 
             await mockProcessor.Object.CloseAsync(cts.Token);
             mockProcessor.Verify(p => p.StopProcessingAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/ProcessorTests.cs
@@ -486,9 +486,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 p => p.IsProcessing).Returns(true);
             var cts = new CancellationTokenSource();
 
-            // mutate the cancellation token to distinguish it from CancellationToken.None
-            cts.CancelAfter(500);
-
             await mockProcessor.Object.CloseAsync(cts.Token);
             mockProcessor.Verify(p => p.StopProcessingAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));
         }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -473,10 +473,9 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 p => p.InnerProcessor).Returns(mockProcessor.Object);
             mockProcessor.Setup(
                 p => p.IsProcessing).Returns(true);
+            // A fresh CTS token is distinguishable from CancellationToken.None without
+            // needing CancelAfter, which can cause flaky failures under CI load.
             var cts = new CancellationTokenSource();
-
-            // mutate the cancellation token to distinguish it from CancellationToken.None
-            cts.CancelAfter(500);
 
             await mockSessionProcessor.Object.CloseAsync(cts.Token);
             mockProcessor.Verify(p => p.StopProcessingAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Processor/SessionProcessorTests.cs
@@ -475,9 +475,6 @@ namespace Azure.Messaging.ServiceBus.Tests.Processor
                 p => p.IsProcessing).Returns(true);
             var cts = new CancellationTokenSource();
 
-            // mutate the cancellation token to distinguish it from CancellationToken.None
-            cts.CancelAfter(500);
-
             await mockSessionProcessor.Object.CloseAsync(cts.Token);
             mockProcessor.Verify(p => p.StopProcessingAsync(It.Is<CancellationToken>(ct => ct == cts.Token)));
         }


### PR DESCRIPTION
## Description

Fixes #57896

Removes `CancelAfter(500)` from `CloseRespectsCancellationToken` tests in both `ProcessorTests.cs` and `SessionProcessorTests.cs`. This eliminates an intermittent `TaskCanceledException` caused by a race condition between the 500ms cancellation timer and the test's call chain through Moq proxies.

## Root Cause

The tests use `CancelAfter(500)` solely to make the token distinguishable from `CancellationToken.None` for a `Verify` assertion. With `CallBase = true`, the real `StopProcessingAsync` runs, which calls `_processingStartStopSemaphore.WaitAsync(cancellationToken)`. Under CI load, the call chain through 2 Moq proxy layers can exceed 500ms, causing the already-cancelled token to throw.

## Evidence from ADO Analytics

Over the past 30 days (March 9 - April 7, 2026):

- **3,732 total executions**, **2 failures** (0.054% failure rate)
- Both failures had durations exceeding the 500ms threshold:
  - April 7: **876ms**
  - April 1: **793ms**

## Fix

A token from `new CancellationTokenSource()` without `CancelAfter` is already identity-distinguishable from `CancellationToken.None` (different backing source reference), so the `Verify` check continues to work correctly. The fix simply removes the timer that creates the race.