### PR TITLE
Prepare release: Microsoft.Extensions.Azure 1.14.0

### DIFF
--- a/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Extensions.Azure/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.14.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.14.0 (2026-04-22)
 
 ### Other Changes
+
+- Adopted the new `Azure.Core` version that includes the identity types moved from `Azure.Identity`.
 
 ## 1.13.1 (2025-11-19)
 

--- a/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
+++ b/sdk/extensions/Microsoft.Extensions.Azure/src/Microsoft.Extensions.Azure.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Azure Client SDK integration with Microsoft.Extensions libraries</Description>
     <AssemblyTitle>Azure Client SDK integration Microsoft.Extensions</AssemblyTitle>
-    <Version>1.14.0-beta.1</Version>
+    <Version>1.14.0</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.13.1</ApiCompatVersion>
     <PackageTags>Microsoft Azure Client Pipeline AspNetCore Extensions</PackageTags>


### PR DESCRIPTION
Prepares release for `Microsoft.Extensions.Azure` 1.14.0.

### Changes

- Bumped version from `1.14.0-beta.1` to `1.14.0`.
- Added CHANGELOG entry noting adoption of the new `Azure.Core` that includes the identity types moved from `Azure.Identity`.