### PR TITLE
[AgentServer] Use FOUNDRY_HOSTED env var to determine IsHosted in FoundryEnvironment

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Platform/FoundryEnvironment.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Platform/FoundryEnvironment.cs
@@ -61,11 +61,12 @@ public static class FoundryEnvironment
 
     /// <summary>
     /// Indicates whether the process is running in a Foundry hosted environment.
-    /// Returns <c>true</c> when the <c>FOUNDRY_HOSTED</c> environment variable is set to <c>true</c>.
+    /// Returns <c>true</c> when the <c>FOUNDRY_HOSTING_ENVIRONMENT</c> environment variable
+    /// is set to a non-empty value.
     /// </summary>
     /// <remarks>
-    /// This variable is injected by the Azure AI Foundry hosting infrastructure.
-    /// The value is compared case-insensitively.
+    /// This variable is injected by the Azure AI Foundry hosting infrastructure as a
+    /// non-empty value when the container is running in a Foundry context.
     /// </remarks>
     public static bool IsHosted { get; private set; }
 
@@ -109,11 +110,8 @@ public static class FoundryEnvironment
                 ? TimeSpan.FromSeconds(seconds)
                 : Timeout.InfiniteTimeSpan;
 
-        // IsHosted: true when the FOUNDRY_HOSTED environment variable is set to "true".
-        // This variable is injected by the Azure AI Foundry hosting infrastructure.
-        IsHosted = string.Equals(
-            Environment.GetEnvironmentVariable("FOUNDRY_HOSTED"),
-            "true",
-            StringComparison.OrdinalIgnoreCase);
+        // IsHosted: true when the FOUNDRY_HOSTING_ENVIRONMENT environment variable exists
+        // and is non-empty. This variable is injected by the Azure AI Foundry hosting infrastructure.
+        IsHosted = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FOUNDRY_HOSTING_ENVIRONMENT"));
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Platform/FoundryEnvironment.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Platform/FoundryEnvironment.cs
@@ -61,14 +61,11 @@ public static class FoundryEnvironment
 
     /// <summary>
     /// Indicates whether the process is running in a Foundry hosted environment.
-    /// Returns <c>true</c> when <see cref="ProjectEndpoint"/>,
-    /// <see cref="AgentName"/>, and <see cref="AgentVersion"/> are all set
-    /// <b>and</b> the .NET hosting environment is not <c>Development</c>.
+    /// Returns <c>true</c> when the <c>FOUNDRY_HOSTED</c> environment variable is set to <c>true</c>.
     /// </summary>
     /// <remarks>
-    /// The hosting environment is determined from the <c>ASPNETCORE_ENVIRONMENT</c>
-    /// or <c>DOTNET_ENVIRONMENT</c> environment variable (checked in that order).
-    /// When neither is set the environment is assumed to be non-development (i.e. hosted).
+    /// This variable is injected by the Azure AI Foundry hosting infrastructure.
+    /// The value is compared case-insensitively.
     /// </remarks>
     public static bool IsHosted { get; private set; }
 
@@ -112,16 +109,11 @@ public static class FoundryEnvironment
                 ? TimeSpan.FromSeconds(seconds)
                 : Timeout.InfiniteTimeSpan;
 
-        // IsHosted: true when all three Foundry platform env vars (ProjectEndpoint,
-        // AgentName, AgentVersion) are configured AND the .NET hosting environment
-        // is not "Development". This mirrors the logic used by
-        // Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions.IsDevelopment().
-        var hostingEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
-            ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
-        var isDevelopment = string.Equals(hostingEnv, "Development", StringComparison.OrdinalIgnoreCase);
-        var hasFoundryVars = !string.IsNullOrWhiteSpace(ProjectEndpoint)
-            && !string.IsNullOrWhiteSpace(AgentName)
-            && !string.IsNullOrWhiteSpace(AgentVersion);
-        IsHosted = hasFoundryVars && !isDevelopment;
+        // IsHosted: true when the FOUNDRY_HOSTED environment variable is set to "true".
+        // This variable is injected by the Azure AI Foundry hosting infrastructure.
+        IsHosted = string.Equals(
+            Environment.GetEnvironmentVariable("FOUNDRY_HOSTED"),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnvironmentTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnvironmentTests.cs
@@ -21,8 +21,7 @@ public class FoundryEnvironmentTests
         Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", null);
         Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", null);
         Environment.SetEnvironmentVariable("SSE_KEEPALIVE_INTERVAL", null);
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
-        Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", null);
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", null);
         FoundryEnvironment.Reload();
     }
 
@@ -175,123 +174,61 @@ public class FoundryEnvironmentTests
     }
 
     // ---------------------------------------------------------------
-    // IsHosted
+    // IsHosted (driven by FOUNDRY_HOSTED env var)
     // ---------------------------------------------------------------
 
     [Test]
-    public void IsHosted_ReturnsTrue_WhenAllFoundryVarsSet_AndNotDevelopment()
+    public void IsHosted_ReturnsTrue_WhenFoundryHostedIsTrue()
     {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT", "https://example.com");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", "1.0.0");
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "true");
         FoundryEnvironment.Reload();
         Assert.That(FoundryEnvironment.IsHosted, Is.True);
     }
 
     [Test]
-    public void IsHosted_ReturnsFalse_WhenNoFoundryVarsSet()
+    public void IsHosted_ReturnsTrue_CaseInsensitive()
     {
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsFalse_WhenOnlyAgentNameSet()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsFalse_WhenOnlyAgentVersionSet()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", "1.0.0");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsFalse_WhenOnlyEndpointSet()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT", "https://example.com");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsFalse_WhenEndpointAndNameSet_ButMissingVersion()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT", "https://example.com");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsFalse_WhenAllVarsSet_ButDevelopment()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT", "https://example.com");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", "1.0.0");
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsFalse_WhenAspNetCoreEnvironmentIsDevelopment()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT", "https://example.com");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", "1.0.0");
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsFalse_WhenDotNetEnvironmentIsDevelopment()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT", "https://example.com");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", "1.0.0");
-        Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Development");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsFalse_WhenDevelopment_CaseInsensitive()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT", "https://example.com");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", "1.0.0");
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "development");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsTrue_WhenEnvironmentIsProduction()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT", "https://example.com");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", "1.0.0");
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "TRUE");
         FoundryEnvironment.Reload();
         Assert.That(FoundryEnvironment.IsHosted, Is.True);
     }
 
     [Test]
-    public void IsHosted_AspNetCoreEnvironment_TakesPrecedence_OverDotNetEnvironment()
+    public void IsHosted_ReturnsTrue_MixedCase()
     {
-        Environment.SetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT", "https://example.com");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "my-agent");
-        Environment.SetEnvironmentVariable("FOUNDRY_AGENT_VERSION", "1.0.0");
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
-        Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Development");
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "True");
         FoundryEnvironment.Reload();
         Assert.That(FoundryEnvironment.IsHosted, Is.True);
+    }
+
+    [Test]
+    public void IsHosted_ReturnsFalse_WhenNotSet()
+    {
+        FoundryEnvironment.Reload();
+        Assert.That(FoundryEnvironment.IsHosted, Is.False);
+    }
+
+    [Test]
+    public void IsHosted_ReturnsFalse_WhenSetToFalse()
+    {
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "false");
+        FoundryEnvironment.Reload();
+        Assert.That(FoundryEnvironment.IsHosted, Is.False);
+    }
+
+    [Test]
+    public void IsHosted_ReturnsFalse_WhenEmpty()
+    {
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "");
+        FoundryEnvironment.Reload();
+        Assert.That(FoundryEnvironment.IsHosted, Is.False);
+    }
+
+    [Test]
+    public void IsHosted_ReturnsFalse_WhenArbitraryValue()
+    {
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "yes");
+        FoundryEnvironment.Reload();
+        Assert.That(FoundryEnvironment.IsHosted, Is.False);
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnvironmentTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnvironmentTests.cs
@@ -21,7 +21,7 @@ public class FoundryEnvironmentTests
         Environment.SetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT", null);
         Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", null);
         Environment.SetEnvironmentVariable("SSE_KEEPALIVE_INTERVAL", null);
-        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", null);
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTING_ENVIRONMENT", null);
         FoundryEnvironment.Reload();
     }
 
@@ -174,29 +174,21 @@ public class FoundryEnvironmentTests
     }
 
     // ---------------------------------------------------------------
-    // IsHosted (driven by FOUNDRY_HOSTED env var)
+    // IsHosted (driven by FOUNDRY_HOSTING_ENVIRONMENT env var)
     // ---------------------------------------------------------------
 
     [Test]
-    public void IsHosted_ReturnsTrue_WhenFoundryHostedIsTrue()
+    public void IsHosted_ReturnsTrue_WhenFoundryHostingEnvironmentIsSet()
     {
-        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "true");
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTING_ENVIRONMENT", "production");
         FoundryEnvironment.Reload();
         Assert.That(FoundryEnvironment.IsHosted, Is.True);
     }
 
     [Test]
-    public void IsHosted_ReturnsTrue_CaseInsensitive()
+    public void IsHosted_ReturnsTrue_WhenAnyNonEmptyValue()
     {
-        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "TRUE");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.True);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsTrue_MixedCase()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "True");
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTING_ENVIRONMENT", "staging");
         FoundryEnvironment.Reload();
         Assert.That(FoundryEnvironment.IsHosted, Is.True);
     }
@@ -209,25 +201,9 @@ public class FoundryEnvironmentTests
     }
 
     [Test]
-    public void IsHosted_ReturnsFalse_WhenSetToFalse()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "false");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
     public void IsHosted_ReturnsFalse_WhenEmpty()
     {
-        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "");
-        FoundryEnvironment.Reload();
-        Assert.That(FoundryEnvironment.IsHosted, Is.False);
-    }
-
-    [Test]
-    public void IsHosted_ReturnsFalse_WhenArbitraryValue()
-    {
-        Environment.SetEnvironmentVariable("FOUNDRY_HOSTED", "yes");
+        Environment.SetEnvironmentVariable("FOUNDRY_HOSTING_ENVIRONMENT", "");
         FoundryEnvironment.Reload();
         Assert.That(FoundryEnvironment.IsHosted, Is.False);
     }


### PR DESCRIPTION
## Summary

Updates `FoundryEnvironment.IsHosted` in `Azure.AI.AgentServer.Core` to use the explicit `FOUNDRY_HOSTED` environment variable injected by the Azure AI Foundry hosting infrastructure, replacing the previous heuristic approach.

## What changed

**Before:** `IsHosted` was derived by checking three Foundry-specific env vars (`FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_AGENT_NAME`, `FOUNDRY_AGENT_VERSION`) combined with verifying the .NET hosting environment (`ASPNETCORE_ENVIRONMENT`/`DOTNET_ENVIRONMENT`) was not `Development`.

**After:** `IsHosted` is `true` if and only if `FOUNDRY_HOSTED=true` is set — an explicit, unambiguous signal injected directly by the hosting platform.

## Why

The previous heuristic was fragile:
- A developer running locally with real Foundry credentials but `ASPNETCORE_ENVIRONMENT=Development` would incorrectly get `IsHosted = false`.

The new `FOUNDRY_HOSTED` variable is the authoritative source of truth from the platform and removes all ambiguity.