### PR TITLE
[Samples] Messaging docs fixes

### DIFF
--- a/samples/servicebus/dead-letter-queue/README.md
+++ b/samples/servicebus/dead-letter-queue/README.md
@@ -47,7 +47,7 @@ In order to run the sample, you will need a Service Bus Namespace. For more info
 
 To build the sample:
 
-1. Install [.NET 5.0](https://dot.net) or newer.
+1. Install [.NET 10.0](https://dotnet.microsoft.com/download) or newer.
 
 2. Run in the project directory:
 

--- a/samples/servicebus/topic-filters/README.md
+++ b/samples/servicebus/topic-filters/README.md
@@ -39,7 +39,7 @@ In order to run the sample, you will need a Service Bus Namespace. For more info
 
 To build the sample:
 
-1. Install [.NET 5.0](https://dot.net) or newer.
+1. Install [.NET 10.0](https://dotnet.microsoft.com/download) or newer.
 
 2. Run in the project directory:
 

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/samples/README.md
@@ -32,3 +32,11 @@ description: Samples for the Azure.Messaging.ServiceBus client library
 - [Long-running processing](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample18_LongRunningProcessing.md)
 - [Distributed tracing and monitoring](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample19_DistributedTracing.md)
 - [Performance patterns](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/samples/Sample20_PerformancePatterns.md)
+
+## Application samples
+
+These samples demonstrate end-to-end application scenarios using Azure Service Bus.
+
+- [Dead-letter queues](https://github.com/Azure/azure-sdk-for-net/blob/main/samples/servicebus/dead-letter-queue/README.md)
+- [Topic filters](https://github.com/Azure/azure-sdk-for-net/blob/main/samples/servicebus/topic-filters/README.md)
+- [Plugin extensibility pattern](https://github.com/Azure/azure-sdk-for-net/blob/main/samples/servicebus/plugin-sample/README.md)


### PR DESCRIPTION
# Summary

 The focus of these changes is to fix stale docs after Service Bus sample centralization (#58506):

 - Added "Application samples" section to the Service Bus samples index with links to the centralized dead-letter-queue, topic-filters, and plugin-sample projects

 - Updated .NET version references from 5.0 to 10.0 in dead-letter-queue and topic-filters READMEs

## References and resources

- [[Service Bus] Docs: Update samples README and fix stale .NET version references after sample centralization (#58506)](https://github.com/Azure/azure-sdk-for-net/issues/58506)
- [[Samples] Centralize messaging samples (#58447)](https://github.com/Azure/azure-sdk-for-net/pull/58447)
