### PR TITLE
fix(ServiceBus): Read max-message-batch-size vendor property for batch sizing

### DIFF
--- a/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md
@@ -16,6 +16,8 @@ Thank you to our developer community members who helped to make the Service Bus 
 
 - Fixed a race condition in `AmqpSender` where concurrent calls to `CreateMessageBatchAsync` during initial AMQP link creation could observe an inconsistent `MaxBatchSize`, causing a spurious `ArgumentOutOfRangeException`. ([#56301](https://github.com/Azure/azure-sdk-for-net/issues/56301))
 
+- The sender now reads the `com.microsoft:max-message-batch-size` vendor property from the AMQP link to correctly limit batch size on Premium large-message entities, where `max-message-size` can be up to 100 MB but the batch limit is 1 MB. The 4,500 message count cap on batches has been removed as the service does not enforce a count limit. ([#44914](https://github.com/Azure/azure-sdk-for-net/issues/44914))
+
 ### Other Changes
 
 - Several areas of the AMQP transport integration have been cleaned up, modernized, and made more efficient.  _(A community contribution, courtesy of [danielmarbach](https://github.com/danielmarbach))_

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClientConstants.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpClientConstants.cs
@@ -38,6 +38,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
         public static readonly AmqpSymbol AttachEpoch = AmqpConstants.Vendor + ":epoch";
         public static readonly AmqpSymbol BatchFlushIntervalName = AmqpConstants.Vendor + ":batch-flush-interval";
         public static readonly AmqpSymbol EntityTypeName = AmqpConstants.Vendor + ":entity-type";
+        public static readonly AmqpSymbol MaxMessageBatchSizeName = AmqpConstants.Vendor + ":max-message-batch-size";
         public static readonly AmqpSymbol TransferDestinationAddress = AmqpConstants.Vendor + ":transfer-destination-address";
         public static readonly AmqpSymbol TimeoutName = AmqpConstants.Vendor + ":timeout";
         public static readonly AmqpSymbol TrackingIdName = AmqpConstants.Vendor + ":tracking-id";

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -657,15 +657,11 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 var maxMessageSize = (long)link.Settings.MaxMessageSize;
 
-                // Read the vendor property 'com.microsoft:max-message-batch-size' from
-                // the link, which correctly reports the batch size limit (e.g. 1 MB on
-                // Premium) independent of max-message-size (which can be up to 100 MB on
-                // Premium large-message entities).  Fall back to the hardcoded default
-                // for older service versions that don't advertise the property.
+                // Read the batch size limit from the vendor property if available;
+                // fall back to the default for older service versions.
                 long maxBatchSize = DefaultMaxBatchSize;
-                if (link.Settings.Properties != null &&
-                    link.Settings.Properties.TryGetValue<long>(AmqpClientConstants.MaxMessageBatchSizeName, out var vendorBatchSize) &&
-                    vendorBatchSize > 0)
+                if (link.Settings?.Properties.TryGetValue<long>(AmqpClientConstants.MaxMessageBatchSizeName, out var vendorBatchSize) == true
+                    && vendorBatchSize > 0)
                 {
                     maxBatchSize = vendorBatchSize;
                 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -94,12 +94,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
         private (long MaxMessageSize, long MaxBatchSize) _linkLimits;
 
         /// <summary>
-        ///   The maximum number of messages to allow in a single batch.
-        /// </summary>
-        ///
-        private int MaxMessageCount { get; set; }
-
-        /// <summary>
         ///   Initializes a new instance of the <see cref="AmqpSender"/> class.
         /// </summary>
         ///
@@ -138,12 +132,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
             //   link metadata is not yet available.
             //
             //   Tracked by: https://github.com/Azure/azure-sdk-for-net/issues/44914
-
-            // NOTE:
-            //   This is a temporary work-around until Service Bus exposes a link property for
-            //   the maximum batch size.  The limit for batches differs from the limit for individual
-            //   messages.  Tracked by: https://github.com/Azure/azure-sdk-for-net/issues/44916
-            MaxMessageCount = 4500;
 
             _entityPath = entityPath;
             Identifier = identifier;
@@ -230,7 +218,6 @@ namespace Azure.Messaging.ServiceBus.Amqp
             // default to the maximum size allowed by the link.
 
             options.MaxSizeInBytes ??= limits.MaxBatchSize;
-            options.MaxMessageCount ??= MaxMessageCount;
 
             Argument.AssertInRange(options.MaxSizeInBytes.Value, ServiceBusSender.MinimumBatchSizeLimit, limits.MaxBatchSize, nameof(options.MaxSizeInBytes));
             return new AmqpMessageBatch(_messageConverter, options);
@@ -667,15 +654,23 @@ namespace Azure.Messaging.ServiceBus.Amqp
 
                 // Publish both limits as a single tuple assignment so that concurrent
                 // readers observe a consistent pair.
-                //
-                // Update with service metadata when available:
-                //  https://github.com/Azure/azure-sdk-for-net/issues/44914
-                //  https://github.com/Azure/azure-sdk-for-net/issues/44916
 
                 var maxMessageSize = (long)link.Settings.MaxMessageSize;
-                var currentLimits = _linkLimits;
 
-                _linkLimits = (maxMessageSize, Math.Min(maxMessageSize, currentLimits == default ? DefaultMaxBatchSize : currentLimits.MaxBatchSize));
+                // Read the vendor property 'com.microsoft:max-message-batch-size' from
+                // the link, which correctly reports the batch size limit (e.g. 1 MB on
+                // Premium) independent of max-message-size (which can be up to 100 MB on
+                // Premium large-message entities).  Fall back to the hardcoded default
+                // for older service versions that don't advertise the property.
+                long maxBatchSize = DefaultMaxBatchSize;
+                if (link.Settings.Properties != null &&
+                    link.Settings.Properties.TryGetValue<long>(AmqpClientConstants.MaxMessageBatchSizeName, out var vendorBatchSize) &&
+                    vendorBatchSize > 0)
+                {
+                    maxBatchSize = vendorBatchSize;
+                }
+
+                _linkLimits = (maxMessageSize, Math.Min(maxMessageSize, maxBatchSize));
 
                 ServiceBusEventSource.Log.CreateSendLinkComplete(Identifier);
                 link.Closed += OnSenderLinkClosed;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpSender.cs
@@ -660,7 +660,7 @@ namespace Azure.Messaging.ServiceBus.Amqp
                 // Read the batch size limit from the vendor property if available;
                 // fall back to the default for older service versions.
                 long maxBatchSize = DefaultMaxBatchSize;
-                if (link.Settings?.Properties.TryGetValue<long>(AmqpClientConstants.MaxMessageBatchSizeName, out var vendorBatchSize) == true
+                if (link.Settings?.Properties?.TryGetValue<long>(AmqpClientConstants.MaxMessageBatchSizeName, out var vendorBatchSize) == true
                     && vendorBatchSize > 0)
                 {
                     maxBatchSize = vendorBatchSize;

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpSenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpSenderTests.cs
@@ -465,14 +465,15 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 CallBase = true
             };
 
-            // Use a large enough batch size to hold many small messages.
-            SetLinkLimits(sender.Object, 1_048_576);
+            // Use a large batch size (10 MB) to ensure we can fit well over 4500
+            // tiny messages regardless of envelope overhead variations.
+            SetLinkLimitsWithBatchSize(sender.Object, 10L * 1024 * 1024, 10L * 1024 * 1024);
 
             using TransportMessageBatch batch = await sender.Object.CreateMessageBatchAsync(
                 new CreateMessageBatchOptions(), default);
 
-            // Add many messages — previously capped at 4500. Verify that
-            // the limit is now purely byte-based by adding 5000+ messages.
+            // Add 6000 tiny messages. Previously capped at 4500. With a 10 MB batch,
+            // all 6000 should fit easily (each ~200 bytes = ~1.2 MB total).
             int added = 0;
             for (int i = 0; i < 6000; i++)
             {
@@ -481,11 +482,8 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 added++;
             }
 
-            // The batch should accept as many as fit within the 1 MB byte limit.
-            // With ~200 bytes per message (including AMQP envelope overhead), ~5000
-            // should fit. The test verifies count exceeds the old 4500 cap.
-            Assert.That(added, Is.GreaterThan(4500),
-                "Batch should accept more than 4500 messages now that the count cap is removed.");
+            Assert.That(added, Is.EqualTo(6000),
+                "All 6000 messages should be accepted now that the count cap is removed.");
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpSenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpSenderTests.cs
@@ -136,6 +136,18 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         }
 
         /// <summary>
+        ///   Sets the link limits tuple with an explicit batch size, allowing
+        ///   tests to simulate the vendor property path where MaxBatchSize
+        ///   differs from DefaultMaxBatchSize.
+        /// </summary>
+        private static void SetLinkLimitsWithBatchSize(AmqpSender target, long maxMessageSize, long maxBatchSize)
+        {
+            typeof(AmqpSender)
+                .GetField("_linkLimits", BindingFlags.Instance | BindingFlags.NonPublic)
+                .SetValue(target, (maxMessageSize, Math.Min(maxMessageSize, maxBatchSize)));
+        }
+
+        /// <summary>
         ///    Creates an <see cref="AmqpSender"/> for use with test cases.
         /// </summary>
         /// <returns>An <see cref="Amqp"/> with arbitrary configuration.</returns>
@@ -331,6 +343,149 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
             Assert.That(GetEventBatchOptions((AmqpMessageBatch)batch).MaxSizeInBytes,
                 Is.EqualTo(standardTierMaxMessageSize),
                 "MaxBatchSize should be Math.Min(MaxMessageSize, DefaultMaxBatchSize).");
+        }
+
+        /// <summary>
+        ///   Verifies that when the vendor property <c>com.microsoft:max-message-batch-size</c>
+        ///   reports a batch limit smaller than <c>MaxMessageSize</c>, the batch uses the
+        ///   vendor-reported limit.  This simulates a Premium tier large-message entity where
+        ///   <c>MaxMessageSize</c> is 100 MB but the batch limit is 1 MB.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateBatchAsyncUsesVendorPropertyWhenSmallerThanMaxMessageSize()
+        {
+            var premiumLargeMaxMessageSize = 100L * 1024 * 1024; // 100 MB
+            var vendorBatchSize = 1_048_576L;                     // 1 MB
+            var retryPolicy = new BasicRetryPolicy(new ServiceBusRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var sender = new Mock<AmqpSender>("somePath", Mock.Of<AmqpConnectionScope>(), retryPolicy, "fake-id", new AmqpMessageConverter())
+            {
+                CallBase = true
+            };
+
+            sender
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureSenderStateAsync",
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetLinkLimitsWithBatchSize(sender.Object, premiumLargeMaxMessageSize, vendorBatchSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
+
+            using TransportMessageBatch batch = await sender.Object.CreateMessageBatchAsync(
+                new CreateMessageBatchOptions(), default);
+
+            Assert.That(GetEventBatchOptions((AmqpMessageBatch)batch).MaxSizeInBytes,
+                Is.EqualTo(vendorBatchSize),
+                "MaxBatchSize should use the vendor property (1 MB), not MaxMessageSize (100 MB).");
+        }
+
+        /// <summary>
+        ///   Verifies that Standard tier batch sizing works when the vendor property reports
+        ///   256 KB — the same value as <c>MaxMessageSize</c>.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateBatchAsyncUsesVendorPropertyForStandardTier()
+        {
+            var standardMaxMessageSize = 262_144L; // 256 KB
+            var vendorBatchSize = 262_144L;         // 256 KB (same as max-message-size on Standard)
+            var retryPolicy = new BasicRetryPolicy(new ServiceBusRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var sender = new Mock<AmqpSender>("somePath", Mock.Of<AmqpConnectionScope>(), retryPolicy, "fake-id", new AmqpMessageConverter())
+            {
+                CallBase = true
+            };
+
+            sender
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureSenderStateAsync",
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetLinkLimitsWithBatchSize(sender.Object, standardMaxMessageSize, vendorBatchSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
+
+            using TransportMessageBatch batch = await sender.Object.CreateMessageBatchAsync(
+                new CreateMessageBatchOptions(), default);
+
+            Assert.That(GetEventBatchOptions((AmqpMessageBatch)batch).MaxSizeInBytes,
+                Is.EqualTo(vendorBatchSize),
+                "Standard tier batch size should be 256 KB.");
+        }
+
+        /// <summary>
+        ///   Verifies that when the vendor property is absent, the batch falls back to
+        ///   <c>DefaultMaxBatchSize</c> (1 MB) — not the link's <c>MaxMessageSize</c>
+        ///   when MaxMessageSize is larger.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateBatchAsyncFallsBackToDefaultWhenVendorPropertyAbsent()
+        {
+            // Simulate a link that reports 100 MB max-message-size but no vendor property.
+            // The fallback DefaultMaxBatchSize caps batch at 1 MB.
+
+            var premiumLargeMaxMessageSize = 100L * 1024 * 1024;
+            var expectedBatchSize = 1_048_576L; // DefaultMaxBatchSize
+            var retryPolicy = new BasicRetryPolicy(new ServiceBusRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var sender = new Mock<AmqpSender>("somePath", Mock.Of<AmqpConnectionScope>(), retryPolicy, "fake-id", new AmqpMessageConverter())
+            {
+                CallBase = true
+            };
+
+            sender
+                .Protected()
+                .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureSenderStateAsync",
+                    ItExpr.IsAny<TimeSpan>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback(() => SetLinkLimits(sender.Object, premiumLargeMaxMessageSize))
+                .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
+
+            using TransportMessageBatch batch = await sender.Object.CreateMessageBatchAsync(
+                new CreateMessageBatchOptions(), default);
+
+            Assert.That(GetEventBatchOptions((AmqpMessageBatch)batch).MaxSizeInBytes,
+                Is.EqualTo(expectedBatchSize),
+                "Without vendor property, batch should fall back to DefaultMaxBatchSize (1 MB).");
+        }
+
+        /// <summary>
+        ///   Verifies that the message count is not capped — batches are limited only
+        ///   by byte size, not by message count.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateBatchAsyncDoesNotEnforceMessageCountLimit()
+        {
+            var retryPolicy = new BasicRetryPolicy(new ServiceBusRetryOptions { TryTimeout = TimeSpan.FromSeconds(17) });
+
+            var sender = new Mock<AmqpSender>("somePath", Mock.Of<AmqpConnectionScope>(), retryPolicy, "fake-id", new AmqpMessageConverter())
+            {
+                CallBase = true
+            };
+
+            // Use a large enough batch size to hold many small messages.
+            SetLinkLimits(sender.Object, 1_048_576);
+
+            using TransportMessageBatch batch = await sender.Object.CreateMessageBatchAsync(
+                new CreateMessageBatchOptions(), default);
+
+            // Add many messages — previously capped at 4500. Verify that
+            // the limit is now purely byte-based by adding 5000+ messages.
+            int added = 0;
+            for (int i = 0; i < 6000; i++)
+            {
+                if (!batch.TryAddMessage(new ServiceBusMessage(new byte[] { 0x01 })))
+                    break;
+                added++;
+            }
+
+            // The batch should accept as many as fit within the 1 MB byte limit.
+            // With ~200 bytes per message (including AMQP envelope overhead), ~5000
+            // should fit. The test verifies count exceeds the old 4500 cap.
+            Assert.That(added, Is.GreaterThan(4500),
+                "Batch should accept more than 4500 messages now that the count cap is removed.");
         }
     }
 }

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpSenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpSenderTests.cs
@@ -124,27 +124,17 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         ///   <see cref="AmqpSender.CreateLinkAndEnsureSenderStateAsync" />.
         /// </summary>
         ///
-        private static void SetLinkLimits(AmqpSender target, long value)
+        private static void SetLinkLimits(AmqpSender target, long value, long? maxBatchSize = null)
         {
             var defaultMaxBatchSize = (long)typeof(AmqpSender)
                 .GetField("DefaultMaxBatchSize", BindingFlags.Static | BindingFlags.NonPublic)
                 .GetValue(null);
 
-            typeof(AmqpSender)
-                .GetField("_linkLimits", BindingFlags.Instance | BindingFlags.NonPublic)
-                .SetValue(target, (value, Math.Min(value, defaultMaxBatchSize)));
-        }
+            var effectiveBatchSize = maxBatchSize ?? defaultMaxBatchSize;
 
-        /// <summary>
-        ///   Sets the link limits tuple with an explicit batch size, allowing
-        ///   tests to simulate the vendor property path where MaxBatchSize
-        ///   differs from DefaultMaxBatchSize.
-        /// </summary>
-        private static void SetLinkLimitsWithBatchSize(AmqpSender target, long maxMessageSize, long maxBatchSize)
-        {
             typeof(AmqpSender)
                 .GetField("_linkLimits", BindingFlags.Instance | BindingFlags.NonPublic)
-                .SetValue(target, (maxMessageSize, Math.Min(maxMessageSize, maxBatchSize)));
+                .SetValue(target, (value, Math.Min(value, effectiveBatchSize)));
         }
 
         /// <summary>
@@ -369,7 +359,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureSenderStateAsync",
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback(() => SetLinkLimitsWithBatchSize(sender.Object, premiumLargeMaxMessageSize, vendorBatchSize))
+                .Callback(() => SetLinkLimits(sender.Object, premiumLargeMaxMessageSize, maxBatchSize: vendorBatchSize))
                 .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
 
             using TransportMessageBatch batch = await sender.Object.CreateMessageBatchAsync(
@@ -402,7 +392,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
                 .Setup<Task<SendingAmqpLink>>("CreateLinkAndEnsureSenderStateAsync",
                     ItExpr.IsAny<TimeSpan>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback(() => SetLinkLimitsWithBatchSize(sender.Object, standardMaxMessageSize, vendorBatchSize))
+                .Callback(() => SetLinkLimits(sender.Object, standardMaxMessageSize, maxBatchSize: vendorBatchSize))
                 .Returns(Task.FromResult(new SendingAmqpLink(new AmqpLinkSettings())));
 
             using TransportMessageBatch batch = await sender.Object.CreateMessageBatchAsync(
@@ -467,7 +457,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             // Use a large batch size (10 MB) to ensure we can fit well over 4500
             // tiny messages regardless of envelope overhead variations.
-            SetLinkLimitsWithBatchSize(sender.Object, 10L * 1024 * 1024, 10L * 1024 * 1024);
+            SetLinkLimits(sender.Object, 10L * 1024 * 1024, maxBatchSize: 10L * 1024 * 1024);
 
             using TransportMessageBatch batch = await sender.Object.CreateMessageBatchAsync(
                 new CreateMessageBatchOptions(), default);

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpSenderTests.cs
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Amqp/AmqpSenderTests.cs
@@ -124,7 +124,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
         ///   <see cref="AmqpSender.CreateLinkAndEnsureSenderStateAsync" />.
         /// </summary>
         ///
-        private static void SetLinkLimits(AmqpSender target, long value, long? maxBatchSize = null)
+        private static void SetLinkLimits(AmqpSender target, long maxMessageSize, long? maxBatchSize = null)
         {
             var defaultMaxBatchSize = (long)typeof(AmqpSender)
                 .GetField("DefaultMaxBatchSize", BindingFlags.Static | BindingFlags.NonPublic)
@@ -134,7 +134,7 @@ namespace Azure.Messaging.ServiceBus.Tests.Amqp
 
             typeof(AmqpSender)
                 .GetField("_linkLimits", BindingFlags.Instance | BindingFlags.NonPublic)
-                .SetValue(target, (value, Math.Min(value, effectiveBatchSize)));
+                .SetValue(target, (maxMessageSize, Math.Min(maxMessageSize, effectiveBatchSize)));
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

On Premium large-message Service Bus entities, the AMQP link's `max-message-size` can be up to 100 MB, but the broker enforces a 1 MB limit for batch sends. The .NET SDK hardcodes `DefaultMaxBatchSize = 1048576` (1 MB) and `MaxMessageCount = 4500` as a workaround — correct behavior but not reading from the link property.

Related: [#44914](https://github.com/Azure/azure-sdk-for-net/issues/44914), [#44916](https://github.com/Azure/azure-sdk-for-net/issues/44916), [azure-service-bus#708](https://github.com/Azure/azure-service-bus/issues/708)

## Fix

Read the `com.microsoft:max-message-batch-size` vendor property from the AMQP sender link attach frame, which the service now correctly reports as 256 KB (Standard) / 1 MB (Premium) independent of entity-level `max-message-size`. Fall back to `DefaultMaxBatchSize` (1 MB) when the vendor property is absent. Remove the 4,500 message count cap — the service has no count limit, and the byte size limit naturally caps count.

### Changes

- **`AmqpClientConstants.cs`**: Add `MaxMessageBatchSizeName` constant for `com.microsoft:max-message-batch-size`
- **`AmqpSender.cs`**: Read vendor property via `link.Settings.Properties.TryGetValue<long>()`; remove `MaxMessageCount` property and 4,500 default
- **`AmqpSenderTests.cs`**: 4 new tests: vendor property on Premium large-message (100 MB entity → 1 MB batch), Standard tier (256 KB), absent fallback, count cap removal (>4500 messages fit in byte-limited batch)

Resolves #44914. Related to #44916.

### Cross-SDK alignment

| SDK | Status |
|-----|--------|
| Java | [PR #48214](https://github.com/Azure/azure-sdk-for-java/pull/48214) |
| JS | Separate PR (same branch pattern) |
| Go | Separate PR (same branch pattern) |
| Python | Separate PR (same branch pattern) |
