### PR TITLE
Remove explicit Azure.Identity references from ServiceBus samples and tests (batch 8)

### DIFF
--- a/samples/servicebus/dead-letter-queue/DeadLetterQueue.csproj
+++ b/samples/servicebus/dead-letter-queue/DeadLetterQueue.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.20.0" />
+    <PackageReference Include="Azure.Core" Version="1.53.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.5" />
   </ItemGroup>

--- a/samples/servicebus/topic-filters/TopicFilters.csproj
+++ b/samples/servicebus/topic-filters/TopicFilters.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.20.0" />
+    <PackageReference Include="Azure.Core" Version="1.53.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.5" />
   </ItemGroup>

--- a/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Azure.Messaging.ServiceBus.Tests.csproj
+++ b/sdk/servicebus/Azure.Messaging.ServiceBus/tests/Azure.Messaging.ServiceBus.Tests.csproj
@@ -18,6 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Pin Azure.Identity to 1.21+ facade to resolve CS0433 with transitive older versions
+         (pulled in via Microsoft.Extensions.Azure 1.13.1). Remove once Microsoft.Extensions.Azure 1.14 ships.
+         See https://github.com/Azure/azure-sdk-for-net/issues/58519 -->
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />


### PR DESCRIPTION
## Batch 8 of Azure.Identity dependency removal

Continues the effort to remove explicit `Azure.Identity` package references in favor of `Azure.Core` 1.53+ (which contains the Identity types directly).

### Changes

| File | Change | Rationale |
|------|--------|-----------|
| `samples/servicebus/dead-letter-queue/DeadLetterQueue.csproj` | `Azure.Identity 1.20.0` → `Azure.Core 1.53.0` | Sample's `using Azure.Identity;` still compiles since Azure.Core 1.53 contains those types. |
| `samples/servicebus/topic-filters/TopicFilters.csproj` | `Azure.Identity 1.20.0` → `Azure.Core 1.53.0` | Same as above. |
| `sdk/servicebus/Azure.Messaging.ServiceBus/tests/Azure.Messaging.ServiceBus.Tests.csproj` | Added rationale comment over the existing `Azure.Identity` pin | The pin was actually serving as a 1.21+ facade to resolve `CS0433` against the transitive Azure.Identity 1.17.1 pulled in via `Microsoft.Extensions.Azure` 1.13.1. Comment now ties it to the tracking issue. |

### Verification

All 3 modified projects build cleanly. Removing the explicit Identity refs from the two samples produced no compile errors — `DefaultAzureCredential` resolves from `Azure.Core` 1.53.

For the ServiceBus tests project, attempting to remove the Identity ref reproduced the expected `CS0433` collisions across 20+ files (`DefaultAzureCredential`, `ManagedIdentityCredential`, `ManagedIdentityId`, etc.). The pin is required until `Microsoft.Extensions.Azure` 1.14 ships and the transitive Identity drag is gone.

### Follow-up

- This Identity ref will be removed alongside the RM Tests + SignalR Tests pins per #58519 once MEA 1.14 publishes.
- Final batch will remove the central `<PackageVersion Include="Azure.Identity" />` from CPM once #58510 (AI.Projects 2.1.0 GA) and #58519 (MEA 1.14) clear.