### PR TITLE
[AgentServer] Eager history validation and storage error preservation

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Features Added
 
+- `previous_response_id` and `conversation.id` are now validated against the provider before
+  the handler is invoked. Invalid references return HTTP 404/400 immediately instead of being
+  silently ignored. The resolved history item IDs are cached — handlers calling
+  `GetHistoryAsync()` reuse the prefetched result without a second storage lookup.
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Bugs Fixed
 
+- Foundry storage error responses now preserve the full error body (`code`, `message`, `param`, `type`)
+  when returned to the client. Previously only the `message` field was forwarded; `param` was lost.
+- Non-400/404 error status codes from Foundry storage are no longer proxied as-is; they are
+  normalized to HTTP 500 to avoid leaking upstream infrastructure details.
+
 ### Other Changes
 
 ## 1.0.0-beta.2 (2026-04-17)

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
@@ -559,6 +559,9 @@ namespace Azure.AI.AgentServer.Responses
     {
         public ResourceNotFoundException(string message) { }
         public ResourceNotFoundException(string message, System.Exception innerException) { }
+        public ResourceNotFoundException(string message, string? code, string? param) { }
+        public string? Code { get { throw null; } }
+        public string? Param { get { throw null; } }
     }
     public partial class ResponseContext
     {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
@@ -559,6 +559,9 @@ namespace Azure.AI.AgentServer.Responses
     {
         public ResourceNotFoundException(string message) { }
         public ResourceNotFoundException(string message, System.Exception innerException) { }
+        public ResourceNotFoundException(string message, string? code, string? param) { }
+        public string? Code { get { throw null; } }
+        public string? Param { get { throw null; } }
     }
     public partial class ResponseContext
     {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Exceptions/ResourceNotFoundException.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Exceptions/ResourceNotFoundException.cs
@@ -19,6 +19,20 @@ public class ResourceNotFoundException : Exception
     }
 
     /// <summary>
+    /// Initializes a new instance of <see cref="ResourceNotFoundException"/> with a message,
+    /// an error code, and the name of the parameter that identifies the missing resource.
+    /// </summary>
+    /// <param name="message">A description of the missing resource.</param>
+    /// <param name="code">An error code identifying the kind of failure, or <c>null</c>.</param>
+    /// <param name="param">The name of the parameter that identifies the missing resource, or <c>null</c>.</param>
+    public ResourceNotFoundException(string message, string? code, string? param)
+        : base(message)
+    {
+        Code = code;
+        Param = param;
+    }
+
+    /// <summary>
     /// Initializes a new instance of <see cref="ResourceNotFoundException"/> with a message
     /// and an inner exception.
     /// </summary>
@@ -28,4 +42,14 @@ public class ResourceNotFoundException : Exception
         : base(message, innerException)
     {
     }
+
+    /// <summary>
+    /// Gets the error code identifying the kind of failure, if applicable.
+    /// </summary>
+    public string? Code { get; }
+
+    /// <summary>
+    /// Gets the name of the parameter that identifies the missing resource, if applicable.
+    /// </summary>
+    public string? Param { get; }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ApiErrorFactory.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ApiErrorFactory.cs
@@ -53,8 +53,8 @@ internal static class ApiErrorFactory
     /// <summary>
     /// Creates an <see cref="IResult"/> for a 404 <c>invalid_request_error</c>.
     /// </summary>
-    internal static IResult NotFound(string message)
-        => CreateErrorResult(404, "invalid_request_error", message, code: "invalid_request_error");
+    internal static IResult NotFound(string message, string? code = null, string? param = null)
+        => CreateErrorResult(404, "invalid_request_error", message, code ?? "invalid_request_error", param);
 
     /// <summary>
     /// Creates an <see cref="IResult"/> for a 500 <c>server_error</c>

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseEndpointHandler.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseEndpointHandler.cs
@@ -223,6 +223,15 @@ internal sealed class ResponseEndpointHandler
             isolation);
         execution.Context = context;
 
+        // Eager history validation: if previous_response_id or conversation_id is present,
+        // resolve history item IDs now to validate they exist before the handler runs.
+        // The provider throws ResourceNotFoundException (404) for invalid references.
+        // The Lazy<Task<>> cache means the handler and persistence can reuse the result.
+        if (!string.IsNullOrEmpty(request.PreviousResponseId) || !string.IsNullOrEmpty(conversationId))
+        {
+            await context.GetHistoryItemIdsAsync();
+        }
+
         // Get cancellation token from provider (supports external cancel)
         var providerCt = await _cancellationProvider.GetResponseCancellationTokenAsync(responseId);
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseEndpointHandler.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponseEndpointHandler.cs
@@ -223,9 +223,10 @@ internal sealed class ResponseEndpointHandler
             isolation);
         execution.Context = context;
 
-        // Eager history validation: if previous_response_id or conversation_id is present,
-        // resolve history item IDs now to validate they exist before the handler runs.
-        // The provider throws ResourceNotFoundException (404) for invalid references.
+        // Eager history validation: if previous_response_id or conversation.id is present,
+        // resolve history item IDs now to validate referenced state before the handler runs.
+        // Invalid references are provider-validated here and may surface as 404 or 400
+        // depending on which identifier is invalid.
         // The Lazy<Task<>> cache means the handler and persistence can reuse the result.
         if (!string.IsNullOrEmpty(request.PreviousResponseId) || !string.IsNullOrEmpty(conversationId))
         {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponsesExceptionFilter.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponsesExceptionFilter.cs
@@ -60,7 +60,7 @@ internal sealed class ResponsesExceptionFilter : IEndpointFilter
         {
             _logger.LogWarning(ex, "Resource not found");
             RecordException(Activity.Current, ex);
-            return ApiErrorFactory.NotFound(ex.Message);
+            return ApiErrorFactory.NotFound(ex.Message, code: ex.Code, param: ex.Param);
         }
         catch (ResponsesApiException ex)
         {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/StorageErrorMapper.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/StorageErrorMapper.cs
@@ -14,9 +14,11 @@ internal static class StorageErrorMapper
     /// <summary>
     /// Reads the HTTP status code of <paramref name="response"/> and throws the appropriate
     /// SDK exception if the response indicates an error condition.
-    /// All structured error fields (code, message, param, type) from the upstream
-    /// response are preserved in the thrown exception so that they can be forwarded to
-    /// the client without loss.
+    /// Structured upstream error information is preserved in the thrown exception where
+    /// supported by the exception type. For 400, 404, and 409 responses, the thrown
+    /// exception preserves the upstream message, code, and param values. For other
+    /// non-success responses, the thrown <see cref="ResponsesApiException"/> also includes
+    /// the upstream error type when present.
     /// </summary>
     /// <param name="response">The Azure.Core HTTP response to check.</param>
     /// <exception cref="ResourceNotFoundException">Thrown for 404 responses.</exception>
@@ -82,8 +84,10 @@ internal static class StorageErrorMapper
                         if (errorElement.TryGetProperty("type", out var typeElement))
                             type = typeElement.GetString();
 
-                        if (!string.IsNullOrEmpty(message))
-                            return (message, code, param, type);
+                        if (!string.IsNullOrEmpty(message) || !string.IsNullOrEmpty(code) || !string.IsNullOrEmpty(param) || !string.IsNullOrEmpty(type))
+                        {
+                            return (message ?? $"Foundry storage request failed with HTTP {response.Status}.", code, param, type);
+                        }
                     }
                 }
             }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/StorageErrorMapper.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/StorageErrorMapper.cs
@@ -14,6 +14,9 @@ internal static class StorageErrorMapper
     /// <summary>
     /// Reads the HTTP status code of <paramref name="response"/> and throws the appropriate
     /// SDK exception if the response indicates an error condition.
+    /// All structured error fields (code, message, param, type) from the upstream
+    /// response are preserved in the thrown exception so that they can be forwarded to
+    /// the client without loss.
     /// </summary>
     /// <param name="response">The Azure.Core HTTP response to check.</param>
     /// <exception cref="ResourceNotFoundException">Thrown for 404 responses.</exception>
@@ -25,26 +28,31 @@ internal static class StorageErrorMapper
             return;
 
         var status = response.Status;
-        var message = ExtractMessage(response);
+        var errorInfo = ExtractErrorInfo(response);
 
         switch (status)
         {
             case 404:
-                throw new ResourceNotFoundException(message);
+                throw new ResourceNotFoundException(errorInfo.Message, errorInfo.Code, errorInfo.Param);
             case 400:
             case 409:
-                throw new BadRequestException(message);
+                throw new BadRequestException(errorInfo.Message, errorInfo.Code, errorInfo.Param);
             default:
-                throw new ResponsesApiException(new Error("storage_error", message), status);
+                var error = new Error(errorInfo.Code ?? "storage_error", errorInfo.Message)
+                {
+                    Param = errorInfo.Param,
+                    Type = errorInfo.Type ?? "server_error",
+                };
+                throw new ResponsesApiException(error, 500);
         }
     }
 
     /// <summary>
-    /// Extracts an error message from the response body.
+    /// Extracts structured error information from the response body.
     /// Falls back to a generic message including the HTTP status code if parsing fails.
     /// Authorization header values are never included in error messages.
     /// </summary>
-    private static string ExtractMessage(Response response)
+    private static (string Message, string? Code, string? Param, string? Type) ExtractErrorInfo(Response response)
     {
         try
         {
@@ -57,12 +65,25 @@ internal static class StorageErrorMapper
                     using var doc = JsonDocument.Parse(body);
                     if (doc.RootElement.TryGetProperty("error", out var errorElement))
                     {
+                        string? message = null;
+                        string? code = null;
+                        string? param = null;
+                        string? type = null;
+
                         if (errorElement.TryGetProperty("message", out var msgElement))
-                        {
-                            var msg = msgElement.GetString();
-                            if (!string.IsNullOrEmpty(msg))
-                                return msg;
-                        }
+                            message = msgElement.GetString();
+
+                        if (errorElement.TryGetProperty("code", out var codeElement))
+                            code = codeElement.GetString();
+
+                        if (errorElement.TryGetProperty("param", out var paramElement) && paramElement.ValueKind != JsonValueKind.Null)
+                            param = paramElement.GetString();
+
+                        if (errorElement.TryGetProperty("type", out var typeElement))
+                            type = typeElement.GetString();
+
+                        if (!string.IsNullOrEmpty(message))
+                            return (message, code, param, type);
                     }
                 }
             }
@@ -72,6 +93,6 @@ internal static class StorageErrorMapper
             // Parsing failed — fall through to generic message
         }
 
-        return $"Foundry storage request failed with HTTP {response.Status}.";
+        return ($"Foundry storage request failed with HTTP {response.Status}.", null, null, null);
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Exceptions/ExceptionTypesTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Exceptions/ExceptionTypesTests.cs
@@ -60,7 +60,19 @@ public class ResourceNotFoundExceptionTests
         var ex = new ResourceNotFoundException("Response 'resp_123' not found.");
 
         Assert.That(ex.Message, Is.EqualTo("Response 'resp_123' not found."));
+        Assert.That(ex.Code, Is.Null);
+        Assert.That(ex.Param, Is.Null);
         Assert.That(ex.InnerException, Is.Null);
+    }
+
+    [Test]
+    public void Constructor_WithMessageCodeAndParam_SetsAll()
+    {
+        var ex = new ResourceNotFoundException("Response not found.", "invalid_request_error", "response_id");
+
+        Assert.That(ex.Message, Is.EqualTo("Response not found."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.Param, Is.EqualTo("response_id"));
     }
 
     [Test]
@@ -71,6 +83,8 @@ public class ResourceNotFoundExceptionTests
 
         Assert.That(ex.Message, Is.EqualTo("Not found"));
         Assert.That(ex.InnerException, Is.SameAs(inner));
+        Assert.That(ex.Code, Is.Null);
+        Assert.That(ex.Param, Is.Null);
     }
 
     [Test]

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/ApiErrorFactoryTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/ApiErrorFactoryTests.cs
@@ -57,6 +57,21 @@ public class ApiErrorFactoryTests
         Assert.That(error.GetProperty("code").GetString(), Is.EqualTo("invalid_request_error"));
     }
 
+    [Test]
+    public async Task NotFound_IncludesCodeAndParam()
+    {
+        var result = ApiErrorFactory.NotFound("Response not found.", code: "invalid_request_error", param: "response_id");
+
+        var (statusCode, body) = await ExecuteResultAsync(result);
+
+        Assert.That(statusCode, Is.EqualTo(404));
+        var error = body.GetProperty("error");
+        Assert.That(error.GetProperty("type").GetString(), Is.EqualTo("invalid_request_error"));
+        Assert.That(error.GetProperty("message").GetString(), Is.EqualTo("Response not found."));
+        Assert.That(error.GetProperty("code").GetString(), Is.EqualTo("invalid_request_error"));
+        Assert.That(error.GetProperty("param").GetString(), Is.EqualTo("response_id"));
+    }
+
     // --- ServerError ---
 
     [Test]

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/StorageErrorMapperTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/StorageErrorMapperTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.AI.AgentServer.Responses.Internal;
+using Azure.Core;
+
+namespace Azure.AI.AgentServer.Responses.Tests.Internal;
+
+public class StorageErrorMapperTests
+{
+    [Test]
+    public void ThrowIfError_404_PreservesFullErrorBody()
+    {
+        var json = """{"error":{"code":"invalid_request_error","message":"Response with id 'caresp_abc123' not found.","param":"response_id","type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(404, json);
+
+        var ex = Assert.Throws<ResourceNotFoundException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Response with id 'caresp_abc123' not found."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.Param, Is.EqualTo("response_id"));
+    }
+
+    [Test]
+    public void ThrowIfError_400_PreservesFullErrorBody()
+    {
+        var json = """{"error":{"code":"invalid_request_error","message":"Conversation 'conv_xyz' is invalid.","param":"conversation_id","type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(400, json);
+
+        var ex = Assert.Throws<BadRequestException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Conversation 'conv_xyz' is invalid."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.ParamName, Is.EqualTo("conversation_id"));
+    }
+
+    [Test]
+    public void ThrowIfError_409_PreservesFullErrorBody()
+    {
+        var json = """{"error":{"code":"conflict","message":"Resource already exists.","param":"id","type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(409, json);
+
+        var ex = Assert.Throws<BadRequestException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Resource already exists."));
+        Assert.That(ex.Code, Is.EqualTo("conflict"));
+        Assert.That(ex.ParamName, Is.EqualTo("id"));
+    }
+
+    [Test]
+    public void ThrowIfError_404_WithNullParam_SetsParamToNull()
+    {
+        var json = """{"error":{"code":"invalid_request_error","message":"Not found.","param":null,"type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(404, json);
+
+        var ex = Assert.Throws<ResourceNotFoundException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Not found."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.Param, Is.Null);
+    }
+
+    [Test]
+    public void ThrowIfError_404_WithMissingParam_SetsParamToNull()
+    {
+        var json = """{"error":{"code":"invalid_request_error","message":"Not found.","type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(404, json);
+
+        var ex = Assert.Throws<ResourceNotFoundException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Not found."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.Param, Is.Null);
+    }
+
+    [Test]
+    public void ThrowIfError_500_PreservesAllFields()
+    {
+        var json = """{"error":{"code":"internal_error","message":"Something went wrong.","param":"request","type":"server_error"}}""";
+        var response = CreateMockResponse(500, json);
+
+        var ex = Assert.Throws<ResponsesApiException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Something went wrong."));
+        Assert.That(ex.StatusCode, Is.EqualTo(500));
+        Assert.That(ex.Error.Code, Is.EqualTo("internal_error"));
+        Assert.That(ex.Error.Param, Is.EqualTo("request"));
+        Assert.That(ex.Error.Type, Is.EqualTo("server_error"));
+    }
+
+    [Test]
+    public void ThrowIfError_502_ReturnsAs500_NotProxied()
+    {
+        var json = """{"error":{"code":"upstream_error","message":"Bad gateway.","param":null,"type":"server_error"}}""";
+        var response = CreateMockResponse(502, json);
+
+        var ex = Assert.Throws<ResponsesApiException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        // Must not proxy the upstream status code — always 500 for unknown errors
+        Assert.That(ex!.StatusCode, Is.EqualTo(500));
+        Assert.That(ex.Error.Code, Is.EqualTo("upstream_error"));
+        Assert.That(ex.Error.Message, Is.EqualTo("Bad gateway."));
+        Assert.That(ex.Error.Type, Is.EqualTo("server_error"));
+    }
+
+    [Test]
+    public void ThrowIfError_EmptyBody_FallsBackToGenericMessage()
+    {
+        var response = CreateMockResponse(404, "");
+
+        var ex = Assert.Throws<ResourceNotFoundException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Foundry storage request failed with HTTP 404."));
+        Assert.That(ex.Code, Is.Null);
+        Assert.That(ex.Param, Is.Null);
+    }
+
+    [Test]
+    public void ThrowIfError_InvalidJson_FallsBackToGenericMessage()
+    {
+        var response = CreateMockResponse(400, "not json");
+
+        var ex = Assert.Throws<BadRequestException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Foundry storage request failed with HTTP 400."));
+        Assert.That(ex.Code, Is.Null);
+        Assert.That(ex.ParamName, Is.Null);
+    }
+
+    [Test]
+    public void ThrowIfError_SuccessResponse_DoesNotThrow()
+    {
+        var response = CreateMockResponse(200, """{"id":"resp_123"}""");
+
+        Assert.DoesNotThrow(() => StorageErrorMapper.ThrowIfError(response));
+    }
+
+    private static Response CreateMockResponse(int statusCode, string body)
+    {
+        return new MockResponse(statusCode, body);
+    }
+
+    /// <summary>
+    /// Minimal mock of Azure.Core.Response for testing StorageErrorMapper.
+    /// </summary>
+    private sealed class MockResponse : Response
+    {
+        private readonly int _status;
+        private readonly BinaryData? _content;
+
+        public MockResponse(int status, string body)
+        {
+            _status = status;
+            _content = string.IsNullOrEmpty(body) ? null : BinaryData.FromString(body);
+        }
+
+        public override int Status => _status;
+        public override string ReasonPhrase => _status switch
+        {
+            200 => "OK",
+            400 => "Bad Request",
+            404 => "Not Found",
+            409 => "Conflict",
+            500 => "Internal Server Error",
+            _ => "Error",
+        };
+        public override BinaryData Content => _content!;
+        public override bool IsError => _status >= 400;
+
+        public override Stream? ContentStream { get => null; set { } }
+        public override string ClientRequestId { get => "test"; set { } }
+
+        public override void Dispose() { }
+
+        protected override bool ContainsHeader(string name) => false;
+        protected override IEnumerable<HttpHeader> EnumerateHeaders() => [];
+        protected override bool TryGetHeader(string name, out string? value) { value = null; return false; }
+        protected override bool TryGetHeaderValues(string name, out IEnumerable<string>? values) { values = null; return false; }
+    }
+}

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/StorageErrorMapperTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/StorageErrorMapperTests.cs
@@ -146,12 +146,12 @@ public class StorageErrorMapperTests
     private sealed class MockResponse : Response
     {
         private readonly int _status;
-        private readonly BinaryData? _content;
+        private readonly BinaryData _content;
 
         public MockResponse(int status, string body)
         {
             _status = status;
-            _content = string.IsNullOrEmpty(body) ? null : BinaryData.FromString(body);
+            _content = BinaryData.FromString(body);
         }
 
         public override int Status => _status;
@@ -164,7 +164,7 @@ public class StorageErrorMapperTests
             500 => "Internal Server Error",
             _ => "Error",
         };
-        public override BinaryData Content => _content!;
+        public override BinaryData Content => _content;
         public override bool IsError => _status >= 400;
 
         public override Stream? ContentStream { get => null; set { } }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/HistoryValidationTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/HistoryValidationTests.cs
@@ -15,7 +15,7 @@ namespace Azure.AI.AgentServer.Responses.Tests.Protocol;
 
 /// <summary>
 /// Protocol tests for eager history validation.
-/// When previous_response_id or conversation_id are provided, GetHistoryItemIdsAsync
+/// When previous_response_id or conversation.id are provided, GetHistoryItemIdsAsync
 /// must be called before the handler runs. If the provider rejects the reference
 /// (e.g., 404 for unknown previous_response_id), the error must surface to the client
 /// without invoking the handler.
@@ -155,8 +155,9 @@ public class HistoryValidationTests : IDisposable
     // ── Validating provider ─────────────────────────────────────
 
     /// <summary>
-    /// Provider that throws ResourceNotFoundException for configured invalid IDs,
-    /// simulating Foundry storage's validation behaviour.
+    /// Provider that throws ResourceNotFoundException for configured invalid previous response IDs
+    /// and BadRequestException for configured invalid conversation IDs, simulating Foundry
+    /// storage's validation behaviour.
     /// </summary>
     private sealed class ValidatingProvider : ResponsesProvider
     {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/HistoryValidationTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Protocol/HistoryValidationTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Azure.AI.AgentServer.Core;
+using Azure.AI.AgentServer.Responses.Internal;
+using Azure.AI.AgentServer.Responses.Models;
+using Azure.AI.AgentServer.Responses.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Azure.AI.AgentServer.Responses.Tests.Protocol;
+
+/// <summary>
+/// Protocol tests for eager history validation.
+/// When previous_response_id or conversation_id are provided, GetHistoryItemIdsAsync
+/// must be called before the handler runs. If the provider rejects the reference
+/// (e.g., 404 for unknown previous_response_id), the error must surface to the client
+/// without invoking the handler.
+/// </summary>
+public class HistoryValidationTests : IDisposable
+{
+    private readonly TestHandler _handler = new();
+    private readonly ValidatingProvider _provider;
+    private readonly TestWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+
+    public HistoryValidationTests()
+    {
+        _provider = new ValidatingProvider();
+
+        _factory = new TestWebApplicationFactory(
+            _handler,
+            configureTestServices: services =>
+            {
+                services.AddSingleton<ResponsesProvider>(_provider);
+            });
+        _client = _factory.CreateClient();
+    }
+
+    [Test]
+    public async Task Post_InvalidPreviousResponseId_Returns404_HandlerNotInvoked()
+    {
+        // Use a well-formatted ID that passes schema validation but doesn't exist in storage
+        var fakeId = IdGenerator.NewResponseId("");
+        _provider.InvalidPreviousResponseIds.Add(fakeId);
+
+        var body = JsonSerializer.Serialize(new
+        {
+            model = "test",
+            previous_response_id = fakeId
+        });
+
+        var response = await _client.PostAsync("/responses",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        Assert.That(_handler.CallCount, Is.EqualTo(0),
+            "Handler must not be invoked when previous_response_id is invalid");
+    }
+
+    [Test]
+    public async Task Post_InvalidConversationId_Returns400_HandlerNotInvoked()
+    {
+        _provider.InvalidConversationIds.Add("conv_does_not_exist");
+
+        var body = JsonSerializer.Serialize(new
+        {
+            model = "test",
+            conversation = new { id = "conv_does_not_exist" }
+        });
+
+        var response = await _client.PostAsync("/responses",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(_handler.CallCount, Is.EqualTo(0),
+            "Handler must not be invoked when conversation_id is invalid");
+    }
+
+    [Test]
+    public async Task Post_ValidPreviousResponseId_HandlerInvoked()
+    {
+        // Create a response first so previous_response_id is valid
+        var createBody = JsonSerializer.Serialize(new { model = "test" });
+        var createResponse = await _client.PostAsync("/responses",
+            new StringContent(createBody, Encoding.UTF8, "application/json"));
+        Assert.That(createResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+        using var createDoc = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());
+        var responseId = createDoc.RootElement.GetProperty("id").GetString()!;
+
+        // Use it as previous_response_id — should succeed
+        var body = JsonSerializer.Serialize(new
+        {
+            model = "test",
+            previous_response_id = responseId
+        });
+
+        var response = await _client.PostAsync("/responses",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        Assert.That(_handler.CallCount, Is.EqualTo(2)); // first create + second with previous
+    }
+
+    [Test]
+    public async Task Post_InvalidPreviousResponseId_Background_Returns404()
+    {
+        var fakeId = IdGenerator.NewResponseId("");
+        _provider.InvalidPreviousResponseIds.Add(fakeId);
+
+        var body = JsonSerializer.Serialize(new
+        {
+            model = "test",
+            previous_response_id = fakeId,
+            background = true
+        });
+
+        var response = await _client.PostAsync("/responses",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        Assert.That(_handler.CallCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Post_InvalidPreviousResponseId_Streaming_Returns404()
+    {
+        var fakeId = IdGenerator.NewResponseId("");
+        _provider.InvalidPreviousResponseIds.Add(fakeId);
+
+        var body = JsonSerializer.Serialize(new
+        {
+            model = "test",
+            previous_response_id = fakeId,
+            stream = true
+        });
+
+        var response = await _client.PostAsync("/responses",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        Assert.That(_handler.CallCount, Is.EqualTo(0));
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+        _factory.Dispose();
+    }
+
+    // ── Validating provider ─────────────────────────────────────
+
+    /// <summary>
+    /// Provider that throws ResourceNotFoundException for configured invalid IDs,
+    /// simulating Foundry storage's validation behaviour.
+    /// </summary>
+    private sealed class ValidatingProvider : ResponsesProvider
+    {
+        private readonly InMemoryResponsesProvider _inner = new(
+            Options.Create(new InMemoryProviderOptions()), TimeProvider.System);
+
+        public HashSet<string> InvalidPreviousResponseIds { get; } = new();
+        public HashSet<string> InvalidConversationIds { get; } = new();
+
+        public override Task CreateResponseAsync(CreateResponseRequest request, IsolationContext isolation, CancellationToken cancellationToken = default)
+            => _inner.CreateResponseAsync(request, isolation, cancellationToken);
+
+        public override Task<ResponseObject> GetResponseAsync(string responseId, IsolationContext isolation, CancellationToken cancellationToken = default)
+            => _inner.GetResponseAsync(responseId, isolation, cancellationToken);
+
+        public override Task UpdateResponseAsync(ResponseObject response, IsolationContext isolation, CancellationToken cancellationToken = default)
+            => _inner.UpdateResponseAsync(response, isolation, cancellationToken);
+
+        public override Task DeleteResponseAsync(string responseId, IsolationContext isolation, CancellationToken cancellationToken = default)
+            => _inner.DeleteResponseAsync(responseId, isolation, cancellationToken);
+
+        public override Task<AgentsPagedResultOutputItem> GetInputItemsAsync(string responseId, IsolationContext isolation, int limit = 20, bool ascending = false, string? after = null, string? before = null, CancellationToken cancellationToken = default)
+            => _inner.GetInputItemsAsync(responseId, isolation, limit, ascending, after, before, cancellationToken);
+
+        public override Task<IEnumerable<OutputItem?>> GetItemsAsync(IEnumerable<string> itemIds, IsolationContext isolation, CancellationToken cancellationToken = default)
+            => _inner.GetItemsAsync(itemIds, isolation, cancellationToken);
+
+        public override Task<IEnumerable<string>> GetHistoryItemIdsAsync(
+            string? previousResponseId,
+            string? conversationId,
+            int limit,
+            IsolationContext isolation,
+            CancellationToken cancellationToken = default)
+        {
+            if (previousResponseId is not null && InvalidPreviousResponseIds.Contains(previousResponseId))
+            {
+                throw new ResourceNotFoundException(
+                    $"Response '{previousResponseId}' not found.");
+            }
+
+            if (conversationId is not null && InvalidConversationIds.Contains(conversationId))
+            {
+                throw new BadRequestException(
+                    $"Conversation '{conversationId}' not found.");
+            }
+
+            return _inner.GetHistoryItemIdsAsync(previousResponseId, conversationId, limit, isolation, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Changes

### Eager history validation (before handler invocation)
- `previous_response_id` and `conversation.id` are validated against the storage provider **before** the handler is invoked
- Invalid references now return HTTP 404/400 immediately instead of being silently ignored
- Resolved history item IDs are cached — handlers calling `GetHistoryAsync()` reuse the prefetched result without a second storage lookup

### Full Foundry storage error body preservation
- Foundry storage error responses now preserve the full error body (`code`, `message`, `param`, `type`) when returned to the client
- Previously only `message` was forwarded; `param` was lost entirely
- Non-400/404 error status codes from Foundry are normalized to HTTP 500 (never proxied)

### Test coverage
- 5 E2E tests for eager history validation (invalid conversation, invalid previous_response_id, valid paths)
- 10 unit tests for StorageErrorMapper covering all error paths
- Additional unit tests for exception types and ApiErrorFactory