### PR TITLE
Remove Azure.Identity dependency from RM test projects (batch 1)

### DIFF
--- a/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/Azure.ResourceManager.AppConfiguration.Tests.csproj
+++ b/sdk/appconfiguration/Azure.ResourceManager.AppConfiguration/tests/Azure.ResourceManager.AppConfiguration.Tests.csproj
@@ -4,9 +4,6 @@
     <PackageReference Include="Azure.ResourceManager.Network" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />
     <Compile Include="..\..\..\..\common\ManagementTestShared\Temp\*.cs" LinkBase="TestShared" />
   </ItemGroup>

--- a/sdk/cdn/Azure.ResourceManager.Cdn/tests/Azure.ResourceManager.Cdn.Tests.csproj
+++ b/sdk/cdn/Azure.ResourceManager.Cdn/tests/Azure.ResourceManager.Cdn.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.ResourceManager.Cdn.csproj" />
-    <PackageReference Include="Azure.Identity" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/Azure.ResourceManager.Communication.Tests.csproj
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/Azure.ResourceManager.Communication.Tests.csproj
@@ -3,9 +3,6 @@
     <ProjectReference Include="..\src\Azure.ResourceManager.Communication.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />
     <Compile Include="..\..\..\..\common\ManagementTestShared\Temp\*.cs" LinkBase="TestShared" />
   </ItemGroup>

--- a/sdk/compute/Azure.ResourceManager.Compute/tests/Azure.ResourceManager.Compute.Tests.csproj
+++ b/sdk/compute/Azure.ResourceManager.Compute/tests/Azure.ResourceManager.Compute.Tests.csproj
@@ -4,9 +4,6 @@
     <PackageReference Include="Azure.ResourceManager.Network" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />
     <Compile Include="..\..\..\..\common\ManagementTestShared\Temp\*.cs" LinkBase="TestShared" />
   </ItemGroup>

--- a/sdk/dns/Azure.ResourceManager.Dns/tests/Azure.ResourceManager.Dns.Tests.csproj
+++ b/sdk/dns/Azure.ResourceManager.Dns/tests/Azure.ResourceManager.Dns.Tests.csproj
@@ -4,7 +4,6 @@
     <ProjectReference Include="..\src\Azure.ResourceManager.Dns.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.ResourceManager.Resources" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/edgeactions/Azure.ResourceManager.EdgeActions/tests/Azure.ResourceManager.EdgeActions.Tests.csproj
+++ b/sdk/edgeactions/Azure.ResourceManager.EdgeActions/tests/Azure.ResourceManager.EdgeActions.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.ResourceManager.EdgeActions.csproj" />
-    <PackageReference Include="Azure.Identity" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />

--- a/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Azure.ResourceManager.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.ResourceManager.EventHubs/tests/Azure.ResourceManager.EventHubs.Tests.csproj
@@ -4,7 +4,6 @@
     <PackageReference Include="Azure.ResourceManager.Network" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.ResourceManager.KeyVault" />
     <PackageReference Include="Azure.ResourceManager.ManagedServiceIdentities" />
   </ItemGroup>

--- a/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/tests/Azure.ResourceManager.HybridConnectivity.Tests.csproj
+++ b/sdk/hybridconnectivity/Azure.ResourceManager.HybridConnectivity/tests/Azure.ResourceManager.HybridConnectivity.Tests.csproj
@@ -4,7 +4,6 @@
     <ProjectReference Include="$(AzureCoreTestFramework)" />
   </ItemGroup>
     <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.ResourceManager.Resources" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/Azure.ResourceManager.IotCentral.Tests.csproj
+++ b/sdk/iotcentral/Azure.ResourceManager.IotCentral/tests/Azure.ResourceManager.IotCentral.Tests.csproj
@@ -3,9 +3,6 @@
     <ProjectReference Include="..\src\Azure.ResourceManager.IotCentral.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />
     <Compile Include="..\..\..\..\common\ManagementTestShared\Temp\*.cs" LinkBase="TestShared" />
   </ItemGroup>

--- a/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/Azure.ResourceManager.KeyVault.Tests.csproj
+++ b/sdk/keyvault/Azure.ResourceManager.KeyVault/tests/Azure.ResourceManager.KeyVault.Tests.csproj
@@ -4,9 +4,6 @@
     <PackageReference Include="Azure.ResourceManager.Network" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="$(TestFrameworkSupportFiles)" LinkBase="Shared\TestFramework" />
     <Compile Include="..\..\..\..\common\ManagementTestShared\Temp\*.cs" LinkBase="TestShared" />
   </ItemGroup>


### PR DESCRIPTION
## Description

Remove `PackageReference` to `Azure.Identity` from 10 ResourceManager test projects. `Azure.Core` now provides all identity types, making this explicit dependency unnecessary.

### Files modified

| # | Project | Change |
|---|---------|--------|
| 1 | Azure.ResourceManager.AppConfiguration.Tests | Removed PackageReference + empty ItemGroup |
| 2 | Azure.ResourceManager.Cdn.Tests | Removed PackageReference |
| 3 | Azure.ResourceManager.Communication.Tests | Removed PackageReference + empty ItemGroup |
| 4 | Azure.ResourceManager.Compute.Tests | Removed PackageReference + empty ItemGroup |
| 5 | Azure.ResourceManager.Dns.Tests | Removed PackageReference |
| 6 | Azure.ResourceManager.EdgeActions.Tests | Removed PackageReference |
| 7 | Azure.ResourceManager.EventHubs.Tests | Removed PackageReference |
| 8 | Azure.ResourceManager.HybridConnectivity.Tests | Removed PackageReference |
| 9 | Azure.ResourceManager.IotCentral.Tests | Removed PackageReference + empty ItemGroup |
| 10 | Azure.ResourceManager.KeyVault.Tests | Removed PackageReference + empty ItemGroup |

### Build verification

CDN, AppConfiguration, and EventHubs test projects all build successfully (0 errors, 0 warnings).

### Batch context

This is batch 1 of ~7 PRs removing `Azure.Identity` dependencies across the repo.