### PR TITLE
[Network] Fix for issue #57391

### DIFF
--- a/eng/apicompatbaselines/Azure.ResourceManager.Network.txt
+++ b/eng/apicompatbaselines/Azure.ResourceManager.Network.txt
@@ -1,0 +1,1 @@
+CannotChangeAttribute : Attribute 'Azure.ResourceManager.Network.WirePathAttribute' on 'Azure.ResourceManager.Network.ApplicationGatewayData.EnableFips' changed from '[WirePathAttribute("properties.enableFips")]' in the contract to '[WirePathAttribute("properties.enableFIPS")]' in the implementation.

--- a/sdk/network/Azure.ResourceManager.Network/CHANGELOG.md
+++ b/sdk/network/Azure.ResourceManager.Network/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where `ApplicationGatewayData.EnableFips` could not be deserialized correctly because the server returns `enableFIPS` (uppercase) while the spec defined `enableFips` (lowercase).
+
 ### Other Changes
 
 ## 1.15.0 (2026-02-02)

--- a/sdk/network/Azure.ResourceManager.Network/src/Generated/ApplicationGatewayData.Serialization.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Generated/ApplicationGatewayData.Serialization.cs
@@ -284,7 +284,7 @@ namespace Azure.ResourceManager.Network
             }
             if (Optional.IsDefined(EnableFips))
             {
-                writer.WritePropertyName("enableFips"u8);
+                writer.WritePropertyName("enableFIPS"u8);
                 writer.WriteBooleanValue(EnableFips.Value);
             }
             if (Optional.IsDefined(AutoscaleConfiguration))
@@ -846,7 +846,7 @@ namespace Azure.ResourceManager.Network
                             enableHttp2 = property0.Value.GetBoolean();
                             continue;
                         }
-                        if (property0.NameEquals("enableFips"u8))
+                        if (property0.NameEquals("enableFIPS"u8))
                         {
                             if (property0.Value.ValueKind == JsonValueKind.Null)
                             {
@@ -1742,14 +1742,14 @@ namespace Azure.ResourceManager.Network
             hasPropertyOverride = hasObjectOverride && propertyOverrides.TryGetValue(nameof(EnableFips), out propertyOverride);
             if (hasPropertyOverride)
             {
-                builder.Append("    enableFips: ");
+                builder.Append("    enableFIPS: ");
                 builder.AppendLine(propertyOverride);
             }
             else
             {
                 if (Optional.IsDefined(EnableFips))
                 {
-                    builder.Append("    enableFips: ");
+                    builder.Append("    enableFIPS: ");
                     var boolValue = EnableFips.Value == true ? "true" : "false";
                     builder.AppendLine($"{boolValue}");
                 }

--- a/sdk/network/Azure.ResourceManager.Network/src/Generated/ApplicationGatewayData.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Generated/ApplicationGatewayData.cs
@@ -238,7 +238,7 @@ namespace Azure.ResourceManager.Network
         [WirePath("properties.enableHttp2")]
         public bool? EnableHttp2 { get; set; }
         /// <summary> Whether FIPS is enabled on the application gateway resource. </summary>
-        [WirePath("properties.enableFips")]
+        [WirePath("properties.enableFIPS")]
         public bool? EnableFips { get; set; }
         /// <summary> Autoscale Configuration. </summary>
         [WirePath("properties.autoscaleConfiguration")]

--- a/sdk/network/Azure.ResourceManager.Network/src/Generated/LongRunningOperation/IListOperationSource.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Generated/LongRunningOperation/IListOperationSource.cs
@@ -14,26 +14,32 @@ using Azure.ResourceManager.Network.Models;
 
 namespace Azure.ResourceManager.Network
 {
-    internal class IListOperationSource : IOperationSource<IList<ExpressRouteFailoverSingleTestDetails>>
+    internal class IListOperationSource : IOperationSource<IList<ExpressRouteFailoverTestDetails>>
     {
-        IList<ExpressRouteFailoverSingleTestDetails> IOperationSource<IList<ExpressRouteFailoverSingleTestDetails>>.CreateResult(Response response, CancellationToken cancellationToken)
+        IList<ExpressRouteFailoverTestDetails> IOperationSource<IList<ExpressRouteFailoverTestDetails>>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream, ModelSerializationExtensions.JsonDocumentOptions);
-            List<ExpressRouteFailoverSingleTestDetails> array = new List<ExpressRouteFailoverSingleTestDetails>();
+            List<ExpressRouteFailoverTestDetails> array = new List<ExpressRouteFailoverTestDetails>();
             foreach (var item in document.RootElement.EnumerateArray())
             {
-                array.Add(ExpressRouteFailoverSingleTestDetails.DeserializeExpressRouteFailoverSingleTestDetails(item));
+                array.Add(ExpressRouteFailoverTestDetails.DeserializeExpressRouteFailoverTestDetails(item));
             }
             return array;
         }
 
-        async ValueTask<IList<ExpressRouteFailoverSingleTestDetails>> IOperationSource<IList<ExpressRouteFailoverSingleTestDetails>>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<IList<ExpressRouteFailoverTestDetails>> IOperationSource<IList<ExpressRouteFailoverTestDetails>>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, ModelSerializationExtensions.JsonDocumentOptions, cancellationToken).ConfigureAwait(false);
-            List<ExpressRouteFailoverSingleTestDetails> array = new List<ExpressRouteFailoverSingleTestDetails>();
+            List<ExpressRouteFailoverTestDetails> array = new List<ExpressRouteFailoverTestDetails>();
             foreach (var item in document.RootElement.EnumerateArray())
             {
-                array.Add(ExpressRouteFailoverSingleTestDetails.DeserializeExpressRouteFailoverSingleTestDetails(item));
+                array.Add(ExpressRouteFailoverTestDetails.DeserializeExpressRouteFailoverTestDetails(item));
+            }
+            return array;
+        }
+    }
+}
+tails(item));
             }
             return array;
         }

--- a/sdk/network/Azure.ResourceManager.Network/src/Generated/LongRunningOperation/IListOperationSource.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Generated/LongRunningOperation/IListOperationSource.cs
@@ -39,9 +39,3 @@ namespace Azure.ResourceManager.Network
         }
     }
 }
-tails(item));
-            }
-            return array;
-        }
-    }
-}

--- a/sdk/network/Azure.ResourceManager.Network/src/Generated/LongRunningOperation/IListOperationSource.cs
+++ b/sdk/network/Azure.ResourceManager.Network/src/Generated/LongRunningOperation/IListOperationSource.cs
@@ -14,26 +14,26 @@ using Azure.ResourceManager.Network.Models;
 
 namespace Azure.ResourceManager.Network
 {
-    internal class IListOperationSource : IOperationSource<IList<ExpressRouteFailoverTestDetails>>
+    internal class IListOperationSource : IOperationSource<IList<ExpressRouteFailoverSingleTestDetails>>
     {
-        IList<ExpressRouteFailoverTestDetails> IOperationSource<IList<ExpressRouteFailoverTestDetails>>.CreateResult(Response response, CancellationToken cancellationToken)
+        IList<ExpressRouteFailoverSingleTestDetails> IOperationSource<IList<ExpressRouteFailoverSingleTestDetails>>.CreateResult(Response response, CancellationToken cancellationToken)
         {
             using var document = JsonDocument.Parse(response.ContentStream, ModelSerializationExtensions.JsonDocumentOptions);
-            List<ExpressRouteFailoverTestDetails> array = new List<ExpressRouteFailoverTestDetails>();
+            List<ExpressRouteFailoverSingleTestDetails> array = new List<ExpressRouteFailoverSingleTestDetails>();
             foreach (var item in document.RootElement.EnumerateArray())
             {
-                array.Add(ExpressRouteFailoverTestDetails.DeserializeExpressRouteFailoverTestDetails(item));
+                array.Add(ExpressRouteFailoverSingleTestDetails.DeserializeExpressRouteFailoverSingleTestDetails(item));
             }
             return array;
         }
 
-        async ValueTask<IList<ExpressRouteFailoverTestDetails>> IOperationSource<IList<ExpressRouteFailoverTestDetails>>.CreateResultAsync(Response response, CancellationToken cancellationToken)
+        async ValueTask<IList<ExpressRouteFailoverSingleTestDetails>> IOperationSource<IList<ExpressRouteFailoverSingleTestDetails>>.CreateResultAsync(Response response, CancellationToken cancellationToken)
         {
             using var document = await JsonDocument.ParseAsync(response.ContentStream, ModelSerializationExtensions.JsonDocumentOptions, cancellationToken).ConfigureAwait(false);
-            List<ExpressRouteFailoverTestDetails> array = new List<ExpressRouteFailoverTestDetails>();
+            List<ExpressRouteFailoverSingleTestDetails> array = new List<ExpressRouteFailoverSingleTestDetails>();
             foreach (var item in document.RootElement.EnumerateArray())
             {
-                array.Add(ExpressRouteFailoverTestDetails.DeserializeExpressRouteFailoverTestDetails(item));
+                array.Add(ExpressRouteFailoverSingleTestDetails.DeserializeExpressRouteFailoverSingleTestDetails(item));
             }
             return array;
         }

--- a/sdk/network/Azure.ResourceManager.Network/src/autorest.md
+++ b/sdk/network/Azure.ResourceManager.Network/src/autorest.md
@@ -676,7 +676,7 @@ directive:
     where: $.definitions
     transform: >
       delete $.CommonResource.properties.id.format;
-  # Replace the property `enableFips` with upper case `enableFIPS` to match the actual service response on behave of issue: https://github.com/Azure/azure-sdk-for-net/issues/57391
+  # Replace the property `enableFips` with uppercase `enableFIPS` to match the actual service response on behalf of the issue: https://github.com/Azure/azure-sdk-for-net/issues/57391
   - from: applicationGateway.json
     where: $.definitions.ApplicationGatewayPropertiesFormat.properties
     transform: >

--- a/sdk/network/Azure.ResourceManager.Network/src/autorest.md
+++ b/sdk/network/Azure.ResourceManager.Network/src/autorest.md
@@ -310,6 +310,7 @@ acronym-mapping:
   Stag: STag|stag
   Nsp: NetworkSecurityPerimeter
   JWT: Jwt|jwt
+  FIPS: Fips
 
 #TODO: remove after we resolve why DdosCustomPolicy has no list
 list-exception:
@@ -675,4 +676,17 @@ directive:
     where: $.definitions
     transform: >
       delete $.CommonResource.properties.id.format;
+  # Replace the property `enableFips` with upper case `enableFIPS` to match the actual service response on behave of issue: https://github.com/Azure/azure-sdk-for-net/issues/57391
+  - from: applicationGateway.json
+    where: $.definitions.ApplicationGatewayPropertiesFormat.properties
+    transform: >
+      var newProps = {};
+      for (var key in $) {
+        if (key === "enableFips") {
+          newProps["enableFIPS"] = $[key];
+        } else {
+          newProps[key] = $[key];
+        }
+      }
+      return newProps;
 ```


### PR DESCRIPTION
Fix for issue #57391 
Fixed an issue where `ApplicationGatewayData.EnableFips` could not be deserialized correctly because the server returns `enableFIPS` (uppercase) while the spec defined `enableFips` (lowercase).

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
