### PR TITLE
[AgentServer] Release prep: Core 1.0.0-beta.21, Responses 1.0.0-beta.1, Invocations 1.0.0-beta.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,10 +80,10 @@
 ####################
 
 # PRLabel: %AI Agents
-/sdk/agentserver/    @ankitbko @RaviPidaparthi @vangarp @ericsuh
+/sdk/agentserver/    @ankitbko @RaviPidaparthi
 
 # ServiceLabel: %AI Agents
-# ServiceOwners: @ankitbko @RaviPidaparthi @vangarp @ericsuh
+# ServiceOwners: @ankitbko @RaviPidaparthi
 
 # PRLabel: %AI Model Inference %AI Projects
 /sdk/ai/    @dargilco @glharper @nick863 @trangevi @trrwilson

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,10 +80,10 @@
 ####################
 
 # PRLabel: %AI Agents
-/sdk/agentserver/    @ankitbko @RaviPidaparthi
+/sdk/agentserver/    @ankitbko @RaviPidaparthi @vangarp @ericsuh
 
 # ServiceLabel: %AI Agents
-# ServiceOwners: @ankitbko @RaviPidaparthi
+# ServiceOwners: @ankitbko @RaviPidaparthi @vangarp @ericsuh
 
 # PRLabel: %AI Model Inference %AI Projects
 /sdk/ai/    @dargilco @glharper @nick863 @trangevi @trrwilson

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.21 (Unreleased)
+## 1.0.0-beta.21 (2026-04-14)
 
 This is a major architectural rewrite. The package has been redesigned as a lightweight hosting
 foundation. Protocol implementations that were previously bundled in this package have moved to

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -2,10 +2,19 @@
 
 ## 1.0.0-beta.21 (Unreleased)
 
+This is a major architectural rewrite. The package has been redesigned as a lightweight hosting
+foundation. Protocol implementations that were previously bundled in this package have moved to
+dedicated protocol packages (`Azure.AI.AgentServer.Responses`, `Azure.AI.AgentServer.Invocations`).
+See the [Migration Guide](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md)
+for upgrading from earlier beta versions.
+
 ### Breaking Changes
 
-- Package renamed from `Azure.AI.AgentServer.Hosting` to `Azure.AI.AgentServer.Core`.
-- Namespace changed from `Azure.AI.AgentServer.Hosting` to `Azure.AI.AgentServer.Core`.
+- **Package split**: All Responses API protocol types (models, invocation handlers, SSE streaming) have moved to `Azure.AI.AgentServer.Responses`. All Invocations protocol types have moved to `Azure.AI.AgentServer.Invocations`. This package now contains only the shared hosting foundation.
+- **Dependency removed**: `Azure.AI.AgentServer.Contracts` is no longer required. The generated OpenAI Responses API models are now built into `Azure.AI.AgentServer.Responses`.
+- **Dependencies removed**: `Azure.AI.Projects`, `Microsoft.Agents.AI.*`, and `ModelContextProtocol` packages are no longer dependencies of this package.
+- **API redesigned**: The old `IAgentInvocation` / `AgentInvocationContext` / `CreateResponseRequest` API surface has been replaced with `AgentHostBuilder` and protocol-specific handler abstractions (`ResponseHandler` in Responses, `InvocationHandler` in Invocations).
+- **Namespace changed**: Code that previously used `Azure.AI.AgentServer.Core.Responses.*` or `Azure.AI.AgentServer.Contracts.*` namespaces must switch to `Azure.AI.AgentServer.Responses`.
 
 ### Features Added
 
@@ -19,3 +28,11 @@
 - `AddAgentServerUserAgent()` and `UseAgentServerUserAgent()` extensions for standalone (Tier 3) setups.
 - `FoundryEnvironment` for Azure AI Foundry platform variable resolution.
 - Distributed tracing context propagation via request ID baggage.
+
+## Previous versions (1.0.0-beta.1 through 1.0.0-beta.11)
+
+Earlier beta versions used a monolithic architecture where `Azure.AI.AgentServer.Core` bundled
+protocol logic and depended on `Azure.AI.AgentServer.Contracts` for generated models. These
+versions are superseded by the new 3-package architecture. See the
+[Migration Guide](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md)
+for details.

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -29,10 +29,10 @@ for upgrading from earlier beta versions.
 - `FoundryEnvironment` for Azure AI Foundry platform variable resolution.
 - Distributed tracing context propagation via request ID baggage.
 
-## Previous versions (1.0.0-beta.1 through 1.0.0-beta.11)
+## Previous versions (prior to 1.0.0-beta.21)
 
-Earlier beta versions used a monolithic architecture where `Azure.AI.AgentServer.Core` bundled
-protocol logic and depended on `Azure.AI.AgentServer.Contracts` for generated models. These
-versions are superseded by the new 3-package architecture. See the
+Versions prior to `1.0.0-beta.21` used a monolithic architecture where `Azure.AI.AgentServer.Core`
+bundled protocol logic and depended on `Azure.AI.AgentServer.Contracts` for generated models.
+These versions are superseded by the new 3-package architecture. See the
 [Migration Guide](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md)
 for details.

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md
@@ -1,6 +1,6 @@
 # Guide for migrating to the new Azure.AI.AgentServer package architecture
 
-This guide helps you migrate from the earlier `Azure.AI.AgentServer.Core` (1.0.0-beta.1 through 1.0.0-beta.11) and `Azure.AI.AgentServer.Contracts` packages to the new three-package architecture introduced in `Azure.AI.AgentServer.Core` 1.0.0-beta.21.
+This guide helps you migrate from the earlier `Azure.AI.AgentServer.Core` (any version prior to 1.0.0-beta.21) and `Azure.AI.AgentServer.Contracts` packages to the new three-package architecture introduced in `Azure.AI.AgentServer.Core` 1.0.0-beta.21.
 
 ## Table of contents
 
@@ -29,8 +29,8 @@ The new package architecture provides:
 
 | Before | After | Notes |
 |--------|-------|-------|
-| `Azure.AI.AgentServer.Core` 1.0.0-beta.11 | `Azure.AI.AgentServer.Core` 1.0.0-beta.21 | Stripped to hosting foundation only |
-| `Azure.AI.AgentServer.Contracts` 1.0.0-beta.11 | _(removed)_ | Models are now built into `Azure.AI.AgentServer.Responses` |
+| `Azure.AI.AgentServer.Core` < 1.0.0-beta.21 | `Azure.AI.AgentServer.Core` 1.0.0-beta.21 | Stripped to hosting foundation only |
+| `Azure.AI.AgentServer.Contracts` (any version) | _(removed)_ | Models are now built into `Azure.AI.AgentServer.Responses` |
 | _(n/a)_ | `Azure.AI.AgentServer.Responses` 1.0.0-beta.1 | New — Responses API protocol |
 | _(n/a)_ | `Azure.AI.AgentServer.Invocations` 1.0.0-beta.1 | New — Invocations protocol |
 
@@ -53,7 +53,7 @@ dotnet add package Azure.AI.AgentServer.Invocations --prerelease
 
 ### Non-streaming handler
 
-**Before (beta.11):**
+**Before (prior to beta.21):**
 
 ```csharp
 using Azure.AI.AgentServer.Contracts.Generated.OpenAI;
@@ -117,7 +117,7 @@ ResponsesServer.Run<TextResponse>(async context => "Hello!");
 
 ### Streaming handler
 
-**Before (beta.11):**
+**Before (prior to beta.21):**
 
 ```csharp
 public async IAsyncEnumerable<ResponseStreamEvent> InvokeStreamAsync(
@@ -170,10 +170,7 @@ public override async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
 
 ### Server startup
 
-**Before (beta.11):**
-
-```csharp
-await AgentServerApplication.RunAsync(new ApplicationOptions(
+**Before (prior to beta.21):**
     ConfigureServices: services => services.AddSingleton<IAgentInvocation, MyAgent>()
 ));
 ```
@@ -207,7 +204,7 @@ app.Run();
 
 ## Deprecation of Azure.AI.AgentServer.Contracts
 
-The `Azure.AI.AgentServer.Contracts` package (1.0.0-beta.1 through 1.0.0-beta.11) is deprecated and will not receive further updates. All model types that were previously in Contracts are now generated directly into `Azure.AI.AgentServer.Responses` from TypeSpec definitions.
+The `Azure.AI.AgentServer.Contracts` package is deprecated and will not receive further updates. All model types that were previously in Contracts are now generated directly into `Azure.AI.AgentServer.Responses` from TypeSpec definitions.
 
 To migrate: remove the `Azure.AI.AgentServer.Contracts` package reference and add `Azure.AI.AgentServer.Responses` instead. Update `using` directives as shown in the [namespace changes](#namespace-changes) table above.
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md
@@ -97,7 +97,7 @@ public class MyAgent : ResponseHandler
         CancellationToken cancellationToken = default)
     {
         // Input text extraction is built-in
-        string inputText = await context.GetInputTextAsync(cancellationToken);
+        string inputText = await context.GetInputTextAsync(cancellationToken: cancellationToken);
 
         // One-liner for a complete text message with all SSE events
         var stream = new ResponseEventStream(context, request);
@@ -171,6 +171,9 @@ public override async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
 ### Server startup
 
 **Before (prior to beta.21):**
+
+```csharp
+await AgentServerApplication.RunAsync(new ApplicationOptions(
     ConfigureServices: services => services.AddSingleton<IAgentInvocation, MyAgent>()
 ));
 ```

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md
@@ -1,0 +1,220 @@
+# Guide for migrating to the new Azure.AI.AgentServer package architecture
+
+This guide helps you migrate from the earlier `Azure.AI.AgentServer.Core` (1.0.0-beta.1 through 1.0.0-beta.11) and `Azure.AI.AgentServer.Contracts` packages to the new three-package architecture introduced in `Azure.AI.AgentServer.Core` 1.0.0-beta.21.
+
+## Table of contents
+
+- [Migration benefits](#migration-benefits)
+- [Package changes](#package-changes)
+- [API changes](#api-changes)
+  - [Non-streaming handler](#non-streaming-handler)
+  - [Streaming handler](#streaming-handler)
+  - [Server startup](#server-startup)
+- [Namespace changes](#namespace-changes)
+- [Deprecation of Azure.AI.AgentServer.Contracts](#deprecation-of-azureaiagentservercontracts)
+- [Additional information](#additional-information)
+
+## Migration benefits
+
+The new package architecture provides:
+
+- **Separation of concerns** — protocol implementations (Responses API, Invocations) are in dedicated packages rather than bundled into a monolithic Core package.
+- **Dramatically simpler API** — the old approach required manually constructing SSE events, tracking sequence numbers, and building response objects from raw model types. The new API provides a `ResponseHandler` base class with builder methods that handle all of this automatically.
+- **Type-safe builder pattern** — `ResponseEventStream` and its child builders manage event sequencing, output indices, and content indices. You cannot accidentally emit events in the wrong order.
+- **Built-in convenience methods** — common patterns like "emit a text message" or "stream tokens" are one-liners via `ResponseEventStream` convenience generators.
+- **Zero-config startup** — `ResponsesServer.Run<T>()` or `InvocationsServer.Run<T>()` replaces `AgentServerApplication.RunAsync()` with sensible defaults including OpenTelemetry, health endpoints, and user-agent headers.
+- **Multi-protocol support** — a single server can host both Responses and Invocations endpoints via `AgentHostBuilder`.
+
+## Package changes
+
+| Before | After | Notes |
+|--------|-------|-------|
+| `Azure.AI.AgentServer.Core` 1.0.0-beta.11 | `Azure.AI.AgentServer.Core` 1.0.0-beta.21 | Stripped to hosting foundation only |
+| `Azure.AI.AgentServer.Contracts` 1.0.0-beta.11 | _(removed)_ | Models are now built into `Azure.AI.AgentServer.Responses` |
+| _(n/a)_ | `Azure.AI.AgentServer.Responses` 1.0.0-beta.1 | New — Responses API protocol |
+| _(n/a)_ | `Azure.AI.AgentServer.Invocations` 1.0.0-beta.1 | New — Invocations protocol |
+
+Update your package references:
+
+```dotnetcli
+# Remove the old packages
+dotnet remove package Azure.AI.AgentServer.Contracts
+
+# Install the new packages (Responses transitively brings in Core)
+dotnet add package Azure.AI.AgentServer.Responses --prerelease
+
+# If you also need the Invocations protocol:
+dotnet add package Azure.AI.AgentServer.Invocations --prerelease
+```
+
+> **Note:** `Azure.AI.AgentServer.Responses` and `Azure.AI.AgentServer.Invocations` both depend on `Azure.AI.AgentServer.Core`, so you do not need to install Core separately.
+
+## API changes
+
+### Non-streaming handler
+
+**Before (beta.11):**
+
+```csharp
+using Azure.AI.AgentServer.Contracts.Generated.OpenAI;
+using Azure.AI.AgentServer.Contracts.Generated.Responses;
+using Azure.AI.AgentServer.Responses.Invocation;
+
+public class MyAgent : IAgentInvocation
+{
+    public Task<Response> InvokeAsync(
+        CreateResponseRequest request,
+        AgentInvocationContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // Manually extract input text from raw JSON
+        var items = request.Input.ToObject<IList<ItemParam>>();
+        var inputText = /* ... manual extraction ... */;
+
+        // Manually construct content, output items, and response
+        IList<ItemContent> contents = [new ItemContentOutputText(text: "Hello", annotations: [])];
+        IList<ItemResource> outputs = [
+            new ResponsesAssistantMessageItemResource(
+                id: Guid.NewGuid().ToString(),
+                status: ResponsesMessageItemResourceStatus.Completed,
+                content: contents)
+        ];
+        return Task.FromResult(request.ToResponse(context: context, output: outputs));
+    }
+}
+```
+
+**After (beta.21):**
+
+```csharp
+using Azure.AI.AgentServer.Responses;
+
+public class MyAgent : ResponseHandler
+{
+    public override async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
+        ResponseContext context,
+        CreateResponse request,
+        CancellationToken cancellationToken = default)
+    {
+        // Input text extraction is built-in
+        string inputText = await context.GetInputTextAsync(cancellationToken);
+
+        // One-liner for a complete text message with all SSE events
+        var stream = new ResponseEventStream(context, request);
+        yield return stream.EmitCreated();
+        await foreach (var e in stream.OutputItemMessage("Hello"))
+            yield return e;
+        yield return stream.EmitCompleted();
+    }
+}
+```
+
+Or, for the simplest case, use `TextResponse`:
+
+```csharp
+ResponsesServer.Run<TextResponse>(async context => "Hello!");
+```
+
+### Streaming handler
+
+**Before (beta.11):**
+
+```csharp
+public async IAsyncEnumerable<ResponseStreamEvent> InvokeStreamAsync(
+    CreateResponseRequest request,
+    AgentInvocationContext context,
+    CancellationToken cancellationToken = default)
+{
+    var seq = -1;
+
+    // Manually emit every SSE event, track sequence numbers, build model objects
+    yield return new ResponseCreatedEvent(++seq, ToResponse(request, context, ResponseStatus.InProgress));
+
+    var itemId = context.IdGenerator.GenerateMessageId();
+    yield return new ResponseOutputItemAddedEvent(++seq, 0,
+        new ResponsesAssistantMessageItemResource(id: itemId, ...));
+    yield return new ResponseContentPartAddedEvent(++seq, itemId, 0, 0,
+        new ItemContentOutputText(text: "", annotations: []));
+
+    foreach (var token in tokens)
+    {
+        yield return new ResponseTextDeltaEvent(++seq, itemId, 0, 0, token);
+    }
+
+    yield return new ResponseTextDoneEvent(++seq, itemId, 0, 0, fullText);
+    yield return new ResponseContentPartDoneEvent(++seq, itemId, 0, 0, content);
+    yield return new ResponseOutputItemDoneEvent(++seq, 0, item);
+    yield return new ResponseCompletedEvent(++seq, ToResponse(...));
+}
+```
+
+**After (beta.21):**
+
+```csharp
+public override async IAsyncEnumerable<ResponseStreamEvent> CreateAsync(
+    ResponseContext context,
+    CreateResponse request,
+    CancellationToken cancellationToken = default)
+{
+    var stream = new ResponseEventStream(context, request);
+    yield return stream.EmitCreated();
+    yield return stream.EmitInProgress();
+
+    // Stream tokens — sequence numbers, indices, and all inner events are automatic
+    await foreach (var e in stream.OutputItemMessage(GetTokens(cancellationToken), cancellationToken))
+        yield return e;
+
+    yield return stream.EmitCompleted();
+}
+```
+
+### Server startup
+
+**Before (beta.11):**
+
+```csharp
+await AgentServerApplication.RunAsync(new ApplicationOptions(
+    ConfigureServices: services => services.AddSingleton<IAgentInvocation, MyAgent>()
+));
+```
+
+**After (beta.21):**
+
+```csharp
+// One-liner startup with built-in OpenTelemetry, health endpoint, and user-agent
+ResponsesServer.Run<MyAgent>();
+```
+
+Or, for multi-protocol composition:
+
+```csharp
+var builder = AgentHost.CreateBuilder();
+builder.AddResponses<MyResponseHandler>();
+builder.AddInvocations<MyInvocationHandler>();
+var app = builder.Build();
+app.Run();
+```
+
+## Namespace changes
+
+| Before | After |
+|--------|-------|
+| `Azure.AI.AgentServer.Contracts.Generated.OpenAI` | `Azure.AI.AgentServer.Responses` |
+| `Azure.AI.AgentServer.Contracts.Generated.Responses` | `Azure.AI.AgentServer.Responses` |
+| `Azure.AI.AgentServer.Core.Common.Http.Json` | _(no longer needed — serialization is built-in)_ |
+| `Azure.AI.AgentServer.Core.Common.Id` | _(no longer needed — ID generation is automatic)_ |
+| `Azure.AI.AgentServer.Responses.Invocation` | `Azure.AI.AgentServer.Responses` |
+
+## Deprecation of Azure.AI.AgentServer.Contracts
+
+The `Azure.AI.AgentServer.Contracts` package (1.0.0-beta.1 through 1.0.0-beta.11) is deprecated and will not receive further updates. All model types that were previously in Contracts are now generated directly into `Azure.AI.AgentServer.Responses` from TypeSpec definitions.
+
+To migrate: remove the `Azure.AI.AgentServer.Contracts` package reference and add `Azure.AI.AgentServer.Responses` instead. Update `using` directives as shown in the [namespace changes](#namespace-changes) table above.
+
+## Additional information
+
+- [Azure.AI.AgentServer.Core README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Core/README.md)
+- [Azure.AI.AgentServer.Responses README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md)
+- [Azure.AI.AgentServer.Invocations README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Invocations/README.md)
+- [Responses samples](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Responses/samples)
+- [Invocations samples](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Invocations/samples)

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/README.md
@@ -19,7 +19,7 @@ dotnet add package Azure.AI.AgentServer.Core --prerelease
 - An [Azure subscription](https://azure.microsoft.com/free/dotnet/)
 - [.NET 8](https://dotnet.microsoft.com/download) or later
 
-> **Upgrading from an earlier beta?** The package has been redesigned as a lightweight hosting
+> **Upgrading from a version prior to beta.21?** The package has been redesigned as a lightweight hosting
 > foundation. Protocol logic has moved to [`Azure.AI.AgentServer.Responses`][responses] and
 > [`Azure.AI.AgentServer.Invocations`][invocations]. See the [Migration Guide][migration] for details.
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/README.md
@@ -19,6 +19,10 @@ dotnet add package Azure.AI.AgentServer.Core --prerelease
 - An [Azure subscription](https://azure.microsoft.com/free/dotnet/)
 - [.NET 8](https://dotnet.microsoft.com/download) or later
 
+> **Upgrading from beta.1–beta.11?** The package has been redesigned as a lightweight hosting
+> foundation. Protocol logic has moved to [`Azure.AI.AgentServer.Responses`][responses] and
+> [`Azure.AI.AgentServer.Invocations`][invocations]. See the [Migration Guide][migration] for details.
+
 ### Start a server (recommended)
 
 Use the builder pattern to create a server. Protocol packages provide extension methods (`AddResponses<T>()`, `AddInvocations<T>()`) to register their endpoints:
@@ -95,3 +99,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 [source]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Core/src
 [nuget]: https://www.nuget.org/packages/Azure.AI.AgentServer.Core
 [product_doc]: https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents
+[migration]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Core/MigrationGuide.md
+[responses]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Responses
+[invocations]: https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/agentserver/Azure.AI.AgentServer.Invocations

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/README.md
@@ -19,7 +19,7 @@ dotnet add package Azure.AI.AgentServer.Core --prerelease
 - An [Azure subscription](https://azure.microsoft.com/free/dotnet/)
 - [.NET 8](https://dotnet.microsoft.com/download) or later
 
-> **Upgrading from beta.1–beta.11?** The package has been redesigned as a lightweight hosting
+> **Upgrading from an earlier beta?** The package has been redesigned as a lightweight hosting
 > foundation. Protocol logic has moved to [`Azure.AI.AgentServer.Responses`][responses] and
 > [`Azure.AI.AgentServer.Invocations`][invocations]. See the [Migration Guide][migration] for details.
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
@@ -3,6 +3,7 @@
     <RequiredTargetFrameworks>$(RequiredRunnableTargetFrameworks)</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Azure.AI.AgentServer.Core</RootNamespace>
+    <Version>1.0.0-beta.21</Version>
     <Description>Shared foundation for Azure AI Agent Server packages — provides port binding, health probes, OpenTelemetry, graceful shutdown, and the composable AgentHostBuilder.</Description>
     <PackageTags>Microsoft Azure AI Agent Server Core ASP.NET Core OpenTelemetry</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 
+- Initial release of the Azure.AI.AgentServer.Invocations library.
 - `InvocationHandler` abstract class for implementing invocation protocol endpoints.
 - `InvocationContext` providing request metadata and session information to handlers.
 - Automatic session ID resolution from query parameters and environment variables for multi-turn invocation tracking.

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2026-04-14)
 
 ### Features Added
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features Added
 
-- Initial release of Azure.AI.AgentServer.Responses.
+- Initial release of the Azure.AI.AgentServer.Responses library.
 - ASP.NET Core server library implementing the Azure AI Responses API.
 - `ResponseHandler` abstract class for custom response handling with `CreateAsync` returning `IAsyncEnumerable<ResponseStreamEvent>`.
 - `TextResponse` convenience class for simple text-only responses with a single delegate.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.1 (Unreleased)
+## 1.0.0-beta.1 (2026-04-14)
 
 ### Features Added
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
@@ -145,6 +145,18 @@ public class EchoHandlerFullControl : ResponseHandler
 }
 ```
 
+### ResponseContext
+
+Injected into every `CreateAsync` call, `ResponseContext` provides access to the client's input and a unique response ID:
+
+- **`GetInputItemsAsync(resolveReferences, cancellationToken)`** — returns the resolved input items from the request. Reference items (`ItemReferenceParam`) are resolved to their referenced content by default; pass `resolveReferences: false` to receive them as-is. The result is computed once and cached per resolve mode.
+- **`GetInputTextAsync(resolveReferences, cancellationToken)`** — shorthand that resolves input items and concatenates all text content from `ItemMessage` entries.
+- **`ResponseId`** — the unique ID for this response, used to construct child item IDs.
+
+For collections of `Item` objects, the `GetInputText()` extension method (on `IEnumerable<Item>`) extracts and joins text content without needing a `ResponseContext`.
+
+See the [handler implementation guide](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md#responsecontext) for the full `ResponseContext` API reference.
+
 ### ResponseEventStream
 
 Manages `sequenceNumber`, `outputIndex`, `contentIndex`, and `itemId` tracking internally. Each `yield return` maps 1:1 to an SSE event with zero bookkeeping.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/README.md
@@ -147,11 +147,16 @@ public class EchoHandlerFullControl : ResponseHandler
 
 ### ResponseContext
 
-Injected into every `CreateAsync` call, `ResponseContext` provides access to the client's input and a unique response ID:
+Injected into every `CreateAsync` call, `ResponseContext` provides access to the client's input, conversation history, and request metadata:
 
-- **`GetInputItemsAsync(resolveReferences, cancellationToken)`** — returns the resolved input items from the request. Reference items (`ItemReferenceParam`) are resolved to their referenced content by default; pass `resolveReferences: false` to receive them as-is. The result is computed once and cached per resolve mode.
+- **`GetInputItemsAsync(resolveReferences, cancellationToken)`** — returns the resolved input items from the request. Item references are resolved to their content by default; pass `resolveReferences: false` to receive them as-is. Computed once and cached.
 - **`GetInputTextAsync(resolveReferences, cancellationToken)`** — shorthand that resolves input items and concatenates all text content from `ItemMessage` entries.
+- **`GetHistoryAsync(cancellationToken)`** — returns output items from previous responses in the conversation chain (oldest-first). Uses `previous_response_id` to walk the conversation and resolves items via the provider. Limit controlled by `ResponsesServerOptions.DefaultFetchHistoryCount` (default: 100).
 - **`ResponseId`** — the unique ID for this response, used to construct child item IDs.
+- **`ClientHeaders`** — forwarded HTTP headers from the original client request.
+- **`QueryParameters`** — query parameters from the original request.
+- **`RawBody`** — the raw request body as `BinaryData` for advanced scenarios.
+- **`Isolation`** — isolation context (tenant/session) extracted from request headers.
 
 For collections of `Item` objects, the `GetInputText()` extension method (on `IEnumerable<Item>`) extracts and joins text content without needing a `ResponseContext`.
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
@@ -406,7 +406,8 @@ Output is constructed through a **builder hierarchy** that enforces correct even
 ```
 ResponseEventStream
   └── OutputItemBuilder (message, function call, reasoning, etc.)
-        └── Content builders (text, refusal, summary, etc.)
+        ├── TextContentBuilder    : EmitAdded → EmitDelta* → EmitTextDone → EmitAnnotationAdded* → EmitDone
+        └── RefusalContentBuilder : EmitAdded → EmitDelta* → EmitRefusalDone → EmitDone
 ```
 
 Each builder tracks its lifecycle state (`NotStarted` → `Added` → `Done`) and will throw if you emit events out of order. This prevents protocol violations at development time rather than runtime.
@@ -650,6 +651,76 @@ yield return message.EmitDone();
 ```
 
 **Tip**: For streaming, emit small deltas frequently for a responsive feel. For non-streaming mode, the library accumulates everything and delivers the final JSON — so delta granularity doesn't affect the JSON response, only SSE streaming UX.
+
+#### Annotations on text content
+
+After calling `EmitTextDone()`, you can attach annotations before closing the content part with `EmitDone()`. The lifecycle is: `EmitAdded` → `EmitDelta` (0+) → `EmitTextDone` → `EmitAnnotationAdded` (0+) → `EmitDone`.
+
+```csharp
+var message = stream.AddOutputItemMessage();
+yield return message.EmitAdded();
+
+var text = message.AddTextContent();
+yield return text.EmitAdded();
+yield return text.EmitDelta("Here are your files.");
+yield return text.EmitTextDone("Here are your files.");
+
+// Annotations are emitted after text is finalized
+yield return text.EmitAnnotationAdded(new FilePath(fileId: "/reports/summary.pdf", index: 0));
+yield return text.EmitAnnotationAdded(new UrlCitationBody(
+    url: new Uri("https://example.com/docs"), startIndex: 0, endIndex: 19, title: "Docs"));
+
+yield return text.EmitDone();
+yield return message.EmitDone();
+```
+
+Or use the `TextContent(string, IEnumerable<Annotation>)` convenience on `OutputItemMessageBuilder` to handle the full sequence in one call:
+
+```csharp
+var message = stream.AddOutputItemMessage();
+yield return message.EmitAdded();
+
+foreach (var evt in message.TextContent("Here are your files.", new Annotation[]
+{
+    new FilePath(fileId: "/reports/summary.pdf", index: 0),
+    new UrlCitationBody(url: new Uri("https://example.com/docs"), startIndex: 0, endIndex: 19, title: "Docs"),
+}))
+    yield return evt;
+
+yield return message.EmitDone();
+```
+
+#### Refusal content
+
+When the model refuses a request, emit a refusal content part instead of (or alongside) text. The lifecycle is: `EmitAdded` → `EmitDelta` (0+) → `EmitRefusalDone` → `EmitDone`.
+
+```csharp
+var message = stream.AddOutputItemMessage();
+yield return message.EmitAdded();
+
+var refusal = message.AddRefusalContent();
+yield return refusal.EmitAdded();
+yield return refusal.EmitDelta("I cannot ");
+yield return refusal.EmitDelta("help with that.");
+yield return refusal.EmitRefusalDone("I cannot help with that.");
+yield return refusal.EmitDone();
+
+yield return message.EmitDone();
+```
+
+Or use the `RefusalContent(string)` convenience for the common case:
+
+```csharp
+var message = stream.AddOutputItemMessage();
+yield return message.EmitAdded();
+
+foreach (var evt in message.RefusalContent("I cannot help with that."))
+    yield return evt;
+
+yield return message.EmitDone();
+```
+
+Both `RefusalContent` overloads follow the same pattern as `TextContent` — a `string` overload for complete text and an `IAsyncEnumerable<string>` overload for streaming chunks.
 
 ### Function Calls (Tool Use)
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/docs/handler-implementation-guide.md
@@ -407,7 +407,8 @@ Output is constructed through a **builder hierarchy** that enforces correct even
 ResponseEventStream
   └── OutputItemBuilder (message, function call, reasoning, etc.)
         ├── TextContentBuilder    : EmitAdded → EmitDelta* → EmitTextDone → EmitAnnotationAdded* → EmitDone
-        └── RefusalContentBuilder : EmitAdded → EmitDelta* → EmitRefusalDone → EmitDone
+        ├── RefusalContentBuilder : EmitAdded → EmitDelta* → EmitRefusalDone → EmitDone
+        └── (other content builders follow the same Added → … → Done pattern)
 ```
 
 Each builder tracks its lifecycle state (`NotStarted` → `Added` → `Done`) and will throw if you emit events out of order. This prevents protocol violations at development time rather than runtime.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SnapshotConsistencyTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SnapshotConsistencyTests.cs
@@ -21,14 +21,22 @@ public class SnapshotConsistencyTests : ProtocolTestBase
     /// T009 / SC-001: Concurrent GET requests during streaming return consistent snapshots.
     /// Each GET response has a consistent status/output pair (in_progress with N items,
     /// never completed with fewer items than final count).
+    ///
+    /// Uses explicit gates instead of Task.Delay so the handler pauses after each item
+    /// until the test releases it — deterministic on any CI machine.
     /// </summary>
     [Test]
-    [Ignore("Flaky due to race condition — https://github.com/Azure/azure-sdk-for-net/issues/57815")]
     public async Task ConcurrentGET_DuringEmission_ReturnsConsistentSnapshots()
     {
+        const int itemCount = 10;
         var handlerStarted = new TaskCompletionSource();
+        // Handler waits on this after each item; test releases to let the next item emit.
+        var continueGate = new SemaphoreSlim(0);
+        // Handler signals this after each item is yielded so the test knows it's safe to GET.
+        var itemEmitted = new SemaphoreSlim(0);
 
-        Handler.EventFactory = (req, ctx, ct) => SlowMultiOutputStream(ctx, 10, handlerStarted, ct);
+        Handler.EventFactory = (req, ctx, ct) =>
+            GatedMultiOutputStream(ctx, itemCount, handlerStarted, continueGate, itemEmitted, ct);
 
         // Start background streaming response
         var postRequest = new HttpRequestMessage(HttpMethod.Post, "/responses")
@@ -62,33 +70,60 @@ public class SnapshotConsistencyTests : ProtocolTestBase
 
         Assert.That(responseId, Is.Not.Null);
 
-        // Issue concurrent GET requests during emission
-        var getResults = new List<(string Status, int OutputCount)>();
-        for (int i = 0; i < 5; i++)
+        // Wait for handler to start emitting (response.created yielded)
+        await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Issue GET requests at deterministic points during emission.
+        // Release items in batches, wait for the signal, then GET while handler is paused.
+        var getResults = new List<(string Status, int OutputCount, int ExpectedMinItems)>();
+        int[] batchSizes = [2, 2, 2, 2, 2]; // 5 batches × 2 items = 10 total
+
+        int totalReleased = 0;
+        foreach (var batch in batchSizes)
         {
-            await Task.Delay(50); // Let some events emit
+            // Release a batch of items
+            continueGate.Release(batch);
+            for (int j = 0; j < batch; j++)
+            {
+                Assert.That(
+                    await itemEmitted.WaitAsync(TimeSpan.FromSeconds(5)),
+                    Is.True, $"Handler did not emit item within timeout (released {totalReleased + j + 1})");
+            }
+            totalReleased += batch;
+
+            // GET while handler is paused on the next gate
             var getResponse = await GetResponseAsync(responseId!);
             using var getDoc = await ParseJsonAsync(getResponse);
             var root = getDoc.RootElement;
             var status = root.GetProperty("status").GetString()!;
             var output = root.GetProperty("output");
             var outputCount = output.GetArrayLength();
-            getResults.Add((status, outputCount));
+            getResults.Add((status, outputCount, totalReleased));
         }
 
-        // Wait for completion
+        // All items released — handler will emit response.completed next
         await WaitForBackgroundCompletionAsync(responseId!);
 
-        // Assert: each GET has consistent state
-        foreach (var (status, outputCount) in getResults)
+        // Assert snapshot consistency at each observation point
+        foreach (var (status, outputCount, expectedMin) in getResults)
         {
             if (status == "completed")
             {
-                // If completed, must have all 10 output items
-                Assert.That(outputCount, Is.EqualTo(10));
+                // If completed, must have all items
+                Assert.That(outputCount, Is.EqualTo(itemCount),
+                    "Completed response must contain all output items");
             }
-            // in_progress with any output count is fine — it's a point-in-time snapshot
+            else
+            {
+                // in_progress — output count should be at least what we released
+                // (events may still be persisting, so >= 0 is the safe lower bound)
+                Assert.That(status, Is.EqualTo("in_progress"));
+            }
         }
+
+        // Verify we observed at least one in_progress snapshot (the whole point of this test)
+        Assert.That(getResults.Any(r => r.Status == "in_progress"), Is.True,
+            "Expected at least one GET to observe in_progress state during gated emission");
     }
 
     /// <summary>
@@ -190,10 +225,13 @@ public class SnapshotConsistencyTests : ProtocolTestBase
     // ── Test helper streams ──────────────────────────────────────
 
     /// <summary>
-    /// Emits output items slowly for concurrent GET testing.
+    /// Emits output items with explicit gates for deterministic concurrent GET testing.
+    /// Pauses after each item until the test releases <paramref name="continueGate"/>,
+    /// and signals <paramref name="itemEmitted"/> after each item is yielded.
     /// </summary>
-    private static async IAsyncEnumerable<ResponseStreamEvent> SlowMultiOutputStream(
+    private static async IAsyncEnumerable<ResponseStreamEvent> GatedMultiOutputStream(
         ResponseContext ctx, int itemCount, TaskCompletionSource handlerStarted,
+        SemaphoreSlim continueGate, SemaphoreSlim itemEmitted,
         [EnumeratorCancellation] CancellationToken ct)
     {
         var response = new Models.ResponseObject(ctx.ResponseId, "test-model") { Status = ResponseStatus.InProgress };
@@ -204,13 +242,17 @@ public class SnapshotConsistencyTests : ProtocolTestBase
         for (int i = 0; i < itemCount; i++)
         {
             ct.ThrowIfCancellationRequested();
-            await Task.Delay(30, ct);
+            // Wait for the test to release the gate before emitting the next item
+            await continueGate.WaitAsync(ct);
 
             var msg = new OutputItemMessage(
                 $"msg_{i}", MessageStatus.Completed, MessageRole.Assistant,
                 Array.Empty<MessageContent>());
             items.Add(msg);
             yield return new ResponseOutputItemAddedEvent(0, i, msg);
+
+            // Signal the test that this item has been yielded
+            itemEmitted.Release();
         }
 
         var completedResponse = new Models.ResponseObject(ctx.ResponseId, "test-model") { Status = ResponseStatus.Completed };

--- a/sdk/agentserver/Directory.Build.props
+++ b/sdk/agentserver/Directory.Build.props
@@ -5,7 +5,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props"/>
 
   <PropertyGroup>
-    <Version>1.0.0-beta.21</Version>
     <Nullable>enable</Nullable>
 
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary

Release preparation for the new 3-package Azure.AI.AgentServer architecture. Release date: **2026-04-14**.

| Package | Version | DevOps Work Item |
|---------|---------|-----------------|
| Azure.AI.AgentServer.Core | 1.0.0-beta.21 | [#29340](https://dev.azure.com/azure-sdk/Release/_workitems/edit/29340/) |
| Azure.AI.AgentServer.Responses | 1.0.0-beta.1 | [#33691](https://dev.azure.com/azure-sdk/Release/_workitems/edit/33691/) |
| Azure.AI.AgentServer.Invocations | 1.0.0-beta.1 | [#33692](https://dev.azure.com/azure-sdk/Release/_workitems/edit/33692/) |

### Changes

**Changelogs**
- Core: Rewrote beta.21 entry to document breaking changes vs last published version — package split, Contracts removal, dependency cleanup, API redesign
- Responses/Invocations: Polished initial release entries
- All three: Release date set to 2026-04-14 via Prepare-Release.ps1

**Migration Guide** (new file)
- MigrationGuide.md covering old Core+Contracts → new 3-package architecture
- Side-by-side code comparisons for non-streaming handlers, streaming handlers, and server startup
- Package change table, namespace mapping, Contracts deprecation notice

**Version hygiene**
- Moved Core Version from shared Directory.Build.props to its own .csproj for cleaner per-package versioning

**Documentation improvements**
- Added migration callout to Core README for returning users
- Added ResponseContext key concept section to Responses README (GetInputItemsAsync, GetInputTextAsync, resolveReferences, ItemExtensions.GetInputText)
- Added annotation builder lifecycle (EmitAnnotationAdded) and RefusalContentBuilder examples to handler implementation guide
- Expanded builder hierarchy diagram with per-builder lifecycles
- Future-proofed version references to use "prior to beta.21" instead of hardcoded version ranges

### Closes

Closes #57976
Closes #57977
Closes #57918
Closes #58098
Closes #57815

### Context

The old Azure.AI.AgentServer.Core (published on NuGet prior to beta.21) was a monolithic package that bundled protocol logic and depended on Azure.AI.AgentServer.Contracts for generated models. The new architecture splits this into three focused packages:
- **Core** — hosting foundation (AgentHostBuilder, OTel, health, user-agent)
- **Responses** — Responses API protocol (TypeSpec models, ResponseHandler, SSE streaming)
- **Invocations** — Invocations protocol (InvocationHandler, session resolution)

The version jump to beta.21 is intentional — signals the major rewrite and leaves buffer versions for potential hotfixes to the old package.
