### PR TITLE
Implement KeySize in KeyVault.Keys

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.10.0-beta.1 (Unreleased)
 
 ### Features Added
-- Added KeySize to `KeyProperties` for symmetric keys
+- Added `KeyProperties.KeySize` to expose the key size in bits.
 
 ### Breaking Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.10.0-beta.1 (Unreleased)
 
 ### Features Added
+- Added KeySize to `KeyProperties` for symmetric keys
 
 ### Breaking Changes
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net10.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net10.0.cs
@@ -260,6 +260,7 @@ namespace Azure.Security.KeyVault.Keys
         public bool? Exportable { get { throw null; } set { } }
         public string HsmPlatform { get { throw null; } }
         public System.Uri Id { get { throw null; } }
+        public int? KeySize { get { throw null; } }
         public bool Managed { get { throw null; } }
         public string Name { get { throw null; } }
         public System.DateTimeOffset? NotBefore { get { throw null; } set { } }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net8.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.net8.0.cs
@@ -260,6 +260,7 @@ namespace Azure.Security.KeyVault.Keys
         public bool? Exportable { get { throw null; } set { } }
         public string HsmPlatform { get { throw null; } }
         public System.Uri Id { get { throw null; } }
+        public int? KeySize { get { throw null; } }
         public bool Managed { get { throw null; } }
         public string Name { get { throw null; } }
         public System.DateTimeOffset? NotBefore { get { throw null; } set { } }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/api/Azure.Security.KeyVault.Keys.netstandard2.0.cs
@@ -260,6 +260,7 @@ namespace Azure.Security.KeyVault.Keys
         public bool? Exportable { get { throw null; } set { } }
         public string HsmPlatform { get { throw null; } }
         public System.Uri Id { get { throw null; } }
+        public int? KeySize { get { throw null; } }
         public bool Managed { get { throw null; } }
         public string Name { get { throw null; } }
         public System.DateTimeOffset? NotBefore { get { throw null; } set { } }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
@@ -18,6 +18,7 @@ namespace Azure.Security.KeyVault.Keys
         private const string ExportablePropertyName = "exportable";
         private const string HsmPlatformPropertyName = "hsmPlatform";
         private const string KeyAttestationPropertyName = "attestation";
+        private const string KeySizePropertyName = "key_size";
 
         private static readonly JsonEncodedText s_enabledPropertyNameBytes = JsonEncodedText.Encode(EnabledPropertyName);
         private static readonly JsonEncodedText s_notBeforePropertyNameBytes = JsonEncodedText.Encode(NotBeforePropertyName);
@@ -44,6 +45,8 @@ namespace Azure.Security.KeyVault.Keys
         public string HsmPlatform { get; internal set; }
 
         public KeyAttestation Attestation { get; set; }
+
+        public int? KeySize { get; internal set; }
 
         internal bool ShouldSerialize =>
             Enabled.HasValue ||
@@ -113,6 +116,9 @@ namespace Azure.Security.KeyVault.Keys
                                 }
                             }
                         }
+                        break;
+                    case KeySizePropertyName:
+                        KeySize = prop.Value.GetInt32();
                         break;
                 }
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
@@ -118,7 +118,10 @@ namespace Azure.Security.KeyVault.Keys
                         }
                         break;
                     case KeySizePropertyName:
-                        KeySize = prop.Value.GetInt32();
+                        if (prop.Value.ValueKind != JsonValueKind.Null)
+                        {
+                            KeySize = prop.Value.GetInt32();
+                        }
                         break;
                 }
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyProperties.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyProperties.cs
@@ -146,6 +146,11 @@ namespace Azure.Security.KeyVault.Keys
         public KeyAttestation Attestation { get => _attributes.Attestation; }
 
         /// <summary>
+        /// Gets the key size in bits for symmetric keys. For example: 128, 192, or 256 for AES keys.
+        /// </summary>
+        public int? KeySize { get => _attributes.KeySize; internal set => _attributes.KeySize = value; }
+
+        /// <summary>
         /// Parses the key identifier into the <see cref="VaultUri"/>, <see cref="Name"/>, and <see cref="Version"/> of the key.
         /// </summary>
         /// <param name="id">The key vault object identifier.</param>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyProperties.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyProperties.cs
@@ -146,7 +146,7 @@ namespace Azure.Security.KeyVault.Keys
         public KeyAttestation Attestation { get => _attributes.Attestation; }
 
         /// <summary>
-        /// Gets the key size in bits for symmetric keys. For example: 128, 192, or 256 for AES keys.
+        /// Gets the key size in bits for keys. For example: 128, 192, or 256 for AES keys.
         /// </summary>
         public int? KeySize { get => _attributes.KeySize; internal set => _attributes.KeySize = value; }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyPropertiesTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyPropertiesTests.cs
@@ -49,5 +49,19 @@ namespace Azure.Security.KeyVault.Keys.Tests
 
             Assert.AreEqual(expected, properties.HsmPlatform);
         }
+
+        [TestCase(@"{""kid"":""https://vault/keys/key-name""}", null)]
+        [TestCase(@"{""kid"":""https://vault/keys/key-name"",""attributes"":{""key_size"":128}}", 128)]
+        [TestCase(@"{""kid"":""https://vault/keys/key-name"",""attributes"":{""key_size"":256}}", 256)]
+        public void DeserializesKeySize(string content, int? expected)
+        {
+            KeyProperties properties = new KeyProperties();
+            using (JsonStream json = new JsonStream(content))
+            {
+                properties.Deserialize(json.AsStream());
+            }
+
+            Assert.AreEqual(expected, properties.KeySize);
+        }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyPropertiesTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyPropertiesTests.cs
@@ -51,6 +51,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
         }
 
         [TestCase(@"{""kid"":""https://vault/keys/key-name""}", null)]
+        [TestCase(@"{""kid"":""https://vault/keys/key-name"",""attributes"":{""key_size"":null}}", null)]
         [TestCase(@"{""kid"":""https://vault/keys/key-name"",""attributes"":{""key_size"":128}}", 128)]
         [TestCase(@"{""kid"":""https://vault/keys/key-name"",""attributes"":{""key_size"":256}}", 256)]
         public void DeserializesKeySize(string content, int? expected)


### PR DESCRIPTION
# Changes
- Added KeySize to KeyProperties
- Asserted Deserialization of KeySize in unit tests

# Verification:
```
var keyClient = new KeyClient(mHsmUri, new DefaultAzureCredential(), keyClientOptions);

KeyVaultKey key = await keyClient.GetKeyAsync(keyName);
Console.WriteLine($"Keysize:{key.Properties.KeySize}");
```
returns : Keysize:2048
