### PR TITLE
Update Azure.Identity CPM version to 1.21.0

### DIFF
--- a/eng/centralpackagemanagement/Directory.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Packages.props
@@ -111,7 +111,7 @@
     <PackageVersion Include="Azure.Core.Expressions.DataFactory" Version="1.0.0" />
     <PackageVersion Include="Azure.Data.AppConfiguration" Version="1.9.0"/>
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.20.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="4.21.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid.SystemEvents" Version="1.0.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />


### PR DESCRIPTION
Updates the Central Package Management (CPM) version for `Azure.Identity` from `1.20.0` to `1.21.0` in `eng/centralpackagemanagement/Directory.Packages.props`.