### PR TITLE
[CODEOWNERS] Baseline wildcard errors

### DIFF
--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -1,5 +1,8 @@
+/sdk/**/NuGet.* ends in a wildcard '*'. For directories use '*/' to match files in multiple directories starting with. For files match the file extension, '*.md' or all files in a single directory '/*'.
+/sdk/**/Nuget.* ends in a wildcard '*'. For directories use '*/' to match files in multiple directories starting with. For files match the file extension, '*.md' or all files in a single directory '/*'.
+/sdk/**/nuget.* ends in a wildcard '*'. For directories use '*/' to match files in multiple directories starting with. For files match the file extension, '*.md' or all files in a single directory '/*'.
+/sdk/**/global.json glob does not have any matches in repository.
 khmic5 is not a public member of Azure.
-schaabs is not a public member of Azure.
 lirenhe is not a public member of Azure.
 mconnew is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.
 adamedx is an invalid user. Ensure the user exists, is public member of Azure and has write permissions.


### PR DESCRIPTION
# Summary

The focus of these changes is to baseline the wildcard errors from the linter until the rules can be adjusted.

## References and resources

- [Linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=6182498&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=c37b8e44-676d-5a6a-0c38-90948b84091a) _(Microsoft internal)_