### PR TITLE
[Mgmt] Preserve WritableSubResource ID flattening compatibility

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Primitives/KnownManagementTypes.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Primitives/KnownManagementTypes.cs
@@ -52,6 +52,12 @@ namespace Azure.Generator.Management.Primitives
             ["Azure.ResourceManager.CommonTypes.ErrorDetail"] = typeof(ResponseError),
         };
 
+        private static readonly IReadOnlyDictionary<CSharpType, FlattenableSystemPropertyInfo> _flattenableSystemPropertyMap = new Dictionary<CSharpType, FlattenableSystemPropertyInfo>(new CSharpFullNameComparer())
+        {
+            [typeof(SubResource)] = new("Id", typeof(ResourceIdentifier), "id", HasPublicSetter: false, CanInstantiate: false),
+            [typeof(WritableSubResource)] = new("Id", typeof(ResourceIdentifier), "id", HasPublicSetter: true, CanInstantiate: true),
+        };
+
         private static readonly Dictionary<string, CSharpType> _idToPrimitiveTypeMap = new Dictionary<string, CSharpType>()
         {
             ["Azure.Core.armResourceType"] = typeof(ResourceType),
@@ -97,6 +103,9 @@ namespace Azure.Generator.Management.Primitives
 
         public static bool TryGetSystemType(string id, [MaybeNullWhen(false)] out CSharpType type) => _idToSystemTypeMap.TryGetValue(id, out type);
 
+        public static bool TryGetFlattenableSystemProperty(CSharpType type, [MaybeNullWhen(false)] out FlattenableSystemPropertyInfo propertyInfo)
+            => _flattenableSystemPropertyMap.TryGetValue(type.WithNullable(false), out propertyInfo);
+
         // The comparison could be CSharpType from Azure.ResourceManager, which is a framework type
         // and CSharpType from InheritableSystemObjectModelProvider, which is not a framework type, they should still be equal if namespace and name match
         // Then, the default Equals of CSharpType doesn't apply here
@@ -129,5 +138,7 @@ namespace Azure.Generator.Management.Primitives
 
         public static bool TryGetJsonDeserializationExpression(CSharpType type, [MaybeNullWhen(false)] out DeserializationExpression expression)
             => _typeToDeserializationExpression.TryGetValue(type.WithNullable(false), out expression);
+
+        internal sealed record FlattenableSystemPropertyInfo(string Name, CSharpType Type, string SerializedName, bool HasPublicSetter, bool CanInstantiate);
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Primitives/KnownManagementTypes.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Primitives/KnownManagementTypes.cs
@@ -52,7 +52,11 @@ namespace Azure.Generator.Management.Primitives
             ["Azure.ResourceManager.CommonTypes.ErrorDetail"] = typeof(ResponseError),
         };
 
-        private static readonly IReadOnlyDictionary<CSharpType, FlattenableSystemPropertyInfo> _flattenableSystemPropertyMap = new Dictionary<CSharpType, FlattenableSystemPropertyInfo>(new CSharpFullNameComparer())
+        private static readonly IReadOnlyDictionary<CSharpType, IReadOnlyList<string>> _systemTypeToIdsMap = _idToSystemTypeMap
+            .GroupBy(kvp => kvp.Value, kvp => kvp.Key, new CSharpFullNameComparer())
+            .ToDictionary(group => group.Key, group => (IReadOnlyList<string>)group.ToList(), new CSharpFullNameComparer());
+
+        private static readonly IReadOnlyDictionary<CSharpType, FlattenableSystemPropertyInfo> _flattenableSystemPropertyOverrides = new Dictionary<CSharpType, FlattenableSystemPropertyInfo>(new CSharpFullNameComparer())
         {
             [typeof(SubResource)] = new("Id", typeof(ResourceIdentifier), "id", HasPublicSetter: false, CanInstantiate: false),
             [typeof(WritableSubResource)] = new("Id", typeof(ResourceIdentifier), "id", HasPublicSetter: true, CanInstantiate: true),
@@ -103,8 +107,11 @@ namespace Azure.Generator.Management.Primitives
 
         public static bool TryGetSystemType(string id, [MaybeNullWhen(false)] out CSharpType type) => _idToSystemTypeMap.TryGetValue(id, out type);
 
-        public static bool TryGetFlattenableSystemProperty(CSharpType type, [MaybeNullWhen(false)] out FlattenableSystemPropertyInfo propertyInfo)
-            => _flattenableSystemPropertyMap.TryGetValue(type.WithNullable(false), out propertyInfo);
+        public static bool TryGetSystemTypeDefinitionIds(CSharpType type, [MaybeNullWhen(false)] out IReadOnlyList<string> definitionIds)
+            => _systemTypeToIdsMap.TryGetValue(type.WithNullable(false), out definitionIds);
+
+        public static bool TryGetFlattenableSystemPropertyOverride(CSharpType type, [MaybeNullWhen(false)] out FlattenableSystemPropertyInfo propertyInfo)
+            => _flattenableSystemPropertyOverrides.TryGetValue(type.WithNullable(false), out propertyInfo);
 
         // The comparison could be CSharpType from Azure.ResourceManager, which is a framework type
         // and CSharpType from InheritableSystemObjectModelProvider, which is not a framework type, they should still be equal if namespace and name match
@@ -138,7 +145,6 @@ namespace Azure.Generator.Management.Primitives
 
         public static bool TryGetJsonDeserializationExpression(CSharpType type, [MaybeNullWhen(false)] out DeserializationExpression expression)
             => _typeToDeserializationExpression.TryGetValue(type.WithNullable(false), out expression);
-
         internal sealed record FlattenableSystemPropertyInfo(string Name, CSharpType Type, string SerializedName, bool HasPublicSetter, bool CanInstantiate);
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -15,7 +15,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Reflection;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Management.Visitors
@@ -728,28 +727,17 @@ namespace Azure.Generator.Management.Visitors
         private static bool TryGetSinglePropertyFromFrameworkType(CSharpType type, [NotNullWhen(true)] out FrameworkSinglePropertyInfo? singleProperty)
         {
             singleProperty = null;
-            if (!type.IsFrameworkType || type.FrameworkType is null || !KnownManagementTypes.IsKnownManagementType(type))
+            if (!KnownManagementTypes.TryGetFlattenableSystemProperty(type, out var propertyInfo))
             {
                 return false;
             }
 
-            var properties = type.FrameworkType
-                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .Where(p => p.GetMethod is not null && p.GetIndexParameters().Length == 0 && p.GetCustomAttribute<ObsoleteAttribute>() is null)
-                .ToList();
-
-            if (properties.Count != 1)
-            {
-                return false;
-            }
-
-            var property = properties[0];
-            bool canInstantiate = type.FrameworkType.IsValueType || type.FrameworkType.GetConstructor(Type.EmptyTypes) is not null;
             singleProperty = new FrameworkSinglePropertyInfo(
-                property.Name,
-                new CSharpType(property.PropertyType),
-                property.SetMethod?.IsPublic == true,
-                canInstantiate);
+                propertyInfo.Name,
+                propertyInfo.Type,
+                propertyInfo.HasPublicSetter,
+                propertyInfo.CanInstantiate,
+                propertyInfo.SerializedName);
             return true;
         }
 
@@ -763,7 +751,7 @@ namespace Azure.Generator.Management.Visitors
                     internalProperty.WireInfo.IsReadOnly,
                     internalProperty.WireInfo.IsNullable,
                     false,
-                    singleProperty.Name.ToVariableName(),
+                    singleProperty.SerializedName,
                     false,
                     false);
             var idProperty = new PropertyProvider(
@@ -1170,7 +1158,7 @@ namespace Azure.Generator.Management.Visitors
             }
         }
 
-        private sealed record FrameworkSinglePropertyInfo(string Name, CSharpType Type, bool HasPublicSetter, bool CanInstantiate)
+        private sealed record FrameworkSinglePropertyInfo(string Name, CSharpType Type, bool HasPublicSetter, bool CanInstantiate, string SerializedName)
         {
             internal bool IsReadOnly => !HasPublicSetter;
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -4,7 +4,6 @@
 using Azure.Core;
 using Azure.Generator.Management.Primitives;
 using Azure.Generator.Management.Utilities;
-using Azure.ResourceManager.Resources.Models;
 using Microsoft.TypeSpec.Generator.ClientModel;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
@@ -16,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Reflection;
 using static Microsoft.TypeSpec.Generator.Snippets.Snippet;
 
 namespace Azure.Generator.Management.Visitors
@@ -580,14 +580,12 @@ namespace Azure.Generator.Management.Visitors
             {
                 // only flatten complex type properties
                 var propertyType = internalProperty.Type;
-                if (IsResourceIdentifierWrapperType(propertyType))
-                {
-                    isSafeFlatten = SafeFlattenResourceIdentifierWrapper(model, propertyMap, internalProperty) || isSafeFlatten;
-                    continue;
-                }
-
                 if (!TryGetModelProvider(propertyType, out var modelProvider))
                 {
+                    if (TryGetSinglePropertyFromFrameworkType(propertyType, out var singleProperty))
+                    {
+                        isSafeFlatten = SafeFlattenFrameworkSingleProperty(model, propertyMap, internalProperty, singleProperty) || isSafeFlatten;
+                    }
                     continue;
                 }
 
@@ -727,17 +725,35 @@ namespace Azure.Generator.Management.Visitors
                 innerPropertyWireInfo.IsApiVersion);
         }
 
-        private static bool IsResourceIdentifierWrapperType(CSharpType type)
+        private static bool TryGetSinglePropertyFromFrameworkType(CSharpType type, [NotNullWhen(true)] out FrameworkSinglePropertyInfo? singleProperty)
         {
-            var nonNullableType = type.WithNullable(false);
-            return nonNullableType.AreNamesEqual(typeof(WritableSubResource))
-                || nonNullableType.AreNamesEqual(typeof(SubResource));
+            singleProperty = null;
+            if (!type.IsFrameworkType || type.FrameworkType is null || !KnownManagementTypes.IsKnownManagementType(type))
+            {
+                return false;
+            }
+
+            var properties = type.FrameworkType
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(p => p.GetMethod is not null && p.GetIndexParameters().Length == 0 && p.GetCustomAttribute<ObsoleteAttribute>() is null)
+                .ToList();
+
+            if (properties.Count != 1)
+            {
+                return false;
+            }
+
+            var property = properties[0];
+            bool canInstantiate = type.FrameworkType.IsValueType || type.FrameworkType.GetConstructor(Type.EmptyTypes) is not null;
+            singleProperty = new FrameworkSinglePropertyInfo(
+                property.Name,
+                new CSharpType(property.PropertyType),
+                property.SetMethod?.IsPublic == true,
+                canInstantiate);
+            return true;
         }
 
-        private static bool IsWritableResourceIdentifierWrapperType(CSharpType type)
-            => type.WithNullable(false).AreNamesEqual(typeof(WritableSubResource));
-
-        private bool SafeFlattenResourceIdentifierWrapper(ModelProvider model, Dictionary<PropertyProvider, List<FlattenPropertyInfo>> propertyMap, PropertyProvider internalProperty)
+        private bool SafeFlattenFrameworkSingleProperty(ModelProvider model, Dictionary<PropertyProvider, List<FlattenPropertyInfo>> propertyMap, PropertyProvider internalProperty, FrameworkSinglePropertyInfo singleProperty)
         {
             var idWireInfo = internalProperty.WireInfo is null
                 ? null
@@ -747,29 +763,33 @@ namespace Azure.Generator.Management.Visitors
                     internalProperty.WireInfo.IsReadOnly,
                     internalProperty.WireInfo.IsNullable,
                     false,
-                    "id",
+                    singleProperty.Name.ToVariableName(),
                     false,
                     false);
             var idProperty = new PropertyProvider(
                 internalProperty.Description,
                 internalProperty.Modifiers,
-                typeof(ResourceIdentifier),
-                "Id",
-                new AutoPropertyBody(false),
+                singleProperty.Type,
+                singleProperty.Name,
+                new AutoPropertyBody(!singleProperty.IsReadOnly),
                 model,
                 explicitInterface: internalProperty.ExplicitInterface,
                 wireInfo: idWireInfo,
                 isRef: internalProperty.IsRef,
                 attributes: internalProperty.Attributes);
 
+            var isOverriddenValueType = singleProperty.Type.IsValueType && !singleProperty.Type.IsNullable;
+            var flattenedType = isOverriddenValueType
+                ? singleProperty.Type.WithNullable(true)
+                : singleProperty.Type;
             var flattenedProperty = new FlattenedPropertyProvider(
                 internalProperty.Description,
                 internalProperty.Modifiers,
-                typeof(ResourceIdentifier),
+                flattenedType,
                 PropertyHelpers.GetCombinedPropertyName(idProperty, internalProperty),
                 new MethodPropertyBody(
-                    BuildResourceIdentifierWrapperGetter(internalProperty),
-                    !internalProperty.Body.HasSetter || !IsWritableResourceIdentifierWrapperType(internalProperty.Type) ? null : BuildResourceIdentifierWrapperSetter(internalProperty)),
+                    BuildFrameworkSinglePropertyGetter(internalProperty, singleProperty),
+                    !internalProperty.Body.HasSetter || singleProperty.IsReadOnly || !singleProperty.CanInstantiate ? null : BuildFrameworkSinglePropertySetter(internalProperty, singleProperty, isOverriddenValueType)),
                 model,
                 internalProperty,
                 idProperty,
@@ -790,25 +810,29 @@ namespace Azure.Generator.Management.Visitors
             return true;
         }
 
-        private static MethodBodyStatement BuildResourceIdentifierWrapperGetter(PropertyProvider internalProperty)
+        private static MethodBodyStatement BuildFrameworkSinglePropertyGetter(PropertyProvider internalProperty, FrameworkSinglePropertyInfo singleProperty)
         {
             var internalPropertyExpression = This.Property(internalProperty.Name);
             return Return(new TernaryConditionalExpression(
                 internalPropertyExpression.Is(Null),
                 Default,
-                internalPropertyExpression.Property("Id")));
+                internalPropertyExpression.Property(singleProperty.Name)));
         }
 
-        private static MethodBodyStatement BuildResourceIdentifierWrapperSetter(PropertyProvider internalProperty)
+        private static MethodBodyStatement BuildFrameworkSinglePropertySetter(PropertyProvider internalProperty, FrameworkSinglePropertyInfo singleProperty, bool isOverriddenValueType)
         {
             var internalPropertyExpression = This.Property(internalProperty.Name);
-            return new MethodBodyStatements([
-                new IfStatement(internalPropertyExpression.Is(Null))
+            var statements = new List<MethodBodyStatement>();
+            if (!internalProperty.Type.IsValueType)
+            {
+                statements.Add(new IfStatement(internalPropertyExpression.Is(Null))
                 {
                     internalPropertyExpression.Assign(New.Instance(internalProperty.Type)).Terminate()
-                },
-                internalPropertyExpression.Property("Id").Assign(Value).Terminate()
-            ]);
+                });
+            }
+            statements.Add(internalPropertyExpression.Property(singleProperty.Name).Assign(
+                isOverriddenValueType ? Value.Property(nameof(Nullable<int>.Value)) : Value).Terminate());
+            return new MethodBodyStatements(statements);
         }
 
         private bool SafeFlatten(ModelProvider model, IReadOnlyList<PropertyProvider> innerProperties, Dictionary<PropertyProvider, List<FlattenPropertyInfo>> propertyMap, PropertyProvider internalProperty, ModelProvider modelProvider)
@@ -1144,6 +1168,11 @@ namespace Azure.Generator.Management.Visitors
                 hashCode.Add(obj.Name);
                 return hashCode.ToHashCode();
             }
+        }
+
+        private sealed record FrameworkSinglePropertyInfo(string Name, CSharpType Type, bool HasPublicSetter, bool CanInstantiate)
+        {
+            internal bool IsReadOnly => !HasPublicSetter;
         }
 
         private record FlattenPropertyInfo(PropertyProvider FlattenedProperty, PropertyProvider InternalProperty);

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Core;
 using Azure.Generator.Management.Primitives;
 using Azure.Generator.Management.Utilities;
+using Azure.ResourceManager.Resources.Models;
 using Microsoft.TypeSpec.Generator.ClientModel;
 using Microsoft.TypeSpec.Generator.Expressions;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
@@ -578,6 +580,12 @@ namespace Azure.Generator.Management.Visitors
             {
                 // only flatten complex type properties
                 var propertyType = internalProperty.Type;
+                if (IsResourceIdentifierWrapperType(propertyType))
+                {
+                    isSafeFlatten = SafeFlattenResourceIdentifierWrapper(model, propertyMap, internalProperty) || isSafeFlatten;
+                    continue;
+                }
+
                 if (!TryGetModelProvider(propertyType, out var modelProvider))
                 {
                     continue;
@@ -717,6 +725,90 @@ namespace Azure.Generator.Management.Visitors
                 innerPropertyWireInfo.SerializedName,
                 innerPropertyWireInfo.IsHttpMetadata,
                 innerPropertyWireInfo.IsApiVersion);
+        }
+
+        private static bool IsResourceIdentifierWrapperType(CSharpType type)
+        {
+            var nonNullableType = type.WithNullable(false);
+            return nonNullableType.AreNamesEqual(typeof(WritableSubResource))
+                || nonNullableType.AreNamesEqual(typeof(SubResource));
+        }
+
+        private static bool IsWritableResourceIdentifierWrapperType(CSharpType type)
+            => type.WithNullable(false).AreNamesEqual(typeof(WritableSubResource));
+
+        private bool SafeFlattenResourceIdentifierWrapper(ModelProvider model, Dictionary<PropertyProvider, List<FlattenPropertyInfo>> propertyMap, PropertyProvider internalProperty)
+        {
+            var idWireInfo = internalProperty.WireInfo is null
+                ? null
+                : new PropertyWireInformation(
+                    internalProperty.WireInfo.SerializationFormat,
+                    internalProperty.WireInfo.IsRequired,
+                    internalProperty.WireInfo.IsReadOnly,
+                    internalProperty.WireInfo.IsNullable,
+                    false,
+                    "id",
+                    false,
+                    false);
+            var idProperty = new PropertyProvider(
+                internalProperty.Description,
+                internalProperty.Modifiers,
+                typeof(ResourceIdentifier),
+                "Id",
+                new AutoPropertyBody(false),
+                model,
+                explicitInterface: internalProperty.ExplicitInterface,
+                wireInfo: idWireInfo,
+                isRef: internalProperty.IsRef,
+                attributes: internalProperty.Attributes);
+
+            var flattenedProperty = new FlattenedPropertyProvider(
+                internalProperty.Description,
+                internalProperty.Modifiers,
+                typeof(ResourceIdentifier),
+                PropertyHelpers.GetCombinedPropertyName(idProperty, internalProperty),
+                new MethodPropertyBody(
+                    BuildResourceIdentifierWrapperGetter(internalProperty),
+                    !internalProperty.Body.HasSetter || !IsWritableResourceIdentifierWrapperType(internalProperty.Type) ? null : BuildResourceIdentifierWrapperSetter(internalProperty)),
+                model,
+                internalProperty,
+                idProperty,
+                internalProperty.ExplicitInterface,
+                ConstructFlattenPropertyWireInfo(internalProperty, idProperty),
+                internalProperty.IsRef,
+                internalProperty.Attributes);
+
+            internalProperty.Update(modifiers: internalProperty.Modifiers & ~MethodSignatureModifiers.Public | MethodSignatureModifiers.Internal);
+            if (propertyMap.TryGetValue(internalProperty, out var value))
+            {
+                value.Add(new(flattenedProperty, internalProperty));
+            }
+            else
+            {
+                propertyMap.Add(internalProperty, new List<FlattenPropertyInfo> { new(flattenedProperty, internalProperty) });
+            }
+            return true;
+        }
+
+        private static MethodBodyStatement BuildResourceIdentifierWrapperGetter(PropertyProvider internalProperty)
+        {
+            var internalPropertyExpression = This.Property(internalProperty.Name);
+            return Return(new TernaryConditionalExpression(
+                internalPropertyExpression.Is(Null),
+                Default,
+                internalPropertyExpression.Property("Id")));
+        }
+
+        private static MethodBodyStatement BuildResourceIdentifierWrapperSetter(PropertyProvider internalProperty)
+        {
+            var internalPropertyExpression = This.Property(internalProperty.Name);
+            return new MethodBodyStatements([
+                new IfStatement(internalPropertyExpression.Is(Null))
+                {
+                    internalPropertyExpression.Assign(New.Instance(internalProperty.Type)).Terminate()
+                },
+                internalPropertyExpression.Property("Id").Assign(Value).Terminate()
+            ]);
         }
 
         private bool SafeFlatten(ModelProvider model, IReadOnlyList<PropertyProvider> innerProperties, Dictionary<PropertyProvider, List<FlattenPropertyInfo>> propertyMap, PropertyProvider internalProperty, ModelProvider modelProvider)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -727,18 +727,58 @@ namespace Azure.Generator.Management.Visitors
         private static bool TryGetSinglePropertyFromFrameworkType(CSharpType type, [NotNullWhen(true)] out FrameworkSinglePropertyInfo? singleProperty)
         {
             singleProperty = null;
-            if (!KnownManagementTypes.TryGetFlattenableSystemProperty(type, out var propertyInfo))
+            if (!KnownManagementTypes.TryGetSystemTypeDefinitionIds(type, out var definitionIds))
             {
                 return false;
             }
 
-            singleProperty = new FrameworkSinglePropertyInfo(
-                propertyInfo.Name,
-                propertyInfo.Type,
-                propertyInfo.HasPublicSetter,
-                propertyInfo.CanInstantiate,
-                propertyInfo.SerializedName);
-            return true;
+            foreach (var definitionId in definitionIds)
+            {
+                if (!ManagementClientGenerator.Instance.InputLibrary.ModelsByCrossLanguageDefinitionId.TryGetValue(definitionId, out var inputModel))
+                {
+                    continue;
+                }
+
+                var flattenableProperties = inputModel.Properties
+                    .Where(p => !p.IsDiscriminator)
+                    .ToArray();
+
+                if (flattenableProperties.Length != 1)
+                {
+                    continue;
+                }
+
+                var inputProperty = flattenableProperties[0];
+                var propertyType = ManagementClientGenerator.Instance.TypeFactory.CreateCSharpType(inputProperty.Type);
+                if (propertyType is null)
+                {
+                    continue;
+                }
+
+                var propertyName = inputProperty.Name.ToIdentifierName();
+                var serializedName = inputProperty.SerializedName;
+                var hasPublicSetter = !inputProperty.IsReadOnly;
+                var canInstantiate = !inputProperty.IsReadOnly;
+
+                if (KnownManagementTypes.TryGetFlattenableSystemPropertyOverride(type, out var propertyOverride))
+                {
+                    propertyName = propertyOverride.Name;
+                    propertyType = propertyOverride.Type;
+                    serializedName = propertyOverride.SerializedName;
+                    hasPublicSetter = propertyOverride.HasPublicSetter;
+                    canInstantiate = propertyOverride.CanInstantiate;
+                }
+
+                singleProperty = new FrameworkSinglePropertyInfo(
+                    propertyName,
+                    propertyType,
+                    hasPublicSetter,
+                    canInstantiate,
+                    serializedName);
+                return true;
+            }
+
+            return false;
         }
 
         private bool SafeFlattenFrameworkSingleProperty(ModelProvider model, Dictionary<PropertyProvider, List<FlattenPropertyInfo>> propertyMap, PropertyProvider internalProperty, FrameworkSinglePropertyInfo singleProperty)

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Core;
 using Azure.Generator.Management;
 using Azure.Generator.Management.Tests.Common;
 using Azure.Generator.Management.Tests.TestHelpers;
@@ -164,6 +165,89 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(rendered, Does.Not.Match(@"\breturn\s+(?:this\.)?Data\.Errors;"));
         }
 
+        [Test]
+        public void TestFlattenPropertyProjectsWritableSubResourceToLegacyIdShape()
+        {
+            var writableSubResourceModel = CreateKnownManagementModel("WritableSubResource", "Azure.ResourceManager.Models.WritableSubResource");
+
+            var virtualNetworkLinkProperty = InputFactory.Property(
+                "virtualNetworkLink",
+                writableSubResourceModel,
+                isRequired: false,
+                serializedName: "virtualNetworkLink");
+            var linkPropertiesModel = InputFactory.Model(
+                "LinkProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [virtualNetworkLinkProperty]);
+
+            var propertiesProperty = InputFactory.Property("properties", linkPropertiesModel, isRequired: false, serializedName: "properties");
+            ApplyFlattenDecorator(propertiesProperty);
+
+            var rulesetModel = InputFactory.Model(
+                "VirtualNetworkDnsForwardingRuleset",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [propertiesProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [rulesetModel, linkPropertiesModel, writableSubResourceModel]);
+
+            var model = plugin.Object.TypeFactory.CreateModel(rulesetModel);
+            Assert.IsNotNull(model);
+
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(visitTypeCore, "Could not find LibraryVisitor.VisitTypeCore method");
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [model]);
+            }
+
+            var projectedProperty = model!.Properties.FirstOrDefault(p => p.Name == "VirtualNetworkLinkId");
+            Assert.IsNotNull(projectedProperty, "Flattened WritableSubResource should project to a legacy ...Id property");
+            Assert.AreEqual(typeof(ResourceIdentifier), projectedProperty!.Type.FrameworkType);
+            Assert.IsTrue(projectedProperty.Body.HasSetter, "WritableSubResource Id projection should preserve a setter");
+            Assert.IsNull(model.Properties.FirstOrDefault(p => p.Name == "VirtualNetworkLink"));
+        }
+
+        [Test]
+        public void TestSafeFlattenProjectsSubResourceToReadOnlyLegacyIdShape()
+        {
+            var subResourceModel = CreateKnownManagementModel("SubResource", "Azure.ResourceManager.Models.SubResource");
+            var privateEndpointProperty = InputFactory.Property(
+                "privateEndpoint",
+                subResourceModel,
+                isRequired: false,
+                isReadOnly: true,
+                serializedName: "privateEndpoint");
+            var connectionPropertiesModel = InputFactory.Model(
+                "PrivateEndpointConnectionProperties",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [privateEndpointProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [connectionPropertiesModel, subResourceModel]);
+
+            var model = plugin.Object.TypeFactory.CreateModel(connectionPropertiesModel);
+            Assert.IsNotNull(model);
+
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(visitTypeCore, "Could not find LibraryVisitor.VisitTypeCore method");
+
+            foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+            {
+                visitTypeCore!.Invoke(visitor, [model]);
+            }
+
+            var projectedProperty = model!.Properties.FirstOrDefault(p => p.Name == "PrivateEndpointId");
+            Assert.IsNotNull(projectedProperty, "Flattened SubResource should project to a legacy ...Id property");
+            Assert.AreEqual(typeof(ResourceIdentifier), projectedProperty!.Type.FrameworkType);
+            Assert.IsFalse(projectedProperty.Body.HasSetter, "SubResource Id projection should remain read-only");
+        }
+
         /// <summary>
         /// Verifies that FixBackwardCompatOverloads correctly reorders arguments in
         /// backward-compat overloads when the primary method's parameter order has changed
@@ -275,6 +359,29 @@ namespace Azure.Generator.Mgmt.Tests
                 BindingFlags.Public | BindingFlags.Instance);
             Assert.IsNotNull(decoratorsProperty, "Could not find InputModelProperty.Decorators property");
             decoratorsProperty!.SetValue(property, new[] { decorator });
+        }
+
+        private static InputModelType CreateKnownManagementModel(string name, string crossLanguageDefinitionId)
+        {
+            return new InputModelType(
+                name,
+                "Azure.ResourceManager.Models",
+                crossLanguageDefinitionId,
+                "public",
+                null,
+                null,
+                $"{name} description",
+                InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                [InputFactory.Property("id", InputPrimitiveType.String, serializedName: "id")],
+                null,
+                [],
+                null,
+                null,
+                new Dictionary<string, InputModelType>().AsReadOnly(),
+                null,
+                false,
+                new(),
+                false);
         }
 
         /// <summary>

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/FooData.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/FooData.cs
@@ -209,24 +209,6 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
             }
         }
 
-        /// <summary> WritableSubResource property for testing WritableSubResource type replacement. </summary>
-        [WirePath("properties.writableSubResourceProp")]
-        public WritableSubResource WritableSubResourceProp
-        {
-            get
-            {
-                return Properties is null ? default : Properties.WritableSubResourceProp;
-            }
-            set
-            {
-                if (Properties is null)
-                {
-                    Properties = new FooProperties();
-                }
-                Properties.WritableSubResourceProp = value;
-            }
-        }
-
         /// <summary> Gets or sets the Properties. </summary>
         [WirePath("properties.nestedProperty.properties")]
         public FooProperties NestedPropertyProperties
@@ -270,6 +252,24 @@ namespace Azure.Generator.MgmtTypeSpec.Tests
                     Properties = new FooProperties();
                 }
                 return Properties.VmGalleryApplications;
+            }
+        }
+
+        /// <summary> WritableSubResource property for testing WritableSubResource type replacement. </summary>
+        [WirePath("properties.writableSubResourceProp.id")]
+        public ResourceIdentifier WritableSubResourcePropId
+        {
+            get
+            {
+                return Properties is null ? default : Properties.WritableSubResourcePropId;
+            }
+            set
+            {
+                if (Properties is null)
+                {
+                    Properties = new FooProperties();
+                }
+                Properties.WritableSubResourcePropId = value;
             }
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
@@ -79,17 +79,16 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 properties);
         }
 
-        /// <summary> Properties of the private endpoint connection. </summary>
         /// <param name="groupIds"> The group ids for the private endpoint resource. </param>
-        /// <param name="privateEndpoint"> The private endpoint resource. </param>
+        /// <param name="privateEndpointId"> The private endpoint resource. </param>
         /// <param name="privateLinkServiceConnectionState"> A collection of information about the state of the connection between service consumer and provider. </param>
         /// <param name="provisioningState"> The provisioning state of the private endpoint connection resource. </param>
         /// <returns> A new <see cref="Models.PrivateEndpointConnectionProperties"/> instance for mocking. </returns>
-        public static PrivateEndpointConnectionProperties PrivateEndpointConnectionProperties(IEnumerable<string> groupIds = default, SubResource privateEndpoint = default, AzureGeneratorMgmtTypeSpecTestsPrivateLinkServiceConnectionState privateLinkServiceConnectionState = default, AzureGeneratorMgmtTypeSpecTestsPrivateEndpointConnectionProvisioningState? provisioningState = default)
+        public static PrivateEndpointConnectionProperties PrivateEndpointConnectionProperties(IEnumerable<string> groupIds = default, ResourceIdentifier privateEndpointId = default, AzureGeneratorMgmtTypeSpecTestsPrivateLinkServiceConnectionState privateLinkServiceConnectionState = default, AzureGeneratorMgmtTypeSpecTestsPrivateEndpointConnectionProvisioningState? provisioningState = default)
         {
             groupIds ??= new ChangeTrackingList<string>();
 
-            return new PrivateEndpointConnectionProperties(groupIds.ToList(), privateEndpoint, privateLinkServiceConnectionState, provisioningState, additionalBinaryDataProperties: null);
+            return new PrivateEndpointConnectionProperties(groupIds.ToList(), default, privateLinkServiceConnectionState, provisioningState, additionalBinaryDataProperties: null);
         }
 
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
@@ -131,17 +130,17 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <param name="prop1"> Gets the Prop1. </param>
         /// <param name="prop2"> Gets the Prop2. </param>
         /// <param name="etag"> ETag property for testing etag parameter name generation. </param>
-        /// <param name="writableSubResourceProp"> WritableSubResource property for testing WritableSubResource type replacement. </param>
         /// <param name="nestedPropertyProperties"> Gets or sets the Properties. </param>
         /// <param name="flattenedProperty"> Gets the FlattenedProperty. </param>
         /// <param name="vmGalleryApplications"> Specifies the gallery applications that should be made available. </param>
+        /// <param name="writableSubResourcePropId"> WritableSubResource property for testing WritableSubResource type replacement. </param>
         /// <param name="computeFleetVmCapacityReservationGroupId"> Gets or sets the Id. </param>
         /// <param name="extendedLocation"></param>
         /// <param name="identity"> The managed service identities assigned to this resource. </param>
         /// <param name="plan"> Details of the resource plan. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="something"/>, <paramref name="prop1"/> or <paramref name="nestedPropertyProperties"/> is null. </exception>
         /// <returns> A new <see cref="Tests.FooData"/> instance for mocking. </returns>
-        public static FooData FooData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, AzureLocation location = default, Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, ETag? etag = default, WritableSubResource writableSubResourceProp = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default, ExtendedLocation extendedLocation = default, ManagedServiceIdentity identity = default, ArmPlan plan = default)
+        public static FooData FooData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, AzureLocation location = default, Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, ETag? etag = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ResourceIdentifier writableSubResourcePropId = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default, ExtendedLocation extendedLocation = default, ManagedServiceIdentity identity = default, ArmPlan plan = default)
         {
             tags ??= new ChangeTrackingDictionary<string, string>();
 
@@ -153,7 +152,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 additionalBinaryDataProperties: null,
                 tags,
                 location,
-                serviceUri is null && something is null && boolValue is null && floatValue is null && doubleValue is null && prop1 is null && prop2 is null && etag is null && writableSubResourceProp is null && nestedPropertyProperties is null && flattenedProperty is null && vmGalleryApplications is null && computeFleetVmCapacityReservationGroupId is null ? default : new FooProperties(
+                serviceUri is null && something is null && boolValue is null && floatValue is null && doubleValue is null && prop1 is null && prop2 is null && etag is null && nestedPropertyProperties is null && flattenedProperty is null && vmGalleryApplications is null && writableSubResourcePropId is null && computeFleetVmCapacityReservationGroupId is null ? default : new FooProperties(
                     serviceUri,
                     something,
                     boolValue,
@@ -165,7 +164,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                     new SafeFlattenModel((flattenedProperty ?? new ChangeTrackingList<string>()).ToList(), null),
                     new VmProfile(new ApplicationProfile((vmGalleryApplications ?? new ChangeTrackingList<string>()).ToList(), null), null),
                     etag,
-                    writableSubResourceProp,
+                    default,
                     new ComputeFleetVmProfile(new CapacityReservationProfile(new TestSubResource(computeFleetVmCapacityReservationGroupId, null), null), null),
                     null),
                 extendedLocation,
@@ -184,11 +183,11 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <param name="flattenedProperty"> Gets the FlattenedProperty. </param>
         /// <param name="vmGalleryApplications"> Specifies the gallery applications that should be made available. </param>
         /// <param name="etag"> ETag property for testing etag parameter name generation. </param>
-        /// <param name="writableSubResourceProp"> WritableSubResource property for testing WritableSubResource type replacement. </param>
+        /// <param name="writableSubResourcePropId"> WritableSubResource property for testing WritableSubResource type replacement. </param>
         /// <param name="computeFleetVmCapacityReservationGroupId"> Gets or sets the Id. </param>
         /// <exception cref="ArgumentNullException"> <paramref name="nestedPropertyProperties"/> is null. </exception>
         /// <returns> A new <see cref="Models.FooProperties"/> instance for mocking. </returns>
-        public static FooProperties FooProperties(Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ETag? etag = default, WritableSubResource writableSubResourceProp = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default)
+        public static FooProperties FooProperties(Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ETag? etag = default, ResourceIdentifier writableSubResourcePropId = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default)
         {
             prop1 ??= new ChangeTrackingList<string>();
             prop2 ??= new ChangeTrackingList<int>();
@@ -205,7 +204,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 flattenedProperty is null ? default : new SafeFlattenModel((flattenedProperty ?? new ChangeTrackingList<string>()).ToList(), null),
                 vmGalleryApplications is null ? default : new VmProfile(new ApplicationProfile((vmGalleryApplications ?? new ChangeTrackingList<string>()).ToList(), null), null),
                 etag,
-                writableSubResourceProp,
+                default,
                 computeFleetVmCapacityReservationGroupId is null ? default : new ComputeFleetVmProfile(new CapacityReservationProfile(new TestSubResource(computeFleetVmCapacityReservationGroupId, null), null), null),
                 additionalBinaryDataProperties: null);
         }

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooProperties.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/FooProperties.cs
@@ -118,7 +118,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
 
         /// <summary> WritableSubResource property for testing WritableSubResource type replacement. </summary>
         [WirePath("writableSubResourceProp")]
-        public WritableSubResource WritableSubResourceProp { get; set; }
+        internal WritableSubResource WritableSubResourceProp { get; set; }
 
         /// <summary> Test case for multi-layer safe flatten. </summary>
         [WirePath("computeFleetVmProfile")]
@@ -163,6 +163,24 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                     VmProfile = new VmProfile();
                 }
                 return VmProfile.GalleryApplications;
+            }
+        }
+
+        /// <summary> WritableSubResource property for testing WritableSubResource type replacement. </summary>
+        [WirePath("writableSubResourceProp.id")]
+        public ResourceIdentifier WritableSubResourcePropId
+        {
+            get
+            {
+                return WritableSubResourceProp is null ? default : WritableSubResourceProp.Id;
+            }
+            set
+            {
+                if (WritableSubResourceProp is null)
+                {
+                    WritableSubResourceProp = new WritableSubResource();
+                }
+                WritableSubResourceProp.Id = value;
             }
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/PrivateEndpointConnectionProperties.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/Models/PrivateEndpointConnectionProperties.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.Core;
 using Azure.Generator.MgmtTypeSpec.Tests;
 using Azure.ResourceManager.Resources.Models;
 
@@ -50,7 +51,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
 
         /// <summary> The private endpoint resource. </summary>
         [WirePath("privateEndpoint")]
-        public SubResource PrivateEndpoint { get; set; }
+        internal SubResource PrivateEndpoint { get; set; }
 
         /// <summary> A collection of information about the state of the connection between service consumer and provider. </summary>
         [WirePath("privateLinkServiceConnectionState")]
@@ -59,5 +60,15 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <summary> The provisioning state of the private endpoint connection resource. </summary>
         [WirePath("provisioningState")]
         public AzureGeneratorMgmtTypeSpecTestsPrivateEndpointConnectionProvisioningState? ProvisioningState { get; }
+
+        /// <summary> The private endpoint resource. </summary>
+        [WirePath("privateEndpoint.id")]
+        public ResourceIdentifier PrivateEndpointId
+        {
+            get
+            {
+                return PrivateEndpoint is null ? default : PrivateEndpoint.Id;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- preserve backward-compatible ...Id projection for flattened WritableSubResource and SubResource wrappers in the mgmt generator
- add regression coverage for both writable and read-only cases
- refresh the affected local generated validation outputs

Fixes #58357.
