### PR TITLE
Refactor GetInputItemsAsync to return Item and add GetInputTextAsync convenience

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -6,8 +6,21 @@
 
 - Initial release of Azure.AI.AgentServer.Responses.
 - ASP.NET Core server library implementing the Azure AI Responses API.
-- `ResponseHandler` abstract class for custom response handling.
-- Streaming event builder pattern for real-time SSE responses.
+- `ResponseHandler` abstract class for custom response handling with `CreateAsync` returning `IAsyncEnumerable<ResponseStreamEvent>`.
+- `TextResponse` convenience class for simple text-only responses with a single delegate.
+- `ResponseEventStream` builder for full control over SSE event generation with automatic `sequenceNumber`, `outputIndex`, `contentIndex`, and `itemId` tracking.
+- `ResponseEventStream` convenience generators for emitting complete output items in one call:
+  - `OutputItemMessage(string text)` — emits a full text message output item (handles all inner SSE events automatically)
+  - `OutputItemMessage(IAsyncEnumerable<string> tokens, CancellationToken)` — streams tokens as `response.output_text.delta` events
+  - `OutputItemFunctionCall(name, callId, arguments)` — emits a complete function call output item
+  - `OutputItemReasoningItem(...)` — emits a reasoning output item
+- `ResponseContext` with `GetInputItemsAsync()` (returns `IReadOnlyList<Item>`) and `GetInputTextAsync()` convenience for accessing resolved input items and text content.
+- `IEnumerable<Item>.GetInputText()` extension method for extracting text from any sequence of input items.
+- `CreateResponse.GetInputExpanded()` extension for advanced access to expanded input items as `OutputItem` types.
 - Built-in in-memory response provider and execution tracking.
 - Support for default, streaming, background, and streaming+background response modes.
+- `AgentHostBuilder` convenience methods for zero-config server startup via `ResponsesServer.Run<T>()`.
 - Protocol identity registration with `ServerUserAgentRegistry` during route mapping.
+- `x-agent-response-id` header validation matching the Responses API specification.
+- Conversation ID round-trip support in both synchronous and SSE streaming modes.
+- OpenTelemetry distributed tracing via `Azure.AI.AgentServer.Responses` activity source.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
@@ -69,9 +69,47 @@ public class EchoHandler : ResponseHandler
 }
 ```
 
-**`ResponseEventStream` — full control over every SSE event:**
+**`ResponseEventStream` convenience generators — recommended for multi-output scenarios:**
 
-Use `ResponseEventStream` when you need multiple output types (reasoning, function calls), fine-grained delta control, or custom Response properties.
+When `TextResponse` is too simple but the full builder API is more than you need, use the convenience generators on `ResponseEventStream`. They handle all inner events (`output_item.added`, content deltas, `output_item.done`) automatically:
+
+```C# Snippet:Responses_ReadMe_EchoHandler_Convenience
+public class EchoHandlerConvenience : ResponseHandler
+{
+    public override async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
+        CreateResponse request,
+        ResponseContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var stream = new ResponseEventStream(context, request);
+
+        yield return stream.EmitCreated();
+        yield return stream.EmitInProgress();
+
+        // One call emits all text output events automatically.
+        var input = await context.GetInputTextAsync(cancellationToken: cancellationToken);
+        foreach (var evt in stream.OutputItemMessage($"Echo: {input}"))
+            yield return evt;
+
+        yield return stream.EmitCompleted();
+    }
+}
+```
+
+Available convenience generators:
+
+| Method | Description |
+|--------|-------------|
+| `OutputItemMessage(string)` | Emits a complete text message output item |
+| `OutputItemMessage(IAsyncEnumerable<string>, CancellationToken)` | Streams tokens as `response.output_text.delta` events |
+| `OutputItemFunctionCall(name, callId, arguments)` | Emits a complete function call output item |
+| `OutputItemReasoningItem(...)` | Emits a reasoning output item |
+
+See [Sample 3 — Full control ResponseStream](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample3_FullControlResponseStream.md) and [Sample 4 — Function calling](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample4_FunctionCalling.md) for more examples.
+
+**`ResponseEventStream` — full builder control:**
+
+Use the full builder API only when you need fine-grained control over individual delta/done events within a content part, or to set custom properties on output items:
 
 ```C# Snippet:Responses_ReadMe_EchoHandler_FullControl
 public class EchoHandlerFullControl : ResponseHandler

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
@@ -60,10 +60,10 @@ public class EchoHandler : ResponseHandler
         CancellationToken cancellationToken)
     {
         return new TextResponse(context, request,
-            createText: ct =>
+            createText: async ct =>
             {
-                var input = request.GetInputText();
-                return Task.FromResult($"Echo: {input}");
+                var input = await context.GetInputTextAsync(cancellationToken: ct);
+                return $"Echo: {input}";
             });
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
@@ -560,7 +560,8 @@ namespace Azure.AI.AgentServer.Responses
         public virtual System.BinaryData? RawBody { get { throw null; } }
         public string ResponseId { get { throw null; } }
         public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Azure.AI.AgentServer.Responses.Models.OutputItem>> GetHistoryAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Azure.AI.AgentServer.Responses.Models.OutputItem>> GetInputItemsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Azure.AI.AgentServer.Responses.Models.Item>> GetInputItemsAsync(bool resolveReferences = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<string> GetInputTextAsync(bool resolveReferences = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public static partial class ResponseContextExtensions
     {
@@ -2267,7 +2268,6 @@ namespace Azure.AI.AgentServer.Responses.Models
         public static Azure.AI.AgentServer.Responses.Models.ConversationParam? GetConversationExpanded(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
         public static string? GetConversationId(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
         public static System.Collections.Generic.List<Azure.AI.AgentServer.Responses.Models.Item> GetInputExpanded(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
-        public static string GetInputText(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
         public static System.BinaryData? GetInstructionsBinaryData(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
         public static Azure.AI.AgentServer.Responses.Models.ToolChoiceParam? GetToolChoiceExpanded(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
     }
@@ -3459,6 +3459,10 @@ namespace Azure.AI.AgentServer.Responses.Models
         Azure.AI.AgentServer.Responses.Models.ItemCustomToolCallOutput System.ClientModel.Primitives.IPersistableModel<Azure.AI.AgentServer.Responses.Models.ItemCustomToolCallOutput>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         string System.ClientModel.Primitives.IPersistableModel<Azure.AI.AgentServer.Responses.Models.ItemCustomToolCallOutput>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.AI.AgentServer.Responses.Models.ItemCustomToolCallOutput>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public static partial class ItemExtensions
+    {
+        public static string GetInputText(this System.Collections.Generic.IEnumerable<Azure.AI.AgentServer.Responses.Models.Item> items) { throw null; }
     }
     public abstract partial class ItemField : System.ClientModel.Primitives.IJsonModel<Azure.AI.AgentServer.Responses.Models.ItemField>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.AgentServer.Responses.Models.ItemField>
     {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
@@ -560,7 +560,8 @@ namespace Azure.AI.AgentServer.Responses
         public virtual System.BinaryData? RawBody { get { throw null; } }
         public string ResponseId { get { throw null; } }
         public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Azure.AI.AgentServer.Responses.Models.OutputItem>> GetHistoryAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Azure.AI.AgentServer.Responses.Models.OutputItem>> GetInputItemsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Azure.AI.AgentServer.Responses.Models.Item>> GetInputItemsAsync(bool resolveReferences = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public virtual System.Threading.Tasks.Task<string> GetInputTextAsync(bool resolveReferences = true, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public static partial class ResponseContextExtensions
     {
@@ -2267,7 +2268,6 @@ namespace Azure.AI.AgentServer.Responses.Models
         public static Azure.AI.AgentServer.Responses.Models.ConversationParam? GetConversationExpanded(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
         public static string? GetConversationId(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
         public static System.Collections.Generic.List<Azure.AI.AgentServer.Responses.Models.Item> GetInputExpanded(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
-        public static string GetInputText(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
         public static System.BinaryData? GetInstructionsBinaryData(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
         public static Azure.AI.AgentServer.Responses.Models.ToolChoiceParam? GetToolChoiceExpanded(this Azure.AI.AgentServer.Responses.Models.CreateResponse request) { throw null; }
     }
@@ -3459,6 +3459,10 @@ namespace Azure.AI.AgentServer.Responses.Models
         Azure.AI.AgentServer.Responses.Models.ItemCustomToolCallOutput System.ClientModel.Primitives.IPersistableModel<Azure.AI.AgentServer.Responses.Models.ItemCustomToolCallOutput>.Create(System.BinaryData data, System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         string System.ClientModel.Primitives.IPersistableModel<Azure.AI.AgentServer.Responses.Models.ItemCustomToolCallOutput>.GetFormatFromOptions(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
         System.BinaryData System.ClientModel.Primitives.IPersistableModel<Azure.AI.AgentServer.Responses.Models.ItemCustomToolCallOutput>.Write(System.ClientModel.Primitives.ModelReaderWriterOptions options) { throw null; }
+    }
+    public static partial class ItemExtensions
+    {
+        public static string GetInputText(this System.Collections.Generic.IEnumerable<Azure.AI.AgentServer.Responses.Models.Item> items) { throw null; }
     }
     public abstract partial class ItemField : System.ClientModel.Primitives.IJsonModel<Azure.AI.AgentServer.Responses.Models.ItemField>, System.ClientModel.Primitives.IPersistableModel<Azure.AI.AgentServer.Responses.Models.ItemField>
     {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
@@ -75,10 +75,10 @@ public class EchoHandler : ResponseHandler
         CancellationToken cancellationToken)
     {
         return new TextResponse(context, request,
-            createText: ct =>
+            createText: async ct =>
             {
-                var input = request.GetInputText();
-                return Task.FromResult($"Echo: {input}");
+                var input = await context.GetInputTextAsync(cancellationToken: ct);
+                return $"Echo: {input}";
             });
     }
 }
@@ -111,7 +111,7 @@ public override IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
     return new TextResponse(context, request,
         createText: async ct =>
         {
-            var answer = await _model.GenerateAsync(request.GetInputText(), ct);
+            var answer = await _model.GenerateAsync(await context.GetInputTextAsync(cancellationToken: ct), ct);
             return answer;
         });
 }
@@ -454,8 +454,10 @@ public class ResponseContext
     public string ResponseId { get; }
     public bool IsShutdownRequested { get; set; }
     public virtual BinaryData? RawBody { get; }
-    public virtual Task<IReadOnlyList<OutputItem>> GetInputItemsAsync(CancellationToken cancellationToken = default);
+    public virtual Task<IReadOnlyList<Item>> GetInputItemsAsync(bool resolveReferences = true, CancellationToken cancellationToken = default);
+    public virtual Task<string> GetInputTextAsync(bool resolveReferences = true, CancellationToken cancellationToken = default);
     public virtual Task<IReadOnlyList<OutputItem>> GetHistoryAsync(CancellationToken cancellationToken = default);
+    public virtual IsolationContext Isolation { get; }
     public virtual IReadOnlyDictionary<string, string> ClientHeaders { get; }
     public virtual IReadOnlyDictionary<string, StringValues> QueryParameters { get; }
 }
@@ -465,22 +467,39 @@ Provides the library-generated response ID, shutdown signalling, access to resol
 
 ### Input Items — `GetInputItemsAsync()`
 
-Returns the caller's input items fully resolved and converted to `OutputItem` types:
+Returns the caller's input items as their `Item` subtypes:
 
 ```csharp
 public async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
     CreateResponse request, ResponseContext context, CancellationToken ct)
 {
-    var inputItems = await context.GetInputItemsAsync(ct);
-    // inputItems contains OutputItemMessage instances with generated IDs
-    // Inline items are converted; item references are resolved via the provider
+    var inputItems = await context.GetInputItemsAsync(cancellationToken: ct);
+    // inputItems contains ItemMessage, FunctionCallOutputItemParam, etc.
+    // Inline items are returned directly; item references are resolved via the provider
 }
 ```
 
-- **Inline items** are converted to their corresponding `OutputItem` subtypes with a generated type-specific ID and `status: completed`. For example, a `{"type":"message","role":"user","content":"Hi"}` becomes an `OutputItemMessage` with a `msg_` prefixed ID, a function call output becomes `OutputItemFunctionCallOutput` with an `fco_` prefixed ID, and so on for all 24+ supported item types.
-- **Item references** (e.g., `{"type":"item_reference","id":"msg_123"}`) are batch-resolved via `ResponsesProvider.GetItemsAsync`.
+- **Inline items** are returned as-is — the same `Item` subtypes from the original request (e.g., `ItemMessage`, `FunctionCallOutputItemParam`, `ItemFunctionToolCall`).
+- **Item references** (e.g., `{"type":"item_reference","id":"msg_123"}`) are batch-resolved via `ResponsesProvider.GetItemsAsync` and converted back to their corresponding `Item` subtypes.
+- **`resolveReferences` parameter** — pass `false` to skip reference resolution and receive `ItemReferenceParam` instances as-is: `await context.GetInputItemsAsync(resolveReferences: false, cancellationToken: ct)`.
 - **Input order is preserved** — items are returned in the same order as in the request.
-- **Lazy singleton** — the result is computed once on first call and cached. Subsequent calls return the same instance. Thread-safe.
+- **Lazy singleton** — the result is computed once on first call and cached per `resolveReferences` mode. Subsequent calls return the same instance. Thread-safe.
+
+### Input Text — `GetInputTextAsync()`
+
+A convenience that resolves input items and extracts all text content as a single string:
+
+```csharp
+var text = await context.GetInputTextAsync(cancellationToken: ct);
+// Equivalent to: (await context.GetInputItemsAsync(ct)).GetInputText()
+```
+
+You can also use the `GetInputText()` extension on any `IEnumerable<Item>`:
+
+```csharp
+var items = await context.GetInputItemsAsync(cancellationToken: ct);
+var text = items.GetInputText(); // filters for ItemMessage, joins text content
+```
 
 ### Conversation History — `GetHistoryAsync()`
 
@@ -672,7 +691,7 @@ public async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
 {
     await Task.CompletedTask;
     var stream = new ResponseEventStream(context, request);
-    var inputItems = request.GetInputExpanded();
+    var inputItems = await context.GetInputItemsAsync(cancellationToken: cancellationToken);
 
     // Check if this is a follow-up with function output
     var toolOutput = inputItems.OfType<FunctionCallOutputItemParam>().FirstOrDefault();
@@ -807,14 +826,20 @@ yield return mcp.EmitDone();       // Output item has Status = Failed
 
 ## Handling Input
 
-Access the client's input via `request.GetInputExpanded()`:
+Access the client's input via `context.GetInputItemsAsync()`:
 
 ```csharp
-var inputItems = request.GetInputExpanded();
+var inputItems = await context.GetInputItemsAsync(cancellationToken: ct);
 
 // Check for specific input types
-var textInputs = inputItems.OfType<EasyInputMessageItemParam>();
+var textMessages = inputItems.OfType<ItemMessage>();
 var functionOutputs = inputItems.OfType<FunctionCallOutputItemParam>();
+```
+
+Or use `context.GetInputTextAsync()` when you only need the text content:
+
+```csharp
+var text = await context.GetInputTextAsync(cancellationToken: ct);
 ```
 
 The `CreateResponse` object also provides:
@@ -845,7 +870,7 @@ foreach (var item in inputItems.OfType<ItemMessage>())
 }
 ```
 
-This complements the request-level helpers (`GetInputExpanded`, `GetInputText`, `GetToolChoiceExpanded`) — they operate on the `CreateResponse` request, while `GetContentExpanded` operates on individual `ItemMessage` instances.
+This complements the context-level helpers (`GetInputItemsAsync`, `GetInputTextAsync`) — they resolve and return input items from the `ResponseContext`, while `GetContentExpanded` operates on individual `ItemMessage` instances.
 
 ---
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
@@ -491,7 +491,7 @@ A convenience that resolves input items and extracts all text content as a singl
 
 ```csharp
 var text = await context.GetInputTextAsync(cancellationToken: ct);
-// Equivalent to: (await context.GetInputItemsAsync(ct)).GetInputText()
+// Equivalent to: (await context.GetInputItemsAsync(cancellationToken: ct)).GetInputText()
 ```
 
 You can also use the `GetInputText()` extension on any `IEnumerable<Item>`:

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample10_StreamingOpenAIUpstream.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample10_StreamingOpenAIUpstream.md
@@ -48,7 +48,7 @@ public class StreamingUpstreamHandler : ResponseHandler
         // Translate every input item. Both model stacks share the
         // same JSON wire contract, so .Translate().To<T>() round-trips
         // through JSON: our Item → JSON → OpenAI ResponseItem.
-        foreach (Item item in request.GetInputExpanded())
+        foreach (Item item in await context.GetInputItemsAsync(cancellationToken: cancellationToken))
         {
             options.InputItems.Add(item.Translate().To<ResponseItem>());
         }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample11_NonStreamingOpenAIUpstream.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample11_NonStreamingOpenAIUpstream.md
@@ -49,7 +49,7 @@ public class NonStreamingUpstreamHandler : ResponseHandler
         // Translate every input item with full fidelity.
         // Both model stacks share the same JSON wire contract, so
         // .Translate().To<T>() round-trips through JSON to convert.
-        foreach (Item item in request.GetInputExpanded())
+        foreach (Item item in await context.GetInputItemsAsync(cancellationToken: cancellationToken))
         {
             options.InputItems.Add(item.Translate().To<ResponseItem>());
         }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample1_GettingStarted.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample1_GettingStarted.md
@@ -19,10 +19,10 @@ public class EchoHandler : ResponseHandler
         CancellationToken cancellationToken)
     {
         return new TextResponse(context, request,
-            createText: ct =>
+            createText: async ct =>
             {
-                var input = request.GetInputText();
-                return Task.FromResult($"Echo: {input}");
+                var input = await context.GetInputTextAsync(cancellationToken: ct);
+                return $"Echo: {input}";
             });
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample3_FullControlResponseStream.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample3_FullControlResponseStream.md
@@ -33,7 +33,7 @@ public class GreetingHandler : ResponseHandler
         yield return stream.EmitInProgress();
 
         // Emit a complete text message in one call.
-        var input = request.GetInputText();
+        var input = await context.GetInputTextAsync(cancellationToken: cancellationToken);
         foreach (var evt in stream.OutputItemMessage($"Hello! You said: \"{input}\""))
             yield return evt;
 
@@ -60,8 +60,9 @@ public class StreamingGreetingHandler : ResponseHandler
         yield return stream.EmitInProgress();
 
         // Stream tokens as they arrive — each chunk becomes a delta event.
+        var inputText = await context.GetInputTextAsync(cancellationToken: cancellationToken);
         await foreach (var evt in stream.OutputItemMessage(
-            GenerateTokensAsync(request.GetInputText(), cancellationToken),
+            GenerateTokensAsync(inputText, cancellationToken),
             cancellationToken))
         {
             yield return evt;
@@ -116,7 +117,7 @@ public class GreetingHandlerFullControl : ResponseHandler
         yield return text.EmitAdded();       // response.content_part.added
 
         // Emit the text body — delta first, then the final "done" with full text.
-        var input = request.GetInputText();
+        var input = await context.GetInputTextAsync(cancellationToken: cancellationToken);
         var reply = $"Hello! You said: \"{input}\"";
         yield return text.EmitDelta(reply);  // response.output_text.delta
         yield return text.EmitDone(reply);   // response.output_text.done

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample4_FunctionCalling.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample4_FunctionCalling.md
@@ -24,7 +24,7 @@ public class WeatherHandler : ResponseHandler
         var stream = new ResponseEventStream(context, request);
 
         // Check if the input contains a function call output (turn 2)
-        var inputItems = request.GetInputExpanded();
+        var inputItems = await context.GetInputItemsAsync(cancellationToken: cancellationToken);
         var toolOutput = inputItems.OfType<FunctionCallOutputItemParam>().FirstOrDefault();
 
         if (toolOutput is not null)
@@ -75,7 +75,7 @@ public class WeatherHandlerFullControl : ResponseHandler
         var stream = new ResponseEventStream(context, request);
 
         // Check if the input contains a function call output (turn 2)
-        var inputItems = request.GetInputExpanded();
+        var inputItems = await context.GetInputItemsAsync(cancellationToken: cancellationToken);
         var toolOutput = inputItems.OfType<FunctionCallOutputItemParam>().FirstOrDefault();
 
         if (toolOutput is not null)

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample5_ConversationHistory.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample5_ConversationHistory.md
@@ -25,7 +25,7 @@ public class StudyTutorHandler : ResponseHandler
                 // Returns empty list if no previous_response_id is set.
                 var history = await context.GetHistoryAsync(ct);
 
-                var currentInput = request.GetInputText();
+                var currentInput = await context.GetInputTextAsync(cancellationToken: ct);
                 var turnNumber = history.OfType<OutputItemMessage>().Count() + 1;
 
                 // In a real agent, pass the history + current question to a model.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample6_MultiOutput.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample6_MultiOutput.md
@@ -22,7 +22,7 @@ public class MathSolverHandler : ResponseHandler
     {
         await Task.CompletedTask;
         var stream = new ResponseEventStream(context, request);
-        var question = request.GetInputText();
+        var question = await context.GetInputTextAsync(cancellationToken: cancellationToken);
 
         yield return stream.EmitCreated();
         yield return stream.EmitInProgress();
@@ -59,7 +59,7 @@ public class MathSolverHandlerFullControl : ResponseHandler
     {
         await Task.CompletedTask;
         var stream = new ResponseEventStream(context, request);
-        var question = request.GetInputText();
+        var question = await context.GetInputTextAsync(cancellationToken: cancellationToken);
 
         yield return stream.EmitCreated();
         yield return stream.EmitInProgress();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample7_Tier1HostingCustomize.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample7_Tier1HostingCustomize.md
@@ -36,7 +36,8 @@ public class KnowledgeHandler : ResponseHandler
         return new TextResponse(context, request,
             createText: async ct =>
             {
-                var question = await context.GetInputTextAsync(cancellationToken: ct);                        return await _kb.SearchAsync(question, ct);
+                var question = await context.GetInputTextAsync(cancellationToken: ct);
+                return await _kb.SearchAsync(question, ct);
             });
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample7_Tier1HostingCustomize.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample7_Tier1HostingCustomize.md
@@ -36,8 +36,7 @@ public class KnowledgeHandler : ResponseHandler
         return new TextResponse(context, request,
             createText: async ct =>
             {
-                var question = request.GetInputText();
-                return await _kb.SearchAsync(question, ct);
+                var question = await context.GetInputTextAsync(cancellationToken: ct);                        return await _kb.SearchAsync(question, ct);
             });
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample8_Tier2HostingBuilder.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample8_Tier2HostingBuilder.md
@@ -75,7 +75,8 @@ public class KnowledgeHandler : ResponseHandler
         return new TextResponse(context, request,
             createText: async ct =>
             {
-                var question = await context.GetInputTextAsync(cancellationToken: ct);                        return await _kb.SearchAsync(question, ct);
+                var question = await context.GetInputTextAsync(cancellationToken: ct);
+                return await _kb.SearchAsync(question, ct);
             });
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample8_Tier2HostingBuilder.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample8_Tier2HostingBuilder.md
@@ -75,8 +75,7 @@ public class KnowledgeHandler : ResponseHandler
         return new TextResponse(context, request,
             createText: async ct =>
             {
-                var question = request.GetInputText();
-                return await _kb.SearchAsync(question, ct);
+                var question = await context.GetInputTextAsync(cancellationToken: ct);                        return await _kb.SearchAsync(question, ct);
             });
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample9_Tier3SelfHosting.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample9_Tier3SelfHosting.md
@@ -49,8 +49,7 @@ public class KnowledgeHandler : ResponseHandler
         return new TextResponse(context, request,
             createText: async ct =>
             {
-                var question = request.GetInputText();
-                return await _kb.SearchAsync(question, ct);
+                var question = await context.GetInputTextAsync(cancellationToken: ct);                        return await _kb.SearchAsync(question, ct);
             });
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample9_Tier3SelfHosting.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample9_Tier3SelfHosting.md
@@ -49,7 +49,8 @@ public class KnowledgeHandler : ResponseHandler
         return new TextResponse(context, request,
             createText: async ct =>
             {
-                var question = await context.GetInputTextAsync(cancellationToken: ct);                        return await _kb.SearchAsync(question, ct);
+                var question = await context.GetInputTextAsync(cancellationToken: ct);
+                return await _kb.SearchAsync(question, ct);
             });
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Custom/CreateResponseExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Custom/CreateResponseExtensions.cs
@@ -115,7 +115,7 @@ public static class CreateResponseExtensions
     /// <exception cref="FormatException">
     /// The input data could not be parsed (propagated from <see cref="GetInputExpanded"/>).
     /// </exception>
-    public static string GetInputText(this CreateResponse request)
+    internal static string GetInputText(this CreateResponse request)
     {
         Argument.AssertNotNull(request, nameof(request));
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Custom/ItemExtensions.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Custom/ItemExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Azure.AI.AgentServer.Responses.Models;
+
+/// <summary>
+/// Extension methods for sequences of <see cref="Item"/> instances.
+/// </summary>
+public static class ItemExtensions
+{
+    /// <summary>
+    /// Extracts all text content from a sequence of <see cref="Item"/> instances as a single string.
+    /// Filters for <see cref="ItemMessage"/> items, expands their content via
+    /// <see cref="ItemMessageExtensions.GetContentExpanded"/>, and joins all
+    /// <see cref="MessageContentInputTextContent.Text"/> values with newline separators.
+    /// </summary>
+    /// <param name="items">The input items to extract text from.</param>
+    /// <returns>
+    /// The combined text content, or an empty string if no text content is found.
+    /// </returns>
+    public static string GetInputText(this IEnumerable<Item> items)
+    {
+        Argument.AssertNotNull(items, nameof(items));
+
+        var texts = items
+            .OfType<ItemMessage>()
+            .SelectMany(msg => msg.GetContentExpanded())
+            .OfType<MessageContentInputTextContent>()
+            .Select(tc => tc.Text);
+
+        return string.Join("\n", texts);
+    }
+}

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ItemConversion.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ItemConversion.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.ClientModel.Primitives;
 using Azure.AI.AgentServer.Responses.Models;
 
 namespace Azure.AI.AgentServer.Responses.Internal;
@@ -184,6 +185,29 @@ internal static class ItemConversion
             {
                 yield return output;
             }
+        }
+    }
+
+    /// <summary>
+    /// Converts an <see cref="OutputItem"/> to its corresponding <see cref="Item"/> representation
+    /// using JSON round-trip serialization. Both hierarchies share the same <c>"type"</c>
+    /// discriminator values, so serializing an <see cref="OutputItem"/> and deserializing as
+    /// <see cref="Item"/> produces the correct concrete subtype (e.g., <see cref="OutputItemMessage"/>
+    /// → <see cref="ItemMessage"/>). Returns <c>null</c> if the output item has a type that does not
+    /// map to any <see cref="Item"/> subtype.
+    /// </summary>
+    /// <param name="outputItem">The output item to convert.</param>
+    /// <returns>The corresponding input item, or <c>null</c> if conversion is not possible.</returns>
+    internal static Item? ToItem(OutputItem outputItem)
+    {
+        try
+        {
+            var json = ModelReaderWriter.Write(outputItem, ModelReaderWriterOptions.Json, AzureAIAgentServerResponsesContext.Default);
+            return ModelReaderWriter.Read<Item>(json, ModelReaderWriterOptions.Json, AzureAIAgentServerResponsesContext.Default);
+        }
+        catch
+        {
+            return null;
         }
     }
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseContextImpl.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseContextImpl.cs
@@ -11,15 +11,17 @@ namespace Azure.AI.AgentServer.Responses.Internal;
 /// <summary>
 /// Enhanced implementation of <see cref="ResponseContext"/> that resolves
 /// input items and conversation history from the request, using lazy-cached async resolution.
-/// Inline items are converted via <see cref="ItemConversion"/>; item
-/// references are resolved via <see cref="ResponsesProvider.GetItemsAsync"/>.
+/// Inline items are returned as their <see cref="Item"/> subtypes;
+/// item references are resolved via <see cref="ResponsesProvider.GetItemsAsync"/>
+/// and converted back to <see cref="Item"/>.
 /// </summary>
 internal sealed class ResponseContextImpl : ResponseContext
 {
     private readonly ResponsesProvider _provider;
     private readonly CreateResponse _request;
     private readonly int _historyLimit;
-    private readonly Lazy<Task<IReadOnlyList<OutputItem>>> _inputItems;
+    private readonly Lazy<Task<IReadOnlyList<Item>>> _inputItemsResolved;
+    private readonly Lazy<Task<IReadOnlyList<Item>>> _inputItemsUnresolved;
     private readonly Lazy<Task<IReadOnlyList<string>>> _historyItemIds;
     private readonly Lazy<Task<IReadOnlyList<OutputItem>>> _history;
     private readonly BinaryData? _rawBody;
@@ -56,7 +58,8 @@ internal sealed class ResponseContextImpl : ResponseContext
         _provider = provider;
         _request = request;
         _historyLimit = options?.Value.DefaultFetchHistoryCount ?? ResponsesServerOptions.DefaultFetchHistoryCountValue;
-        _inputItems = new Lazy<Task<IReadOnlyList<OutputItem>>>(ResolveInputItemsAsync);
+        _inputItemsResolved = new Lazy<Task<IReadOnlyList<Item>>>(() => ResolveInputItemsAsync(resolveReferences: true));
+        _inputItemsUnresolved = new Lazy<Task<IReadOnlyList<Item>>>(() => ResolveInputItemsAsync(resolveReferences: false));
         _historyItemIds = new Lazy<Task<IReadOnlyList<string>>>(ResolveHistoryItemIdsAsync);
         _history = new Lazy<Task<IReadOnlyList<OutputItem>>>(ResolveHistoryAsync);
     }
@@ -74,12 +77,26 @@ internal sealed class ResponseContextImpl : ResponseContext
     public override IReadOnlyDictionary<string, StringValues> QueryParameters => _queryParameters;
 
     /// <inheritdoc/>
-    public override Task<IReadOnlyList<OutputItem>> GetInputItemsAsync(CancellationToken cancellationToken = default)
-        => _inputItems.Value;
+    public override Task<IReadOnlyList<Item>> GetInputItemsAsync(bool resolveReferences = true, CancellationToken cancellationToken = default)
+        => resolveReferences ? _inputItemsResolved.Value : _inputItemsUnresolved.Value;
 
     /// <inheritdoc/>
     public override Task<IReadOnlyList<OutputItem>> GetHistoryAsync(CancellationToken cancellationToken = default)
         => _history.Value;
+
+    /// <summary>
+    /// Returns the input items as <see cref="OutputItem"/> for persistence.
+    /// The orchestrator needs output items when creating the stored response.
+    /// </summary>
+    internal async Task<IReadOnlyList<OutputItem>> GetInputItemsForPersistenceAsync()
+    {
+        var items = await GetInputItemsAsync(resolveReferences: true).ConfigureAwait(false);
+        return items
+            .Select(item => ItemConversion.ToOutputItem(item, ResponseId))
+            .Where(item => item is not null)
+            .Select(item => item!)
+            .ToList();
+    }
 
     /// <summary>
     /// Gets the cached history item IDs. Used by the orchestrator to pass IDs
@@ -88,15 +105,21 @@ internal sealed class ResponseContextImpl : ResponseContext
     internal Task<IReadOnlyList<string>> GetHistoryItemIdsAsync()
         => _historyItemIds.Value;
 
-    private async Task<IReadOnlyList<OutputItem>> ResolveInputItemsAsync()
+    private async Task<IReadOnlyList<Item>> ResolveInputItemsAsync(bool resolveReferences)
     {
         var input = _request.GetInputExpanded();
         if (input.Count == 0)
         {
-            return Array.Empty<OutputItem>();
+            return Array.Empty<Item>();
         }
 
-        var results = new List<OutputItem>();
+        if (!resolveReferences)
+        {
+            // Return items as-is (including ItemReferenceParam)
+            return input;
+        }
+
+        var results = new List<Item>();
 
         // Collect item references for batch resolution
         var referenceIds = new List<string>();
@@ -113,11 +136,7 @@ internal sealed class ResponseContextImpl : ResponseContext
             }
             else
             {
-                var output = ItemConversion.ToOutputItem(item, ResponseId);
-                if (output is not null)
-                {
-                    results.Add(output);
-                }
+                results.Add(item);
             }
 
             position++;
@@ -133,7 +152,11 @@ internal sealed class ResponseContextImpl : ResponseContext
                 var pos = referencePositions[i];
                 if (i < resolved.Count && resolved[i] is not null)
                 {
-                    results[pos] = resolved[i]!;
+                    var converted = ItemConversion.ToItem(resolved[i]!);
+                    if (converted is not null)
+                    {
+                        results[pos] = converted;
+                    }
                 }
             }
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseOrchestrator.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseOrchestrator.cs
@@ -823,7 +823,20 @@ internal sealed class ResponseOrchestrator
 
         try
         {
-            inputItems = await context.GetInputItemsAsync();
+            if (context is ResponseContextImpl impl)
+            {
+                inputItems = await impl.GetInputItemsForPersistenceAsync();
+            }
+            else
+            {
+                // Fallback: resolve items and convert to OutputItem for persistence
+                var items = await context.GetInputItemsAsync();
+                inputItems = items
+                    .Select(item => ItemConversion.ToOutputItem(item, context.ResponseId))
+                    .Where(item => item is not null)
+                    .Select(item => item!)
+                    .ToList();
+            }
         }
         catch
         {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/ResponseContext.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/ResponseContext.cs
@@ -45,14 +45,21 @@ public class ResponseContext
 
     /// <summary>
     /// Resolves and returns the input items for the current request.
-    /// Inline items are converted to <see cref="OutputItem"/> instances;
-    /// item references are resolved via the provider. Results are cached
-    /// after the first call.
+    /// Inline items are returned as their <see cref="Item"/> subtypes;
+    /// item references are optionally resolved via the provider and converted
+    /// to <see cref="Item"/> subtypes. Results are cached after the first call
+    /// for each <paramref name="resolveReferences"/> mode.
     /// </summary>
+    /// <param name="resolveReferences">
+    /// When <c>true</c> (the default), <see cref="Models.ItemReferenceParam"/> items
+    /// are resolved via the provider and returned as their concrete <see cref="Item"/> subtype.
+    /// When <c>false</c>, item references are left as <see cref="Models.ItemReferenceParam"/>
+    /// in the returned list.
+    /// </param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>The resolved input items.</returns>
-    public virtual Task<IReadOnlyList<OutputItem>> GetInputItemsAsync(CancellationToken cancellationToken = default)
-        => Task.FromResult<IReadOnlyList<OutputItem>>(Array.Empty<OutputItem>());
+    public virtual Task<IReadOnlyList<Item>> GetInputItemsAsync(bool resolveReferences = true, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<Item>>(Array.Empty<Item>());
 
     /// <summary>
     /// Resolves and returns the conversation history items for the current request.
@@ -64,6 +71,24 @@ public class ResponseContext
     /// <returns>The resolved history items, or an empty list if no conversation context exists.</returns>
     public virtual Task<IReadOnlyList<OutputItem>> GetHistoryAsync(CancellationToken cancellationToken = default)
         => Task.FromResult<IReadOnlyList<OutputItem>>(Array.Empty<OutputItem>());
+
+    /// <summary>
+    /// Resolves input items and extracts all text content as a single string.
+    /// Filters for <see cref="Models.ItemMessage"/> items, expands their content,
+    /// and joins all text values with newline separators.
+    /// </summary>
+    /// <param name="resolveReferences">
+    /// When <c>true</c> (the default), item references are resolved before extracting text.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// The combined text content, or an empty string if no text content is found.
+    /// </returns>
+    public virtual async Task<string> GetInputTextAsync(bool resolveReferences = true, CancellationToken cancellationToken = default)
+    {
+        var items = await GetInputItemsAsync(resolveReferences, cancellationToken).ConfigureAwait(false);
+        return items.GetInputText();
+    }
 
     /// <summary>
     /// Gets the platform-injected isolation keys for this request.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/ResponseContextImplTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/ResponseContextImplTests.cs
@@ -27,11 +27,11 @@ public class ResponseContextImplTests
     }
 
     // ═══════════════════════════════════════════════════════════════════════
-    // T044: Resolves inline ItemMessage to OutputItemMessage
+    // T044: Resolves inline ItemMessage — returned as ItemMessage (not OutputItemMessage)
     // ═══════════════════════════════════════════════════════════════════════
 
     [Test]
-    public async Task GetInputItemsAsync_Resolves_Inline_ItemMessage_To_OutputItemMessage()
+    public async Task GetInputItemsAsync_Returns_Inline_ItemMessage_Directly()
     {
         var request = CreateRequestWithJsonInput(
             """[{"type":"message","role":"user","content":[{"type":"input_text","text":"Hello, world!"}]}]""");
@@ -40,14 +40,13 @@ public class ResponseContextImplTests
         var items = await context.GetInputItemsAsync();
 
         XAssert.Single(items);
-        var msg = XAssert.IsType<OutputItemMessage>(items[0]);
-        XAssert.StartsWith("msg_", msg.Id);
-        Assert.That(msg.Status, Is.EqualTo(MessageStatus.Completed));
+        var msg = XAssert.IsType<ItemMessage>(items[0]);
         Assert.That(msg.Role, Is.EqualTo(MessageRole.User));
     }
 
     // ═══════════════════════════════════════════════════════════════════════
     // T045: Resolves ItemReferenceParam via ResponsesProvider.GetItemsAsync
+    //       and converts resolved OutputItem back to Item
     // ═══════════════════════════════════════════════════════════════════════
 
     [Test]
@@ -72,8 +71,8 @@ public class ResponseContextImplTests
         var items = await context.GetInputItemsAsync();
 
         XAssert.Single(items);
-        var msg = XAssert.IsType<OutputItemMessage>(items[0]);
-        Assert.That(msg.Id, Is.EqualTo("msg_existing"));
+        // Resolved reference is converted from OutputItemMessage to ItemMessage
+        var msg = XAssert.IsType<ItemMessage>(items[0]);
         Assert.That(msg.Role, Is.EqualTo(MessageRole.Assistant));
     }
 
@@ -119,7 +118,8 @@ public class ResponseContextImplTests
     }
 
     // ═══════════════════════════════════════════════════════════════════════
-    // T047: Preserves input item order
+    // T047: Preserves input item order (inline items stay as Item,
+    //       resolved references are converted from OutputItem to Item)
     // ═══════════════════════════════════════════════════════════════════════
 
     [Test]
@@ -143,20 +143,14 @@ public class ResponseContextImplTests
 
         Assert.That(items.Count, Is.EqualTo(3));
 
-        // First item: inline message
-        var first = XAssert.IsType<OutputItemMessage>(items[0]);
-        XAssert.StartsWith("msg_", first.Id);
+        // First item: inline message (stays as ItemMessage)
+        XAssert.IsType<ItemMessage>(items[0]);
 
-        // Second item: resolved reference
-        var second = XAssert.IsType<OutputItemMessage>(items[1]);
-        Assert.That(second.Id, Is.EqualTo("ref_middle"));
+        // Second item: resolved reference (converted from OutputItemMessage to ItemMessage)
+        XAssert.IsType<ItemMessage>(items[1]);
 
         // Third item: inline message
-        var third = XAssert.IsType<OutputItemMessage>(items[2]);
-        XAssert.StartsWith("msg_", third.Id);
-
-        // First and third should have different generated IDs
-        Assert.That(third.Id, Is.Not.EqualTo(first.Id));
+        XAssert.IsType<ItemMessage>(items[2]);
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -184,6 +178,122 @@ public class ResponseContextImplTests
         var items = await context.GetInputItemsAsync();
 
         Assert.That(items, Is.Empty);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // resolveReferences=false leaves ItemReferenceParam in result
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetInputItemsAsync_ResolveReferencesFalse_Returns_ItemReferenceParam_AsIs()
+    {
+        var request = CreateRequestWithJsonInput("""
+            [
+                {"type":"message","role":"user","content":[{"type":"input_text","text":"inline"}]},
+                {"type":"item_reference","id":"ref_1"}
+            ]
+            """);
+
+        var context = CreateContext(request);
+        var items = await context.GetInputItemsAsync(resolveReferences: false);
+
+        Assert.That(items.Count, Is.EqualTo(2));
+        XAssert.IsType<ItemMessage>(items[0]);
+        XAssert.IsType<ItemReferenceParam>(items[1]);
+    }
+
+    [Test]
+    public async Task GetInputItemsAsync_ResolveReferencesFalse_DoesNotCallProvider()
+    {
+        var provider = new RecordingProvider();
+        provider.AddItem("ref_1", new OutputItemMessage(
+            "ref_1", MessageStatus.Completed, MessageRole.User,
+            new List<MessageContent> { new MessageContentInputTextContent("ref") }));
+
+        var request = CreateRequestWithJsonInput(
+            """[{"type":"item_reference","id":"ref_1"}]""");
+
+        var context = CreateContext(request, provider);
+        await context.GetInputItemsAsync(resolveReferences: false);
+
+        Assert.That(provider.GetItemsCallCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task GetInputItemsAsync_BothModes_CacheIndependently()
+    {
+        var provider = new RecordingProvider();
+        provider.AddItem("ref_1", new OutputItemMessage(
+            "ref_1", MessageStatus.Completed, MessageRole.User,
+            new List<MessageContent> { new MessageContentInputTextContent("resolved") }));
+
+        var request = CreateRequestWithJsonInput(
+            """[{"type":"item_reference","id":"ref_1"}]""");
+
+        var context = CreateContext(request, provider);
+
+        var unresolved = await context.GetInputItemsAsync(resolveReferences: false);
+        var resolved = await context.GetInputItemsAsync(resolveReferences: true);
+
+        // Unresolved keeps the reference
+        XAssert.IsType<ItemReferenceParam>(unresolved[0]);
+
+        // Resolved converts to concrete type
+        XAssert.IsType<ItemMessage>(resolved[0]);
+
+        // Each mode is cached independently
+        Assert.That(await context.GetInputItemsAsync(resolveReferences: false), Is.SameAs(unresolved));
+        Assert.That(await context.GetInputItemsAsync(resolveReferences: true), Is.SameAs(resolved));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // GetInputTextAsync convenience method
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetInputTextAsync_Returns_ConcatenatedText_FromInlineMessages()
+    {
+        var request = CreateRequestWithJsonInput("""
+            [
+                {"type":"message","role":"user","content":[{"type":"input_text","text":"Hello"}]},
+                {"type":"message","role":"user","content":[{"type":"input_text","text":"World"}]}
+            ]
+            """);
+
+        var context = CreateContext(request);
+        var text = await context.GetInputTextAsync();
+
+        Assert.That(text, Is.EqualTo("Hello\nWorld"));
+    }
+
+    [Test]
+    public async Task GetInputTextAsync_Returns_Empty_When_No_Input()
+    {
+        var request = new CreateResponse { Model = "test" };
+        var context = CreateContext(request);
+
+        var text = await context.GetInputTextAsync();
+
+        Assert.That(text, Is.EqualTo(string.Empty));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // GetInputItemsForPersistenceAsync returns OutputItem for orchestrator
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetInputItemsForPersistenceAsync_Returns_OutputItems()
+    {
+        var request = CreateRequestWithJsonInput(
+            """[{"type":"message","role":"user","content":[{"type":"input_text","text":"Hello"}]}]""");
+
+        var context = CreateContext(request);
+        var items = await context.GetInputItemsForPersistenceAsync();
+
+        XAssert.Single(items);
+        var msg = XAssert.IsType<OutputItemMessage>(items[0]);
+        XAssert.StartsWith("msg_", msg.Id);
+        Assert.That(msg.Role, Is.EqualTo(MessageRole.User));
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/ItemReferenceMultiTurnTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/ItemReferenceMultiTurnTests.cs
@@ -298,9 +298,11 @@ public class ItemReferenceMultiTurnTests : IDisposable
         return doc.RootElement.Clone();
     }
 
-    private async Task WaitForCompletionAsync(string responseId, int maxAttempts = 20)
+    private async Task WaitForCompletionAsync(string responseId, TimeSpan? timeout = null)
     {
-        for (int i = 0; i < maxAttempts; i++)
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(5));
+
+        while (DateTime.UtcNow < deadline)
         {
             var response = await _client.GetAsync($"/responses/{responseId}");
             if (response.StatusCode == HttpStatusCode.OK)
@@ -317,7 +319,7 @@ public class ItemReferenceMultiTurnTests : IDisposable
             await Task.Delay(50);
         }
 
-        Assert.Fail($"Response {responseId} did not complete within timeout");
+        Assert.Fail($"Response {responseId} did not complete within {timeout ?? TimeSpan.FromSeconds(5)}");
     }
 
     public void Dispose()

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/ItemReferenceMultiTurnTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/ItemReferenceMultiTurnTests.cs
@@ -1,0 +1,329 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using Azure.AI.AgentServer.Responses.Models;
+using Azure.AI.AgentServer.Responses.Tests.Helpers;
+
+namespace Azure.AI.AgentServer.Responses.Tests.Protocol;
+
+/// <summary>
+/// E2E protocol tests for multi-turn scenarios where the second turn references
+/// an output item from the first turn's response via <c>item_reference</c>.
+/// Covers both default (streaming SSE) and background modes, verifying that
+/// the referenced item is resolved correctly and the handler receives the
+/// concrete <see cref="Item"/> content.
+/// </summary>
+public class ItemReferenceMultiTurnTests : IDisposable
+{
+    private readonly TestHandler _handler = new();
+    private readonly TestWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public ItemReferenceMultiTurnTests()
+    {
+        _handler.EventFactory = (_, ctx, ct) => EchoWithOutputMessage(ctx, ct);
+        _factory = new TestWebApplicationFactory(_handler);
+        _client = _factory.CreateClient();
+    }
+
+    /// <summary>
+    /// Turn 1 produces an output message. Turn 2 references that output via
+    /// <c>item_reference</c>. The response succeeds (200) and the handler's
+    /// <c>context.GetInputItemsAsync()</c> resolves the reference to the
+    /// original message content.
+    /// </summary>
+    [Test]
+    public async Task Turn2_ItemReference_ResolvesToTurn1OutputMessage()
+    {
+        // ── Turn 1: produce a response with an output message ──
+        var turn1Json = """
+        {
+            "model": "test",
+            "input": "What is the capital of France?"
+        }
+        """;
+        var turn1Response = await _client.PostAsync("/responses",
+            new StringContent(turn1Json, Encoding.UTF8, "application/json"));
+        var turn1Body = await turn1Response.Content.ReadAsStringAsync();
+        Assert.That(turn1Response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"Turn 1 POST failed: {turn1Body}");
+
+        using var turn1Doc = JsonDocument.Parse(turn1Body);
+        var turn1ResponseId = turn1Doc.RootElement.GetProperty("id").GetString()!;
+
+        // Extract the output item ID from turn 1's response
+        var outputItems = turn1Doc.RootElement.GetProperty("output");
+        Assert.That(outputItems.GetArrayLength(), Is.GreaterThan(0), "Turn 1 should have output items");
+        var outputItemId = outputItems[0].GetProperty("id").GetString()!;
+
+        // ── Turn 2: reference the output item from turn 1 ──
+        var turn2Json = $$"""
+        {
+            "model": "test",
+            "input": [
+                { "type": "item_reference", "id": "{{outputItemId}}" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "Summarize the above" }] }
+            ]
+        }
+        """;
+        var turn2Response = await _client.PostAsync("/responses",
+            new StringContent(turn2Json, Encoding.UTF8, "application/json"));
+        var turn2Body = await turn2Response.Content.ReadAsStringAsync();
+        Assert.That(turn2Response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"Turn 2 POST failed: {turn2Body}");
+
+        using var turn2Doc = JsonDocument.Parse(turn2Body);
+        var turn2ResponseId = turn2Doc.RootElement.GetProperty("id").GetString()!;
+        Assert.That(turn2ResponseId, Is.Not.EqualTo(turn1ResponseId));
+
+        // ── Verify: GET turn 2's input_items shows the resolved reference + inline message ──
+        var getResponse = await _client.GetAsync($"/responses/{turn2ResponseId}/input_items?order=asc");
+        Assert.That(getResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var getBody = await getResponse.Content.ReadAsStringAsync();
+        using var getDoc = JsonDocument.Parse(getBody);
+        var data = getDoc.RootElement.GetProperty("data");
+
+        // Should have 2 items: resolved reference + inline message
+        Assert.That(data.GetArrayLength(), Is.EqualTo(2),
+            $"Expected 2 input items (resolved ref + inline), got {data.GetArrayLength()}. Body: {getBody}");
+
+        // First item: the resolved reference (originally an output message from turn 1)
+        var resolvedItem = data[0];
+        Assert.That(resolvedItem.GetProperty("type").GetString(), Is.EqualTo("message"));
+
+        // Second item: the inline user message
+        var inlineItem = data[1];
+        Assert.That(inlineItem.GetProperty("type").GetString(), Is.EqualTo("message"));
+        var inlineContent = inlineItem.GetProperty("content");
+        Assert.That(inlineContent[0].GetProperty("text").GetString(), Is.EqualTo("Summarize the above"));
+    }
+
+    /// <summary>
+    /// Same as above but in background mode — verifies item_reference resolution works
+    /// for background responses too.
+    /// </summary>
+    [Test]
+    public async Task Turn2_Background_ItemReference_ResolvesToTurn1OutputMessage()
+    {
+        // ── Turn 1: produce a response ──
+        var turn1Json = """
+        {
+            "model": "test",
+            "input": "Tell me a joke"
+        }
+        """;
+        var turn1Response = await _client.PostAsync("/responses",
+            new StringContent(turn1Json, Encoding.UTF8, "application/json"));
+        var turn1Body = await turn1Response.Content.ReadAsStringAsync();
+        Assert.That(turn1Response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"Turn 1 failed: {turn1Body}");
+
+        using var turn1Doc = JsonDocument.Parse(turn1Body);
+        var outputItems = turn1Doc.RootElement.GetProperty("output");
+        Assert.That(outputItems.GetArrayLength(), Is.GreaterThan(0), "Turn 1 should have output items");
+        var outputItemId = outputItems[0].GetProperty("id").GetString()!;
+
+        // ── Turn 2: background mode with item_reference ──
+        var turn2Json = $$"""
+        {
+            "model": "test",
+            "background": true,
+            "input": [
+                { "type": "item_reference", "id": "{{outputItemId}}" }
+            ]
+        }
+        """;
+        var turn2Response = await _client.PostAsync("/responses",
+            new StringContent(turn2Json, Encoding.UTF8, "application/json"));
+        var turn2Body = await turn2Response.Content.ReadAsStringAsync();
+        Assert.That(turn2Response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"Turn 2 failed: {turn2Body}");
+
+        using var turn2Doc = JsonDocument.Parse(turn2Body);
+        var turn2ResponseId = turn2Doc.RootElement.GetProperty("id").GetString()!;
+
+        // Wait for background response to complete
+        await WaitForCompletionAsync(turn2ResponseId);
+
+        // ── Verify: GET input_items resolves the reference ──
+        var getResponse = await _client.GetAsync($"/responses/{turn2ResponseId}/input_items?order=asc");
+        Assert.That(getResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var getBody = await getResponse.Content.ReadAsStringAsync();
+        using var getDoc = JsonDocument.Parse(getBody);
+        var data = getDoc.RootElement.GetProperty("data");
+
+        Assert.That(data.GetArrayLength(), Is.EqualTo(1),
+            $"Expected 1 resolved input item, got {data.GetArrayLength()}. Body: {getBody}");
+        Assert.That(data[0].GetProperty("type").GetString(), Is.EqualTo("message"));
+    }
+
+    /// <summary>
+    /// Turn 2 references a non-existent item ID. The response still succeeds (200)
+    /// — unresolvable references are silently dropped.
+    /// </summary>
+    [Test]
+    public async Task Turn2_ItemReference_NonExistentId_IsDropped()
+    {
+        var json = """
+        {
+            "model": "test",
+            "input": [
+                { "type": "item_reference", "id": "msg_does_not_exist" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "Hello" }] }
+            ]
+        }
+        """;
+        var response = await _client.PostAsync("/responses",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"POST failed: {body}");
+
+        using var doc = JsonDocument.Parse(body);
+        var responseId = doc.RootElement.GetProperty("id").GetString()!;
+
+        // GET input_items — the unresolvable reference should be dropped,
+        // leaving only the inline message
+        var getResponse = await _client.GetAsync($"/responses/{responseId}/input_items?order=asc");
+        Assert.That(getResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var getBody = await getResponse.Content.ReadAsStringAsync();
+        using var getDoc = JsonDocument.Parse(getBody);
+        var data = getDoc.RootElement.GetProperty("data");
+
+        Assert.That(data.GetArrayLength(), Is.EqualTo(1),
+            $"Expected 1 item (unresolvable ref dropped), got {data.GetArrayLength()}. Body: {getBody}");
+        Assert.That(data[0].GetProperty("type").GetString(), Is.EqualTo("message"));
+    }
+
+    /// <summary>
+    /// Three-turn chain: turn 1 output → turn 2 references it via item_reference →
+    /// turn 3 uses previous_response_id to chain from turn 2. Verifies that
+    /// both item_reference resolution and previous_response_id history work
+    /// together in a realistic multi-turn flow.
+    /// </summary>
+    [Test]
+    public async Task ThreeTurnChain_ItemRefAndPreviousResponseId_Combined()
+    {
+        // ── Turn 1 ──
+        var turn1Response = await PostResponseAsync("""{ "model": "test", "input": "Turn 1 question" }""");
+        var turn1Id = turn1Response.GetProperty("id").GetString()!;
+        var outputItems = turn1Response.GetProperty("output");
+        Assert.That(outputItems.GetArrayLength(), Is.GreaterThan(0), "Turn 1 should have output items");
+        var outputItemId = outputItems[0].GetProperty("id").GetString()!;
+
+        // ── Turn 2: reference turn 1's output item ──
+        var turn2Json = $$"""
+        {
+            "model": "test",
+            "input": [
+                { "type": "item_reference", "id": "{{outputItemId}}" },
+                { "type": "message", "role": "user", "content": [{ "type": "input_text", "text": "Turn 2 follow-up" }] }
+            ]
+        }
+        """;
+        var turn2Response = await PostResponseAsync(turn2Json);
+        var turn2Id = turn2Response.GetProperty("id").GetString()!;
+
+        // ── Turn 3: chain from turn 2 via previous_response_id ──
+        var turn3Json = $$"""
+        {
+            "model": "test",
+            "input": "Turn 3 final question",
+            "previous_response_id": "{{turn2Id}}"
+        }
+        """;
+        var turn3Response = await PostResponseAsync(turn3Json);
+        var turn3Id = turn3Response.GetProperty("id").GetString()!;
+
+        // ── Verify turn 3's input_items include history from turn 2 + turn 3's inline ──
+        var getResponse = await _client.GetAsync($"/responses/{turn3Id}/input_items?order=asc");
+        Assert.That(getResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        var getBody = await getResponse.Content.ReadAsStringAsync();
+        using var getDoc = JsonDocument.Parse(getBody);
+        var data = getDoc.RootElement.GetProperty("data");
+
+        // Turn 2 stored 2 input items (resolved ref + inline) + turn 2's output.
+        // Turn 3 has its own inline input + history from turn 2.
+        // The exact count depends on history resolution, but must be > 1
+        Assert.That(data.GetArrayLength(), Is.GreaterThan(1),
+            $"Turn 3 should have history + current input. Body: {getBody}");
+
+        // The last item should be turn 3's inline input
+        var lastItem = data[data.GetArrayLength() - 1];
+        var lastContent = lastItem.GetProperty("content");
+        Assert.That(lastContent[0].GetProperty("text").GetString(), Is.EqualTo("Turn 3 final question"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Handler helper — produces an output message so item_reference can resolve it
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private static async IAsyncEnumerable<ResponseStreamEvent> EchoWithOutputMessage(
+        ResponseContext ctx,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+        var response = new Models.ResponseObject(ctx.ResponseId, "test") { Status = ResponseStatus.InProgress };
+        yield return new ResponseCreatedEvent(0, response);
+
+        var textContent = new MessageContentOutputTextContent(
+            "Echo reply", Array.Empty<Annotation>(), Array.Empty<LogProb>());
+        var msg = new OutputItemMessage(
+            $"msg_{Guid.NewGuid():N}",
+            MessageStatus.Completed,
+            new MessageContent[] { textContent });
+        yield return new ResponseOutputItemAddedEvent(0, 0, msg);
+        yield return new ResponseOutputItemDoneEvent(0, 0, msg);
+
+        var completedResponse = new Models.ResponseObject(ctx.ResponseId, "test");
+        completedResponse.Output.Add(msg);
+        completedResponse.SetCompleted();
+        yield return new ResponseCompletedEvent(0, completedResponse);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Helpers
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private async Task<JsonElement> PostResponseAsync(string json)
+    {
+        var response = await _client.PostAsync("/responses",
+            new StringContent(json, Encoding.UTF8, "application/json"));
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), $"POST failed: {body}");
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.Clone();
+    }
+
+    private async Task WaitForCompletionAsync(string responseId, int maxAttempts = 20)
+    {
+        for (int i = 0; i < maxAttempts; i++)
+        {
+            var response = await _client.GetAsync($"/responses/{responseId}");
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                using var doc = JsonDocument.Parse(body);
+                var status = doc.RootElement.GetProperty("status").GetString();
+                if (status is "completed" or "failed" or "cancelled" or "incomplete")
+                {
+                    return;
+                }
+            }
+
+            await Task.Delay(50);
+        }
+
+        Assert.Fail($"Response {responseId} did not complete within timeout");
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/ReadMeSnippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/ReadMeSnippets.cs
@@ -64,10 +64,10 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 CancellationToken cancellationToken)
             {
                 return new TextResponse(context, request,
-                    createText: ct =>
+                    createText: async ct =>
                     {
-                        var input = request.GetInputText();
-                        return Task.FromResult($"Echo: {input}");
+                        var input = await context.GetInputTextAsync(cancellationToken: ct);
+                        return $"Echo: {input}";
                     });
             }
         }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/ReadMeSnippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/ReadMeSnippets.cs
@@ -75,6 +75,38 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
         #endregion
 
         [Test]
+        public void Implement_EchoHandlerConvenience()
+        {
+            var handler = new EchoHandlerConvenience();
+            Assert.That(handler, Is.Not.Null);
+        }
+
+        #region Snippet:Responses_ReadMe_EchoHandler_Convenience
+
+        public class EchoHandlerConvenience : ResponseHandler
+        {
+            public override async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
+                CreateResponse request,
+                ResponseContext context,
+                [EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                var stream = new ResponseEventStream(context, request);
+
+                yield return stream.EmitCreated();
+                yield return stream.EmitInProgress();
+
+                // One call emits all text output events automatically.
+                var input = await context.GetInputTextAsync(cancellationToken: cancellationToken);
+                foreach (var evt in stream.OutputItemMessage($"Echo: {input}"))
+                    yield return evt;
+
+                yield return stream.EmitCompleted();
+            }
+        }
+
+        #endregion
+
+        [Test]
         public void Implement_EchoHandlerFullControl()
         {
             var handler = new EchoHandlerFullControl();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample10Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample10Snippets.cs
@@ -71,7 +71,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 // Translate every input item. Both model stacks share the
                 // same JSON wire contract, so .Translate().To<T>() round-trips
                 // through JSON: our Item → JSON → OpenAI ResponseItem.
-                foreach (Item item in request.GetInputExpanded())
+                foreach (Item item in await context.GetInputItemsAsync(cancellationToken: cancellationToken))
                 {
                     options.InputItems.Add(item.Translate().To<ResponseItem>());
                 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample11Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample11Snippets.cs
@@ -70,7 +70,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 // Translate every input item with full fidelity.
                 // Both model stacks share the same JSON wire contract, so
                 // .Translate().To<T>() round-trips through JSON to convert.
-                foreach (Item item in request.GetInputExpanded())
+                foreach (Item item in await context.GetInputItemsAsync(cancellationToken: cancellationToken))
                 {
                     options.InputItems.Add(item.Translate().To<ResponseItem>());
                 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample1Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample1Snippets.cs
@@ -41,10 +41,10 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 CancellationToken cancellationToken)
             {
                 return new TextResponse(context, request,
-                    createText: ct =>
+                    createText: async ct =>
                     {
-                        var input = request.GetInputText();
-                        return Task.FromResult($"Echo: {input}");
+                        var input = await context.GetInputTextAsync(cancellationToken: ct);
+                        return $"Echo: {input}";
                     });
             }
         }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample3Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample3Snippets.cs
@@ -66,7 +66,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 yield return stream.EmitInProgress();
 
                 // Emit a complete text message in one call.
-                var input = request.GetInputText();
+                var input = await context.GetInputTextAsync(cancellationToken: cancellationToken);
                 foreach (var evt in stream.OutputItemMessage($"Hello! You said: \"{input}\""))
                     yield return evt;
 
@@ -91,8 +91,9 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 yield return stream.EmitInProgress();
 
                 // Stream tokens as they arrive — each chunk becomes a delta event.
+                var inputText = await context.GetInputTextAsync(cancellationToken: cancellationToken);
                 await foreach (var evt in stream.OutputItemMessage(
-                    GenerateTokensAsync(request.GetInputText(), cancellationToken),
+                    GenerateTokensAsync(inputText, cancellationToken),
                     cancellationToken))
                 {
                     yield return evt;
@@ -145,7 +146,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 yield return text.EmitAdded();       // response.content_part.added
 
                 // Emit the text body — delta first, then the final "done" with full text.
-                var input = request.GetInputText();
+                var input = await context.GetInputTextAsync(cancellationToken: cancellationToken);
                 var reply = $"Hello! You said: \"{input}\"";
                 yield return text.EmitDelta(reply);  // response.output_text.delta
                 yield return text.EmitDone(reply);   // response.output_text.done

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample4Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample4Snippets.cs
@@ -53,7 +53,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 var stream = new ResponseEventStream(context, request);
 
                 // Check if the input contains a function call output (turn 2)
-                var inputItems = request.GetInputExpanded();
+                var inputItems = await context.GetInputItemsAsync(cancellationToken: cancellationToken);
                 var toolOutput = inputItems.OfType<FunctionCallOutputItemParam>().FirstOrDefault();
 
                 if (toolOutput is not null)
@@ -102,7 +102,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 var stream = new ResponseEventStream(context, request);
 
                 // Check if the input contains a function call output (turn 2)
-                var inputItems = request.GetInputExpanded();
+                var inputItems = await context.GetInputItemsAsync(cancellationToken: cancellationToken);
                 var toolOutput = inputItems.OfType<FunctionCallOutputItemParam>().FirstOrDefault();
 
                 if (toolOutput is not null)

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample5Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample5Snippets.cs
@@ -54,7 +54,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                         // Returns empty list if no previous_response_id is set.
                         var history = await context.GetHistoryAsync(ct);
 
-                        var currentInput = request.GetInputText();
+                        var currentInput = await context.GetInputTextAsync(cancellationToken: ct);
                         var turnNumber = history.OfType<OutputItemMessage>().Count() + 1;
 
                         // In a real agent, pass the history + current question to a model.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample6Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample6Snippets.cs
@@ -50,7 +50,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
             {
                 await Task.CompletedTask;
                 var stream = new ResponseEventStream(context, request);
-                var question = request.GetInputText();
+                var question = await context.GetInputTextAsync(cancellationToken: cancellationToken);
 
                 yield return stream.EmitCreated();
                 yield return stream.EmitInProgress();
@@ -85,7 +85,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
             {
                 await Task.CompletedTask;
                 var stream = new ResponseEventStream(context, request);
-                var question = request.GetInputText();
+                var question = await context.GetInputTextAsync(cancellationToken: cancellationToken);
 
                 yield return stream.EmitCreated();
                 yield return stream.EmitInProgress();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample7Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample7Snippets.cs
@@ -122,7 +122,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 return new TextResponse(context, request,
                     createText: async ct =>
                     {
-                        var question = request.GetInputText();
+                        var question = await context.GetInputTextAsync(cancellationToken: ct);
                         return await _kb.SearchAsync(question, ct);
                     });
             }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample8Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample8Snippets.cs
@@ -89,7 +89,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 return new TextResponse(context, request,
                     createText: async ct =>
                     {
-                        var question = request.GetInputText();
+                        var question = await context.GetInputTextAsync(cancellationToken: ct);
                         return await _kb.SearchAsync(question, ct);
                     });
             }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample9Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample9Snippets.cs
@@ -68,7 +68,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 return new TextResponse(context, request,
                     createText: async ct =>
                     {
-                        var question = request.GetInputText();
+                        var question = await context.GetInputTextAsync(cancellationToken: ct);
                         return await _kb.SearchAsync(question, ct);
                     });
             }

--- a/sdk/agentserver/README.md
+++ b/sdk/agentserver/README.md
@@ -38,10 +38,10 @@ public class EchoHandler : ResponseHandler
         CancellationToken cancellationToken)
     {
         return new TextResponse(context, request,
-            createText: ct =>
+            createText: async ct =>
             {
-                var input = request.GetInputText();
-                return Task.FromResult($"Echo: {input}");
+                var input = await context.GetInputTextAsync(cancellationToken: ct);
+                return $"Echo: {input}";
             });
     }
 }


### PR DESCRIPTION
## Summary

Refactors `ResponseContext.GetInputItemsAsync()` to return `IReadOnlyList<Item>` (the developer-facing input type hierarchy) instead of `IReadOnlyList<OutputItem>` (the internal storage types). Adds convenience methods that dramatically simplify the most common handler patterns.

### API changes

| Method | Before | After |
|--------|--------|-------|
| `ResponseContext.GetInputItemsAsync()` | Returns `IReadOnlyList<OutputItem>` | Returns `IReadOnlyList<Item>` with `bool resolveReferences = true` |
| `ResponseContext.GetInputTextAsync()` | *(new)* | Convenience: resolves items + extracts all text content |
| `IEnumerable<Item>.GetInputText()` | *(new)* | Extension: extracts text from any `Item` sequence |
| `CreateResponse.GetInputText()` | `public` | `internal` (replaced by `context.GetInputTextAsync()`) |
| `CreateResponse.GetInputExpanded()` | `public` | **Stays public** for advanced users |

### Developer experience improvement

**Before** — handlers had to work with storage types:
```csharp
var items = await context.GetInputItemsAsync(ct);
// items are OutputItem — must pattern-match on OutputItemMessage, etc.
```

**After** — handlers work with the natural input types:
```csharp
// One-liner for text:
var text = await context.GetInputTextAsync(cancellationToken: ct);

// Or get typed items:
var items = await context.GetInputItemsAsync(cancellationToken: ct);
var messages = items.OfType<ItemMessage>();  // natural type
```

### Implementation details

- **JSON round-trip conversion** (`OutputItem → Item`): Uses `ModelReaderWriter` to serialize an `OutputItem` and deserialize as `Item`, leveraging the shared `"type"` discriminator
- **Dual caching** in `ResponseContextImpl`: Separate lazy caches for `resolveReferences=true` vs `false`
- **Internal persistence path**: `GetInputItemsForPersistenceAsync()` preserves `OutputItem` format for the orchestrator's storage needs

### Samples & docs

All 14 snippet files and all markdown samples updated to use `context.GetInputTextAsync()` / `context.GetInputItemsAsync()` as the primary pattern. Handler implementation guide updated with new API shapes.

### Tests

- 4 new multi-turn item reference E2E protocol tests (default mode, background mode, non-existent ref, 3-turn chain)
- 6 new `ResponseContextImpl` unit tests (resolveReferences=false, GetInputTextAsync, persistence)
- All 2009 tests pass (Core: 121, Invocations: 78, Responses: 1810)