### PR TITLE
[Mgmt Generator] Thread extra collection ctor params through ArmClient extension methods

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableArmClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/MockableArmClientProvider.cs
@@ -99,19 +99,21 @@ namespace Azure.Generator.Management.Providers
         {
             var result = new List<MethodProvider>();
             var scopeParameter = new ParameterProvider("scope", $"The scope of the resource collection to get.", typeof(ResourceIdentifier));
+            var extraParameters = resource.FactoryMethodSignature.Parameters;
             var signature = new MethodSignature(
                 $"{resource.FactoryMethodSignature.Name}",
                 $"Gets a collection of {resource.ResourceCollection!.Type:C} objects within the specified scope.",
                 MethodSignatureModifiers.Public | MethodSignatureModifiers.Virtual,
                 resource.ResourceCollection!.Type,
                 $"Returns a collection of {resource.Type:C} objects.",
-                [scopeParameter]);
+                [scopeParameter, .. extraParameters]);
             var body = new MethodBodyStatement[]
             {
                 Return(New.Instance(resource.ResourceCollection!.Type,
                     [
                         This.As<ArmResource>().Client(),
-                        scopeParameter
+                        scopeParameter,
+                        .. extraParameters
                     ]))
             };
             result.Add(new MethodProvider(signature, body, this));
@@ -164,13 +166,14 @@ namespace Azure.Generator.Management.Providers
             var result = new List<MethodProvider>();
 
             var scopeParameter = new ParameterProvider("scope", $"The scope that the resource will apply against.", typeof(ResourceIdentifier));
+            var extraParameters = resource.FactoryMethodSignature.Parameters;
             var signature = new MethodSignature(
                 $"{resource.FactoryMethodSignature.Name}",
                 $"Gets an object representing a {resource.Type:C} along with the instance operations that can be performed on it in the ArmClient",
                 MethodSignatureModifiers.Public | MethodSignatureModifiers.Virtual,
                 resource.Type,
                 $"Returns a {resource.Type:C} object.",
-                [scopeParameter]);
+                [scopeParameter, .. extraParameters]);
 
             var body = new MethodBodyStatement[]
             {


### PR DESCRIPTION
## Summary

Fixes a regression in the mgmt generator where `MockableArmClientProvider` emits `GetXxxCollection(ResourceIdentifier scope)` extension methods that only pass `scope` to the collection constructor. When a listable extension resource's collection has extra constructor parameters (derived from `SecondaryContextualPathParameters`), this produces code that fails to compile with `CS7036` because the required ctor parameters are missing.

## Root cause

`MockableArmClientProvider.BuildMethodsForExtensionNonSingletonResource` (and the singleton variant) built the collection factory method signature from scratch using only a hand-rolled `scope` parameter, ignoring `ResourceClientProvider.FactoryMethodSignature.Parameters` which include the collection's extra path parameters.

Contrast this with the non-extension child-resource path in `ResourceClientProvider` which uses `childResource.FactoryMethodSignature` in full, correctly threading the extras.

## Repro

The `Azure.ResourceManager.Quota` library's `QuotaAllocationRequestStatus` is a listable extension resource whose collection stores `groupQuotaName` and `resourceProviderName` as fields. Regenerating today produces:

```csharp
// Generated (broken):
public virtual QuotaAllocationRequestStatusCollection GetQuotaAllocationRequestStatuses(ResourceIdentifier scope)
{
    return new QuotaAllocationRequestStatusCollection(Client, scope); // CS7036: missing groupQuotaName, resourceProviderName
}
```

## Fix

In both `BuildMethodsForExtensionNonSingletonResource` and `BuildMethodsForExtensionSingletonResource`, append `resource.FactoryMethodSignature.Parameters` after the `scope` parameter in the method signature and pass them through to the `new Collection(...)` / `new Resource(...)` instantiation.

## Testing

- `dotnet build` of the mgmt generator passes.
- `eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1` regenerates all test projects with no diff (none of the current in-tree test TypeSpecs exercise a listable extension resource with extra collection ctor params, so their output is unchanged).
- Validated on the real `Azure.ResourceManager.Quota` regen: the generated `MockableQuotaArmClient.GetQuotaAllocationRequestStatuses` now takes and forwards the extra parameters, removing the CS7036 build failure.