### PR TITLE
[ConfidentialLedger] README docs and tags snippet coverage

### DIFF
--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
@@ -50,6 +50,8 @@ var ledgerClient = new ConfidentialLedgerClient(new Uri("https://my-ledger-url.c
 ```
 
 > Security Note: By default when a confidential ledger Client is created it will connect to Azure's confidential ledger Identity Service to obtain the latest TLS service certificate for your Ledger in order to secure connections to Ledger Nodes. The details of this process are available in [this sample][client_construction_sample]. This behavior can be overridden by setting the `options` argument when creating the Ledger Client.
+>
+> `ConfidentialLedgerClientOptions.VerifyConnection` defaults to `true`, which verifies node TLS certificates against the trusted identity service certificate. Set `VerifyConnection = false` only for development or testing scenarios.
 
 ## Key concepts
 
@@ -91,6 +93,14 @@ while (status == "Pending")
 
 Console.WriteLine($"Transaction status: {status}");
 ```
+
+### Redirect handling
+
+The `ConfidentialLedgerClient` automatically follows HTTP 307 and 308 redirects while preserving the `Authorization` header. This is required because Azure confidential ledger routes write operations to the primary node, and non-primary nodes may return redirects.
+
+The SDK also caches the latest primary node URL from redirect responses and reuses it for subsequent non-`GET` requests to reduce extra network round-trips for write-heavy workloads.
+
+No additional configuration is required to enable this behavior.
 
 #### Receipts
 
@@ -296,17 +306,10 @@ It is possible to further organize data within a collection as part of the lates
 
 Specify the `tags` parameter as part of the create entry operation. Multiple tags can be specified using commas. There is a limit of five tags per transaction.
 
-```C#
-string tags = "tag1,tag2";
-
-Response result = await Client.CreateLedgerEntryAsync(content, collectionId, tags);
+```C# Snippet:CreateLedgerEntryWithTags
 ```
 
-```C#
-
-// Specify collection ID and tag. Optionally add a range of transaction IDs.
-// Only one tag is permitted in each retrieval operation.
-var result = Client.GetLedgerEntriesAsync(collectionId, "tag1");
+```C# Snippet:GetLedgerEntriesWithTags
 ```
 ### User management
 
@@ -367,7 +370,17 @@ We guarantee that all client instance methods are thread-safe and independent of
 
 ## Examples
 
-Coming Soon...
+The [samples directory][samples] includes end-to-end usage patterns. A typical flow is:
+
+1. Append an entry and capture the transaction ID (`Snippet:AppendToLedger`).
+2. Verify the transaction is committed (`Snippet:GetStatus`).
+3. Retrieve the entry or receipt (`Snippet:GetEnteryWithNoTransactionId`, `Snippet:GetReceipt`).
+
+For additional scenarios such as collections, tags, and advanced certificate verification, see:
+
+- `tests/samples/HelloWorldSamples.cs`
+- `tests/samples/AdvancedSamples.cs`
+- `tests/samples/TagsSamples.cs`
 
 ## Troubleshooting
 
@@ -406,6 +419,7 @@ For more information see the [Code of Conduct FAQ][coc_faq] or contact
 [style-guide-cloud]: https://aka.ms/azsdk/cloud-style-guide
 [client_src]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/confidentialledger/Azure.Security.ConfidentialLedger
 [client_nuget_package]: https://www.nuget.org/packages?q=Azure.Security.ConfidentialLedger
+[samples]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/samples
 [azure_cli]: https://learn.microsoft.com/cli/azure
 [azure_cloud_shell]: https://shell.azure.com/bash
 [azure_confidential_computing]: https://azure.microsoft.com/solutions/confidential-compute

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/README.md
@@ -307,9 +307,19 @@ It is possible to further organize data within a collection as part of the lates
 Specify the `tags` parameter as part of the create entry operation. Multiple tags can be specified using commas. There is a limit of five tags per transaction.
 
 ```C# Snippet:CreateLedgerEntryWithTags
+RequestContent content = RequestContent.Create(new { contents = "Hello world with tags!" });
+string collectionId = "my-collection";
+string tags = "tag1,tag2";
+
+Response result = await client.CreateLedgerEntryAsync(content, collectionId, tags);
 ```
 
 ```C# Snippet:GetLedgerEntriesWithTags
+string collectionIdForQuery = "my-collection";
+
+// Specify collection ID and tag. Optionally add a range of transaction IDs.
+// Only one tag is permitted in each retrieval operation.
+var queryResult = client.GetLedgerEntriesAsync(collectionIdForQuery, tag: "tag1");
 ```
 ### User management
 

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/samples/TagsSamples.cs
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/samples/TagsSamples.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.TestFramework;
+using Azure.Identity;
+using NUnit.Framework;
+
+namespace Azure.Security.ConfidentialLedger.Tests.samples
+{
+    public class TagsSamples : SamplesBase<ConfidentialLedgerEnvironment>
+    {
+        [Test]
+        public async Task Tags()
+        {
+#if SNIPPET
+            var client = new ConfidentialLedgerClient(new Uri("https://my-ledger-url.confidential-ledger.azure.com"), new DefaultAzureCredential());
+#else
+            var client = new ConfidentialLedgerClient(TestEnvironment.ConfidentialLedgerUrl, TestEnvironment.Credential);
+#endif
+
+            #region Snippet:CreateLedgerEntryWithTags
+            RequestContent content = RequestContent.Create(new { contents = "Hello world with tags!" });
+            string collectionId = "my-collection";
+            string tags = "tag1,tag2";
+
+            Response result = await client.CreateLedgerEntryAsync(content, collectionId, tags);
+            #endregion
+
+            #region Snippet:GetLedgerEntriesWithTags
+            string collectionIdForQuery = "my-collection";
+
+            // Specify collection ID and tag. Optionally add a range of transaction IDs.
+            // Only one tag is permitted in each retrieval operation.
+            var queryResult = client.GetLedgerEntriesAsync(collectionIdForQuery, tag: "tag1");
+            #endregion
+
+            Assert.NotNull(result);
+            Assert.NotNull(queryResult);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update Azure.Security.ConfidentialLedger README with redirect handling behavior and VerifyConnection default note
- replace inline Tags code blocks with snippet-backed markers
- replace Examples placeholder with real guidance and sample links
- add new sample file with snippet regions: Snippet:CreateLedgerEntryWithTags and Snippet:GetLedgerEntriesWithTags

Fixes #57944