### PR TITLE
Enrich spans with session ID and conversation ID from OTel baggage

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/FoundryEnrichmentProcessor.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/FoundryEnrichmentProcessor.cs
@@ -50,13 +50,13 @@ internal sealed class FoundryEnrichmentProcessor : BaseProcessor<Activity>
         // them without extra plumbing. The two are independent — no fallback
         // between them.
         var sessionId = activity.GetBaggageItem("azure.ai.agentserver.session_id");
-        if (sessionId is not null)
+        if (!string.IsNullOrWhiteSpace(sessionId))
         {
             activity.SetTag("microsoft.session.id", sessionId);
         }
 
         var conversationId = activity.GetBaggageItem("azure.ai.agentserver.conversation_id");
-        if (conversationId is not null)
+        if (!string.IsNullOrWhiteSpace(conversationId))
         {
             activity.SetTag("gen_ai.conversation.id", conversationId);
         }

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/FoundryEnrichmentProcessor.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Telemetry/FoundryEnrichmentProcessor.cs
@@ -43,6 +43,23 @@ internal sealed class FoundryEnrichmentProcessor : BaseProcessor<Activity>
         {
             activity.SetTag("microsoft.foundry.project.id", _projectId);
         }
+
+        // Session ID and conversation ID are correlation IDs propagated via
+        // OTel baggage by the calling service / hosting packages. Stamp them
+        // as span attributes so every span (root + framework child) carries
+        // them without extra plumbing. The two are independent — no fallback
+        // between them.
+        var sessionId = activity.GetBaggageItem("azure.ai.agentserver.session_id");
+        if (sessionId is not null)
+        {
+            activity.SetTag("microsoft.session.id", sessionId);
+        }
+
+        var conversationId = activity.GetBaggageItem("azure.ai.agentserver.conversation_id");
+        if (conversationId is not null)
+        {
+            activity.SetTag("gen_ai.conversation.id", conversationId);
+        }
     }
 
     /// <inheritdoc/>

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnrichmentProcessorTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnrichmentProcessorTests.cs
@@ -136,6 +136,120 @@ public class FoundryEnrichmentProcessorTests
         Assert.That(activity.GetTagItem("gen_ai.agent.id"), Is.EqualTo("my-agent:1.0"));
     }
 
+    // ── Session ID / Conversation ID baggage enrichment ────────────────
+
+    [Test]
+    public void SetsSessionId_WhenBaggagePresent()
+    {
+        BuildProvider();
+
+        using var parent = _activitySource.StartActivity("parent")!;
+        parent.SetBaggage("azure.ai.agentserver.session_id", "sess-123");
+
+        using var child = _activitySource.StartActivity("child")!;
+        child.Stop();
+
+        Assert.That(child.GetTagItem("microsoft.session.id"), Is.EqualTo("sess-123"));
+    }
+
+    [Test]
+    public void SetsConversationId_WhenBaggagePresent()
+    {
+        BuildProvider();
+
+        using var parent = _activitySource.StartActivity("parent")!;
+        parent.SetBaggage("azure.ai.agentserver.conversation_id", "conv-456");
+
+        using var child = _activitySource.StartActivity("child")!;
+        child.Stop();
+
+        Assert.That(child.GetTagItem("gen_ai.conversation.id"), Is.EqualTo("conv-456"));
+    }
+
+    [Test]
+    public void SetsBothIds_WhenBothBaggagePresent()
+    {
+        BuildProvider();
+
+        using var parent = _activitySource.StartActivity("parent")!;
+        parent.SetBaggage("azure.ai.agentserver.session_id", "sess-A");
+        parent.SetBaggage("azure.ai.agentserver.conversation_id", "conv-B");
+
+        using var child = _activitySource.StartActivity("child")!;
+        child.Stop();
+
+        Assert.That(child.GetTagItem("microsoft.session.id"), Is.EqualTo("sess-A"));
+        Assert.That(child.GetTagItem("gen_ai.conversation.id"), Is.EqualTo("conv-B"));
+    }
+
+    [Test]
+    public void DoesNotSetSessionId_WhenBaggageAbsent()
+    {
+        BuildProvider();
+
+        using var activity = _activitySource.StartActivity("test")!;
+        activity.Stop();
+
+        Assert.That(activity.GetTagItem("microsoft.session.id"), Is.Null);
+    }
+
+    [Test]
+    public void DoesNotSetConversationId_WhenBaggageAbsent()
+    {
+        BuildProvider();
+
+        using var activity = _activitySource.StartActivity("test")!;
+        activity.Stop();
+
+        Assert.That(activity.GetTagItem("gen_ai.conversation.id"), Is.Null);
+    }
+
+    [Test]
+    public void SessionId_DoesNotGoToConversationId()
+    {
+        BuildProvider();
+
+        using var parent = _activitySource.StartActivity("parent")!;
+        parent.SetBaggage("azure.ai.agentserver.session_id", "sess-only");
+
+        using var child = _activitySource.StartActivity("child")!;
+        child.Stop();
+
+        Assert.That(child.GetTagItem("microsoft.session.id"), Is.EqualTo("sess-only"));
+        Assert.That(child.GetTagItem("gen_ai.conversation.id"), Is.Null);
+    }
+
+    [Test]
+    public void ConversationId_DoesNotGoToSessionId()
+    {
+        BuildProvider();
+
+        using var parent = _activitySource.StartActivity("parent")!;
+        parent.SetBaggage("azure.ai.agentserver.conversation_id", "conv-only");
+
+        using var child = _activitySource.StartActivity("child")!;
+        child.Stop();
+
+        Assert.That(child.GetTagItem("gen_ai.conversation.id"), Is.EqualTo("conv-only"));
+        Assert.That(child.GetTagItem("microsoft.session.id"), Is.Null);
+    }
+
+    [Test]
+    public void SessionIdAndConversationId_AreIndependent()
+    {
+        BuildProvider();
+
+        using var parent = _activitySource.StartActivity("parent")!;
+        parent.SetBaggage("azure.ai.agentserver.session_id", "sess-X");
+        // No conversation_id baggage
+
+        using var child = _activitySource.StartActivity("child")!;
+        child.Stop();
+
+        Assert.That(child.GetTagItem("microsoft.session.id"), Is.EqualTo("sess-X"));
+        Assert.That(child.GetTagItem("gen_ai.conversation.id"), Is.Null);
+    }
+
     private static void SetEnv(string? agentName = null, string? agentVersion = null, string? projectArmId = null)
     {
         Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", agentName);

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnrichmentProcessorTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/tests/FoundryEnrichmentProcessorTests.cs
@@ -250,6 +250,48 @@ public class FoundryEnrichmentProcessorTests
         Assert.That(child.GetTagItem("gen_ai.conversation.id"), Is.Null);
     }
 
+    [Test]
+    public void DoesNotSetSessionId_WhenBaggageIsEmpty()
+    {
+        BuildProvider();
+
+        using var parent = _activitySource.StartActivity("parent")!;
+        parent.SetBaggage("azure.ai.agentserver.session_id", string.Empty);
+
+        using var child = _activitySource.StartActivity("child")!;
+        child.Stop();
+
+        Assert.That(child.GetTagItem("microsoft.session.id"), Is.Null);
+    }
+
+    [Test]
+    public void DoesNotSetConversationId_WhenBaggageIsEmpty()
+    {
+        BuildProvider();
+
+        using var parent = _activitySource.StartActivity("parent")!;
+        parent.SetBaggage("azure.ai.agentserver.conversation_id", string.Empty);
+
+        using var child = _activitySource.StartActivity("child")!;
+        child.Stop();
+
+        Assert.That(child.GetTagItem("gen_ai.conversation.id"), Is.Null);
+    }
+
+    [Test]
+    public void DoesNotSetSessionId_WhenBaggageIsWhitespace()
+    {
+        BuildProvider();
+
+        using var parent = _activitySource.StartActivity("parent")!;
+        parent.SetBaggage("azure.ai.agentserver.session_id", "   ");
+
+        using var child = _activitySource.StartActivity("child")!;
+        child.Stop();
+
+        Assert.That(child.GetTagItem("microsoft.session.id"), Is.Null);
+    }
+
     private static void SetEnv(string? agentName = null, string? agentVersion = null, string? projectArmId = null)
     {
         Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", agentName);

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/InvocationsActivitySource.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/src/InvocationsActivitySource.cs
@@ -108,7 +108,7 @@ public class InvocationsActivitySource
 
         if (!string.IsNullOrEmpty(context.SessionId))
         {
-            activity.SetTag("gen_ai.conversation.id", context.SessionId);
+            activity.SetTag("microsoft.session.id", context.SessionId);
         }
 
         if (!string.IsNullOrEmpty(agentName))

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/tests/InvocationsActivitySourceTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/tests/InvocationsActivitySourceTests.cs
@@ -133,7 +133,7 @@ public class InvocationsActivitySourceTests
         Assert.That(activity.GetTagItem("gen_ai.provider.name"), Is.EqualTo("AzureAI Hosted Agents"));
         Assert.That(activity.GetTagItem("gen_ai.operation.name"), Is.EqualTo("invoke_agent"));
         Assert.That(activity.GetTagItem("gen_ai.response.id"), Is.EqualTo("inv-abc"));
-        Assert.That(activity.GetTagItem("gen_ai.conversation.id"), Is.EqualTo("sess-def"));
+        Assert.That(activity.GetTagItem("microsoft.session.id"), Is.EqualTo("sess-def"));
         Assert.That(activity.GetTagItem("gen_ai.agent.id"), Is.EqualTo("my-agent:2.0.0"));
         Assert.That(activity.GetTagItem("gen_ai.agent.name"), Is.EqualTo("my-agent"));
         Assert.That(activity.GetTagItem("gen_ai.agent.version"), Is.EqualTo("2.0.0"));
@@ -205,7 +205,7 @@ public class InvocationsActivitySourceTests
     }
 
     [Test]
-    public void StartInvocationActivity_ConversationId_SetWhenSessionPresent()
+    public void StartInvocationActivity_SessionId_MapsToMicrosoftSessionId()
     {
         Environment.SetEnvironmentVariable("FOUNDRY_AGENT_NAME", "agent");
         FoundryEnvironment.Reload();
@@ -227,8 +227,11 @@ public class InvocationsActivitySourceTests
         using var activity = source.StartInvocationActivity(context, new HeaderDictionary());
 
         Assert.That(activity, Is.Not.Null);
-        Assert.That(activity!.GetTagItem("gen_ai.conversation.id"), Is.EqualTo("sess-42"));
+        Assert.That(activity!.GetTagItem("microsoft.session.id"), Is.EqualTo("sess-42"));
         Assert.That(activity.GetTagItem("azure.ai.agentserver.invocations.session_id"), Is.EqualTo("sess-42"));
+
+        // Session ID must NOT go to gen_ai.conversation.id
+        Assert.That(activity.GetTagItem("gen_ai.conversation.id"), Is.Null);
     }
 
     [Test]


### PR DESCRIPTION
## Changes

`FoundryEnrichmentProcessor.OnStart` now reads two baggage keys and stamps them as independent span attributes on all spans (root + framework child):

| Baggage Key | Span Attribute | When Set |
|---|---|---|
| `azure.ai.agentserver.session_id` | `microsoft.session.id` | Always when present |
| `azure.ai.agentserver.conversation_id` | `gen_ai.conversation.id` | Only when present |

**Key rules:**
- Session ID and conversation ID are independent — no fallback between them
- Session ID never goes into `gen_ai.conversation.id`
- Both are read from OTel baggage in `OnStart` (correlation IDs, not agent identity — frameworks won't overwrite them)
- `InvocationsActivitySource` now maps its `session_id` param to `microsoft.session.id` (not `gen_ai.conversation.id`)

**Why `OnStart`:** These are correlation IDs, not agent identity — frameworks won't overwrite them, so no need for `OnEnd`.

**Why baggage:** Session/conversation IDs are request-scoped, not container-scoped. Baggage propagates through OTel context automatically, so child spans created by LangChain, Semantic Kernel, etc. pick them up without extra plumbing.

## Testing

- 8 new tests in `FoundryEnrichmentProcessorTests` (both-present, each-alone, neither, independence/no cross-contamination)
- 1 new + 1 updated test in `InvocationsActivitySourceTests` (session_id → `microsoft.session.id`, `gen_ai.conversation.id` is null)
- Full solution: **2,017 passed, 0 failed**