### PR TITLE
[AgentServer] Builder lifecycle ownership: each builder owns its full event lifecycle

### DIFF
--- a/sdk/agentserver/AGENTS.md
+++ b/sdk/agentserver/AGENTS.md
@@ -263,27 +263,37 @@ dotnet format Azure.AI.AgentServer.sln
 
 ### Pre-commit checks (strict ordering)
 
-Run these **in this exact order** before every commit. Order matters — `dotnet format`
+Run these **in this exact order** before every commit. Order matters — tests must
+run **first** to catch regressions before any formatting work, and `dotnet format`
 must run **last** so it catches formatting issues introduced by earlier steps.
 
-Steps 1–2 run from the **repo root**; steps 3–4 run from `sdk/agentserver/`.
+Step 1 runs from `sdk/agentserver/`; steps 2–3 run from the **repo root**;
+steps 4–5 run from `sdk/agentserver/`.
 
 ```powershell
-# 1. Export public API  (from repo root)
+# 1. Run tests FIRST  (from sdk/agentserver/ — catches regressions before formatting)
+cd sdk/agentserver
+dotnet test Azure.AI.AgentServer.sln --filter TestCategory!=Live
+
+# 2. Export public API  (from repo root)
 eng/scripts/Export-API.ps1 agentserver
 
-# 2. Update doc snippets  (from repo root — syncs #region blocks into markdown)
+# 3. Update doc snippets  (from repo root — syncs #region blocks into markdown)
 eng/scripts/Update-Snippets.ps1 agentserver
 
-# 3. Build snippets  (from sdk/agentserver/ — reproduces CI "Build snippets" step)
+# 4. Build snippets  (from sdk/agentserver/ — reproduces CI "Build snippets" step)
 cd sdk/agentserver
 dotnet build Azure.AI.AgentServer.sln /p:BuildSnippets=true
 
-# 4. Format LAST  (from sdk/agentserver/ — catches indent/whitespace from all prior steps)
+# 5. Format LAST  (from sdk/agentserver/ — catches indent/whitespace from all prior steps)
 dotnet format Azure.AI.AgentServer.sln
 ```
 
-**Why format last?** Steps 1–3 may modify files (API listings, snippet markdown, or
+**Why tests first?** Lifecycle validation, protocol compliance, and handler logic
+bugs are only caught by tests — not by formatting or API export. Running tests
+first prevents pushing regressions that pass all static checks but fail at runtime.
+
+**Why format last?** Steps 2–4 may modify files (API listings, snippet markdown, or
 code via scripts like `sed`). Running format first would miss those changes. The CI
 "Build snippets" step defines the `SNIPPET` preprocessor constant — snippet code must
 compile in that mode.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
@@ -136,9 +136,9 @@ public class EchoHandlerFullControl : ResponseHandler
         var text = message.AddTextContent();
         yield return text.EmitAdded();
         yield return text.EmitDelta("Hello, world!");
-        yield return text.EmitDone("Hello, world!");
+        yield return text.EmitTextDone("Hello, world!");
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
         yield return stream.EmitCompleted();
     }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
@@ -505,9 +505,6 @@ namespace Azure.AI.AgentServer.Responses
         public virtual Azure.AI.AgentServer.Responses.RefusalContentBuilder AddRefusalContent() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.TextContentBuilder AddTextContent() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputItemAddedEvent EmitAdded() { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitContentDone(Azure.AI.AgentServer.Responses.RefusalContentBuilder refusalContent) { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitContentDone(Azure.AI.AgentServer.Responses.TextContentBuilder textContent) { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitContentDone(Azure.AI.AgentServer.Responses.TextContentBuilder textContent, System.Collections.Generic.IEnumerable<Azure.AI.AgentServer.Responses.Models.Annotation> annotations) { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputItemDoneEvent EmitDone() { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent> RefusalContent(System.Collections.Generic.IAsyncEnumerable<string> chunks, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Collections.Generic.IEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent> RefusalContent(string text) { throw null; }
@@ -521,7 +518,6 @@ namespace Azure.AI.AgentServer.Responses
         public virtual Azure.AI.AgentServer.Responses.ReasoningSummaryPartBuilder AddSummaryPart() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputItemAddedEvent EmitAdded() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputItemDoneEvent EmitDone() { throw null; }
-        public virtual void EmitSummaryPartDone(Azure.AI.AgentServer.Responses.ReasoningSummaryPartBuilder summaryPart) { }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent> SummaryPart(System.Collections.Generic.IAsyncEnumerable<string> chunks, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Collections.Generic.IEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent> SummaryPart(string text) { throw null; }
     }
@@ -556,7 +552,8 @@ namespace Azure.AI.AgentServer.Responses
         public string? FinalRefusal { get { throw null; } }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartAddedEvent EmitAdded() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseRefusalDeltaEvent EmitDelta(string text) { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseRefusalDoneEvent EmitDone(string finalRefusal) { throw null; }
+        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitDone() { throw null; }
+        public virtual Azure.AI.AgentServer.Responses.Models.ResponseRefusalDoneEvent EmitRefusalDone(string finalRefusal) { throw null; }
     }
     public partial class ResourceNotFoundException : System.Exception
     {
@@ -779,12 +776,14 @@ namespace Azure.AI.AgentServer.Responses
     public partial class TextContentBuilder
     {
         protected TextContentBuilder() { }
+        public System.Collections.Generic.IReadOnlyList<Azure.AI.AgentServer.Responses.Models.Annotation> Annotations { get { throw null; } }
         public long ContentIndex { get { throw null; } }
         public string? FinalText { get { throw null; } }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartAddedEvent EmitAdded() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputTextAnnotationAddedEvent EmitAnnotationAdded(Azure.AI.AgentServer.Responses.Models.Annotation annotation) { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseTextDeltaEvent EmitDelta(string text) { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseTextDoneEvent EmitDone(string finalText) { throw null; }
+        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitDone() { throw null; }
+        public virtual Azure.AI.AgentServer.Responses.Models.ResponseTextDoneEvent EmitTextDone(string? finalText = null) { throw null; }
     }
     public partial class TextResponse : System.Collections.Generic.IAsyncEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent>
     {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
@@ -505,9 +505,6 @@ namespace Azure.AI.AgentServer.Responses
         public virtual Azure.AI.AgentServer.Responses.RefusalContentBuilder AddRefusalContent() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.TextContentBuilder AddTextContent() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputItemAddedEvent EmitAdded() { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitContentDone(Azure.AI.AgentServer.Responses.RefusalContentBuilder refusalContent) { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitContentDone(Azure.AI.AgentServer.Responses.TextContentBuilder textContent) { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitContentDone(Azure.AI.AgentServer.Responses.TextContentBuilder textContent, System.Collections.Generic.IEnumerable<Azure.AI.AgentServer.Responses.Models.Annotation> annotations) { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputItemDoneEvent EmitDone() { throw null; }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent> RefusalContent(System.Collections.Generic.IAsyncEnumerable<string> chunks, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Collections.Generic.IEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent> RefusalContent(string text) { throw null; }
@@ -521,7 +518,6 @@ namespace Azure.AI.AgentServer.Responses
         public virtual Azure.AI.AgentServer.Responses.ReasoningSummaryPartBuilder AddSummaryPart() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputItemAddedEvent EmitAdded() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputItemDoneEvent EmitDone() { throw null; }
-        public virtual void EmitSummaryPartDone(Azure.AI.AgentServer.Responses.ReasoningSummaryPartBuilder summaryPart) { }
         public virtual System.Collections.Generic.IAsyncEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent> SummaryPart(System.Collections.Generic.IAsyncEnumerable<string> chunks, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Collections.Generic.IEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent> SummaryPart(string text) { throw null; }
     }
@@ -556,7 +552,8 @@ namespace Azure.AI.AgentServer.Responses
         public string? FinalRefusal { get { throw null; } }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartAddedEvent EmitAdded() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseRefusalDeltaEvent EmitDelta(string text) { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseRefusalDoneEvent EmitDone(string finalRefusal) { throw null; }
+        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitDone() { throw null; }
+        public virtual Azure.AI.AgentServer.Responses.Models.ResponseRefusalDoneEvent EmitRefusalDone(string finalRefusal) { throw null; }
     }
     public partial class ResourceNotFoundException : System.Exception
     {
@@ -779,12 +776,14 @@ namespace Azure.AI.AgentServer.Responses
     public partial class TextContentBuilder
     {
         protected TextContentBuilder() { }
+        public System.Collections.Generic.IReadOnlyList<Azure.AI.AgentServer.Responses.Models.Annotation> Annotations { get { throw null; } }
         public long ContentIndex { get { throw null; } }
         public string? FinalText { get { throw null; } }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartAddedEvent EmitAdded() { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseOutputTextAnnotationAddedEvent EmitAnnotationAdded(Azure.AI.AgentServer.Responses.Models.Annotation annotation) { throw null; }
         public virtual Azure.AI.AgentServer.Responses.Models.ResponseTextDeltaEvent EmitDelta(string text) { throw null; }
-        public virtual Azure.AI.AgentServer.Responses.Models.ResponseTextDoneEvent EmitDone(string finalText) { throw null; }
+        public virtual Azure.AI.AgentServer.Responses.Models.ResponseContentPartDoneEvent EmitDone() { throw null; }
+        public virtual Azure.AI.AgentServer.Responses.Models.ResponseTextDoneEvent EmitTextDone(string? finalText = null) { throw null; }
     }
     public partial class TextResponse : System.Collections.Generic.IAsyncEnumerable<Azure.AI.AgentServer.Responses.Models.ResponseStreamEvent>
     {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
@@ -320,9 +320,9 @@ public class EchoHandler : ResponseHandler
         var text = message.AddTextContent();
         yield return text.EmitAdded();
         yield return text.EmitDelta("Hello, world!");
-        yield return text.EmitDone("Hello, world!");
+        yield return text.EmitTextDone("Hello, world!");
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         // 3. Signal completion
@@ -643,9 +643,9 @@ yield return text.EmitDelta("First chunk of text. ");
 yield return text.EmitDelta("Second chunk. ");
 
 // Finalise the text content (final text = full accumulated text)
-yield return text.EmitDone("First chunk of text. Second chunk. ");
+yield return text.EmitTextDone("First chunk of text. Second chunk. ");
 
-yield return message.EmitContentDone(text);
+yield return text.EmitDone();
 yield return message.EmitDone();
 ```
 
@@ -765,7 +765,6 @@ yield return summary.EmitAdded();
 yield return summary.EmitTextDelta("Let me think about this...");
 yield return summary.EmitTextDone("Let me think about this...");
 yield return summary.EmitDone();
-reasoning.EmitSummaryPartDone(summary);
 yield return reasoning.EmitDone();
 ```
 
@@ -972,8 +971,8 @@ public async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
         yield return text.EmitDelta(chunk);
     }
 
-    yield return text.EmitDone(fullText);
-    yield return message.EmitContentDone(text);
+    yield return text.EmitTextDone(fullText);
+    yield return text.EmitDone();
     yield return message.EmitDone();
     yield return stream.EmitCompleted();
 }
@@ -1554,17 +1553,17 @@ yield return stream.EmitCompleted();
 ### Not Closing Content Builders
 
 ```csharp
-// ❌ Missing EmitContentDone
+// ❌ Missing EmitDone on the content builder
 var text = message.AddTextContent();
 yield return text.EmitAdded();
-yield return text.EmitDone("text");
+yield return text.EmitTextDone("text");
 yield return message.EmitDone(); // Content wasn't properly closed
 
-// ✅ Always call EmitContentDone before closing the message
+// ✅ Always call EmitDone on the content builder before closing the message
 var text = message.AddTextContent();
 yield return text.EmitAdded();
-yield return text.EmitDone("text");
-yield return message.EmitContentDone(text); // Close the content part
+yield return text.EmitTextDone("text");
+yield return text.EmitDone(); // Close the content part
 yield return message.EmitDone();
 ```
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample3_FullControlResponseStream.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample3_FullControlResponseStream.md
@@ -120,10 +120,10 @@ public class GreetingHandlerFullControl : ResponseHandler
         var input = await context.GetInputTextAsync(cancellationToken: cancellationToken);
         var reply = $"Hello! You said: \"{input}\"";
         yield return text.EmitDelta(reply);  // response.output_text.delta
-        yield return text.EmitDone(reply);   // response.output_text.done
+        yield return text.EmitTextDone(reply);   // response.output_text.done
 
         // Close the content, message, and response.
-        yield return message.EmitContentDone(text);  // response.content_part.done
+        yield return text.EmitDone();  // response.content_part.done
         yield return message.EmitDone();              // response.output_item.done
         yield return stream.EmitCompleted();          // response.completed
     }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample4_FunctionCalling.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample4_FunctionCalling.md
@@ -96,9 +96,9 @@ public class WeatherHandlerFullControl : ResponseHandler
 
             var reply = $"The weather is: {weatherJson}";
             yield return text.EmitDelta(reply);
-            yield return text.EmitDone(reply);
+            yield return text.EmitTextDone(reply);
 
-            yield return message.EmitContentDone(text);
+            yield return text.EmitDone();
             yield return message.EmitDone();
 
             yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample6_MultiOutput.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/samples/Sample6_MultiOutput.md
@@ -78,7 +78,6 @@ public class MathSolverHandlerFullControl : ResponseHandler
         yield return summary.EmitTextDelta(thought);
         yield return summary.EmitTextDone(thought);
         yield return summary.EmitDone();
-        reasoning.EmitSummaryPartDone(summary);
 
         yield return reasoning.EmitDone();
 
@@ -92,9 +91,9 @@ public class MathSolverHandlerFullControl : ResponseHandler
         var answer = "The answer is 42. Here's how: " +
                      "6 × 7 = 42. The multiplication of 6 and 7 gives 42.";
         yield return text.EmitDelta(answer);
-        yield return text.EmitDone(answer);
+        yield return text.EmitTextDone(answer);
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemMessageBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemMessageBuilder.cs
@@ -196,19 +196,36 @@ public class OutputItemMessageBuilder : OutputItemBuilder<OutputItemMessage>
         }
 
         var completedContents = new List<MessageContent>();
-        foreach (var builder in _contentBuilders)
+        for (int i = 0; i < _contentBuilders.Count; i++)
         {
+            object builder = _contentBuilders[i];
             if (builder is TextContentBuilder tc)
             {
+                if (tc.FinalText is null)
+                {
+                    throw new ResponseValidationException(
+                    [
+                        new ValidationError($"$.content[{i}]", "Text content must be finalized (EmitTextDone + EmitDone) before message EmitDone().")
+                    ]);
+                }
+
                 completedContents.Add(new MessageContentOutputTextContent(
-                    text: tc.FinalText ?? string.Empty,
+                    text: tc.FinalText,
                     annotations: tc.Annotations,
                     logprobs: Array.Empty<LogProb>()));
             }
             else if (builder is RefusalContentBuilder rc)
             {
+                if (rc.FinalRefusal is null)
+                {
+                    throw new ResponseValidationException(
+                    [
+                        new ValidationError($"$.content[{i}]", "Refusal content must be finalized (EmitRefusalDone + EmitDone) before message EmitDone().")
+                    ]);
+                }
+
                 completedContents.Add(new MessageContentRefusalContent(
-                    refusal: rc.FinalRefusal ?? string.Empty));
+                    refusal: rc.FinalRefusal));
             }
         }
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemMessageBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemMessageBuilder.cs
@@ -10,11 +10,13 @@ namespace Azure.AI.AgentServer.Responses;
 /// <summary>
 /// Scoped builder for a message-type output item. Manages the content index
 /// counter within the message and provides factory methods for content part scopes.
+/// Child content builders are auto-tracked so <see cref="EmitDone"/> can build
+/// the final message from their accumulated state.
 /// </summary>
 public class OutputItemMessageBuilder : OutputItemBuilder<OutputItemMessage>
 {
     private long _contentIndex;
-    private readonly List<MessageContent> _completedContents = new();
+    private readonly List<object> _contentBuilders = new();
 
     /// <summary>
     /// Initializes a new instance of <see cref="OutputItemMessageBuilder"/>.
@@ -48,75 +50,28 @@ public class OutputItemMessageBuilder : OutputItemBuilder<OutputItemMessage>
 
     /// <summary>
     /// Creates a text content part scope with the next content index.
+    /// The builder is auto-tracked for inclusion in <see cref="EmitDone"/>.
     /// </summary>
     /// <returns>A new <see cref="TextContentBuilder"/> for the text content part.</returns>
     public virtual TextContentBuilder AddTextContent()
     {
         var contentIndex = _contentIndex++;
-        return new TextContentBuilder(_stream, _outputIndex, contentIndex, _itemId);
+        var builder = new TextContentBuilder(_stream, _outputIndex, contentIndex, _itemId);
+        _contentBuilders.Add(builder);
+        return builder;
     }
 
     /// <summary>
     /// Creates a refusal content part scope with the next content index.
+    /// The builder is auto-tracked for inclusion in <see cref="EmitDone"/>.
     /// </summary>
     /// <returns>A new <see cref="RefusalContentBuilder"/> for the refusal content part.</returns>
     public virtual RefusalContentBuilder AddRefusalContent()
     {
         var contentIndex = _contentIndex++;
-        return new RefusalContentBuilder(_stream, _outputIndex, contentIndex, _itemId);
-    }
-
-    /// <summary>
-    /// Produces a <c>response.content_part.done</c> event for the given
-    /// text content builder, using its accumulated final text.
-    /// </summary>
-    /// <param name="textContent">The text content builder whose final text to use.</param>
-    /// <returns>A <see cref="ResponseContentPartDoneEvent"/> for this content part.</returns>
-    public virtual ResponseContentPartDoneEvent EmitContentDone(TextContentBuilder textContent)
-    {
-        return EmitContentDone(textContent, Array.Empty<Annotation>());
-    }
-
-    /// <summary>
-    /// Produces a <c>response.content_part.done</c> event for the given
-    /// text content builder, including the specified annotations.
-    /// </summary>
-    /// <param name="textContent">The text content builder whose final text to use.</param>
-    /// <param name="annotations">The annotations to include in the completed content part.</param>
-    /// <returns>A <see cref="ResponseContentPartDoneEvent"/> for this content part.</returns>
-    public virtual ResponseContentPartDoneEvent EmitContentDone(
-        TextContentBuilder textContent, IEnumerable<Annotation> annotations)
-    {
-        ArgumentNullException.ThrowIfNull(textContent);
-        ArgumentNullException.ThrowIfNull(annotations);
-
-        var annotationList = annotations as IList<Annotation> ?? annotations.ToList();
-        var part = new OutputContentOutputTextContent(
-            text: textContent.FinalText ?? string.Empty,
-            annotations: annotationList,
-            logprobs: Array.Empty<LogProb>());
-        _completedContents.Add(new MessageContentOutputTextContent(
-            text: textContent.FinalText ?? string.Empty,
-            annotations: annotationList,
-            logprobs: Array.Empty<LogProb>()));
-        return new ResponseContentPartDoneEvent(
-            _stream.NextSequenceNumber(), _itemId, _outputIndex, textContent.ContentIndex, part);
-    }
-
-    /// <summary>
-    /// Produces a <c>response.content_part.done</c> event for the given
-    /// refusal content builder, using its accumulated final refusal text.
-    /// </summary>
-    /// <param name="refusalContent">The refusal content builder whose final refusal to use.</param>
-    /// <returns>A <see cref="ResponseContentPartDoneEvent"/> for this content part.</returns>
-    public virtual ResponseContentPartDoneEvent EmitContentDone(RefusalContentBuilder refusalContent)
-    {
-        var part = new OutputContentRefusalContent(
-            refusal: refusalContent.FinalRefusal ?? string.Empty);
-        _completedContents.Add(new MessageContentRefusalContent(
-            refusal: refusalContent.FinalRefusal ?? string.Empty));
-        return new ResponseContentPartDoneEvent(
-            _stream.NextSequenceNumber(), _itemId, _outputIndex, refusalContent.ContentIndex, part);
+        var builder = new RefusalContentBuilder(_stream, _outputIndex, contentIndex, _itemId);
+        _contentBuilders.Add(builder);
+        return builder;
     }
 
     // ── Sub-Item Convenience Generators (S-053/S-054/S-055) ────
@@ -148,14 +103,14 @@ public class OutputItemMessageBuilder : OutputItemBuilder<OutputItemMessage>
         var builder = AddTextContent();
         yield return builder.EmitAdded();
         yield return builder.EmitDelta(text);
-        yield return builder.EmitDone(text);
+        yield return builder.EmitTextDone(text);
 
         foreach (var annotation in annotationList)
         {
             yield return builder.EmitAnnotationAdded(annotation);
         }
 
-        yield return EmitContentDone(builder, annotationList);
+        yield return builder.EmitDone();
     }
 
     /// <summary>
@@ -173,16 +128,13 @@ public class OutputItemMessageBuilder : OutputItemBuilder<OutputItemMessage>
         var builder = AddTextContent();
         yield return builder.EmitAdded();
 
-        var sb = new StringBuilder();
         await foreach (var chunk in chunks.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
-            sb.Append(chunk);
             yield return builder.EmitDelta(chunk);
         }
 
-        var finalText = sb.ToString();
-        yield return builder.EmitDone(finalText);
-        yield return EmitContentDone(builder);
+        yield return builder.EmitTextDone();
+        yield return builder.EmitDone();
     }
 
     /// <summary>
@@ -196,8 +148,8 @@ public class OutputItemMessageBuilder : OutputItemBuilder<OutputItemMessage>
         var builder = AddRefusalContent();
         yield return builder.EmitAdded();
         yield return builder.EmitDelta(text);
-        yield return builder.EmitDone(text);
-        yield return EmitContentDone(builder);
+        yield return builder.EmitRefusalDone(text);
+        yield return builder.EmitDone();
     }
 
     /// <summary>
@@ -222,20 +174,20 @@ public class OutputItemMessageBuilder : OutputItemBuilder<OutputItemMessage>
             yield return builder.EmitDelta(chunk);
         }
 
-        var finalText = sb.ToString();
-        yield return builder.EmitDone(finalText);
-        yield return EmitContentDone(builder);
+        yield return builder.EmitRefusalDone(sb.ToString());
+        yield return builder.EmitDone();
     }
 
     /// <summary>
     /// Produces a <c>response.output_item.done</c> event with a
-    /// completed message output item containing the accumulated content.
+    /// completed message output item. The content list is built automatically
+    /// from the tracked child content builders.
     /// </summary>
     /// <returns>A <see cref="ResponseOutputItemDoneEvent"/> for this message.</returns>
     /// <exception cref="ResponseValidationException">No content parts have been added to this message.</exception>
     public virtual ResponseOutputItemDoneEvent EmitDone()
     {
-        if (_completedContents.Count == 0)
+        if (_contentBuilders.Count == 0)
         {
             throw new ResponseValidationException(
             [
@@ -243,10 +195,27 @@ public class OutputItemMessageBuilder : OutputItemBuilder<OutputItemMessage>
             ]);
         }
 
+        var completedContents = new List<MessageContent>();
+        foreach (var builder in _contentBuilders)
+        {
+            if (builder is TextContentBuilder tc)
+            {
+                completedContents.Add(new MessageContentOutputTextContent(
+                    text: tc.FinalText ?? string.Empty,
+                    annotations: tc.Annotations,
+                    logprobs: Array.Empty<LogProb>()));
+            }
+            else if (builder is RefusalContentBuilder rc)
+            {
+                completedContents.Add(new MessageContentRefusalContent(
+                    refusal: rc.FinalRefusal ?? string.Empty));
+            }
+        }
+
         var message = new OutputItemMessage(
             id: _itemId,
             status: MessageStatus.Completed,
-            content: _completedContents);
+            content: completedContents);
         return EmitDone(message);
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemMessageBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemMessageBuilder.cs
@@ -201,31 +201,31 @@ public class OutputItemMessageBuilder : OutputItemBuilder<OutputItemMessage>
             object builder = _contentBuilders[i];
             if (builder is TextContentBuilder tc)
             {
-                if (tc.FinalText is null)
+                if (!tc.IsDone)
                 {
                     throw new ResponseValidationException(
                     [
-                        new ValidationError($"$.content[{i}]", "Text content must be finalized (EmitTextDone + EmitDone) before message EmitDone().")
+                        new ValidationError($"$.content[{i}]", "Text content builder must complete its full lifecycle (EmitTextDone + EmitDone) before message EmitDone().")
                     ]);
                 }
 
                 completedContents.Add(new MessageContentOutputTextContent(
-                    text: tc.FinalText,
+                    text: tc.FinalText!,
                     annotations: tc.Annotations,
                     logprobs: Array.Empty<LogProb>()));
             }
             else if (builder is RefusalContentBuilder rc)
             {
-                if (rc.FinalRefusal is null)
+                if (!rc.IsDone)
                 {
                     throw new ResponseValidationException(
                     [
-                        new ValidationError($"$.content[{i}]", "Refusal content must be finalized (EmitRefusalDone + EmitDone) before message EmitDone().")
+                        new ValidationError($"$.content[{i}]", "Refusal content builder must complete its full lifecycle (EmitRefusalDone + EmitDone) before message EmitDone().")
                     ]);
                 }
 
                 completedContents.Add(new MessageContentRefusalContent(
-                    refusal: rc.FinalRefusal));
+                    refusal: rc.FinalRefusal!));
             }
         }
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemReasoningItemBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemReasoningItemBuilder.cs
@@ -9,11 +9,13 @@ namespace Azure.AI.AgentServer.Responses;
 /// <summary>
 /// Scoped builder for a reasoning output item. Manages the summary part index
 /// counter and provides factory methods for creating summary part scopes.
+/// Child summary builders are auto-tracked so <see cref="EmitDone"/> can build
+/// the final reasoning item from their accumulated state.
 /// </summary>
 public class OutputItemReasoningItemBuilder : OutputItemBuilder<OutputItemReasoningItem>
 {
     private long _summaryIndex;
-    private readonly List<SummaryTextContent> _completedSummaries = new();
+    private readonly List<ReasoningSummaryPartBuilder> _summaryBuilders = new();
 
     /// <summary>
     /// Initializes a new instance of <see cref="OutputItemReasoningItemBuilder"/>.
@@ -47,22 +49,15 @@ public class OutputItemReasoningItemBuilder : OutputItemBuilder<OutputItemReason
 
     /// <summary>
     /// Creates a reasoning summary part scope with the next summary index.
+    /// The builder is auto-tracked for inclusion in <see cref="EmitDone"/>.
     /// </summary>
     /// <returns>A new <see cref="ReasoningSummaryPartBuilder"/> for the summary part.</returns>
     public virtual ReasoningSummaryPartBuilder AddSummaryPart()
     {
         var summaryIndex = _summaryIndex++;
-        return new ReasoningSummaryPartBuilder(_stream, _outputIndex, summaryIndex, _itemId);
-    }
-
-    /// <summary>
-    /// Records a completed summary part for inclusion in the done event.
-    /// </summary>
-    /// <param name="summaryPart">The summary part builder whose final text to accumulate.</param>
-    public virtual void EmitSummaryPartDone(ReasoningSummaryPartBuilder summaryPart)
-    {
-        _completedSummaries.Add(new SummaryTextContent(
-            text: summaryPart.FinalText ?? string.Empty));
+        var builder = new ReasoningSummaryPartBuilder(_stream, _outputIndex, summaryIndex, _itemId);
+        _summaryBuilders.Add(builder);
+        return builder;
     }
 
     // ── Sub-Item Convenience Generators (S-053/S-054/S-055) ────
@@ -80,7 +75,6 @@ public class OutputItemReasoningItemBuilder : OutputItemBuilder<OutputItemReason
         yield return builder.EmitTextDelta(text);
         yield return builder.EmitTextDone(text);
         yield return builder.EmitDone();
-        EmitSummaryPartDone(builder);
     }
 
     /// <summary>
@@ -108,19 +102,26 @@ public class OutputItemReasoningItemBuilder : OutputItemBuilder<OutputItemReason
         var finalText = sb.ToString();
         yield return builder.EmitTextDone(finalText);
         yield return builder.EmitDone();
-        EmitSummaryPartDone(builder);
     }
 
     /// <summary>
     /// Produces a <c>response.output_item.done</c> event with a
-    /// completed reasoning output item containing the accumulated summaries.
+    /// completed reasoning output item. The summary list is built automatically
+    /// from the tracked child summary builders.
     /// </summary>
     /// <returns>A <see cref="ResponseOutputItemDoneEvent"/> for this reasoning item.</returns>
     public virtual ResponseOutputItemDoneEvent EmitDone()
     {
+        var completedSummaries = new List<SummaryTextContent>();
+        foreach (var builder in _summaryBuilders)
+        {
+            completedSummaries.Add(new SummaryTextContent(
+                text: builder.FinalText ?? string.Empty));
+        }
+
         var item = new OutputItemReasoningItem(
             id: _itemId,
-            summary: _completedSummaries);
+            summary: completedSummaries);
         item.Status = OutputItemReasoningItemStatus.Completed;
         return EmitDone(item);
     }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemReasoningItemBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemReasoningItemBuilder.cs
@@ -113,10 +113,19 @@ public class OutputItemReasoningItemBuilder : OutputItemBuilder<OutputItemReason
     public virtual ResponseOutputItemDoneEvent EmitDone()
     {
         var completedSummaries = new List<SummaryTextContent>();
-        foreach (var builder in _summaryBuilders)
+        for (int i = 0; i < _summaryBuilders.Count; i++)
         {
+            var builder = _summaryBuilders[i];
+            if (builder.FinalText is null)
+            {
+                throw new ResponseValidationException(
+                [
+                    new ValidationError($"$.summary[{i}]", "Summary part must be finalized (EmitTextDone + EmitDone) before reasoning EmitDone().")
+                ]);
+            }
+
             completedSummaries.Add(new SummaryTextContent(
-                text: builder.FinalText ?? string.Empty));
+                text: builder.FinalText));
         }
 
         var item = new OutputItemReasoningItem(

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemReasoningItemBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/OutputItemReasoningItemBuilder.cs
@@ -116,11 +116,11 @@ public class OutputItemReasoningItemBuilder : OutputItemBuilder<OutputItemReason
         for (int i = 0; i < _summaryBuilders.Count; i++)
         {
             var builder = _summaryBuilders[i];
-            if (builder.FinalText is null)
+            if (!builder.IsDone)
             {
                 throw new ResponseValidationException(
                 [
-                    new ValidationError($"$.summary[{i}]", "Summary part must be finalized (EmitTextDone + EmitDone) before reasoning EmitDone().")
+                    new ValidationError($"$.summary[{i}]", "Summary part builder must complete its full lifecycle (EmitTextDone + EmitDone) before reasoning EmitDone().")
                 ]);
             }
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/ReasoningSummaryPartBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/ReasoningSummaryPartBuilder.cs
@@ -41,6 +41,9 @@ public class ReasoningSummaryPartBuilder
     /// <summary>The final text passed to <see cref="EmitTextDone"/>. Null if not yet finalized.</summary>
     public string? FinalText => _finalText;
 
+    /// <summary>Whether this builder has completed its full lifecycle (<see cref="EmitDone"/> called).</summary>
+    internal bool IsDone => _lifecycleState == BuilderLifecycleState.Done;
+
     /// <summary>The summary index assigned to this summary part.</summary>
     public long SummaryIndex => _summaryIndex;
 
@@ -66,6 +69,11 @@ public class ReasoningSummaryPartBuilder
     /// <returns>A <see cref="ResponseReasoningSummaryTextDeltaEvent"/> with the delta.</returns>
     public virtual ResponseReasoningSummaryTextDeltaEvent EmitTextDelta(string text)
     {
+        if (_lifecycleState != BuilderLifecycleState.Added)
+            throw new InvalidOperationException($"Cannot call EmitTextDelta — builder is in '{_lifecycleState}' state.");
+        if (_finalText is not null)
+            throw new InvalidOperationException("Cannot emit deltas after EmitTextDone has been called.");
+
         return new ResponseReasoningSummaryTextDeltaEvent(
             _stream.NextSequenceNumber(), _itemId, _outputIndex, _summaryIndex, text);
     }
@@ -77,6 +85,11 @@ public class ReasoningSummaryPartBuilder
     /// <returns>A <see cref="ResponseReasoningSummaryTextDoneEvent"/> with the final text.</returns>
     public virtual ResponseReasoningSummaryTextDoneEvent EmitTextDone(string finalText)
     {
+        if (_lifecycleState != BuilderLifecycleState.Added)
+            throw new InvalidOperationException($"Cannot call EmitTextDone — builder is in '{_lifecycleState}' state.");
+        if (_finalText is not null)
+            throw new InvalidOperationException("EmitTextDone has already been called.");
+
         _finalText = finalText;
         return new ResponseReasoningSummaryTextDoneEvent(
             _stream.NextSequenceNumber(), _itemId, _outputIndex, _summaryIndex, finalText);

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/RefusalContentBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/RefusalContentBuilder.cs
@@ -6,8 +6,9 @@ using Azure.AI.AgentServer.Responses.Models;
 namespace Azure.AI.AgentServer.Responses;
 
 /// <summary>
-/// Scoped builder for a refusal content part within a message. Provides methods
-/// for the refusal content lifecycle: added, delta, and done events.
+/// Scoped builder for a refusal content part within a message. Owns its full
+/// lifecycle: <c>EmitAdded</c> → <c>EmitDelta</c> (0+) → <c>EmitRefusalDone</c>
+/// → <c>EmitDone</c>.
 /// </summary>
 public class RefusalContentBuilder
 {
@@ -16,6 +17,7 @@ public class RefusalContentBuilder
     private readonly long _contentIndex;
     private readonly string _itemId;
     private string? _finalRefusal;
+    private bool _refusalDone;
     private BuilderLifecycleState _lifecycleState;
 
     /// <summary>
@@ -38,7 +40,7 @@ public class RefusalContentBuilder
         _itemId = string.Empty;
     }
 
-    /// <summary>The final refusal text passed to <see cref="EmitDone"/>. Null if not yet finalized.</summary>
+    /// <summary>The final refusal text set by <see cref="EmitRefusalDone"/>. Null if not yet finalized.</summary>
     public string? FinalRefusal => _finalRefusal;
 
     /// <summary>The content index assigned to this refusal content part.</summary>
@@ -72,17 +74,39 @@ public class RefusalContentBuilder
 
     /// <summary>
     /// Produces a <c>response.refusal.done</c> event with the final complete refusal text.
+    /// Call this after all deltas have been emitted and before <see cref="EmitDone"/>.
     /// </summary>
     /// <param name="finalRefusal">The final complete refusal text.</param>
     /// <returns>A <see cref="ResponseRefusalDoneEvent"/> with the final refusal.</returns>
-    public virtual ResponseRefusalDoneEvent EmitDone(string finalRefusal)
+    public virtual ResponseRefusalDoneEvent EmitRefusalDone(string finalRefusal)
     {
         if (_lifecycleState != BuilderLifecycleState.Added)
-            throw new InvalidOperationException($"Cannot call EmitDone — builder is in '{_lifecycleState}' state.");
-        _lifecycleState = BuilderLifecycleState.Done;
+            throw new InvalidOperationException($"Cannot call EmitRefusalDone — builder is in '{_lifecycleState}' state.");
+        if (_refusalDone)
+            throw new InvalidOperationException("EmitRefusalDone has already been called.");
 
+        _refusalDone = true;
         _finalRefusal = finalRefusal;
         return new ResponseRefusalDoneEvent(
             _stream.NextSequenceNumber(), _itemId, _outputIndex, _contentIndex, finalRefusal);
+    }
+
+    /// <summary>
+    /// Produces a <c>response.content_part.done</c> event, closing this content part.
+    /// Must be called after <see cref="EmitRefusalDone"/>.
+    /// </summary>
+    /// <returns>A <see cref="ResponseContentPartDoneEvent"/> for this content part.</returns>
+    public virtual ResponseContentPartDoneEvent EmitDone()
+    {
+        if (_lifecycleState != BuilderLifecycleState.Added)
+            throw new InvalidOperationException($"Cannot call EmitDone — builder is in '{_lifecycleState}' state.");
+        if (!_refusalDone)
+            throw new InvalidOperationException("Must call EmitRefusalDone() before EmitDone().");
+        _lifecycleState = BuilderLifecycleState.Done;
+
+        var part = new OutputContentRefusalContent(
+            refusal: _finalRefusal ?? string.Empty);
+        return new ResponseContentPartDoneEvent(
+            _stream.NextSequenceNumber(), _itemId, _outputIndex, _contentIndex, part);
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/RefusalContentBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/RefusalContentBuilder.cs
@@ -46,6 +46,9 @@ public class RefusalContentBuilder
     /// <summary>The content index assigned to this refusal content part.</summary>
     public long ContentIndex => _contentIndex;
 
+    /// <summary>Whether this builder has completed its full lifecycle (<see cref="EmitDone"/> called).</summary>
+    internal bool IsDone => _lifecycleState == BuilderLifecycleState.Done;
+
     /// <summary>
     /// Produces a <c>response.content_part.added</c> event with an empty refusal content part.
     /// </summary>
@@ -68,6 +71,11 @@ public class RefusalContentBuilder
     /// <returns>A <see cref="ResponseRefusalDeltaEvent"/> with the delta.</returns>
     public virtual ResponseRefusalDeltaEvent EmitDelta(string text)
     {
+        if (_lifecycleState != BuilderLifecycleState.Added)
+            throw new InvalidOperationException($"Cannot call EmitDelta — builder is in '{_lifecycleState}' state.");
+        if (_refusalDone)
+            throw new InvalidOperationException("Cannot emit deltas after EmitRefusalDone has been called.");
+
         return new ResponseRefusalDeltaEvent(
             _stream.NextSequenceNumber(), _itemId, _outputIndex, _contentIndex, text);
     }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/TextContentBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/TextContentBuilder.cs
@@ -7,8 +7,9 @@ using Azure.AI.AgentServer.Responses.Models;
 namespace Azure.AI.AgentServer.Responses;
 
 /// <summary>
-/// Scoped builder for a text content part within a message. Provides methods
-/// for the text content lifecycle: added, delta, and done events.
+/// Scoped builder for a text content part within a message. Owns its full
+/// lifecycle: <c>EmitAdded</c> → <c>EmitDelta</c> (0+) → <c>EmitTextDone</c>
+/// → <c>EmitAnnotationAdded</c> (0+) → <c>EmitDone</c>.
 /// </summary>
 public class TextContentBuilder
 {
@@ -16,8 +17,11 @@ public class TextContentBuilder
     private readonly long _outputIndex;
     private readonly long _contentIndex;
     private readonly string _itemId;
+    private readonly List<string> _deltaFragments = new();
+    private readonly List<Annotation> _annotations = new();
     private string? _finalText;
     private long _annotationIndex;
+    private bool _textDone;
     private BuilderLifecycleState _lifecycleState;
 
     /// <summary>
@@ -40,11 +44,14 @@ public class TextContentBuilder
         _itemId = string.Empty;
     }
 
-    /// <summary>The final text passed to <see cref="EmitDone"/>. Null if not yet finalized.</summary>
+    /// <summary>The final text set by <see cref="EmitTextDone"/>. Null if not yet finalized.</summary>
     public string? FinalText => _finalText;
 
     /// <summary>The content index assigned to this text content part.</summary>
     public long ContentIndex => _contentIndex;
+
+    /// <summary>The annotations emitted via <see cref="EmitAnnotationAdded"/>.</summary>
+    public IReadOnlyList<Annotation> Annotations => _annotations;
 
     /// <summary>
     /// Produces a <c>response.content_part.added</c> event with an empty text content part.
@@ -71,6 +78,7 @@ public class TextContentBuilder
     /// <returns>A <see cref="ResponseTextDeltaEvent"/> with the text delta.</returns>
     public virtual ResponseTextDeltaEvent EmitDelta(string text)
     {
+        _deltaFragments.Add(text);
         return new ResponseTextDeltaEvent(
             _stream.NextSequenceNumber(), _itemId, _outputIndex, _contentIndex,
             text, Array.Empty<ResponseLogProb>());
@@ -78,30 +86,65 @@ public class TextContentBuilder
 
     /// <summary>
     /// Produces a <c>response.output_text.done</c> event with the final complete text.
+    /// Call this after all deltas have been emitted. After this, you may call
+    /// <see cref="EmitAnnotationAdded"/> and then <see cref="EmitDone"/>.
     /// </summary>
-    /// <param name="finalText">The final complete text.</param>
+    /// <param name="finalText">
+    /// Optional override for the final text. When <c>null</c>, the accumulated delta
+    /// fragments are merged automatically.
+    /// </param>
     /// <returns>A <see cref="ResponseTextDoneEvent"/> with the final text.</returns>
-    public virtual ResponseTextDoneEvent EmitDone(string finalText)
+    public virtual ResponseTextDoneEvent EmitTextDone(string? finalText = null)
     {
         if (_lifecycleState != BuilderLifecycleState.Added)
-            throw new InvalidOperationException($"Cannot call EmitDone — builder is in '{_lifecycleState}' state.");
-        _lifecycleState = BuilderLifecycleState.Done;
+            throw new InvalidOperationException($"Cannot call EmitTextDone — builder is in '{_lifecycleState}' state.");
+        if (_textDone)
+            throw new InvalidOperationException("EmitTextDone has already been called.");
 
-        _finalText = finalText;
+        _textDone = true;
+        var merged = string.Concat(_deltaFragments);
+        if (string.IsNullOrEmpty(merged) && finalText != null)
+            merged = finalText;
+        _finalText = merged;
+
         return new ResponseTextDoneEvent(
             _stream.NextSequenceNumber(), _itemId, _outputIndex, _contentIndex,
-            finalText, Array.Empty<ResponseLogProb>());
+            merged, Array.Empty<ResponseLogProb>());
     }
 
     /// <summary>
     /// Produces a <c>response.output_text.annotation.added</c> event with the given annotation.
+    /// The annotation is also tracked so that <see cref="EmitDone"/> can include it in
+    /// the <c>content_part.done</c> event.
     /// </summary>
     /// <param name="annotation">The annotation to emit.</param>
     /// <returns>A <see cref="ResponseOutputTextAnnotationAddedEvent"/> with the annotation.</returns>
     public virtual ResponseOutputTextAnnotationAddedEvent EmitAnnotationAdded(Annotation annotation)
     {
+        _annotations.Add(annotation);
         var annotationIndex = _annotationIndex++;
         return new ResponseOutputTextAnnotationAddedEvent(
             _stream.NextSequenceNumber(), _itemId, _outputIndex, _contentIndex, annotationIndex, annotation);
+    }
+
+    /// <summary>
+    /// Produces a <c>response.content_part.done</c> event, closing this content part.
+    /// Must be called after <see cref="EmitTextDone"/>.
+    /// </summary>
+    /// <returns>A <see cref="ResponseContentPartDoneEvent"/> for this content part.</returns>
+    public virtual ResponseContentPartDoneEvent EmitDone()
+    {
+        if (_lifecycleState != BuilderLifecycleState.Added)
+            throw new InvalidOperationException($"Cannot call EmitDone — builder is in '{_lifecycleState}' state.");
+        if (!_textDone)
+            throw new InvalidOperationException("Must call EmitTextDone() before EmitDone().");
+        _lifecycleState = BuilderLifecycleState.Done;
+
+        var part = new OutputContentOutputTextContent(
+            text: _finalText ?? string.Empty,
+            annotations: _annotations,
+            logprobs: Array.Empty<LogProb>());
+        return new ResponseContentPartDoneEvent(
+            _stream.NextSequenceNumber(), _itemId, _outputIndex, _contentIndex, part);
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/TextContentBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/TextContentBuilder.cs
@@ -102,14 +102,11 @@ public class TextContentBuilder
             throw new InvalidOperationException("EmitTextDone has already been called.");
 
         _textDone = true;
-        var merged = string.Concat(_deltaFragments);
-        if (string.IsNullOrEmpty(merged) && finalText != null)
-            merged = finalText;
-        _finalText = merged;
+        _finalText = finalText ?? string.Concat(_deltaFragments);
 
         return new ResponseTextDoneEvent(
             _stream.NextSequenceNumber(), _itemId, _outputIndex, _contentIndex,
-            merged, Array.Empty<ResponseLogProb>());
+            _finalText, Array.Empty<ResponseLogProb>());
     }
 
     /// <summary>

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/TextContentBuilder.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Builders/TextContentBuilder.cs
@@ -50,8 +50,11 @@ public class TextContentBuilder
     /// <summary>The content index assigned to this text content part.</summary>
     public long ContentIndex => _contentIndex;
 
+    /// <summary>Whether this builder has completed its full lifecycle (<see cref="EmitDone"/> called).</summary>
+    internal bool IsDone => _lifecycleState == BuilderLifecycleState.Done;
+
     /// <summary>The annotations emitted via <see cref="EmitAnnotationAdded"/>.</summary>
-    public IReadOnlyList<Annotation> Annotations => _annotations;
+    public IReadOnlyList<Annotation> Annotations => _annotations.AsReadOnly();
 
     /// <summary>
     /// Produces a <c>response.content_part.added</c> event with an empty text content part.
@@ -78,6 +81,11 @@ public class TextContentBuilder
     /// <returns>A <see cref="ResponseTextDeltaEvent"/> with the text delta.</returns>
     public virtual ResponseTextDeltaEvent EmitDelta(string text)
     {
+        if (_lifecycleState != BuilderLifecycleState.Added)
+            throw new InvalidOperationException($"Cannot call EmitDelta — builder is in '{_lifecycleState}' state.");
+        if (_textDone)
+            throw new InvalidOperationException("Cannot emit deltas after EmitTextDone has been called.");
+
         _deltaFragments.Add(text);
         return new ResponseTextDeltaEvent(
             _stream.NextSequenceNumber(), _itemId, _outputIndex, _contentIndex,
@@ -118,6 +126,11 @@ public class TextContentBuilder
     /// <returns>A <see cref="ResponseOutputTextAnnotationAddedEvent"/> with the annotation.</returns>
     public virtual ResponseOutputTextAnnotationAddedEvent EmitAnnotationAdded(Annotation annotation)
     {
+        if (_lifecycleState != BuilderLifecycleState.Added)
+            throw new InvalidOperationException($"Cannot call EmitAnnotationAdded — builder is in '{_lifecycleState}' state.");
+        if (!_textDone)
+            throw new InvalidOperationException("Must call EmitTextDone() before EmitAnnotationAdded().");
+
         _annotations.Add(annotation);
         var annotationIndex = _annotationIndex++;
         return new ResponseOutputTextAnnotationAddedEvent(

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/TextResponse.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/TextResponse.cs
@@ -114,7 +114,7 @@ public class TextResponse : IAsyncEnumerable<ResponseStreamEvent>
             // Complete-text mode: one delta with the full text.
             var result = await _createText(cancellationToken).ConfigureAwait(false);
             yield return text.EmitDelta(result);
-            yield return text.EmitDone(result);
+            yield return text.EmitTextDone(result);
         }
         else
         {
@@ -125,10 +125,10 @@ public class TextResponse : IAsyncEnumerable<ResponseStreamEvent>
                 sb.Append(chunk);
                 yield return text.EmitDelta(chunk);
             }
-            yield return text.EmitDone(sb.ToString());
+            yield return text.EmitTextDone(sb.ToString());
         }
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/BuilderAccumulationTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/BuilderAccumulationTests.cs
@@ -28,8 +28,8 @@ public class BuilderAccumulationTests
         msg.EmitAdded();
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Hello");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("Hello");
+        text.EmitDone();
 
         msg.EmitDone();
 
@@ -62,8 +62,8 @@ public class BuilderAccumulationTests
         msg.EmitAdded();
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Hi");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("Hi");
+        text.EmitDone();
         msg.EmitDone();
 
         var fc = stream.AddOutputItemFunctionCall("fn", "c1");
@@ -85,8 +85,8 @@ public class BuilderAccumulationTests
         msg.EmitAdded();
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Result");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("Result");
+        text.EmitDone();
         msg.EmitDone();
 
         var completed = stream.EmitCompleted();
@@ -104,16 +104,16 @@ public class BuilderAccumulationTests
         msg1.EmitAdded();
         var t1 = msg1.AddTextContent();
         t1.EmitAdded();
-        t1.EmitDone("Hello ");
-        msg1.EmitContentDone(t1);
+        t1.EmitTextDone("Hello ");
+        t1.EmitDone();
         msg1.EmitDone();
 
         var msg2 = stream.AddOutputItemMessage();
         msg2.EmitAdded();
         var t2 = msg2.AddTextContent();
         t2.EmitAdded();
-        t2.EmitDone("World");
-        msg2.EmitContentDone(t2);
+        t2.EmitTextDone("World");
+        t2.EmitDone();
         msg2.EmitDone();
 
         var completed = stream.EmitCompleted();
@@ -136,8 +136,8 @@ public class BuilderAccumulationTests
         msg.EmitAdded();
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Only this");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("Only this");
+        text.EmitDone();
         msg.EmitDone();
 
         var completed = stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/BuilderLifecycleTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/BuilderLifecycleTests.cs
@@ -38,9 +38,9 @@ public class BuilderLifecycleTests
         events.Add(refusal.EmitAdded());
         events.Add(refusal.EmitDelta("I cannot"));
         events.Add(refusal.EmitDelta(" do that."));
-        events.Add(refusal.EmitDone("I cannot do that."));
+        events.Add(refusal.EmitRefusalDone("I cannot do that."));
 
-        events.Add(message.EmitContentDone(refusal));
+        events.Add(refusal.EmitDone());
         events.Add(message.EmitDone());
         events.Add(stream.EmitCompleted());
 
@@ -87,7 +87,6 @@ public class BuilderLifecycleTests
         events.Add(part1.EmitTextDelta("thinking"));
         events.Add(part1.EmitTextDone("thinking deeply"));
         events.Add(part1.EmitDone());
-        reasoning.EmitSummaryPartDone(part1);
 
         // Second summary part
         var part2 = reasoning.AddSummaryPart();
@@ -95,7 +94,6 @@ public class BuilderLifecycleTests
         events.Add(part2.EmitTextDelta("more"));
         events.Add(part2.EmitTextDone("more analysis"));
         events.Add(part2.EmitDone());
-        reasoning.EmitSummaryPartDone(part2);
 
         events.Add(reasoning.EmitDone());
         events.Add(stream.EmitCompleted());

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/MessageBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/MessageBuilderTests.cs
@@ -123,10 +123,10 @@ public class MessageBuilderTests
         Assert.That(evt.OutputIndex, Is.EqualTo(0));
     }
 
-    // ── T009: EmitContentDone ─────────────────────────────────
+    // ── T009: TextContentBuilder.EmitDone (content_part.done) ──
 
     [Test]
-    public void EmitContentDone_ReturnsContentPartDoneEvent()
+    public void TextContentEmitDone_ReturnsContentPartDoneEvent()
     {
         var stream = CreateStream();
         var msg = stream.AddOutputItemMessage();
@@ -143,7 +143,7 @@ public class MessageBuilderTests
     }
 
     [Test]
-    public void EmitContentDone_ContainsFinalText()
+    public void TextContentEmitDone_ContainsFinalText()
     {
         var stream = CreateStream();
         var msg = stream.AddOutputItemMessage();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/MessageBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/MessageBuilderTests.cs
@@ -132,9 +132,9 @@ public class MessageBuilderTests
         var msg = stream.AddOutputItemMessage();
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Hello!");
+        text.EmitTextDone("Hello!");
 
-        var evt = msg.EmitContentDone(text);
+        var evt = text.EmitDone();
 
         XAssert.IsType<ResponseContentPartDoneEvent>(evt);
         Assert.That(evt.ItemId, Is.EqualTo(msg.ItemId));
@@ -149,9 +149,9 @@ public class MessageBuilderTests
         var msg = stream.AddOutputItemMessage();
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Final text here");
+        text.EmitTextDone("Final text here");
 
-        var evt = msg.EmitContentDone(text);
+        var evt = text.EmitDone();
 
         var part = XAssert.IsType<OutputContentOutputTextContent>(evt.Part);
         Assert.That(part.Text, Is.EqualTo("Final text here"));
@@ -168,8 +168,8 @@ public class MessageBuilderTests
 
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("test");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("test");
+        text.EmitDone();
 
         var evt = msg.EmitDone();
 
@@ -186,8 +186,8 @@ public class MessageBuilderTests
 
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Hello, world!");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("Hello, world!");
+        text.EmitDone();
 
         var evt = msg.EmitDone();
 
@@ -209,8 +209,8 @@ public class MessageBuilderTests
 
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("test");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("test");
+        text.EmitDone();
 
         var evt = msg.EmitDone();
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/MultiOutputTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/MultiOutputTests.cs
@@ -29,8 +29,8 @@ public class MultiOutputTests
         events.Add(msg0.EmitAdded());          // 2
         var text0 = msg0.AddTextContent();
         events.Add(text0.EmitAdded());         // 3
-        events.Add(text0.EmitDone("First"));   // 4
-        events.Add(msg0.EmitContentDone(text0)); // 5
+        events.Add(text0.EmitTextDone("First"));   // 4
+        events.Add(text0.EmitDone()); // 5
         events.Add(msg0.EmitDone());           // 6
 
         // Second message
@@ -38,8 +38,8 @@ public class MultiOutputTests
         events.Add(msg1.EmitAdded());          // 7
         var text1 = msg1.AddTextContent();
         events.Add(text1.EmitAdded());         // 8
-        events.Add(text1.EmitDone("Second"));  // 9
-        events.Add(msg1.EmitContentDone(text1)); // 10
+        events.Add(text1.EmitTextDone("Second"));  // 9
+        events.Add(text1.EmitDone()); // 10
         events.Add(msg1.EmitDone());           // 11
 
         events.Add(stream.EmitCompleted());    // 12
@@ -90,8 +90,8 @@ public class MultiOutputTests
         events.Add(msg.EmitAdded());           // 2
         var text = msg.AddTextContent();
         events.Add(text.EmitAdded());          // 3
-        events.Add(text.EmitDone("Hello"));    // 4
-        events.Add(msg.EmitContentDone(text)); // 5
+        events.Add(text.EmitTextDone("Hello"));    // 4
+        events.Add(text.EmitDone()); // 5
         events.Add(msg.EmitDone());            // 6
 
         // Function call (outputIndex=1)

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemBuilderAutoStampTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemBuilderAutoStampTests.cs
@@ -39,8 +39,8 @@ public class OutputItemBuilderAutoStampTests
         builder.EmitAdded();
         var text = builder.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Hello");
-        builder.EmitContentDone(text);
+        text.EmitTextDone("Hello");
+        text.EmitDone();
 
         var doneEvt = builder.EmitDone();
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemMessageBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemMessageBuilderTests.cs
@@ -132,9 +132,9 @@ public class OutputItemMessageBuilderTests
         var msg = stream.AddOutputItemMessage();
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Hello!");
+        text.EmitTextDone("Hello!");
 
-        var evt = msg.EmitContentDone(text);
+        var evt = text.EmitDone();
 
         XAssert.IsType<ResponseContentPartDoneEvent>(evt);
         Assert.That(evt.ItemId, Is.EqualTo(msg.ItemId));
@@ -149,9 +149,9 @@ public class OutputItemMessageBuilderTests
         var msg = stream.AddOutputItemMessage();
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Final text here");
+        text.EmitTextDone("Final text here");
 
-        var evt = msg.EmitContentDone(text);
+        var evt = text.EmitDone();
 
         var part = XAssert.IsType<OutputContentOutputTextContent>(evt.Part);
         Assert.That(part.Text, Is.EqualTo("Final text here"));
@@ -168,8 +168,8 @@ public class OutputItemMessageBuilderTests
 
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("test");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("test");
+        text.EmitDone();
 
         var evt = msg.EmitDone();
 
@@ -186,8 +186,8 @@ public class OutputItemMessageBuilderTests
 
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Hello, world!");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("Hello, world!");
+        text.EmitDone();
 
         var evt = msg.EmitDone();
 
@@ -209,8 +209,8 @@ public class OutputItemMessageBuilderTests
 
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("test");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("test");
+        text.EmitDone();
 
         var evt = msg.EmitDone();
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemMessageBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemMessageBuilderTests.cs
@@ -123,10 +123,10 @@ public class OutputItemMessageBuilderTests
         Assert.That(evt.OutputIndex, Is.EqualTo(0));
     }
 
-    // ── T009: EmitContentDone ─────────────────────────────────
+    // ── T009: TextContentBuilder.EmitDone (content_part.done) ──
 
     [Test]
-    public void EmitContentDone_ReturnsContentPartDoneEvent()
+    public void TextContentEmitDone_ReturnsContentPartDoneEvent()
     {
         var stream = CreateStream();
         var msg = stream.AddOutputItemMessage();
@@ -143,7 +143,7 @@ public class OutputItemMessageBuilderTests
     }
 
     [Test]
-    public void EmitContentDone_ContainsFinalText()
+    public void TextContentEmitDone_ContainsFinalText()
     {
         var stream = CreateStream();
         var msg = stream.AddOutputItemMessage();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemReasoningItemBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemReasoningItemBuilderTests.cs
@@ -159,10 +159,12 @@ public class OutputItemReasoningItemBuilderTests
         var s0 = builder.AddSummaryPart();
         s0.EmitAdded();
         s0.EmitTextDone("First summary");
+        s0.EmitDone();
 
         var s1 = builder.AddSummaryPart();
         s1.EmitAdded();
         s1.EmitTextDone("Second summary");
+        s1.EmitDone();
 
         var evt = builder.EmitDone();
         var item = XAssert.IsType<OutputItemReasoningItem>(evt.Item);

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemReasoningItemBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/OutputItemReasoningItemBuilderTests.cs
@@ -159,12 +159,10 @@ public class OutputItemReasoningItemBuilderTests
         var s0 = builder.AddSummaryPart();
         s0.EmitAdded();
         s0.EmitTextDone("First summary");
-        builder.EmitSummaryPartDone(s0);
 
         var s1 = builder.AddSummaryPart();
         s1.EmitAdded();
         s1.EmitTextDone("Second summary");
-        builder.EmitSummaryPartDone(s1);
 
         var evt = builder.EmitDone();
         var item = XAssert.IsType<OutputItemReasoningItem>(evt.Item);

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/RawEventInteropTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/RawEventInteropTests.cs
@@ -65,8 +65,8 @@ public class RawEventInteropTests
 
         var text = msg.AddTextContent();
         events.Add(text.EmitAdded());          // 3
-        events.Add(text.EmitDone("Hello"));    // 4
-        events.Add(msg.EmitContentDone(text)); // 5
+        events.Add(text.EmitTextDone("Hello"));    // 4
+        events.Add(text.EmitDone()); // 5
         events.Add(msg.EmitDone());            // 6
 
         // Use raw event for a custom output item manually

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/ReasoningItemBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/ReasoningItemBuilderTests.cs
@@ -159,10 +159,12 @@ public class ReasoningItemBuilderTests
         var s0 = builder.AddSummaryPart();
         s0.EmitAdded();
         s0.EmitTextDone("First summary");
+        s0.EmitDone();
 
         var s1 = builder.AddSummaryPart();
         s1.EmitAdded();
         s1.EmitTextDone("Second summary");
+        s1.EmitDone();
 
         var evt = builder.EmitDone();
         var item = XAssert.IsType<OutputItemReasoningItem>(evt.Item);

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/ReasoningItemBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/ReasoningItemBuilderTests.cs
@@ -159,12 +159,10 @@ public class ReasoningItemBuilderTests
         var s0 = builder.AddSummaryPart();
         s0.EmitAdded();
         s0.EmitTextDone("First summary");
-        builder.EmitSummaryPartDone(s0);
 
         var s1 = builder.AddSummaryPart();
         s1.EmitAdded();
         s1.EmitTextDone("Second summary");
-        builder.EmitSummaryPartDone(s1);
 
         var evt = builder.EmitDone();
         var item = XAssert.IsType<OutputItemReasoningItem>(evt.Item);

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/ReasoningSummaryPartBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/ReasoningSummaryPartBuilderTests.cs
@@ -54,6 +54,7 @@ public class ReasoningSummaryPartBuilderTests
     {
         var (_, reasoning) = CreateReasoningScope();
         var summary = reasoning.AddSummaryPart();
+        summary.EmitAdded();
         var evt = summary.EmitTextDelta("chunk");
         XAssert.IsType<ResponseReasoningSummaryTextDeltaEvent>(evt);
         Assert.That(evt.Delta, Is.EqualTo("chunk"));
@@ -64,6 +65,7 @@ public class ReasoningSummaryPartBuilderTests
     {
         var (_, reasoning) = CreateReasoningScope();
         var summary = reasoning.AddSummaryPart();
+        summary.EmitAdded();
         var evt = summary.EmitTextDelta("chunk");
         Assert.That(evt.ItemId, Is.EqualTo(reasoning.ItemId));
         Assert.That(evt.OutputIndex, Is.EqualTo(reasoning.OutputIndex));
@@ -75,6 +77,7 @@ public class ReasoningSummaryPartBuilderTests
     {
         var (_, reasoning) = CreateReasoningScope();
         var summary = reasoning.AddSummaryPart();
+        summary.EmitAdded();
         var d1 = summary.EmitTextDelta("Hello, ");
         var d2 = summary.EmitTextDelta("world!");
         Assert.That(d1.Delta, Is.EqualTo("Hello, "));
@@ -88,6 +91,7 @@ public class ReasoningSummaryPartBuilderTests
     {
         var (_, reasoning) = CreateReasoningScope();
         var summary = reasoning.AddSummaryPart();
+        summary.EmitAdded();
         var evt = summary.EmitTextDone("Final text");
         XAssert.IsType<ResponseReasoningSummaryTextDoneEvent>(evt);
         Assert.That(evt.Text, Is.EqualTo("Final text"));
@@ -99,6 +103,7 @@ public class ReasoningSummaryPartBuilderTests
         var (_, reasoning) = CreateReasoningScope();
         var summary = reasoning.AddSummaryPart();
         Assert.That(summary.FinalText, Is.Null);
+        summary.EmitAdded();
         summary.EmitTextDone("Final value");
         Assert.That(summary.FinalText, Is.EqualTo("Final value"));
     }
@@ -108,6 +113,7 @@ public class ReasoningSummaryPartBuilderTests
     {
         var (_, reasoning) = CreateReasoningScope();
         var summary = reasoning.AddSummaryPart();
+        summary.EmitAdded();
         var evt = summary.EmitTextDone("done");
         Assert.That(evt.ItemId, Is.EqualTo(reasoning.ItemId));
         Assert.That(evt.OutputIndex, Is.EqualTo(reasoning.OutputIndex));

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/RefusalContentBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/RefusalContentBuilderTests.cs
@@ -119,7 +119,7 @@ public class RefusalContentBuilderTests
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
         refusal.EmitAdded();
-        var evt = refusal.EmitDone("I can't help with that.");
+        var evt = refusal.EmitRefusalDone("I can't help with that.");
         XAssert.IsType<ResponseRefusalDoneEvent>(evt);
         Assert.That(evt.Refusal, Is.EqualTo("I can't help with that."));
     }
@@ -131,7 +131,7 @@ public class RefusalContentBuilderTests
         var refusal = msg.AddRefusalContent();
         Assert.That(refusal.FinalRefusal, Is.Null);
         refusal.EmitAdded();
-        refusal.EmitDone("Final refusal");
+        refusal.EmitRefusalDone("Final refusal");
         Assert.That(refusal.FinalRefusal, Is.EqualTo("Final refusal"));
     }
 
@@ -141,13 +141,13 @@ public class RefusalContentBuilderTests
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
         refusal.EmitAdded();
-        var evt = refusal.EmitDone("done text");
+        var evt = refusal.EmitRefusalDone("done text");
         Assert.That(evt.ItemId, Is.EqualTo(msg.ItemId));
         Assert.That(evt.OutputIndex, Is.EqualTo(msg.OutputIndex));
         Assert.That(evt.ContentIndex, Is.EqualTo(refusal.ContentIndex));
     }
 
-    // ── OutputItemMessageBuilder.EmitContentDone(RefusalContentBuilder) ─
+    // ── RefusalContentBuilder.EmitDone() ─
 
     [Test]
     public void EmitContentDone_Refusal_ReturnsContentPartDoneEvent()
@@ -155,8 +155,8 @@ public class RefusalContentBuilderTests
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
         refusal.EmitAdded();
-        refusal.EmitDone("I can't help with that.");
-        var evt = msg.EmitContentDone(refusal);
+        refusal.EmitRefusalDone("I can't help with that.");
+        var evt = refusal.EmitDone();
         XAssert.IsType<ResponseContentPartDoneEvent>(evt);
     }
 
@@ -166,8 +166,8 @@ public class RefusalContentBuilderTests
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
         refusal.EmitAdded();
-        refusal.EmitDone("I can't help with that.");
-        var evt = msg.EmitContentDone(refusal);
+        refusal.EmitRefusalDone("I can't help with that.");
+        var evt = refusal.EmitDone();
         var part = XAssert.IsType<OutputContentRefusalContent>(evt.Part);
         Assert.That(part.Refusal, Is.EqualTo("I can't help with that."));
     }
@@ -178,8 +178,8 @@ public class RefusalContentBuilderTests
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
         refusal.EmitAdded();
-        refusal.EmitDone("refused");
-        var evt = msg.EmitContentDone(refusal);
+        refusal.EmitRefusalDone("refused");
+        var evt = refusal.EmitDone();
         Assert.That(evt.ItemId, Is.EqualTo(msg.ItemId));
         Assert.That(evt.OutputIndex, Is.EqualTo(msg.OutputIndex));
         Assert.That(evt.ContentIndex, Is.EqualTo(refusal.ContentIndex));
@@ -194,8 +194,8 @@ public class RefusalContentBuilderTests
         msg.EmitAdded();
         var refusal = msg.AddRefusalContent();
         refusal.EmitAdded();
-        refusal.EmitDone("I can't help with that.");
-        msg.EmitContentDone(refusal);
+        refusal.EmitRefusalDone("I can't help with that.");
+        refusal.EmitDone();
         var evt = msg.EmitDone();
         var item = XAssert.IsType<OutputItemMessage>(evt.Item);
         XAssert.Single(item.Content);
@@ -211,13 +211,13 @@ public class RefusalContentBuilderTests
 
         var text = msg.AddTextContent();
         text.EmitAdded();
-        text.EmitDone("Hello!");
-        msg.EmitContentDone(text);
+        text.EmitTextDone("Hello!");
+        text.EmitDone();
 
         var refusal = msg.AddRefusalContent();
         refusal.EmitAdded();
-        refusal.EmitDone("I can't help.");
-        msg.EmitContentDone(refusal);
+        refusal.EmitRefusalDone("I can't help.");
+        refusal.EmitDone();
 
         var evt = msg.EmitDone();
         var item = XAssert.IsType<OutputItemMessage>(evt.Item);
@@ -235,7 +235,7 @@ public class RefusalContentBuilderTests
         var refusal = msg.AddRefusalContent();
         var added = refusal.EmitAdded();       // seq 0
         var delta = refusal.EmitDelta("Hi");   // seq 1
-        var done = refusal.EmitDone("Hi");     // seq 2
+        var done = refusal.EmitRefusalDone("Hi");     // seq 2
         Assert.That(added.SequenceNumber, Is.EqualTo(0));
         Assert.That(delta.SequenceNumber, Is.EqualTo(1));
         Assert.That(done.SequenceNumber, Is.EqualTo(2));

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/RefusalContentBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/RefusalContentBuilderTests.cs
@@ -147,10 +147,10 @@ public class RefusalContentBuilderTests
         Assert.That(evt.ContentIndex, Is.EqualTo(refusal.ContentIndex));
     }
 
-    // ── RefusalContentBuilder.EmitDone() ─
+    // ── RefusalContentBuilder.EmitDone (content_part.done) ─
 
     [Test]
-    public void EmitContentDone_Refusal_ReturnsContentPartDoneEvent()
+    public void RefusalEmitDone_ReturnsContentPartDoneEvent()
     {
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
@@ -161,7 +161,7 @@ public class RefusalContentBuilderTests
     }
 
     [Test]
-    public void EmitContentDone_Refusal_ContainsFinalRefusalText()
+    public void RefusalEmitDone_ContainsFinalRefusalText()
     {
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
@@ -173,7 +173,7 @@ public class RefusalContentBuilderTests
     }
 
     [Test]
-    public void EmitContentDone_Refusal_HasCorrectBookkeepingFields()
+    public void RefusalEmitDone_HasCorrectBookkeepingFields()
     {
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/RefusalContentBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/RefusalContentBuilderTests.cs
@@ -84,6 +84,7 @@ public class RefusalContentBuilderTests
     {
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
+        refusal.EmitAdded();
         var evt = refusal.EmitDelta("I can't ");
         XAssert.IsType<ResponseRefusalDeltaEvent>(evt);
         Assert.That(evt.Delta, Is.EqualTo("I can't "));
@@ -94,6 +95,7 @@ public class RefusalContentBuilderTests
     {
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
+        refusal.EmitAdded();
         var evt = refusal.EmitDelta("chunk");
         Assert.That(evt.ItemId, Is.EqualTo(msg.ItemId));
         Assert.That(evt.OutputIndex, Is.EqualTo(msg.OutputIndex));
@@ -105,6 +107,7 @@ public class RefusalContentBuilderTests
     {
         var (_, msg) = CreateMessageScope();
         var refusal = msg.AddRefusalContent();
+        refusal.EmitAdded();
         var d1 = refusal.EmitDelta("I can't ");
         var d2 = refusal.EmitDelta("help with that.");
         Assert.That(d1.Delta, Is.EqualTo("I can't "));

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/SimpleTextResponseTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/SimpleTextResponseTests.cs
@@ -33,9 +33,9 @@ public class SimpleTextResponseTests
         events.Add(text.EmitAdded());                 // 3: content_part.added
         events.Add(text.EmitDelta("Hello, "));        // 4: output_text.delta
         events.Add(text.EmitDelta("world!"));         // 5: output_text.delta
-        events.Add(text.EmitDone("Hello, world!"));   // 6: output_text.done
+        events.Add(text.EmitTextDone("Hello, world!"));   // 6: output_text.done
 
-        events.Add(message.EmitContentDone(text));    // 7: content_part.done
+        events.Add(text.EmitDone());    // 7: content_part.done
         events.Add(message.EmitDone());               // 8: output_item.done
         events.Add(stream.EmitCompleted());           // 9: response.completed
 
@@ -134,9 +134,9 @@ public class SimpleTextResponseTests
         yield return text.EmitAdded();
         yield return text.EmitDelta("Hello, ");
         yield return text.EmitDelta("world!");
-        yield return text.EmitDone("Hello, world!");
+        yield return text.EmitTextDone("Hello, world!");
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
         yield return stream.EmitCompleted();
     }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/TextContentAnnotationTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/TextContentAnnotationTests.cs
@@ -24,6 +24,8 @@ public class TextContentAnnotationTests
     {
         var (_, msg) = CreateMessageScope();
         var text = msg.AddTextContent();
+        text.EmitAdded();
+        text.EmitTextDone("test");
         var annotation = CreateTestAnnotation();
         var evt = text.EmitAnnotationAdded(annotation);
         XAssert.IsType<ResponseOutputTextAnnotationAddedEvent>(evt);
@@ -34,6 +36,8 @@ public class TextContentAnnotationTests
     {
         var (_, msg) = CreateMessageScope();
         var text = msg.AddTextContent();
+        text.EmitAdded();
+        text.EmitTextDone("test");
         var annotation = CreateTestAnnotation();
         var evt = text.EmitAnnotationAdded(annotation);
         Assert.That(evt.Annotation, Is.SameAs(annotation));
@@ -44,6 +48,8 @@ public class TextContentAnnotationTests
     {
         var (_, msg) = CreateMessageScope();
         var text = msg.AddTextContent();
+        text.EmitAdded();
+        text.EmitTextDone("test");
         var annotation = CreateTestAnnotation();
         var evt = text.EmitAnnotationAdded(annotation);
         Assert.That(evt.ItemId, Is.EqualTo(msg.ItemId));
@@ -56,6 +62,8 @@ public class TextContentAnnotationTests
     {
         var (_, msg) = CreateMessageScope();
         var text = msg.AddTextContent();
+        text.EmitAdded();
+        text.EmitTextDone("test");
         var annotation = CreateTestAnnotation();
         var evt = text.EmitAnnotationAdded(annotation);
         Assert.That(evt.AnnotationIndex, Is.EqualTo(0));
@@ -66,6 +74,8 @@ public class TextContentAnnotationTests
     {
         var (_, msg) = CreateMessageScope();
         var text = msg.AddTextContent();
+        text.EmitAdded();
+        text.EmitTextDone("test");
         var a1 = text.EmitAnnotationAdded(CreateTestAnnotation());
         var a2 = text.EmitAnnotationAdded(CreateTestAnnotation());
         var a3 = text.EmitAnnotationAdded(CreateTestAnnotation());
@@ -81,12 +91,12 @@ public class TextContentAnnotationTests
         var text = msg.AddTextContent();
         var added = text.EmitAdded();                                // seq 0
         var delta = text.EmitDelta("Hi");                            // seq 1
-        var ann = text.EmitAnnotationAdded(CreateTestAnnotation());  // seq 2
-        var done = text.EmitTextDone("Hi");                              // seq 3
+        var done = text.EmitTextDone("Hi");                          // seq 2
+        var ann = text.EmitAnnotationAdded(CreateTestAnnotation());  // seq 3
         Assert.That(added.SequenceNumber, Is.EqualTo(0));
         Assert.That(delta.SequenceNumber, Is.EqualTo(1));
-        Assert.That(ann.SequenceNumber, Is.EqualTo(2));
-        Assert.That(done.SequenceNumber, Is.EqualTo(3));
+        Assert.That(done.SequenceNumber, Is.EqualTo(2));
+        Assert.That(ann.SequenceNumber, Is.EqualTo(3));
     }
 
     [Test]
@@ -94,7 +104,11 @@ public class TextContentAnnotationTests
     {
         var (_, msg) = CreateMessageScope();
         var text1 = msg.AddTextContent();
+        text1.EmitAdded();
+        text1.EmitTextDone("test1");
         var text2 = msg.AddTextContent();
+        text2.EmitAdded();
+        text2.EmitTextDone("test2");
         var a1 = text1.EmitAnnotationAdded(CreateTestAnnotation());
         var a2 = text2.EmitAnnotationAdded(CreateTestAnnotation());
         Assert.That(a1.AnnotationIndex, Is.EqualTo(0));

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/TextContentAnnotationTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/TextContentAnnotationTests.cs
@@ -82,7 +82,7 @@ public class TextContentAnnotationTests
         var added = text.EmitAdded();                                // seq 0
         var delta = text.EmitDelta("Hi");                            // seq 1
         var ann = text.EmitAnnotationAdded(CreateTestAnnotation());  // seq 2
-        var done = text.EmitDone("Hi");                              // seq 3
+        var done = text.EmitTextDone("Hi");                              // seq 3
         Assert.That(added.SequenceNumber, Is.EqualTo(0));
         Assert.That(delta.SequenceNumber, Is.EqualTo(1));
         Assert.That(ann.SequenceNumber, Is.EqualTo(2));

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/TextContentBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/TextContentBuilderTests.cs
@@ -97,6 +97,7 @@ public class TextContentBuilderTests
     {
         var (_, msg) = CreateMessageScope();
         var text = msg.AddTextContent();
+        text.EmitAdded();
 
         var evt = text.EmitDelta("Hello, ");
 
@@ -109,6 +110,7 @@ public class TextContentBuilderTests
     {
         var (_, msg) = CreateMessageScope();
         var text = msg.AddTextContent();
+        text.EmitAdded();
 
         var evt = text.EmitDelta("chunk");
 
@@ -122,6 +124,7 @@ public class TextContentBuilderTests
     {
         var (_, msg) = CreateMessageScope();
         var text = msg.AddTextContent();
+        text.EmitAdded();
 
         var d1 = text.EmitDelta("Hello, ");
         var d2 = text.EmitDelta("world!");

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/TextContentBuilderTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Builders/TextContentBuilderTests.cs
@@ -137,7 +137,7 @@ public class TextContentBuilderTests
         var text = msg.AddTextContent();
 
         text.EmitAdded();
-        var evt = text.EmitDone("Hello, world!");
+        var evt = text.EmitTextDone("Hello, world!");
 
         XAssert.IsType<ResponseTextDoneEvent>(evt);
         Assert.That(evt.Text, Is.EqualTo("Hello, world!"));
@@ -152,7 +152,7 @@ public class TextContentBuilderTests
         Assert.That(text.FinalText, Is.Null);
 
         text.EmitAdded();
-        text.EmitDone("Final value");
+        text.EmitTextDone("Final value");
 
         Assert.That(text.FinalText, Is.EqualTo("Final value"));
     }
@@ -164,7 +164,7 @@ public class TextContentBuilderTests
         var text = msg.AddTextContent();
 
         text.EmitAdded();
-        var evt = text.EmitDone("done text");
+        var evt = text.EmitTextDone("done text");
 
         Assert.That(evt.ItemId, Is.EqualTo(msg.ItemId));
         Assert.That(evt.OutputIndex, Is.EqualTo(msg.OutputIndex));
@@ -181,7 +181,7 @@ public class TextContentBuilderTests
 
         var added = text.EmitAdded();       // seq 0
         var delta = text.EmitDelta("Hi");   // seq 1
-        var done = text.EmitDone("Hi");     // seq 2
+        var done = text.EmitTextDone("Hi");     // seq 2
 
         Assert.That(added.SequenceNumber, Is.EqualTo(0));
         Assert.That(delta.SequenceNumber, Is.EqualTo(1));

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Interop/SdkRoundTripTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Interop/SdkRoundTripTests.cs
@@ -497,8 +497,8 @@ public class SdkRoundTripTests
         var tc = msg.AddTextContent();
         yield return tc.EmitAdded();
         yield return tc.EmitDelta(text);
-        yield return tc.EmitDone(text);
-        yield return msg.EmitContentDone(tc);
+        yield return tc.EmitTextDone(text);
+        yield return tc.EmitDone();
         yield return msg.EmitDone();
 
         yield return stream.EmitCompleted();
@@ -549,7 +549,6 @@ public class SdkRoundTripTests
         yield return part.EmitTextDelta(summaryText);
         yield return part.EmitTextDone(summaryText);
         yield return part.EmitDone();
-        reasoning.EmitSummaryPartDone(part);
         yield return reasoning.EmitDone();
 
         yield return stream.EmitCompleted();
@@ -722,7 +721,6 @@ public class SdkRoundTripTests
         yield return sp.EmitAdded();
         yield return sp.EmitTextDone("Thinking about the answer...");
         yield return sp.EmitDone();
-        reasoning.EmitSummaryPartDone(sp);
         yield return reasoning.EmitDone();
 
         // 2. Function call
@@ -736,8 +734,8 @@ public class SdkRoundTripTests
         yield return msg.EmitAdded();
         var tc = msg.AddTextContent();
         yield return tc.EmitAdded();
-        yield return tc.EmitDone("The answer is 42");
-        yield return msg.EmitContentDone(tc);
+        yield return tc.EmitTextDone("The answer is 42");
+        yield return tc.EmitDone();
         yield return msg.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/OpenAIProxyEndToEndTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/OpenAIProxyEndToEndTests.cs
@@ -245,8 +245,8 @@ public class OpenAIProxyEndToEndTests
             }
 
             var resultText = fullText.ToString();
-            yield return text.EmitDone(resultText);
-            yield return message.EmitContentDone(text);
+            yield return text.EmitTextDone(resultText);
+            yield return text.EmitDone();
             yield return message.EmitDone();
             yield return stream.EmitCompleted();
         }
@@ -292,8 +292,8 @@ public class OpenAIProxyEndToEndTests
 
             var text = message.AddTextContent();
             yield return text.EmitAdded();
-            yield return text.EmitDone(outputText ?? string.Empty);
-            yield return message.EmitContentDone(text);
+            yield return text.EmitTextDone(outputText ?? string.Empty);
+            yield return text.EmitDone();
             yield return message.EmitDone();
 
             yield return stream.EmitCompleted();
@@ -805,7 +805,6 @@ public class OpenAIProxyEndToEndTests
         yield return sp.EmitTextDelta(" the answer...");
         yield return sp.EmitTextDone("Thinking about the answer...");
         yield return sp.EmitDone();
-        reasoning.EmitSummaryPartDone(sp);
         yield return reasoning.EmitDone();
 
         // 2. Function call
@@ -823,8 +822,8 @@ public class OpenAIProxyEndToEndTests
         yield return tc.EmitAdded();
         yield return tc.EmitDelta("The answer");
         yield return tc.EmitDelta(" is 42.");
-        yield return tc.EmitDone("The answer is 42.");
-        yield return msg.EmitContentDone(tc);
+        yield return tc.EmitTextDone("The answer is 42.");
+        yield return tc.EmitDone();
         yield return msg.EmitDone();
 
         yield return stream.EmitCompleted();
@@ -856,8 +855,8 @@ public class OpenAIProxyEndToEndTests
         yield return msg.EmitAdded();
         var tc = msg.AddTextContent();
         yield return tc.EmitAdded();
-        yield return tc.EmitDone(text);
-        yield return msg.EmitContentDone(tc);
+        yield return tc.EmitTextDone(text);
+        yield return tc.EmitDone();
         yield return msg.EmitDone();
         yield return stream.EmitCompleted();
         await Task.CompletedTask;

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/AgentReferenceAutoStampProtocolTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/AgentReferenceAutoStampProtocolTests.cs
@@ -156,8 +156,8 @@ public class AgentReferenceAutoStampProtocolTests : ProtocolTestBase
         var text = message.AddTextContent();
         yield return text.EmitAdded();
         yield return text.EmitDelta("Hello");
-        yield return text.EmitDone("Hello");
-        yield return message.EmitContentDone(text);
+        yield return text.EmitTextDone("Hello");
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/CancelBehaviourProtocolTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/CancelBehaviourProtocolTests.cs
@@ -246,6 +246,7 @@ public class CancelBehaviourProtocolTests : ProtocolTestBase
         // Emit some content before waiting
         var item = stream.AddOutputItemMessage();
         var content = item.AddTextContent();
+        yield return content.EmitAdded();
         yield return content.EmitDelta("Hello ");
         yield return content.EmitDelta("World");
         deltasEmitted.TrySetResult();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/CrossApiE2eTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/CrossApiE2eTests.cs
@@ -1283,8 +1283,8 @@ public class CrossApiE2eTests : ProtocolTestBase
         var text1 = msg1.AddTextContent();
         yield return text1.EmitAdded();
         yield return text1.EmitDelta("Hello");
-        yield return text1.EmitDone("Hello");
-        yield return msg1.EmitContentDone(text1);
+        yield return text1.EmitTextDone("Hello");
+        yield return text1.EmitDone();
         yield return msg1.EmitDone();
 
         item1Emitted.TrySetResult();
@@ -1296,8 +1296,8 @@ public class CrossApiE2eTests : ProtocolTestBase
         var text2 = msg2.AddTextContent();
         yield return text2.EmitAdded();
         yield return text2.EmitDelta("World");
-        yield return text2.EmitDone("World");
-        yield return msg2.EmitContentDone(text2);
+        yield return text2.EmitTextDone("World");
+        yield return text2.EmitDone();
         yield return msg2.EmitDone();
 
         item2Emitted.TrySetResult();
@@ -1336,8 +1336,8 @@ public class CrossApiE2eTests : ProtocolTestBase
         var text1 = msg1.AddTextContent();
         yield return text1.EmitAdded();
         yield return text1.EmitDelta("Hello");
-        yield return text1.EmitDone("Hello");
-        yield return msg1.EmitContentDone(text1);
+        yield return text1.EmitTextDone("Hello");
+        yield return text1.EmitDone();
         yield return msg1.EmitDone();
 
         itemDone.TrySetResult();
@@ -1349,8 +1349,8 @@ public class CrossApiE2eTests : ProtocolTestBase
         var text2 = msg2.AddTextContent();
         yield return text2.EmitAdded();
         yield return text2.EmitDelta("World");
-        yield return text2.EmitDone("World");
-        yield return msg2.EmitContentDone(text2);
+        yield return text2.EmitTextDone("World");
+        yield return text2.EmitDone();
         yield return msg2.EmitDone();
 
         item2Done.TrySetResult();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/DefaultModeProtocolTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/DefaultModeProtocolTests.cs
@@ -140,9 +140,9 @@ public class DefaultModeProtocolTests : ProtocolTestBase
             : "Hello!";
         var echoText = $"Echo: {inputText}";
         yield return text.EmitDelta(echoText);
-        yield return text.EmitDone(echoText);
+        yield return text.EmitTextDone(echoText);
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/GetResponseProtocolTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/GetResponseProtocolTests.cs
@@ -315,9 +315,9 @@ public class GetResponseProtocolTests : ProtocolTestBase
         yield return text.EmitAdded();
 
         yield return text.EmitDelta("Hello");
-        yield return text.EmitDone("Hello");
+        yield return text.EmitTextDone("Hello");
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/ResponseIdAutoStampProtocolTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/ResponseIdAutoStampProtocolTests.cs
@@ -149,8 +149,8 @@ public class ResponseIdAutoStampProtocolTests : ProtocolTestBase
         var text = message.AddTextContent();
         yield return text.EmitAdded();
         yield return text.EmitDelta("Hello");
-        yield return text.EmitDone("Hello");
-        yield return message.EmitContentDone(text);
+        yield return text.EmitTextDone("Hello");
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();
@@ -195,8 +195,8 @@ public class ResponseIdAutoStampProtocolTests : ProtocolTestBase
         yield return msg1.EmitAdded();
         var text1 = msg1.AddTextContent();
         yield return text1.EmitAdded();
-        yield return text1.EmitDone("Hello");
-        yield return msg1.EmitContentDone(text1);
+        yield return text1.EmitTextDone("Hello");
+        yield return text1.EmitDone();
         yield return msg1.EmitDone();
 
         // Second output item
@@ -204,8 +204,8 @@ public class ResponseIdAutoStampProtocolTests : ProtocolTestBase
         yield return msg2.EmitAdded();
         var text2 = msg2.AddTextContent();
         yield return text2.EmitAdded();
-        yield return text2.EmitDone("World");
-        yield return msg2.EmitContentDone(text2);
+        yield return text2.EmitTextDone("World");
+        yield return text2.EmitDone();
         yield return msg2.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/ResponseShapeProtocolTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/ResponseShapeProtocolTests.cs
@@ -130,9 +130,9 @@ public class ResponseShapeProtocolTests : ProtocolTestBase
         yield return text.EmitAdded();
 
         yield return text.EmitDelta("Hello");
-        yield return text.EmitDone("Hello");
+        yield return text.EmitTextDone("Hello");
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SdkIdentityHeaderProtocolTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SdkIdentityHeaderProtocolTests.cs
@@ -225,9 +225,9 @@ public class SdkIdentityHeaderProtocolTests : ProtocolTestBase
         yield return text.EmitAdded();
 
         yield return text.EmitDelta("Hello");
-        yield return text.EmitDone("Hello");
+        yield return text.EmitTextDone("Hello");
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SentinelRemovalProtocolTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SentinelRemovalProtocolTests.cs
@@ -95,8 +95,8 @@ public class SentinelRemovalProtocolTests : ProtocolTestBase
         var text = message.AddTextContent();
         yield return text.EmitAdded();
         yield return text.EmitDelta("Hello");
-        yield return text.EmitDone("Hello");
-        yield return message.EmitContentDone(text);
+        yield return text.EmitTextDone("Hello");
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/StreamingModeProtocolTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/StreamingModeProtocolTests.cs
@@ -207,9 +207,9 @@ public class StreamingModeProtocolTests : ProtocolTestBase
         yield return text.EmitAdded();
 
         yield return text.EmitDelta("Hello");
-        yield return text.EmitDone("Hello");
+        yield return text.EmitTextDone("Hello");
 
-        yield return message.EmitContentDone(text);
+        yield return text.EmitDone();
         yield return message.EmitDone();
 
         yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/ReadMeSnippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/ReadMeSnippets.cs
@@ -133,9 +133,9 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 var text = message.AddTextContent();
                 yield return text.EmitAdded();
                 yield return text.EmitDelta("Hello, world!");
-                yield return text.EmitDone("Hello, world!");
+                yield return text.EmitTextDone("Hello, world!");
 
-                yield return message.EmitContentDone(text);
+                yield return text.EmitDone();
                 yield return message.EmitDone();
                 yield return stream.EmitCompleted();
             }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample3Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample3Snippets.cs
@@ -149,10 +149,10 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 var input = await context.GetInputTextAsync(cancellationToken: cancellationToken);
                 var reply = $"Hello! You said: \"{input}\"";
                 yield return text.EmitDelta(reply);  // response.output_text.delta
-                yield return text.EmitDone(reply);   // response.output_text.done
+                yield return text.EmitTextDone(reply);   // response.output_text.done
 
                 // Close the content, message, and response.
-                yield return message.EmitContentDone(text);  // response.content_part.done
+                yield return text.EmitDone();  // response.content_part.done
                 yield return message.EmitDone();              // response.output_item.done
                 yield return stream.EmitCompleted();          // response.completed
             }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample4Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample4Snippets.cs
@@ -123,9 +123,9 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
 
                     var reply = $"The weather is: {weatherJson}";
                     yield return text.EmitDelta(reply);
-                    yield return text.EmitDone(reply);
+                    yield return text.EmitTextDone(reply);
 
-                    yield return message.EmitContentDone(text);
+                    yield return text.EmitDone();
                     yield return message.EmitDone();
 
                     yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample6Snippets.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Snippets/Sample6Snippets.cs
@@ -104,7 +104,6 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 yield return summary.EmitTextDelta(thought);
                 yield return summary.EmitTextDone(thought);
                 yield return summary.EmitDone();
-                reasoning.EmitSummaryPartDone(summary);
 
                 yield return reasoning.EmitDone();
 
@@ -118,9 +117,9 @@ namespace Azure.AI.AgentServer.Responses.Tests.Snippets
                 var answer = "The answer is 42. Here's how: " +
                              "6 × 7 = 42. The multiplication of 6 and 7 gives 42.";
                 yield return text.EmitDelta(answer);
-                yield return text.EmitDone(answer);
+                yield return text.EmitTextDone(answer);
 
-                yield return message.EmitContentDone(text);
+                yield return text.EmitDone();
                 yield return message.EmitDone();
 
                 yield return stream.EmitCompleted();

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Validation/BuilderLifecycleValidationTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Validation/BuilderLifecycleValidationTests.cs
@@ -54,8 +54,8 @@ public class BuilderLifecycleValidationTests
         builder.EmitAdded();
         var textBuilder = builder.AddTextContent();
         textBuilder.EmitAdded();
-        textBuilder.EmitDone("Hello, world!");
-        builder.EmitContentDone(textBuilder);
+        textBuilder.EmitTextDone("Hello, world!");
+        textBuilder.EmitDone();
 
         // EmitDone with content should succeed
         var evt = builder.EmitDone();


### PR DESCRIPTION
## Summary

Refactors the Responses builder API so that **each builder owns its complete event lifecycle** from `EmitAdded()` through `EmitDone()`, matching the Python SDK pattern ([azure-sdk-for-python@3b72d38](https://github.com/Azure/azure-sdk-for-python/commit/3b72d38476f0db87832e04de8464c9058b513bfd), [azure-sdk-for-python@8faa1ca](https://github.com/Azure/azure-sdk-for-python/commit/8faa1ca68053cdafbd738490c275157c607ac85b)).

### Problem

Previously, parent builders managed child lifecycle endings — an anti-pattern where the parent emitted `content_part.done` on behalf of its children:

```csharp
// ❌ Old pattern: parent manages child lifecycle
text.EmitDone("Hello");                  // output_text.done
message.EmitContentDone(text);           // parent emits content_part.done for child
message.EmitDone();                      // builds from manually tracked _completedContents
```

### Solution

Each builder now owns its full lifecycle. Parents auto-track children via their `Add*()` factory methods:

```csharp
// ✅ New pattern: each builder owns its lifecycle
text.EmitTextDone("Hello");              // output_text.done (specific name)
text.EmitDone();                         // content_part.done (builder owns its end)
message.EmitDone();                      // builds from auto-tracked children
```

### Changes

| Builder | Change |
|---|---|
| **TextContentBuilder** | `EmitDone(string)` → `EmitTextDone(string?)` + new `EmitDone()` for `content_part.done`; tracks deltas/annotations internally; new `Annotations` property |
| **RefusalContentBuilder** | `EmitDone(string)` → `EmitRefusalDone(string)` + new `EmitDone()` for `content_part.done` |
| **OutputItemMessageBuilder** | Removed 3 `EmitContentDone()` overloads; `AddTextContent()`/`AddRefusalContent()` auto-track children; `EmitDone()` builds from tracked children |
| **OutputItemReasoningItemBuilder** | Removed `EmitSummaryPartDone()`; `AddSummaryPart()` auto-tracks children; `EmitDone()` builds from tracked children |
| **TextResponse** | Updated to use new lifecycle pattern |
| **All tests** (29 files) | Mechanical update to new API |
| **Samples & docs** (5 markdown files) | Updated code examples and guidance |

### API surface

**Removed** (anti-patterns):
- `OutputItemMessageBuilder.EmitContentDone(TextContentBuilder)`
- `OutputItemMessageBuilder.EmitContentDone(TextContentBuilder, IEnumerable<Annotation>)`
- `OutputItemMessageBuilder.EmitContentDone(RefusalContentBuilder)`
- `OutputItemReasoningItemBuilder.EmitSummaryPartDone(ReasoningSummaryPartBuilder)`

**Renamed**:
- `TextContentBuilder.EmitDone(string)` → `EmitTextDone(string?)`
- `RefusalContentBuilder.EmitDone(string)` → `EmitRefusalDone(string)`

**Added**:
- `TextContentBuilder.EmitDone()` — emits `content_part.done`
- `RefusalContentBuilder.EmitDone()` — emits `content_part.done`
- `TextContentBuilder.Annotations` — `IReadOnlyList<Annotation>`

All 4,148 tests pass.