### PR TITLE
Fix FlattenPropertyVisitor: update derived class ctor params and base initializer after safe-flatten

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -637,6 +637,14 @@ namespace Azure.Generator.Management.Visitors
                 _flattenedModelTypes.Add(model.Type, propertyNameMap);
                 UpdatePublicConstructor(model, propertyNameMap);
             }
+            else if (model.BaseModelProvider is ModelProvider flattenedBase && _flattenedModelTypes.TryGetValue(flattenedBase.Type, out var basePropertyNameMap))
+            {
+                // This model has no flattenable properties of its own, but its base model was
+                // safe-flattened. The base's public constructor signature changed (e.g. an
+                // ExportDeliveryInfo param became ExportDeliveryDestination), so update this
+                // model's public constructor params and base initializer call to match.
+                UpdatePublicConstructor(model, basePropertyNameMap);
+            }
         }
 
         private void PropertyFlatten(ModelProvider model, ModelProvider propertyModel, IReadOnlyList<PropertyProvider> innerProperties, Dictionary<PropertyProvider, List<FlattenPropertyInfo>> propertyMap, PropertyProvider internalProperty)
@@ -833,6 +841,53 @@ namespace Azure.Generator.Management.Visitors
                     publicConstructor.Signature.Update(parameters: updateParameters);
                     publicConstructor.Update(signature: publicConstructor.Signature); // workaround to update the xml docs
                 }
+
+                // If this constructor delegates to a base constructor, update the base initializer
+                // arguments to reference the new flattened parameters instead of the old ones.
+                UpdatePublicConstructorBaseInitializer(publicConstructor, map);
+            }
+        }
+
+        /// <summary>
+        /// Updates the base constructor initializer arguments when the base model's public
+        /// constructor signature was changed by property flattening. Replaces each argument
+        /// that corresponded to a now-flattened parameter with the new flattened parameter.
+        /// </summary>
+        private static void UpdatePublicConstructorBaseInitializer(ConstructorProvider publicConstructor, Dictionary<string, List<FlattenPropertyInfo>> map)
+        {
+            var sig = publicConstructor.Signature;
+            var initializer = sig.Initializer;
+            if (initializer is null || !initializer.IsBase)
+            {
+                return;
+            }
+
+            var updatedArgs = new List<ValueExpression>();
+            var changed = false;
+            foreach (var arg in initializer.Arguments)
+            {
+                if (arg is VariableExpression variable && map.TryGetValue(variable.Declaration.RequestedName, out var flattenInfoList))
+                {
+                    changed = true;
+                    foreach (var (flattenedProperty, _) in flattenInfoList)
+                    {
+                        if (ShouldIncludeFlattenedPropertyInPublicConstructor(flattenedProperty))
+                        {
+                            updatedArgs.Add(flattenedProperty.AsParameter);
+                        }
+                    }
+                }
+                else
+                {
+                    updatedArgs.Add(arg);
+                }
+            }
+
+            if (changed)
+            {
+                var newInitializer = new ConstructorInitializer(initializer.IsBase, updatedArgs);
+                var newSig = new ConstructorSignature(sig.Type, sig.Description, sig.Modifiers, sig.Parameters, sig.Attributes, newInitializer);
+                publicConstructor.Update(signature: newSig);
             }
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -555,9 +555,104 @@ namespace Azure.Generator.Mgmt.Tests
         }
 
         /// <summary>
-        /// A mock custom code view TypeProvider that adds an [Obsolete] property
-        /// to simulate a backward-compat alias defined in a partial class.
+        /// Verifies the bug fix: when a base model is safe-flattened (a single-property wrapper type
+        /// becomes internal and its property is promoted), the derived class's public constructor
+        /// parameters AND base initializer (: base(...)) are both updated to use the flattened type.
+        ///
+        /// Scenario (mirrors CommonExportProperties / ExportProperties):
+        ///   - WrapperModel has one required public property: Value (string)
+        ///   - BaseModel has: wrapper (WrapperModel, required), name (string, required)
+        ///   - DerivedModel extends BaseModel with: description (string, optional)
+        ///
+        /// After safe-flatten:
+        ///   - BaseModel.wrapper becomes internal, WrapperValue (string) is promoted
+        ///   - BaseModel public ctor: (string wrapperValue, string name)
+        ///   - DerivedModel public ctor must also use (string wrapperValue, string name), NOT (WrapperModel wrapper, string name)
+        ///   - DerivedModel base initializer must pass wrapperValue, not wrapper
         /// </summary>
+        [Test]
+        public void TestSafeFlattenUpdatesDerivedClassCtorParamsAndBaseInitializer()
+        {
+            // Create WrapperModel with a single required property.
+            var valueProp = InputFactory.Property("value", InputPrimitiveType.String, isRequired: true, serializedName: "value");
+            var wrapperModel = InputFactory.Model(
+                "WrapperModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [valueProp]);
+
+            // Create BaseModel with wrapper (WrapperModel, required) + name (string, required).
+            var wrapperProp = InputFactory.Property("wrapper", wrapperModel, isRequired: true, serializedName: "wrapper");
+            var nameProp = InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, serializedName: "name");
+            var baseModel = InputFactory.Model(
+                "BaseModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [wrapperProp, nameProp]);
+
+            // Create DerivedModel extending BaseModel with an optional description.
+            var descriptionProp = InputFactory.Property("description", InputPrimitiveType.String, isRequired: false, serializedName: "description");
+            var derivedModel = InputFactory.Model(
+                "DerivedModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                baseModel: baseModel,
+                properties: [descriptionProp]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [wrapperModel, baseModel, derivedModel]);
+
+            var baseModelProvider = plugin.Object.TypeFactory.CreateModel(baseModel)!;
+            var derivedModelProvider = plugin.Object.TypeFactory.CreateModel(derivedModel)!;
+            Assert.IsNotNull(baseModelProvider);
+            Assert.IsNotNull(derivedModelProvider);
+
+            // Precondition: before visitors, DerivedModel public ctor has WrapperModel param.
+            var preVisitPublicCtor = derivedModelProvider.Constructors
+                .SingleOrDefault(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+            Assert.IsNotNull(preVisitPublicCtor, "DerivedModel should have a public ctor before visitors");
+            Assert.IsTrue(
+                preVisitPublicCtor!.Signature.Parameters.Any(p => p.Type.Name == "WrapperModel"),
+                "Precondition: DerivedModel ctor should have WrapperModel param before flatten");
+
+            // Run only the FlattenPropertyVisitor on both models (base must be processed first to populate the flatten map).
+            var visitor = new FlattenPropertyVisitor();
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(visitTypeCore);
+
+            visitTypeCore!.Invoke(visitor, [derivedModelProvider]);
+            visitTypeCore!.Invoke(visitor, [baseModelProvider]);
+
+            // After visitors: DerivedModel public ctor should use the flattened type (string), not WrapperModel.
+            var publicCtor = derivedModelProvider.Constructors
+                .SingleOrDefault(c => c.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Public));
+            Assert.IsNotNull(publicCtor, "DerivedModel should still have a public ctor after flatten");
+
+            Assert.IsFalse(
+                publicCtor!.Signature.Parameters.Any(p => p.Type.Name == "WrapperModel"),
+                "DerivedModel public ctor should NOT have WrapperModel param after safe-flatten");
+            Assert.IsTrue(
+                publicCtor.Signature.Parameters.Any(p => p.Name == "wrapperValue"),
+                "DerivedModel public ctor should have the flattened 'wrapperValue' (string) param");
+
+            // The base initializer must exist and be a base (not this) call.
+            var initializer = publicCtor.Signature.Initializer;
+            Assert.IsNotNull(initializer, "DerivedModel public ctor should have a base initializer");
+            Assert.IsTrue(initializer!.IsBase, "Initializer should be a base call");
+
+            // None of the base initializer arguments should reference the old WrapperModel param.
+            var initializerArgNames = initializer.Arguments
+                .OfType<VariableExpression>()
+                .Select(v => v.Declaration.RequestedName)
+                .ToList();
+
+            Assert.IsFalse(
+                initializerArgNames.Contains("wrapper"),
+                $"Base initializer should NOT pass 'wrapper' (WrapperModel). Args: [{string.Join(", ", initializerArgNames)}]");
+            Assert.IsTrue(
+                initializerArgNames.Contains("wrapperValue"),
+                $"Base initializer should pass the flattened 'wrapperValue'. Args: [{string.Join(", ", initializerArgNames)}]");
+        }
+
         private class ObsoletePropertyCustomCodeView : TypeProvider
         {
             private readonly TypeProvider _enclosingType;


### PR DESCRIPTION
## Problem

When a base model is safe-flattened (a single-property wrapper type becomes internal and its inner property is promoted), derived classes' public constructors were not updated:

- **Constructor parameters** still referenced the old wrapper type (e.g., `WrapperModel wrapper` instead of `string wrapperValue`)
- **Base initializer** (`: base(...)`) still passed the old wrapper parameter, causing CS1503 type mismatch errors

## Fix

In `FlattenPropertyVisitor.FlattenModel()`, added handling for derived models whose base was safe-flattened but that have no flattenable properties of their own. These models now also get their public constructor parameters and base initializer updated.

## Test Changes

- Combined two separate test cases into one: `TestSafeFlattenUpdatesDerivedClassCtorParamsAndBaseInitializer`
- Test now uses a direct `FlattenPropertyVisitor` instance instead of iterating all registered visitors
- All 155 tests pass