### PR TITLE
Fix mgmt generator scope-based extension resource parameter ordering and ValidateResourceId

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/resource-metadata.ts
@@ -813,24 +813,69 @@ function getExpectedParentResourceType(
     lastProvidersIndex
   );
 
-  // Only accept simple parent segments: "<namespace>/<type>/{name}"
-  // Reject complex paths (nested types, mixed scopes) to avoid false positives
   const segments = parentSegment.split("/");
-  if (segments.length !== 3) {
+
+  // Simple case: "<namespace>/<type>/{name}" — e.g., Microsoft.Compute/virtualMachines/{vmName}
+  if (segments.length === 3) {
+    const [providerNamespace, resourceType, nameSegment] = segments;
+    if (
+      providerNamespace.includes("{") ||
+      resourceType.includes("{") ||
+      !nameSegment.startsWith("{") ||
+      !nameSegment.endsWith("}")
+    ) {
+      return undefined;
+    }
+    return `${providerNamespace}/${resourceType}`;
+  }
+
+  // Complex case: parent path between providers has more segments
+  // (e.g., Microsoft.Management/managementGroups/{mgId}/subscriptions/{subId})
+  // Fall back to computing the parent scope's resource type from the resource ID pattern.
+  // Remove the leaf type/name pair, then extract the resource type from the last /providers/ segment.
+  const allSegments = resourceIdPattern.split("/").filter((s) => s !== "");
+  // Remove the last two segments (leaf type and name, e.g., "quotaAllocations" and "{location}")
+  if (allSegments.length < 2) {
+    return undefined;
+  }
+  const parentPathSegments = allSegments.slice(0, -2);
+  const parentPath = "/" + parentPathSegments.join("/");
+
+  // Find the last /providers/ in the parent path
+  const parentLastProvidersIndex = parentPath.lastIndexOf("/providers/");
+  if (parentLastProvidersIndex === -1) {
     return undefined;
   }
 
-  const [providerNamespace, resourceType, nameSegment] = segments;
+  // Extract everything after the last /providers/ in parent path
+  const afterProviders = parentPath
+    .substring(parentLastProvidersIndex + "/providers/".length)
+    .split("/");
 
-  // All three segments must be well-formed: constants for namespace/type, variable for name
-  if (
-    providerNamespace.includes("{") ||
-    resourceType.includes("{") ||
-    !nameSegment.startsWith("{") ||
-    !nameSegment.endsWith("}")
-  ) {
+  // Must have at least namespace/type/{name} (3 segments)
+  if (afterProviders.length < 3) {
     return undefined;
   }
 
-  return `${providerNamespace}/${resourceType}`;
+  const namespace = afterProviders[0];
+  // Namespace must be a constant
+  if (namespace.includes("{")) {
+    return undefined;
+  }
+
+  // Collect constant type segments (every other segment starting at index 1)
+  const typeSegments: string[] = [];
+  for (let i = 1; i < afterProviders.length; i += 2) {
+    const typeSeg = afterProviders[i];
+    if (typeSeg.includes("{")) {
+      return undefined; // variable type segment — can't determine parent type
+    }
+    typeSegments.push(typeSeg);
+  }
+
+  if (typeSegments.length === 0) {
+    return undefined;
+  }
+
+  return `${namespace}/${typeSegments.join("/")}`;
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/OperationContexts/OperationContext.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Models/OperationContexts/OperationContext.cs
@@ -149,11 +149,13 @@ internal class OperationContext
                     // Handle the case when key is a variable
                     // we have to reassign the value of parentLayerCount to a local variable to avoid the closure to wrap the parentLayerCount variable which changes during recursion.
                     int currentParentCount = parentLayerCount;
-                    parameterStack.Push(new ContextualParameter(key.VariableName, key.VariableName, id => BuildParentInvocation(currentParentCount, id).ResourceType().Type()));
+                    // Push value (Name) before key (ResourceType.Type) because the stack is LIFO —
+                    // when popped, key (ResourceType.Type) will come out first, matching the positional order in the operation path.
                     if (!value.IsConstant)
                     {
                         parameterStack.Push(new ContextualParameter(value.VariableName, value.VariableName, id => BuildParentInvocation(currentParentCount, id).Name()));
                     }
+                    parameterStack.Push(new ContextualParameter(key.VariableName, key.VariableName, id => BuildParentInvocation(currentParentCount, id).ResourceType().Type()));
                     appendParent = true;
                 }
                 else if (!value.IsConstant)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/OperationContextTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/OperationContextTests.cs
@@ -612,15 +612,15 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.AreEqual("parentProviderNamespace", contextualParameters[2].VariableName);
             Assert.AreEqual("id.Parent.ResourceType.Namespace", contextualParameters[2].BuildValueExpression(_idVariable).ToDisplayString());
 
-            // parentResourceName uses the variable key - appears first due to stack order
-            Assert.AreEqual("parentResourceName", contextualParameters[3].Key);
-            Assert.AreEqual("parentResourceName", contextualParameters[3].VariableName);
-            Assert.AreEqual("id.Parent.Name", contextualParameters[3].BuildValueExpression(_idVariable).ToDisplayString());
-
             // parentResourceType is a variable key - should use ResourceType().Type()
-            Assert.AreEqual("parentResourceType", contextualParameters[4].Key);
-            Assert.AreEqual("parentResourceType", contextualParameters[4].VariableName);
-            Assert.AreEqual("id.Parent.ResourceType.Type", contextualParameters[4].BuildValueExpression(_idVariable).ToDisplayString());
+            Assert.AreEqual("parentResourceType", contextualParameters[3].Key);
+            Assert.AreEqual("parentResourceType", contextualParameters[3].VariableName);
+            Assert.AreEqual("id.Parent.ResourceType.Type", contextualParameters[3].BuildValueExpression(_idVariable).ToDisplayString());
+
+            // parentResourceName uses Name
+            Assert.AreEqual("parentResourceName", contextualParameters[4].Key);
+            Assert.AreEqual("parentResourceName", contextualParameters[4].VariableName);
+            Assert.AreEqual("id.Parent.Name", contextualParameters[4].BuildValueExpression(_idVariable).ToDisplayString());
 
             Assert.AreEqual("targets", contextualParameters[5].Key);
             Assert.AreEqual("targetName", contextualParameters[5].VariableName);
@@ -649,15 +649,15 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.AreEqual("parentProviderNamespace", contextualParameters[2].VariableName);
             Assert.AreEqual("id.ResourceType.Namespace", contextualParameters[2].BuildValueExpression(_idVariable).ToDisplayString());
 
-            // parentResourceName uses the variable key - appears first due to stack order
-            Assert.AreEqual("parentResourceName", contextualParameters[3].Key);
-            Assert.AreEqual("parentResourceName", contextualParameters[3].VariableName);
-            Assert.AreEqual("id.Name", contextualParameters[3].BuildValueExpression(_idVariable).ToDisplayString());
-
             // parentResourceType is a variable key
-            Assert.AreEqual("parentResourceType", contextualParameters[4].Key);
-            Assert.AreEqual("parentResourceType", contextualParameters[4].VariableName);
-            Assert.AreEqual("id.ResourceType.Type", contextualParameters[4].BuildValueExpression(_idVariable).ToDisplayString());
+            Assert.AreEqual("parentResourceType", contextualParameters[3].Key);
+            Assert.AreEqual("parentResourceType", contextualParameters[3].VariableName);
+            Assert.AreEqual("id.ResourceType.Type", contextualParameters[3].BuildValueExpression(_idVariable).ToDisplayString());
+
+            // parentResourceName uses Name
+            Assert.AreEqual("parentResourceName", contextualParameters[4].Key);
+            Assert.AreEqual("parentResourceName", contextualParameters[4].VariableName);
+            Assert.AreEqual("id.Name", contextualParameters[4].BuildValueExpression(_idVariable).ToDisplayString());
         }
 
         [Test]

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/SubscriptionQuotaAllocationsListCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/SubscriptionQuotaAllocationsListCollection.cs
@@ -6,6 +6,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
@@ -38,6 +39,17 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             TryGetApiVersion(SubscriptionQuotaAllocationsListResource.ResourceType, out string subscriptionQuotaAllocationsListApiVersion);
             _subscriptionQuotaAllocationsListsClientDiagnostics = new ClientDiagnostics("Azure.Generator.MgmtTypeSpec.Tests", SubscriptionQuotaAllocationsListResource.ResourceType.Namespace, Diagnostics);
             _subscriptionQuotaAllocationsListsRestClient = new SubscriptionQuotaAllocationsLists(_subscriptionQuotaAllocationsListsClientDiagnostics, Pipeline, Endpoint, subscriptionQuotaAllocationsListApiVersion ?? "2024-05-01");
+            ValidateResourceId(id);
+        }
+
+        /// <param name="id"></param>
+        [Conditional("DEBUG")]
+        internal static void ValidateResourceId(ResourceIdentifier id)
+        {
+            if (id.ResourceType != "MgmtTypeSpec/groupQuotas/resourceProviders")
+            {
+                throw new ArgumentException(string.Format("Invalid resource type {0} expected {1}", id.ResourceType, "MgmtTypeSpec/groupQuotas/resourceProviders"), nameof(id));
+            }
         }
 
         /// <summary>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/TargetCollection.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/TargetCollection.cs
@@ -78,7 +78,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.Name, Id.ResourceType.Type, targetName, TargetData.ToRequestContent(data), context);
+                HttpMessage message = _targetsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.ResourceType.Type, Id.Name, targetName, TargetData.ToRequestContent(data), context);
                 Response result = await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
                 Response<TargetData> response = Response.FromValue(TargetData.FromResponse(result), result);
                 RequestUriBuilder uri = message.Request.Uri;
@@ -133,7 +133,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.Name, Id.ResourceType.Type, targetName, TargetData.ToRequestContent(data), context);
+                HttpMessage message = _targetsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.ResourceType.Type, Id.Name, targetName, TargetData.ToRequestContent(data), context);
                 Response result = Pipeline.ProcessMessage(message, context);
                 Response<TargetData> response = Response.FromValue(TargetData.FromResponse(result), result);
                 RequestUriBuilder uri = message.Request.Uri;
@@ -185,7 +185,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.Name, Id.ResourceType.Type, targetName, context);
+                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.ResourceType.Type, Id.Name, targetName, context);
                 Response result = await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
                 Response<TargetData> response = Response.FromValue(TargetData.FromResponse(result), result);
                 if (response.Value == null)
@@ -234,7 +234,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.Name, Id.ResourceType.Type, targetName, context);
+                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.ResourceType.Type, Id.Name, targetName, context);
                 Response result = Pipeline.ProcessMessage(message, context);
                 Response<TargetData> response = Response.FromValue(TargetData.FromResponse(result), result);
                 if (response.Value == null)
@@ -281,8 +281,8 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 Guid.Parse(Id.SubscriptionId),
                 Id.ResourceGroupName,
                 Id.ResourceType.Namespace,
-                Id.Name,
                 Id.ResourceType.Type,
+                Id.Name,
                 continuationToken,
                 context,
                 "TargetCollection.GetAll"), data => new TargetResource(Client, data));
@@ -319,8 +319,8 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 Guid.Parse(Id.SubscriptionId),
                 Id.ResourceGroupName,
                 Id.ResourceType.Namespace,
-                Id.Name,
                 Id.ResourceType.Type,
+                Id.Name,
                 continuationToken,
                 context,
                 "TargetCollection.GetAll"), data => new TargetResource(Client, data));
@@ -359,7 +359,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.Name, Id.ResourceType.Type, targetName, context);
+                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.ResourceType.Type, Id.Name, targetName, context);
                 await Pipeline.SendAsync(message, context.CancellationToken).ConfigureAwait(false);
                 Response result = message.Response;
                 Response<TargetData> response = default;
@@ -416,7 +416,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.Name, Id.ResourceType.Type, targetName, context);
+                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.ResourceType.Type, Id.Name, targetName, context);
                 Pipeline.Send(message, context.CancellationToken);
                 Response result = message.Response;
                 Response<TargetData> response = default;
@@ -473,7 +473,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.Name, Id.ResourceType.Type, targetName, context);
+                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.ResourceType.Type, Id.Name, targetName, context);
                 await Pipeline.SendAsync(message, context.CancellationToken).ConfigureAwait(false);
                 Response result = message.Response;
                 Response<TargetData> response = default;
@@ -534,7 +534,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.Name, Id.ResourceType.Type, targetName, context);
+                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.ResourceType.Namespace, Id.ResourceType.Type, Id.Name, targetName, context);
                 Pipeline.Send(message, context.CancellationToken);
                 Response result = message.Response;
                 Response<TargetData> response = default;

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/TargetResource.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/TargetResource.cs
@@ -125,7 +125,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.Name, Id.Parent.ResourceType.Type, Id.Name, context);
+                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.ResourceType.Type, Id.Parent.Name, Id.Name, context);
                 Response result = await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
                 Response<TargetData> response = Response.FromValue(TargetData.FromResponse(result), result);
                 if (response.Value == null)
@@ -173,7 +173,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.Name, Id.Parent.ResourceType.Type, Id.Name, context);
+                HttpMessage message = _targetsRestClient.CreateGetRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.ResourceType.Type, Id.Parent.Name, Id.Name, context);
                 Response result = Pipeline.ProcessMessage(message, context);
                 Response<TargetData> response = Response.FromValue(TargetData.FromResponse(result), result);
                 if (response.Value == null)
@@ -222,7 +222,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateDeleteRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.Name, Id.Parent.ResourceType.Type, Id.Name, context);
+                HttpMessage message = _targetsRestClient.CreateDeleteRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.ResourceType.Type, Id.Parent.Name, Id.Name, context);
                 Response response = await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
                 RequestUriBuilder uri = message.Request.Uri;
                 RehydrationToken rehydrationToken = NextLinkOperationImplementation.GetRehydrationToken(RequestMethod.Delete, uri.ToUri(), uri.ToString(), "None", null, OperationFinalStateVia.OriginalUri.ToString());
@@ -273,7 +273,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateDeleteRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.Name, Id.Parent.ResourceType.Type, Id.Name, context);
+                HttpMessage message = _targetsRestClient.CreateDeleteRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.ResourceType.Type, Id.Parent.Name, Id.Name, context);
                 Response response = Pipeline.ProcessMessage(message, context);
                 RequestUriBuilder uri = message.Request.Uri;
                 RehydrationToken rehydrationToken = NextLinkOperationImplementation.GetRehydrationToken(RequestMethod.Delete, uri.ToUri(), uri.ToString(), "None", null, OperationFinalStateVia.OriginalUri.ToString());
@@ -328,7 +328,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.Name, Id.Parent.ResourceType.Type, Id.Name, TargetData.ToRequestContent(data), context);
+                HttpMessage message = _targetsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.ResourceType.Type, Id.Parent.Name, Id.Name, TargetData.ToRequestContent(data), context);
                 Response result = await Pipeline.ProcessMessageAsync(message, context).ConfigureAwait(false);
                 Response<TargetData> response = Response.FromValue(TargetData.FromResponse(result), result);
                 RequestUriBuilder uri = message.Request.Uri;
@@ -384,7 +384,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                 {
                     CancellationToken = cancellationToken
                 };
-                HttpMessage message = _targetsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.Name, Id.Parent.ResourceType.Type, Id.Name, TargetData.ToRequestContent(data), context);
+                HttpMessage message = _targetsRestClient.CreateCreateOrUpdateRequest(Guid.Parse(Id.SubscriptionId), Id.ResourceGroupName, Id.Parent.ResourceType.Namespace, Id.Parent.ResourceType.Type, Id.Parent.Name, Id.Name, TargetData.ToRequestContent(data), context);
                 Response result = Pipeline.ProcessMessage(message, context);
                 Response<TargetData> response = Response.FromValue(TargetData.FromResponse(result), result);
                 RequestUriBuilder uri = message.Request.Uri;

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/tspCodeModel.json
@@ -23510,6 +23510,7 @@
                   }
                 ],
                 "resourceScope": "Extension",
+                "parentResourceType": "MgmtTypeSpec/groupQuotas/resourceProviders",
                 "resourceName": "SubscriptionQuotaAllocationsList",
                 "nameConstraints": {},
                 "apiVersions": [


### PR DESCRIPTION
## Fix scope-based extension resource parameter ordering and ValidateResourceId generation

### Bug 1: Swapped Id.Name / Id.ResourceType.Type in extension resource collections

**Root cause**: In `OperationContext.BuildContextualParameterHierarchy`, when processing variable-key/variable-value pairs (e.g., `{parentResourceType}/{parentResourceName}`), parameters were pushed onto a Stack (LIFO) in the wrong order. When later matched positionally to REST operation parameters, `Id.Name` and `Id.ResourceType.Type` were swapped.

**Fix**: Swap the push order so `value` (Name) is pushed before `key` (ResourceType.Type) — LIFO then produces the correct positional order.

**Affected SDKs**: Chaos (ChaosTargetCollection/Resource), KubernetesConfiguration.Extensions (KubernetesClusterExtensionCollection)

### Bug 2: Missing ValidateResourceId for extension resources with complex parent paths

**Root cause**: In the emitter, `getExpectedParentResourceType` only accepted parent segments with exactly 3 parts (`namespace/type/{name}`). For resources with complex nested scopes like Quota (`Microsoft.Management/managementGroups/{mgId}/subscriptions/{subId}`), it returned `undefined`, causing the generator to skip `ValidateResourceId` generation.

**Fix**: Add a fallback that computes the parent scope's resource type from the `resourceIdPattern` by removing the leaf type/name pair and extracting from the last `/providers/` segment. For Quota, this correctly produces `Microsoft.Quota/groupQuotas/resourceProviders`.

### Testing
- All 151 generator tests pass (2 updated to reflect correct parameter order)
- All 67 emitter tests pass
- Mgmt test projects regenerated and build successfully
