### PR TITLE
[.NET] Updated external feed to azure artifacts feed in the package-installation-check step

### DIFF
--- a/eng/scripts/InstallationCheck.ps1
+++ b/eng/scripts/InstallationCheck.ps1
@@ -30,9 +30,11 @@ if ($LASTEXITCODE) {
   exit $LASTEXITCODE
 }
 
+$internalFeed = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
+
 while ($retries++ -lt $RetryLimit) {
-  Write-Host "dotnet restore -s https://api.nuget.org/v3/index.json -s $localFeed --no-cache --verbosity detailed"
-  dotnet restore -s https://api.nuget.org/v3/index.json -s $localFeed --no-cache --verbosity detailed
+  Write-Host "dotnet restore -s $internalFeed -s $localFeed --no-cache --verbosity detailed"
+  dotnet restore -s $internalFeed -s $localFeed --no-cache --verbosity detailed
   if ($LASTEXITCODE) {
     if ($retries -ge $RetryLimit) {
       exit $LASTEXITCODE


### PR DESCRIPTION
This pull request makes a targeted change to the `eng/scripts/InstallationCheck.ps1` script by switching the primary NuGet feed to an internal Azure SDK feed instead of the public NuGet.org feed for restoring packages.

Fixed the error:
```
Build FAILED.

       "D:\a\_work\1\s\InstallationCheck\InstallationCheck.csproj" (Restore target) (1) ->
       (Restore target) -> 
         D:\a\_work\1\s\InstallationCheck\InstallationCheck.csproj : error NU1301: Unable to load the service index for source https://api.nuget.org/v3/index.json.
       D:\a\_work\1\s\InstallationCheck\InstallationCheck.csproj : error NU1301:   An attempt was made to access a socket in a way forbidden by its access permissions. (api.nuget.org:443)
       D:\a\_work\1\s\InstallationCheck\InstallationCheck.csproj : error NU1301:   An attempt was made to access a socket in a way forbidden by its access permissions.

    0 Warning(s)
    1 Error(s)
```