### PR TITLE
[AgentServer] Release prep: Core 1.0.0-beta.22, Responses 1.0.0-beta.2, Invocations 1.0.0-beta.2

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,18 +1,12 @@
 # Release History
 
-## 1.0.0-beta.22 (Unreleased)
+## 1.0.0-beta.22 (2026-05-05)
 
 ### Features Added
 
 - Added `HttpClient` instrumentation (`AddHttpClientInstrumentation`) for both tracing and metrics
   in the OTLP-only telemetry path. This exports outbound HTTP client spans, enabling end-to-end
   distributed trace correlation through Foundry storage and other downstream services.
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.0.0-beta.21 (2026-04-14)
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.2 (2026-05-05)
 
 ### Other Changes
+
+- Updated dependency on `Azure.AI.AgentServer.Core` to 1.0.0-beta.22, which adds outbound
+  `HttpClient` instrumentation for distributed trace correlation.
 
 ## 1.0.0-beta.1 (2026-04-14)
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0-beta.2 (2026-05-05)
 
 ### Features Added
 
@@ -19,8 +19,6 @@
   outbound Foundry storage API call with HTTP method, URI, status code, duration, and correlation
   headers (`x-ms-client-request-id`, `x-ms-request-id`, `x-request-id`, `apim-request-id`).
 
-### Breaking Changes
-
 ### Bugs Fixed
 
 - Fixed error response shapes to match the container specification: `invalid_request_error` type
@@ -30,8 +28,6 @@
 - Fixed DELETE endpoint to return 404 (not 400) when the response ID does not exist, aligning
   with the specification.
 - Fixed cancel-after-delete to return 404 (not-found) per the specification.
-
-### Other Changes
 
 ## 1.0.0-beta.1 (2026-04-14)
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -13,8 +13,8 @@
   and length) are rejected with 400 and a descriptive error message.
 - Added metadata constraint validation: metadata maps are limited to 16 keys with key length ≤ 64
   and value length ≤ 512 characters, enforced via the validator pipeline.
-- Added deterministic `agent_session_id` derivation matching the Python SDK algorithm: SHA-256
-  hash of `"{agent_name}:{agent_version}:{partition_hint}"` truncated to 63 lowercase hex chars.
+- Added deterministic `agent_session_id` derivation: SHA-256 hash of
+  `"{agent_name}:{agent_version}:{partition_hint}"` truncated to 63 lowercase hex chars.
   Falls back to random hex when no conversational context is available.
 - Added eager eviction of completed `ResponseExecution` entries from the in-flight tracker,
   reducing memory pressure for long-running servers.

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -13,6 +13,9 @@
   and length) are rejected with 400 and a descriptive error message.
 - Added metadata constraint validation: metadata maps are limited to 16 keys with key length ≤ 64
   and value length ≤ 512 characters, enforced via the validator pipeline.
+- Added deterministic `agent_session_id` derivation matching the Python SDK algorithm: SHA-256
+  hash of `"{agent_name}:{agent_version}:{partition_hint}"` truncated to 63 lowercase hex chars.
+  Falls back to random hex when no conversational context is available.
 - Added eager eviction of completed `ResponseExecution` entries from the in-flight tracker,
   reducing memory pressure for long-running servers.
 - Added `FoundryStorageLoggingPolicy` — an Azure.Core per-retry pipeline policy that logs every

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseEndpointHandler.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseEndpointHandler.cs
@@ -162,13 +162,16 @@ internal sealed class ResponseEndpointHandler
             responseId = IdGenerator.NewResponseId(partitionKeyHint);
         }
 
-        // B39: Resolve session ID — request payload → environment variable → generated UUID.
+        // B39: Resolve session ID — request payload → environment variable → deterministic derivation.
         // Stamp on the request so the orchestrator can propagate it to the ResponseObject.
         if (string.IsNullOrEmpty(request.AgentSessionId))
         {
             request.AgentSessionId = !string.IsNullOrEmpty(FoundryEnvironment.SessionId)
                 ? FoundryEnvironment.SessionId
-                : Guid.NewGuid().ToString();
+                : SessionIdDerivation.Derive(
+                    request.GetConversationId(),
+                    request.PreviousResponseId,
+                    request.AgentReference);
         }
 
         // Start distributed tracing span — delegates all tag/baggage logic

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/SessionIdDerivation.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/SessionIdDerivation.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Cryptography;
+using System.Text;
+using Azure.AI.AgentServer.Responses.Models;
+
+namespace Azure.AI.AgentServer.Responses.Internal;
+
+/// <summary>
+/// Deterministic session ID derivation per B39 specification.
+/// <para>
+/// When the request payload and environment do not supply an explicit session ID,
+/// this helper derives one from the agent identity and conversational context
+/// (conversation ID or previous_response_id partition key). If no conversational
+/// context is available, a random 63-char hex string is generated.
+/// </para>
+/// </summary>
+internal static class SessionIdDerivation
+{
+    /// <summary>
+    /// Session IDs are 63 lowercase hex characters (one less than a full SHA-256 hex digest).
+    /// This matches the cross-language contract with the Python SDK.
+    /// </summary>
+    private const int SessionIdLength = 63;
+
+    private const string DefaultAgentName = "server-default-agent";
+
+    /// <summary>
+    /// Derives a session ID from conversational context and agent identity.
+    /// </summary>
+    /// <param name="conversationId">Conversation ID from the request, if any.</param>
+    /// <param name="previousResponseId">Previous response ID from the request, if any.</param>
+    /// <param name="agentReference">Agent reference containing name/version, if any.</param>
+    /// <returns>A 63-char lowercase hex session ID.</returns>
+    public static string Derive(
+        string? conversationId,
+        string? previousResponseId,
+        AgentReference? agentReference)
+    {
+        // Select partition source: conversation_id first, then previous_response_id
+        var partitionSource = !string.IsNullOrEmpty(conversationId) ? conversationId
+            : !string.IsNullOrEmpty(previousResponseId) ? previousResponseId
+            : null;
+
+        if (partitionSource is not null)
+        {
+            string partitionHint;
+            try
+            {
+                partitionHint = IdGenerator.ExtractPartitionKey(partitionSource);
+            }
+            catch (ArgumentException)
+            {
+                // If partition key extraction fails, use the raw source as-is
+                partitionHint = partitionSource;
+            }
+
+            var (agentName, agentVersion) = ExtractAgentIdentity(agentReference);
+            var seed = $"{agentName}:{agentVersion}:{partitionHint}";
+            return ComputeHexHash(seed);
+        }
+
+        // One-shot: no conversational context → random session
+        return GenerateRandomHex();
+    }
+
+    /// <summary>
+    /// Extracts the agent name and version from an agent reference.
+    /// </summary>
+    private static (string Name, string Version) ExtractAgentIdentity(AgentReference? agentReference)
+    {
+        if (agentReference is null)
+        {
+            return (DefaultAgentName, "");
+        }
+
+        var name = agentReference.Name;
+        var version = agentReference.Version;
+        return (
+            string.IsNullOrEmpty(name) ? DefaultAgentName : name,
+            version ?? ""
+        );
+    }
+
+    /// <summary>
+    /// SHA-256 hashes a string and returns the first 63 lowercase hex characters.
+    /// </summary>
+    private static string ComputeHexHash(string value)
+    {
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(hashBytes).ToLowerInvariant()[..SessionIdLength];
+    }
+
+    /// <summary>
+    /// Generates a random 63-char lowercase hex string.
+    /// </summary>
+    private static string GenerateRandomHex()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Convert.ToHexString(bytes).ToLowerInvariant()[..SessionIdLength];
+    }
+}

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/SessionIdDerivation.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/SessionIdDerivation.cs
@@ -20,7 +20,7 @@ internal static class SessionIdDerivation
 {
     /// <summary>
     /// Session IDs are 63 lowercase hex characters (one less than a full SHA-256 hex digest).
-    /// This matches the cross-language contract with the Python SDK.
+    /// This matches the cross-language session ID derivation contract.
     /// </summary>
     private const int SessionIdLength = 63;
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/SseResult.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/SseResult.cs
@@ -20,8 +20,8 @@ namespace Azure.AI.AgentServer.Responses.Internal;
 /// Takes ownership of the <see cref="Activity"/> created by
 /// <see cref="ResponsesActivitySource.StartCreateResponseActivity"/> so that the
 /// tracing span covers the full SSE streaming duration. The activity is disposed
-/// in the <c>finally</c> block of <see cref="ExecuteAsync"/>, matching Python's
-/// <c>trace_stream</c> / <c>end_span</c> pattern.
+/// in the <c>finally</c> block of <see cref="ExecuteAsync"/>, matching the
+/// cross-language <c>trace_stream</c> / <c>end_span</c> pattern.
 /// </remarks>
 internal sealed class SseResult : IResult
 {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SessionIdResolutionTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/SessionIdResolutionTests.cs
@@ -12,7 +12,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Protocol;
 
 /// <summary>
 /// Protocol conformance tests for session ID resolution (B39).
-/// Priority: request payload <c>agent_session_id</c> → <c>FOUNDRY_AGENT_SESSION_ID</c> env var → generated UUID.
+/// Priority: request payload <c>agent_session_id</c> → <c>FOUNDRY_AGENT_SESSION_ID</c> env var → deterministic derivation.
 /// The resolved session ID MUST be auto-stamped on the <c>ResponseObject.AgentSessionId</c>.
 /// </summary>
 public class SessionIdResolutionTests : ProtocolTestBase
@@ -123,7 +123,7 @@ public class SessionIdResolutionTests : ProtocolTestBase
         }
     }
 
-    // ── Tier 3: Fallback to generated UUID ──
+    // ── Tier 3: Fallback to deterministic derivation / random hex ──
 
     [Test]
     public async Task POST_Default_NoPayloadOrEnv_GeneratesSessionId()
@@ -141,9 +141,10 @@ public class SessionIdResolutionTests : ProtocolTestBase
             var sessionId = doc.RootElement.GetProperty("agent_session_id").GetString();
             Assert.That(sessionId, Is.Not.Null.And.Not.Empty);
 
-            // Verify it's a valid GUID
-            Assert.That(Guid.TryParse(sessionId, out _), Is.True,
-                $"Expected a GUID-format session ID, got: {sessionId}");
+            // Session ID should be 63-char lowercase hex (SHA-256 derived or random)
+            Assert.That(sessionId, Has.Length.EqualTo(63));
+            Assert.That(sessionId, Does.Match("^[0-9a-f]+$"),
+                $"Expected 63-char lowercase hex session ID, got: {sessionId}");
         }
         finally
         {
@@ -198,7 +199,8 @@ public class SessionIdResolutionTests : ProtocolTestBase
             var sessionId = doc.RootElement.GetProperty("response").GetProperty("agent_session_id").GetString();
 
             Assert.That(sessionId, Is.Not.Null.And.Not.Empty);
-            Assert.That(Guid.TryParse(sessionId, out _), Is.True);
+            Assert.That(sessionId, Has.Length.EqualTo(63));
+            Assert.That(sessionId, Does.Match("^[0-9a-f]+$"));
         }
         finally
         {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Unit/SessionIdDerivationTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Unit/SessionIdDerivationTests.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Cryptography;
+using System.Text;
+using Azure.AI.AgentServer.Responses.Internal;
+using Azure.AI.AgentServer.Responses.Models;
+
+namespace Azure.AI.AgentServer.Responses.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="SessionIdDerivation"/> — deterministic session ID
+/// derivation per B39 specification.
+/// </summary>
+public class SessionIdDerivationTests
+{
+    private const int ExpectedLength = 63;
+
+    // ── Format tests ──
+
+    [Test]
+    public void Derive_NoContext_Returns63CharHex()
+    {
+        var result = SessionIdDerivation.Derive(null, null, null);
+
+        Assert.That(result, Has.Length.EqualTo(ExpectedLength));
+        Assert.That(result, Does.Match("^[0-9a-f]+$"), "Should be lowercase hex");
+    }
+
+    [Test]
+    public void Derive_WithConversationId_Returns63CharHex()
+    {
+        var result = SessionIdDerivation.Derive("conv-123", null, null);
+
+        Assert.That(result, Has.Length.EqualTo(ExpectedLength));
+        Assert.That(result, Does.Match("^[0-9a-f]+$"));
+    }
+
+    // ── Determinism tests ──
+
+    [Test]
+    public void Derive_SameInputs_ReturnsSameSessionId()
+    {
+        var agentRef = new AgentReference("my-agent") { Version = "1.0.0" };
+
+        var result1 = SessionIdDerivation.Derive("conv-abc", null, agentRef);
+        var result2 = SessionIdDerivation.Derive("conv-abc", null, agentRef);
+
+        Assert.That(result1, Is.EqualTo(result2), "Same inputs should produce same session ID");
+    }
+
+    [Test]
+    public void Derive_DifferentConversationId_ReturnsDifferentSessionId()
+    {
+        var result1 = SessionIdDerivation.Derive("conv-aaa", null, null);
+        var result2 = SessionIdDerivation.Derive("conv-bbb", null, null);
+
+        Assert.That(result1, Is.Not.EqualTo(result2));
+    }
+
+    [Test]
+    public void Derive_DifferentAgentVersion_ReturnsDifferentSessionId()
+    {
+        var agentV1 = new AgentReference("my-agent") { Version = "1.0.0" };
+        var agentV2 = new AgentReference("my-agent") { Version = "2.0.0" };
+
+        var result1 = SessionIdDerivation.Derive("conv-abc", null, agentV1);
+        var result2 = SessionIdDerivation.Derive("conv-abc", null, agentV2);
+
+        Assert.That(result1, Is.Not.EqualTo(result2),
+            "Different agent versions should produce different session IDs");
+    }
+
+    // ── Priority tests ──
+
+    [Test]
+    public void Derive_ConversationId_TakesPriorityOverPreviousResponseId()
+    {
+        var withConvOnly = SessionIdDerivation.Derive("conv-abc", null, null);
+        var withBoth = SessionIdDerivation.Derive("conv-abc", "caresp_abcdef0123456789001234567890123456789012345678901234", null);
+
+        Assert.That(withConvOnly, Is.EqualTo(withBoth),
+            "conversation_id should take priority; previous_response_id is ignored when conversation_id is present");
+    }
+
+    [Test]
+    public void Derive_PreviousResponseId_UsedWhenNoConversationId()
+    {
+        var prevId = "caresp_abcdef0123456789001234567890123456789012345678901234";
+        var result1 = SessionIdDerivation.Derive(null, prevId, null);
+
+        Assert.That(result1, Has.Length.EqualTo(ExpectedLength));
+        Assert.That(result1, Does.Match("^[0-9a-f]+$"));
+
+        // Should be deterministic with same input
+        var result2 = SessionIdDerivation.Derive(null, prevId, null);
+        Assert.That(result1, Is.EqualTo(result2));
+    }
+
+    // ── No context → random tests ──
+
+    [Test]
+    public void Derive_NoContext_ProducesUniqueValues()
+    {
+        var result1 = SessionIdDerivation.Derive(null, null, null);
+        var result2 = SessionIdDerivation.Derive(null, null, null);
+
+        Assert.That(result1, Is.Not.EqualTo(result2),
+            "Without conversational context, each derivation should be random/unique");
+    }
+
+    // ── Null/empty agent reference fallback ──
+
+    [Test]
+    public void Derive_NullAgentReference_UsesDefaultName()
+    {
+        var withNull = SessionIdDerivation.Derive("conv-abc", null, null);
+        var withEmptyName = SessionIdDerivation.Derive("conv-abc", null,
+            new AgentReference("") { Version = "" });
+
+        // Both should use the default agent name, producing the same result
+        Assert.That(withNull, Is.EqualTo(withEmptyName));
+    }
+
+    // ── Cross-language compatibility ──
+
+    [Test]
+    public void Derive_MatchesPythonSdkOutput()
+    {
+        // Verify the hash matches what the Python SDK produces for the same seed.
+        // Python: hashlib.sha256("my-agent:1.0:partition_hint".encode()).hexdigest()[:63]
+        var agentRef = new AgentReference("my-agent") { Version = "1.0" };
+
+        // Use a raw conversation_id that will be used as-is (not a valid ID for partition extraction)
+        var result = SessionIdDerivation.Derive("partition_hint", null, agentRef);
+
+        // Compute expected value independently
+        var seed = "my-agent:1.0:partition_hint";
+        var expectedBytes = SHA256.HashData(Encoding.UTF8.GetBytes(seed));
+        var expected = Convert.ToHexString(expectedBytes).ToLowerInvariant()[..63];
+
+        Assert.That(result, Is.EqualTo(expected),
+            "Should match Python SDK's SHA-256 derivation for the same seed");
+    }
+
+    // ── Partition key extraction from valid IDs ──
+
+    [Test]
+    public void Derive_ValidResponseId_ExtractsPartitionKey()
+    {
+        // Create a valid response ID with a known partition key
+        var responseId = IdGenerator.NewResponseId("some-hint");
+
+        // Deriving with the full ID should use the extracted partition key
+        var result1 = SessionIdDerivation.Derive(null, responseId, null);
+
+        // The result should be deterministic
+        var result2 = SessionIdDerivation.Derive(null, responseId, null);
+        Assert.That(result1, Is.EqualTo(result2));
+    }
+}

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Unit/SessionIdDerivationTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Unit/SessionIdDerivationTests.cs
@@ -125,10 +125,10 @@ public class SessionIdDerivationTests
     // ── Cross-language compatibility ──
 
     [Test]
-    public void Derive_MatchesPythonSdkOutput()
+    public void Derive_MatchesCrossLanguageOutput()
     {
-        // Verify the hash matches what the Python SDK produces for the same seed.
-        // Python: hashlib.sha256("my-agent:1.0:partition_hint".encode()).hexdigest()[:63]
+        // Verify the hash matches the cross-language contract for the same seed.
+        // SHA-256("my-agent:1.0:partition_hint") truncated to 63 hex chars
         var agentRef = new AgentReference("my-agent") { Version = "1.0" };
 
         // Use a raw conversation_id that will be used as-is (not a valid ID for partition extraction)
@@ -140,7 +140,7 @@ public class SessionIdDerivationTests
         var expected = Convert.ToHexString(expectedBytes).ToLowerInvariant()[..63];
 
         Assert.That(result, Is.EqualTo(expected),
-            "Should match Python SDK's SHA-256 derivation for the same seed");
+            "Should match cross-language SHA-256 derivation for the same seed");
     }
 
     // ── Partition key extraction from valid IDs ──


### PR DESCRIPTION
## Release preparation

Sets release date **2026-05-05** for all three AgentServer packages:

| Package | Version | DevOps Work Item |
|---------|---------|-----------------|
| Azure.AI.AgentServer.Core | 1.0.0-beta.22 | #29340 |
| Azure.AI.AgentServer.Responses | 1.0.0-beta.2 | #33691 |
| Azure.AI.AgentServer.Invocations | 1.0.0-beta.2 | #33692 |

### Changes

Changelog date stamps for all three packages, plus an Invocations changelog entry for the Core dependency update. Most code was merged in #58252.

### Core beta.22
- HttpClient instrumentation for outbound trace correlation
- Inbound request logging middleware: logs all incoming HTTP requests with method, path, status code, duration, correlation headers (`x-request-id`, `x-ms-client-request-id`), and OTel trace ID

### Responses beta.2
- Chat isolation key enforcement
- Malformed ID validation (prefix + length)
- Metadata constraint validation
- Deterministic agent_session_id derivation (SHA-256 cross-language contract)
- Eager eviction of completed executions
- FoundryStorageLoggingPolicy for structured outbound logging
- Handler-level diagnostic logging on all endpoints (responseId, status, output count, handler type)
- Error shape fixes (invalid_request_error, 404 alignment)

### Invocations beta.2
- Core dependency update (beta.22 with HttpClient instrumentation)