### PR TITLE
Fix provisioning Generator build: IsPackable=false and TODO notes

### DIFF
--- a/sdk/provisioning/Generator/src/Generator.csproj
+++ b/sdk/provisioning/Generator/src/Generator.csproj
@@ -7,6 +7,7 @@
     <Version>1.0.0-beta.1</Version>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
     <IsTestSupportProject>true</IsTestSupportProject>
     <NoWarn>IDE0130;CS1591;CS1572;CS1587;$(NoWarn)</NoWarn> <!-- Ignore namespace not matching folder structure and XML comments -->
     <WarningsNotAsErrors>CS8600</WarningsNotAsErrors> <!-- Emitted as a warning before common properties were imported -->

--- a/sdk/provisioning/Generator/src/Specifications/SecurityCenterSpecification.cs
+++ b/sdk/provisioning/Generator/src/Specifications/SecurityCenterSpecification.cs
@@ -40,6 +40,8 @@ public class SecurityCenterSpecification() :
         RemoveProperties<DataExportSettings>("Id", "Name", "SystemData");
         RemoveProperties<SecurityAlertSyncSettings>("Id", "Name", "SystemData");
 
+        // TODO: Uncomment when Azure.ResourceManager.SecurityCenter is regenerated
+        // from a ProjectReference with enable-bicep-serialization (see note above).
         // ServerVulnerabilityAssessmentsSetting is polymorphic with a 'kind' discriminator.
         // Commented out: AzureServersSetting and ServerVulnerabilityAssessmentsSettingResource
         // were removed from the latest Azure.ResourceManager.SecurityCenter package.
@@ -62,6 +64,7 @@ public class SecurityCenterSpecification() :
             typeof(SecurityCenterSpecification).GetMethod(nameof(CreateDataExportSettings), BindingFlags.NonPublic | BindingFlags.Static)!);
         result.Add(typeof(SecurityAlertSyncSettings),
             typeof(SecurityCenterSpecification).GetMethod(nameof(CreateSecurityAlertSyncSettings), BindingFlags.NonPublic | BindingFlags.Static)!);
+        // TODO: Uncomment when Azure.ResourceManager.SecurityCenter is regenerated (see note above).
         // result.Add(typeof(AzureServersSetting),
         //     typeof(SecurityCenterSpecification).GetMethod(nameof(CreateAzureServersSetting), BindingFlags.NonPublic | BindingFlags.Static)!);
 
@@ -71,5 +74,6 @@ public class SecurityCenterSpecification() :
     // Dummy methods for the reflection-based generator to discover constructible data types.
     private static ArmOperation<SecuritySettingResource> CreateDataExportSettings(DataExportSettings content) => null!;
     private static ArmOperation<SecuritySettingResource> CreateSecurityAlertSyncSettings(SecurityAlertSyncSettings content) => null!;
+    // TODO: Uncomment when Azure.ResourceManager.SecurityCenter is regenerated (see note above).
     // private static ArmOperation<ServerVulnerabilityAssessmentsSettingResource> CreateAzureServersSetting(AzureServersSetting content) => null!;
 }


### PR DESCRIPTION
## Summary

- Set `IsPackable=false` on `Generator.csproj` to prevent `NU5046` pack error (Generator is a tool, not a shipping package — it has no `pkgicon.png`)
- Add TODO notes on commented-out `AzureServersSetting` references to uncomment when `Azure.ResourceManager.SecurityCenter` mgmt library is regenerated from a ProjectReference with `enable-bicep-serialization`

## Changes

- `sdk/provisioning/Generator/src/Generator.csproj`: Added `<IsPackable>false</IsPackable>`
- `sdk/provisioning/Generator/src/Specifications/SecurityCenterSpecification.cs`: Added TODO comments on 3 commented-out blocks