### PR TITLE
Bump provisioning generator base to mgmt 1.0.0-alpha.20260421.1

### DIFF
--- a/doc/GeneratorVersions/Emitter_Version_Dashboard.md
+++ b/doc/GeneratorVersions/Emitter_Version_Dashboard.md
@@ -1,14 +1,14 @@
 # Emitter Version Dashboard
 
-> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-04-21 03:19:10 UTC.
+> **Auto-generated** by `Emitter_Version_Dashboard` on 2026-04-22 05:49:48 UTC.
 > Run that script to refresh this file after dependency version changes.
 
 ## Dependency Chain
 
 ```
-@typespec/http-client-csharp (alpha.20260420.8)
+@typespec/http-client-csharp (alpha.20260421.4)
   └─ @azure-typespec/http-client-csharp (alpha.20260420.3)
-       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260419.1)
+       └─ @azure-typespec/http-client-csharp-mgmt (alpha.20260421.1)
             └─ @azure-typespec/http-client-csharp-provisioning (alpha.20260410.1)
 ```
 
@@ -16,9 +16,9 @@
 
 | Emitter | Depends On | Dependency Version | Latest on npm | Dependency Commit |
 |---|---|---|---|---|
-| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260420.6](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260420.6) | [1.0.0-alpha.20260420.8](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260420.8) | [565e025](https://github.com/microsoft/typespec/commit/565e025f7150929f1c3e3998ffad46ca55bd7092) |
+| `@azure-typespec/http-client-csharp` | `@typespec/http-client-csharp` | [1.0.0-alpha.20260420.6](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260420.6) | [1.0.0-alpha.20260421.4](https://www.npmjs.com/package/@typespec/http-client-csharp/v/1.0.0-alpha.20260421.4) | [565e025](https://github.com/microsoft/typespec/commit/565e025f7150929f1c3e3998ffad46ca55bd7092) |
 | `@azure-typespec/http-client-csharp-mgmt` | `@azure-typespec/http-client-csharp` | [1.0.0-alpha.20260415.3](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260415.3) | [1.0.0-alpha.20260420.3](https://www.npmjs.com/package/@azure-typespec/http-client-csharp/v/1.0.0-alpha.20260420.3) | [652555d](https://github.com/Azure/azure-sdk-for-net/commit/652555d044a9636401bb54afc099b0601365fade) |
-| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260408.3](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260408.3) | [1.0.0-alpha.20260419.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260419.1) | [9c2425a](https://github.com/Azure/azure-sdk-for-net/commit/9c2425a3ba733f6a31ee7fe4209baa4db3322e76) |
+| `@azure-typespec/http-client-csharp-provisioning` | `@azure-typespec/http-client-csharp-mgmt` | [1.0.0-alpha.20260421.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260421.1) | [1.0.0-alpha.20260421.1](https://www.npmjs.com/package/@azure-typespec/http-client-csharp-mgmt/v/1.0.0-alpha.20260421.1) | [b5e931a](https://github.com/Azure/azure-sdk-for-net/commit/b5e931a2589ea09ec1edad377740f13d587e1f7b) |
 
 ## Source Files
 

--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <UnbrandedGeneratorVersion>1.0.0-alpha.20260420.6</UnbrandedGeneratorVersion>
     <AzureGeneratorVersion>1.0.0-alpha.20260415.3</AzureGeneratorVersion>
-    <AzureManagementGeneratorVersion>1.0.0-alpha.20260408.3</AzureManagementGeneratorVersion>
+    <AzureManagementGeneratorVersion>1.0.0-alpha.20260421.1</AzureManagementGeneratorVersion>
   </PropertyGroup>
 
   <!-- Packages used by the TypeSpec generators -->

--- a/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
+++ b/eng/packages/http-client-csharp-provisioning/generator/TestProjects/Local/Provisioning-TypeSpec/tspCodeModel.json
@@ -2698,7 +2698,7 @@
       "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
       "crossLanguageDefinitionId": "Azure.ResourceManager.ArmOperationStatus",
       "usage": "LroPolling",
-      "doc": "Standard Azure Resource Manager operation status response",
+      "doc": "Standard Azure Resource Manager operation status response, used as the response\nbody for `GetResourceOperationStatus`.",
       "decorators": [
         {
           "name": "Azure.ResourceManager.@armProviderNamespace",
@@ -2757,14 +2757,14 @@
               "name": "id"
             }
           },
-          "isHttpMetadata": true
+          "isHttpMetadata": false
         },
         {
           "$id": "207",
           "kind": "property",
           "name": "name",
           "serializedName": "name",
-          "doc": "The name of the  operationStatus resource",
+          "doc": "The name of the operationStatus resource",
           "type": {
             "$id": "208",
             "kind": "string",
@@ -3894,49 +3894,80 @@
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}"
-                  },
-                  {
-                    "$id": "281",
-                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.get",
-                    "kind": "Read",
-                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}"
+                    "scope": {
+                      "$id": "281",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   },
                   {
                     "$id": "282",
-                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.update",
-                    "kind": "Update",
+                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.get",
+                    "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}"
-                  },
-                  {
-                    "$id": "283",
-                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.delete",
-                    "kind": "Delete",
-                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}"
+                    "scope": {
+                      "$id": "283",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   },
                   {
                     "$id": "284",
+                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.update",
+                    "kind": "Update",
+                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                    "scope": {
+                      "$id": "285",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
+                  },
+                  {
+                    "$id": "286",
+                    "methodId": "ProvisioningTypeSpec.ConfigurationStores.delete",
+                    "kind": "Delete",
+                    "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                    "scope": {
+                      "$id": "287",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
+                  },
+                  {
+                    "$id": "288",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores",
-                    "operationScope": "ResourceGroup"
+                    "scope": {
+                      "$id": "289",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   },
                   {
-                    "$id": "285",
+                    "$id": "290",
                     "methodId": "ProvisioningTypeSpec.ConfigurationStores.listBySubscription",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/providers/ProvisioningTypeSpec/configurationStores",
-                    "operationScope": "Subscription"
+                    "scope": {
+                      "$id": "291",
+                      "kind": "Subscription",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}",
+                      "scopeResourceType": "Microsoft.Resources/subscriptions"
+                    }
                   }
                 ],
-                "resourceScope": "ResourceGroup",
+                "scope": {
+                  "$id": "292",
+                  "kind": "ResourceGroup",
+                  "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+                  "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                },
                 "resourceName": "ConfigurationStore",
                 "nameConstraints": {
                   "pattern": "^[a-zA-Z0-9-]{3,24}$"
@@ -3967,39 +3998,60 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/keyValues",
                 "methods": [
                   {
-                    "$id": "286",
+                    "$id": "293",
                     "methodId": "ProvisioningTypeSpec.KeyValues.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}"
+                    "scope": {
+                      "$id": "294",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   },
                   {
-                    "$id": "287",
+                    "$id": "295",
                     "methodId": "ProvisioningTypeSpec.KeyValues.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}"
+                    "scope": {
+                      "$id": "296",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   },
                   {
-                    "$id": "288",
+                    "$id": "297",
                     "methodId": "ProvisioningTypeSpec.KeyValues.delete",
                     "kind": "Delete",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}"
+                    "scope": {
+                      "$id": "298",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues/{keyValueName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   },
                   {
-                    "$id": "289",
+                    "$id": "299",
                     "methodId": "ProvisioningTypeSpec.KeyValues.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/keyValues",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}"
+                    "scope": {
+                      "$id": "300",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   }
                 ],
-                "resourceScope": "ResourceGroup",
+                "scope": {
+                  "$id": "301",
+                  "kind": "ResourceGroup",
+                  "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+                  "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                },
                 "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                 "resourceName": "KeyValue",
                 "nameConstraints": {
@@ -4018,31 +4070,48 @@
                 "resourceType": "ProvisioningTypeSpec/configurationStores/items",
                 "methods": [
                   {
-                    "$id": "290",
+                    "$id": "302",
                     "methodId": "ProvisioningTypeSpec.Items.createOrUpdate",
                     "kind": "Create",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}"
+                    "scope": {
+                      "$id": "303",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   },
                   {
-                    "$id": "291",
+                    "$id": "304",
                     "methodId": "ProvisioningTypeSpec.Items.get",
                     "kind": "Read",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}"
+                    "scope": {
+                      "$id": "305",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items/{itemName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   },
                   {
-                    "$id": "292",
+                    "$id": "306",
                     "methodId": "ProvisioningTypeSpec.Items.list",
                     "kind": "List",
                     "operationPath": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}/items",
-                    "operationScope": "ResourceGroup",
-                    "resourceScope": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}"
+                    "scope": {
+                      "$id": "307",
+                      "kind": "ResourceGroup",
+                      "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
+                      "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                    }
                   }
                 ],
-                "resourceScope": "ResourceGroup",
+                "scope": {
+                  "$id": "308",
+                  "kind": "ResourceGroup",
+                  "scopeIdPattern": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}",
+                  "scopeResourceType": "Microsoft.Resources/resourceGroups"
+                },
                 "parentResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/ProvisioningTypeSpec/configurationStores/{configurationStoreName}",
                 "resourceName": "Item",
                 "nameConstraints": {
@@ -4060,7 +4129,12 @@
               {
                 "methodId": "Azure.ResourceManager.Operations.list",
                 "operationPath": "/providers/ProvisioningTypeSpec/operations",
-                "operationScope": "Tenant"
+                "scope": {
+                  "$id": "309",
+                  "kind": "Tenant",
+                  "scopeIdPattern": "",
+                  "scopeResourceType": "Microsoft.Resources/tenants"
+                }
               }
             ]
           }
@@ -4074,13 +4148,13 @@
       ],
       "children": [
         {
-          "$id": "293",
+          "$id": "310",
           "kind": "client",
           "name": "Operations",
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "294",
+              "$id": "311",
               "kind": "paging",
               "name": "list",
               "accessibility": "public",
@@ -4091,20 +4165,20 @@
               ],
               "doc": "List the operations for the provider",
               "operation": {
-                "$id": "295",
+                "$id": "312",
                 "name": "list",
                 "resourceName": "Operations",
                 "doc": "List the operations for the provider",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "296",
+                    "$id": "313",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "297",
+                      "$id": "314",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4114,7 +4188,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "298",
+                        "$id": "315",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -4142,7 +4216,7 @@
                     ]
                   },
                   {
-                    "$id": "299",
+                    "$id": "316",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -4158,7 +4232,7 @@
                     "crossLanguageDefinitionId": "Azure.ResourceManager.Operations.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "300",
+                        "$id": "317",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -4204,7 +4278,7 @@
               },
               "parameters": [
                 {
-                  "$ref": "300"
+                  "$ref": "317"
                 }
               ],
               "response": {
@@ -4235,13 +4309,13 @@
           ],
           "parameters": [
             {
-              "$id": "301",
+              "$id": "318",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "302",
+                "$id": "319",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -4252,7 +4326,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "303",
+                  "$id": "320",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -4282,13 +4356,13 @@
           "isMultiServiceClient": false
         },
         {
-          "$id": "304",
+          "$id": "321",
           "kind": "client",
           "name": "ConfigurationStores",
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "305",
+              "$id": "322",
               "kind": "lro",
               "name": "createOrUpdate",
               "accessibility": "public",
@@ -4299,20 +4373,20 @@
               ],
               "doc": "Create a ConfigurationStore",
               "operation": {
-                "$id": "306",
+                "$id": "323",
                 "name": "createOrUpdate",
                 "resourceName": "ConfigurationStore",
                 "doc": "Create a ConfigurationStore",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "307",
+                    "$id": "324",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "308",
+                      "$id": "325",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4322,7 +4396,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "309",
+                        "$id": "326",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -4345,13 +4419,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "310",
+                        "$id": "327",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "311",
+                          "$id": "328",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4361,7 +4435,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "312",
+                            "$id": "329",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -4387,18 +4461,18 @@
                     ]
                   },
                   {
-                    "$id": "313",
+                    "$id": "330",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "314",
+                      "$id": "331",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "315",
+                        "$id": "332",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4427,18 +4501,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "316",
+                        "$id": "333",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "317",
+                          "$id": "334",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "318",
+                            "$id": "335",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4467,13 +4541,13 @@
                     ]
                   },
                   {
-                    "$id": "319",
+                    "$id": "336",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "320",
+                      "$id": "337",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4514,13 +4588,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "321",
+                        "$id": "338",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "322",
+                          "$id": "339",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4561,13 +4635,13 @@
                     ]
                   },
                   {
-                    "$id": "323",
+                    "$id": "340",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "324",
+                      "$id": "341",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4592,13 +4666,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "325",
+                        "$id": "342",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "326",
+                          "$id": "343",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4623,7 +4697,7 @@
                     ]
                   },
                   {
-                    "$id": "327",
+                    "$id": "344",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -4640,7 +4714,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "328",
+                        "$id": "345",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -4660,7 +4734,7 @@
                     ]
                   },
                   {
-                    "$id": "329",
+                    "$id": "346",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -4676,7 +4750,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "330",
+                        "$id": "347",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -4695,7 +4769,7 @@
                     ]
                   },
                   {
-                    "$id": "331",
+                    "$id": "348",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
@@ -4715,7 +4789,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "332",
+                        "$id": "349",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
@@ -4762,7 +4836,7 @@
                         "nameInResponse": "Azure-AsyncOperation",
                         "doc": "A link to the status monitor",
                         "type": {
-                          "$id": "333",
+                          "$id": "350",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4774,7 +4848,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "334",
+                          "$id": "351",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -4808,27 +4882,27 @@
               },
               "parameters": [
                 {
-                  "$ref": "321"
+                  "$ref": "338"
                 },
                 {
-                  "$ref": "325"
+                  "$ref": "342"
                 },
                 {
-                  "$ref": "332"
+                  "$ref": "349"
                 },
                 {
-                  "$ref": "328"
+                  "$ref": "345"
                 },
                 {
-                  "$ref": "330"
+                  "$ref": "347"
                 },
                 {
-                  "$id": "335",
+                  "$id": "352",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "314"
+                    "$ref": "331"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -4861,7 +4935,7 @@
               }
             },
             {
-              "$id": "336",
+              "$id": "353",
               "kind": "basic",
               "name": "get",
               "accessibility": "public",
@@ -4872,20 +4946,20 @@
               ],
               "doc": "Get a ConfigurationStore",
               "operation": {
-                "$id": "337",
+                "$id": "354",
                 "name": "get",
                 "resourceName": "ConfigurationStore",
                 "doc": "Get a ConfigurationStore",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "338",
+                    "$id": "355",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "339",
+                      "$id": "356",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4895,7 +4969,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "340",
+                        "$id": "357",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -4918,23 +4992,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "310"
+                        "$ref": "327"
                       }
                     ]
                   },
                   {
-                    "$id": "341",
+                    "$id": "358",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "342",
+                      "$id": "359",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "343",
+                        "$id": "360",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -4963,18 +5037,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "316"
+                        "$ref": "333"
                       }
                     ]
                   },
                   {
-                    "$id": "344",
+                    "$id": "361",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "345",
+                      "$id": "362",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5015,13 +5089,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "346",
+                        "$id": "363",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "347",
+                          "$id": "364",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5062,13 +5136,13 @@
                     ]
                   },
                   {
-                    "$id": "348",
+                    "$id": "365",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "349",
+                      "$id": "366",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5093,13 +5167,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "350",
+                        "$id": "367",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "351",
+                          "$id": "368",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5124,7 +5198,7 @@
                     ]
                   },
                   {
-                    "$id": "352",
+                    "$id": "369",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -5140,7 +5214,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "353",
+                        "$id": "370",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -5191,21 +5265,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "346"
+                  "$ref": "363"
                 },
                 {
-                  "$ref": "350"
+                  "$ref": "367"
                 },
                 {
-                  "$ref": "353"
+                  "$ref": "370"
                 },
                 {
-                  "$id": "354",
+                  "$id": "371",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "342"
+                    "$ref": "359"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -5227,7 +5301,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.get"
             },
             {
-              "$id": "355",
+              "$id": "372",
               "kind": "lro",
               "name": "update",
               "accessibility": "public",
@@ -5238,20 +5312,20 @@
               ],
               "doc": "Update a ConfigurationStore",
               "operation": {
-                "$id": "356",
+                "$id": "373",
                 "name": "update",
                 "resourceName": "ConfigurationStore",
                 "doc": "Update a ConfigurationStore",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "357",
+                    "$id": "374",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "358",
+                      "$id": "375",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5261,7 +5335,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "359",
+                        "$id": "376",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5284,23 +5358,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "310"
+                        "$ref": "327"
                       }
                     ]
                   },
                   {
-                    "$id": "360",
+                    "$id": "377",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "361",
+                      "$id": "378",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "362",
+                        "$id": "379",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5329,18 +5403,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "316"
+                        "$ref": "333"
                       }
                     ]
                   },
                   {
-                    "$id": "363",
+                    "$id": "380",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "364",
+                      "$id": "381",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5381,13 +5455,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "365",
+                        "$id": "382",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "366",
+                          "$id": "383",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5428,13 +5502,13 @@
                     ]
                   },
                   {
-                    "$id": "367",
+                    "$id": "384",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "368",
+                      "$id": "385",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5459,13 +5533,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "369",
+                        "$id": "386",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "370",
+                          "$id": "387",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5490,7 +5564,7 @@
                     ]
                   },
                   {
-                    "$id": "371",
+                    "$id": "388",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -5507,7 +5581,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "372",
+                        "$id": "389",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -5527,7 +5601,7 @@
                     ]
                   },
                   {
-                    "$id": "373",
+                    "$id": "390",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -5543,7 +5617,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "374",
+                        "$id": "391",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -5562,7 +5636,7 @@
                     ]
                   },
                   {
-                    "$id": "375",
+                    "$id": "392",
                     "kind": "body",
                     "name": "properties",
                     "serializedName": "properties",
@@ -5582,7 +5656,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.update.properties",
                     "methodParameterSegments": [
                       {
-                        "$id": "376",
+                        "$id": "393",
                         "kind": "method",
                         "name": "properties",
                         "serializedName": "properties",
@@ -5626,7 +5700,7 @@
                         "nameInResponse": "Location",
                         "doc": "The Location header contains the URL where the status of the long running operation can be checked.",
                         "type": {
-                          "$id": "377",
+                          "$id": "394",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5638,7 +5712,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "378",
+                          "$id": "395",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -5669,27 +5743,27 @@
               },
               "parameters": [
                 {
-                  "$ref": "365"
+                  "$ref": "382"
                 },
                 {
-                  "$ref": "369"
+                  "$ref": "386"
                 },
                 {
-                  "$ref": "376"
+                  "$ref": "393"
                 },
                 {
-                  "$ref": "372"
+                  "$ref": "389"
                 },
                 {
-                  "$ref": "374"
+                  "$ref": "391"
                 },
                 {
-                  "$id": "379",
+                  "$id": "396",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "361"
+                    "$ref": "378"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -5722,7 +5796,7 @@
               }
             },
             {
-              "$id": "380",
+              "$id": "397",
               "kind": "lro",
               "name": "delete",
               "accessibility": "public",
@@ -5733,20 +5807,20 @@
               ],
               "doc": "Delete a ConfigurationStore",
               "operation": {
-                "$id": "381",
+                "$id": "398",
                 "name": "delete",
                 "resourceName": "ConfigurationStore",
                 "doc": "Delete a ConfigurationStore",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "382",
+                    "$id": "399",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "383",
+                      "$id": "400",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5756,7 +5830,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "384",
+                        "$id": "401",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -5779,23 +5853,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "310"
+                        "$ref": "327"
                       }
                     ]
                   },
                   {
-                    "$id": "385",
+                    "$id": "402",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "386",
+                      "$id": "403",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "387",
+                        "$id": "404",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5824,18 +5898,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.delete.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "316"
+                        "$ref": "333"
                       }
                     ]
                   },
                   {
-                    "$id": "388",
+                    "$id": "405",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "389",
+                      "$id": "406",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5876,13 +5950,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.delete.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "390",
+                        "$id": "407",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "391",
+                          "$id": "408",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5923,13 +5997,13 @@
                     ]
                   },
                   {
-                    "$id": "392",
+                    "$id": "409",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "393",
+                      "$id": "410",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5954,13 +6028,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.delete.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "394",
+                        "$id": "411",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "395",
+                          "$id": "412",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -5996,7 +6070,7 @@
                         "nameInResponse": "Location",
                         "doc": "The Location header contains the URL where the status of the long running operation can be checked.",
                         "type": {
-                          "$id": "396",
+                          "$id": "413",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6008,7 +6082,7 @@
                         "nameInResponse": "Retry-After",
                         "doc": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
                         "type": {
-                          "$id": "397",
+                          "$id": "414",
                           "kind": "int32",
                           "name": "int32",
                           "crossLanguageDefinitionId": "TypeSpec.int32",
@@ -6043,18 +6117,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "390"
+                  "$ref": "407"
                 },
                 {
-                  "$ref": "394"
+                  "$ref": "411"
                 },
                 {
-                  "$id": "398",
+                  "$id": "415",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "386"
+                    "$ref": "403"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -6080,7 +6154,7 @@
               }
             },
             {
-              "$id": "399",
+              "$id": "416",
               "kind": "paging",
               "name": "list",
               "accessibility": "public",
@@ -6091,20 +6165,20 @@
               ],
               "doc": "List ConfigurationStore resources by resource group",
               "operation": {
-                "$id": "400",
+                "$id": "417",
                 "name": "list",
                 "resourceName": "ConfigurationStore",
                 "doc": "List ConfigurationStore resources by resource group",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "401",
+                    "$id": "418",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "402",
+                      "$id": "419",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6114,7 +6188,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "403",
+                        "$id": "420",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6137,23 +6211,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "310"
+                        "$ref": "327"
                       }
                     ]
                   },
                   {
-                    "$id": "404",
+                    "$id": "421",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "405",
+                      "$id": "422",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "406",
+                        "$id": "423",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6182,18 +6256,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "316"
+                        "$ref": "333"
                       }
                     ]
                   },
                   {
-                    "$id": "407",
+                    "$id": "424",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "408",
+                      "$id": "425",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6234,13 +6308,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "409",
+                        "$id": "426",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "410",
+                          "$id": "427",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6281,7 +6355,7 @@
                     ]
                   },
                   {
-                    "$id": "411",
+                    "$id": "428",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -6297,7 +6371,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "412",
+                        "$id": "429",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -6348,18 +6422,18 @@
               },
               "parameters": [
                 {
-                  "$ref": "409"
+                  "$ref": "426"
                 },
                 {
-                  "$ref": "412"
+                  "$ref": "429"
                 },
                 {
-                  "$id": "413",
+                  "$id": "430",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "405"
+                    "$ref": "422"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -6396,7 +6470,7 @@
               }
             },
             {
-              "$id": "414",
+              "$id": "431",
               "kind": "paging",
               "name": "listBySubscription",
               "accessibility": "public",
@@ -6407,20 +6481,20 @@
               ],
               "doc": "List ConfigurationStore resources by subscription ID",
               "operation": {
-                "$id": "415",
+                "$id": "432",
                 "name": "listBySubscription",
                 "resourceName": "ConfigurationStore",
                 "doc": "List ConfigurationStore resources by subscription ID",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "416",
+                    "$id": "433",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "417",
+                      "$id": "434",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6430,7 +6504,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "418",
+                        "$id": "435",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6453,23 +6527,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "310"
+                        "$ref": "327"
                       }
                     ]
                   },
                   {
-                    "$id": "419",
+                    "$id": "436",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "420",
+                      "$id": "437",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "421",
+                        "$id": "438",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6498,12 +6572,12 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.listBySubscription.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "316"
+                        "$ref": "333"
                       }
                     ]
                   },
                   {
-                    "$id": "422",
+                    "$id": "439",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -6519,7 +6593,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.listBySubscription.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "423",
+                        "$id": "440",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -6570,15 +6644,15 @@
               },
               "parameters": [
                 {
-                  "$ref": "423"
+                  "$ref": "440"
                 },
                 {
-                  "$id": "424",
+                  "$id": "441",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "420"
+                    "$ref": "437"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -6617,13 +6691,13 @@
           ],
           "parameters": [
             {
-              "$id": "425",
+              "$id": "442",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "426",
+                "$id": "443",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -6634,7 +6708,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "427",
+                  "$id": "444",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6647,7 +6721,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.ConfigurationStores.endpoint"
             },
             {
-              "$ref": "310"
+              "$ref": "327"
             }
           ],
           "initializedBy": 0,
@@ -6669,13 +6743,13 @@
           "isMultiServiceClient": false
         },
         {
-          "$id": "428",
+          "$id": "445",
           "kind": "client",
           "name": "KeyValues",
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "429",
+              "$id": "446",
               "kind": "basic",
               "name": "createOrUpdate",
               "accessibility": "public",
@@ -6686,20 +6760,20 @@
               ],
               "doc": "Create a KeyValue",
               "operation": {
-                "$id": "430",
+                "$id": "447",
                 "name": "createOrUpdate",
                 "resourceName": "KeyValue",
                 "doc": "Create a KeyValue",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "431",
+                    "$id": "448",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "432",
+                      "$id": "449",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6709,7 +6783,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "433",
+                        "$id": "450",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6732,13 +6806,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "434",
+                        "$id": "451",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "435",
+                          "$id": "452",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6748,7 +6822,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "436",
+                            "$id": "453",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -6774,18 +6848,18 @@
                     ]
                   },
                   {
-                    "$id": "437",
+                    "$id": "454",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "438",
+                      "$id": "455",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "439",
+                        "$id": "456",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6814,18 +6888,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "440",
+                        "$id": "457",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "441",
+                          "$id": "458",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "442",
+                            "$id": "459",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6854,13 +6928,13 @@
                     ]
                   },
                   {
-                    "$id": "443",
+                    "$id": "460",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "444",
+                      "$id": "461",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6901,13 +6975,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "445",
+                        "$id": "462",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "446",
+                          "$id": "463",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6948,13 +7022,13 @@
                     ]
                   },
                   {
-                    "$id": "447",
+                    "$id": "464",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "448",
+                      "$id": "465",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -6979,13 +7053,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "449",
+                        "$id": "466",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "450",
+                          "$id": "467",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7010,13 +7084,13 @@
                     ]
                   },
                   {
-                    "$id": "451",
+                    "$id": "468",
                     "kind": "path",
                     "name": "keyValueName",
                     "serializedName": "keyValueName",
                     "doc": "The name of the KeyValue",
                     "type": {
-                      "$id": "452",
+                      "$id": "469",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7041,13 +7115,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.keyValueName",
                     "methodParameterSegments": [
                       {
-                        "$id": "453",
+                        "$id": "470",
                         "kind": "method",
                         "name": "keyValueName",
                         "serializedName": "keyValueName",
                         "doc": "The name of the KeyValue",
                         "type": {
-                          "$id": "454",
+                          "$id": "471",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7072,7 +7146,7 @@
                     ]
                   },
                   {
-                    "$id": "455",
+                    "$id": "472",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -7089,7 +7163,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "456",
+                        "$id": "473",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -7109,7 +7183,7 @@
                     ]
                   },
                   {
-                    "$id": "457",
+                    "$id": "474",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -7125,7 +7199,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "458",
+                        "$id": "475",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -7144,7 +7218,7 @@
                     ]
                   },
                   {
-                    "$id": "459",
+                    "$id": "476",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
@@ -7164,7 +7238,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "460",
+                        "$id": "477",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
@@ -7219,30 +7293,30 @@
               },
               "parameters": [
                 {
-                  "$ref": "445"
+                  "$ref": "462"
                 },
                 {
-                  "$ref": "449"
+                  "$ref": "466"
                 },
                 {
-                  "$ref": "453"
+                  "$ref": "470"
                 },
                 {
-                  "$ref": "460"
+                  "$ref": "477"
                 },
                 {
-                  "$ref": "456"
+                  "$ref": "473"
                 },
                 {
-                  "$ref": "458"
+                  "$ref": "475"
                 },
                 {
-                  "$id": "461",
+                  "$id": "478",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "438"
+                    "$ref": "455"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -7264,7 +7338,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.createOrUpdate"
             },
             {
-              "$id": "462",
+              "$id": "479",
               "kind": "basic",
               "name": "get",
               "accessibility": "public",
@@ -7275,20 +7349,20 @@
               ],
               "doc": "Get a KeyValue",
               "operation": {
-                "$id": "463",
+                "$id": "480",
                 "name": "get",
                 "resourceName": "KeyValue",
                 "doc": "Get a KeyValue",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "464",
+                    "$id": "481",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "465",
+                      "$id": "482",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7298,7 +7372,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "466",
+                        "$id": "483",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -7321,23 +7395,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "434"
+                        "$ref": "451"
                       }
                     ]
                   },
                   {
-                    "$id": "467",
+                    "$id": "484",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "468",
+                      "$id": "485",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "469",
+                        "$id": "486",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7366,18 +7440,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "440"
+                        "$ref": "457"
                       }
                     ]
                   },
                   {
-                    "$id": "470",
+                    "$id": "487",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "471",
+                      "$id": "488",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7418,13 +7492,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "472",
+                        "$id": "489",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "473",
+                          "$id": "490",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7465,13 +7539,13 @@
                     ]
                   },
                   {
-                    "$id": "474",
+                    "$id": "491",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "475",
+                      "$id": "492",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7496,13 +7570,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "476",
+                        "$id": "493",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "477",
+                          "$id": "494",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7527,13 +7601,13 @@
                     ]
                   },
                   {
-                    "$id": "478",
+                    "$id": "495",
                     "kind": "path",
                     "name": "keyValueName",
                     "serializedName": "keyValueName",
                     "doc": "The name of the KeyValue",
                     "type": {
-                      "$id": "479",
+                      "$id": "496",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7558,13 +7632,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.keyValueName",
                     "methodParameterSegments": [
                       {
-                        "$id": "480",
+                        "$id": "497",
                         "kind": "method",
                         "name": "keyValueName",
                         "serializedName": "keyValueName",
                         "doc": "The name of the KeyValue",
                         "type": {
-                          "$id": "481",
+                          "$id": "498",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7589,7 +7663,7 @@
                     ]
                   },
                   {
-                    "$id": "482",
+                    "$id": "499",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -7605,7 +7679,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "483",
+                        "$id": "500",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -7656,24 +7730,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "472"
+                  "$ref": "489"
                 },
                 {
-                  "$ref": "476"
+                  "$ref": "493"
                 },
                 {
-                  "$ref": "480"
+                  "$ref": "497"
                 },
                 {
-                  "$ref": "483"
+                  "$ref": "500"
                 },
                 {
-                  "$id": "484",
+                  "$id": "501",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "468"
+                    "$ref": "485"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -7695,7 +7769,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.get"
             },
             {
-              "$id": "485",
+              "$id": "502",
               "kind": "basic",
               "name": "delete",
               "accessibility": "public",
@@ -7706,20 +7780,20 @@
               ],
               "doc": "Delete a KeyValue",
               "operation": {
-                "$id": "486",
+                "$id": "503",
                 "name": "delete",
                 "resourceName": "KeyValue",
                 "doc": "Delete a KeyValue",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "487",
+                    "$id": "504",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "488",
+                      "$id": "505",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7729,7 +7803,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "489",
+                        "$id": "506",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -7752,23 +7826,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "434"
+                        "$ref": "451"
                       }
                     ]
                   },
                   {
-                    "$id": "490",
+                    "$id": "507",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "491",
+                      "$id": "508",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "492",
+                        "$id": "509",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7797,18 +7871,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "440"
+                        "$ref": "457"
                       }
                     ]
                   },
                   {
-                    "$id": "493",
+                    "$id": "510",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "494",
+                      "$id": "511",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7849,13 +7923,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "495",
+                        "$id": "512",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "496",
+                          "$id": "513",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7896,13 +7970,13 @@
                     ]
                   },
                   {
-                    "$id": "497",
+                    "$id": "514",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "498",
+                      "$id": "515",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7927,13 +8001,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "499",
+                        "$id": "516",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "500",
+                          "$id": "517",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7958,13 +8032,13 @@
                     ]
                   },
                   {
-                    "$id": "501",
+                    "$id": "518",
                     "kind": "path",
                     "name": "keyValueName",
                     "serializedName": "keyValueName",
                     "doc": "The name of the KeyValue",
                     "type": {
-                      "$id": "502",
+                      "$id": "519",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -7989,13 +8063,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete.keyValueName",
                     "methodParameterSegments": [
                       {
-                        "$id": "503",
+                        "$id": "520",
                         "kind": "method",
                         "name": "keyValueName",
                         "serializedName": "keyValueName",
                         "doc": "The name of the KeyValue",
                         "type": {
-                          "$id": "504",
+                          "$id": "521",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8053,21 +8127,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "495"
+                  "$ref": "512"
                 },
                 {
-                  "$ref": "499"
+                  "$ref": "516"
                 },
                 {
-                  "$ref": "503"
+                  "$ref": "520"
                 },
                 {
-                  "$id": "505",
+                  "$id": "522",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "491"
+                    "$ref": "508"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -8085,7 +8159,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.delete"
             },
             {
-              "$id": "506",
+              "$id": "523",
               "kind": "paging",
               "name": "list",
               "accessibility": "public",
@@ -8096,20 +8170,20 @@
               ],
               "doc": "List KeyValue resources by ConfigurationStore",
               "operation": {
-                "$id": "507",
+                "$id": "524",
                 "name": "list",
                 "resourceName": "KeyValue",
                 "doc": "List KeyValue resources by ConfigurationStore",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "508",
+                    "$id": "525",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "509",
+                      "$id": "526",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8119,7 +8193,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "510",
+                        "$id": "527",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8142,23 +8216,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "434"
+                        "$ref": "451"
                       }
                     ]
                   },
                   {
-                    "$id": "511",
+                    "$id": "528",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "512",
+                      "$id": "529",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "513",
+                        "$id": "530",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8187,18 +8261,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "440"
+                        "$ref": "457"
                       }
                     ]
                   },
                   {
-                    "$id": "514",
+                    "$id": "531",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "515",
+                      "$id": "532",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8239,13 +8313,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "516",
+                        "$id": "533",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "517",
+                          "$id": "534",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8286,13 +8360,13 @@
                     ]
                   },
                   {
-                    "$id": "518",
+                    "$id": "535",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "519",
+                      "$id": "536",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8317,13 +8391,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "520",
+                        "$id": "537",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "521",
+                          "$id": "538",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8348,7 +8422,7 @@
                     ]
                   },
                   {
-                    "$id": "522",
+                    "$id": "539",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8364,7 +8438,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "523",
+                        "$id": "540",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -8415,21 +8489,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "516"
+                  "$ref": "533"
                 },
                 {
-                  "$ref": "520"
+                  "$ref": "537"
                 },
                 {
-                  "$ref": "523"
+                  "$ref": "540"
                 },
                 {
-                  "$id": "524",
+                  "$id": "541",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "512"
+                    "$ref": "529"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -8468,13 +8542,13 @@
           ],
           "parameters": [
             {
-              "$id": "525",
+              "$id": "542",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "526",
+                "$id": "543",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -8485,7 +8559,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "527",
+                  "$id": "544",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8498,7 +8572,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.KeyValues.endpoint"
             },
             {
-              "$ref": "434"
+              "$ref": "451"
             }
           ],
           "initializedBy": 0,
@@ -8520,13 +8594,13 @@
           "isMultiServiceClient": false
         },
         {
-          "$id": "528",
+          "$id": "545",
           "kind": "client",
           "name": "Items",
           "namespace": "Azure.Provisioning.ProvisioningTypeSpec",
           "methods": [
             {
-              "$id": "529",
+              "$id": "546",
               "kind": "basic",
               "name": "get",
               "accessibility": "public",
@@ -8537,20 +8611,20 @@
               ],
               "doc": "Get a Item",
               "operation": {
-                "$id": "530",
+                "$id": "547",
                 "name": "get",
                 "resourceName": "Item",
                 "doc": "Get a Item",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "531",
+                    "$id": "548",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "532",
+                      "$id": "549",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8560,7 +8634,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "533",
+                        "$id": "550",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8583,13 +8657,13 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$id": "534",
+                        "$id": "551",
                         "kind": "method",
                         "name": "apiVersion",
                         "serializedName": "apiVersion",
                         "doc": "The API version to use for this operation.",
                         "type": {
-                          "$id": "535",
+                          "$id": "552",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8599,7 +8673,7 @@
                         "isApiVersion": true,
                         "defaultValue": {
                           "type": {
-                            "$id": "536",
+                            "$id": "553",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string"
@@ -8625,18 +8699,18 @@
                     ]
                   },
                   {
-                    "$id": "537",
+                    "$id": "554",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "538",
+                      "$id": "555",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "539",
+                        "$id": "556",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8665,18 +8739,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$id": "540",
+                        "$id": "557",
                         "kind": "method",
                         "name": "subscriptionId",
                         "serializedName": "subscriptionId",
                         "doc": "The ID of the target subscription. The value must be an UUID.",
                         "type": {
-                          "$id": "541",
+                          "$id": "558",
                           "kind": "string",
                           "name": "uuid",
                           "crossLanguageDefinitionId": "Azure.Core.uuid",
                           "baseType": {
-                            "$id": "542",
+                            "$id": "559",
                             "kind": "string",
                             "name": "string",
                             "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8705,13 +8779,13 @@
                     ]
                   },
                   {
-                    "$id": "543",
+                    "$id": "560",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "544",
+                      "$id": "561",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8752,13 +8826,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "545",
+                        "$id": "562",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "546",
+                          "$id": "563",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8799,13 +8873,13 @@
                     ]
                   },
                   {
-                    "$id": "547",
+                    "$id": "564",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "548",
+                      "$id": "565",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8830,13 +8904,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "549",
+                        "$id": "566",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "550",
+                          "$id": "567",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8861,13 +8935,13 @@
                     ]
                   },
                   {
-                    "$id": "551",
+                    "$id": "568",
                     "kind": "path",
                     "name": "itemName",
                     "serializedName": "itemName",
                     "doc": "The name of the Item",
                     "type": {
-                      "$id": "552",
+                      "$id": "569",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8892,13 +8966,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.itemName",
                     "methodParameterSegments": [
                       {
-                        "$id": "553",
+                        "$id": "570",
                         "kind": "method",
                         "name": "itemName",
                         "serializedName": "itemName",
                         "doc": "The name of the Item",
                         "type": {
-                          "$id": "554",
+                          "$id": "571",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -8923,7 +8997,7 @@
                     ]
                   },
                   {
-                    "$id": "555",
+                    "$id": "572",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -8939,7 +9013,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "556",
+                        "$id": "573",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -8990,24 +9064,24 @@
               },
               "parameters": [
                 {
-                  "$ref": "545"
+                  "$ref": "562"
                 },
                 {
-                  "$ref": "549"
+                  "$ref": "566"
                 },
                 {
-                  "$ref": "553"
+                  "$ref": "570"
                 },
                 {
-                  "$ref": "556"
+                  "$ref": "573"
                 },
                 {
-                  "$id": "557",
+                  "$id": "574",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "538"
+                    "$ref": "555"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -9029,7 +9103,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.get"
             },
             {
-              "$id": "558",
+              "$id": "575",
               "kind": "basic",
               "name": "createOrUpdate",
               "accessibility": "public",
@@ -9039,19 +9113,19 @@
                 "2024-05-01"
               ],
               "operation": {
-                "$id": "559",
+                "$id": "576",
                 "name": "createOrUpdate",
                 "resourceName": "Item",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "560",
+                    "$id": "577",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "561",
+                      "$id": "578",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9061,7 +9135,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "562",
+                        "$id": "579",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -9084,23 +9158,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "534"
+                        "$ref": "551"
                       }
                     ]
                   },
                   {
-                    "$id": "563",
+                    "$id": "580",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "564",
+                      "$id": "581",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "565",
+                        "$id": "582",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9129,18 +9203,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "540"
+                        "$ref": "557"
                       }
                     ]
                   },
                   {
-                    "$id": "566",
+                    "$id": "583",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "567",
+                      "$id": "584",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9181,13 +9255,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "568",
+                        "$id": "585",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "569",
+                          "$id": "586",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9228,13 +9302,13 @@
                     ]
                   },
                   {
-                    "$id": "570",
+                    "$id": "587",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "571",
+                      "$id": "588",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9259,13 +9333,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "572",
+                        "$id": "589",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "573",
+                          "$id": "590",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9290,13 +9364,13 @@
                     ]
                   },
                   {
-                    "$id": "574",
+                    "$id": "591",
                     "kind": "path",
                     "name": "itemName",
                     "serializedName": "itemName",
                     "doc": "The name of the Item",
                     "type": {
-                      "$id": "575",
+                      "$id": "592",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9321,13 +9395,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.itemName",
                     "methodParameterSegments": [
                       {
-                        "$id": "576",
+                        "$id": "593",
                         "kind": "method",
                         "name": "itemName",
                         "serializedName": "itemName",
                         "doc": "The name of the Item",
                         "type": {
-                          "$id": "577",
+                          "$id": "594",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9352,7 +9426,7 @@
                     ]
                   },
                   {
-                    "$id": "578",
+                    "$id": "595",
                     "kind": "header",
                     "name": "contentType",
                     "serializedName": "Content-Type",
@@ -9369,7 +9443,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.contentType",
                     "methodParameterSegments": [
                       {
-                        "$id": "579",
+                        "$id": "596",
                         "kind": "method",
                         "name": "contentType",
                         "serializedName": "Content-Type",
@@ -9389,7 +9463,7 @@
                     ]
                   },
                   {
-                    "$id": "580",
+                    "$id": "597",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9405,7 +9479,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "581",
+                        "$id": "598",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -9424,7 +9498,7 @@
                     ]
                   },
                   {
-                    "$id": "582",
+                    "$id": "599",
                     "kind": "body",
                     "name": "resource",
                     "serializedName": "resource",
@@ -9444,7 +9518,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate.resource",
                     "methodParameterSegments": [
                       {
-                        "$id": "583",
+                        "$id": "600",
                         "kind": "method",
                         "name": "resource",
                         "serializedName": "resource",
@@ -9512,30 +9586,30 @@
               },
               "parameters": [
                 {
-                  "$ref": "568"
+                  "$ref": "585"
                 },
                 {
-                  "$ref": "572"
+                  "$ref": "589"
                 },
                 {
-                  "$ref": "576"
+                  "$ref": "593"
                 },
                 {
-                  "$ref": "583"
+                  "$ref": "600"
                 },
                 {
-                  "$ref": "579"
+                  "$ref": "596"
                 },
                 {
-                  "$ref": "581"
+                  "$ref": "598"
                 },
                 {
-                  "$id": "584",
+                  "$id": "601",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "564"
+                    "$ref": "581"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -9557,7 +9631,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.createOrUpdate"
             },
             {
-              "$id": "585",
+              "$id": "602",
               "kind": "paging",
               "name": "list",
               "accessibility": "public",
@@ -9568,20 +9642,20 @@
               ],
               "doc": "List Item resources by ConfigurationStore",
               "operation": {
-                "$id": "586",
+                "$id": "603",
                 "name": "list",
                 "resourceName": "Item",
                 "doc": "List Item resources by ConfigurationStore",
                 "accessibility": "public",
                 "parameters": [
                   {
-                    "$id": "587",
+                    "$id": "604",
                     "kind": "query",
                     "name": "apiVersion",
                     "serializedName": "api-version",
                     "doc": "The API version to use for this operation.",
                     "type": {
-                      "$id": "588",
+                      "$id": "605",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9591,7 +9665,7 @@
                     "explode": false,
                     "defaultValue": {
                       "type": {
-                        "$id": "589",
+                        "$id": "606",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string"
@@ -9614,23 +9688,23 @@
                     "readOnly": false,
                     "methodParameterSegments": [
                       {
-                        "$ref": "534"
+                        "$ref": "551"
                       }
                     ]
                   },
                   {
-                    "$id": "590",
+                    "$id": "607",
                     "kind": "path",
                     "name": "subscriptionId",
                     "serializedName": "subscriptionId",
                     "doc": "The ID of the target subscription. The value must be an UUID.",
                     "type": {
-                      "$id": "591",
+                      "$id": "608",
                       "kind": "string",
                       "name": "uuid",
                       "crossLanguageDefinitionId": "Azure.Core.uuid",
                       "baseType": {
-                        "$id": "592",
+                        "$id": "609",
                         "kind": "string",
                         "name": "string",
                         "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9659,18 +9733,18 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.subscriptionId",
                     "methodParameterSegments": [
                       {
-                        "$ref": "540"
+                        "$ref": "557"
                       }
                     ]
                   },
                   {
-                    "$id": "593",
+                    "$id": "610",
                     "kind": "path",
                     "name": "resourceGroupName",
                     "serializedName": "resourceGroupName",
                     "doc": "The name of the resource group. The name is case insensitive.",
                     "type": {
-                      "$id": "594",
+                      "$id": "611",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9711,13 +9785,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.resourceGroupName",
                     "methodParameterSegments": [
                       {
-                        "$id": "595",
+                        "$id": "612",
                         "kind": "method",
                         "name": "resourceGroupName",
                         "serializedName": "resourceGroupName",
                         "doc": "The name of the resource group. The name is case insensitive.",
                         "type": {
-                          "$id": "596",
+                          "$id": "613",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9758,13 +9832,13 @@
                     ]
                   },
                   {
-                    "$id": "597",
+                    "$id": "614",
                     "kind": "path",
                     "name": "configurationStoreName",
                     "serializedName": "configurationStoreName",
                     "doc": "The name of the ConfigurationStore",
                     "type": {
-                      "$id": "598",
+                      "$id": "615",
                       "kind": "string",
                       "name": "string",
                       "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9789,13 +9863,13 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.configurationStoreName",
                     "methodParameterSegments": [
                       {
-                        "$id": "599",
+                        "$id": "616",
                         "kind": "method",
                         "name": "configurationStoreName",
                         "serializedName": "configurationStoreName",
                         "doc": "The name of the ConfigurationStore",
                         "type": {
-                          "$id": "600",
+                          "$id": "617",
                           "kind": "string",
                           "name": "string",
                           "crossLanguageDefinitionId": "TypeSpec.string",
@@ -9820,7 +9894,7 @@
                     ]
                   },
                   {
-                    "$id": "601",
+                    "$id": "618",
                     "kind": "header",
                     "name": "accept",
                     "serializedName": "Accept",
@@ -9836,7 +9910,7 @@
                     "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.list.accept",
                     "methodParameterSegments": [
                       {
-                        "$id": "602",
+                        "$id": "619",
                         "kind": "method",
                         "name": "accept",
                         "serializedName": "Accept",
@@ -9887,21 +9961,21 @@
               },
               "parameters": [
                 {
-                  "$ref": "595"
+                  "$ref": "612"
                 },
                 {
-                  "$ref": "599"
+                  "$ref": "616"
                 },
                 {
-                  "$ref": "602"
+                  "$ref": "619"
                 },
                 {
-                  "$id": "603",
+                  "$id": "620",
                   "kind": "method",
                   "name": "subscriptionId",
                   "doc": "The ID of the target subscription. The value must be an UUID.",
                   "type": {
-                    "$ref": "591"
+                    "$ref": "608"
                   },
                   "optional": false,
                   "readOnly": false,
@@ -9940,13 +10014,13 @@
           ],
           "parameters": [
             {
-              "$id": "604",
+              "$id": "621",
               "kind": "endpoint",
               "name": "endpoint",
               "serializedName": "endpoint",
               "doc": "Service host",
               "type": {
-                "$id": "605",
+                "$id": "622",
                 "kind": "url",
                 "name": "endpoint",
                 "crossLanguageDefinitionId": "TypeSpec.url"
@@ -9957,7 +10031,7 @@
               "isEndpoint": true,
               "defaultValue": {
                 "type": {
-                  "$id": "606",
+                  "$id": "623",
                   "kind": "string",
                   "name": "string",
                   "crossLanguageDefinitionId": "TypeSpec.string"
@@ -9970,7 +10044,7 @@
               "crossLanguageDefinitionId": "ProvisioningTypeSpec.Items.endpoint"
             },
             {
-              "$ref": "534"
+              "$ref": "551"
             }
           ],
           "initializedBy": 0,

--- a/eng/packages/http-client-csharp-provisioning/package-lock.json
+++ b/eng/packages/http-client-csharp-provisioning/package-lock.json
@@ -9,22 +9,22 @@
       "version": "1.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260408.3"
+        "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260421.1"
       },
       "devDependencies": {
-        "@azure-tools/typespec-autorest": "0.66.0",
-        "@azure-tools/typespec-azure-core": "0.66.1",
-        "@azure-tools/typespec-azure-resource-manager": "0.66.1",
-        "@azure-tools/typespec-azure-rulesets": "0.66.0",
-        "@azure-tools/typespec-client-generator-core": "0.66.3",
-        "@azure-tools/typespec-liftr-base": "0.12.0",
+        "@azure-tools/typespec-autorest": "0.67.0",
+        "@azure-tools/typespec-azure-core": "0.67.0",
+        "@azure-tools/typespec-azure-resource-manager": "0.67.0",
+        "@azure-tools/typespec-azure-rulesets": "0.67.0",
+        "@azure-tools/typespec-client-generator-core": "0.67.2",
+        "@azure-tools/typespec-liftr-base": "0.13.0",
         "@eslint/js": "^9.2.0",
         "@types/node": "~22.12.0",
-        "@typespec/compiler": "1.10.0",
-        "@typespec/http": "1.10.0",
-        "@typespec/openapi": "1.10.0",
-        "@typespec/rest": "0.80.0",
-        "@typespec/versioning": "0.80.0",
+        "@typespec/compiler": "1.11.0",
+        "@typespec/http": "1.11.0",
+        "@typespec/openapi": "1.11.0",
+        "@typespec/rest": "0.81.0",
+        "@typespec/versioning": "0.81.0",
         "@vitest/coverage-v8": "^3.0.5",
         "@vitest/ui": "^3.0.5",
         "eslint": "^8.57.0",
@@ -54,24 +54,24 @@
       }
     },
     "node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.66.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.66.0.tgz",
-      "integrity": "sha512-sznnlQ2Cyxny7bXSl+PzGu+qQf/rrSIvf2qR7G/bqWbK6MNykXwiDk9uR5q93Y8spA9vv4jk38Il4rSXqmAzLQ==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.67.0.tgz",
+      "integrity": "sha512-RP0TZB46tnYGfN5FKaaXDP5/rDff0PEERKz4epoYsm4RmXeRDYXVcOjw7DXLbcgFpMLTLBf/w/5dqJZBx03KpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.66.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.66.0",
-        "@azure-tools/typespec-client-generator-core": "^0.66.0",
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/http": "^1.10.0",
-        "@typespec/openapi": "^1.10.0",
-        "@typespec/rest": "^0.80.0",
-        "@typespec/versioning": "^0.80.0",
-        "@typespec/xml": "^0.80.0"
+        "@azure-tools/typespec-azure-core": "^0.67.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.67.0",
+        "@azure-tools/typespec-client-generator-core": "^0.67.0",
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/openapi": "^1.11.0",
+        "@typespec/rest": "^0.81.0",
+        "@typespec/versioning": "^0.81.0",
+        "@typespec/xml": "^0.81.0"
       },
       "peerDependenciesMeta": {
         "@typespec/xml": {
@@ -80,23 +80,23 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.66.1.tgz",
-      "integrity": "sha512-i8lMegL4s0I6xQT61zIIhmN1aA6iYFoH+7owSl/msOD0yVWx3Khf3ETULX53yHFd7OoUDAjmFx7+8j9atWXzHQ==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.67.0.tgz",
+      "integrity": "sha512-6DO/fOlVihMlPG0oDXrgURf5MNF4iBzPx5SMA5aaFDx/fW6MjiD+TN9Yy9O+l9mVNh1XaEMjhjA8/lmnHZ/U0g==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/http": "^1.10.0",
-        "@typespec/rest": "^0.80.0"
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/rest": "^0.81.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.66.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.66.1.tgz",
-      "integrity": "sha512-LExgmD3oK7iaX0bIdQsoxBYLCMKwPPBHYmLMhNW/GseMF1Dqi1Ne/VP7rmMP0dhrZNFh22LaZI2lTyCKm08DFQ==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.67.0.tgz",
+      "integrity": "sha512-NFE1O4zlpo6Y+Lkh3XCo59g+7r141+oBomYib1LncbbpqoGDakHvBH4sLelt9ZCMnYAxlKGbjXrO9E6jd53P2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -107,34 +107,34 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.66.1",
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/http": "^1.10.0",
-        "@typespec/openapi": "^1.10.0",
-        "@typespec/rest": "^0.80.0",
-        "@typespec/versioning": "^0.80.0"
+        "@azure-tools/typespec-azure-core": "^0.67.0",
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/openapi": "^1.11.0",
+        "@typespec/rest": "^0.81.0",
+        "@typespec/versioning": "^0.81.0"
       }
     },
     "node_modules/@azure-tools/typespec-azure-rulesets": {
-      "version": "0.66.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.66.0.tgz",
-      "integrity": "sha512-Wf0SpphmKDDzHgaqpxl68DpP65VUWjpD3mrnZ3Lw4Pdtt8BcZf7+LKgFF06gPRnh15hR0VbjAERCzxI/qGY4ag==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.67.0.tgz",
+      "integrity": "sha512-YCkyTm090xQR0Gb3CnIdbEd+SbVUY1TRtuPXrBPTsNu3MJwvlaESnkJ7bt9zkP94mAFTNoSTuZlAUKDfPrFaFA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.66.0",
-        "@azure-tools/typespec-azure-resource-manager": "^0.66.0",
-        "@azure-tools/typespec-client-generator-core": "^0.66.1",
-        "@typespec/compiler": "^1.10.0"
+        "@azure-tools/typespec-azure-core": "^0.67.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.67.0",
+        "@azure-tools/typespec-client-generator-core": "^0.67.0",
+        "@typespec/compiler": "^1.11.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.66.3",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.66.3.tgz",
-      "integrity": "sha512-sNetQ6igxAp/vL6X2kEIy715ToDTqoJeb+OL59GEUtOW/3KBSi5tsxvDdCwSfEoaNEmv/FYjh/gJDwAWCJdFJg==",
+      "version": "0.67.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.67.2.tgz",
+      "integrity": "sha512-sI2Lw7F6aTXWNrLGQU6fjyx4H3ztq/Y3VKOUfe4nNQY664NgrBA6B8e0Wa4wVTEXDs9BeZZYMgzTeAIl5eu6sg==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -145,41 +145,237 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.66.0",
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/events": "^0.80.0",
-        "@typespec/http": "^1.10.0",
-        "@typespec/openapi": "^1.10.0",
-        "@typespec/rest": "^0.80.0",
-        "@typespec/sse": "^0.80.0",
-        "@typespec/streams": "^0.80.0",
-        "@typespec/versioning": "^0.80.0",
-        "@typespec/xml": "^0.80.0"
+        "@azure-tools/typespec-azure-core": "^0.67.0",
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/events": "^0.81.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/openapi": "^1.11.0",
+        "@typespec/rest": "^0.81.0",
+        "@typespec/sse": "^0.81.0",
+        "@typespec/streams": "^0.81.0",
+        "@typespec/versioning": "^0.81.0",
+        "@typespec/xml": "^0.81.0"
       }
     },
     "node_modules/@azure-tools/typespec-liftr-base": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.12.0.tgz",
-      "integrity": "sha512-jM5jjhiWUsqRvzYNiDc+7q4UXs02EbA3m8LRaUiLUkF61n7Vzz2Y0Jw2pW88zD4feCyyXoixRjpqvmurIY8K2w==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-liftr-base/-/typespec-liftr-base-0.13.0.tgz",
+      "integrity": "sha512-MF40K/IHwyy3N606DTZSPhFSwA/84ekR9RqvmtJXsXD0SdYcQSoAHOJp4o5qw8OAPSC+aKZ5A+TXRx333V/3PQ==",
       "dev": true
     },
     "node_modules/@azure-typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260408.3",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260408.3.tgz",
-      "integrity": "sha1-OvqprQQYBG8JWru+5U+YFWOn98Q=",
+      "version": "1.0.0-alpha.20260415.3",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260415.3.tgz",
+      "integrity": "sha1-7mnjfMQlQhwPuUlSMED5X8HeFeg=",
       "license": "MIT",
       "dependencies": {
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260408.2"
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260414.6"
       }
     },
     "node_modules/@azure-typespec/http-client-csharp-mgmt": {
-      "version": "1.0.0-alpha.20260408.3",
-      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260408.3.tgz",
-      "integrity": "sha1-wSZg/633lmE5/ppCg8ijE0t/ufk=",
+      "version": "1.0.0-alpha.20260421.1",
+      "resolved": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/@azure-typespec/http-client-csharp-mgmt/-/http-client-csharp-mgmt-1.0.0-alpha.20260421.1.tgz",
+      "integrity": "sha1-6RW0DJqj+MdlgOlQpNpPKdsQSsk=",
       "license": "MIT",
       "dependencies": {
-        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260408.3",
-        "@typespec/http-client-csharp": "1.0.0-alpha.20260408.2"
+        "@azure-typespec/http-client-csharp": "1.0.0-alpha.20260415.3",
+        "@typespec/http-client-csharp": "1.0.0-alpha.20260414.6"
+      }
+    },
+    "node_modules/@azure-typespec/http-client-csharp-mgmt/node_modules/@typespec/http-client-csharp": {
+      "version": "1.0.0-alpha.20260414.6",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260414.6.tgz",
+      "integrity": "sha512-RrSeMd+waCsFvLYSonmwpzetj51I495+6R8Vlogl6+I70Z2MVOksi7ocQ5D/sg3Sml2QlD96oyUmv/envNFfmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.13.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-client-generator-core": ">=0.67.1 <0.68.0 || ~0.68.0-0",
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/openapi": "^1.11.0",
+        "@typespec/rest": ">=0.81.0 <0.82.0 || ~0.82.0-0",
+        "@typespec/sse": ">=0.81.0 <0.82.0 || ~0.82.0-0",
+        "@typespec/streams": ">=0.81.0 <0.82.0 || ~0.82.0-0",
+        "@typespec/versioning": ">=0.81.0 <0.82.0 || ~0.82.0-0"
+      }
+    },
+    "node_modules/@azure-typespec/http-client-csharp/node_modules/@typespec/http-client-csharp": {
+      "version": "1.0.0-alpha.20260414.6",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260414.6.tgz",
+      "integrity": "sha512-RrSeMd+waCsFvLYSonmwpzetj51I495+6R8Vlogl6+I70Z2MVOksi7ocQ5D/sg3Sml2QlD96oyUmv/envNFfmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.13.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-client-generator-core": ">=0.67.1 <0.68.0 || ~0.68.0-0",
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/openapi": "^1.11.0",
+        "@typespec/rest": ">=0.81.0 <0.82.0 || ~0.82.0-0",
+        "@typespec/sse": ">=0.81.0 <0.82.0 || ~0.82.0-0",
+        "@typespec/streams": ">=0.81.0 <0.82.0 || ~0.82.0-0",
+        "@typespec/versioning": ">=0.81.0 <0.82.0 || ~0.82.0-0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.8.0.tgz",
+      "integrity": "sha512-X7IZV77bN56l7sbLjkcbQJX1t3U4tgxqztDr/XFbUcUfKk+z2FavcLgKP+OYUNj0wl/pEEtV9lldW9siY8BuHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.1.tgz",
+      "integrity": "sha512-WS9w9SfI8SEYO7mTnxGeZ3UwQfhAVYCWglYF2/7GNx3ioHiAs2gPkl9eSwVs8cPrmiGh+zi9ai/OOKoq4cyzDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.4.tgz",
+      "integrity": "sha512-G4LXGGggok1QC48uKu64/SV2DPRDlddmV8EieK8pflsNYMj9/Zz+Y9OHoEBhT15h+zpdwXXLYA/7PJCR/yZ8aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.5.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1925,24 +2121,24 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.10.0.tgz",
-      "integrity": "sha512-R6BATDkughntPpaxeESJF+wxma5PEjgmnnKvH0/ByqUH8VyhIckQWE9kkP0Uc/EJ0o0VYhe8qCwWQvV70k5lTw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.11.0.tgz",
+      "integrity": "sha512-4vuWtoepc4rYJ81K+P7xn2ByXIRhBM40rfzAGnpagNuGSVHuKEC6lqJqs3ePvhCpnxiYAC8XWpaOi+BEDzyhnQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.29.0",
-        "@inquirer/prompts": "^8.0.1",
+        "@inquirer/prompts": "^8.3.0",
         "ajv": "~8.18.0",
         "change-case": "~5.4.4",
         "env-paths": "^4.0.0",
-        "globby": "~16.1.0",
+        "globby": "~16.1.1",
         "is-unicode-supported": "^2.1.0",
         "mustache": "~4.2.0",
         "picocolors": "~1.1.1",
-        "prettier": "~3.8.0",
-        "semver": "^7.7.1",
-        "tar": "^7.5.2",
-        "temporal-polyfill": "^0.3.0",
+        "prettier": "~3.8.1",
+        "semver": "^7.7.4",
+        "tar": "^7.5.11",
+        "temporal-polyfill": "^0.3.2",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.12",
         "yaml": "~2.8.2",
@@ -1972,29 +2168,29 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.80.0.tgz",
-      "integrity": "sha512-FrWEUwxhDNbE2YN4fyqV5Qrz9qFJbvPoiKrJM7dexkb7eyhepq3dbc5zZgAm/qFBQ+XxGQQVJ4swXxKT+338fw==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.81.0.tgz",
+      "integrity": "sha512-ee9QSBL+k6ccPlbJICZzaGt4iC1nTIl+J9sELY9yJNISvOvUEzY5MU8c7HaISB10cUESRJW+oaLWwyc8XjwHng==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0"
+        "@typespec/compiler": "^1.11.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.10.0.tgz",
-      "integrity": "sha512-/fj55fmUj4m/FmNdfH0V52menVrmS2r5Xj9d1H+pnjQbxvvaxS906RSRcoF8kbg3PvlibP/Py5u82TAk53AyqA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.11.0.tgz",
+      "integrity": "sha512-/DOkN2+MUZyLdmqYmSMZDjxikJTOuNxikTeOwG2fVOibnu8e6S1jzPAuN/mn6YyQBKeBCItMPmUOXIj61Wy8Bg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/streams": "^0.80.0"
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/streams": "^0.81.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -2003,99 +2199,117 @@
       }
     },
     "node_modules/@typespec/http-client-csharp": {
-      "version": "1.0.0-alpha.20260408.2",
-      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260408.2.tgz",
-      "integrity": "sha512-Us6tGgWuJoVoe14XtVsV8lGTUznb7wW9u+eXkslr8BkztZPv5Bo9vwG8BT224nF8ur6/7PAteFTcH9IbY5aBWQ==",
+      "version": "1.0.0-alpha.20260421.4",
+      "resolved": "https://registry.npmjs.org/@typespec/http-client-csharp/-/http-client-csharp-1.0.0-alpha.20260421.4.tgz",
+      "integrity": "sha512-QA003cNpe0F4fuN1Cw3a7vb3V+EhP+xGfRsGqg+KEDVm+ZxdFtwQzOI5sZVPZgu80n3i9Hs0ShE2xNpK5moV0Q==",
       "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@azure/identity": "^4.13.0"
+      },
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.66.3 <0.67.0 || ~0.67.0-0",
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/http": "^1.10.0",
-        "@typespec/openapi": "^1.10.0",
-        "@typespec/rest": ">=0.80.0 <0.81.0 || ~0.81.0-0",
-        "@typespec/sse": ">=0.80.0 <0.81.0 || ~0.81.0-0",
-        "@typespec/streams": ">=0.80.0 <0.81.0 || ~0.81.0-0",
-        "@typespec/versioning": ">=0.80.0 <0.81.0 || ~0.81.0-0"
+        "@azure-tools/typespec-client-generator-core": ">=0.67.1 <0.68.0 || ~0.68.0-0",
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/openapi": "^1.11.0",
+        "@typespec/rest": ">=0.81.0 <0.82.0 || ~0.82.0-0",
+        "@typespec/sse": ">=0.81.0 <0.82.0 || ~0.82.0-0",
+        "@typespec/streams": ">=0.81.0 <0.82.0 || ~0.82.0-0",
+        "@typespec/versioning": ">=0.81.0 <0.82.0 || ~0.82.0-0"
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.10.0.tgz",
-      "integrity": "sha512-tukmyp+c9CFlA2FdF61XfT9eTe5WXWz6J8pOrJ9+IYg0BcBwhJkvDj6BYpDD6SjxbRr1wO5ZL2Whe6MequsyVw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.11.0.tgz",
+      "integrity": "sha512-xUQrHExKBh0XSP4cn+HcondDXjHJM5HCq2Xfy9tB1QflsFh5uP1JJt1+67g73VmHlhZVSUDcoFrnU95pfjyubg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/http": "^1.10.0"
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.80.0.tgz",
-      "integrity": "sha512-xczXLoB2akSIDner41gQYTS9CG6TdCN0QHYvXBT6ZrYEnBh+pMvdymW//5CSOTamZLOGo9AOJVJaFfwbFA4vQQ==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.81.0.tgz",
+      "integrity": "sha512-qQXZRKEvq5aNlDFEUqBiiXXPIFyr/+PWgBY0kIrnhyZzMjfUqPInkB12QgXpVp2O2Wm3jmETJD45SaLHTCYBbg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/http": "^1.10.0"
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/http": "^1.11.0"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.80.0.tgz",
-      "integrity": "sha512-/lxYgMaxgEcjBVhep9tf/VnFD2wnkZlkmjUHLeZL8Cuf+qip61Ren6Ml91YtNnnIFYsuuymDzRclrA073ZBR6Q==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.81.0.tgz",
+      "integrity": "sha512-VinoeN+5ClKlGXf77fWayAQna8SaYtvEBhnLR8t8FdvmMsL6ce1LghR2kAL3ARbNXfwMZRmQiq+ajKKebDLIng==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/events": "^0.80.0",
-        "@typespec/http": "^1.10.0",
-        "@typespec/streams": "^0.80.0"
+        "@typespec/compiler": "^1.11.0",
+        "@typespec/events": "^0.81.0",
+        "@typespec/http": "^1.11.0",
+        "@typespec/streams": "^0.81.0"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.80.0.tgz",
-      "integrity": "sha512-lNvzrvX/ZRIxRpxIBZu90XNsT+uWsMbLtxHd9edspHAiID3c9WKZbl2fnLcPqdR/60odqKve4yGzB9gF58GUDQ==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.81.0.tgz",
+      "integrity": "sha512-IIEKq18aqAtM65f8ZLs3Kzua97wjkr8fTehqPs/Q4neWo2UkDJp64LfA37iXJzaku8xMFSwXdVu4EW8wo+KV8w==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0"
+        "@typespec/compiler": "^1.11.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.80.0.tgz",
-      "integrity": "sha512-WQCT0jN2lSRfwOy+Cd1KUYzenpKR5TdoX0uW6zQdvxQ9nQZIXoaSaReh9/ldhmSV4xv3p2dqF9oq1cdbVGfJTg==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.81.0.tgz",
+      "integrity": "sha512-5bha4t64xA85zLY8VGm/6jNd2kwPHzjPq/dlCUjtgGfGXv2R6Ow/YIukqhqZnwnIgNAIlZ7nguekRMRx+2oO2w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0"
+        "@typespec/compiler": "^1.11.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.80.0.tgz",
-      "integrity": "sha512-Qfy5eyCcOF3xYOU/dejhpmmeY75U1Q9C8XBE+GvSZ3lakRfKBIpT+X6Q07qmKSAbGYJZKYLWCIAy/dgCuu/OAA==",
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.81.0.tgz",
+      "integrity": "sha512-4docnAcV1a8gE4c4TmYuirZf2PEzS4xHUH4QjHFU6hk6J2M6OMU6YG4iSq9tmlUzQ/2DraVcWNO/fsG8Lt383A==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0"
+        "@typespec/compiler": "^1.11.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -2299,6 +2513,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -2415,6 +2638,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cac": {
@@ -2598,7 +2842,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2628,6 +2871,46 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2661,6 +2944,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
@@ -3384,6 +3676,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -3456,6 +3774,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3485,6 +3818,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -3525,6 +3876,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3646,6 +4012,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3686,11 +4095,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -3818,7 +4269,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mustache": {
@@ -3873,6 +4323,24 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -4225,6 +4693,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4247,6 +4727,26 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4916,6 +5416,12 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5010,6 +5516,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -5416,6 +5931,21 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/eng/packages/http-client-csharp-provisioning/package.json
+++ b/eng/packages/http-client-csharp-provisioning/package.json
@@ -36,26 +36,26 @@
     "dist/**"
   ],
   "dependencies": {
-    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260408.3"
+    "@azure-typespec/http-client-csharp-mgmt": "1.0.0-alpha.20260421.1"
   },
   "peerDependencies": {
     "@azure-typespec/http-client-csharp": "^1.0.0-alpha",
     "@typespec/http-client-csharp": "^1.0.0-alpha"
   },
   "devDependencies": {
-    "@azure-tools/typespec-autorest": "0.66.0",
-    "@azure-tools/typespec-azure-core": "0.66.1",
-    "@azure-tools/typespec-azure-resource-manager": "0.66.1",
-    "@azure-tools/typespec-azure-rulesets": "0.66.0",
-    "@azure-tools/typespec-client-generator-core": "0.66.3",
-    "@azure-tools/typespec-liftr-base": "0.12.0",
+    "@azure-tools/typespec-autorest": "0.67.0",
+    "@azure-tools/typespec-azure-core": "0.67.0",
+    "@azure-tools/typespec-azure-resource-manager": "0.67.0",
+    "@azure-tools/typespec-azure-rulesets": "0.67.0",
+    "@azure-tools/typespec-client-generator-core": "0.67.2",
+    "@azure-tools/typespec-liftr-base": "0.13.0",
     "@eslint/js": "^9.2.0",
     "@types/node": "~22.12.0",
-    "@typespec/compiler": "1.10.0",
-    "@typespec/http": "1.10.0",
-    "@typespec/openapi": "1.10.0",
-    "@typespec/rest": "0.80.0",
-    "@typespec/versioning": "0.80.0",
+    "@typespec/compiler": "1.11.0",
+    "@typespec/http": "1.11.0",
+    "@typespec/openapi": "1.11.0",
+    "@typespec/rest": "0.81.0",
+    "@typespec/versioning": "0.81.0",
     "@vitest/coverage-v8": "^3.0.5",
     "@vitest/ui": "^3.0.5",
     "eslint": "^8.57.0",


### PR DESCRIPTION
Aligns the provisioning emitter and generator dependencies with the just-released `@azure-typespec/http-client-csharp-mgmt@1.0.0-alpha.20260421.1`, which carries the http-client-csharp base bump merged in #58419.

## Changes

**npm (`eng/packages/http-client-csharp-provisioning/package.json`)**
- `@azure-typespec/http-client-csharp-mgmt` `20260408.3` → `20260421.1`
- `@typespec/{compiler,http,openapi}` `1.10.0` → `1.11.0`
- `@typespec/{rest,versioning}` `0.80.0` → `0.81.0`
- `@azure-tools/typespec-{autorest,azure-core,azure-resource-manager,azure-rulesets,client-generator-core}` `0.66.x` → `0.67.x`
- `@azure-tools/typespec-liftr-base` `0.12.0` → `0.13.0`

**NuGet (`eng/centralpackagemanagement/Directory.Generation.Packages.props`)**
- `AzureManagementGeneratorVersion` `20260408.3` → `20260421.1`

**Regenerated**
- `Provisioning-TypeSpec/tspCodeModel.json`
- `doc/GeneratorVersions/Emitter_Version_Dashboard.md`

## Validation

- `npm run build:emitter` ✅
- `npm run build:generator` ✅
- `npm run lint` ✅
- `npm run prettier` ✅
- `Generate.ps1` (Provisioning-TypeSpec regen + csproj build) ✅
- `npm run test:generator` / `test:emitter` ✅ (no tests defined yet)

## Notes

The new mgmt build inherits the `[WirePath]` flatten fix and the `IsFrameworkType` guards from #58419, plus the `autoMergeService: true` requirement from tcgc 0.67. No additional source changes are needed in the provisioning emitter or generator.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>