### PR TITLE
[Mgmt] Catch generic naming gaps in PR review skill

### DIFF
--- a/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
+++ b/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
@@ -187,6 +187,14 @@ function Get-RpPrefix([string]$ns) {
     return ''
 }
 
+function Get-PascalCaseTokens([string]$name) {
+    if ([string]::IsNullOrWhiteSpace($name)) {
+        return @()
+    }
+
+    return @([regex]::Matches($name, '[A-Z]+(?![a-z])|[A-Z]?[a-z]+|\d+') | ForEach-Object { $_.Value })
+}
+
 #endregion
 
 #region --- Rule Checks ---
@@ -509,6 +517,9 @@ for ($i = 0; $i -lt $totalLines; $i++) {
 # =====================================================
 # These are known generic names that should be prefixed with service/resource context.
 $ambiguousPatterns = @(
+    'Scope'
+    'GroupScope'
+    'Sensitivity'
     'ProvisioningState'
     'EncryptionStatus'
     'EncryptionState'
@@ -536,6 +547,17 @@ $ambiguousPatterns = @(
     'CheckNameAvailabilityResult'
     'CheckNameAvailabilityRequest'
     'NameAvailabilityReason'
+    'ManagedRuleSetScope'
+    'ManagedRuleSetException'
+)
+
+# Generic suffixes that are still too vague when the type name only contains a few generic words
+# and lacks an RP/resource prefix (e.g., Scope, GroupScope, ManagedRuleSetException).
+$genericContextSuffixes = @(
+    'GroupScope'
+    'Scope'
+    'Sensitivity'
+    'Exception'
 )
 
 foreach ($typeName in $typeInfos.Keys) {
@@ -545,15 +567,28 @@ foreach ($typeName in $typeInfos.Keys) {
 
     # Skip types in .Models namespace that start with the RP prefix (already qualified)
     $rpPrefix = Get-RpPrefix $info.Namespace
+    $hasRpPrefix = -not [string]::IsNullOrEmpty($rpPrefix) -and
+        $typeName.StartsWith($rpPrefix, [System.StringComparison]::Ordinal)
+    $tokens = Get-PascalCaseTokens $typeName
 
-    if ($typeName -in $ambiguousPatterns) {
+    $isAmbiguousContextName = $typeName -in $ambiguousPatterns
+    if (-not $isAmbiguousContextName -and -not $hasRpPrefix) {
+        foreach ($suffix in $genericContextSuffixes) {
+            if ($typeName.EndsWith($suffix) -and $tokens.Count -le 4) {
+                $isAmbiguousContextName = $true
+                break
+            }
+        }
+    }
+
+    if ($isAmbiguousContextName) {
         # Check if the type name is exactly one of the ambiguous patterns
         # (not prefixed with the RP name)
         if ([string]::IsNullOrEmpty($rpPrefix)) {
             $suggestion = "Type '$typeName' is a generic/ambiguous name. Consider adding a service or resource prefix for clarity."
         }
         else {
-            $suggestion = "Rename to '${rpPrefix}${typeName}' or similar qualified name."
+            $suggestion = "Rename to '${rpPrefix}${typeName}' or another service/resource-qualified name."
         }
         $violations.Add([NamingViolation]::new(
             'CONTEXT001', 'Warning', 'Contextual Naming',

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -99,8 +99,9 @@ To determine the review scope:
 #### Contextual Naming for Types
 - All types must have a name that includes sufficient context about what the type represents.
 - Avoid generic or ambiguous names that could apply to many different services. The type name should make it clear which service or resource it belongs to.
-- **Bad examples:** `PublicNetworkAccess`, `EncryptionStatus`, `PrivateEndpointConnection` — these names lack context; a reader cannot tell which service they belong to without looking at the namespace.
-- **Good examples:** `StorageAccountPublicNetworkAccess`, `CosmosDBEncryptionStatus`, `KeyVaultPrivateEndpointConnection` — these names include the service or resource context.
+- **Bad examples:** `PublicNetworkAccess`, `EncryptionStatus`, `PrivateEndpointConnection`, `Scope`, `GroupScope`, `Sensitivity`, `ManagedRuleSetException` — these names lack context; a reader cannot tell which service or resource they belong to without looking at the namespace.
+- **Good examples:** `StorageAccountPublicNetworkAccess`, `CosmosDBEncryptionStatus`, `KeyVaultPrivateEndpointConnection`, `FrontDoorRuleScope`, `FrontDoorSensitivityType` — these names include the service or resource context.
+- Short names built mostly from generic suffixes like `Scope`, `Exception`, or `Sensitivity` should usually be flagged unless they are already prefixed with the RP or resource name.
 - Exception: If the type is scoped within a clearly named parent model or the namespace already provides unambiguous context (e.g., a property type used exclusively by one resource), a shorter name may be acceptable.
 
 #### Naming Fix Recommendations

--- a/.github/skills/mpg-migration-pr-review/SKILL.md
+++ b/.github/skills/mpg-migration-pr-review/SKILL.md
@@ -26,6 +26,8 @@ Use this skill instead of `azure-sdk-mgmt-pr-review` when the PR is a **migratio
 
 Run the full review from the `azure-sdk-mgmt-pr-review` skill (Phase 1: Versioning, Phase 2: API Review, Phase 3: Breaking Change Detection). All rules from that skill apply.
 
+**Migration-specific note for Phase 2**: Migrations often introduce newly generated enums/models with names that are technically valid C# but still too generic for the public API, such as `Scope`, `GroupScope`, `Sensitivity`, or `ManagedRuleSetException`. Flag these as contextual naming issues and recommend a `@@clientName(..., "csharp")` rename that adds service or resource context (for example, `FrontDoorRuleScope`).
+
 **Migration-specific note for Phase 3**: In migration PRs, breaking changes are expected but must still be mitigated. Pay close attention to `ApiCompatBaseline.txt` — migration PRs are the most tempting place to add baseline entries, but they are still **not allowed**. Every ApiCompat error must be mitigated through customization code or TypeSpec decorators.
 
 ## Phase 4: Migration Customization Review


### PR DESCRIPTION
## Summary
- update the management PR review skill to better catch overly generic public type names
- extend the naming checker to flag gaps like Scope, GroupScope, Sensitivity, and similar context-free names
- document the preferred @@clientName(..., "csharp") guidance for migration PR reviews

## Notes
This PR is scoped to the review skill and checker updates only.
