### PR TITLE
[AgentServer] Roll back Core version to beta.22 (unblock Responses beta.3 release)

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Release History
 
-## 1.0.0-beta.23 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.0.0-beta.22 (2026-04-17)
 
 ### Features Added

--- a/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/src/Azure.AI.AgentServer.Core.csproj
@@ -3,7 +3,7 @@
     <RequiredTargetFrameworks>$(RequiredRunnableTargetFrameworks)</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Azure.AI.AgentServer.Core</RootNamespace>
-    <Version>1.0.0-beta.23</Version>
+    <Version>1.0.0-beta.22</Version>
     <Description>Shared foundation for Azure AI Agent Server packages — provides port binding, health probes, OpenTelemetry, graceful shutdown, and the composable AgentHostBuilder.</Description>
     <PackageTags>Microsoft Azure AI Agent Server Core ASP.NET Core OpenTelemetry</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Fix

Rolls back Azure.AI.AgentServer.Core from `1.0.0-beta.23` to `1.0.0-beta.22`.

Core was auto-bumped to beta.23 after the beta.22 release but has **no changes**. Since beta.23 was never published to NuGet, the Responses beta.3 release pipeline fails with:

```
error NU1102: Unable to find package Azure.AI.AgentServer.Core with version (>= 1.0.0-beta.23)
```

### Changes
- Reverted `Azure.AI.AgentServer.Core.csproj` version to `1.0.0-beta.22`
- Removed the empty `## 1.0.0-beta.23 (Unreleased)` changelog section