### PR TITLE
Remove Azure.Identity dependency from perf and sample projects (batch 5)

### DIFF
--- a/eng/templates/Azure.ResourceManager.Template/samples/Azure.ResourceManager.Template.Samples.csproj
+++ b/eng/templates/Azure.ResourceManager.Template/samples/Azure.ResourceManager.Template.Samples.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Azure.Identity"/>
     <PackageReference Include="NUnit"  />
     <PackageReference Include="NUnit3TestAdapter"  />
   </ItemGroup>

--- a/samples/keyvault/getcert/GetCert.csproj
+++ b/samples/keyvault/getcert/GetCert.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.20.0" />
+    <PackageReference Include="Azure.Core" Version="1.53.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.5" />

--- a/sdk/cognitivelanguage/Azure.AI.Language.Conversations/perf/Azure.AI.Language.Conversations.Perf.csproj
+++ b/sdk/cognitivelanguage/Azure.AI.Language.Conversations/perf/Azure.AI.Language.Conversations.Perf.csproj
@@ -10,8 +10,5 @@
     <ProjectReference Include="..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
 
 </Project>

--- a/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/perf/Azure.AI.Language.QuestionAnswering.Perf.csproj
+++ b/sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/perf/Azure.AI.Language.QuestionAnswering.Perf.csproj
@@ -9,8 +9,5 @@
     <ProjectReference Include="..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
 
 </Project>

--- a/sdk/contentsafety/Azure.AI.ContentSafety/perf/Azure.AI.ContentSafety.Perf.csproj
+++ b/sdk/contentsafety/Azure.AI.ContentSafety/perf/Azure.AI.ContentSafety.Perf.csproj
@@ -9,8 +9,5 @@
     <ProjectReference Include="..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
 
 </Project>

--- a/sdk/devcenter/Azure.Developer.DevCenter/perf/Azure.Developer.DevCenter.Perf.csproj
+++ b/sdk/devcenter/Azure.Developer.DevCenter/perf/Azure.Developer.DevCenter.Perf.csproj
@@ -9,8 +9,5 @@
     <ProjectReference Include="..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
 
 </Project>

--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj
@@ -13,14 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Azure.Storage.Blobs" />
   </ItemGroup>
 
   <!-- Use decentralized package references when building outside https://github.com/Azure/azure-sdk-for-net -->
   <ItemGroup Condition="'$(IsSamplesProject)' != 'true'">
-    <PackageReference Update="Azure.Identity" Version="1.11.4" />
     <PackageReference Update="CommandLineParser" Version="2.7.82" />
     <PackageReference Update="Azure.Storage.Blobs" Version="12.16.0" />
   </ItemGroup>

--- a/sdk/easm/Azure.Analytics.Defender.Easm/perf/Azure.Analytics.Defender.Easm.Perf.csproj
+++ b/sdk/easm/Azure.Analytics.Defender.Easm/perf/Azure.Analytics.Defender.Easm.Perf.csproj
@@ -9,8 +9,5 @@
     <ProjectReference Include="..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
 
 </Project>

--- a/sdk/monitor/Azure.Monitor.Ingestion/perf/Azure.Monitor.Ingestion.Perf.csproj
+++ b/sdk/monitor/Azure.Monitor.Ingestion/perf/Azure.Monitor.Ingestion.Perf.csproj
@@ -10,8 +10,5 @@
     <ProjectReference Include="..\tests\Azure.Monitor.Ingestion.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
 
 </Project>

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/perf/Azure.Monitor.OpenTelemetry.Exporter.Perf.csproj
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/perf/Azure.Monitor.OpenTelemetry.Exporter.Perf.csproj
@@ -10,8 +10,5 @@
     <ProjectReference Include="..\..\..\..\common\Perf\Azure.Test.Perf\Azure.Test.Perf.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Remove Azure.Identity dependency from perf and sample projects (batch 5)

Azure.Core 1.53+ now type-forwards the `Azure.Identity` namespace, so projects no longer need an explicit `Azure.Identity` reference when they pick up Azure.Core 1.53+ transitively (or directly).

### Files in this batch (10)

**Perf projects (CPM, removed `<PackageReference Include="Azure.Identity" />`)**
- `sdk/cognitivelanguage/Azure.AI.Language.Conversations/perf/Azure.AI.Language.Conversations.Perf.csproj`
- `sdk/cognitivelanguage/Azure.AI.Language.QuestionAnswering/perf/Azure.AI.Language.QuestionAnswering.Perf.csproj`
- `sdk/contentsafety/Azure.AI.ContentSafety/perf/Azure.AI.ContentSafety.Perf.csproj`
- `sdk/devcenter/Azure.Developer.DevCenter/perf/Azure.Developer.DevCenter.Perf.csproj`
- `sdk/easm/Azure.Analytics.Defender.Easm/perf/Azure.Analytics.Defender.Easm.Perf.csproj`
- `sdk/monitor/Azure.Monitor.Ingestion/perf/Azure.Monitor.Ingestion.Perf.csproj`
- `sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/perf/Azure.Monitor.OpenTelemetry.Exporter.Perf.csproj`

**Samples**
- `eng/templates/Azure.ResourceManager.Template/samples/Azure.ResourceManager.Template.Samples.csproj` — removed Azure.Identity package reference (CPM)
- `sdk/digitaltwins/Azure.DigitalTwins.Core/samples/DigitalTwinsClientSample/DigitalTwinsClientSample.csproj` — removed Azure.Identity package reference and the corresponding decentralized-build version `Update` override
- `samples/keyvault/getcert/GetCert.csproj` — removed `Azure.Identity` 1.20.0; added explicit `Azure.Core` 1.53.0 (this sample is outside CPM and its KeyVault packages don't transitively bring Azure.Core 1.53+)

### Verification
All 10 modified projects build clean locally.

### Related batches
- Batch 1 #58124, Batch 2 #58128, Batch 3 #58388, Batch 4 #58393 (all merged)
- Remaining: SignalR Extensions Tests + Azure.ResourceManager.Tests are blocked on #58129 (deliberate Azure.Identity 1.21+ facade pin); src/production projects coming in later batches.
