### PR TITLE
Remove Azure.Identity dependency from data plane test projects (batch 3)

### DIFF
--- a/sdk/ai/Azure.AI.Extensions.OpenAI/tests/Azure.AI.Extensions.OpenAI.Tests.csproj
+++ b/sdk/ai/Azure.AI.Extensions.OpenAI/tests/Azure.AI.Extensions.OpenAI.Tests.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\..\Azure.AI.Extensions.OpenAI\src\Azure.AI.Extensions.OpenAI.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="Microsoft.ClientModel.TestFramework" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/sdk/ai/Azure.AI.Projects.Agents/tests/Azure.AI.Projects.Agents.Tests.csproj
+++ b/sdk/ai/Azure.AI.Projects.Agents/tests/Azure.AI.Projects.Agents.Tests.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="System.Linq.AsyncEnumerable" />
     <PackageReference Include="Azure.ResourceManager.CognitiveServices" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />

--- a/sdk/attestation/Azure.Security.Attestation/tests/Azure.Security.Attestation.Tests.csproj
+++ b/sdk/attestation/Azure.Security.Attestation/tests/Azure.Security.Attestation.Tests.csproj
@@ -4,7 +4,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/Azure.Security.CodeTransparency.Tests.csproj
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/Azure.Security.CodeTransparency.Tests.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-  <ItemGroup>
     <Folder Include="SessionRecords\" />
     <EmbeddedResource Include="TestFiles\**" LinkBase="EmbeddedTestFiles" />
   </ItemGroup>

--- a/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/Azure.Security.CodeTransparency.Tests.csproj
+++ b/sdk/confidentialledger/Azure.Security.CodeTransparency/tests/Azure.Security.CodeTransparency.Tests.csproj
@@ -20,10 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- TODO: Revert to PackageReference after Azure.Core 1.52 ships with Identity types -->
-    <ProjectReference Include="..\..\..\identity\Azure.Identity\src\Azure.Identity.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <Folder Include="SessionRecords\" />
     <EmbeddedResource Include="TestFiles\**" LinkBase="EmbeddedTestFiles" />

--- a/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/Azure.Security.ConfidentialLedger.Tests.csproj
+++ b/sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/Azure.Security.ConfidentialLedger.Tests.csproj
@@ -8,8 +8,6 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <!-- TODO: Revert to PackageReference after Azure.Core 1.52 ships with Identity types -->
-    <ProjectReference Include="..\..\..\identity\Azure.Identity\src\Azure.Identity.csproj" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 

--- a/sdk/face/Azure.AI.Vision.Face/tests/Azure.AI.Vision.Face.Tests.csproj
+++ b/sdk/face/Azure.AI.Vision.Face/tests/Azure.AI.Vision.Face.Tests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/sdk/healthdataaiservices/Azure.Health.Deidentification/tests/Azure.Health.Deidentification.Tests.csproj
+++ b/sdk/healthdataaiservices/Azure.Health.Deidentification/tests/Azure.Health.Deidentification.Tests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/sdk/healthinsights/Azure.Health.Insights.RadiologyInsights/tests/Azure.Health.Insights.RadiologyInsights.Tests.csproj
+++ b/sdk/healthinsights/Azure.Health.Insights.RadiologyInsights/tests/Azure.Health.Insights.RadiologyInsights.Tests.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/sdk/loadtestservice/Azure.Developer.Playwright/tests/Azure.Developer.Playwright.Tests.csproj
+++ b/sdk/loadtestservice/Azure.Developer.Playwright/tests/Azure.Developer.Playwright.Tests.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Azure.Identity" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/openai/Azure.AI.OpenAI/tests/Azure.AI.OpenAI.Tests.csproj
+++ b/sdk/openai/Azure.AI.OpenAI/tests/Azure.AI.OpenAI.Tests.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
## Description

Continues the effort to remove explicit `Azure.Identity` dependencies from projects that no longer need them. Azure.Core 1.53+ now contains all identity types, so these projects can rely on the transitive Azure.Core reference.

This is **batch 3** of a multi-PR cleanup. Previous batches:
- Batch 1: #58124 (merged)
- Batch 2: #58128 (merged)

## Changes

Removed `Azure.Identity` `PackageReference` (or `ProjectReference`) from 10 data plane test projects:

| Service | Project |
| --- | --- |
| AI Extensions OpenAI | `sdk/ai/Azure.AI.Extensions.OpenAI/tests/Azure.AI.Extensions.OpenAI.Tests.csproj` |
| AI Projects Agents | `sdk/ai/Azure.AI.Projects.Agents/tests/Azure.AI.Projects.Agents.Tests.csproj` |
| Attestation | `sdk/attestation/Azure.Security.Attestation/tests/Azure.Security.Attestation.Tests.csproj` |
| Code Transparency | `sdk/confidentialledger/Azure.Security.CodeTransparency/tests/Azure.Security.CodeTransparency.Tests.csproj` |
| Confidential Ledger | `sdk/confidentialledger/Azure.Security.ConfidentialLedger/tests/Azure.Security.ConfidentialLedger.Tests.csproj` |
| Face | `sdk/face/Azure.AI.Vision.Face/tests/Azure.AI.Vision.Face.Tests.csproj` |
| Health Deidentification | `sdk/healthdataaiservices/Azure.Health.Deidentification/tests/Azure.Health.Deidentification.Tests.csproj` |
| Radiology Insights | `sdk/healthinsights/Azure.Health.Insights.RadiologyInsights/tests/Azure.Health.Insights.RadiologyInsights.Tests.csproj` |
| Playwright | `sdk/loadtestservice/Azure.Developer.Playwright/tests/Azure.Developer.Playwright.Tests.csproj` |
| OpenAI | `sdk/openai/Azure.AI.OpenAI/tests/Azure.AI.OpenAI.Tests.csproj` |

Total: 10 files changed, 14 deletions.

## Notes

- The two `confidentialledger` projects had a `ProjectReference` to Azure.Identity (with a `TODO: Revert to PackageReference` comment); both the reference and the comment were removed since the types are now in Azure.Core.
- No production code is touched — these are all test project edits.

## Validation

Built locally:
- `Azure.Security.Attestation.Tests` ✅
- `Azure.Security.ConfidentialLedger.Tests` ✅
- `Azure.AI.Vision.Face.Tests` ✅

`Azure.AI.OpenAI` has a pre-existing CS0115 build error on `main` (`AzureFileClient.Protocol.cs(114,39)`) unrelated to this change.
