### PR TITLE
[Storage] Override CreateDeveloperCredential to use DefaultAzureCredential

### DIFF
--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestEnvironment.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestEnvironment.cs
@@ -10,5 +10,10 @@ namespace Azure.Storage.Test.Shared
 {
     public class StorageTestEnvironment : TestEnvironment
     {
+        protected override TokenCredential CreateDeveloperCredential()
+        {
+            return new DefaultAzureCredential(
+                new DefaultAzureCredentialOptions { ExcludeManagedIdentityCredential = true });
+        }
     }
 }


### PR DESCRIPTION
Allow local run storage tests to use the DefaultAzureCredential
