### PR TITLE
Add SecretClient IHostApplicationBuilder extensions

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net10.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net10.0.cs
@@ -94,6 +94,14 @@ namespace Azure.Security.KeyVault.Secrets
         public virtual Azure.Response<Azure.Security.KeyVault.Secrets.SecretProperties> UpdateSecretProperties(Azure.Security.KeyVault.Secrets.SecretProperties properties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.KeyVault.Secrets.SecretProperties>> UpdateSecretPropertiesAsync(Azure.Security.KeyVault.Secrets.SecretProperties properties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+    public static partial class SecretClientHostExtensions
+    {
+        public static System.ClientModel.Primitives.IClientBuilder AddKeyedSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string key, string sectionName) { throw null; }
+        public static System.ClientModel.Primitives.IClientBuilder AddKeyedSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string key, string sectionName, System.Action<Azure.Security.KeyVault.Secrets.SecretClientSettings> configureSettings) { throw null; }
+        public static System.ClientModel.Primitives.IClientBuilder AddSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string sectionName) { throw null; }
+        public static System.ClientModel.Primitives.IClientBuilder AddSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string sectionName, System.Action<Azure.Security.KeyVault.Secrets.SecretClientSettings> configureSettings) { throw null; }
+    }
     public partial class SecretClientOptions : Azure.Core.ClientOptions
     {
         public SecretClientOptions(Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion version = Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion.V2025_07_01) { }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net8.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.net8.0.cs
@@ -94,6 +94,14 @@ namespace Azure.Security.KeyVault.Secrets
         public virtual Azure.Response<Azure.Security.KeyVault.Secrets.SecretProperties> UpdateSecretProperties(Azure.Security.KeyVault.Secrets.SecretProperties properties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.KeyVault.Secrets.SecretProperties>> UpdateSecretPropertiesAsync(Azure.Security.KeyVault.Secrets.SecretProperties properties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("SCME0002")]
+    public static partial class SecretClientHostExtensions
+    {
+        public static System.ClientModel.Primitives.IClientBuilder AddKeyedSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string key, string sectionName) { throw null; }
+        public static System.ClientModel.Primitives.IClientBuilder AddKeyedSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string key, string sectionName, System.Action<Azure.Security.KeyVault.Secrets.SecretClientSettings> configureSettings) { throw null; }
+        public static System.ClientModel.Primitives.IClientBuilder AddSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string sectionName) { throw null; }
+        public static System.ClientModel.Primitives.IClientBuilder AddSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string sectionName, System.Action<Azure.Security.KeyVault.Secrets.SecretClientSettings> configureSettings) { throw null; }
+    }
     public partial class SecretClientOptions : Azure.Core.ClientOptions
     {
         public SecretClientOptions(Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion version = Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion.V2025_07_01) { }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/api/Azure.Security.KeyVault.Secrets.netstandard2.0.cs
@@ -93,6 +93,13 @@ namespace Azure.Security.KeyVault.Secrets
         public virtual Azure.Response<Azure.Security.KeyVault.Secrets.SecretProperties> UpdateSecretProperties(Azure.Security.KeyVault.Secrets.SecretProperties properties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task<Azure.Response<Azure.Security.KeyVault.Secrets.SecretProperties>> UpdateSecretPropertiesAsync(Azure.Security.KeyVault.Secrets.SecretProperties properties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
+    public static partial class SecretClientHostExtensions
+    {
+        public static System.ClientModel.Primitives.IClientBuilder AddKeyedSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string key, string sectionName) { throw null; }
+        public static System.ClientModel.Primitives.IClientBuilder AddKeyedSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string key, string sectionName, System.Action<Azure.Security.KeyVault.Secrets.SecretClientSettings> configureSettings) { throw null; }
+        public static System.ClientModel.Primitives.IClientBuilder AddSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string sectionName) { throw null; }
+        public static System.ClientModel.Primitives.IClientBuilder AddSecretClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder host, string sectionName, System.Action<Azure.Security.KeyVault.Secrets.SecretClientSettings> configureSettings) { throw null; }
+    }
     public partial class SecretClientOptions : Azure.Core.ClientOptions
     {
         public SecretClientOptions(Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion version = Azure.Security.KeyVault.Secrets.SecretClientOptions.ServiceVersion.V2025_07_01) { }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientHostExtensions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientHostExtensions.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using System.Diagnostics.CodeAnalysis;
+using Azure.Identity;
+using Microsoft.Extensions.Hosting;
+
+namespace Azure.Security.KeyVault.Secrets
+{
+    /// <summary>
+    /// Extension methods to add <see cref="SecretClient"/> to an <see cref="IHostApplicationBuilder"/>.
+    /// </summary>
+    [Experimental("SCME0002")]
+    public static class SecretClientHostExtensions
+    {
+        /// <summary>
+        /// Adds a singleton <see cref="SecretClient"/> to the <see cref="IHostApplicationBuilder"/>'s service collection.
+        /// </summary>
+        /// <param name="host">The <see cref="IHostApplicationBuilder"/> to add to.</param>
+        /// <param name="sectionName">The section of <see cref="Microsoft.Extensions.Configuration.IConfiguration"/> to use.</param>
+        /// <returns>An <see cref="IClientBuilder"/> that can be used to further configure the client.</returns>
+        public static IClientBuilder AddSecretClient(
+            this IHostApplicationBuilder host,
+            string sectionName)
+            => host.AddAzureClient<SecretClient, SecretClientSettings>(sectionName);
+
+        /// <summary>
+        /// Adds a singleton <see cref="SecretClient"/> to the <see cref="IHostApplicationBuilder"/>'s service collection.
+        /// </summary>
+        /// <param name="host">The <see cref="IHostApplicationBuilder"/> to add to.</param>
+        /// <param name="sectionName">The section of <see cref="Microsoft.Extensions.Configuration.IConfiguration"/> to use.</param>
+        /// <param name="configureSettings">Factory method to modify the <see cref="SecretClientSettings"/> after they are created.</param>
+        /// <returns>An <see cref="IClientBuilder"/> that can be used to further configure the client.</returns>
+        public static IClientBuilder AddSecretClient(
+            this IHostApplicationBuilder host,
+            string sectionName,
+            Action<SecretClientSettings> configureSettings)
+            => host.AddAzureClient<SecretClient, SecretClientSettings>(sectionName, configureSettings);
+
+        /// <summary>
+        /// Adds a keyed singleton <see cref="SecretClient"/> to the <see cref="IHostApplicationBuilder"/>'s service collection.
+        /// </summary>
+        /// <param name="host">The <see cref="IHostApplicationBuilder"/> to add to.</param>
+        /// <param name="key">The unique key to register as.</param>
+        /// <param name="sectionName">The section of <see cref="Microsoft.Extensions.Configuration.IConfiguration"/> to use.</param>
+        /// <returns>An <see cref="IClientBuilder"/> that can be used to further configure the client.</returns>
+        public static IClientBuilder AddKeyedSecretClient(
+            this IHostApplicationBuilder host,
+            string key,
+            string sectionName)
+            => host.AddKeyedAzureClient<SecretClient, SecretClientSettings>(key, sectionName);
+
+        /// <summary>
+        /// Adds a keyed singleton <see cref="SecretClient"/> to the <see cref="IHostApplicationBuilder"/>'s service collection.
+        /// </summary>
+        /// <param name="host">The <see cref="IHostApplicationBuilder"/> to add to.</param>
+        /// <param name="key">The unique key to register as.</param>
+        /// <param name="sectionName">The section of <see cref="Microsoft.Extensions.Configuration.IConfiguration"/> to use.</param>
+        /// <param name="configureSettings">Factory method to modify the <see cref="SecretClientSettings"/> after they are created.</param>
+        /// <returns>An <see cref="IClientBuilder"/> that can be used to further configure the client.</returns>
+        public static IClientBuilder AddKeyedSecretClient(
+            this IHostApplicationBuilder host,
+            string key,
+            string sectionName,
+            Action<SecretClientSettings> configureSettings)
+            => host.AddKeyedAzureClient<SecretClient, SecretClientSettings>(key, sectionName, configureSettings);
+    }
+}


### PR DESCRIPTION
## Summary

Adds convenience extension methods on `IHostApplicationBuilder` in the `Azure.Security.KeyVault.Secrets` project that delegate to the Azure.Core `AddAzureClient`/`AddKeyedAzureClient` methods with `SecretClient` and `SecretClientSettings` type parameters pre-filled.

## Methods Added

- `AddSecretClient(host, sectionName)`
- `AddSecretClient(host, sectionName, configureSettings)`
- `AddKeyedSecretClient(host, key, sectionName)`
- `AddKeyedSecretClient(host, key, sectionName, configureSettings)`

## Details

- Extension class is in `Azure.Security.KeyVault.Secrets` namespace for discoverability
- Marked `[Experimental("SCME0002")]` matching `SecretClientSettings`
- All return `IClientBuilder` for further configuration
- Follows the same pattern as #58123 (ArmClient host extensions)