### PR TITLE
[Azure.ResourceManager.Hci] Stable release 1.3.0 for API version 2026-02-01

### DIFF
--- a/sdk/azurestackhci/Azure.ResourceManager.Hci/CHANGELOG.md
+++ b/sdk/azurestackhci/Azure.ResourceManager.Hci/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
+## 1.3.0 (2026-04-12)
 
 ### Features Added
 
-- Upgraded API version to `2026-04-01-preview`
+- Upgraded API version to `2026-02-01` (stable)
 - Migrated from Swagger/AutoRest to TypeSpec-based generation
 - Added support for new resource types and operations from the latest API version
 

--- a/sdk/azurestackhci/Azure.ResourceManager.Hci/src/Azure.ResourceManager.Hci.csproj
+++ b/sdk/azurestackhci/Azure.ResourceManager.Hci/src/Azure.ResourceManager.Hci.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta.1</Version>
+    <Version>1.3.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.Hci</PackageId>

--- a/sdk/azurestackhci/Azure.ResourceManager.Hci/tsp-location.yaml
+++ b/sdk/azurestackhci/Azure.ResourceManager.Hci/tsp-location.yaml
@@ -1,4 +1,6 @@
 directory: specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI
 commit: a2a282a01e1ca8394ea12624fe8c10e64cf7e908
 repo: Azure/azure-rest-api-specs
+additionalDirectories: 
+
 emitterPackageJsonPath: eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json


### PR DESCRIPTION
## What\nStable .NET SDK for `Azure.ResourceManager.Hci` targeting API version `2026-02-01`.\n\n## Why\nRelease stable 1.3.0 of the Azure Stack HCI .NET management SDK with the latest API version.\n\n## Changes\n- Upgraded API version to `2026-02-01` (stable)\n- Migrated from Swagger/AutoRest to TypeSpec-based generation\n- Added support for new resource types and operations from the latest API version\n- Updated changelog, metadata, and version to 1.3.0