### PR TITLE
draft of migrating error analyzers, add deterministic fixers

### DIFF
--- a/sdk/tools/Azure.SdkAnalyzers/README.md
+++ b/sdk/tools/Azure.SdkAnalyzers/README.md
@@ -6,11 +6,25 @@ This package is automatically included in all Azure SDK libraries in this reposi
 
 ## Implemented Rules
 
-- [**AZC0012**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md#azc0012): Avoid single word type names
-- [**AZC0020**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0020.md): Propagate CancellationToken to RequestContext
+### Unsuppressible (Error severity)
+
+These rules enforce internal implementation correctness and **cannot be suppressed** via `#pragma`, `<NoWarn>`, or `.editorconfig`.
+
+| Rule | Description | Fix |
+|------|-------------|-----|
+| [**AZC0013**](docs/AZC0013.md) | Use `TaskCreationOptions.RunContinuationsAsynchronously` | — |
+| [**AZC0101**](docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
+| [**AZC0108**](docs/AZC0108.md) | Incorrect `async` parameter value | — |
+| [**AZC0109**](docs/AZC0109.md) | Misuse of `async` parameter | — |
+| [**AZC0111**](docs/AZC0111.md) | Do not use `EnsureCompleted` in possibly async scope | — |
+
+### Suppressible (Warning severity)
+
+| Rule | Description | Fix |
+|------|-------------|-----|
+| [**AZC0012**](docs/list-of-diagnostics.md#azc0012) | Avoid single word type names | ✅ |
+| [**AZC0020**](docs/AZC0020.md) | Propagate CancellationToken to RequestContext | — |
 
 ## For Library Authors
 
-These analyzers run automatically during build and will produce warnings when your code doesn't follow Azure SDK conventions. Review the [Azure SDK Design Guidelines](https://azure.github.io/azure-sdk/dotnet_introduction.html) for detailed guidance on all rules.
-
-For detailed information about each diagnostic rule, see the [list of diagnostics](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md).
+These analyzers run automatically during build. Unsuppressible rules produce errors that must be fixed — they prevent deadlocks and threading issues that are difficult to diagnose at runtime. Review the [list of diagnostics](docs/list-of-diagnostics.md) for detailed guidance on each rule.

--- a/sdk/tools/Azure.SdkAnalyzers/README.md
+++ b/sdk/tools/Azure.SdkAnalyzers/README.md
@@ -12,7 +12,7 @@ These rules enforce internal implementation correctness and **cannot be suppress
 
 | Rule | Description | Fix |
 |------|-------------|-----|
-| [**AZC0013**](docs/AZC0013.md) | Use `TaskCreationOptions.RunContinuationsAsynchronously` | — |
+| [**AZC0013**](docs/AZC0013.md) | Use `TaskCreationOptions.RunContinuationsAsynchronously` | ✅ |
 | [**AZC0101**](docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
 | [**AZC0108**](docs/AZC0108.md) | Incorrect `async` parameter value | — |
 | [**AZC0109**](docs/AZC0109.md) | Misuse of `async` parameter | — |

--- a/sdk/tools/Azure.SdkAnalyzers/README.md
+++ b/sdk/tools/Azure.SdkAnalyzers/README.md
@@ -23,7 +23,7 @@ These rules enforce internal implementation correctness and **cannot be suppress
 | Rule | Description | Fix |
 |------|-------------|-----|
 | [**AZC0012**](docs/list-of-diagnostics.md#azc0012) | Avoid single word type names | ✅ |
-| [**AZC0020**](docs/AZC0020.md) | Propagate CancellationToken to RequestContext | — |
+| [**AZC0020**](docs/AZC0020.md) | Propagate CancellationToken to RequestContext | ✅ |
 
 ## For Library Authors
 

--- a/sdk/tools/Azure.SdkAnalyzers/README.md
+++ b/sdk/tools/Azure.SdkAnalyzers/README.md
@@ -14,9 +14,11 @@ These rules enforce internal implementation correctness and **cannot be suppress
 |------|-------------|-----|
 | [**AZC0013**](docs/AZC0013.md) | Use `TaskCreationOptions.RunContinuationsAsynchronously` | ✅ |
 | [**AZC0101**](docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
-| [**AZC0108**](docs/AZC0108.md) | Incorrect `async` parameter value | — |
+| [**AZC0108**](docs/AZC0108.md) | Incorrect `async` parameter value | ✅* |
 | [**AZC0109**](docs/AZC0109.md) | Misuse of `async` parameter | — |
 | [**AZC0111**](docs/AZC0111.md) | Do not use `EnsureCompleted` in possibly async scope | — |
+
+\* Fix only offered when containing method has a `bool async` parameter to forward.
 
 ### Suppressible (Warning severity)
 

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0013.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0013.md
@@ -1,0 +1,48 @@
+# AZC0013: Use TaskCreationOptions.RunContinuationsAsynchronously
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+| **Code fix** | No |
+
+## Cause
+
+A `TaskCompletionSource<T>` is created without specifying `TaskCreationOptions.RunContinuationsAsynchronously`.
+
+## Why this matters
+
+By default, `TaskCompletionSource<T>` runs continuations synchronously on the thread that calls `SetResult`, `SetException`, or `SetCanceled`. This means code after `await` runs inside the code that completes the task, which can cause:
+
+- **Deadlocks** — if the completing code holds a lock, the continuation runs under that lock
+- **Stack overflows** — deeply chained continuations consume the completing thread's stack
+- **Thread starvation** — long-running continuations block the completing thread
+
+`RunContinuationsAsynchronously` forces continuations to be scheduled on the thread pool, making the completing code finish immediately and preventing these issues.
+
+## How to fix
+
+Add `TaskCreationOptions.RunContinuationsAsynchronously` to the constructor:
+
+```diff
+- var tcs = new TaskCompletionSource<string>();
++ var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+```
+
+If you already pass a state object, add the option as the second parameter:
+
+```diff
+- var tcs = new TaskCompletionSource<string>(state);
++ var tcs = new TaskCompletionSource<string>(state, TaskCreationOptions.RunContinuationsAsynchronously);
+```
+
+You can combine it with other flags:
+
+```csharp
+var tcs = new TaskCompletionSource<string>(
+    TaskCreationOptions.RunContinuationsAsynchronously | TaskCreationOptions.LongRunning);
+```
+
+## When to suppress
+
+This rule cannot be suppressed. There is no legitimate reason to omit `RunContinuationsAsynchronously` in Azure SDK code.

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0013.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0013.md
@@ -22,6 +22,8 @@ By default, `TaskCompletionSource<T>` runs continuations synchronously on the th
 
 ## How to fix
 
+A code fix is available for this rule. Use the lightbulb (💡) in your editor or apply "Fix All" to add the option automatically.
+
 Add `TaskCreationOptions.RunContinuationsAsynchronously` to the constructor:
 
 ```diff

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0020.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0020.md
@@ -15,7 +15,9 @@ Missing cancellation propagation can lead to:
 
 ## How to fix violations
 
-Set the `CancellationToken` property on the `RequestContext` object to the incoming cancellation token:
+A code fix is available for this rule. Use the lightbulb (💡) in your editor or apply "Fix All" to propagate the cancellation token automatically.
+
+Manually, set the `CancellationToken` property on the `RequestContext` object to the incoming cancellation token:
 
 ```csharp
 public async Task UpdateAsync(CancellationToken cancellationToken)

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0101.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0101.md
@@ -1,0 +1,35 @@
+# AZC0101: Do not use ConfigureAwait(true)
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+| **Code fix** | Yes — replaces `true` with `false` |
+
+## Cause
+
+An awaitable expression uses `ConfigureAwait(true)` instead of `ConfigureAwait(false)`.
+
+## Why this matters
+
+Azure SDK libraries are general-purpose and must not capture or rely on the caller's `SynchronizationContext`. Using `ConfigureAwait(true)` (or omitting ConfigureAwait entirely) can cause:
+
+- **Deadlocks** in UI or ASP.NET (pre-Core) applications that have a single-threaded synchronization context
+- **Performance issues** from unnecessary thread marshaling back to the original context
+
+`ConfigureAwait(false)` ensures continuations run on the thread pool, which is always correct for library code.
+
+## How to fix
+
+Replace `true` with `false`:
+
+```diff
+- await task.ConfigureAwait(true);
++ await task.ConfigureAwait(false);
+```
+
+The built-in code fix will do this automatically — look for the lightbulb **"Use ConfigureAwait(false)"** in your editor.
+
+## When to suppress
+
+This rule cannot be suppressed. `ConfigureAwait(true)` is never correct in Azure SDK library code.

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0108.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0108.md
@@ -1,0 +1,47 @@
+# AZC0108: Incorrect 'async' parameter value
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+| **Code fix** | No |
+
+## Cause
+
+A method with a `bool async` parameter calls another `bool async` method with the wrong literal value — `false` in async scope or `true` in sync scope.
+
+## Why this matters
+
+Azure SDK libraries use the dual async/sync pattern: a single implementation method accepts a `bool async` parameter to control whether it runs asynchronously or synchronously. Passing the wrong value means:
+
+- **In async scope** (`if (async) { ... }`): passing `false` forces synchronous execution inside an async context, blocking the thread
+- **In sync scope** (`if (!async) { ... }`): passing `true` attempts async execution inside a sync context, which can deadlock
+
+## How to fix
+
+Pass the correct literal or forward the `async` parameter:
+
+```diff
+  private static async Task FooAsync(bool async)
+  {
+      if (async)
+      {
+-         await BarAsync(false).ConfigureAwait(false);  // ❌ wrong value
++         await BarAsync(true).ConfigureAwait(false);   // ✅ correct
++         // or better: forward the parameter
++         await BarAsync(async).ConfigureAwait(false);   // ✅ also correct
+      }
+      else
+      {
+-         BarAsync(true).EnsureCompleted();              // ❌ wrong value
++         BarAsync(false).EnsureCompleted();             // ✅ correct
++         BarAsync(async).EnsureCompleted();             // ✅ also correct
+      }
+  }
+```
+
+Forwarding the `async` parameter is preferred — it keeps both branches correct automatically.
+
+## When to suppress
+
+This rule cannot be suppressed. Incorrect `async` parameter values indicate a logic error that will cause threading issues at runtime.

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0108.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0108.md
@@ -19,6 +19,8 @@ Azure SDK libraries use the dual async/sync pattern: a single implementation met
 
 ## How to fix
 
+A code fix is available when the containing method has a `bool async` parameter — it replaces the incorrect literal with the `async` parameter. Use the lightbulb (💡) in your editor.
+
 Pass the correct literal or forward the `async` parameter:
 
 ```diff

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0109.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0109.md
@@ -1,0 +1,47 @@
+# AZC0109: Misuse of 'async' parameter
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+| **Code fix** | No |
+
+## Cause
+
+The `bool async` parameter is used in a way other than as an exclusive condition in an `if`/`else` statement, a ternary `? :` operator, or as an argument to another `bool async` method.
+
+## Why this matters
+
+The `bool async` parameter controls whether a method runs asynchronously or synchronously. It must only be used to branch execution — any other use (assigning it, reading it into a variable, combining it with other conditions) breaks the analyzer's ability to verify scope correctness for related rules (AZC0108, AZC0110, AZC0111) and likely indicates a logic error.
+
+## How to fix
+
+Use the `async` parameter only as an exclusive branch condition:
+
+```diff
+  private static async Task<int> FooAsync(bool async)
+  {
+-     async = false;                           // ❌ assignment
+-     var isAsync = async;                     // ❌ reading into variable
+-     if (async && someOtherCondition) { ... } // ❌ combined condition
+
++     if (async)                               // ✅ exclusive condition
++     {
++         return await Task.FromResult(42).ConfigureAwait(false);
++     }
++     else
++     {
++         return 42;
++     }
+
++     // ✅ ternary is also fine
++     return async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+
++     // ✅ passing to another async method is fine
++     await BarAsync(async).ConfigureAwait(false);
+  }
+```
+
+## When to suppress
+
+This rule cannot be suppressed. Misuse of the `async` parameter indicates a pattern that will cause incorrect async/sync behavior.

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0111.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0111.md
@@ -1,0 +1,58 @@
+# AZC0111: Do not use EnsureCompleted in possibly asynchronous scope
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+| **Code fix** | No |
+
+## Cause
+
+`EnsureCompleted()` is called in a method that has a `bool async` parameter, outside of a guaranteed synchronous scope (i.e., not inside `if (!async) { ... }`).
+
+## Why this matters
+
+`EnsureCompleted()` blocks the calling thread until the task completes. In a method with a `bool async` parameter, the method may be called from either synchronous or asynchronous contexts. If `EnsureCompleted()` is called without first checking that `async` is `false`:
+
+- **When called asynchronously** (`async = true`): the method blocks a thread pool thread waiting for a task that may itself need that thread, causing a **deadlock**
+- **In unknown scope**: the analyzer cannot verify the call is safe, so it reports an error
+
+## How to fix
+
+Move `EnsureCompleted()` calls inside a guaranteed sync scope:
+
+```diff
+  private static async Task FooAsync(bool async)
+  {
+-     Task.Delay(0).EnsureCompleted();           // ❌ unknown scope
+
++     if (!async)
++     {
++         Task.Delay(0).EnsureCompleted();        // ✅ guaranteed sync
++     }
++     else
++     {
++         await Task.Delay(0).ConfigureAwait(false);
++     }
+  }
+```
+
+Or better, use the dual pattern where async methods accept and forward the `bool async` parameter:
+
+```csharp
+private static async Task FooAsync(bool async)
+{
+    if (async)
+    {
+        await BarAsync(async).ConfigureAwait(false);    // ✅ async path
+    }
+    else
+    {
+        BarAsync(async).EnsureCompleted();              // ✅ sync path
+    }
+}
+```
+
+## When to suppress
+
+This rule cannot be suppressed. `EnsureCompleted()` outside of a guaranteed sync scope is a deadlock risk.

--- a/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
@@ -1,5 +1,144 @@
 # List of diagnostics produced by Azure.SdkAnalyzers
 
+## Unsuppressible Rules (Error severity)
+
+These rules enforce internal implementation correctness and cannot be disabled via `#pragma`, `<NoWarn>`, or `.editorconfig`. They exist to prevent deadlocks, threading issues, and other runtime problems in Azure SDK libraries.
+
+### AZC0013
+
+**Use TaskCreationOptions.RunContinuationsAsynchronously when instantiating TaskCompletionSource**
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+
+#### Cause
+
+A `TaskCompletionSource<T>` is created without `TaskCreationOptions.RunContinuationsAsynchronously`, which can cause deadlocks and thread starvation.
+
+#### How to fix violation
+
+```diff
+- var tcs = new TaskCompletionSource<string>();
++ var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+```
+
+See [AZC0013 documentation](AZC0013.md) for details.
+
+---
+
+### AZC0101
+
+**Do not use ConfigureAwait(true)**
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+| **Code fix** | Yes |
+
+#### Cause
+
+An awaitable expression uses `ConfigureAwait(true)` instead of `ConfigureAwait(false)`.
+
+#### How to fix violation
+
+Replace `true` with `false`. A code fix is available:
+
+```diff
+- await task.ConfigureAwait(true);
++ await task.ConfigureAwait(false);
+```
+
+See [AZC0101 documentation](AZC0101.md) for details.
+
+---
+
+### AZC0108
+
+**Incorrect 'async' parameter value**
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+
+#### Cause
+
+A `bool async` method is called with the wrong literal value — `false` in async scope or `true` in sync scope.
+
+#### How to fix violation
+
+Pass the correct literal or forward the `async` parameter:
+
+```diff
+  if (async)
+  {
+-     await BarAsync(false).ConfigureAwait(false);
++     await BarAsync(async).ConfigureAwait(false);
+  }
+```
+
+See [AZC0108 documentation](AZC0108.md) for details.
+
+---
+
+### AZC0109
+
+**Misuse of 'async' parameter**
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+
+#### Cause
+
+The `bool async` parameter is assigned, read into a variable, or combined with other conditions instead of being used as an exclusive branch condition.
+
+#### How to fix violation
+
+Use `async` only as the sole condition in `if`/`else` or `? :`:
+
+```diff
+- if (async && someCondition) { ... }
++ if (async) { ... }
+```
+
+See [AZC0109 documentation](AZC0109.md) for details.
+
+---
+
+### AZC0111
+
+**Do not use EnsureCompleted in possibly asynchronous scope**
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Error |
+| **Suppressible** | No |
+
+#### Cause
+
+`EnsureCompleted()` is called in a method with `bool async` parameter outside of a guaranteed sync scope (`if (!async) { ... }`).
+
+#### How to fix violation
+
+Move the call inside a sync-guarded block:
+
+```diff
+- task.EnsureCompleted();
++ if (!async) { task.EnsureCompleted(); }
++ else { await task.ConfigureAwait(false); }
+```
+
+See [AZC0111 documentation](AZC0111.md) for details.
+
+---
+
+## Suppressible Rules (Warning severity)
+
 ## AZC0012
 
 ### Cause

--- a/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/list-of-diagnostics.md
@@ -208,7 +208,7 @@ A method that accepts a `CancellationToken` parameter calls an Azure SDK API wit
 
 ### How to fix violation
 
-Set the `CancellationToken` property on the `RequestContext` object to the incoming cancellation token.
+A **code fix** is available. Set the `CancellationToken` property on the `RequestContext` object to the incoming cancellation token.
 
 ### Example of a violation
 

--- a/sdk/tools/Azure.SdkAnalyzers/perf/AnalyzerBenchmark.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/perf/AnalyzerBenchmark.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.SdkAnalyzers.Perf
+{
+    /// <summary>
+    /// Measures wall-clock time for running analyzers against a compilation.
+    /// This is the standard way to benchmark Roslyn analyzers — it captures the
+    /// end-to-end cost of registering, walking the tree, and reporting diagnostics.
+    /// </summary>
+    [MemoryDiagnoser]
+    [SimpleJob(RunStrategy.Throughput, warmupCount: 3, iterationCount: 10)]
+    public class AnalyzerBenchmark
+    {
+        private Compilation _smallCompilation;
+        private Compilation _largeCompilation;
+        private ImmutableArray<DiagnosticAnalyzer> _asyncAnalyzers;
+        private ImmutableArray<DiagnosticAnalyzer> _taskCompletionSourceAnalyzers;
+        private ImmutableArray<DiagnosticAnalyzer> _requestContextAnalyzers;
+        private CompilationWithAnalyzersOptions _options;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var references = new MetadataReference[]
+            {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(Task).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(CancellationToken).Assembly.Location),
+            };
+
+            // Try to add System.Runtime for newer TFMs
+            var runtimeAssembly = typeof(object).Assembly.GetReferencedAssemblies()
+                .FirstOrDefault(a => a.Name == "System.Runtime");
+            var refList = references.ToList();
+            if (runtimeAssembly != null)
+            {
+                try
+                {
+                    refList.Add(MetadataReference.CreateFromFile(
+                        System.Reflection.Assembly.Load(runtimeAssembly).Location));
+                }
+                catch { }
+            }
+
+            _smallCompilation = CSharpCompilation.Create("SmallBench",
+                new[] { CSharpSyntaxTree.ParseText(SmallSource) },
+                refList,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            _largeCompilation = CSharpCompilation.Create("LargeBench",
+                new[] { CSharpSyntaxTree.ParseText(LargeSource) },
+                refList,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            _asyncAnalyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new AsyncPatternAnalyzer());
+            _taskCompletionSourceAnalyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new TaskCompletionSourceAnalyzer());
+            _requestContextAnalyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new RequestContextCancellationTokenAnalyzer());
+
+            _options = new CompilationWithAnalyzersOptions(
+                options: null,
+                onAnalyzerException: null,
+                concurrentAnalysis: false,  // Single-threaded for stable measurements
+                logAnalyzerExecutionTime: false);
+        }
+
+        [Benchmark(Description = "AsyncPatternAnalyzer - small (1 method)")]
+        public async Task<ImmutableArray<Diagnostic>> AsyncPattern_Small()
+        {
+            var cwa = new CompilationWithAnalyzers(_smallCompilation, _asyncAnalyzers, _options);
+            return await cwa.GetAnalyzerDiagnosticsAsync();
+        }
+
+        [Benchmark(Description = "AsyncPatternAnalyzer - large (20 methods)")]
+        public async Task<ImmutableArray<Diagnostic>> AsyncPattern_Large()
+        {
+            var cwa = new CompilationWithAnalyzers(_largeCompilation, _asyncAnalyzers, _options);
+            return await cwa.GetAnalyzerDiagnosticsAsync();
+        }
+
+        [Benchmark(Description = "TaskCompletionSourceAnalyzer - large")]
+        public async Task<ImmutableArray<Diagnostic>> TaskCompletionSource_Large()
+        {
+            var cwa = new CompilationWithAnalyzers(_largeCompilation, _taskCompletionSourceAnalyzers, _options);
+            return await cwa.GetAnalyzerDiagnosticsAsync();
+        }
+
+        [Benchmark(Description = "RequestContextAnalyzer - large")]
+        public async Task<ImmutableArray<Diagnostic>> RequestContext_Large()
+        {
+            var cwa = new CompilationWithAnalyzers(_largeCompilation, _requestContextAnalyzers, _options);
+            return await cwa.GetAnalyzerDiagnosticsAsync();
+        }
+
+        // A single method with an async pattern — minimal workload
+        private const string SmallSource = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sample
+{
+    public static class TaskExtensions
+    {
+        public static T EnsureCompleted<T>(this Task<T> task) => task.GetAwaiter().GetResult();
+        public static void EnsureCompleted(this Task task) => task.GetAwaiter().GetResult();
+    }
+
+    public class SmallClient
+    {
+        internal async Task<int> MethodAsync(bool async)
+        {
+            if (async)
+            {
+                return await Task.FromResult(42).ConfigureAwait(false);
+            }
+            else
+            {
+                return Task.FromResult(42).EnsureCompleted();
+            }
+        }
+    }
+}
+";
+
+        // 20 methods with varying async patterns — realistic workload
+        private static readonly string LargeSource = BuildLargeSource();
+
+        private static string BuildLargeSource()
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine(@"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sample
+{
+    public static class TaskExtensions
+    {
+        public static T EnsureCompleted<T>(this Task<T> task) => task.GetAwaiter().GetResult();
+        public static void EnsureCompleted(this Task task) => task.GetAwaiter().GetResult();
+    }
+
+    public class RequestContext
+    {
+        public CancellationToken CancellationToken { get; set; }
+    }
+
+    public class TaskCompletionSourceUser
+    {
+        private TaskCompletionSource<int> _tcs1 = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private TaskCompletionSource<string> _tcs2 = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    public class LargeClient
+    {
+        public async Task<int> ProtocolAsync(string content, RequestContext context = null) => 0;");
+
+            for (int i = 0; i < 20; i++)
+            {
+                sb.AppendLine($@"
+        internal async Task<int> Method{i}Async(bool async)
+        {{
+            if (async)
+            {{
+                var result = await Task.FromResult({i}).ConfigureAwait(false);
+                var result2 = await Task.FromResult(result + 1).ConfigureAwait(false);
+                return result2;
+            }}
+            else
+            {{
+                var result = Task.FromResult({i}).EnsureCompleted();
+                return Task.FromResult(result + 1).EnsureCompleted();
+            }}
+        }}
+
+        public async Task Caller{i}Async(CancellationToken cancellationToken)
+        {{
+            await ProtocolAsync(""data"", new RequestContext {{ CancellationToken = cancellationToken }});
+        }}");
+            }
+
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/perf/Program.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/perf/Program.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 using Perfolizer.Horology;
 
 namespace Azure.SdkAnalyzers.Perf
@@ -17,6 +18,7 @@ namespace Azure.SdkAnalyzers.Perf
             config.Options = ConfigOptions.JoinSummary | ConfigOptions.StopOnFirstError;
             config = config.AddDiagnoser(MemoryDiagnoser.Default);
             config.AddJob(Job.Default
+                .WithToolchain(InProcessNoEmitToolchain.Instance)
                 .WithWarmupCount(1)
                 .WithIterationTime(TimeInterval.FromMilliseconds(250))
                 .WithMinIterationCount(15)

--- a/sdk/tools/Azure.SdkAnalyzers/src/AsyncAnalyzerUtilities.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/AsyncAnalyzerUtilities.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace Azure.SdkAnalyzers
+{
+    internal sealed class AsyncAnalyzerUtilities
+    {
+        private INamedTypeSymbol BooleanTypeSymbol { get; }
+        private INamedTypeSymbol TaskTypeSymbol { get; }
+        private INamedTypeSymbol TaskOfTTypeSymbol { get; }
+        private INamedTypeSymbol ValueTaskTypeSymbol { get; }
+        private INamedTypeSymbol ValueTaskOfTTypeSymbol { get; }
+        private INamedTypeSymbol NotifyCompletionTypeSymbol { get; }
+        private INamedTypeSymbol TaskAsyncEnumerableExtensionsSymbol { get; }
+        private INamedTypeSymbol AzureTaskExtensionsType { get; }
+
+        public AsyncAnalyzerUtilities(Compilation compilation)
+        {
+            BooleanTypeSymbol = compilation.GetSpecialType(SpecialType.System_Boolean);
+            TaskTypeSymbol = compilation.GetTypeByMetadataName(typeof(Task).FullName);
+            TaskOfTTypeSymbol = compilation.GetTypeByMetadataName(typeof(Task<>).FullName);
+            ValueTaskTypeSymbol = compilation.GetTypeByMetadataName(typeof(ValueTask).FullName);
+            ValueTaskOfTTypeSymbol = compilation.GetTypeByMetadataName(typeof(ValueTask<>).FullName);
+            NotifyCompletionTypeSymbol = compilation.GetTypeByMetadataName(typeof(INotifyCompletion).FullName);
+            TaskAsyncEnumerableExtensionsSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.TaskAsyncEnumerableExtensions");
+            AzureTaskExtensionsType = compilation.GetTypeByMetadataName("Azure.Core.Pipeline.TaskExtensions");
+        }
+
+        public bool IsAsyncParameter(IParameterSymbol parameter)
+            => parameter.Name == "async" && SymbolEqualityComparer.Default.Equals(parameter.Type, BooleanTypeSymbol);
+
+        public bool IsEnsureCompleted(IMethodSymbol method)
+            => AzureTaskExtensionsType != null &&
+               method.Name == "EnsureCompleted" &&
+               method.IsExtensionMethod &&
+               method.Parameters.Length == 1 &&
+               SymbolEqualityComparer.Default.Equals(method.ReceiverType, AzureTaskExtensionsType);
+
+        public bool IsConfigureAwait(IMethodSymbol method)
+        {
+            if (method.Name != nameof(Task.ConfigureAwait))
+            {
+                return false;
+            }
+
+            if (method.Parameters.Length == 1 && IsTaskType(method.ReceiverType))
+            {
+                return true;
+            }
+
+            if (method.Parameters.Length == 2 && SymbolEqualityComparer.Default.Equals(method.ReceiverType, TaskAsyncEnumerableExtensionsSymbol))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool IsGetAwaiter(IMethodSymbol method)
+        {
+            if (method.Name != nameof(Task.GetAwaiter))
+            {
+                return false;
+            }
+
+            if (!(method.Parameters.Length == 0 || method.Parameters.Length == 1 && method.IsExtensionMethod))
+            {
+                return false;
+            }
+
+            if (method.ReturnsVoid || !(method.ReturnType is INamedTypeSymbol returnType))
+            {
+                return false;
+            }
+
+            if (!returnType.AllInterfaces.Contains(NotifyCompletionTypeSymbol))
+            {
+                return false;
+            }
+
+            var hasGetResult = false;
+            var hasIsCompleted = false;
+            foreach (var member in returnType.GetMembers())
+            {
+                hasGetResult |= IsAwaiterGetResultMethod(member);
+                hasIsCompleted |= IsIsCompletedProperty(member);
+
+                if (hasIsCompleted && hasGetResult)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool IsAwaiterGetResultMethod(ISymbol symbol)
+            => symbol.Name == nameof(TaskAwaiter.GetResult) &&
+               IsAwaiterAccessibleMember(symbol) &&
+               symbol is IMethodSymbol getResultCandidate &&
+               getResultCandidate.Parameters.Length == 0;
+
+        private bool IsIsCompletedProperty(ISymbol symbol)
+            => symbol.Name == nameof(TaskAwaiter.IsCompleted) &&
+               IsAwaiterAccessibleMember(symbol) &&
+               symbol is IPropertySymbol property &&
+               property.IsReadOnly &&
+               SymbolEqualityComparer.Default.Equals(property.GetMethod.ReturnType, BooleanTypeSymbol);
+
+        private static bool IsAwaiterAccessibleMember(ISymbol symbol) =>
+            symbol.DeclaredAccessibility switch {
+                Accessibility.Public => true,
+                Accessibility.ProtectedOrInternal => true,
+                Accessibility.Internal => true,
+                _ => false
+            };
+
+        public bool IsTaskType(ITypeSymbol type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(type, TaskTypeSymbol) || SymbolEqualityComparer.Default.Equals(type, ValueTaskTypeSymbol))
+            {
+                return true;
+            }
+
+            if (type is INamedTypeSymbol namedType && namedType.IsGenericType)
+            {
+                var genericType = namedType.ConstructedFrom;
+                if (SymbolEqualityComparer.Default.Equals(genericType, TaskOfTTypeSymbol) || SymbolEqualityComparer.Default.Equals(genericType, ValueTaskOfTTypeSymbol))
+                {
+                    return true;
+                }
+            }
+
+            if (type.TypeKind == TypeKind.Error)
+            {
+                return type.Name.Equals("Task") || type.Name.Equals("ValueTask");
+            }
+
+            return false;
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/src/AsyncParameterCodeFixProvider.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/AsyncParameterCodeFixProvider.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Azure.SdkAnalyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AsyncParameterCodeFixProvider)), Shared]
+    public class AsyncParameterCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("AZC0108");
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return;
+            }
+
+            Diagnostic diagnostic = context.Diagnostics.First();
+            SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan);
+
+            // The diagnostic is on the boolean literal argument (true/false)
+            LiteralExpressionSyntax literal = node.DescendantNodesAndSelf()
+                .OfType<LiteralExpressionSyntax>()
+                .FirstOrDefault(l => l.IsKind(SyntaxKind.TrueLiteralExpression) || l.IsKind(SyntaxKind.FalseLiteralExpression));
+
+            if (literal == null)
+            {
+                return;
+            }
+
+            // Only offer the fix if the containing method has a 'bool async' parameter
+            string asyncParamName = FindAsyncParameterName(literal);
+            if (asyncParamName == null)
+            {
+                return;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: $"Forward '{asyncParamName}' parameter",
+                    createChangedDocument: c => ForwardAsyncParameterAsync(context.Document, literal, asyncParamName, c),
+                    equivalenceKey: "AZC0108_ForwardAsyncParameter"),
+                diagnostic);
+        }
+
+        private static string FindAsyncParameterName(SyntaxNode node)
+        {
+            foreach (SyntaxNode ancestor in node.Ancestors())
+            {
+                ParameterListSyntax parameterList = null;
+
+                switch (ancestor)
+                {
+                    case MethodDeclarationSyntax method:
+                        parameterList = method.ParameterList;
+                        break;
+                    case LocalFunctionStatementSyntax localFunc:
+                        parameterList = localFunc.ParameterList;
+                        break;
+                    case ParenthesizedLambdaExpressionSyntax lambda:
+                        parameterList = lambda.ParameterList;
+                        break;
+                }
+
+                if (parameterList != null)
+                {
+                    ParameterSyntax asyncParam = parameterList.Parameters
+                        .FirstOrDefault(p => p.Type != null &&
+                            (p.Type.ToString() == "bool" || p.Type.ToString() == "Boolean" || p.Type.ToString() == "System.Boolean") &&
+                            p.Identifier.Text == "async");
+
+                    if (asyncParam != null)
+                    {
+                        return asyncParam.Identifier.Text;
+                    }
+
+                    // Stop at the first method-like ancestor
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
+        private static async Task<Document> ForwardAsyncParameterAsync(
+            Document document,
+            LiteralExpressionSyntax literal,
+            string asyncParamName,
+            CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            IdentifierNameSyntax asyncIdentifier = SyntaxFactory.IdentifierName(asyncParamName)
+                .WithTriviaFrom(literal);
+
+            return document.WithSyntaxRoot(root.ReplaceNode(literal, asyncIdentifier));
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/src/AsyncPatternAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/AsyncPatternAnalyzer.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Azure.SdkAnalyzers
+{
+    /// <summary>
+    /// Analyzes async/sync patterns in method bodies.
+    /// Reports: AZC0101 (ConfigureAwait(true)), AZC0108 (wrong async param value),
+    /// AZC0109 (async param misuse), AZC0111 (EnsureCompleted in async scope).
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class AsyncPatternAnalyzer : DiagnosticAnalyzer
+    {
+        private AsyncAnalyzerUtilities _asyncUtilities;
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(Descriptors.AZC0101, Descriptors.AZC0108, Descriptors.AZC0109, Descriptors.AZC0111);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterCompilationStartAction(CompilationStart);
+        }
+
+        private void CompilationStart(CompilationStartAnalysisContext context)
+        {
+            _asyncUtilities = new AsyncAnalyzerUtilities(context.Compilation);
+
+            context.RegisterSyntaxNodeAction(AnalyzeArrowExpressionClause, SyntaxKind.ArrowExpressionClause);
+            context.RegisterOperationAction(AnalyzeMethodBody, OperationKind.MethodBody);
+            context.RegisterOperationAction(AnalyzeAnonymousFunction, OperationKind.AnonymousFunction);
+        }
+
+        private void AnalyzeArrowExpressionClause(SyntaxNodeAnalysisContext context)
+        {
+            if (!(context.ContainingSymbol is IMethodSymbol method) || method.MethodKind != MethodKind.PropertyGet)
+            {
+                return;
+            }
+
+            var operation = context.SemanticModel.GetOperation(context.Node, context.CancellationToken);
+            if (operation is IBlockOperation block && block.Parent == null)
+            {
+                MethodBodyAnalyzer.Run(context.ReportDiagnostic, context.Compilation, _asyncUtilities, method, block);
+            }
+        }
+
+        private void AnalyzeMethodBody(OperationAnalysisContext context)
+        {
+            var method = (IMethodSymbol) context.ContainingSymbol;
+            var methodBody = (IMethodBodyOperation)context.Operation;
+            MethodBodyAnalyzer.Run(context.ReportDiagnostic, context.Compilation, _asyncUtilities, method, methodBody.BlockBody ?? methodBody.ExpressionBody);
+        }
+
+        private void AnalyzeAnonymousFunction(OperationAnalysisContext context)
+        {
+            var operation = (IAnonymousFunctionOperation) context.Operation;
+            var method = operation.Symbol;
+            if (method.ContainingSymbol.Kind != SymbolKind.Method)
+            {
+                MethodBodyAnalyzer.Run(context.ReportDiagnostic, context.Compilation, _asyncUtilities, method, operation.Body);
+            }
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/src/ConfigureAwaitCodeFixProvider.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/ConfigureAwaitCodeFixProvider.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Azure.SdkAnalyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ConfigureAwaitCodeFixProvider)), Shared]
+    public class ConfigureAwaitCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("AZC0101");
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return;
+            }
+
+            Diagnostic diagnostic = context.Diagnostics.First();
+
+            // The diagnostic span covers "ConfigureAwait(true)" — find the invocation
+            SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan);
+            InvocationExpressionSyntax invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>()
+                .FirstOrDefault(i => i.Expression is MemberAccessExpressionSyntax m && m.Name.Identifier.Text == "ConfigureAwait");
+
+            if (invocation == null)
+            {
+                return;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Use ConfigureAwait(false)",
+                    createChangedDocument: c => ReplaceWithFalseAsync(context.Document, invocation, c),
+                    equivalenceKey: "AZC0101_UseConfigureAwaitFalse"),
+                diagnostic);
+        }
+
+        private static async Task<Document> ReplaceWithFalseAsync(Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            // Replace the last argument (true) with false
+            ArgumentSyntax lastArg = invocation.ArgumentList.Arguments.Last();
+            LiteralExpressionSyntax falseLiteral = SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)
+                .WithTriviaFrom(lastArg.Expression);
+
+            ArgumentSyntax newArg = lastArg.WithExpression(falseLiteral);
+            SyntaxNode newRoot = root.ReplaceNode(lastArg, newArg);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/Descriptors.cs
@@ -7,6 +7,55 @@ namespace Azure.SdkAnalyzers
 {
     internal class Descriptors
     {
+        #region Tier 1: Error + NotConfigurable (internal implementation rules)
+
+        public static DiagnosticDescriptor AZC0013 = new(
+            nameof(AZC0013),
+            "Use TaskCreationOptions.RunContinuationsAsynchronously when instantiating TaskCompletionSource",
+            "All the task's continuations are executed synchronously unless TaskCreationOptions.RunContinuationsAsynchronously option is specified. This may cause deadlocks and other threading issues if all \"async\" continuations have to run in the thread that sets the result of a task.",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Error,
+            true,
+            customTags: new[] { WellKnownDiagnosticTags.NotConfigurable });
+
+        public static DiagnosticDescriptor AZC0101 = new(
+            nameof(AZC0101),
+            "Use ConfigureAwait(false) instead of ConfigureAwait(true).",
+            "Use ConfigureAwait(false) instead of ConfigureAwait(true).",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Error,
+            true,
+            customTags: new[] { WellKnownDiagnosticTags.NotConfigurable });
+
+        public static DiagnosticDescriptor AZC0108 = new(
+            nameof(AZC0108),
+            "Incorrect 'async' parameter value.",
+            "In {0} scope 'async' parameter for the '{1}' method call should {2}.",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Error,
+            true,
+            customTags: new[] { WellKnownDiagnosticTags.NotConfigurable });
+
+        public static DiagnosticDescriptor AZC0109 = new(
+            nameof(AZC0109),
+            "Misuse of 'async' parameter.",
+            "'async' parameter in asynchronous method can't be changed and can only be used as an exclusive condition in '?:' operator or conditional statement.",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Error,
+            true,
+            customTags: new[] { WellKnownDiagnosticTags.NotConfigurable });
+
+        public static DiagnosticDescriptor AZC0111 = new(
+            nameof(AZC0111),
+            "DO NOT use EnsureCompleted in possibly asynchronous scope.",
+            "Asynchronous method with `async` parameter can be called from both synchronous and asynchronous scopes. 'EnsureCompleted' extension method can be safely used on in guaranteed synchronous scope (i.e. `if (!async) {{...}}`).",
+            DiagnosticCategory.Usage,
+            DiagnosticSeverity.Error,
+            true,
+            customTags: new[] { WellKnownDiagnosticTags.NotConfigurable });
+
+        #endregion
+
         public static DiagnosticDescriptor AZC0012 = new(
             nameof(AZC0012),
             "Avoid single word type names",

--- a/sdk/tools/Azure.SdkAnalyzers/src/MethodBodyAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/MethodBodyAnalyzer.cs
@@ -1,0 +1,421 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma warning disable CS0618 // IOperation.Children is obsolete, but ChildOperations returns a struct enumerator
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Azure.SdkAnalyzers
+{
+    /// <summary>
+    /// Analyzes method bodies for async/sync pattern correctness.
+    /// Reports: AZC0101 (ConfigureAwait(true)), AZC0108 (wrong async param value),
+    /// AZC0109 (async param misuse), AZC0111 (EnsureCompleted in async scope).
+    /// </summary>
+    internal readonly struct MethodBodyAnalyzer
+    {
+        private readonly AsyncAnalyzerUtilities _asyncUtilities;
+        private readonly Stack<(IEnumerator<IOperation>, MethodAnalysisContext)> _symbolIteratorsStack;
+        private readonly Action<Diagnostic> _reportDiagnostic;
+
+        public static void Run(Action<Diagnostic> reportDiagnostic, Compilation compilation, AsyncAnalyzerUtilities utilities, IMethodSymbol method, IBlockOperation methodBody)
+            => new MethodBodyAnalyzer(reportDiagnostic, compilation, utilities).Run(method, methodBody);
+
+        private MethodBodyAnalyzer(Action<Diagnostic> reportDiagnostic, Compilation compilation, AsyncAnalyzerUtilities utilities)
+        {
+            _reportDiagnostic = reportDiagnostic;
+            _asyncUtilities = utilities;
+            _symbolIteratorsStack = new Stack<(IEnumerator<IOperation>, MethodAnalysisContext)>();
+        }
+
+        private void Run(IMethodSymbol method, IBlockOperation methodBody)
+        {
+            var asyncParameter = GetAsyncParameter(method);
+
+            _symbolIteratorsStack.Push((methodBody.Children.GetEnumerator(), new MethodAnalysisContext(method, asyncParameter)));
+
+            while (_symbolIteratorsStack.Count > 0)
+            {
+                var (enumerator, context) = _symbolIteratorsStack.Peek();
+                if (!enumerator.MoveNext())
+                {
+                    _symbolIteratorsStack.Pop();
+                    continue;
+                }
+
+                var current = enumerator.Current;
+                if (current == null)
+                {
+                    continue;
+                }
+
+                var analyzeChildren = AnalyzeOperation(current, ref context);
+                if (analyzeChildren)
+                {
+                    _symbolIteratorsStack.Push((current.Children.GetEnumerator(), context));
+                }
+            }
+        }
+
+        private bool AnalyzeOperation(IOperation current, ref MethodAnalysisContext context)
+        {
+            switch (current)
+            {
+                case IParameterReferenceOperation reference when SymbolEqualityComparer.Default.Equals(reference.Parameter, context.AsyncParameter):
+                    AnalyzeAsyncParameterReference(context, reference);
+                    return false;
+                case IAnonymousFunctionOperation function when function.Symbol != null:
+                    context = context.WithNewMethod(function.Symbol, GetAsyncParameter(function.Symbol));
+                    return true;
+                case ILocalFunctionOperation function when function.Symbol != null:
+                    context = context.WithNewMethod(function.Symbol, GetAsyncParameter(function.Symbol));
+                    return true;
+                case IAwaitOperation awaitOperation when context.Scope == Scope.Unknown:
+                    AnalyzeAwaitableOperationInUnknownScope(awaitOperation, context);
+                    return false;
+                case IInvocationOperation invocation:
+                    AnalyzeInvocation(invocation, context);
+                    return true;
+                default:
+                    return true;
+            }
+        }
+
+        // AZC0109: async parameter can only be used as exclusive condition in ?: or if/else
+        private void AnalyzeAsyncParameterReference(in MethodAnalysisContext context, IOperation reference)
+        {
+            switch (reference.Parent)
+            {
+                case IConditionalOperation conditional:
+                    _symbolIteratorsStack.Pop();
+                    TryPushOperationToStack(context, conditional.WhenFalse, Scope.Sync);
+                    TryPushOperationToStack(context, conditional.WhenTrue, Scope.Async);
+                    return;
+                case IUnaryOperation unary when unary.OperatorKind == UnaryOperatorKind.Not && unary.Parent is IConditionalOperation conditional:
+                    _symbolIteratorsStack.Pop();
+                    _symbolIteratorsStack.Pop();
+                    TryPushOperationToStack(context, conditional.WhenFalse, Scope.Async);
+                    TryPushOperationToStack(context, conditional.WhenTrue, Scope.Sync);
+                    return;
+                case IArgumentOperation argument when _asyncUtilities.IsAsyncParameter(argument.Parameter):
+                    return;
+                default:
+                    ReportDiagnosticOnOperation(reference.Parent, Descriptors.AZC0109);
+                    return;
+            }
+        }
+
+        // AZC0111: EnsureCompleted in unknown scope (possibly async)
+        private void AnalyzeAwaitableOperationInUnknownScope(in IAwaitOperation awaitOperation, in MethodAnalysisContext context)
+        {
+            var operation = GetAwaitableOperation(awaitOperation.Operation);
+
+            if (operation is IInvocationOperation invocation &&
+                TryGetAsyncArgument(invocation, out var argument) &&
+                IsEqualsToParameter(argument.Value, context.AsyncParameter))
+            {
+                return;
+            }
+
+            // AZC0110 would be reported here for await in unknown scope,
+            // but that rule is not migrated in this tier.
+        }
+
+        private IOperation GetAwaitableOperation(IOperation operation)
+        {
+            while (operation is IInvocationOperation invocation)
+            {
+                if (IsExtensionMethodOnInvocation(invocation, out var argumentInvocation))
+                {
+                    operation = argumentInvocation;
+                }
+                else if (invocation.Instance != null && _asyncUtilities.IsTaskType(invocation.Instance.Type))
+                {
+                    operation = invocation.Instance;
+                }
+                else
+                {
+                    return operation;
+                }
+            }
+            return operation;
+        }
+
+        private void AnalyzeInvocation(in IInvocationOperation invocation, in MethodAnalysisContext context)
+        {
+            switch (context.Scope) {
+                case Scope.Unknown:
+                    AnalyzeInvocationUnknownScope(invocation, context);
+                    return;
+                case Scope.Async:
+                    AnalyzeInvocationAsyncScope(invocation, context);
+                    return;
+                case Scope.Sync:
+                    AnalyzeInvocationSyncScope(invocation, context);
+                    return;
+            }
+        }
+
+        private void AnalyzeInvocationUnknownScope(in IInvocationOperation invocation, in MethodAnalysisContext context)
+        {
+            var method = invocation.TargetMethod;
+            if (_asyncUtilities.IsConfigureAwait(method))
+            {
+                AnalyzeConfigureAwait(invocation);
+            }
+            else if (IsGetAwaiterGetResult(invocation))
+            {
+                // AZC0102 not migrated in this tier
+            }
+            else if (IsEnsureCompleted(invocation, out var firstArgument))
+            {
+                var operation = GetAwaitableOperation(firstArgument);
+                ReportDiagnosticOnOperation(operation, Descriptors.AZC0111);
+            }
+        }
+
+        private void AnalyzeInvocationAsyncScope(IInvocationOperation invocation, in MethodAnalysisContext context)
+        {
+            var method = invocation.TargetMethod;
+            if (_asyncUtilities.IsConfigureAwait(method))
+            {
+                AnalyzeConfigureAwait(invocation);
+            }
+            else if (IsGetAwaiterGetResult(invocation))
+            {
+                // AZC0103 not migrated in this tier
+            }
+            else if (IsEnsureCompleted(invocation, out _))
+            {
+                // AZC0103 not migrated in this tier
+            }
+            else if (method.IsAsync && !IsPublicMethod(method) && TryGetAsyncArgument(invocation, out var asyncArgument))
+            {
+                AnalyzeAsyncParameterValue(invocation, context.AsyncParameter, asyncArgument, true);
+            }
+        }
+
+        private void AnalyzeInvocationSyncScope(IInvocationOperation invocation, in MethodAnalysisContext context)
+        {
+            if (_asyncUtilities.IsConfigureAwait(invocation.TargetMethod))
+            {
+                // AZC0104 not migrated in this tier
+            }
+            else if (IsGetAwaiterGetResult(invocation))
+            {
+                // AZC0102 not migrated in this tier
+            }
+            else if (IsEnsureCompleted(invocation, out var firstArgument))
+            {
+                AnalyzeEnsureCompleted(firstArgument, context);
+            }
+        }
+
+        // AZC0101: ConfigureAwait(true) is always wrong
+        private void AnalyzeConfigureAwait(IInvocationOperation invocation)
+        {
+            if (IsEqualsToBoolValue(invocation.Arguments.Last().Value, true))
+            {
+                ReportDiagnosticOnMember(invocation, Descriptors.AZC0101);
+            }
+        }
+
+        private void AnalyzeEnsureCompleted(in IOperation firstArgument, in MethodAnalysisContext context)
+        {
+            switch (firstArgument)
+            {
+                case IFieldReferenceOperation _:
+                case ILocalReferenceOperation _:
+                case IParameterReferenceOperation _:
+                case IPropertyReferenceOperation _:
+                    // AZC0104 not migrated in this tier
+                    return;
+                case IInvocationOperation invocation:
+                    AnalyzeEnsureCompletedOnInvocation(invocation, context);
+                    return;
+            }
+        }
+
+        private void AnalyzeEnsureCompletedOnInvocation(IInvocationOperation invocation, in MethodAnalysisContext context)
+        {
+            while (true)
+            {
+                var method = invocation.TargetMethod;
+                if (TryGetAsyncArgument(invocation, out var asyncArgument))
+                {
+                    AnalyzeAsyncParameterValue(invocation, context.AsyncParameter, asyncArgument, false);
+                    return;
+                }
+
+                if (IsExtensionMethodOnInvocation(invocation, out var argumentInvocation))
+                {
+                    invocation = argumentInvocation;
+                    continue;
+                }
+
+                // AZC0106/AZC0107 not migrated in this tier
+                return;
+            }
+        }
+
+        private bool IsExtensionMethodOnInvocation(IInvocationOperation invocation, out IInvocationOperation invocationOperation)
+        {
+            var method = invocation.TargetMethod;
+            if (method.IsExtensionMethod && invocation.Arguments[0].Value is IInvocationOperation argument && _asyncUtilities.IsTaskType(argument.Type))
+            {
+                invocationOperation = argument;
+                return true;
+            }
+
+            invocationOperation = default;
+            return false;
+        }
+
+        // AZC0108: async parameter has incorrect value
+        private void AnalyzeAsyncParameterValue(IInvocationOperation invocation, IParameterSymbol asyncParameter, IArgumentOperation asyncArgument, bool asyncValue)
+        {
+            if (IsEqualsToParameter(asyncArgument.Value, asyncParameter) || IsEqualsToBoolValue(asyncArgument.Value, asyncValue))
+            {
+                return;
+            }
+
+            var messageArgs = asyncValue
+                ? new object[] {"asynchronous", invocation.TargetMethod.Name, "be 'true'"}
+                : new object[] {"synchronous", invocation.TargetMethod.Name, "be 'false'"};
+
+            ReportDiagnosticOnOperation(asyncArgument, Descriptors.AZC0108, messageArgs);
+        }
+
+        private static bool IsEqualsToBoolValue(IOperation operation, bool value)
+            => operation != null && operation.ConstantValue.HasValue && operation.ConstantValue.Value is bool boolValue && value == boolValue;
+
+        private static bool IsEqualsToParameter(IOperation operation, IParameterSymbol parameter)
+            => operation != null && operation is IParameterReferenceOperation reference && SymbolEqualityComparer.Default.Equals(reference.Parameter, parameter);
+
+        private IParameterSymbol GetAsyncParameter(IMethodSymbol method)
+            => method.Parameters.FirstOrDefault(_asyncUtilities.IsAsyncParameter);
+
+        private bool TryGetAsyncArgument(IInvocationOperation invocation, out IArgumentOperation asyncArgument)
+        {
+            asyncArgument = invocation.Arguments.FirstOrDefault(IsAsyncArgument);
+            return asyncArgument != default;
+        }
+
+        private bool IsAsyncArgument(IArgumentOperation argument)
+            => _asyncUtilities.IsAsyncParameter(argument.Parameter);
+
+        public bool IsGetAwaiterGetResult(IInvocationOperation invocation)
+            => _asyncUtilities.IsGetAwaiter(invocation.TargetMethod) && invocation.Parent is IInvocationOperation parentInvocation && _asyncUtilities.IsAwaiterGetResultMethod(parentInvocation.TargetMethod);
+
+        private bool IsEnsureCompleted(IInvocationOperation invocation, out IOperation firstArgument)
+        {
+            if (_asyncUtilities.IsEnsureCompleted(invocation.TargetMethod))
+            {
+                firstArgument = invocation.Arguments[0].Value;
+                return true;
+            }
+
+            firstArgument = default;
+            return false;
+        }
+
+        private void TryPushOperationToStack(in MethodAnalysisContext context, IOperation operation, Scope scope)
+        {
+            if (operation == null)
+            {
+                return;
+            }
+
+            IEnumerable<IOperation> enumerable = new[] {operation};
+            _symbolIteratorsStack.Push((enumerable.GetEnumerator(), context.WithScope(scope)));
+        }
+
+        private void ReportDiagnosticOnOperation(IOperation operation, DiagnosticDescriptor diagnosticDescriptor, params object[] messageArgs)
+        {
+            var location = operation.Syntax.GetLocation();
+            var diagnostic = Diagnostic.Create(diagnosticDescriptor, location, messageArgs);
+            _reportDiagnostic(diagnostic);
+        }
+
+        private void ReportDiagnosticOnMember(IOperation operation, DiagnosticDescriptor diagnosticDescriptor, params object[] messageArgs)
+        {
+            var location = Location.Create(operation.Syntax.SyntaxTree, GetMemberTextSpan(operation));
+            var diagnostic = Diagnostic.Create(diagnosticDescriptor, location, messageArgs);
+            _reportDiagnostic(diagnostic);
+        }
+
+        private static TextSpan GetMemberTextSpan(IOperation operation)
+        {
+            var invocation = (InvocationExpressionSyntax) operation.Syntax;
+            var name = invocation.Expression is MemberAccessExpressionSyntax memberAccess ? memberAccess.Name : invocation.Expression;
+            var start = name.Span.Start;
+            var end = invocation.Span.End;
+            return TextSpan.FromBounds(start, end);
+        }
+
+        private static bool IsPublicMethod(IMethodSymbol method)
+        {
+            if (method.DeclaredAccessibility != Accessibility.Public)
+            {
+                return false;
+            }
+
+            if (method.AssociatedSymbol != null && method.AssociatedSymbol.DeclaredAccessibility != Accessibility.Public)
+            {
+                return false;
+            }
+
+            var type = method.ContainingType;
+            while (type != null)
+            {
+                if (type.DeclaredAccessibility != Accessibility.Public)
+                {
+                    return false;
+                }
+
+                type = type.ContainingType;
+            }
+
+            return true;
+        }
+
+        private readonly struct MethodAnalysisContext
+        {
+            public IParameterSymbol AsyncParameter { get; }
+            public Scope Scope { get; }
+
+            public MethodAnalysisContext(IMethodSymbol method, IParameterSymbol asyncParameter)
+                :this(asyncParameter, GetScope(method, asyncParameter)) { }
+
+            private MethodAnalysisContext(IParameterSymbol asyncParameter, Scope scope)
+            {
+                AsyncParameter = asyncParameter;
+                Scope = scope;
+            }
+
+            public MethodAnalysisContext WithNewMethod(IMethodSymbol method, IParameterSymbol asyncParameter)
+                => new MethodAnalysisContext(asyncParameter ?? AsyncParameter, GetScope(method, asyncParameter));
+
+            public MethodAnalysisContext WithScope(Scope scope)
+                => new MethodAnalysisContext(AsyncParameter, Scope == Scope.Sync ? Scope.Sync : scope);
+
+            private static Scope GetScope(IMethodSymbol method, IParameterSymbol asyncParameter) =>
+                method.IsAsync
+                    ? asyncParameter != null ? Scope.Unknown : Scope.Async
+                    : Scope.Sync;
+        }
+
+        private enum Scope
+        {
+            Unknown,
+            Async,
+            Sync
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/src/RequestContextCodeFixProvider.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/RequestContextCodeFixProvider.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Azure.SdkAnalyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RequestContextCodeFixProvider)), Shared]
+    public class RequestContextCodeFixProvider : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("AZC0020");
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return;
+            }
+
+            Diagnostic diagnostic = context.Diagnostics.First();
+            SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan);
+
+            // The diagnostic is reported on the argument syntax — the ObjectCreation is a descendant
+            ObjectCreationExpressionSyntax objectCreation = node.DescendantNodesAndSelf()
+                .OfType<ObjectCreationExpressionSyntax>()
+                .FirstOrDefault();
+
+            if (objectCreation == null)
+            {
+                return;
+            }
+
+            // Find the CancellationToken parameter name from the containing method/lambda
+            SemanticModel semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            string tokenParamName = FindCancellationTokenParameterName(objectCreation, semanticModel);
+
+            if (tokenParamName == null)
+            {
+                return;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: $"Propagate {tokenParamName} to RequestContext",
+                    createChangedDocument: c => PropagateCancellationTokenAsync(context.Document, objectCreation, tokenParamName, c),
+                    equivalenceKey: "AZC0020_PropagateCancellationToken"),
+                diagnostic);
+        }
+
+        private static string FindCancellationTokenParameterName(SyntaxNode node, SemanticModel semanticModel)
+        {
+            // Walk up to the containing method/lambda/local function
+            foreach (SyntaxNode ancestor in node.Ancestors())
+            {
+                switch (ancestor)
+                {
+                    case SimpleLambdaExpressionSyntax lambda:
+                        return GetCancellationTokenParam(lambda.Parameter, semanticModel);
+
+                    case ParenthesizedLambdaExpressionSyntax lambda:
+                        return GetCancellationTokenParam(lambda.ParameterList.Parameters, semanticModel);
+
+                    case AnonymousMethodExpressionSyntax anonymous when anonymous.ParameterList != null:
+                        return GetCancellationTokenParam(anonymous.ParameterList.Parameters, semanticModel);
+
+                    case LocalFunctionStatementSyntax localFunction:
+                        return GetCancellationTokenParam(localFunction.ParameterList.Parameters, semanticModel);
+
+                    case MethodDeclarationSyntax method:
+                        return GetCancellationTokenParam(method.ParameterList.Parameters, semanticModel);
+                }
+            }
+
+            return null;
+        }
+
+        private static string GetCancellationTokenParam(ParameterSyntax parameter, SemanticModel semanticModel)
+        {
+            if (parameter.Type != null)
+            {
+                string typeName = parameter.Type.ToString();
+                if (typeName == "CancellationToken" || typeName == "System.Threading.CancellationToken")
+                {
+                    return parameter.Identifier.Text;
+                }
+            }
+
+            // Fall back to semantic model for type-inferred parameters (e.g. lambdas)
+            if (semanticModel != null)
+            {
+                IParameterSymbol symbol = semanticModel.GetDeclaredSymbol(parameter) as IParameterSymbol;
+                if (symbol?.Type?.Name == "CancellationToken" &&
+                    symbol.Type.ContainingNamespace?.ToDisplayString() == "System.Threading")
+                {
+                    return parameter.Identifier.Text;
+                }
+            }
+
+            return null;
+        }
+
+        private static string GetCancellationTokenParam(SeparatedSyntaxList<ParameterSyntax> parameters, SemanticModel semanticModel = null)
+        {
+            foreach (ParameterSyntax param in parameters)
+            {
+                if (param.Type != null)
+                {
+                    string typeName = param.Type.ToString();
+                    if (typeName == "CancellationToken" || typeName == "System.Threading.CancellationToken")
+                    {
+                        return param.Identifier.Text;
+                    }
+                }
+
+                // Fall back to semantic model if type syntax isn't clear
+                if (semanticModel != null)
+                {
+                    IParameterSymbol symbol = semanticModel.GetDeclaredSymbol(param) as IParameterSymbol;
+                    if (symbol?.Type?.Name == "CancellationToken" &&
+                        symbol.Type.ContainingNamespace?.ToDisplayString() == "System.Threading")
+                    {
+                        return param.Identifier.Text;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static async Task<Document> PropagateCancellationTokenAsync(
+            Document document,
+            ObjectCreationExpressionSyntax objectCreation,
+            string tokenParamName,
+            CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            ExpressionSyntax tokenExpression = SyntaxFactory.IdentifierName(tokenParamName);
+
+            AssignmentExpressionSyntax ctAssignment = SyntaxFactory.AssignmentExpression(
+                SyntaxKind.SimpleAssignmentExpression,
+                SyntaxFactory.IdentifierName("CancellationToken"),
+                tokenExpression);
+
+            if (objectCreation.Initializer != null)
+            {
+                // Check if CancellationToken is already in the initializer (set to wrong value like None/default)
+                InitializerExpressionSyntax initializer = objectCreation.Initializer;
+                for (int i = 0; i < initializer.Expressions.Count; i++)
+                {
+                    if (initializer.Expressions[i] is AssignmentExpressionSyntax assignment &&
+                        assignment.Left is IdentifierNameSyntax id &&
+                        id.Identifier.Text == "CancellationToken")
+                    {
+                        // Replace the value
+                        AssignmentExpressionSyntax newAssignment = assignment.WithRight(
+                            tokenExpression.WithTriviaFrom(assignment.Right));
+                        InitializerExpressionSyntax newInitializer = initializer.WithExpressions(
+                            initializer.Expressions.Replace(initializer.Expressions[i], newAssignment));
+                        ObjectCreationExpressionSyntax newCreation = objectCreation.WithInitializer(newInitializer);
+                        return document.WithSyntaxRoot(root.ReplaceNode(objectCreation, newCreation));
+                    }
+                }
+
+                // CancellationToken not in initializer — add it
+                SeparatedSyntaxList<ExpressionSyntax> newExpressions = initializer.Expressions.Add(ctAssignment);
+                InitializerExpressionSyntax updatedInitializer = initializer.WithExpressions(newExpressions);
+                ObjectCreationExpressionSyntax updatedCreation = objectCreation.WithInitializer(updatedInitializer);
+                return document.WithSyntaxRoot(root.ReplaceNode(objectCreation, updatedCreation));
+            }
+            else
+            {
+                // No initializer — create one and remove the argument list (empty parens)
+                InitializerExpressionSyntax newInitializer = SyntaxFactory.InitializerExpression(
+                    SyntaxKind.ObjectInitializerExpression,
+                    SyntaxFactory.SingletonSeparatedList<ExpressionSyntax>(ctAssignment))
+                    .WithLeadingTrivia(SyntaxFactory.Space);
+
+                ObjectCreationExpressionSyntax newCreation = objectCreation
+                    .WithArgumentList(null)
+                    .WithInitializer(newInitializer);
+
+                return document.WithSyntaxRoot(root.ReplaceNode(objectCreation, newCreation));
+            }
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/src/TaskCompletionSourceAnalyzer.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/TaskCompletionSourceAnalyzer.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Azure.SdkAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class TaskCompletionSourceAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.AZC0013);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+            context.RegisterCompilationStartAction(CompilationStart);
+        }
+
+        private void CompilationStart(CompilationStartAnalysisContext context)
+        {
+            var oca = new ObjectCreationAnalyzer(context.Compilation);
+            context.RegisterOperationAction(oca.Analyze, OperationKind.ObjectCreation);
+        }
+
+        private class ObjectCreationAnalyzer
+        {
+            private readonly INamedTypeSymbol _taskCompletionSourceOfTTypeSymbol;
+            private readonly INamedTypeSymbol _taskCreationOptionsTypeSymbol;
+
+            public ObjectCreationAnalyzer(Compilation compilation)
+            {
+                _taskCompletionSourceOfTTypeSymbol = compilation.GetTypeByMetadataName(typeof(TaskCompletionSource<>).FullName);
+                _taskCreationOptionsTypeSymbol = compilation.GetTypeByMetadataName(typeof(TaskCreationOptions).FullName);
+            }
+
+            public void Analyze(OperationAnalysisContext context)
+            {
+                var objectCreation = (IObjectCreationOperation) context.Operation;
+                if (!SymbolEqualityComparer.Default.Equals(_taskCompletionSourceOfTTypeSymbol, objectCreation.Type.OriginalDefinition))
+                {
+                    return;
+                }
+
+                if (objectCreation.Arguments.Length == 0)
+                {
+                    ReportDiagnostics(context, objectCreation.Syntax.Span);
+                    return;
+                }
+
+                var arguments = objectCreation.Arguments;
+                var argument = arguments.FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.Parameter.Type, _taskCreationOptionsTypeSymbol));
+                if (argument == null)
+                {
+                    var textSpan = TextSpan.FromBounds(arguments.First().Syntax.Span.Start, arguments.Last().Syntax.Span.End);
+                    ReportDiagnostics(context, textSpan);
+                    return;
+                }
+
+                if (argument.Value is IFieldReferenceOperation fieldReference)
+                {
+                    if (!IsRunContinuationsAsynchronously(fieldReference))
+                    {
+                        ReportDiagnostics(context, argument.Syntax.Span);
+                    }
+                    return;
+                }
+
+                if (!HasRunContinuationsAsynchronously(argument.Value))
+                {
+                    ReportDiagnostics(context, argument.Syntax.Span);
+                }
+            }
+        }
+
+        private static bool HasRunContinuationsAsynchronously(IOperation operation)
+            => operation.Descendants().OfType<IFieldReferenceOperation>().Any(IsRunContinuationsAsynchronously);
+
+        private static bool IsRunContinuationsAsynchronously(IFieldReferenceOperation fieldReference)
+            => fieldReference.Member.Name == "RunContinuationsAsynchronously";
+
+        private static void ReportDiagnostics(OperationAnalysisContext context, TextSpan textSpan)
+        {
+            var location = context.Operation.Syntax.SyntaxTree.GetLocation(textSpan);
+            var diagnostic = Diagnostic.Create(Descriptors.AZC0013, location);
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/src/TaskCompletionSourceCodeFixProvider.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/src/TaskCompletionSourceCodeFixProvider.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Azure.SdkAnalyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(TaskCompletionSourceCodeFixProvider)), Shared]
+    public class TaskCompletionSourceCodeFixProvider : CodeFixProvider
+    {
+        private const string RunContinuationsAsynchronously = "TaskCreationOptions.RunContinuationsAsynchronously";
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("AZC0013");
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                return;
+            }
+
+            Diagnostic diagnostic = context.Diagnostics.First();
+            SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan);
+
+            ObjectCreationExpressionSyntax objectCreation = node.AncestorsAndSelf()
+                .OfType<ObjectCreationExpressionSyntax>()
+                .FirstOrDefault();
+
+            if (objectCreation == null)
+            {
+                return;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Add TaskCreationOptions.RunContinuationsAsynchronously",
+                    createChangedDocument: c => AddRunContinuationsAsynchronouslyAsync(context.Document, objectCreation, c),
+                    equivalenceKey: "AZC0013_AddRunContinuationsAsynchronously"),
+                diagnostic);
+        }
+
+        private static async Task<Document> AddRunContinuationsAsynchronouslyAsync(
+            Document document,
+            ObjectCreationExpressionSyntax objectCreation,
+            CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            SemanticModel semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            ExpressionSyntax runContinuationsExpr = SyntaxFactory.ParseExpression(RunContinuationsAsynchronously);
+
+            ObjectCreationExpressionSyntax newCreation;
+
+            if (objectCreation.ArgumentList == null || objectCreation.ArgumentList.Arguments.Count == 0)
+            {
+                // Case 1: new TaskCompletionSource<T>()
+                // → new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously)
+                ArgumentListSyntax newArgList = SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Argument(runContinuationsExpr)));
+                newCreation = objectCreation.WithArgumentList(newArgList);
+            }
+            else
+            {
+                // Find the TaskCreationOptions argument
+                int taskCreationOptionsArgIndex = -1;
+                for (int i = 0; i < objectCreation.ArgumentList.Arguments.Count; i++)
+                {
+                    ArgumentSyntax arg = objectCreation.ArgumentList.Arguments[i];
+                    TypeInfo typeInfo = semanticModel.GetTypeInfo(arg.Expression, cancellationToken);
+                    ITypeSymbol resolvedType = typeInfo.Type ?? typeInfo.ConvertedType;
+                    if (resolvedType?.Name == "TaskCreationOptions" &&
+                        resolvedType.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks")
+                    {
+                        taskCreationOptionsArgIndex = i;
+                        break;
+                    }
+                }
+
+                if (taskCreationOptionsArgIndex == -1)
+                {
+                    // Case 2: new TaskCompletionSource<T>(stateObj) — no TaskCreationOptions arg
+                    // → new TaskCompletionSource<T>(stateObj, TaskCreationOptions.RunContinuationsAsynchronously)
+                    SeparatedSyntaxList<ArgumentSyntax> newArgs = objectCreation.ArgumentList.Arguments.Add(
+                        SyntaxFactory.Argument(runContinuationsExpr));
+                    newCreation = objectCreation.WithArgumentList(
+                        objectCreation.ArgumentList.WithArguments(newArgs));
+                }
+                else
+                {
+                    // Case 3: Has TaskCreationOptions but missing RunContinuationsAsynchronously
+                    // → prepend: TaskCreationOptions.RunContinuationsAsynchronously | <existing>
+                    ArgumentSyntax existingArg = objectCreation.ArgumentList.Arguments[taskCreationOptionsArgIndex];
+                    string existingText = existingArg.Expression.WithoutLeadingTrivia().ToFullString();
+                    ExpressionSyntax combinedExpr = SyntaxFactory.ParseExpression(
+                        $"{RunContinuationsAsynchronously} | {existingText}");
+                    ArgumentSyntax newArg = existingArg.WithExpression(combinedExpr);
+                    SeparatedSyntaxList<ArgumentSyntax> newArgs = objectCreation.ArgumentList.Arguments.Replace(existingArg, newArg);
+                    newCreation = objectCreation.WithArgumentList(
+                        objectCreation.ArgumentList.WithArguments(newArgs));
+                }
+            }
+
+            return document.WithSyntaxRoot(root.ReplaceNode(objectCreation, newCreation));
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0013CodeFixTests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0013CodeFixTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0013CodeFixTests
+    {
+        private static CSharpCodeFixTest<TaskCompletionSourceAnalyzer, TaskCompletionSourceCodeFixProvider, DefaultVerifier> CreateCodeFixTest(
+            string source,
+            string fixedSource)
+        {
+            var test = new CSharpCodeFixTest<TaskCompletionSourceAnalyzer, TaskCompletionSourceCodeFixProvider, DefaultVerifier>
+            {
+                ReferenceAssemblies = AzureTestReferences.DefaultReferenceAssemblies,
+                SolutionTransforms = {(solution, projectId) =>
+                {
+                    var project = solution.GetProject(projectId);
+                    var parseOptions = (CSharpParseOptions?)project?.ParseOptions;
+                    if (parseOptions != null && solution != null && project != null)
+                    {
+                        return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.Latest));
+                    }
+                    return solution!;
+                }},
+                TestCode = source,
+                FixedCode = fixedSource,
+                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck
+            };
+
+            test.TestState.Sources.Add((AzureTestReferences.CodeGenTypeAttributeFilePath, AzureTestReferences.CodeGenTypeAttributeSource));
+            test.FixedState.Sources.Add((AzureTestReferences.CodeGenTypeAttributeFilePath, AzureTestReferences.CodeGenTypeAttributeSource));
+
+            return test;
+        }
+
+        [Test]
+        public async Task FixDefaultConstructor()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = {|AZC0013:new TaskCompletionSource<string>()|};
+    }
+}
+";
+
+            const string fixedCode = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}
+";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public async Task FixWithStateObjectOnly()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>({|AZC0013:new object()|});
+    }
+}
+";
+
+            const string fixedCode = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>(new object(), TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}
+";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public async Task FixWithWrongTaskCreationOptions()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>(new object(), {|AZC0013:TaskCreationOptions.LongRunning | TaskCreationOptions.PreferFairness|});
+    }
+}
+";
+
+            const string fixedCode = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>(new object(), TaskCreationOptions.RunContinuationsAsynchronously | TaskCreationOptions.LongRunning | TaskCreationOptions.PreferFairness);
+    }
+}
+";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public async Task FixWithSingleWrongOption()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>({|AZC0013:TaskCreationOptions.None|});
+    }
+}
+";
+
+            const string fixedCode = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously | TaskCreationOptions.None);
+    }
+}
+";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0013Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0013Tests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.TaskCompletionSourceAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0013Tests
+    {
+        [Test]
+        public async Task AZC0013ErrorOnTaskCompletionSourceDefaultConstructor()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = {|AZC0013:new TaskCompletionSource<string>()|};
+    }
+}
+";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0013ErrorOnTaskCompletionSourceWithState()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>({|AZC0013:new object()|});
+    }
+}
+";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0013ErrorOnTaskCompletionSourceWithoutRunContinuationsAsynchronously()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>(new object(), {|AZC0013:TaskCreationOptions.LongRunning | TaskCreationOptions.PreferFairness|});
+    }
+}
+";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0013ErrorOnTaskCompletionSourceWithField()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private static TaskCreationOptions _option = TaskCreationOptions.RunContinuationsAsynchronously;
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>({|AZC0013:TaskCreationOptions.LongRunning | _option | TaskCreationOptions.PreferFairness|});
+    }
+}
+";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0013NoErrorOnTaskCompletionSourceWithRunContinuationsAsynchronously()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}
+";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0013NoErrorOnTaskCompletionSourceWithRunContinuationsAsynchronouslyAndState()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>(new object(), TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+}
+";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0013NoErrorOnTaskCompletionSourceContainsRunContinuationsAsynchronously()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+
+    internal class RandomClass
+    {
+        private TaskCompletionSource<string> _tcs = new TaskCompletionSource<string>(TaskCreationOptions.LongRunning | TaskCreationOptions.RunContinuationsAsynchronously | TaskCreationOptions.PreferFairness);
+    }
+}
+";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0020CodeFixTests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0020CodeFixTests.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0020CodeFixTests
+    {
+        private const string AzureStubs = @"
+namespace Azure
+{
+    public class RequestContext
+    {
+        public System.Threading.CancellationToken CancellationToken { get; set; }
+        public ErrorOptions ErrorOptions { get; set; }
+    }
+
+    public enum ErrorOptions
+    {
+        Default
+    }
+
+    public class Response { }
+}
+
+namespace Azure.Sample
+{
+    public class SampleClient
+    {
+        public System.Threading.Tasks.Task<Azure.Response> UpdateAsync(string content, Azure.RequestContext context = null)
+        {
+            return System.Threading.Tasks.Task.FromResult<Azure.Response>(null);
+        }
+    }
+}
+";
+
+        private static CSharpCodeFixTest<RequestContextCancellationTokenAnalyzer, RequestContextCodeFixProvider, DefaultVerifier> CreateCodeFixTest(
+            string source,
+            string fixedSource)
+        {
+            var test = new CSharpCodeFixTest<RequestContextCancellationTokenAnalyzer, RequestContextCodeFixProvider, DefaultVerifier>
+            {
+                ReferenceAssemblies = AzureTestReferences.DefaultReferenceAssemblies,
+                SolutionTransforms = {(solution, projectId) =>
+                {
+                    var project = solution.GetProject(projectId);
+                    var parseOptions = (CSharpParseOptions?)project?.ParseOptions;
+                    if (parseOptions != null && solution != null && project != null)
+                    {
+                        return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.Latest));
+                    }
+                    return solution!;
+                }},
+                TestCode = source,
+                FixedCode = fixedSource,
+                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck
+            };
+
+            test.TestState.Sources.Add((AzureTestReferences.CodeGenTypeAttributeFilePath, AzureTestReferences.CodeGenTypeAttributeSource));
+            test.TestState.Sources.Add(AzureStubs);
+            test.FixedState.Sources.Add((AzureTestReferences.CodeGenTypeAttributeFilePath, AzureTestReferences.CodeGenTypeAttributeSource));
+            test.FixedState.Sources.Add(AzureStubs);
+
+            return test;
+        }
+
+        [Test]
+        public async Task FixNewRequestContextWithNoInitializer()
+        {
+            const string code = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task UpdateAsync(CancellationToken cancellationToken)
+    {
+        await _client.UpdateAsync(
+            ""test"",
+            {|AZC0020:new RequestContext()|});
+    }
+}
+";
+
+            const string fixedCode = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task UpdateAsync(CancellationToken cancellationToken)
+    {
+        await _client.UpdateAsync(
+            ""test"",
+            new RequestContext { CancellationToken = cancellationToken });
+    }
+}
+";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public async Task FixNewRequestContextWithExistingInitializerMissingCT()
+        {
+            const string code = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task UpdateAsync(CancellationToken cancellationToken)
+    {
+        await _client.UpdateAsync(
+            ""test"",
+            {|AZC0020:new RequestContext { ErrorOptions = ErrorOptions.Default }|});
+    }
+}
+";
+
+            const string fixedCode = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task UpdateAsync(CancellationToken cancellationToken)
+    {
+        await _client.UpdateAsync(
+            ""test"",
+            new RequestContext { ErrorOptions = ErrorOptions.Default, CancellationToken = cancellationToken });
+    }
+}
+";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public async Task FixNewRequestContextWithCancellationTokenNone()
+        {
+            const string code = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task UpdateAsync(CancellationToken cancellationToken)
+    {
+        await _client.UpdateAsync(
+            ""test"",
+            {|AZC0020:new RequestContext { CancellationToken = CancellationToken.None }|});
+    }
+}
+";
+
+            const string fixedCode = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task UpdateAsync(CancellationToken cancellationToken)
+    {
+        await _client.UpdateAsync(
+            ""test"",
+            new RequestContext { CancellationToken = cancellationToken });
+    }
+}
+";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public async Task FixInLambdaWithCancellationToken()
+        {
+            const string code = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task ProcessAsync()
+    {
+        Func<CancellationToken, Task> action = async (ct) =>
+        {
+            await _client.UpdateAsync(
+                ""test"",
+                {|AZC0020:new RequestContext()|});
+        };
+        await action(CancellationToken.None);
+    }
+}
+";
+
+            const string fixedCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task ProcessAsync()
+    {
+        Func<CancellationToken, Task> action = async (ct) =>
+        {
+            await _client.UpdateAsync(
+                ""test"",
+                new RequestContext { CancellationToken = ct });
+        };
+        await action(CancellationToken.None);
+    }
+}
+";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public async Task FixMultipleViolationsInSameMethod()
+        {
+            const string code = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task ProcessAsync(CancellationToken cancellationToken)
+    {
+        await _client.UpdateAsync(
+            ""test1"",
+            {|AZC0020:new RequestContext()|});
+
+        await _client.UpdateAsync(
+            ""test2"",
+            {|AZC0020:new RequestContext()|});
+    }
+}
+";
+
+            const string fixedCode = @"
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Sample;
+
+public class MyService
+{
+    private SampleClient _client = new SampleClient();
+
+    public async Task ProcessAsync(CancellationToken cancellationToken)
+    {
+        await _client.UpdateAsync(
+            ""test1"",
+            new RequestContext { CancellationToken = cancellationToken });
+
+        await _client.UpdateAsync(
+            ""test2"",
+            new RequestContext { CancellationToken = cancellationToken });
+    }
+}
+";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0101CodeFixTests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0101CodeFixTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0101CodeFixTests
+    {
+        private static CSharpCodeFixTest<AsyncPatternAnalyzer, ConfigureAwaitCodeFixProvider, DefaultVerifier> CreateCodeFixTest(
+            string source,
+            string fixedSource)
+        {
+            var test = new CSharpCodeFixTest<AsyncPatternAnalyzer, ConfigureAwaitCodeFixProvider, DefaultVerifier>
+            {
+                ReferenceAssemblies = AzureTestReferences.DefaultReferenceAssemblies,
+                SolutionTransforms = {(solution, projectId) =>
+                {
+                    var project = solution.GetProject(projectId);
+                    var parseOptions = (CSharpParseOptions?)project?.ParseOptions;
+                    if (parseOptions != null && solution != null && project != null)
+                    {
+                        return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.Latest));
+                    }
+                    return solution!;
+                }},
+                TestCode = source,
+                FixedCode = fixedSource,
+                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck
+            };
+
+            test.TestState.Sources.Add((AzureTestReferences.CodeGenTypeAttributeFilePath, AzureTestReferences.CodeGenTypeAttributeSource));
+            test.FixedState.Sources.Add((AzureTestReferences.CodeGenTypeAttributeFilePath, AzureTestReferences.CodeGenTypeAttributeSource));
+
+            return test;
+        }
+
+        [NUnit.Framework.Test]
+        public async Task FixReplacesConfigureAwaitTrueWithFalse()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class MyClass
+    {
+        public static async System.Threading.Tasks.Task Foo()
+        {
+            await System.Threading.Tasks.Task.Run(() => {}).{|AZC0101:ConfigureAwait(true)|};
+        }
+    }
+}";
+
+            const string fixedCode = @"
+namespace RandomNamespace
+{
+    public class MyClass
+    {
+        public static async System.Threading.Tasks.Task Foo()
+        {
+            await System.Threading.Tasks.Task.Run(() => {}).ConfigureAwait(false);
+        }
+    }
+}";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [NUnit.Framework.Test]
+        public async Task FixReplacesConfigureAwaitTrueInAsyncScope()
+        {
+            const string source = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await Task.Run(() => {}).{|AZC0101:ConfigureAwait(true)|};
+            }
+        }
+    }
+}";
+
+            const string fixedSource = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await Task.Run(() => {}).ConfigureAwait(false);
+            }
+        }
+    }
+}";
+
+            var test = CreateCodeFixTest(source, fixedSource);
+            test.TestState.Sources.Add(AzureCorePipelineTaskExtensions);
+            test.FixedState.Sources.Add(AzureCorePipelineTaskExtensions);
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        private const string AzureCorePipelineTaskExtensions = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+        public static T EnsureCompleted<T>(this Task<T> task) => default(T);
+    }
+}
+";
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0101Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0101Tests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.AsyncPatternAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0101Tests
+    {
+        [Test]
+        public async Task AZC0101ErrorOnExistingConfigureAwaitTrue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class MyClass
+    {
+        public static async System.Threading.Tasks.Task Foo()
+        {
+            await System.Threading.Tasks.Task.Run(() => {}).{|AZC0101:ConfigureAwait(true)|};
+        }
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0101NoErrorOnConfigureAwaitFalse()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class MyClass
+    {
+        public static async System.Threading.Tasks.Task Foo()
+        {
+            await System.Threading.Tasks.Task.Run(() => {}).ConfigureAwait(false);
+        }
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Test]
+        public async Task AZC0101ErrorInAsyncScopeConfigureAwaitTrue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await Task.Run(() => {}).{|AZC0101:ConfigureAwait(true)|};
+            }
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        private const string AzureCorePipelineTaskExtensions = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+        public static T EnsureCompleted<T>(this Task<T> task) => default(T);
+    }
+}
+";
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0108CodeFixTests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0108CodeFixTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0108CodeFixTests
+    {
+        private const string AzureCorePipelineTaskExtensions = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+        public static T EnsureCompleted<T>(this Task<T> task) => default(T);
+    }
+}
+";
+
+        private static CSharpCodeFixTest<AsyncPatternAnalyzer, AsyncParameterCodeFixProvider, DefaultVerifier> CreateCodeFixTest(
+            string source,
+            string fixedSource)
+        {
+            var test = new CSharpCodeFixTest<AsyncPatternAnalyzer, AsyncParameterCodeFixProvider, DefaultVerifier>
+            {
+                ReferenceAssemblies = AzureTestReferences.DefaultReferenceAssemblies,
+                SolutionTransforms = {(solution, projectId) =>
+                {
+                    var project = solution.GetProject(projectId);
+                    var parseOptions = (CSharpParseOptions?)project?.ParseOptions;
+                    if (parseOptions != null && solution != null && project != null)
+                    {
+                        return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.Latest));
+                    }
+                    return solution!;
+                }},
+                TestCode = source,
+                FixedCode = fixedSource,
+                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck
+            };
+
+            test.TestState.Sources.Add((AzureTestReferences.CodeGenTypeAttributeFilePath, AzureTestReferences.CodeGenTypeAttributeSource));
+            test.TestState.Sources.Add(AzureCorePipelineTaskExtensions);
+            test.FixedState.Sources.Add((AzureTestReferences.CodeGenTypeAttributeFilePath, AzureTestReferences.CodeGenTypeAttributeSource));
+            test.FixedState.Sources.Add(AzureCorePipelineTaskExtensions);
+
+            return test;
+        }
+
+        [Test]
+        public async Task FixFalseInAsyncScope()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await FooImplAsync({|AZC0108:false|}).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            const string fixedCode = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await FooImplAsync(async).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public async Task FixTrueInSyncScope()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (!async)
+            {
+                FooImplAsync({|AZC0108:true|}).EnsureCompleted();
+            }
+            else
+            {
+                await Task.Yield();
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            const string fixedCode = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (!async)
+            {
+                FooImplAsync(async).EnsureCompleted();
+            }
+            else
+            {
+                await Task.Yield();
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await CreateCodeFixTest(code, fixedCode).RunAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public async Task NoFixOfferedWithoutAsyncParameter()
+        {
+            // In a plain async method without a 'bool async' parameter,
+            // there is no async parameter to forward, so no fix should be offered.
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        public static async Task FooAsync()
+        {
+            await FooImplAsync({|AZC0108:false|}).ConfigureAwait(false);
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            // Fixed code is the same as the input — no fix applied
+            var test = CreateCodeFixTest(code, code);
+            test.NumberOfFixAllIterations = 0;
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0108Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0108Tests.cs
@@ -1,0 +1,337 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.AsyncPatternAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0108Tests
+    {
+        private const string AzureCorePipelineTaskExtensions = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+        public static T EnsureCompleted<T>(this Task<T> task) => default(T);
+    }
+}
+";
+
+        [Test]
+        public async Task AZC0108ErrorInAsyncMethodFalseValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static async Task FooAsync()
+        {
+            await FooImplAsync({|AZC0108:false|}).ConfigureAwait(false);
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108ErrorInAsyncScopeFalseValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await FooImplAsync({|AZC0108:false|}).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108ErrorInSyncMethodTrueValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync({|AZC0108:true|}).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108ErrorInSyncScopeTrueValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (!async)
+            {
+                FooImplAsync({|AZC0108:true|}).EnsureCompleted();
+            }
+            else
+            {
+                await Task.Yield();
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108ErrorInSyncPropertyTrueValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        public static int Foo { get { return FooImplAsync({|AZC0108:true|}).EnsureCompleted(); } }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108ErrorInSyncExpressionPropertyTrueValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        public static int Foo => FooImplAsync({|AZC0108:true|}).EnsureCompleted();
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108NoErrorInAsyncMethodTrueValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        public static async Task FooAsync()
+        {
+            await FooImplAsync(true).ConfigureAwait(false);
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108NoErrorInAsyncScopeTrueValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await FooImplAsync(true).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108NoErrorInSyncMethodFalseValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108NoErrorInSyncScopeFalseValue()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (!async)
+            {
+                FooImplAsync(false).EnsureCompleted();
+            }
+            else
+            {
+                await Task.Yield();
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0108NoErrorOnAsyncParameterPassing()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await FooImplAsync(async).ConfigureAwait(false);
+            }
+            else
+            {
+                FooImplAsync(async).EnsureCompleted();
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0109Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0109Tests.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.AsyncPatternAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0109Tests
+    {
+        private const string AzureCorePipelineTaskExtensions = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+        public static T EnsureCompleted<T>(this Task<T> task) => default(T);
+    }
+}
+";
+
+        [Test]
+        public async Task AZC0109ErrorOnAssignment()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+        {
+            {|AZC0109:async = false|};
+            return async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0109ErrorOnReading()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+        {
+            var x {|AZC0109:= async|};
+            if (x)
+            {
+                return async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+            }
+
+            return 42;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0109ErrorOnBinaryOperation()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+        {
+            var x = false;
+            if ({|AZC0109:async && x|})
+            {
+                return async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+            }
+            return 42;
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0109NoErrorOnUnaryNot()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0109NoErrorOnTernary()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0109NoErrorOnConditional()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken))
+        {
+            if (async)
+            {
+                return await Task.FromResult(42).ConfigureAwait(false);
+            }
+            else
+            {
+                return 42;
+            }
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0111Tests.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AZC0111Tests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Verifier = Azure.SdkAnalyzers.Tests.AzureAnalyzerVerifier<Azure.SdkAnalyzers.AsyncPatternAnalyzer>;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public class AZC0111Tests
+    {
+        private const string AzureCorePipelineTaskExtensions = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+        public static void EnsureCompleted(this Task task) => task.GetAwaiter().GetResult();
+    }
+}
+";
+
+        [Test]
+        public async Task AZC0111ErrorEnsureCompleted()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            {|AZC0111:Task.Delay(0)|}.EnsureCompleted();
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0111ErrorEnsureCompletedOnVariable()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            var task = Task.Delay(0);
+            {|AZC0111:task|}.EnsureCompleted();
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0111ErrorEnsureCompletedWithAsyncParameter()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            {|AZC0111:FooImplAsync(async)|}.EnsureCompleted();
+        }
+
+        private static async Task FooImplAsync(bool async)
+        {
+            if (async) { await Task.Delay(0).ConfigureAwait(false); }
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0111NoErrorEnsureCompletedInSyncScope()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (!async)
+            {
+                Task.Delay(0).EnsureCompleted();
+            }
+            else
+            {
+                await Task.Delay(0).ConfigureAwait(false);
+            }
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+
+        [Test]
+        public async Task AZC0111NoErrorEnsureCompletedInSyncMethod()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+
+    public class MyClass
+    {
+        private static void Foo()
+        {
+            Task.Delay(0).EnsureCompleted();
+        }
+    }
+}";
+
+            await Verifier.CreateAnalyzer(code)
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
+        }
+    }
+}

--- a/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AzureTestExtensions.cs
+++ b/sdk/tools/Azure.SdkAnalyzers/tests/Azure.SdkAnalyzers.Tests/AzureTestExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Azure.SdkAnalyzers.Tests
+{
+    public static class AzureTestExtensions
+    {
+        public static CSharpAnalyzerTest<TAnalyzer, DefaultVerifier> WithSources<TAnalyzer>(this CSharpAnalyzerTest<TAnalyzer, DefaultVerifier> test, params string[] sources)
+            where TAnalyzer : DiagnosticAnalyzer, new()
+        {
+            foreach (var source in sources)
+            {
+                test.TestState.Sources.Add(source);
+            }
+            return test;
+        }
+
+        public static CSharpAnalyzerTest<TAnalyzer, DefaultVerifier> WithDisabledDiagnostics<TAnalyzer>(this CSharpAnalyzerTest<TAnalyzer, DefaultVerifier> test, params string[] diagnostics)
+            where TAnalyzer : DiagnosticAnalyzer, new()
+        {
+            test.DisabledDiagnostics.AddRange(diagnostics);
+            return test;
+        }
+    }
+}


### PR DESCRIPTION
Migrate AZC0013, AZC0101, AZC0108, AZC0109, AZC0111 from azure-sdk-tools to in-repo Azure.SdkAnalyzers project as Error + NotConfigurable.

These 5 rules have zero existing suppressions and are internal implementation correctness rules (not public API surface).

New files:
- AsyncPatternAnalyzer (AZC0101/0108/0109/0111)
- TaskCompletionSourceAnalyzer (AZC0013)
- MethodBodyAnalyzer + AsyncAnalyzerUtilities (supporting infrastructure)
- Tests for all 5 rules

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
