### PR TITLE
Remove Azure.Identity from cloudmachine projects (batch 7)

### DIFF
--- a/eng/centralpackagemanagement/overrides/Azure.Projects.AI.Foundry.Packages.props
+++ b/eng/centralpackagemanagement/overrides/Azure.Projects.AI.Foundry.Packages.props
@@ -8,6 +8,7 @@
 
     REMOVE THIS OVERRIDE once Azure.AI.Projects 2.1.0 GA ships and the
     central version in Directory.Packages.props is bumped.
+    Tracking issue: https://github.com/Azure/azure-sdk-for-net/issues/58510
   -->
   <ItemGroup>
     <PackageVersion Update="Azure.AI.Projects" Version="2.1.0-beta.1" />

--- a/eng/centralpackagemanagement/overrides/Azure.Projects.AI.Foundry.Packages.props
+++ b/eng/centralpackagemanagement/overrides/Azure.Projects.AI.Foundry.Packages.props
@@ -12,7 +12,4 @@
   <ItemGroup>
     <PackageVersion Update="Azure.AI.Projects" Version="2.1.0-beta.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageVersion Include="Azure.Provisioning.Deployment" Version="1.0.0-beta.2" />
-  </ItemGroup>
 </Project>

--- a/eng/centralpackagemanagement/overrides/Azure.Projects.Packages.props
+++ b/eng/centralpackagemanagement/overrides/Azure.Projects.Packages.props
@@ -8,6 +8,7 @@
 
     REMOVE THIS OVERRIDE once Azure.AI.Projects 2.1.0 GA ships and the
     central version in Directory.Packages.props is bumped.
+    Tracking issue: https://github.com/Azure/azure-sdk-for-net/issues/58510
   -->
   <ItemGroup>
     <PackageVersion Update="Azure.AI.Projects" Version="2.1.0-beta.1" />

--- a/eng/centralpackagemanagement/overrides/Azure.Projects.Provisioning.Packages.props
+++ b/eng/centralpackagemanagement/overrides/Azure.Projects.Provisioning.Packages.props
@@ -6,6 +6,7 @@
       Pulled in transitively via the Azure.Projects project reference. See
       Azure.Projects.Packages.props for full rationale. REMOVE once
       Azure.AI.Projects 2.1.0 GA ships.
+      Tracking issue: https://github.com/Azure/azure-sdk-for-net/issues/58510
     -->
     <PackageVersion Update="Azure.AI.Projects" Version="2.1.0-beta.1" />
   </ItemGroup>

--- a/eng/centralpackagemanagement/overrides/Azure.Projects.Provisioning.Packages.props
+++ b/eng/centralpackagemanagement/overrides/Azure.Projects.Provisioning.Packages.props
@@ -2,6 +2,15 @@
   <ItemGroup Condition="$(MSBuildProjectName.Contains('Azure.Projects.Provisioning'))">
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="1.0.0"/>
   </ItemGroup>
+  <!--
+    TEMPORARY: Override Azure.AI.Projects to the 2.1.0-beta.1 prerelease.
+    Pulled in transitively via the Azure.Projects project reference. See
+    Azure.Projects.Packages.props for full rationale. REMOVE once
+    Azure.AI.Projects 2.1.0 GA ships.
+  -->
+  <ItemGroup>
+    <PackageVersion Update="Azure.AI.Projects" Version="2.1.0-beta.1" />
+  </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <PackageVersion Include="Azure.Provisioning.Deployment" Version="1.0.0-beta.2" />
   </ItemGroup>

--- a/eng/centralpackagemanagement/overrides/Azure.Projects.Provisioning.Packages.props
+++ b/eng/centralpackagemanagement/overrides/Azure.Projects.Provisioning.Packages.props
@@ -1,14 +1,12 @@
 <Project>
   <ItemGroup Condition="$(MSBuildProjectName.Contains('Azure.Projects.Provisioning'))">
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="1.0.0"/>
-  </ItemGroup>
-  <!--
-    TEMPORARY: Override Azure.AI.Projects to the 2.1.0-beta.1 prerelease.
-    Pulled in transitively via the Azure.Projects project reference. See
-    Azure.Projects.Packages.props for full rationale. REMOVE once
-    Azure.AI.Projects 2.1.0 GA ships.
-  -->
-  <ItemGroup>
+    <!--
+      TEMPORARY: Override Azure.AI.Projects to the 2.1.0-beta.1 prerelease.
+      Pulled in transitively via the Azure.Projects project reference. See
+      Azure.Projects.Packages.props for full rationale. REMOVE once
+      Azure.AI.Projects 2.1.0 GA ships.
+    -->
     <PackageVersion Update="Azure.AI.Projects" Version="2.1.0-beta.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">

--- a/sdk/cloudmachine/Azure.Projects.AI.Foundry/Azure.Projects.AI.Foundry.csproj
+++ b/sdk/cloudmachine/Azure.Projects.AI.Foundry/Azure.Projects.AI.Foundry.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.Projects" />
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="System.ClientModel" />
   </ItemGroup>

--- a/sdk/cloudmachine/Azure.Projects.Provisioning/src/Azure.Projects.Provisioning.csproj
+++ b/sdk/cloudmachine/Azure.Projects.Provisioning/src/Azure.Projects.Provisioning.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.KeyVault" />
     <PackageReference Include="Azure.Provisioning.Storage" />

--- a/sdk/cloudmachine/Azure.Projects.Provisioning/tests/Azure.Projects.Provisioning.Tests.csproj
+++ b/sdk/cloudmachine/Azure.Projects.Provisioning/tests/Azure.Projects.Provisioning.Tests.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Azure.AI.OpenAI" />
-    <PackageReference Include="Azure.Provisioning.Deployment" />
     <PackageReference Include="System.Memory.Data" />
   </ItemGroup>
 

--- a/sdk/cloudmachine/Azure.Projects/src/Azure.Projects.csproj
+++ b/sdk/cloudmachine/Azure.Projects/src/Azure.Projects.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Data.AppConfiguration" />
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Messaging.ServiceBus" />
     <PackageReference Include="Azure.Messaging.EventGrid" />
     <PackageReference Include="Azure.Storage.Blobs" />


### PR DESCRIPTION
## Description

Batch 7 of the Azure.Identity dependency cleanup. Removes the explicit `Azure.Identity` PackageReference from the 3 cloudmachine source projects.

The Identity types these projects use are now provided via Azure.Core 1.53's type-forwards.

## Changes

- `sdk/cloudmachine/Azure.Projects/src/Azure.Projects.csproj` — remove `Azure.Identity` PackageReference
- `sdk/cloudmachine/Azure.Projects.Provisioning/src/Azure.Projects.Provisioning.csproj` — remove `Azure.Identity` PackageReference
- `sdk/cloudmachine/Azure.Projects.AI.Foundry/Azure.Projects.AI.Foundry.csproj` — remove `Azure.Identity` PackageReference
- `sdk/cloudmachine/Azure.Projects.Provisioning/tests/Azure.Projects.Provisioning.Tests.csproj` — remove unused `Azure.Provisioning.Deployment` PackageReference (no `using` statements or API calls reference it; it was the transitive source of `Azure.Identity 1.12.0` causing CS0433 in CI after the src project's Identity ref was removed)
- `eng/centralpackagemanagement/overrides/Azure.Projects.Packages.props` — add temporary `Azure.AI.Projects` 2.1.0-beta.1 override
- `eng/centralpackagemanagement/overrides/Azure.Projects.Provisioning.Packages.props` — add temporary `Azure.AI.Projects` 2.1.0-beta.1 override
- `eng/centralpackagemanagement/overrides/Azure.Projects.AI.Foundry.Packages.props` — new file with temporary `Azure.AI.Projects` 2.1.0-beta.1 override

## Why the override

The CPM version of `Azure.AI.Projects` is 2.0.0 (GA), which transitively pulls `Azure.Identity 1.20.0`. That conflicts (CS0433) with the credential types now type-forwarded by `Azure.Core 1.53`. The published `Azure.AI.Projects 2.1.0-beta.1` depends only on `Azure.Core 1.53` and does not pull `Azure.Identity`.

Each override file contains a comment instructing maintainers to remove the override and bump the central version once `Azure.AI.Projects 2.1.0` GA ships. Tracking issue: #58510

## Validation

All 3 cloudmachine src projects and the Provisioning test project build cleanly (0 warnings, 0 errors).

## Related

Batches 1-6 (merged): #58124, #58128, #58388, #58393, #58409, #58459