### PR TITLE
Update spec repo commit for ApiCompat compatibility fix

### DIFF
--- a/sdk/appcomplianceautomation/Azure.ResourceManager.AppComplianceAutomation/tsp-location.yaml
+++ b/sdk/appcomplianceautomation/Azure.ResourceManager.AppComplianceAutomation/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/appcomplianceautomation/AppComplianceAutomation.Management
-commit: 597787853507d6b0f9e17721a6702d9991af4cb5
+commit: 4850dea187a72ae7ceaf0bd61b2e4a4c4b4a3b3e
 repo: Azure/azure-rest-api-specs
 emitterPackageJsonPath: eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json

--- a/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/tsp-location.yaml
+++ b/sdk/dataprotection/Azure.ResourceManager.DataProtectionBackup/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection
-commit: 71d57305112ac6d20afd2338e88422f4fb3fd6b8
+commit: 4850dea187a72ae7ceaf0bd61b2e4a4c4b4a3b3e
 repo: Azure/azure-rest-api-specs
 emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"

--- a/sdk/resources/Azure.ResourceManager.Resources.DeploymentStacks/tsp-location.yaml
+++ b/sdk/resources/Azure.ResourceManager.Resources.DeploymentStacks/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/resources/resource-manager/Microsoft.Resources/deploymentStacks
-commit: 597787853507d6b0f9e17721a6702d9991af4cb5
+commit: 4850dea187a72ae7ceaf0bd61b2e4a4c4b4a3b3e
 repo: Azure/azure-rest-api-specs
 emitterPackageJsonPath: eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json

--- a/sdk/search/Azure.ResourceManager.Search/tsp-location.yaml
+++ b/sdk/search/Azure.ResourceManager.Search/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/search/resource-manager/Microsoft.Search/Search
-commit: 597787853507d6b0f9e17721a6702d9991af4cb5
+commit: 4850dea187a72ae7ceaf0bd61b2e4a4c4b4a3b3e
 repo: Azure/azure-rest-api-specs
 emitterPackageJsonPath: eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json

--- a/sdk/storage/Azure.ResourceManager.Storage/tsp-location.yaml
+++ b/sdk/storage/Azure.ResourceManager.Storage/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Storage.Management
 repo: Azure/azure-rest-api-specs
-commit: 597787853507d6b0f9e17721a6702d9991af4cb5
+commit: 4850dea187a72ae7ceaf0bd61b2e4a4c4b4a3b3e
 emitterPackageJsonPath: "eng/azure-typespec-http-client-csharp-mgmt-emitter-package.json"


### PR DESCRIPTION
## Description

Updates `tsp-location.yaml` spec repo commit to [4850dea](https://github.com/Azure/azure-rest-api-specs/commit/4850dea187a72ae7ceaf0bd61b2e4a4c4b4a3b3e) (`Add @@usage(Model, Usage.input, "csharp") for C# ApiCompat compatibility`) for the following 5 RPs that had ApiCompat breaking changes after the mgmt generator bump in #58438:

- **appcomplianceautomation** — Azure.ResourceManager.AppComplianceAutomation
- **dataprotection** — Azure.ResourceManager.DataProtectionBackup
- **resources** — Azure.ResourceManager.Resources.DeploymentStacks
- **search** — Azure.ResourceManager.Search
- **storage** — Azure.ResourceManager.Storage

No code regeneration included — CI will handle that.