### PR TITLE
Force-track TestResult.cs ignored by gitignore pattern

### DIFF
--- a/sdk/tools/Azure.GeneratorAgent/src/Mcp/Tools/TestResult.cs
+++ b/sdk/tools/Azure.GeneratorAgent/src/Mcp/Tools/TestResult.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.GeneratorAgent.Mcp.Tools;
+
+/// <summary>
+/// Structured test execution result.
+/// </summary>
+public sealed class TestResult
+{
+    public bool Success { get; set; }
+    public int ExitCode { get; set; }
+    public int Passed { get; set; }
+    public int Failed { get; set; }
+    public int Skipped { get; set; }
+    public int Total { get; set; }
+    public List<string> Failures { get; set; } = [];
+    public string? Error { get; set; }
+    public string RawOutput { get; set; } = string.Empty;
+}


### PR DESCRIPTION
TestResult.cs was inadvertently excluded from PR #57134  (feature/generator-agent-mcp-tools) because the root .gitignore contains the pattern [Tt]est[Rr]esult* (line 115), which is intended to ignore MSTest/NUnit test result output files but also matches source files named TestResult.cs.

This PR force-adds the file using git add -f so it is tracked despite the .gitignore rule. The file is required by the RunTestsTool in Azure.GeneratorAgent and was already referenced in the project but never committed.
