### PR TITLE
Remove Azure.Identity dependency from src and sample projects (batch 6)

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Azure.AI.AgentServer.Responses.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Azure.AI.AgentServer.Responses.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Azure.AI.AgentServer.Responses.csproj
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Azure.AI.AgentServer.Responses.csproj
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="System.ClientModel" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>

--- a/sdk/voicelive/Azure.AI.VoiceLive/samples/BasicVoiceAssistant/BasicVoiceAssistant.csproj
+++ b/sdk/voicelive/Azure.AI.VoiceLive/samples/BasicVoiceAssistant/BasicVoiceAssistant.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="NAudio" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />

--- a/sdk/voicelive/Azure.AI.VoiceLive/samples/CustomerServiceBot/CustomerServiceBot.csproj
+++ b/sdk/voicelive/Azure.AI.VoiceLive/samples/CustomerServiceBot/CustomerServiceBot.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity"/>
     <PackageReference Include="NAudio" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />

--- a/sdk/voicelive/Azure.AI.VoiceLive/samples/snippets/Azure.AI.VoiceLive.Snippets.csproj
+++ b/sdk/voicelive/Azure.AI.VoiceLive/samples/snippets/Azure.AI.VoiceLive.Snippets.csproj
@@ -13,8 +13,4 @@
     <ProjectReference Include="..\..\src\Azure.AI.VoiceLive.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Azure.Identity"/>
-  </ItemGroup>
-
 </Project>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.csproj
@@ -24,7 +24,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Identity" />
 		<PackageReference Include="Microsoft.AspNetCore.Http" />
 		<PackageReference Include="Microsoft.Azure.WebJobs" />
 		<PackageReference Include="Microsoft.IdentityModel.Tokens" />


### PR DESCRIPTION
## Remove Azure.Identity dependency from src and sample projects (batch 6)

Azure.Core 1.53+ now type-forwards the `Azure.Identity` namespace, so projects no longer need an explicit `Azure.Identity` reference when they pick up Azure.Core 1.53+ transitively or directly.

### Files in this batch (6)

**Src/production projects**
- `sdk/agentserver/Azure.AI.AgentServer.Responses/src/Azure.AI.AgentServer.Responses.csproj` — replaced `Azure.Identity` with `Azure.Core` (source uses `using Azure.Identity;`)
- `sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/src/Azure.Extensions.AspNetCore.Configuration.Secrets.csproj` — removed `Azure.Identity` (already had `Azure.Core`)
- `sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO/src/Microsoft.Azure.WebJobs.Extensions.WebPubSubForSocketIO.csproj` — removed `Azure.Identity`

**Samples**
- `sdk/voicelive/Azure.AI.VoiceLive/samples/BasicVoiceAssistant/BasicVoiceAssistant.csproj`
- `sdk/voicelive/Azure.AI.VoiceLive/samples/CustomerServiceBot/CustomerServiceBot.csproj`
- `sdk/voicelive/Azure.AI.VoiceLive/samples/snippets/Azure.AI.VoiceLive.Snippets.csproj`

### Verification
All 6 modified projects build clean locally.

### Deferred to a follow-up batch
- 3 cloudmachine src projects (`Azure.Projects`, `Azure.Projects.Provisioning`, `Azure.Projects.AI.Foundry`) hit CS0433 type conflicts because transitive `Azure.Identity` 1.20 (from `Azure.AI.Projects`/etc.) clashes with `Azure.Core` 1.53. Same root cause as #58129.
- 2 ServiceBus end-user samples (`DeadLetterQueue`, `TopicFilters`) hit CS0234. They're customer-facing demos, so adding an explicit `Azure.Core` reference would be unidiomatic; leaving the explicit `Azure.Identity` reference for now.

### Related batches
- Batch 1 #58124, Batch 2 #58128, Batch 3 #58388, Batch 4 #58393, Batch 5 #58409 (all merged)
