### PR TITLE
Remove duplicate CredentialSource required from Azure.Core credential schema

### DIFF
--- a/sdk/core/Azure.Core/schema/ConfigurationSchema.json
+++ b/sdk/core/Azure.Core/schema/ConfigurationSchema.json
@@ -121,9 +121,6 @@
           ]
         }
       },
-      "required": [
-        "CredentialSource"
-      ],
       "allOf": [
         {
           "if": {


### PR DESCRIPTION
## Problem

When a consumer references a client library that ships a `ConfigurationSchema.json` segment (via the per-package `buildTransitive` `.targets`), the appsettings schema combiner produces a combined `obj/{config}/{tfm}/AppSettingsSchema.json`. In that combined file, the `required` array on the merged `definitions/credential` ends up containing `CredentialSource` twice:

```json
"required": [
  "CredentialSource",
  "CredentialSource"
]
```

## Reproduction

1. `dotnet pack` `Azure.Security.KeyVault.Secrets` locally.
2. Reference the resulting nupkg from a fresh `net10.0` console project.
3. `dotnet build` the consumer.
4. Inspect `obj\Debug\net10.0\AppSettingsSchema.json` — exactly one `required` array contains `CredentialSource` twice; 22 others contain it once.

## Root Cause

Both segments declare `required: ["CredentialSource"]` at the top of `definitions/credential`:

- `sdk/core/System.ClientModel/schema/ConfigurationSchema.json` (line 13)
- `sdk/core/Azure.Core/schema/ConfigurationSchema.json` (formerly lines 124-126)

The combiner merges segments by definition name and concatenates their `required` arrays without dedup, producing the duplicate.

## Fix

Remove the top-level `required: ["CredentialSource"]` from `definitions/credential` in Azure.Core's schema. System.ClientModel still asserts it, so the combined schema's behavior is unchanged. All `if`-clause `required` arrays and the `chainableCredential` definition (which has no scm counterpart) are preserved.

## Verification

After repacking Azure.Core with this change and rebuilding the same consumer:

- 23 `required` arrays with `CredentialSource` (unchanged total)
- **0 duplicates** (was 1)

## Follow-up Suggestion

The schema combiner should dedup `required` arrays when merging same-named definitions across segments, since multiple segments can legitimately declare the same required key. This PR fixes the symptom on the segment side; a combiner-side fix would prevent recurrences for any segment pair.