### PR TITLE
Thread enclosing TypeProvider through GetConvenienceMethodByOperation

### DIFF
--- a/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
+++ b/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
@@ -83,6 +83,10 @@
         $(MSBuildProjectName) == 'Azure.Extensions.AspNetCore.DataProtection.Keys.Tests' or
         $(MSBuildProjectName) == 'Azure.Generator.Tests' or
         $(MSBuildProjectName) == 'Azure.Generator.Tests.Common' or
+        $(MSBuildProjectName) == 'Azure.Generator.Management.Tests.Common' or
+        $(MSBuildProjectName) == 'Azure.Generator.Mgmt.Tests' or
+        $(MSBuildProjectName) == 'Azure.Generator.MgmtTypeSpec.Tests' or
+        $(MSBuildProjectName) == 'Azure.Generator.MgmtTypeSpec.MultiService.Tests' or
         $(MSBuildProjectName) == 'Azure.GeneratorAgent.Tests' or
         $(MSBuildProjectName) == 'Azure.Health.Deidentification.Tests' or
         $(MSBuildProjectName) == 'Azure.Health.Insights.CancerProfiling.Tests' or

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ArrayResponseCollectionResultDefinition.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ArrayResponseCollectionResultDefinition.cs
@@ -32,6 +32,7 @@ namespace Azure.Generator.Management.Providers
     internal class ArrayResponseCollectionResultDefinition : TypeProvider
     {
         private readonly ClientProvider _restClient;
+        private readonly TypeProvider _enclosingType;
         private readonly InputServiceMethod _serviceMethod;
         private readonly CSharpType _itemType;
         private readonly bool _isAsync;
@@ -51,6 +52,7 @@ namespace Azure.Generator.Management.Providers
 
         public ArrayResponseCollectionResultDefinition(
             ClientProvider restClient,
+            TypeProvider enclosingType,
             InputServiceMethod serviceMethod,
             CSharpType itemType,
             bool isAsync,
@@ -59,6 +61,7 @@ namespace Azure.Generator.Management.Providers
             string enclosingTypeName)
         {
             _restClient = restClient;
+            _enclosingType = enclosingType;
             _serviceMethod = serviceMethod;
             _itemType = itemType;
             _isAsync = isAsync;
@@ -218,7 +221,7 @@ namespace Azure.Generator.Management.Providers
             // Since we're generating collection result, we just need to call the Create*Request method on the client
             // The method name is derived from the original convenience method name from the REST client, not the potentially customized _methodName
             // (e.g., operation "listDependencies" -> convenience method "GetDependencies" -> request method "CreateGetDependenciesRequest")
-            var convenienceMethod = _restClient.GetConvenienceMethodByOperation(_serviceMethod.Operation, _isAsync);
+            var convenienceMethod = _restClient.GetConvenienceMethodByOperation(_serviceMethod.Operation, _isAsync, _enclosingType);
             var originalMethodName = convenienceMethod.Signature.Name;
             var baseName = originalMethodName.EndsWith("Async") ? originalMethodName.Substring(0, originalMethodName.Length - 5) : originalMethodName;
             var createRequestMethodName = $"Create{baseName}Request";

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ArrayResponseOperationMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ArrayResponseOperationMethodProvider.cs
@@ -58,7 +58,7 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             _scopeParameter = scopeParameter;
             _restClient = restClientInfo.RestClientProvider;
             _serviceMethod = method;
-            _convenienceMethod = _restClient.GetConvenienceMethodByOperation(_serviceMethod.Operation, isAsync);
+            _convenienceMethod = _restClient.GetConvenienceMethodByOperation(_serviceMethod.Operation, isAsync, _enclosingType);
             _parameterMapping = _operationContext.BuildParameterMapping(new RequestPathPattern(method.Operation.Path));
             _isAsync = isAsync;
             _restClientField = restClientInfo.RestClient;
@@ -201,6 +201,7 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
 
             var collectionResult = new ArrayResponseCollectionResultDefinition(
                 _restClient,
+                _enclosingType,
                 _serviceMethod,
                 _itemType,
                 _isAsync,

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/PageableOperationMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/PageableOperationMethodProvider.cs
@@ -51,7 +51,7 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             _restClientInfo = restClientInfo;
             _method = method;
             _parameterMappings = operationContext.BuildParameterMapping(new RequestPathPattern(method.Operation.Path));
-            _convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_method.Operation, isAsync);
+            _convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_method.Operation, isAsync, _enclosingType);
             _isAsync = isAsync;
             _itemType = _convenienceMethod.Signature.ReturnType!.Arguments[0]; // a paging method's return type should be `Pageable<T>` or `AsyncPageable<T>`, so we can safely access the first argument as the item type.
             InitializeTypeInfo(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/OperationMethodProviders/ResourceOperationMethodProvider.cs
@@ -88,7 +88,7 @@ namespace Azure.Generator.Management.Providers.OperationMethodProviders
             _serviceMethod = method;
             _parameterMappings = operationContext.BuildParameterMapping(new RequestPathPattern(method.Operation.Path));
             _isAsync = isAsync;
-            _convenienceMethod = _restClient.GetConvenienceMethodByOperation(_serviceMethod.Operation, isAsync);
+            _convenienceMethod = _restClient.GetConvenienceMethodByOperation(_serviceMethod.Operation, isAsync, _enclosingType);
             bool isLongRunningOperation = false;
             bool isFakeLongRunningOperation = false;
             InitializeLroFlags(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -369,8 +369,8 @@ namespace Azure.Generator.Management.Providers
                 // Get the appropriate rest client for this specific method
                 var restClientInfo = _clientInfos[inputClient];
 
-                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(method.Operation, false);
-                var asyncConvenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(method.Operation, true);
+                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(method.Operation, false, this);
+                var asyncConvenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(method.Operation, true, this);
 
                 if (method is InputPagingServiceMethod pagingMethod)
                 {

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceCollectionClientProvider.cs
@@ -387,7 +387,7 @@ namespace Azure.Generator.Management.Providers
             var restClientInfo = _clientInfos[_create.InputClient];
             foreach (var isAsync in new List<bool> { true, false })
             {
-                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_create.InputMethod.Operation, isAsync);
+                var convenienceMethod = restClientInfo.RestClientProvider.GetConvenienceMethodByOperation(_create.InputMethod.Operation, isAsync, this);
                 var methodName = ResourceHelpers.GetOperationMethodName(ResourceOperationKind.Create, isAsync, true);
                 result.Add(new ResourceOperationMethodProvider(this, _operationContext, restClientInfo, _create.InputMethod, isAsync, methodName: methodName, forceLro: true));
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ClientProviderExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ClientProviderExtensions.cs
@@ -9,9 +9,12 @@ namespace Azure.Generator.Management.Utilities
 {
     internal static class ClientProviderExtensions
     {
-        public static MethodProvider GetConvenienceMethodByOperation(this ClientProvider clientProvider, InputOperation operation, bool isAsync)
+        public static MethodProvider GetConvenienceMethodByOperation(this ClientProvider clientProvider, InputOperation operation, bool isAsync, TypeProvider? backCompatProvider = null)
         {
-            var methods = clientProvider.GetMethodCollectionByOperation(operation, clientProvider);
+            // Threading the enclosing public-surface TypeProvider (e.g. ResourceClientProvider, ResourceCollectionClientProvider)
+            // here lets the underlying RestClientProvider consult that provider's LastContractView when deciding parameter
+            // names (e.g. preserving the previously-published "top" name instead of the new "maxCount" rename).
+            var methods = clientProvider.GetMethodCollectionByOperation(operation, backCompatProvider);
             return isAsync ? methods[^1] : methods[^2];
         }
 


### PR DESCRIPTION
The GetConvenienceMethodByOperation extension previously hardcoded the ClientProvider as its own backcompat provider, which the underlying ClientProvider.GetMethodCollectionByOperation explicitly ignores (backCompatProvider == this). Widen the extension to accept the enclosing public-surface TypeProvider (e.g. ResourceClientProvider, ResourceCollectionClientProvider) and forward it so RestClientProvider can consult its LastContractView when preserving previously-published parameter names (e.g. 'top' instead of 'maxCount').

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
