### PR TITLE
[AgentServer] Release Azure.AI.AgentServer.Core 1.0.0-beta.23, Invocations 1.0.0-beta.3, Responses 1.0.0-beta.4

### DIFF
--- a/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.23 (Unreleased)
+## 1.0.0-beta.23 (2026-04-22)
 
 ### Features Added
 
@@ -23,10 +23,6 @@
   `UseAgentServerRequestId()`, `UseAgentServerVersion()`, and `UseAgentServerLogging()` with a
   single `AddAgentServerCore()` / `UseAgentServerCore()` pair. Tier 3 standalone setups now use
   two calls instead of six.
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.0.0-beta.22 (2026-04-17)
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Invocations/CHANGELOG.md
@@ -1,15 +1,11 @@
 # Release History
 
-## 1.0.0-beta.3 (Unreleased)
+## 1.0.0-beta.3 (2026-04-22)
 
 ### Features Added
 
 - All endpoints now return the `x-request-id` response header for request correlation (via Core
   `RequestIdMiddleware`). Value is resolved from OTEL trace ID → incoming `x-request-id` header → GUID.
-
-### Breaking Changes
-
-### Bugs Fixed
 
 ### Other Changes
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.4 (Unreleased)
+## 1.0.0-beta.4 (2026-04-22)
 
 ### Features Added
 
@@ -10,8 +10,6 @@
   `RequestIdMiddleware`). Value is resolved from OTEL trace ID → incoming `x-request-id` header → GUID.
 - Error responses (`ApiErrorResponse`) are automatically enriched with `error.additionalInfo.request_id`
   matching the `x-request-id` response header value, enabling client-side error correlation.
-
-### Breaking Changes
 
 ### Bugs Fixed
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Migrated header name constants to use `PlatformHeaders` from Core package instead of
   local `private const` declarations.
 
-## 1.0.0-beta.3 (2026-05-05)
+## 1.0.0-beta.3 (2026-04-20)
 
 ### Features Added
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -10,6 +10,13 @@
   `RequestIdMiddleware`). Value is resolved from OTEL trace ID → incoming `x-request-id` header → GUID.
 - Error responses (`ApiErrorResponse`) are automatically enriched with `error.additionalInfo.request_id`
   matching the `x-request-id` response header value, enabling client-side error correlation.
+- Persistence failure resilience — when storage operations fail, responses now complete gracefully
+  with `status: "failed"` and `error.code: "storage_error"` instead of crashing or leaving responses
+  permanently stuck at `in_progress`. Covers all execution modes (streaming, background+streaming,
+  background+non-streaming, synchronous). For streaming responses, terminal SSE events are buffered,
+  persistence is attempted, and on failure the terminal event is replaced with `response.failed`
+  carrying `error_code="storage_error"`. Synchronous persistence failures return HTTP 500 with the
+  storage error details.
 
 ### Bugs Fixed
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/CHANGELOG.md
@@ -24,6 +24,10 @@
   a transport-level failure (DNS resolution, connection refused, timeout) occurs before any HTTP
   response is received. These failures are now logged at `Error` level without triggering the
   logging crash, and the original transport exception continues to propagate.
+- Fixed `GetInputExpanded` not normalizing string content shorthand on `ItemMessage`. When
+  `content` is a plain JSON string (e.g., `"Hello"`), it is now auto-expanded to the canonical
+  array form (`[{"type":"input_text","text":"Hello"}]`) so that `ItemMessage.Content` BinaryData
+  is always consistent regardless of input format.
 
 ### Other Changes
 

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Custom/BinaryDataExpansionHelpers.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/src/Custom/BinaryDataExpansionHelpers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
 
 namespace Azure.AI.AgentServer.Responses.Models;
@@ -63,7 +64,7 @@ internal static class BinaryDataExpansionHelpers
             using var doc = JsonDocument.Parse(input.ToMemory());
             var root = doc.RootElement;
 
-            return root.ValueKind switch
+            var items = root.ValueKind switch
             {
                 JsonValueKind.String => new List<Item>
                 {
@@ -73,6 +74,9 @@ internal static class BinaryDataExpansionHelpers
                 _ => throw new FormatException(
                     $"Expected a string or array for Input, but got {root.ValueKind}."),
             };
+
+            NormalizeMessageContent(items);
+            return items;
         }
         catch (FormatException)
         {
@@ -210,5 +214,43 @@ internal static class BinaryDataExpansionHelpers
         }
 
         return items;
+    }
+
+    /// <summary>
+    /// Normalizes <see cref="ItemMessage.Content"/> from JSON string shorthand to
+    /// the canonical array form so that downstream consumers always see an array
+    /// of <see cref="MessageContent"/> regardless of how the input was submitted.
+    /// </summary>
+    private static void NormalizeMessageContent(List<Item> items)
+    {
+        foreach (var item in items)
+        {
+            if (item is ItemMessage message && message.Content is not null)
+            {
+                using var doc = JsonDocument.Parse(message.Content.ToMemory());
+                if (doc.RootElement.ValueKind == JsonValueKind.String)
+                {
+                    var expanded = ExpandContent(message.Content);
+                    message.Content = SerializeContentArray(expanded);
+                }
+            }
+        }
+    }
+
+    private static BinaryData SerializeContentArray(List<MessageContent> content)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartArray();
+            foreach (var part in content)
+            {
+                ((IJsonModel<MessageContent>)part).Write(writer, ModelReaderWriterOptions.Json);
+            }
+
+            writer.WriteEndArray();
+        }
+
+        return BinaryData.FromBytes(stream.ToArray());
     }
 }

--- a/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/PublicApi/CreateResponseExtensionsTests.cs
+++ b/sdk/agentserver/Azure.AI.AgentServer.Responses/tests/PublicApi/CreateResponseExtensionsTests.cs
@@ -301,6 +301,70 @@ public class CreateResponseExtensionsTests
         Assert.That(ex.InnerException, Is.Not.Null);
     }
 
+    [Test]
+    public void GetInputExpanded_StringContent_NormalizedToArray()
+    {
+        // content is a plain JSON string — should be auto-expanded to array form
+        var json = """[{"type":"message","role":"user","content":"Hello world"}]""";
+        var request = new CreateResponse
+        {
+            Input = BinaryData.FromString(json),
+        };
+
+        var result = request.GetInputExpanded();
+
+        var itemMsg = XAssert.IsType<ItemMessage>(XAssert.Single(result));
+
+        // Content BinaryData should now be a JSON array, not a string
+        using var doc = System.Text.Json.JsonDocument.Parse(itemMsg.Content.ToMemory());
+        Assert.That(doc.RootElement.ValueKind, Is.EqualTo(System.Text.Json.JsonValueKind.Array));
+
+        // GetContentExpanded should still work correctly
+        var content = itemMsg.GetContentExpanded();
+        var textContent = XAssert.IsType<MessageContentInputTextContent>(XAssert.Single(content));
+        Assert.That(textContent.Text, Is.EqualTo("Hello world"));
+    }
+
+    [Test]
+    public void GetInputExpanded_ArrayContent_RemainsUnchanged()
+    {
+        // content is already an array — should pass through without re-serialization
+        var json = """[{"type":"message","role":"user","content":[{"type":"input_text","text":"Already expanded"}]}]""";
+        var request = new CreateResponse
+        {
+            Input = BinaryData.FromString(json),
+        };
+
+        var result = request.GetInputExpanded();
+
+        var itemMsg = XAssert.IsType<ItemMessage>(XAssert.Single(result));
+        using var doc = System.Text.Json.JsonDocument.Parse(itemMsg.Content.ToMemory());
+        Assert.That(doc.RootElement.ValueKind, Is.EqualTo(System.Text.Json.JsonValueKind.Array));
+
+        var content = itemMsg.GetContentExpanded();
+        var textContent = XAssert.IsType<MessageContentInputTextContent>(XAssert.Single(content));
+        Assert.That(textContent.Text, Is.EqualTo("Already expanded"));
+    }
+
+    [Test]
+    public void GetInputText_StringContent_ExtractsTextCorrectly()
+    {
+        // Ensures GetInputText works when content is a string shorthand
+        var json = """
+        [
+            {"type":"message","role":"user","content":"First message"},
+            {"type":"message","role":"user","content":[{"type":"input_text","text":"Second message"}]}
+        ]
+        """;
+        var request = new CreateResponse
+        {
+            Input = BinaryData.FromString(json),
+        };
+
+        var result = request.GetInputText();
+        Assert.That(result, Is.EqualTo("First message\nSecond message"));
+    }
+
     // ── GetInputText ──────────────────────────────────────────────────
 
     [Test]


### PR DESCRIPTION
## Release: AgentServer packages — 2026-04-22

### Packages

| Package | Version | Work Item |
|---------|---------|-----------|
| Azure.AI.AgentServer.Core | 1.0.0-beta.23 | [29340](https://dev.azure.com/azure-sdk/Release/_workitems/edit/29340/) |
| Azure.AI.AgentServer.Invocations | 1.0.0-beta.3 | [33692](https://dev.azure.com/azure-sdk/Release/_workitems/edit/33692/) |
| Azure.AI.AgentServer.Responses | 1.0.0-beta.4 | [33691](https://dev.azure.com/azure-sdk/Release/_workitems/edit/33691/) |

### What's in this release

#### Core (beta.23)
**Features:**
- `PlatformHeaders` static class centralizing all platform HTTP header name constants
- `RequestIdMiddleware` — sets `x-request-id` response header on every HTTP response (OTEL trace ID → incoming header → GUID)
- `RequestIdBaggagePropagator` — propagates `x-request-id` into `Activity.Baggage` for distributed tracing

**Breaking changes:**
- Removed `IsolationContext.UserIsolationKeyHeaderName` / `ChatIsolationKeyHeaderName` → use `PlatformHeaders` constants
- Consolidated six middleware registration methods into `AddAgentServerCore()` / `UseAgentServerCore()`

#### Invocations (beta.3)
- `x-request-id` response header on all endpoints
- Migrated to `PlatformHeaders` constants

#### Responses (beta.4)
**Features:**
- Persistence failure resilience — storage failures now complete responses gracefully with `status: "failed"` and `error.code: "storage_error"` instead of crashing or leaving responses stuck at `in_progress`. Covers all execution modes (streaming, background, synchronous).
- `traceparent` header in Foundry storage log messages for distributed trace correlation
- `x-request-id` response header on all endpoints
- Error responses enriched with `error.additionalInfo.request_id`

**Bug fixes:**
- Fixed `InvalidOperationException: Response was not set` crash in `FoundryStorageLoggingPolicy` on transport-level failures

### Changes
- Changelog date stamps set to 2026-04-22
- Fixed Responses beta.3 date (was incorrectly 2026-05-05, actually released 2026-04-20)
- Added missing persistence failure resilience changelog entry (aligned with Python SDK release)