### PR TITLE
Add @Azure/azure-sdk-write-net-core to extensions CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,7 +54,7 @@
 # AzureSdkOwners:                                                  @JonathanCrd
 
 # PRLabel: %Extensions
-/sdk/extensions/                                                   @jsquire
+/sdk/extensions/                                                   @jsquire @Azure/azure-sdk-write-net-core
 
 # ServiceLabel: %Extensions
 # AzureSdkOwners:                                                  @jsquire


### PR DESCRIPTION
The release pipeline for `Microsoft.Extensions.Azure` 1.14.0 failed CODEOWNERS validation because `sdk/extensions/Microsoft.Extensions.Azure` only had a single owner (`@jsquire`), and the rule requires at least 2.

Adds `@Azure/azure-sdk-write-net-core` alongside `@jsquire` on the `/sdk/extensions/` line so all extensions packages have sufficient codeowners coverage.

Failing build log: https://dev.azure.com/azure-sdk/590cfd2a-581c-4dcb-a12e-6568ce786175/_apis/build/builds/6194487/logs/514