### PR TITLE
[mgmt] Fix null-safe flattened property getters

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/PropertyHelpers.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/PropertyHelpers.cs
@@ -84,6 +84,7 @@ namespace Azure.Generator.Management.Utilities
         public static MethodBodyStatement BuildGetter(bool? includeGetterNullCheck, PropertyProvider internalProperty, TypeProvider innerModel, PropertyProvider innerProperty)
         {
             var checkNullExpression = This.Property(internalProperty.Name).Is(Null);
+            var shouldNullGuard = internalProperty.Type.IsNullable || internalProperty.WireInfo?.IsRequired == false || innerModel.Type.IsNullable;
             // For collection types, we initialize the internal property if it's null and return the inner property.
             if (innerProperty.Type.IsCollection && internalProperty.WireInfo?.IsRequired == true)
             {
@@ -129,9 +130,9 @@ namespace Azure.Generator.Management.Utilities
             }
             else
             {
-                if (innerModel.Type.IsNullable)
+                if (shouldNullGuard)
                 {
-                    return Return(new MemberExpression(internalProperty.AsVariableExpression.NullConditional(), innerProperty.Name));
+                    return Return(new TernaryConditionalExpression(checkNullExpression, Default, new MemberExpression(internalProperty, innerProperty.Name)));
                 }
                 return Return(new MemberExpression(internalProperty, innerProperty.Name));
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -159,9 +159,9 @@ namespace Azure.Generator.Mgmt.Tests
             }
 
             var rendered = new TypeProviderWriter(model!).Write().Content;
-            StringAssert.Contains("this.Data is null", rendered);
+            Assert.That(rendered, Does.Match(@"(?:this\.)?Data is null"));
             StringAssert.Contains("Data.Errors", rendered);
-            StringAssert.DoesNotContain("return Data.Errors;", rendered);
+            Assert.That(rendered, Does.Not.Match(@"\breturn\s+(?:this\.)?Data\.Errors;"));
         }
 
         /// <summary>

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -125,6 +125,45 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.IsTrue(FlattenPropertyVisitor.IsBackwardCompatMethod(backCompatMethod));
         }
 
+        [Test]
+        public void TestFlattenedGetterAddsNullGuardForOptionalReadOnlyParent()
+        {
+            var errorsProperty = InputFactory.Property("errors", InputFactory.Array(InputPrimitiveType.String), isRequired: false, serializedName: "errors");
+            var dataModel = InputFactory.Model(
+                "AnalysisData",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties: [errorsProperty]);
+
+            var dataProperty = InputFactory.Property("data", dataModel, isRequired: false, serializedName: "data");
+            ApplyFlattenDecorator(dataProperty);
+
+            var resultModel = InputFactory.Model(
+                "AnalysisResult",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties: [dataProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [resultModel, dataModel]);
+
+            var model = plugin.Object.TypeFactory.CreateModel(resultModel);
+            Assert.IsNotNull(model);
+
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(visitTypeCore, "Could not find LibraryVisitor.VisitTypeCore method");
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [model]);
+            }
+
+            var rendered = new TypeProviderWriter(model!).Write().Content;
+            StringAssert.Contains("this.Data is null", rendered);
+            StringAssert.Contains("Data.Errors", rendered);
+            StringAssert.DoesNotContain("return Data.Errors;", rendered);
+        }
+
         /// <summary>
         /// Verifies that FixBackwardCompatOverloads correctly reorders arguments in
         /// backward-compat overloads when the primary method's parameter order has changed

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/HciVmInstanceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/HciVmInstanceData.cs
@@ -47,7 +47,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         {
             get
             {
-                return Properties.Sku;
+                return Properties is null ? default : Properties.Sku;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/ContainerItemLike.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/ContainerItemLike.cs
@@ -44,7 +44,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         {
             get
             {
-                return Properties.Something;
+                return Properties is null ? default : Properties.Something;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooSettingsProperties.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooSettingsProperties.cs
@@ -73,7 +73,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         {
             get
             {
-                return MetaData.MetaDatas;
+                return MetaData is null ? default : MetaData.MetaDatas;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/GrandparentFlattenBase.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/GrandparentFlattenBase.cs
@@ -47,7 +47,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         {
             get
             {
-                return Identifier.UniqueId;
+                return Identifier is null ? default : Identifier.UniqueId;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/GrandparentFlattenProxyGrandparentFlattenLeafProperties.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/GrandparentFlattenProxyGrandparentFlattenLeafProperties.cs
@@ -44,7 +44,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         {
             get
             {
-                return Properties.Disclaimer;
+                return Properties is null ? default : Properties.Disclaimer;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/GroupQuotaDetails.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/GroupQuotaDetails.cs
@@ -71,7 +71,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         {
             get
             {
-                return AllocatedToSubscriptions.Value;
+                return AllocatedToSubscriptions is null ? default : AllocatedToSubscriptions.Value;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/JooProperties.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/JooProperties.cs
@@ -52,7 +52,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         {
             get
             {
-                return Prediction.PredictionInputHistoricalData;
+                return Prediction is null ? default : Prediction.PredictionInputHistoricalData;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/RedisPrivateEndpointConnectionProperties.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/RedisPrivateEndpointConnectionProperties.cs
@@ -55,7 +55,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         {
             get
             {
-                return PrivateEndpoint.Id;
+                return PrivateEndpoint is null ? default : PrivateEndpoint.Id;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/SelfHelpResourceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/SelfHelpResourceData.cs
@@ -47,7 +47,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         {
             get
             {
-                return Properties.SelfHelpId;
+                return Properties is null ? default : Properties.SelfHelpId;
             }
         }
     }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/StorageSyncServiceData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/StorageSyncServiceData.cs
@@ -56,7 +56,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
         {
             get
             {
-                return Properties.StorageSyncServiceLocation;
+                return Properties is null ? default : Properties.StorageSyncServiceLocation;
             }
         }
     }


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-for-net/pull/57070#discussion_r2939008137

## Summary
- fix mgmt generator flattened getters to guard against null optional parent models
- add a regression unit test for the null-parent flattening case
- regenerate local mgmt test-project outputs affected by the generator change

## Testing
- `dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj --filter FlattenPropertyVisitorTests`
- `eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1`
