### PR TITLE
[Provisioning] Migrate Azure.Provisioning.* tests to NUnit 4

### DIFF
--- a/common/ManagementTestShared/Redesign/InheritanceCheckTests.cs
+++ b/common/ManagementTestShared/Redesign/InheritanceCheckTests.cs
@@ -24,7 +24,7 @@ namespace Azure.ResourceManager.TestFramework
         {
             var testAssembly = Assembly.GetExecutingAssembly();
             var assemblyName = testAssembly.GetName().Name;
-            Assert.IsTrue(assemblyName.EndsWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
+            Assert.That(assemblyName, Does.EndWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
             var rpNamespace = assemblyName.Substring(0, assemblyName.Length - TestAssemblySuffix.Length);
 
             if (rpNamespace == TestFrameworkAssembly)
@@ -41,7 +41,7 @@ namespace Azure.ResourceManager.TestFramework
 
             var sdkAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == rpNamespace) ?? Assembly.Load(rpNamespace);
 
-            Assert.IsNotNull(sdkAssembly, $"The SDK assembly {rpNamespace} not found");
+            Assert.That(sdkAssembly, Is.Not.Null, $"The SDK assembly {rpNamespace} not found");
 
             // Verify all class end with `Resource` & `Collection`
             HashSet<string> exceptionList = ExceptionList == null ? new HashSet<string>() : new HashSet<string>(ExceptionList);
@@ -69,8 +69,8 @@ namespace Azure.ResourceManager.TestFramework
                 }
             }
 
-            Assert.IsEmpty(exceptionList, "InheritanceCheck exception list have values which is not included in current package, please check: " + string.Join(",", exceptionList));
-            Assert.IsEmpty(errorList, "InheritanceCheck failed with Type: " + string.Join(",", errorList));
+            Assert.That(exceptionList, Is.Empty, "InheritanceCheck exception list have values which is not included in current package, please check: " + string.Join(",", exceptionList));
+            Assert.That(errorList, Is.Empty, "InheritanceCheck failed with Type: " + string.Join(",", errorList));
         }
     }
 }

--- a/common/ManagementTestShared/Redesign/ManagementMockingPatternTests.cs
+++ b/common/ManagementTestShared/Redesign/ManagementMockingPatternTests.cs
@@ -29,7 +29,7 @@ namespace Azure.ResourceManager.TestFramework
         {
             var testAssembly = Assembly.GetExecutingAssembly();
             var assemblyName = testAssembly.GetName().Name;
-            Assert.IsTrue(assemblyName.EndsWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
+            Assert.That(assemblyName, Does.EndWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
             var rpNamespace = assemblyName.Substring(0, assemblyName.Length - TestAssemblySuffix.Length);
 
             if (rpNamespace == ResourceManagerAssemblyName || rpNamespace == TestFrameworkAssembly)
@@ -48,7 +48,7 @@ namespace Azure.ResourceManager.TestFramework
             // find the SDK assembly by filtering the assemblies in current domain, or load it if not found (when there is no test case)
             var sdkAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == rpNamespace) ?? Assembly.Load(rpNamespace);
 
-            Assert.IsNotNull(sdkAssembly, $"The SDK assembly {rpNamespace} not found");
+            Assert.That(sdkAssembly, Is.Not.Null, $"The SDK assembly {rpNamespace} not found");
 
             // find the extension class
             foreach (var type in sdkAssembly.GetTypes())
@@ -75,7 +75,7 @@ namespace Azure.ResourceManager.TestFramework
             var rpNamespace = extensionType.Namespace;
             var rpName = GetRPName(rpNamespace);
 
-            Assert.IsNotNull(extensionType);
+            Assert.That(extensionType, Is.Not.Null);
 
             foreach (var method in extensionType.GetMethods(BindingFlags.Public | BindingFlags.Static))
             {
@@ -109,19 +109,19 @@ namespace Azure.ResourceManager.TestFramework
             var mockingExtensionTypeName = GetMockableResourceTypeName(rpNamespace, rpName, extendedType.Name);
 
             var mockingExtensionType = assembly.GetType(mockingExtensionTypeName);
-            Assert.IsNotNull(mockingExtensionType, $"The mocking extension class {mockingExtensionTypeName} must exist");
-            Assert.IsTrue(mockingExtensionType.IsPublic, $"The mocking extension class {mockingExtensionType} must be public");
+            Assert.That(mockingExtensionType, Is.Not.Null, $"The mocking extension class {mockingExtensionTypeName} must exist");
+            Assert.That(mockingExtensionType.IsPublic, Is.True, $"The mocking extension class {mockingExtensionType} must be public");
 
             // validate the mocking extension class has a method with the exact name and parameter list
             var expectedTypes = parameters.Skip(1).Select(p => p.ParameterType).ToArray();
             var methodOnExtension = mockingExtensionType.GetMethod(method.Name, parameters.Skip(1).Select(p => p.ParameterType).ToArray());
 
-            Assert.IsNotNull(methodOnExtension, $"The class {mockingExtensionType} must have method {method}");
-            Assert.IsTrue(methodOnExtension.IsVirtual, $"The method on {mockingExtensionType} must be virtual");
-            Assert.IsTrue(methodOnExtension.IsPublic, $"The method on {mockingExtensionType} must be public");
+            Assert.That(methodOnExtension, Is.Not.Null, $"The class {mockingExtensionType} must have method {method}");
+            Assert.That(methodOnExtension.IsVirtual, Is.True, $"The method on {mockingExtensionType} must be virtual");
+            Assert.That(methodOnExtension.IsPublic, Is.True, $"The method on {mockingExtensionType} must be public");
 
             // validate they should both have or both not have the EditorBrowsable(Never) attribute
-            Assert.AreEqual(method.IsDefined(typeof(EditorBrowsableAttribute)), methodOnExtension.IsDefined(typeof(EditorBrowsableAttribute)), $"The method {method} and {methodOnExtension} should both have or neither have the EditorBrowsableAttribute on them");
+            Assert.That(methodOnExtension.IsDefined(typeof(EditorBrowsableAttribute)), Is.EqualTo(method.IsDefined(typeof(EditorBrowsableAttribute))), $"The method {method} and {methodOnExtension} should both have or neither have the EditorBrowsableAttribute on them");
 
             ValidateMocking(extendedType, mockingExtensionType, method, methodOnExtension);
         }
@@ -151,7 +151,7 @@ namespace Azure.ResourceManager.TestFramework
             {
                 var result = extensionMethod.Invoke(null, arguments.ToArray());
 
-                Assert.IsNotNull(result, $"Mocking of extension method {extensionMethod} is not working properly, please check the implementation to ensure it to call the method with same name and parameter list in {mockingExtensionType}");
+                Assert.That(result, Is.Not.Null, $"Mocking of extension method {extensionMethod} is not working properly, please check the implementation to ensure it to call the method with same name and parameter list in {mockingExtensionType}");
             }
             catch (Exception)
             {

--- a/common/ProvisioningTestShared/Trycep.cs
+++ b/common/ProvisioningTestShared/Trycep.cs
@@ -92,9 +92,9 @@ public class Trycep : IAsyncDisposable
     public Trycep Compare(string expectedBicep)
     {
         BicepModules = GetPlan().Compile();
-        Assert.AreEqual(1, BicepModules.Count, $"Expected exactly one bicep module, not <{string.Join(", ", BicepModules.Keys)}>");
+        Assert.That(BicepModules.Count, Is.EqualTo(1), $"Expected exactly one bicep module, not <{string.Join(", ", BicepModules.Keys)}>");
 
-        Assert.IsNotNull(Bicep, "The produced Bicep module was null!");
+        Assert.That(Bicep, Is.Not.Null, "The produced Bicep module was null!");
         if (!CompareBicepContent(expectedBicep, Bicep!, "main.bicep"))
         {
             Assert.Fail("Bicep content comparison failed. See output above for details.");
@@ -106,9 +106,9 @@ public class Trycep : IAsyncDisposable
     public Trycep Compare(IDictionary<string, string> expectedBicepModules)
     {
         BicepModules = GetPlan().Compile();
-        Assert.AreEqual(
-            expectedBicepModules.Count,
+        Assert.That(
             BicepModules.Count,
+            Is.EqualTo(expectedBicepModules.Count),
             $"Expected {expectedBicepModules.Count} modules but found {BicepModules.Count}.  " +
                 $"Expected: <{string.Join(", ", expectedBicepModules.Keys)}>  " +
                 $"Actual: <{string.Join(", ", BicepModules.Keys)}>");
@@ -118,7 +118,7 @@ public class Trycep : IAsyncDisposable
         {
             string expected = expectedBicepModules[name];
             string? actual = BicepModules.TryGetValue(name, out string? b) ? b : null;
-            Assert.IsNotNull(actual, $"Did not find expected module {name} in the actual modules!");
+            Assert.That(actual, Is.Not.Null, $"Did not find expected module {name} in the actual modules!");
 
             if (!CompareBicepContent(expected, actual!, name))
             {
@@ -233,7 +233,7 @@ public class Trycep : IAsyncDisposable
             Console.WriteLine("Actual:");
             Console.WriteLine(arm);
         }
-        Assert.AreEqual(expectedArm, arm);
+        Assert.That(arm, Is.EqualTo(expectedArm));
         return this;
     }
 
@@ -257,7 +257,7 @@ public class Trycep : IAsyncDisposable
             {
                 remaining = [.. remaining.Where(m => !ignore.Contains(m.Code ?? ""))];
             }
-            Assert.Zero(remaining.Count,
+            Assert.That(remaining.Count, Is.Zero,
                 $"Found {remaining.Count} unexpected warnings:{Environment.NewLine}" +
                 $"{string.Join(Environment.NewLine, remaining.Select(s => s.ToString()))}");
         }

--- a/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
+++ b/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
@@ -118,47 +118,6 @@
         $(MSBuildProjectName) == 'Azure.Projects.AI.Tests' or
         $(MSBuildProjectName) == 'Azure.Projects.Provisioning.Tests' or
         $(MSBuildProjectName) == 'Azure.Projects.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.ApiManagement.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.AppConfiguration.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.AppContainers.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.ApplicationInsights.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.AppService.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Batch.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Cdn.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.CognitiveServices.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Communication.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Compute.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.ContainerRegistry.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.ContainerService.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.CosmosDB.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.DataFactory.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Deployment.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Dns.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.EventGrid.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.EventHubs.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.FrontDoor.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.KeyVault.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Kubernetes.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.KubernetesConfiguration.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Kusto.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Monitor.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.MySql.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Network.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.OperationalInsights.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.PostgreSql.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.PrivateDns.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Redis.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.RedisEnterprise.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.ResourceGraph.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Search.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.SecurityCenter.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.ServiceBus.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.ServiceNetworking.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.SignalR.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Sql.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Storage.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.WebPubSub.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Advisor.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.AgFoodPlatform.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.AgriculturePlatform.Tests' or

--- a/sdk/provisioning/Azure.Provisioning.Deployment/tests/ExtensionTests.cs
+++ b/sdk/provisioning/Azure.Provisioning.Deployment/tests/ExtensionTests.cs
@@ -35,7 +35,7 @@ internal class ExtensionTests(bool async)
         // Lint
         ProvisioningPlan plan = infra.Build();
         IReadOnlyList<BicepErrorMessage> messages = plan.Lint();
-        Assert.AreEqual(0, messages.Count);
+        Assert.That(messages, Is.Empty);
     }
 
     [Test]
@@ -53,10 +53,10 @@ internal class ExtensionTests(bool async)
         IReadOnlyList<BicepErrorMessage> messages = plan.Lint();
 
         // Make sure it warns about the unused param
-        Assert.AreEqual(1, messages.Count);
-        Assert.IsFalse(messages[0].IsError);
-        Assert.AreEqual("no-unused-params", messages[0].Code);
-        StringAssert.Contains("endpoint", messages[0].Message);
+        Assert.That(messages.Count, Is.EqualTo(1));
+        Assert.That(messages[0].IsError, Is.False);
+        Assert.That(messages[0].Code, Is.EqualTo("no-unused-params"));
+        Assert.That(messages[0].Message, Does.Contain("endpoint"));
     }
 
     [Test]
@@ -74,10 +74,10 @@ internal class ExtensionTests(bool async)
         IReadOnlyList<BicepErrorMessage> messages = plan.Lint();
 
         // Ignore the "unused param" first warning and make sure we get a type error
-        Assert.AreEqual(2, messages.Count);
-        Assert.IsTrue(messages[1].IsError);
-        Assert.AreEqual("BCP033", messages[1].Code);
-        StringAssert.Contains("int", messages[1].Message);
+        Assert.That(messages.Count, Is.EqualTo(2));
+        Assert.That(messages[1].IsError, Is.True);
+        Assert.That(messages[1].Code, Is.EqualTo("BCP033"));
+        Assert.That(messages[1].Message, Does.Contain("int"));
     }
 
     [Test]
@@ -105,25 +105,26 @@ internal class ExtensionTests(bool async)
         // installed tool
         string resources = JsonDocument.Parse(arm).RootElement.GetProperty("resources").ToString();
 
-        Assert.AreEqual(
-            """
-            [
-                {
-                  "type": "Microsoft.Storage/storageAccounts",
-                  "apiVersion": "2023-01-01",
-                  "name": "[take(format('storage{0}', uniqueString(resourceGroup().id)), 24)]",
-                  "kind": "StorageV2",
-                  "location": "[resourceGroup().location]",
-                  "sku": {
-                    "name": "Standard_LRS"
-                  },
-                  "properties": {
-                    "allowBlobPublicAccess": false,
-                    "isHnsEnabled": true
-                  }
-                }
-              ]
-            """,
-            resources);
+        Assert.That(
+            resources,
+            Is.EqualTo(
+                """
+                [
+                    {
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2023-01-01",
+                      "name": "[take(format('storage{0}', uniqueString(resourceGroup().id)), 24)]",
+                      "kind": "StorageV2",
+                      "location": "[resourceGroup().location]",
+                      "sku": {
+                        "name": "Standard_LRS"
+                      },
+                      "properties": {
+                        "allowBlobPublicAccess": false,
+                        "isHnsEnabled": true
+                      }
+                    }
+                  ]
+                """));
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/tests/BicepValues/BicepValueToExpressionTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/BicepValues/BicepValueToExpressionTests.cs
@@ -248,7 +248,7 @@ namespace Azure.Provisioning.Tests.BicepValues
             }
             """, validIndexer);
             TestModel? model = validIndexer.Value;
-            Assert.IsNotNull(model);
+            Assert.That(model, Is.Not.Null);
             TestHelpers.AssertExpression("'model1'", model!.Name);
             TestHelpers.AssertExpression("test.models[0]", validIndexer.ToBicepExpression());
 
@@ -277,7 +277,7 @@ namespace Azure.Provisioning.Tests.BicepValues
             var validIndexer = resource.Models[0];
 
             var item = validIndexer.Value!;
-            Assert.IsNotNull(item);
+            Assert.That(item, Is.Not.Null);
             var name = item.Name;
 
             TestHelpers.AssertExpression("'model1'", name);
@@ -1097,12 +1097,12 @@ namespace Azure.Provisioning.Tests.BicepValues
 
             // Assert individual elements
             var model1 = resource.Models[0].Value!;
-            Assert.IsNotNull(model1);
+            Assert.That(model1, Is.Not.Null);
             TestHelpers.AssertExpression("'model1'", model1.Name);
             TestHelpers.AssertExpression("test.models[0].name", model1.Name.ToBicepExpression());
 
             var model2 = resource.Models[1].Value!;
-            Assert.IsNotNull(model2);
+            Assert.That(model2, Is.Not.Null);
             TestHelpers.AssertExpression("'model2'", model2.Name);
             TestHelpers.AssertExpression("test.models[1].name", model2.Name.ToBicepExpression());
         }

--- a/sdk/provisioning/Azure.Provisioning/tests/Expressions/ArrayExpressionTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/Expressions/ArrayExpressionTests.cs
@@ -45,9 +45,9 @@ namespace Azure.Provisioning.Tests.Expressions
                 );
 
             static void AssertExpression(string expected, ArrayExpression expression)
-                => Assert.AreEqual(
-                   expected.NormalizeLineEndings(),
-                   expression.ToString().NormalizeLineEndings()
+                => Assert.That(
+                   expression.ToString().NormalizeLineEndings(),
+                   Is.EqualTo(expected.NormalizeLineEndings())
                 );
         }
     }

--- a/sdk/provisioning/Azure.Provisioning/tests/Expressions/InterpolatedStringExpressionTest.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/Expressions/InterpolatedStringExpressionTest.cs
@@ -30,7 +30,7 @@ namespace Azure.Provisioning.Tests.Expressions
                 );
 
             static void AssertExpression(string expected, BicepValue<string> expression)
-                => Assert.AreEqual(expected, expression.ToString());
+                => Assert.That(expression.ToString(), Is.EqualTo(expected));
         }
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/tests/Expressions/LiteralExpressionTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/Expressions/LiteralExpressionTests.cs
@@ -48,7 +48,7 @@ namespace Azure.Provisioning.Tests.Expressions
                 );
 
             static void AssertExpression(string expected, LiteralExpression expression)
-                => Assert.AreEqual(expected, expression.ToString());
+                => Assert.That(expression.ToString(), Is.EqualTo(expected));
         }
     }
 }

--- a/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/InfrastructureTests.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/Infrastructure/InfrastructureTests.cs
@@ -14,7 +14,7 @@ namespace Azure.Provisioning.Tests
         public void ValidNames()
         {
             // Check null is invalid
-            Assert.IsFalse(Infrastructure.IsValidBicepIdentifier(null));
+            Assert.That(Infrastructure.IsValidBicepIdentifier(null), Is.False);
             Assert.Throws<ArgumentNullException>(() => Infrastructure.ValidateBicepIdentifier(null));
             Assert.Throws<ArgumentNullException>(() => new StorageAccount(null!));
 
@@ -22,11 +22,11 @@ namespace Azure.Provisioning.Tests
             List<string> invalid = ["", "my-storage", "my storage", "my:storage", "storage$", "1storage", "KforKelvin"];
             foreach (string name in invalid)
             {
-                Assert.IsFalse(Infrastructure.IsValidBicepIdentifier(name));
+                Assert.That(Infrastructure.IsValidBicepIdentifier(name), Is.False);
                 Assert.Throws<ArgumentException>(() => Infrastructure.ValidateBicepIdentifier(name));
                 if (!string.IsNullOrEmpty(name))
                 {
-                    Assert.AreNotEqual(name, Infrastructure.NormalizeBicepIdentifier(name));
+                    Assert.That(Infrastructure.NormalizeBicepIdentifier(name), Is.Not.EqualTo(name));
                 }
                 Assert.Throws<ArgumentException>(() => new StorageAccount(name));
             }
@@ -35,9 +35,9 @@ namespace Azure.Provisioning.Tests
             List<string> valid = ["foo", "FOO", "Foo", "f", "_foo", "_", "foo123", "ABCdef123_"];
             foreach (string name in valid)
             {
-                Assert.IsTrue(Infrastructure.IsValidBicepIdentifier(name));
+                Assert.That(Infrastructure.IsValidBicepIdentifier(name), Is.True);
                 Assert.DoesNotThrow(() => Infrastructure.ValidateBicepIdentifier(name));
-                Assert.AreEqual(name, Infrastructure.NormalizeBicepIdentifier(name));
+                Assert.That(Infrastructure.NormalizeBicepIdentifier(name), Is.EqualTo(name));
                 Assert.DoesNotThrow(() => new StorageAccount(name));
             }
         }

--- a/sdk/provisioning/Azure.Provisioning/tests/TestHelpers.cs
+++ b/sdk/provisioning/Azure.Provisioning/tests/TestHelpers.cs
@@ -17,12 +17,12 @@ namespace Azure.Provisioning.Tests
 
         public static void AssertExpression(string expected, IBicepValue bicepValue)
         {
-            Assert.AreEqual(expected.NormalizeLineEndings(), bicepValue.ToString()?.NormalizeLineEndings());
+            Assert.That(bicepValue.ToString()?.NormalizeLineEndings(), Is.EqualTo(expected.NormalizeLineEndings()));
         }
 
         public static void AssertExpression(string expected, BicepExpression expression)
         {
-            Assert.AreEqual(expected.NormalizeLineEndings(), expression.ToString().NormalizeLineEndings());
+            Assert.That(expression.ToString().NormalizeLineEndings(), Is.EqualTo(expected.NormalizeLineEndings()));
         }
     }
 }


### PR DESCRIPTION
Migrates all ``Azure.Provisioning.*.Tests`` projects off the NUnit 3 baseline to the repo-default NUnit 4.4.0 + NUnit3TestAdapter 4.6.0.

### What changed

NUnit 4 removed the classic assertion model (``Assert.IsTrue``, ``Assert.IsNotNull``, ``Assert.AreEqual``, ``Assert.Zero``, ``Assert.IsEmpty``, ``StringAssert.Contains``, etc.). Rewrote those call sites in the shared test sources consumed by every provisioning test project, plus the one in-tree provisioning test that used them directly, to the constraint-model form ``Assert.That(actual, Is.EqualTo(expected))`` / ``Is.Not.Null`` / ``Is.Zero`` / ``Is.Empty`` / ``Does.Contain`` / ``Does.EndWith``:

- ``common/ProvisioningTestShared/Trycep.cs`` (auto-included into every ``Azure.Provisioning.*.Tests``)
- ``common/ManagementTestShared/Redesign/InheritanceCheckTests.cs`` (auto-included into every ``IsMgmtLibrary`` test project)
- ``common/ManagementTestShared/Redesign/ManagementMockingPatternTests.cs`` (same)
- ``sdk/provisioning/Azure.Provisioning.Deployment/tests/ExtensionTests.cs``

Then removed all 41 ``Azure.Provisioning.*.Tests`` (and ``Azure.Provisioning.Tests``) entries from ``eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props``.

### Impact on non-provisioning projects

The two ``ManagementTestShared/Redesign/*.cs`` files are auto-included into **all** ``Azure.ResourceManager.*.Tests`` projects too, which remain pinned to NUnit 3 by the baseline file. The constraint-model form (``Assert.That(x, Is.EqualTo(y))``) is supported by NUnit 3.14 as well as NUnit 4, so those projects continue to build and run without modification. Verified by building ``Azure.ResourceManager.Advisor.Tests`` locally.

### Verification

Built under NUnit 4:
- ``Azure.Provisioning.Deployment.Tests``
- ``Azure.Provisioning.Batch.Tests`` (also ``dotnet test`` — 3/3 pass across net8.0/net9.0/net10.0/net462)
- ``Azure.Provisioning.Storage.Tests``

Built under NUnit 3:
- ``Azure.ResourceManager.Advisor.Tests``

---
🤖 arcturus-copilot