### PR TITLE
[AgentServer] Preserve full Foundry storage error body in client responses

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Bugs Fixed
 
+- Foundry storage error responses now preserve the full error body (`code`, `message`, `param`, `type`)
+  when returned to the client. Previously only the `message` field was forwarded; `param` was lost.
+- Non-400/404 error status codes from Foundry storage are no longer proxied as-is; they are
+  normalized to HTTP 500 to avoid leaking upstream infrastructure details.
+
 ### Other Changes
 
 ## 1.0.0-beta.2 (2026-04-17)

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net10.0.cs
@@ -559,6 +559,9 @@ namespace Azure.AI.AgentServer.Responses
     {
         public ResourceNotFoundException(string message) { }
         public ResourceNotFoundException(string message, System.Exception innerException) { }
+        public ResourceNotFoundException(string message, string? code, string? param) { }
+        public string? Code { get { throw null; } }
+        public string? Param { get { throw null; } }
     }
     public partial class ResponseContext
     {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/api/Azure.AI.AgentServer.Responses.net8.0.cs
@@ -559,6 +559,9 @@ namespace Azure.AI.AgentServer.Responses
     {
         public ResourceNotFoundException(string message) { }
         public ResourceNotFoundException(string message, System.Exception innerException) { }
+        public ResourceNotFoundException(string message, string? code, string? param) { }
+        public string? Code { get { throw null; } }
+        public string? Param { get { throw null; } }
     }
     public partial class ResponseContext
     {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Exceptions/ResourceNotFoundException.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Exceptions/ResourceNotFoundException.cs
@@ -19,6 +19,20 @@ public class ResourceNotFoundException : Exception
     }
 
     /// <summary>
+    /// Initializes a new instance of <see cref="ResourceNotFoundException"/> with a message,
+    /// an error code, and the name of the parameter that identifies the missing resource.
+    /// </summary>
+    /// <param name="message">A description of the missing resource.</param>
+    /// <param name="code">An error code identifying the kind of failure, or <c>null</c>.</param>
+    /// <param name="param">The name of the parameter that identifies the missing resource, or <c>null</c>.</param>
+    public ResourceNotFoundException(string message, string? code, string? param)
+        : base(message)
+    {
+        Code = code;
+        Param = param;
+    }
+
+    /// <summary>
     /// Initializes a new instance of <see cref="ResourceNotFoundException"/> with a message
     /// and an inner exception.
     /// </summary>
@@ -28,4 +42,14 @@ public class ResourceNotFoundException : Exception
         : base(message, innerException)
     {
     }
+
+    /// <summary>
+    /// Gets the error code identifying the kind of failure, if applicable.
+    /// </summary>
+    public string? Code { get; }
+
+    /// <summary>
+    /// Gets the name of the parameter that identifies the missing resource, if applicable.
+    /// </summary>
+    public string? Param { get; }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ApiErrorFactory.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ApiErrorFactory.cs
@@ -53,8 +53,8 @@ internal static class ApiErrorFactory
     /// <summary>
     /// Creates an <see cref="IResult"/> for a 404 <c>invalid_request_error</c>.
     /// </summary>
-    internal static IResult NotFound(string message)
-        => CreateErrorResult(404, "invalid_request_error", message, code: "invalid_request_error");
+    internal static IResult NotFound(string message, string? code = null, string? param = null)
+        => CreateErrorResult(404, "invalid_request_error", message, code ?? "invalid_request_error", param);
 
     /// <summary>
     /// Creates an <see cref="IResult"/> for a 500 <c>server_error</c>

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponsesExceptionFilter.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/ResponsesExceptionFilter.cs
@@ -60,7 +60,7 @@ internal sealed class ResponsesExceptionFilter : IEndpointFilter
         {
             _logger.LogWarning(ex, "Resource not found");
             RecordException(Activity.Current, ex);
-            return ApiErrorFactory.NotFound(ex.Message);
+            return ApiErrorFactory.NotFound(ex.Message, code: ex.Code, param: ex.Param);
         }
         catch (ResponsesApiException ex)
         {

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/StorageErrorMapper.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/StorageErrorMapper.cs
@@ -14,9 +14,11 @@ internal static class StorageErrorMapper
     /// <summary>
     /// Reads the HTTP status code of <paramref name="response"/> and throws the appropriate
     /// SDK exception if the response indicates an error condition.
-    /// All structured error fields (code, message, param, type) from the upstream
-    /// response are preserved in the thrown exception so that they can be forwarded to
-    /// the client without loss.
+    /// Structured upstream error information is preserved in the thrown exception where
+    /// supported by the exception type. For 400, 404, and 409 responses, the thrown
+    /// exception preserves the upstream message, code, and param values. For other
+    /// non-success responses, the thrown <see cref="ResponsesApiException"/> also includes
+    /// the upstream error type when present.
     /// </summary>
     /// <param name="response">The Azure.Core HTTP response to check.</param>
     /// <exception cref="ResourceNotFoundException">Thrown for 404 responses.</exception>
@@ -82,8 +84,10 @@ internal static class StorageErrorMapper
                         if (errorElement.TryGetProperty("type", out var typeElement))
                             type = typeElement.GetString();
 
-                        if (!string.IsNullOrEmpty(message))
-                            return (message, code, param, type);
+                        if (!string.IsNullOrEmpty(message) || !string.IsNullOrEmpty(code) || !string.IsNullOrEmpty(param) || !string.IsNullOrEmpty(type))
+                        {
+                            return (message ?? $"Foundry storage request failed with HTTP {response.Status}.", code, param, type);
+                        }
                     }
                 }
             }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/StorageErrorMapper.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Internal/StorageErrorMapper.cs
@@ -14,6 +14,9 @@ internal static class StorageErrorMapper
     /// <summary>
     /// Reads the HTTP status code of <paramref name="response"/> and throws the appropriate
     /// SDK exception if the response indicates an error condition.
+    /// All structured error fields (code, message, param, type) from the upstream
+    /// response are preserved in the thrown exception so that they can be forwarded to
+    /// the client without loss.
     /// </summary>
     /// <param name="response">The Azure.Core HTTP response to check.</param>
     /// <exception cref="ResourceNotFoundException">Thrown for 404 responses.</exception>
@@ -25,26 +28,31 @@ internal static class StorageErrorMapper
             return;
 
         var status = response.Status;
-        var message = ExtractMessage(response);
+        var errorInfo = ExtractErrorInfo(response);
 
         switch (status)
         {
             case 404:
-                throw new ResourceNotFoundException(message);
+                throw new ResourceNotFoundException(errorInfo.Message, errorInfo.Code, errorInfo.Param);
             case 400:
             case 409:
-                throw new BadRequestException(message);
+                throw new BadRequestException(errorInfo.Message, errorInfo.Code, errorInfo.Param);
             default:
-                throw new ResponsesApiException(new Error("storage_error", message), status);
+                var error = new Error(errorInfo.Code ?? "storage_error", errorInfo.Message)
+                {
+                    Param = errorInfo.Param,
+                    Type = errorInfo.Type ?? "server_error",
+                };
+                throw new ResponsesApiException(error, 500);
         }
     }
 
     /// <summary>
-    /// Extracts an error message from the response body.
+    /// Extracts structured error information from the response body.
     /// Falls back to a generic message including the HTTP status code if parsing fails.
     /// Authorization header values are never included in error messages.
     /// </summary>
-    private static string ExtractMessage(Response response)
+    private static (string Message, string? Code, string? Param, string? Type) ExtractErrorInfo(Response response)
     {
         try
         {
@@ -57,12 +65,25 @@ internal static class StorageErrorMapper
                     using var doc = JsonDocument.Parse(body);
                     if (doc.RootElement.TryGetProperty("error", out var errorElement))
                     {
+                        string? message = null;
+                        string? code = null;
+                        string? param = null;
+                        string? type = null;
+
                         if (errorElement.TryGetProperty("message", out var msgElement))
-                        {
-                            var msg = msgElement.GetString();
-                            if (!string.IsNullOrEmpty(msg))
-                                return msg;
-                        }
+                            message = msgElement.GetString();
+
+                        if (errorElement.TryGetProperty("code", out var codeElement))
+                            code = codeElement.GetString();
+
+                        if (errorElement.TryGetProperty("param", out var paramElement) && paramElement.ValueKind != JsonValueKind.Null)
+                            param = paramElement.GetString();
+
+                        if (errorElement.TryGetProperty("type", out var typeElement))
+                            type = typeElement.GetString();
+
+                        if (!string.IsNullOrEmpty(message))
+                            return (message, code, param, type);
                     }
                 }
             }
@@ -72,6 +93,6 @@ internal static class StorageErrorMapper
             // Parsing failed — fall through to generic message
         }
 
-        return $"Foundry storage request failed with HTTP {response.Status}.";
+        return ($"Foundry storage request failed with HTTP {response.Status}.", null, null, null);
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Exceptions/ExceptionTypesTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Exceptions/ExceptionTypesTests.cs
@@ -60,7 +60,19 @@ public class ResourceNotFoundExceptionTests
         var ex = new ResourceNotFoundException("Response 'resp_123' not found.");
 
         Assert.That(ex.Message, Is.EqualTo("Response 'resp_123' not found."));
+        Assert.That(ex.Code, Is.Null);
+        Assert.That(ex.Param, Is.Null);
         Assert.That(ex.InnerException, Is.Null);
+    }
+
+    [Test]
+    public void Constructor_WithMessageCodeAndParam_SetsAll()
+    {
+        var ex = new ResourceNotFoundException("Response not found.", "invalid_request_error", "response_id");
+
+        Assert.That(ex.Message, Is.EqualTo("Response not found."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.Param, Is.EqualTo("response_id"));
     }
 
     [Test]
@@ -71,6 +83,8 @@ public class ResourceNotFoundExceptionTests
 
         Assert.That(ex.Message, Is.EqualTo("Not found"));
         Assert.That(ex.InnerException, Is.SameAs(inner));
+        Assert.That(ex.Code, Is.Null);
+        Assert.That(ex.Param, Is.Null);
     }
 
     [Test]

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/ApiErrorFactoryTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/ApiErrorFactoryTests.cs
@@ -57,6 +57,21 @@ public class ApiErrorFactoryTests
         Assert.That(error.GetProperty("code").GetString(), Is.EqualTo("invalid_request_error"));
     }
 
+    [Test]
+    public async Task NotFound_IncludesCodeAndParam()
+    {
+        var result = ApiErrorFactory.NotFound("Response not found.", code: "invalid_request_error", param: "response_id");
+
+        var (statusCode, body) = await ExecuteResultAsync(result);
+
+        Assert.That(statusCode, Is.EqualTo(404));
+        var error = body.GetProperty("error");
+        Assert.That(error.GetProperty("type").GetString(), Is.EqualTo("invalid_request_error"));
+        Assert.That(error.GetProperty("message").GetString(), Is.EqualTo("Response not found."));
+        Assert.That(error.GetProperty("code").GetString(), Is.EqualTo("invalid_request_error"));
+        Assert.That(error.GetProperty("param").GetString(), Is.EqualTo("response_id"));
+    }
+
     // --- ServerError ---
 
     [Test]

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/StorageErrorMapperTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/StorageErrorMapperTests.cs
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.AI.AgentServer.Responses.Internal;
+using Azure.Core;
+
+namespace Azure.AI.AgentServer.Responses.Tests.Internal;
+
+public class StorageErrorMapperTests
+{
+    [Test]
+    public void ThrowIfError_404_PreservesFullErrorBody()
+    {
+        var json = """{"error":{"code":"invalid_request_error","message":"Response with id 'caresp_abc123' not found.","param":"response_id","type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(404, json);
+
+        var ex = Assert.Throws<ResourceNotFoundException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Response with id 'caresp_abc123' not found."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.Param, Is.EqualTo("response_id"));
+    }
+
+    [Test]
+    public void ThrowIfError_400_PreservesFullErrorBody()
+    {
+        var json = """{"error":{"code":"invalid_request_error","message":"Conversation 'conv_xyz' is invalid.","param":"conversation_id","type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(400, json);
+
+        var ex = Assert.Throws<BadRequestException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Conversation 'conv_xyz' is invalid."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.ParamName, Is.EqualTo("conversation_id"));
+    }
+
+    [Test]
+    public void ThrowIfError_409_PreservesFullErrorBody()
+    {
+        var json = """{"error":{"code":"conflict","message":"Resource already exists.","param":"id","type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(409, json);
+
+        var ex = Assert.Throws<BadRequestException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Resource already exists."));
+        Assert.That(ex.Code, Is.EqualTo("conflict"));
+        Assert.That(ex.ParamName, Is.EqualTo("id"));
+    }
+
+    [Test]
+    public void ThrowIfError_404_WithNullParam_SetsParamToNull()
+    {
+        var json = """{"error":{"code":"invalid_request_error","message":"Not found.","param":null,"type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(404, json);
+
+        var ex = Assert.Throws<ResourceNotFoundException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Not found."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.Param, Is.Null);
+    }
+
+    [Test]
+    public void ThrowIfError_404_WithMissingParam_SetsParamToNull()
+    {
+        var json = """{"error":{"code":"invalid_request_error","message":"Not found.","type":"invalid_request_error"}}""";
+        var response = CreateMockResponse(404, json);
+
+        var ex = Assert.Throws<ResourceNotFoundException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Not found."));
+        Assert.That(ex.Code, Is.EqualTo("invalid_request_error"));
+        Assert.That(ex.Param, Is.Null);
+    }
+
+    [Test]
+    public void ThrowIfError_500_PreservesAllFields()
+    {
+        var json = """{"error":{"code":"internal_error","message":"Something went wrong.","param":"request","type":"server_error"}}""";
+        var response = CreateMockResponse(500, json);
+
+        var ex = Assert.Throws<ResponsesApiException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Something went wrong."));
+        Assert.That(ex.StatusCode, Is.EqualTo(500));
+        Assert.That(ex.Error.Code, Is.EqualTo("internal_error"));
+        Assert.That(ex.Error.Param, Is.EqualTo("request"));
+        Assert.That(ex.Error.Type, Is.EqualTo("server_error"));
+    }
+
+    [Test]
+    public void ThrowIfError_502_ReturnsAs500_NotProxied()
+    {
+        var json = """{"error":{"code":"upstream_error","message":"Bad gateway.","param":null,"type":"server_error"}}""";
+        var response = CreateMockResponse(502, json);
+
+        var ex = Assert.Throws<ResponsesApiException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        // Must not proxy the upstream status code — always 500 for unknown errors
+        Assert.That(ex!.StatusCode, Is.EqualTo(500));
+        Assert.That(ex.Error.Code, Is.EqualTo("upstream_error"));
+        Assert.That(ex.Error.Message, Is.EqualTo("Bad gateway."));
+        Assert.That(ex.Error.Type, Is.EqualTo("server_error"));
+    }
+
+    [Test]
+    public void ThrowIfError_EmptyBody_FallsBackToGenericMessage()
+    {
+        var response = CreateMockResponse(404, "");
+
+        var ex = Assert.Throws<ResourceNotFoundException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Foundry storage request failed with HTTP 404."));
+        Assert.That(ex.Code, Is.Null);
+        Assert.That(ex.Param, Is.Null);
+    }
+
+    [Test]
+    public void ThrowIfError_InvalidJson_FallsBackToGenericMessage()
+    {
+        var response = CreateMockResponse(400, "not json");
+
+        var ex = Assert.Throws<BadRequestException>(() => StorageErrorMapper.ThrowIfError(response));
+
+        Assert.That(ex!.Message, Is.EqualTo("Foundry storage request failed with HTTP 400."));
+        Assert.That(ex.Code, Is.Null);
+        Assert.That(ex.ParamName, Is.Null);
+    }
+
+    [Test]
+    public void ThrowIfError_SuccessResponse_DoesNotThrow()
+    {
+        var response = CreateMockResponse(200, """{"id":"resp_123"}""");
+
+        Assert.DoesNotThrow(() => StorageErrorMapper.ThrowIfError(response));
+    }
+
+    private static Response CreateMockResponse(int statusCode, string body)
+    {
+        return new MockResponse(statusCode, body);
+    }
+
+    /// <summary>
+    /// Minimal mock of Azure.Core.Response for testing StorageErrorMapper.
+    /// </summary>
+    private sealed class MockResponse : Response
+    {
+        private readonly int _status;
+        private readonly BinaryData? _content;
+
+        public MockResponse(int status, string body)
+        {
+            _status = status;
+            _content = string.IsNullOrEmpty(body) ? null : BinaryData.FromString(body);
+        }
+
+        public override int Status => _status;
+        public override string ReasonPhrase => _status switch
+        {
+            200 => "OK",
+            400 => "Bad Request",
+            404 => "Not Found",
+            409 => "Conflict",
+            500 => "Internal Server Error",
+            _ => "Error",
+        };
+        public override BinaryData Content => _content!;
+        public override bool IsError => _status >= 400;
+
+        public override Stream? ContentStream { get => null; set { } }
+        public override string ClientRequestId { get => "test"; set { } }
+
+        public override void Dispose() { }
+
+        protected override bool ContainsHeader(string name) => false;
+        protected override IEnumerable<HttpHeader> EnumerateHeaders() => [];
+        protected override bool TryGetHeader(string name, out string? value) { value = null; return false; }
+        protected override bool TryGetHeaderValues(string name, out IEnumerable<string>? values) { values = null; return false; }
+    }
+}

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/StorageErrorMapperTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/Internal/StorageErrorMapperTests.cs
@@ -146,12 +146,12 @@ public class StorageErrorMapperTests
     private sealed class MockResponse : Response
     {
         private readonly int _status;
-        private readonly BinaryData? _content;
+        private readonly BinaryData _content;
 
         public MockResponse(int status, string body)
         {
             _status = status;
-            _content = string.IsNullOrEmpty(body) ? null : BinaryData.FromString(body);
+            _content = BinaryData.FromString(body);
         }
 
         public override int Status => _status;
@@ -164,7 +164,7 @@ public class StorageErrorMapperTests
             500 => "Internal Server Error",
             _ => "Error",
         };
-        public override BinaryData Content => _content!;
+        public override BinaryData Content => _content;
         public override bool IsError => _status >= 400;
 
         public override Stream? ContentStream { get => null; set { } }


### PR DESCRIPTION
## Summary

Foundry storage returns spec-compliant error bodies like:
```json
{"error":{"code":"invalid_request_error","message":"Response with id '...' not found.","param":"response_id","type":"invalid_request_error"}}
```

Previously, `StorageErrorMapper` only extracted the `message` field. The `param`, `code`, and `type` fields were discarded and reconstructed with hard-coded defaults — losing the `param` field entirely.

This PR ensures the full error structure is preserved end-to-end from Foundry → exception → HTTP response to client.

## Changes

| File | Change |
|------|--------|
| `StorageErrorMapper.cs` | `ExtractErrorInfo` now returns `(Message, Code, Param, Type)` tuple; default branch uses HTTP 500 (never proxies upstream status) and sets all `Error` fields |
| `ResourceNotFoundException.cs` | Added `Code` and `Param` properties (new 3-arg constructor) |
| `ApiErrorFactory.cs` | `NotFound()` accepts optional `code` and `param` |
| `ResponsesExceptionFilter.cs` | Passes `ex.Code`/`ex.Param` for `ResourceNotFoundException` |
| `StorageErrorMapperTests.cs` | 10 new unit tests covering all error paths |
| `ExceptionTypesTests.cs` | Tests for new `ResourceNotFoundException` constructor |
| `ApiErrorFactoryTests.cs` | Test for `NotFound` with code+param |
| API listings | Updated to reflect new public surface |
| `CHANGELOG.md` | Bug fix entries |

## Key design decisions

1. **Non-400/404 status codes → always 500**: We never proxy arbitrary Foundry status codes (e.g., 502) to the client. This prevents leaking upstream infrastructure details.
2. **`type` preserved on catch-all path**: The `ResponsesApiException.Error.Type` is set from Foundry's `type` field (via `FromApiException` serialization path).
3. **400/404 paths use exception filter**: `code`/`param` flow through exception properties → `ApiErrorFactory` methods which hard-code `type: "invalid_request_error"` per spec.

## Testing

- 10 new `StorageErrorMapperTests` (404/400/409/500/502, null param, missing param, empty body, invalid JSON, success)
- Updated `ResourceNotFoundExceptionTests` and `ApiErrorFactoryTests`
- Full suite passes: 2166 tests across all projects
