### PR TITLE
Batch: Do not re-record tests on every run

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
@@ -449,7 +449,6 @@ namespace Azure.Storage.Blobs.Specialized
                 }
                 else
                 {
-                    // hello
                     if (async)
                     {
                         response = await _serviceRestClient.SubmitBatchAsync(

--- a/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/src/BlobBatchClient.cs
@@ -449,6 +449,7 @@ namespace Azure.Storage.Blobs.Specialized
                 }
                 else
                 {
+                    // hello
                     if (async)
                     {
                         response = await _serviceRestClient.SubmitBatchAsync(

--- a/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs.Batch/tests/BlobBatchClientTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Storage.Blobs.Test
         private static Regex pattern = new Regex(@"sig=\S+\s", RegexOptions.Compiled);
 
         public BlobBatchClientTests(bool async, BlobClientOptions.ServiceVersion serviceVersion)
-            : base(async, serviceVersion, RecordedTestMode.Record /* RecordedTestMode.Record /* to re-record */)
+            : base(async, serviceVersion, null /* RecordedTestMode.Record /* to re-record */)
         {
             // Batch delimiters are random so disable body comparison
             CompareBodies = false;


### PR DESCRIPTION
Fixes the existing tests to not re-record on every run.