### PR TITLE
[EngSys] Exclude compiler attribute from API Compat

### DIFF
--- a/eng/ApiListing.exclude-attributes.txt
+++ b/eng/ApiListing.exclude-attributes.txt
@@ -22,6 +22,7 @@ T:Microsoft.TypeSpec.Generator.Customizations.CodeGenMemberAttribute
 T:Microsoft.TypeSpec.Generator.Customizations.CodeGenSerializationAttribute
 T:Microsoft.TypeSpec.Generator.Customizations.CodeGenSuppressAttribute
 T:Microsoft.TypeSpec.Generator.Customizations.CodeGenTypeAttribute
+T:Microsoft.Cci.DummyTypeReference
 T:System.ClientModel.Primitives.ModelReaderWriterBuildableAttribute
 T:Azure.Data.AppConfiguration.CodeGenMemberAttribute
 T:Azure.Data.AppConfiguration.CodeGenSerializationAttribute


### PR DESCRIPTION
# Summary

The focus of these changes is to add the `Microsoft.Cci.DummyTypeReference` compiler attribute to the exclusion list for API Compat checks.   This attribute is applied for scenarios such as type forwarding where there is unresolved information that is handled later and does not have any impact to the public API nor developer experience using the library.