### PR TITLE
[Identity] Prepare patch v1.17.2 to upgrade MSAL dependencies (Approach 2)

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -185,9 +185,9 @@
     <!-- Other approved packages -->
     <PackageReference Update="Microsoft.Azure.Amqp" Version="2.7.0" />
     <PackageReference Update="Microsoft.Azure.WebPubSub.Common" Version="1.5.0" />
-    <PackageReference Update="Microsoft.Identity.Client" Version="4.78.0" />
-    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.78.0" />
-    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.78.0" />
+    <PackageReference Update="Microsoft.Identity.Client" Version="4.83.1" />
+    <PackageReference Update="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.1" />
+    <PackageReference Update="Microsoft.Identity.Client.Broker" Version="4.83.1" />
     <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.14.0" />
     <PackageReference Update="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
     <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />

--- a/sdk/identity/Azure.Identity/CHANGELOG.md
+++ b/sdk/identity/Azure.Identity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.17.2 (Unreleased)
+
+### Other Changes
+
+- Updated `Microsoft.Identity.Client` and `Microsoft.Identity.Client.Extensions.Msal` dependencies to version 4.83.1.
+
 ## 1.17.1 (2025-11-18)
 
 ### Other Changes

--- a/sdk/identity/Azure.Identity/assets.json
+++ b/sdk/identity/Azure.Identity/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/identity/Azure.Identity",
-  "Tag": "net/identity/Azure.Identity_0224d294dd"
+  "Tag": "net/identity/Azure.Identity_4e73ccefde"
 }

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <Description>Provides APIs for authenticating to Microsoft Entra ID</Description>
     <AssemblyTitle>Microsoft Azure.Identity Component</AssemblyTitle>
-    <Version>1.17.1</Version>
+    <Version>1.17.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
-    <ApiCompatVersion>1.17.0</ApiCompatVersion>
+    <ApiCompatVersion>1.17.1</ApiCompatVersion>
     <PackageTags>Microsoft Azure Identity;$(PackageCommonTags)</PackageTags>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021;AZC0011</NoWarn>

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -63,17 +63,21 @@ namespace Azure.Identity
         {
             AuthenticationResult result;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             MSAL.ManagedIdentitySource availableSource = ManagedIdentityApplication.GetManagedIdentitySource();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             AzureIdentityEventSource.Singleton.ManagedIdentityCredentialSelected(availableSource.ToString(), _options.ManagedIdentityId.ToString());
 
             // If the source is DefaultToImds and the credential is chained, we should probe the IMDS endpoint first.
+#pragma warning disable CS0618 // Type or member is obsolete
             if (availableSource == MSAL.ManagedIdentitySource.DefaultToImds && _isChainedCredential && !_probeRequestSent)
             {
                 var probedFlowTokenResult = await AuthenticateCoreAsync(async, context, cancellationToken).ConfigureAwait(false);
                 _probeRequestSent = true;
                 return probedFlowTokenResult;
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // ServiceFabric does not support specifying user-assigned managed identity by client ID or resource ID. The managed identity selected is based on the resource configuration.
             if (availableSource == MSAL.ManagedIdentitySource.ServiceFabric && (ManagedIdentityId?._idType != ManagedIdentityIdType.SystemAssigned))

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -520,7 +520,7 @@ namespace Azure.Identity.Tests
 
             ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
                 new ManagedIdentityClient(
-                    new ManagedIdentityClientOptions() { ManagedIdentityId = clientId is null ? ManagedIdentityId.SystemAssigned : ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true, Options = options })
+                    new ManagedIdentityClientOptions() { ManagedIdentityId = clientId is null ? ManagedIdentityId.SystemAssigned : ManagedIdentityId.FromUserAssignedClientId(clientId), Pipeline = pipeline, IsForceRefreshEnabled = true, PreserveTransport = true, Options = options })
             ));
 
             AccessToken actualToken = await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default));
@@ -558,6 +558,7 @@ namespace Azure.Identity.Tests
                         Pipeline = CredentialPipeline.GetInstance(options),
                         ManagedIdentityId = ManagedIdentityId.FromUserAssignedResourceId(new ResourceIdentifier(_expectedResourceId)),
                         IsForceRefreshEnabled = true,
+                        PreserveTransport = true,
                         Options = options
                     })
             ));

--- a/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
+++ b/sdk/identity/Azure.Identity/tests/ManagedIdentityCredentialTests.cs
@@ -27,6 +27,12 @@ namespace Azure.Identity.Tests
         {
         }
 
+        [SetUp]
+        public void Setup()
+        {
+            ApplicationBase.ResetStateForTest();
+        }
+
         private const string ExpectedToken = "mock-msi-access-token";
 
         [NonParallelizable]
@@ -548,7 +554,9 @@ namespace Azure.Identity.Tests
             using var environment = new TestEnvVar(new() { { "MSI_ENDPOINT", null }, { "MSI_SECRET", null }, { "IDENTITY_ENDPOINT", null }, { "IDENTITY_HEADER", null }, { "AZURE_POD_IDENTITY_AUTHORITY_HOST", "https://mock.podid.endpoint/" } });
 
             var response = CreateMockResponse(200, ExpectedToken);
-            var mockTransport = new MockTransport(response);
+            var mockTransport = new MockTransport(req => {
+                return response;
+            });
             var options = new TokenCredentialOptions() { Transport = mockTransport };
 
             ManagedIdentityCredential credential = InstrumentClient(new ManagedIdentityCredential(
@@ -569,7 +577,7 @@ namespace Azure.Identity.Tests
 
             MockRequest request = mockTransport.SingleRequest;
 
-            Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.podid.endpoint" + ImdsManagedIdentityProbeSource.imddsTokenPath));
+            Assert.IsTrue(request.Uri.ToString().StartsWith("https://mock.podid.endpoint" + ImdsManagedIdentityProbeSource.imddsTokenPath), $"Unexpected Uri: {request.Uri}");
 
             string query = request.Uri.Query;
 

--- a/sdk/identity/Azure.Identity/tests/StaticCachesUtilities.cs
+++ b/sdk/identity/Azure.Identity/tests/StaticCachesUtilities.cs
@@ -14,9 +14,8 @@ namespace Azure.Identity.Tests
         private static readonly Lazy<Action> s_clearStaticMetadataProvider = new Lazy<Action>(() =>
         {
             Type staticMetadataProviderType = typeof(PublicClientApplication).Assembly.GetType("Microsoft.Identity.Client.Instance.Discovery.NetworkCacheMetadataProvider", true);
-            MethodInfo clearMethod = staticMetadataProviderType.GetMethod("Clear", BindingFlags.Public | BindingFlags.Instance);
-            NewExpression callConstructor = Expression.New(staticMetadataProviderType);
-            MethodCallExpression invokeClear = Expression.Call(callConstructor, clearMethod);
+            MethodInfo clearMethod = staticMetadataProviderType.GetMethod("ResetStaticCacheForTest", BindingFlags.NonPublic | BindingFlags.Static);
+            MethodCallExpression invokeClear = Expression.Call(clearMethod);
             return Expression.Lambda<Action>(invokeClear).Compile();
         });
         public static void ClearStaticMetadataProviderCache() => s_clearStaticMetadataProvider.Value();


### PR DESCRIPTION

This pull request updates the `Azure.Identity` package to version 1.17.2 and upgrades its dependencies on Microsoft Identity Client libraries. It also includes minor code and test adjustments to align with the new dependency versions and maintain compatibility.

Dependency updates:

* Upgraded `Microsoft.Identity.Client`, `Microsoft.Identity.Client.Extensions.Msal`, and `Microsoft.Identity.Client.Broker` dependencies from version 4.78.0 to 4.83.1 in `eng/Packages.Data.props` and documented the change in the `CHANGELOG.md`. [[1]](diffhunk://#diff-93a28d9569550c68624a8ad2209a6fae1d4f88237e4b5414eed2ecac4ef8c98fL188-R190) [[2]](diffhunk://#diff-f824a763552cf3fbdf7c8904d9b72e450b698001baa07f96466ac381b9d47c4cR3-R8)
* Updated the version of `Azure.Identity` to 1.17.2 and incremented `ApiCompatVersion` in `Azure.Identity.csproj`; updated the release tag in `assets.json`. [[1]](diffhunk://#diff-a4eb924020aa5a1e6ddf53b38269f78ec9c30d8fa786a6a5f9a0315f9d7bee88L5-R7) [[2]](diffhunk://#diff-241f7ef07f4cd92f734ab3b6c2af9bbc402ddc78978cf54b9959273a1f643e3cL5-R5)

Code compatibility and maintenance:

* Suppressed obsolete warnings (`CS0618`) around usage of `ManagedIdentitySource` enum members in `ManagedIdentityClient.cs` to maintain compatibility with the latest `Microsoft.Identity.Client` changes.
* Updated test utility `StaticCachesUtilities.cs` to call the new `ResetStaticCacheForTest` method (non-public, static) instead of the previous `Clear` method for clearing static metadata provider cache, reflecting changes in the updated dependency.