### PR TITLE
Update Azure.Identity.Broker to depend on Azure.Core instead of Azure.Identity

### DIFF
--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Other Changes
 
-- Updated dependency from `Azure.Identity` to `Azure.Core` directly, as the Azure.Identity types have been moved to Azure.Core.
+- Updated dependency from `Azure.Identity` to `Azure.Core` directly, as the `Azure.Identity` types moved to `Azure.Core`.
 
 ## 1.5.0 (2026-04-02)
 

--- a/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity.Broker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated dependency from `Azure.Identity` to `Azure.Core` directly, as the Azure.Identity types have been moved to Azure.Core.
+
 ## 1.5.0 (2026-04-02)
 
 ### Features Added

--- a/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
+++ b/sdk/identity/Azure.Identity.Broker/src/Azure.Identity.Broker.csproj
@@ -12,8 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <!-- TODO: Revert to PackageReference after Azure.Core 1.52 ships with Identity types -->
-    <ProjectReference Include="..\..\Azure.Identity\src\Azure.Identity.csproj" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Identity.Client.Broker" />
   </ItemGroup>
 </Project>

--- a/sdk/identity/Azure.Identity.Broker/tests/Azure.Identity.Broker.Tests.csproj
+++ b/sdk/identity/Azure.Identity.Broker/tests/Azure.Identity.Broker.Tests.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(AzureCoreTestFramework)" />
-    <ProjectReference Include="..\..\Azure.Identity\src\Azure.Identity.csproj" />
     <ProjectReference Include="..\src\Azure.Identity.Broker.csproj" />
     <ProjectReference Include="..\..\..\core\Azure.Core.Experimental\src\Azure.Core.Experimental.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## What

Update Azure.Identity.Broker to depend on Azure.Core directly instead of Azure.Identity, now that all Azure.Identity types have been moved to Azure.Core via #57200.

## Changes

- **Azure.Identity.Broker.csproj**: Replaced \ProjectReference\ to \Azure.Identity.csproj\ with \PackageReference\ to \Azure.Core\. Removed the TODO comment.
- **Azure.Identity.Broker.Tests.csproj**: Removed the direct \ProjectReference\ to \Azure.Identity.csproj\ (types now come transitively through Azure.Core).
- **CHANGELOG.md**: Added entry under Other Changes for 1.6.0-beta.1.

## Validation

- Build: 0 errors, 0 warnings (all TFMs: netstandard2.0, net8.0, net10.0, net462)
- ApiCompat: Passed against published 1.5.0
- Tests: 156 passed, 0 failed
