### PR TITLE
[Identity] Update README docs to reflect Azure.Core 1.53 type consolidation

### DIFF
--- a/sdk/core/Azure.Core/README.md
+++ b/sdk/core/Azure.Core/README.md
@@ -28,6 +28,7 @@ The main shared concepts of Azure.Core (and so Azure SDK libraries using Azure.C
 - Exceptions for reporting errors from service requests in a consistent fashion. (`RequestFailedException`).
 - Customizing requests (`RequestContext`).
 - Abstractions for representing Azure SDK credentials. (`TokenCredentials`).
+- Authenticating Azure SDK clients using credential types from Microsoft Entra ID without a separate package dependency. (`DefaultAzureCredential`, `ManagedIdentityCredential`, and all other credential types from `Azure.Identity` are included directly in `Azure.Core` starting with version 1.53.)
 
 Below, you will find sections explaining these shared concepts in more detail.
 
@@ -233,6 +234,16 @@ KeyVaultSecret secret = client.GetSecret("Name");
 ```
 
 More on mocking in [Unit testing and mocking with the Azure SDK for .NET](https://learn.microsoft.com/dotnet/azure/sdk/unit-testing-mocking).
+
+### Authenticating Service Clients
+
+Starting with Azure.Core 1.53, all credential types previously in `Azure.Identity` are available directly:
+
+```C# Snippet:AzureCoreDefaultCredential
+// No Azure.Identity package reference required for Azure.Core 1.53+
+var credential = new DefaultAzureCredential();
+var client = new SecretClient(new Uri("https://myvault.vault.azure.net/"), credential);
+```
 
 ## Distributed tracing with OpenTelemetry
 

--- a/sdk/core/Azure.Core/README.md
+++ b/sdk/core/Azure.Core/README.md
@@ -240,7 +240,7 @@ More on mocking in [Unit testing and mocking with the Azure SDK for .NET](https:
 Starting with Azure.Core 1.53.0, all credential types previously in `Azure.Identity` are available directly from the Azure service client libraries, which all take a dependency on `Azure.Core`:
 
 ```C# Snippet:AzureCoreDefaultCredential
-// No Azure.Identity package reference required for client SDKs that depend on Azure.Core 1.53.0+
+// No Azure.Identity package reference required for client libraries that depend on Azure.Core 1.53.0+
 var credential = new DefaultAzureCredential();
 var client = new SecretClient(new Uri("https://myvault.vault.azure.net/"), credential);
 ```

--- a/sdk/core/Azure.Core/README.md
+++ b/sdk/core/Azure.Core/README.md
@@ -240,7 +240,7 @@ More on mocking in [Unit testing and mocking with the Azure SDK for .NET](https:
 Starting with Azure.Core 1.53.0, all credential types previously in `Azure.Identity` are available directly from the Azure service client libraries, which all take a dependency on `Azure.Core`:
 
 ```C# Snippet:AzureCoreDefaultCredential
-// No Azure.Identity package reference required for client SDKs that depend on Azure.Core 1.53.0+
+// No Azure.Identity package reference required for Azure.Core 1.53+
 var credential = new DefaultAzureCredential();
 var client = new SecretClient(new Uri("https://myvault.vault.azure.net/"), credential);
 ```

--- a/sdk/core/Azure.Core/README.md
+++ b/sdk/core/Azure.Core/README.md
@@ -240,7 +240,7 @@ More on mocking in [Unit testing and mocking with the Azure SDK for .NET](https:
 Starting with Azure.Core 1.53.0, all credential types previously in `Azure.Identity` are available directly from the Azure service client libraries, which all take a dependency on `Azure.Core`:
 
 ```C# Snippet:AzureCoreDefaultCredential
-// No Azure.Identity package reference required for Azure.Core 1.53+
+// No Azure.Identity package reference required for client SDKs that depend on Azure.Core 1.53.0+
 var credential = new DefaultAzureCredential();
 var client = new SecretClient(new Uri("https://myvault.vault.azure.net/"), credential);
 ```

--- a/sdk/core/Azure.Core/README.md
+++ b/sdk/core/Azure.Core/README.md
@@ -28,7 +28,7 @@ The main shared concepts of Azure.Core (and so Azure SDK libraries using Azure.C
 - Exceptions for reporting errors from service requests in a consistent fashion. (`RequestFailedException`).
 - Customizing requests (`RequestContext`).
 - Abstractions for representing Azure SDK credentials. (`TokenCredentials`).
-- Authenticating Azure SDK clients using credential types from Microsoft Entra ID without a separate package dependency. (`DefaultAzureCredential`, `ManagedIdentityCredential`, and all other credential types from `Azure.Identity` are included directly in `Azure.Core` starting with version 1.53.)
+- Authenticating Azure SDK clients to Microsoft Entra ID using token-based credential types without a separate package dependency. `DefaultAzureCredential`, `ManagedIdentityCredential`, and all other credential types from the `Azure.Identity` package are included in `Azure.Core`, starting with version 1.53.0.
 
 Below, you will find sections explaining these shared concepts in more detail.
 
@@ -237,10 +237,10 @@ More on mocking in [Unit testing and mocking with the Azure SDK for .NET](https:
 
 ### Authenticating Service Clients
 
-Starting with Azure.Core 1.53, all credential types previously in `Azure.Identity` are available directly:
+Starting with Azure.Core 1.53.0, all credential types previously in `Azure.Identity` are available directly from the Azure service client libraries, which all take a dependency on `Azure.Core`:
 
 ```C# Snippet:AzureCoreDefaultCredential
-// No Azure.Identity package reference required for Azure.Core 1.53+
+// No Azure.Identity package reference required for client SDKs that depend on Azure.Core 1.53.0+
 var credential = new DefaultAzureCredential();
 var client = new SecretClient(new Uri("https://myvault.vault.azure.net/"), credential);
 ```

--- a/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
+++ b/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Samples
         public void AuthenticateWithDefaultCredential()
         {
             #region Snippet:AzureCoreDefaultCredential
-            // No Azure.Identity package reference required for client SDKs that depend on Azure.Core 1.53.0+
+            // No Azure.Identity package reference required for client libraries that depend on Azure.Core 1.53.0+
             var credential = new DefaultAzureCredential();
             var client = new SecretClient(new Uri("https://myvault.vault.azure.net/"), credential);
             #endregion

--- a/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
+++ b/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Samples
         public void AuthenticateWithDefaultCredential()
         {
             #region Snippet:AzureCoreDefaultCredential
-            // No Azure.Identity package reference required for Azure.Core 1.53+
+            // No Azure.Identity package reference required for client SDKs that depend on Azure.Core 1.53.0+
             var credential = new DefaultAzureCredential();
             var client = new SecretClient(new Uri("https://myvault.vault.azure.net/"), credential);
             #endregion

--- a/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
+++ b/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
@@ -6,12 +6,12 @@ using Azure.Security.KeyVault.Secrets;
 using NUnit.Framework;
 using System;
 
-namespace Azure.Core.Tests.Samples
+namespace Azure.Core.Samples
 {
     public class CredentialsSamples
     {
         [Test]
-        [Ignore("Sample only")]
+        [Ignore("Only verifying that the sample builds")]
         public void AuthenticateWithDefaultCredential()
         {
             #region Snippet:AzureCoreDefaultCredential

--- a/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
+++ b/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+using NUnit.Framework;
+using System;
+
+namespace Azure.Core.Tests.Samples
+{
+    public class CredentialsSamples
+    {
+        [Test]
+        [Ignore("Sample only")]
+        public void AuthenticateWithDefaultCredential()
+        {
+            #region Snippet:AzureCoreDefaultCredential
+            // No Azure.Identity package reference required for Azure.Core 1.53+
+            var credential = new DefaultAzureCredential();
+            var client = new SecretClient(new Uri("https://myvault.vault.azure.net/"), credential);
+            #endregion
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
+++ b/sdk/core/Azure.Core/tests/samples/CredentialsSamples.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using NUnit.Framework;
-using System;
 
 namespace Azure.Core.Samples
 {

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -15,7 +15,7 @@ dotnet add package Azure.Identity
 ```
 
 > [!NOTE]
-> Starting with `Azure.Core` 1.53.0, all credential types (including `DefaultAzureCredential`) are bundled directly in `Azure.Core`. If your project already targets `Azure.Core` 1.53.0 or later and you do not use any `Azure.Identity`-specific APIs, you can omit the `Azure.Identity` package reference entirely. See the [Migration Guide](./MigrationGuide.md) for upgrade and compatibility details.
+> Starting with `Azure.Core` 1.53.0, all credential types (including `DefaultAzureCredential`) are bundled directly in `Azure.Core`. If your project already targets `Azure.Core` 1.53.0+ or does so through a transitive dependency, you should omit the `Azure.Identity` package reference entirely. See the [Migration Guide](./MigrationGuide.md) for upgrade and compatibility details.
 
 ### Prerequisites
 
@@ -36,7 +36,7 @@ The Azure Identity library focuses on OAuth authentication with Microsoft Entra 
 
 See [Credential classes](#credential-classes) for a complete listing of available credential types.
 
-For details on the assembly consolidation introduced in version 1.53 and how to handle `CS0433` conflicts when mixing package versions, see the [Migration Guide](./MigrationGuide.md).
+For details on the assembly consolidation introduced in version 1.53.0 and how to handle [`CS0433`](https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/cs0433) conflicts when mixing package versions, see the [Migration Guide](./MigrationGuide.md).
 
 ### DefaultAzureCredential
 

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -14,6 +14,9 @@ Install the Azure Identity client library for .NET with NuGet:
 dotnet add package Azure.Identity
 ```
 
+> [!NOTE]
+> Starting with `Azure.Core` 1.53.0, all credential types (including `DefaultAzureCredential`) are bundled directly in `Azure.Core`. If your project already targets `Azure.Core` 1.53.0 or later and you do not use any `Azure.Identity`-specific APIs, you can omit the `Azure.Identity` package reference entirely. See the [Migration Guide](./MigrationGuide.md) for upgrade and compatibility details.
+
 ### Prerequisites
 
 * An [Azure subscription][azure_sub].
@@ -32,6 +35,8 @@ A credential is a class that contains or can obtain the data needed for a servic
 The Azure Identity library focuses on OAuth authentication with Microsoft Entra ID. It offers numerous credentials capable of acquiring a Microsoft Entra token to authenticate service requests. Each credential in this library is an implementation of the `TokenCredential` abstract class in [Azure.Core][azure_core_library], and any of them can be used to construct service clients capable of authenticating with a `TokenCredential`.
 
 See [Credential classes](#credential-classes) for a complete listing of available credential types.
+
+For details on the assembly consolidation introduced in version 1.53 and how to handle `CS0433` conflicts when mixing package versions, see the [Migration Guide](./MigrationGuide.md).
 
 ### DefaultAzureCredential
 

--- a/sdk/identity/Azure.Identity/README.md
+++ b/sdk/identity/Azure.Identity/README.md
@@ -15,7 +15,7 @@ dotnet add package Azure.Identity
 ```
 
 > [!NOTE]
-> Starting with `Azure.Core` 1.53.0, all credential types (including `DefaultAzureCredential`) are bundled directly in `Azure.Core`. If your project already targets `Azure.Core` 1.53.0+ or does so through a transitive dependency, you should omit the `Azure.Identity` package reference entirely. See the [Migration Guide](./MigrationGuide.md) for upgrade and compatibility details.
+> Starting with `Azure.Core` 1.53.0, all credential types (including `DefaultAzureCredential`) are bundled directly in `Azure.Core`. If your project already targets `Azure.Core` 1.53.0+ or does so through a transitive dependency, you should omit the `Azure.Identity` package reference entirely. See the [Migration Guide](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/MigrationGuide.md) for upgrade and compatibility details.
 
 ### Prerequisites
 
@@ -36,7 +36,7 @@ The Azure Identity library focuses on OAuth authentication with Microsoft Entra 
 
 See [Credential classes](#credential-classes) for a complete listing of available credential types.
 
-For details on the assembly consolidation introduced in version 1.53.0 and how to handle [`CS0433`](https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/cs0433) conflicts when mixing package versions, see the [Migration Guide](./MigrationGuide.md).
+For details on the assembly consolidation introduced in version 1.53.0 and how to handle [`CS0433`](https://learn.microsoft.com/dotnet/csharp/language-reference/compiler-messages/cs0433) conflicts when mixing package versions, see the [Migration Guide](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/MigrationGuide.md).
 
 ### DefaultAzureCredential
 


### PR DESCRIPTION
## Description

Update the Azure.Identity and Azure.Core README documentation to reflect the type consolidation introduced in Azure.Core 1.53.0 (PR #57200).

### Changes

**sdk/identity/Azure.Identity/README.md**
- Added a note in the "Install the package" section that Azure.Core 1.53+ bundles all credential types
- Added a link to MigrationGuide.md in the "Credentials" subsection covering CS0433 conflicts

**sdk/core/Azure.Core/README.md**
- Added a bullet in "Key concepts" about bundled credential types from Azure.Identity
- Added an "Authenticating Service Clients" example section with a code sample

**sdk/core/Azure.Core/tests/Samples/CredentialsSamples.cs** (new)
- Test file backing the `Snippet:AzureCoreDefaultCredential` snippet

Fixes #58010, https://github.com/Azure/azure-sdk-for-net/issues/58008

---
:robot: PR Created with JonathanCrd's copilot