### PR TITLE
Make Analyze verify artifact publish retry-safe

### DIFF
--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -112,12 +112,6 @@ jobs:
     - job: "Analyze"
       timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
       condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))
-      templateContext:
-        outputs:
-          - output: pipelineArtifact
-            targetPath: '$(Build.ArtifactStagingDirectory)'
-            artifactName: 'verify_$(System.JobName)_$(System.JobAttempt)'
-
       pool:
         name: $(LINUXPOOL)
         image: $(LINUXVMIMAGE)

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -45,194 +45,195 @@ parameters:
 
 jobs:
   - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-      - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-        parameters:
-          GenerateJobName: generate_build_matrix
-          JobTemplatePath: /eng/pipelines/templates/jobs/batched-build-analyze.yml
-          Pools: # eng/pipelines/templates/stages/build-matrix.json only contains windows OS currently so only pass the Windows pool to avoid the other OS's being marked skipped in DevOps
-            - name: Windows
-              filter: .*Windows.*Pool$
-              os: windows
-          MatrixConfigs:
-            - Name: NET_ci_build_base
-              Path: eng/pipelines/templates/stages/build-matrix.json
-              Selection: sparse
-              GenerateVMJobs: true
+    - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+      parameters:
+        GenerateJobName: generate_build_matrix
+        JobTemplatePath: /eng/pipelines/templates/jobs/batched-build-analyze.yml
+        Pools: # eng/pipelines/templates/stages/build-matrix.json only contains windows OS currently so only pass the Windows pool to avoid the other OS's being marked skipped in DevOps
+          - name: Windows
+            filter: .*Windows.*Pool$
+            os: windows
+        MatrixConfigs:
+        - Name: NET_ci_build_base
+          Path: eng/pipelines/templates/stages/build-matrix.json
+          Selection: sparse
+          GenerateVMJobs: true
+        SparseCheckoutPaths:
+          - "/*"
+          - "!SessionRecords"
+        EnablePRGeneration: true
+        PRMatrixSetting: ProjectNames
+        PRJobBatchSize: 5
+        AdditionalParameters:
+          Artifacts: ${{ parameters.Artifacts }}
+          TestPipeline: ${{ parameters.TestPipeline }}
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          SDKType: ${{ parameters.SDKType }}
+          BuildSnippets: ${{ parameters.BuildSnippets }}
+        PreGenerationSteps:
+          - template: /eng/pipelines/templates/steps/pr-matrix-presteps.yml
+            parameters:
+              ServiceDirectory: ${{ parameters.ServiceDirectory }}
+              PublishingArtifactName: BuildPackagesArtifact
+              ForceDirect: true
+              ExcludePaths: ${{ parameters.ExcludePaths }}
+
+  - ${{ else }}:
+    - job: Build
+      pool:
+        name: $(WINDOWSPOOL)
+        image: $(WINDOWSVMIMAGE)
+        os: windows
+
+      variables:
+      - name: SDKType
+        value: ${{ parameters.SDKType }}
+
+      # Only run CG and codeql on internal build job
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        templateContext:
+          sdl:
+            componentgovernance:
+              enabled: true
+            codeql:
+              # Need to specify the language because we clone after the codeql initialize step
+              language: csharp, javascript
+              compiled:
+                enabled: true
+
+      steps:
+        - template: /eng/pipelines/templates/steps/build.yml
+          parameters:
+            Artifacts: ${{ parameters.Artifacts }}
+            TestPipeline: ${{ parameters.TestPipeline }}
+            ServiceDirectory: ${{ parameters.ServiceDirectory }}
+            SDKType: ${{ parameters.SDKType }}
+
+    - job: "Analyze"
+      timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+      condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))
+
+      pool:
+        name: $(LINUXPOOL)
+        image: $(LINUXVMIMAGE)
+        os: linux
+
+      steps:
+        - template: /eng/pipelines/templates/steps/analyze.yml
+          parameters:
+            Artifacts: ${{ parameters.Artifacts }}
+            ServiceDirectory: ${{ parameters.ServiceDirectory }}
+            SDKType: ${{ parameters.SDKType }}
+            BuildSnippets: ${{ parameters.BuildSnippets }}
+
+  # For some pipelines like mgmt which are tested in aggregate we want to limit the pipeline to no tests or
+  # other stages that are aggregate in nature as those are tested in another aggregate pipeline
+  - ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), ne(parameters.LimitForPullRequest, 'true')) }}:
+    - job: Compliance
+      pool:
+        name: $(WINDOWSPOOL)
+        image: $(WINDOWSVMIMAGE)
+        os: windows
+      steps:
+        - checkout: self
+          fetchFilter: tree:0
+          fetchTags: false
+
+        - task: UsePythonVersion@0
+          displayName: "Use Python 3.11"
+          inputs:
+            versionSpec: "3.11"
+
+        - template: /eng/common/pipelines/templates/steps/validate-filename.yml
+
+        - template: /eng/common/pipelines/templates/steps/check-spelling.yml
+          parameters:
+            ScriptToValidateUpgrade: eng/scripts/spell-check-public-api.ps1
+
+        - template: /eng/common/pipelines/templates/steps/verify-links.yml
+          parameters:
+            ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+              Directory: ''
+              Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
+            ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+              Directory: sdk/${{ parameters.ServiceDirectory }}
+            CheckLinkGuidance: $true
+
+        - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
+          parameters:
+            SourceDirectory: $(Build.SourcesDirectory)
+
+        - template: /eng/common/pipelines/templates/steps/verify-codeowners-sections.yml
+          parameters:
+            Sections:
+              - 'Client Libraries'
+
+        - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
+
+    - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+      parameters:
+        GenerateJobName: generate_target_service_test_matrix
+        JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
+        MatrixConfigs: ${{ parameters.MatrixConfigs }}
+        MatrixFilters: ${{ parameters.MatrixFilters }}
+        MatrixReplace: ${{ parameters.MatrixReplace }}
+        CloudConfig:
+          Cloud: public
+        ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
           SparseCheckoutPaths:
             - "/*"
             - "!SessionRecords"
           EnablePRGeneration: true
           PRMatrixSetting: ProjectNames
-          PRJobBatchSize: 5
-          AdditionalParameters:
-            Artifacts: ${{ parameters.Artifacts }}
-            TestPipeline: ${{ parameters.TestPipeline }}
-            ServiceDirectory: ${{ parameters.ServiceDirectory }}
-            SDKType: ${{ parameters.SDKType }}
-            BuildSnippets: ${{ parameters.BuildSnippets }}
+          PRJobBatchSize: 10
+          PRMatrixIndirectFilters:
+            - 'AdditionalTestArguments=.*true'
+            - 'Pool=.*LinuxPool$'
           PreGenerationSteps:
             - template: /eng/pipelines/templates/steps/pr-matrix-presteps.yml
               parameters:
                 ServiceDirectory: ${{ parameters.ServiceDirectory }}
-                PublishingArtifactName: BuildPackagesArtifact
-                ForceDirect: true
+                PublishingArtifactName: TestPackagesArtifact
                 ExcludePaths: ${{ parameters.ExcludePaths }}
 
-  - ${{ else }}:
-      - job: Build
-        pool:
-          name: $(WINDOWSPOOL)
-          image: $(WINDOWSVMIMAGE)
-          os: windows
-
-        variables:
-          - name: SDKType
-            value: ${{ parameters.SDKType }}
-
-        # Only run CG and codeql on internal build job
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          templateContext:
-            sdl:
-              componentgovernance:
-                enabled: true
-              codeql:
-                # Need to specify the language because we clone after the codeql initialize step
-                language: csharp, javascript
-                compiled:
-                  enabled: true
-
-        steps:
-          - template: /eng/pipelines/templates/steps/build.yml
-            parameters:
-              Artifacts: ${{ parameters.Artifacts }}
-              TestPipeline: ${{ parameters.TestPipeline }}
-              ServiceDirectory: ${{ parameters.ServiceDirectory }}
-              SDKType: ${{ parameters.SDKType }}
-
-      - job: "Analyze"
-        timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
-        condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))
-        pool:
-          name: $(LINUXPOOL)
-          image: $(LINUXVMIMAGE)
-          os: linux
-
-        steps:
-          - template: /eng/pipelines/templates/steps/analyze.yml
-            parameters:
-              Artifacts: ${{ parameters.Artifacts }}
-              ServiceDirectory: ${{ parameters.ServiceDirectory }}
-              SDKType: ${{ parameters.SDKType }}
-              BuildSnippets: ${{ parameters.BuildSnippets }}
-
-  # For some pipelines like mgmt which are tested in aggregate we want to limit the pipeline to no tests or
-  # other stages that are aggregate in nature as those are tested in another aggregate pipeline
-  - ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), ne(parameters.LimitForPullRequest, 'true')) }}:
-      - job: Compliance
-        pool:
-          name: $(WINDOWSPOOL)
-          image: $(WINDOWSVMIMAGE)
-          os: windows
-        steps:
-          - checkout: self
-            fetchFilter: tree:0
-            fetchTags: false
-
-          - task: UsePythonVersion@0
-            displayName: "Use Python 3.11"
-            inputs:
-              versionSpec: "3.11"
-
-          - template: /eng/common/pipelines/templates/steps/validate-filename.yml
-
-          - template: /eng/common/pipelines/templates/steps/check-spelling.yml
-            parameters:
-              ScriptToValidateUpgrade: eng/scripts/spell-check-public-api.ps1
-
-          - template: /eng/common/pipelines/templates/steps/verify-links.yml
-            parameters:
-              ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-                Directory: ""
-                Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-              ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-                Directory: sdk/${{ parameters.ServiceDirectory }}
-              CheckLinkGuidance: $true
-
-          - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
-            parameters:
-              SourceDirectory: $(Build.SourcesDirectory)
-
-          - template: /eng/common/pipelines/templates/steps/verify-codeowners-sections.yml
-            parameters:
-              Sections:
-                - "Client Libraries"
-
-          - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
-
-      - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-        parameters:
-          GenerateJobName: generate_target_service_test_matrix
-          JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
-          MatrixConfigs: ${{ parameters.MatrixConfigs }}
-          MatrixFilters: ${{ parameters.MatrixFilters }}
-          MatrixReplace: ${{ parameters.MatrixReplace }}
-          CloudConfig:
-            Cloud: public
-          ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-            SparseCheckoutPaths:
-              - "/*"
-              - "!SessionRecords"
-            EnablePRGeneration: true
-            PRMatrixSetting: ProjectNames
-            PRJobBatchSize: 10
-            PRMatrixIndirectFilters:
-              - "AdditionalTestArguments=.*true"
-              - "Pool=.*LinuxPool$"
-            PreGenerationSteps:
-              - template: /eng/pipelines/templates/steps/pr-matrix-presteps.yml
-                parameters:
-                  ServiceDirectory: ${{ parameters.ServiceDirectory }}
-                  PublishingArtifactName: TestPackagesArtifact
-                  ExcludePaths: ${{ parameters.ExcludePaths }}
-
-          AdditionalParameters:
-            SDKType: ${{ parameters.SDKType }}
-            ServiceDirectory: ${{ parameters.ServiceDirectory }}
-            TestSetupSteps: ${{ parameters.TestSetupSteps }}
-            TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+        AdditionalParameters:
+          SDKType: ${{ parameters.SDKType }}
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          TestSetupSteps: ${{ parameters.TestSetupSteps }}
+          TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
 
   - ${{ if ne(parameters.TestDependsOnDependency, 'not-specified') }}:
-      - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-        parameters:
-          GenerateJobName: generate_target_dependencies_test_matrix
-          JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
-          MatrixConfigs: ${{ parameters.MatrixConfigs }}
-          MatrixFilters: ${{ parameters.MatrixFilters }}
-          MatrixReplace:
-            # Force UseProjectReferenceToAzureClients option to always be true because we only want to test with ProjectReference for dependency tests
-            - AdditionalTestArguments=\/p:UseProjectReferenceToAzureClients\=false/\/p:UseProjectReferenceToAzureClients\=true
-            - ${{ each matrixReplace in parameters.MatrixReplace }}:
-                - ${{ matrixReplace }}
-          CloudConfig:
-            Cloud: public
-          SparseCheckoutPaths:
-            - /*
-            - "!/sdk/*/**/SessionRecords/*"
-          PreGenerationSteps:
-            - ${{ each config in parameters.MatrixConfigs }}:
-                - template: /eng/pipelines/templates/steps/dependency.tests.yml
-                  parameters:
-                    TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
-                    # The value for ProjectListOverrideFilePropertyName should be the same as AdditionalParameters ProjectListOverrideFilePropertyName below
-                    ProjectListOverrideFilePropertyName: "ProjectListOverrideFile"
-                    ProjectFilesOutputFolder: $(Build.ArtifactStagingDirectory)
-                    ExcludeTargetTestProjects: true
-                    ServiceDirectory: ${{ parameters.ServiceDirectory }}
-                    MatrixConfigsFile: ${{ config.Path }}
-          AdditionalParameters:
-            SDKType: ${{ parameters.SDKType }}
-            ServiceDirectory: ${{ parameters.ServiceDirectory }}
-            TestSetupSteps: ${{ parameters.TestSetupSteps }}
-            TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
-            # The value for ProjectListOverrideFilePropertyName should be the same as dependency.tests.yml parameter ProjectListOverrideFilePropertyName
-            ProjectListOverrideFilePropertyName: "ProjectListOverrideFile"
+    - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+      parameters:
+        GenerateJobName: generate_target_dependencies_test_matrix
+        JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
+        MatrixConfigs: ${{ parameters.MatrixConfigs }}
+        MatrixFilters: ${{ parameters.MatrixFilters }}
+        MatrixReplace:
+          # Force UseProjectReferenceToAzureClients option to always be true because we only want to test with ProjectReference for dependency tests
+          - AdditionalTestArguments=\/p:UseProjectReferenceToAzureClients\=false/\/p:UseProjectReferenceToAzureClients\=true
+          - ${{ each matrixReplace in parameters.MatrixReplace }}:
+              - ${{ matrixReplace }}
+        CloudConfig:
+          Cloud: public
+        SparseCheckoutPaths:
+          - /*
+          - '!/sdk/*/**/SessionRecords/*'
+        PreGenerationSteps:
+          - ${{ each config in parameters.MatrixConfigs }}:
+              - template: /eng/pipelines/templates/steps/dependency.tests.yml
+                parameters:
+                  TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
+                  # The value for ProjectListOverrideFilePropertyName should be the same as AdditionalParameters ProjectListOverrideFilePropertyName below
+                  ProjectListOverrideFilePropertyName: 'ProjectListOverrideFile'
+                  ProjectFilesOutputFolder: $(Build.ArtifactStagingDirectory)
+                  ExcludeTargetTestProjects: true
+                  ServiceDirectory: ${{ parameters.ServiceDirectory }}
+                  MatrixConfigsFile: ${{ config.Path }}
+        AdditionalParameters:
+          SDKType: ${{ parameters.SDKType }}
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+          TestSetupSteps: ${{ parameters.TestSetupSteps }}
+          TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+          # The value for ProjectListOverrideFilePropertyName should be the same as dependency.tests.yml parameter ProjectListOverrideFilePropertyName
+          ProjectListOverrideFilePropertyName: 'ProjectListOverrideFile'

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -45,200 +45,194 @@ parameters:
 
 jobs:
   - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-    - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-      parameters:
-        GenerateJobName: generate_build_matrix
-        JobTemplatePath: /eng/pipelines/templates/jobs/batched-build-analyze.yml
-        Pools: # eng/pipelines/templates/stages/build-matrix.json only contains windows OS currently so only pass the Windows pool to avoid the other OS's being marked skipped in DevOps
-          - name: Windows
-            filter: .*Windows.*Pool$
-            os: windows
-        MatrixConfigs:
-        - Name: NET_ci_build_base
-          Path: eng/pipelines/templates/stages/build-matrix.json
-          Selection: sparse
-          GenerateVMJobs: true
-        SparseCheckoutPaths:
-          - "/*"
-          - "!SessionRecords"
-        EnablePRGeneration: true
-        PRMatrixSetting: ProjectNames
-        PRJobBatchSize: 5
-        AdditionalParameters:
-          Artifacts: ${{ parameters.Artifacts }}
-          TestPipeline: ${{ parameters.TestPipeline }}
-          ServiceDirectory: ${{ parameters.ServiceDirectory }}
-          SDKType: ${{ parameters.SDKType }}
-          BuildSnippets: ${{ parameters.BuildSnippets }}
-        PreGenerationSteps:
-          - template: /eng/pipelines/templates/steps/pr-matrix-presteps.yml
-            parameters:
-              ServiceDirectory: ${{ parameters.ServiceDirectory }}
-              PublishingArtifactName: BuildPackagesArtifact
-              ForceDirect: true
-              ExcludePaths: ${{ parameters.ExcludePaths }}
-
-  - ${{ else }}:
-    - job: Build
-      pool:
-        name: $(WINDOWSPOOL)
-        image: $(WINDOWSVMIMAGE)
-        os: windows
-
-      variables:
-      - name: SDKType
-        value: ${{ parameters.SDKType }}
-
-      # Only run CG and codeql on internal build job
-      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        templateContext:
-          sdl:
-            componentgovernance:
-              enabled: true
-            codeql:
-              # Need to specify the language because we clone after the codeql initialize step
-              language: csharp, javascript
-              compiled:
-                enabled: true
-
-      steps:
-        - template: /eng/pipelines/templates/steps/build.yml
-          parameters:
-            Artifacts: ${{ parameters.Artifacts }}
-            TestPipeline: ${{ parameters.TestPipeline }}
-            ServiceDirectory: ${{ parameters.ServiceDirectory }}
-            SDKType: ${{ parameters.SDKType }}
-
-    - job: "Analyze"
-      timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
-      condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))
-      templateContext:
-        outputs:
-          - output: pipelineArtifact
-            targetPath: '$(Build.ArtifactStagingDirectory)'
-            artifactName: 'verify'
-
-      pool:
-        name: $(LINUXPOOL)
-        image: $(LINUXVMIMAGE)
-        os: linux
-
-      steps:
-        - template: /eng/pipelines/templates/steps/analyze.yml
-          parameters:
-            Artifacts: ${{ parameters.Artifacts }}
-            ServiceDirectory: ${{ parameters.ServiceDirectory }}
-            SDKType: ${{ parameters.SDKType }}
-            BuildSnippets: ${{ parameters.BuildSnippets }}
-
-  # For some pipelines like mgmt which are tested in aggregate we want to limit the pipeline to no tests or
-  # other stages that are aggregate in nature as those are tested in another aggregate pipeline
-  - ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), ne(parameters.LimitForPullRequest, 'true')) }}:
-    - job: Compliance
-      pool:
-        name: $(WINDOWSPOOL)
-        image: $(WINDOWSVMIMAGE)
-        os: windows
-      steps:
-        - checkout: self
-          fetchFilter: tree:0
-          fetchTags: false
-
-        - task: UsePythonVersion@0
-          displayName: "Use Python 3.11"
-          inputs:
-            versionSpec: "3.11"
-
-        - template: /eng/common/pipelines/templates/steps/validate-filename.yml
-
-        - template: /eng/common/pipelines/templates/steps/check-spelling.yml
-          parameters:
-            ScriptToValidateUpgrade: eng/scripts/spell-check-public-api.ps1
-
-        - template: /eng/common/pipelines/templates/steps/verify-links.yml
-          parameters:
-            ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-              Directory: ''
-              Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
-            ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-              Directory: sdk/${{ parameters.ServiceDirectory }}
-            CheckLinkGuidance: $true
-
-        - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
-          parameters:
-            SourceDirectory: $(Build.SourcesDirectory)
-
-        - template: /eng/common/pipelines/templates/steps/verify-codeowners-sections.yml
-          parameters:
-            Sections:
-              - 'Client Libraries'
-
-        - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
-
-    - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-      parameters:
-        GenerateJobName: generate_target_service_test_matrix
-        JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
-        MatrixConfigs: ${{ parameters.MatrixConfigs }}
-        MatrixFilters: ${{ parameters.MatrixFilters }}
-        MatrixReplace: ${{ parameters.MatrixReplace }}
-        CloudConfig:
-          Cloud: public
-        ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+      - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+        parameters:
+          GenerateJobName: generate_build_matrix
+          JobTemplatePath: /eng/pipelines/templates/jobs/batched-build-analyze.yml
+          Pools: # eng/pipelines/templates/stages/build-matrix.json only contains windows OS currently so only pass the Windows pool to avoid the other OS's being marked skipped in DevOps
+            - name: Windows
+              filter: .*Windows.*Pool$
+              os: windows
+          MatrixConfigs:
+            - Name: NET_ci_build_base
+              Path: eng/pipelines/templates/stages/build-matrix.json
+              Selection: sparse
+              GenerateVMJobs: true
           SparseCheckoutPaths:
             - "/*"
             - "!SessionRecords"
           EnablePRGeneration: true
           PRMatrixSetting: ProjectNames
-          PRJobBatchSize: 10
-          PRMatrixIndirectFilters:
-            - 'AdditionalTestArguments=.*true'
-            - 'Pool=.*LinuxPool$'
+          PRJobBatchSize: 5
+          AdditionalParameters:
+            Artifacts: ${{ parameters.Artifacts }}
+            TestPipeline: ${{ parameters.TestPipeline }}
+            ServiceDirectory: ${{ parameters.ServiceDirectory }}
+            SDKType: ${{ parameters.SDKType }}
+            BuildSnippets: ${{ parameters.BuildSnippets }}
           PreGenerationSteps:
             - template: /eng/pipelines/templates/steps/pr-matrix-presteps.yml
               parameters:
                 ServiceDirectory: ${{ parameters.ServiceDirectory }}
-                PublishingArtifactName: TestPackagesArtifact
+                PublishingArtifactName: BuildPackagesArtifact
+                ForceDirect: true
                 ExcludePaths: ${{ parameters.ExcludePaths }}
 
-        AdditionalParameters:
-          SDKType: ${{ parameters.SDKType }}
-          ServiceDirectory: ${{ parameters.ServiceDirectory }}
-          TestSetupSteps: ${{ parameters.TestSetupSteps }}
-          TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+  - ${{ else }}:
+      - job: Build
+        pool:
+          name: $(WINDOWSPOOL)
+          image: $(WINDOWSVMIMAGE)
+          os: windows
+
+        variables:
+          - name: SDKType
+            value: ${{ parameters.SDKType }}
+
+        # Only run CG and codeql on internal build job
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          templateContext:
+            sdl:
+              componentgovernance:
+                enabled: true
+              codeql:
+                # Need to specify the language because we clone after the codeql initialize step
+                language: csharp, javascript
+                compiled:
+                  enabled: true
+
+        steps:
+          - template: /eng/pipelines/templates/steps/build.yml
+            parameters:
+              Artifacts: ${{ parameters.Artifacts }}
+              TestPipeline: ${{ parameters.TestPipeline }}
+              ServiceDirectory: ${{ parameters.ServiceDirectory }}
+              SDKType: ${{ parameters.SDKType }}
+
+      - job: "Analyze"
+        timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+        condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))
+        pool:
+          name: $(LINUXPOOL)
+          image: $(LINUXVMIMAGE)
+          os: linux
+
+        steps:
+          - template: /eng/pipelines/templates/steps/analyze.yml
+            parameters:
+              Artifacts: ${{ parameters.Artifacts }}
+              ServiceDirectory: ${{ parameters.ServiceDirectory }}
+              SDKType: ${{ parameters.SDKType }}
+              BuildSnippets: ${{ parameters.BuildSnippets }}
+
+  # For some pipelines like mgmt which are tested in aggregate we want to limit the pipeline to no tests or
+  # other stages that are aggregate in nature as those are tested in another aggregate pipeline
+  - ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), ne(parameters.LimitForPullRequest, 'true')) }}:
+      - job: Compliance
+        pool:
+          name: $(WINDOWSPOOL)
+          image: $(WINDOWSVMIMAGE)
+          os: windows
+        steps:
+          - checkout: self
+            fetchFilter: tree:0
+            fetchTags: false
+
+          - task: UsePythonVersion@0
+            displayName: "Use Python 3.11"
+            inputs:
+              versionSpec: "3.11"
+
+          - template: /eng/common/pipelines/templates/steps/validate-filename.yml
+
+          - template: /eng/common/pipelines/templates/steps/check-spelling.yml
+            parameters:
+              ScriptToValidateUpgrade: eng/scripts/spell-check-public-api.ps1
+
+          - template: /eng/common/pipelines/templates/steps/verify-links.yml
+            parameters:
+              ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+                Directory: ""
+                Urls: (eng/common/scripts/get-markdown-files-from-changed-files.ps1)
+              ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+                Directory: sdk/${{ parameters.ServiceDirectory }}
+              CheckLinkGuidance: $true
+
+          - template: /eng/common/pipelines/templates/steps/verify-path-length.yml
+            parameters:
+              SourceDirectory: $(Build.SourcesDirectory)
+
+          - template: /eng/common/pipelines/templates/steps/verify-codeowners-sections.yml
+            parameters:
+              Sections:
+                - "Client Libraries"
+
+          - template: /eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
+
+      - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+        parameters:
+          GenerateJobName: generate_target_service_test_matrix
+          JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
+          MatrixConfigs: ${{ parameters.MatrixConfigs }}
+          MatrixFilters: ${{ parameters.MatrixFilters }}
+          MatrixReplace: ${{ parameters.MatrixReplace }}
+          CloudConfig:
+            Cloud: public
+          ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+            SparseCheckoutPaths:
+              - "/*"
+              - "!SessionRecords"
+            EnablePRGeneration: true
+            PRMatrixSetting: ProjectNames
+            PRJobBatchSize: 10
+            PRMatrixIndirectFilters:
+              - "AdditionalTestArguments=.*true"
+              - "Pool=.*LinuxPool$"
+            PreGenerationSteps:
+              - template: /eng/pipelines/templates/steps/pr-matrix-presteps.yml
+                parameters:
+                  ServiceDirectory: ${{ parameters.ServiceDirectory }}
+                  PublishingArtifactName: TestPackagesArtifact
+                  ExcludePaths: ${{ parameters.ExcludePaths }}
+
+          AdditionalParameters:
+            SDKType: ${{ parameters.SDKType }}
+            ServiceDirectory: ${{ parameters.ServiceDirectory }}
+            TestSetupSteps: ${{ parameters.TestSetupSteps }}
+            TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
 
   - ${{ if ne(parameters.TestDependsOnDependency, 'not-specified') }}:
-    - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
-      parameters:
-        GenerateJobName: generate_target_dependencies_test_matrix
-        JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
-        MatrixConfigs: ${{ parameters.MatrixConfigs }}
-        MatrixFilters: ${{ parameters.MatrixFilters }}
-        MatrixReplace:
-          # Force UseProjectReferenceToAzureClients option to always be true because we only want to test with ProjectReference for dependency tests
-          - AdditionalTestArguments=\/p:UseProjectReferenceToAzureClients\=false/\/p:UseProjectReferenceToAzureClients\=true
-          - ${{ each matrixReplace in parameters.MatrixReplace }}:
-              - ${{ matrixReplace }}
-        CloudConfig:
-          Cloud: public
-        SparseCheckoutPaths:
-          - /*
-          - '!/sdk/*/**/SessionRecords/*'
-        PreGenerationSteps:
-          - ${{ each config in parameters.MatrixConfigs }}:
-              - template: /eng/pipelines/templates/steps/dependency.tests.yml
-                parameters:
-                  TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
-                  # The value for ProjectListOverrideFilePropertyName should be the same as AdditionalParameters ProjectListOverrideFilePropertyName below
-                  ProjectListOverrideFilePropertyName: 'ProjectListOverrideFile'
-                  ProjectFilesOutputFolder: $(Build.ArtifactStagingDirectory)
-                  ExcludeTargetTestProjects: true
-                  ServiceDirectory: ${{ parameters.ServiceDirectory }}
-                  MatrixConfigsFile: ${{ config.Path }}
-        AdditionalParameters:
-          SDKType: ${{ parameters.SDKType }}
-          ServiceDirectory: ${{ parameters.ServiceDirectory }}
-          TestSetupSteps: ${{ parameters.TestSetupSteps }}
-          TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
-          # The value for ProjectListOverrideFilePropertyName should be the same as dependency.tests.yml parameter ProjectListOverrideFilePropertyName
-          ProjectListOverrideFilePropertyName: 'ProjectListOverrideFile'
+      - template: /eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+        parameters:
+          GenerateJobName: generate_target_dependencies_test_matrix
+          JobTemplatePath: /eng/pipelines/templates/jobs/ci.tests.yml
+          MatrixConfigs: ${{ parameters.MatrixConfigs }}
+          MatrixFilters: ${{ parameters.MatrixFilters }}
+          MatrixReplace:
+            # Force UseProjectReferenceToAzureClients option to always be true because we only want to test with ProjectReference for dependency tests
+            - AdditionalTestArguments=\/p:UseProjectReferenceToAzureClients\=false/\/p:UseProjectReferenceToAzureClients\=true
+            - ${{ each matrixReplace in parameters.MatrixReplace }}:
+                - ${{ matrixReplace }}
+          CloudConfig:
+            Cloud: public
+          SparseCheckoutPaths:
+            - /*
+            - "!/sdk/*/**/SessionRecords/*"
+          PreGenerationSteps:
+            - ${{ each config in parameters.MatrixConfigs }}:
+                - template: /eng/pipelines/templates/steps/dependency.tests.yml
+                  parameters:
+                    TestDependsOnDependency: ${{ parameters.TestDependsOnDependency }}
+                    # The value for ProjectListOverrideFilePropertyName should be the same as AdditionalParameters ProjectListOverrideFilePropertyName below
+                    ProjectListOverrideFilePropertyName: "ProjectListOverrideFile"
+                    ProjectFilesOutputFolder: $(Build.ArtifactStagingDirectory)
+                    ExcludeTargetTestProjects: true
+                    ServiceDirectory: ${{ parameters.ServiceDirectory }}
+                    MatrixConfigsFile: ${{ config.Path }}
+          AdditionalParameters:
+            SDKType: ${{ parameters.SDKType }}
+            ServiceDirectory: ${{ parameters.ServiceDirectory }}
+            TestSetupSteps: ${{ parameters.TestSetupSteps }}
+            TestTimeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
+            # The value for ProjectListOverrideFilePropertyName should be the same as dependency.tests.yml parameter ProjectListOverrideFilePropertyName
+            ProjectListOverrideFilePropertyName: "ProjectListOverrideFile"

--- a/eng/pipelines/templates/jobs/ci.yml
+++ b/eng/pipelines/templates/jobs/ci.yml
@@ -112,6 +112,11 @@ jobs:
     - job: "Analyze"
       timeoutInMinutes: ${{ parameters.TestTimeoutInMinutes }}
       condition: and(succeededOrFailed(), ne(variables['Skip.Analyze'], true))
+      templateContext:
+        outputs:
+          - output: pipelineArtifact
+            targetPath: '$(Build.ArtifactStagingDirectory)'
+            artifactName: 'verify_$(System.JobName)_$(System.JobAttempt)'
 
       pool:
         name: $(LINUXPOOL)

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -143,3 +143,8 @@ steps:
       parameters:
         ArtifactPath: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'verify_$(System.JobName)'
+  - ${{ else }}:
+    - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+      parameters:
+        ArtifactPath: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: 'verify'

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -14,8 +14,8 @@ parameters:
 
 steps:
   - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
-      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-        parameters:
+    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+      parameters:
           Paths:
             - "/*"
             - "!SessionRecords"
@@ -25,18 +25,18 @@ steps:
   - template: /eng/common/pipelines/templates/steps/cache-ps-modules.yml
 
   - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          artifact: BuildPackagesArtifact
-          path: $(Build.ArtifactStagingDirectory)/PackageInfo
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifact: BuildPackagesArtifact
+        path: $(Build.ArtifactStagingDirectory)/PackageInfo
   - ${{ else }}:
-      - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
-        parameters:
-          ServiceDirectory: ${{ parameters.ServiceDirectory }}
+    - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
+      parameters:
+        ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
     parameters:
-      PackageInfo: "$(Build.ArtifactStagingDirectory)/PackageInfo"
+      PackageInfo: '$(Build.ArtifactStagingDirectory)/PackageInfo'
       Artifacts: ${{ parameters.Artifacts }}
 
   - template: /eng/common/pipelines/templates/steps/verify-samples.yml
@@ -44,32 +44,32 @@ steps:
       ServiceDirectories: "$(ChangedServices)"
 
   - task: UsePythonVersion@0
-    displayName: "Use Python 3.11"
+    displayName: 'Use Python 3.11'
     inputs:
-      versionSpec: "3.11"
+      versionSpec: '3.11'
 
   - template: /eng/common/pipelines/templates/steps/verify-readmes.yml
     parameters:
-      PackagePropertiesFolder: "$(Build.ArtifactStagingDirectory)/PackageInfo"
+      PackagePropertiesFolder: '$(Build.ArtifactStagingDirectory)/PackageInfo'
 
   - task: NodeTool@0
     inputs:
       versionSpec: 20.x
-    displayName: "Use Node 20.x"
+    displayName: 'Use Node 20.x'
 
   # Authenticate npm to Azure Artifacts
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
     parameters:
       npmrcPath: $(Agent.TempDirectory)/analyze-job/.npmrc
-      registryUrl: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
+      registryUrl: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
 
   - task: DotNetCoreCLI@2
-    displayName: "Install Snippet Generator Tool"
+    displayName: 'Install Snippet Generator Tool'
     inputs:
       command: custom
-      custom: "tool"
-      arguments: "restore"
-      workingDirectory: "$(Agent.BuildDirectory)"
+      custom: 'tool'
+      arguments: 'restore'
+      workingDirectory: '$(Agent.BuildDirectory)'
 
   - pwsh: |
       $failed = $false
@@ -138,12 +138,11 @@ steps:
         -BuildConfiguration "$(BuildConfiguration)"
       pwsh: true
 
-  # Publish the analyze output via the shared helper so retry/failed attempts use unique artifact names.
   - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
     parameters:
-      ArtifactPath: "$(Build.ArtifactStagingDirectory)"
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)'
       ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-        ArtifactName: "verify_$(System.JobName)"
+        ArtifactName: 'verify_$(System.JobName)'
       ${{ else }}:
-        ArtifactName: "verify"
+        ArtifactName: 'verify'
       SbomEnabled: false

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -14,8 +14,8 @@ parameters:
 
 steps:
   - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
-    - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-      parameters:
+      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        parameters:
           Paths:
             - "/*"
             - "!SessionRecords"
@@ -25,18 +25,18 @@ steps:
   - template: /eng/common/pipelines/templates/steps/cache-ps-modules.yml
 
   - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        artifact: BuildPackagesArtifact
-        path: $(Build.ArtifactStagingDirectory)/PackageInfo
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifact: BuildPackagesArtifact
+          path: $(Build.ArtifactStagingDirectory)/PackageInfo
   - ${{ else }}:
-    - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
-      parameters:
-        ServiceDirectory: ${{ parameters.ServiceDirectory }}
+      - template: /eng/common/pipelines/templates/steps/save-package-properties.yml
+        parameters:
+          ServiceDirectory: ${{ parameters.ServiceDirectory }}
 
   - template: /eng/pipelines/templates/steps/set-artifact-packages.yml
     parameters:
-      PackageInfo: '$(Build.ArtifactStagingDirectory)/PackageInfo'
+      PackageInfo: "$(Build.ArtifactStagingDirectory)/PackageInfo"
       Artifacts: ${{ parameters.Artifacts }}
 
   - template: /eng/common/pipelines/templates/steps/verify-samples.yml
@@ -44,32 +44,32 @@ steps:
       ServiceDirectories: "$(ChangedServices)"
 
   - task: UsePythonVersion@0
-    displayName: 'Use Python 3.11'
+    displayName: "Use Python 3.11"
     inputs:
-      versionSpec: '3.11'
+      versionSpec: "3.11"
 
   - template: /eng/common/pipelines/templates/steps/verify-readmes.yml
     parameters:
-      PackagePropertiesFolder: '$(Build.ArtifactStagingDirectory)/PackageInfo'
+      PackagePropertiesFolder: "$(Build.ArtifactStagingDirectory)/PackageInfo"
 
   - task: NodeTool@0
     inputs:
       versionSpec: 20.x
-    displayName: 'Use Node 20.x'
+    displayName: "Use Node 20.x"
 
   # Authenticate npm to Azure Artifacts
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
     parameters:
       npmrcPath: $(Agent.TempDirectory)/analyze-job/.npmrc
-      registryUrl: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
+      registryUrl: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
 
   - task: DotNetCoreCLI@2
-    displayName: 'Install Snippet Generator Tool'
+    displayName: "Install Snippet Generator Tool"
     inputs:
       command: custom
-      custom: 'tool'
-      arguments: 'restore'
-      workingDirectory: '$(Agent.BuildDirectory)'
+      custom: "tool"
+      arguments: "restore"
+      workingDirectory: "$(Agent.BuildDirectory)"
 
   - pwsh: |
       $failed = $false
@@ -138,8 +138,12 @@ steps:
         -BuildConfiguration "$(BuildConfiguration)"
       pwsh: true
 
-  - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
-    - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-      parameters:
-        ArtifactPath: '$(Build.ArtifactStagingDirectory)'
-        ArtifactName: 'verify_$(System.JobName)'
+  # Publish the analyze output via the shared helper so retry/failed attempts use unique artifact names.
+  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+    parameters:
+      ArtifactPath: "$(Build.ArtifactStagingDirectory)"
+      ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+        ArtifactName: "verify_$(System.JobName)"
+      ${{ else }}:
+        ArtifactName: "verify"
+      SbomEnabled: false

--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -138,11 +138,8 @@ steps:
         -BuildConfiguration "$(BuildConfiguration)"
       pwsh: true
 
-  - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-    parameters:
-      ArtifactPath: '$(Build.ArtifactStagingDirectory)'
-      ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+  - ${{ if eq(parameters.ServiceDirectory, 'auto') }}:
+    - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+      parameters:
+        ArtifactPath: '$(Build.ArtifactStagingDirectory)'
         ArtifactName: 'verify_$(System.JobName)'
-      ${{ else }}:
-        ArtifactName: 'verify'
-      SbomEnabled: false


### PR DESCRIPTION
Fixes https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6169817&view=logs&j=3facec84-71ec-57ab-8937-e7da3fbb0ee2&t=d3bf9238-44a1-57b3-970c-6f428f376433&l=32
This is blocking the release for Azure.ResourceManager.KubernetesConfiguration.Extensions

## Summary
- keep the existing Analyze job flow unchanged
- make the shared `verify` pipeline artifact name retry-safe
- prevent `Artifact verify already exists for build ...` on reattempts within the same run

## Change
This PR only updates the Analyze job artifact name in `eng/pipelines/templates/jobs/ci.yml`:

- from `verify`
- to `verify_$(System.JobName)_$(System.JobAttempt)`

## Why
Azure DevOps pipeline artifacts are immutable per build run. A fixed artifact name can collide when the Analyze job is re-attempted within the same build.
