### PR TITLE
reset resource safely for background task process - MonitorCache

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -826,7 +826,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 // After one wait cycle, cancel the background task cancellation token source. It can be assumed that there will never be more than the
                 // minimum batch size number of messages in the cache. The monitoring cycle will be restarted by the receive batch loop if needed.
                 CancelExistingMonitoringTasks();
-                
                 if (acquiredSemaphore)
                 {
                     _cachedMessagesGuard.Release();

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -816,16 +816,22 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 {
                     _logger.LogDebug($"Service Bus Listener has waited MaxWaitTime since last invocation but there are no messages still being held.");
                 }
+                // After one wait cycle, cancel the background task cancellation token source. It can be assumed that there will never be more than the
+                // minimum batch size number of messages in the cache. The monitoring cycle will be restarted by the receive batch loop if needed.
+                CancelExistingMonitoringTasks();
             }
             catch (OperationCanceledException)
             {
                 // Do nothing.
             }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"Unhandled exception occurred in MonitorCache ({_details.Value}).");
+                // Dispose background task resources when exception occurs other than the intended OperationCanceledException.
+                CancelExistingMonitoringTasks();
+            }
             finally
             {
-                // After one wait cycle, cancel the background task cancellation token source. It can be assumed that there will never be more than the
-                // minimum batch size number of messages in the cache. The monitoring cycle will be restarted by the receive batch loop if needed.
-                CancelExistingMonitoringTasks();
                 if (acquiredSemaphore)
                 {
                     _cachedMessagesGuard.Release();

--- a/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
+++ b/sdk/servicebus/Microsoft.Azure.WebJobs.Extensions.ServiceBus/src/Listeners/ServiceBusListener.cs
@@ -816,10 +816,6 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
                 {
                     _logger.LogDebug($"Service Bus Listener has waited MaxWaitTime since last invocation but there are no messages still being held.");
                 }
-
-                // After one wait cycle, cancel the background task cancellation token source. It can be assumed that there will never be more than the
-                // minimum batch size number of messages in the cache. The monitoring cycle will be restarted by the receive batch loop if needed.
-                CancelExistingMonitoringTasks();
             }
             catch (OperationCanceledException)
             {
@@ -827,6 +823,10 @@ namespace Microsoft.Azure.WebJobs.ServiceBus.Listeners
             }
             finally
             {
+                // After one wait cycle, cancel the background task cancellation token source. It can be assumed that there will never be more than the
+                // minimum batch size number of messages in the cache. The monitoring cycle will be restarted by the receive batch loop if needed.
+                CancelExistingMonitoringTasks();
+                
                 if (acquiredSemaphore)
                 {
                     _cachedMessagesGuard.Release();


### PR DESCRIPTION
## Summary
When a message batch is dispatched via `TriggerAndCompleteMessagesInternal` and an exception is thrown while settling messages, the exception can propagate out of `MonitorCache` without `_backgroundCacheMonitoringCts` being reset to null. Subsequent iterations of the batch receive loop then skip starting a new monitoring task (because the CTS is non-null), so any messages held in the cache sit there indefinitely unless a later batch exceeds `MinMessageBatchSize`. 
## Reproduction conditions
All of the following must be true to hit this:
- `.NET Isolated` worker model
- `ServiceBusOptions.MinMessageBatchSize > 1`
- The function settles messages itself (e.g. `CompleteMessageAsync`) instead of relying on auto-complete
- `AutoCompleteMessages` is effectively `true` on the trigger (easy to do by accident in Isolated, since `host.json`'s `autoComplete` is ignored — it must be set at the trigger attribute level) Under those conditions, `TriggerAndCompleteMessagesInternal` tries to complete messages that the function already settled, which throws. The existing `input.MessageActions.SettledMessages` short-circuit does not protect against this in Isolated because `MessageActions` is marshaled as a different object by the time it reaches user code, so the settled-message set on the host side is empty.
## Fix
Wrap the body of `MonitorCache` such that `CancelExistingMonitoringTasks()` runs on the failure path, ensuring `_backgroundCacheMonitoringCts` is disposed and nulled even when the trigger throws. The next receive-loop iteration can then start a fresh monitoring cycle and drain cached messages as expected.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
