### PR TITLE
Remove Azure.Identity dependency from test/sample/stress projects (batch 4)

### DIFF
--- a/sdk/carbon/Azure.ResourceManager.CarbonOptimization/samples/Azure.ResourceManager.CarbonOptimization.Samples.csproj
+++ b/sdk/carbon/Azure.ResourceManager.CarbonOptimization/samples/Azure.ResourceManager.CarbonOptimization.Samples.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Azure.Identity"/>
     <PackageReference Include="NUnit"  />
     <PackageReference Include="NUnit3TestAdapter"  />
   </ItemGroup>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Azure.Monitor.OpenTelemetry.Exporter.Demo.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Azure.Monitor.OpenTelemetry.Exporter.Demo.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <ProjectReference Include="..\..\src\Azure.Monitor.OpenTelemetry.Exporter.csproj" />
   </ItemGroup>
 

--- a/sdk/resourcemanager/Azure.ResourceManager/samples/Azure.ResourceManager.Samples.csproj
+++ b/sdk/resourcemanager/Azure.ResourceManager/samples/Azure.ResourceManager.Samples.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk\">
   <ItemGroup>
-    <PackageReference Include="Azure.Identity"/>
     <PackageReference Include="NUnit"/>
     <PackageReference Include="NUnit3TestAdapter"/>
   </ItemGroup>

--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/stress/src/Azure.Storage.DataMovement.Blobs.Stress.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/stress/src/Azure.Storage.DataMovement.Blobs.Stress.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Memory.Data" />
     <PackageReference Include="CommandLineParser" />

--- a/sdk/synapse/Azure.ResourceManager.Synapse/samples/Azure.ResourceManager.Synapse.Samples.csproj
+++ b/sdk/synapse/Azure.ResourceManager.Synapse/samples/Azure.ResourceManager.Synapse.Samples.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk\">
   <ItemGroup>
-    <PackageReference Include="Azure.Identity"/>
     <PackageReference Include="NUnit"/>
     <PackageReference Include="NUnit3TestAdapter"/>
   </ItemGroup>

--- a/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples/TimeSeriesInsightsClientSample/Azure.IoT.TimeSeriesInsights.Tests.ClientSample.csproj
+++ b/sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples/TimeSeriesInsightsClientSample/Azure.IoT.TimeSeriesInsights.Tests.ClientSample.csproj
@@ -14,7 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Microsoft.Azure.Devices" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" />

--- a/sdk/vision/Azure.AI.Vision.ImageAnalysis/tests/Azure.AI.Vision.ImageAnalysis.Tests.csproj
+++ b/sdk/vision/Azure.AI.Vision.ImageAnalysis/tests/Azure.AI.Vision.ImageAnalysis.Tests.csproj
@@ -20,10 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="image-analysis-sample.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/sdk/voicelive/Azure.AI.VoiceLive/tests/Azure.AI.VoiceLive.Tests.csproj
+++ b/sdk/voicelive/Azure.AI.VoiceLive/tests/Azure.AI.VoiceLive.Tests.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <ProjectReference Include="$(AzureCoreTestFramework)" />
     <ProjectReference Include="..\src\Azure.AI.VoiceLive.csproj" />
-    <ProjectReference Include="..\..\..\identity\Azure.Identity\src\Azure.Identity.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/webpubsub/Azure.ResourceManager.WebPubSub/tests/Azure.ResourceManager.WebPubSub.Tests.csproj
+++ b/sdk/webpubsub/Azure.ResourceManager.WebPubSub/tests/Azure.ResourceManager.WebPubSub.Tests.csproj
@@ -1,8 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\src\Azure.ResourceManager.WebPubSub.csproj" />
     <PackageReference Include="Azure.ResourceManager.Network" />
   </ItemGroup>

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Microsoft.Azure.WebPubSub.AspNetCore.Tests.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Microsoft.Azure.WebPubSub.AspNetCore.Tests.csproj
@@ -22,6 +22,7 @@
 		<PackageReference Include="Moq" />
 		<PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Azure.Core" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) != 'net462'">

--- a/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Microsoft.Azure.WebPubSub.AspNetCore.Tests.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Microsoft.Azure.WebPubSub.AspNetCore.Tests.csproj
@@ -18,7 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-		<PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="NUnit" />


### PR DESCRIPTION
## Description

Continues the effort to remove explicit `Azure.Identity` dependencies from projects that no longer need them. Azure.Core 1.53+ now contains all identity types, so these projects can rely on the transitive Azure.Core reference.

This is **batch 4** of a multi-PR cleanup. Previous batches:
- Batch 1: #58124 (merged)
- Batch 2: #58128 (merged)
- Batch 3: #58388 (merged)

## Changes

Removed `Azure.Identity` `PackageReference` (or `ProjectReference`) from 10 projects:

| Service | Project |
| --- | --- |
| Monitor OpenTelemetry Demo | `sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Demo/Azure.Monitor.OpenTelemetry.Exporter.Demo.csproj` |
| TimeSeries Insights sample | `sdk/timeseriesinsights/Azure.IoT.TimeSeriesInsights/samples/TimeSeriesInsightsClientSample/Azure.IoT.TimeSeriesInsights.Tests.ClientSample.csproj` |
| Vision ImageAnalysis | `sdk/vision/Azure.AI.Vision.ImageAnalysis/tests/Azure.AI.Vision.ImageAnalysis.Tests.csproj` |
| VoiceLive | `sdk/voicelive/Azure.AI.VoiceLive/tests/Azure.AI.VoiceLive.Tests.csproj` |
| WebPubSub RM | `sdk/webpubsub/Azure.ResourceManager.WebPubSub/tests/Azure.ResourceManager.WebPubSub.Tests.csproj` |
| WebPubSub AspNetCore | `sdk/webpubsub/Microsoft.Azure.WebPubSub.AspNetCore/tests/Microsoft.Azure.WebPubSub.AspNetCore.Tests.csproj` |
| ResourceManager samples | `sdk/resourcemanager/Azure.ResourceManager/samples/Azure.ResourceManager.Samples.csproj` |
| Storage DataMovement Stress | `sdk/storage/Azure.Storage.DataMovement.Blobs/stress/src/Azure.Storage.DataMovement.Blobs.Stress.csproj` |
| Carbon Optimization samples | `sdk/carbon/Azure.ResourceManager.CarbonOptimization/samples/Azure.ResourceManager.CarbonOptimization.Samples.csproj` |
| Synapse samples | `sdk/synapse/Azure.ResourceManager.Synapse/samples/Azure.ResourceManager.Synapse.Samples.csproj` |

Total: 10 files changed, 15 deletions.

## Notes

- The VoiceLive test project had a `<ProjectReference Include="..\..\..\identity\Azure.Identity\src\Azure.Identity.csproj" />`; that was removed since the types come from Azure.Core now.
- Two more candidates — `Azure.ResourceManager.Tests.csproj` and `Microsoft.Azure.WebJobs.Extensions.SignalRService.Tests.csproj` — were deferred. They have a deliberate `Azure.Identity` 1.21+ pin acting as a facade to resolve CS0433 with transitive older versions (issue #58129). Removing the pin in `Azure.ResourceManager.Tests` produces 684 CS0433 errors locally (`DefaultAzureCredential` exists in both Azure.Core 1.54 and the transitive Azure.Identity 1.17.1). These will be cleaned up in a later batch once the underlying transitive dependency is addressed.

## Validation

Built locally:
- `Azure.AI.Vision.ImageAnalysis.Tests` ✅
- `Azure.Storage.DataMovement.Blobs.Stress` — has 9 pre-existing build errors that also reproduce on `main` (`Azure.Core.TestFramework` / `IsExternalInit`); unrelated to this change.
