### PR TITLE
Fix NullReference issue with custom connection name

### DIFF
--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/CHANGELOG.md
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/CHANGELOG.md
@@ -1,14 +1,9 @@
 # Release History
 
-## 1.11.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.10.1 (2026-04-24)
 
 ### Bugs Fixed
-
-### Other Changes
+- Fix NullPointerException with custom connection name.
 
 ## 1.10.0 (2026-01-19)
 

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubContextBinding.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubContextBinding.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebPubSub.Common;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 {
@@ -19,17 +20,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         private readonly Type _userType;
         private readonly WebPubSubServiceAccessOptions _options;
         private readonly WebPubSubServiceAccessFactory _accessFactory;
+        private readonly ILogger _logger;
 
         public WebPubSubContextBinding(
             BindingProviderContext context,
             IConfiguration configuration,
             INameResolver nameResolver,
             WebPubSubServiceAccessOptions options,
-            WebPubSubServiceAccessFactory accessFactory) : base(context, configuration, nameResolver)
+            WebPubSubServiceAccessFactory accessFactory,
+            ILogger logger) : base(context, configuration, nameResolver)
         {
             _userType = context.Parameter.ParameterType;
             _options = options;
             _accessFactory = accessFactory;
+            _logger = logger;
         }
 
         protected async override Task<IValueProvider> BuildAsync(WebPubSubContextAttribute attrResolved, IReadOnlyDictionary<string, object> bindingData)
@@ -50,23 +54,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 
             try
             {
-                WebPubSubServiceAccess[]? accesses = null;
-                if (attrResolved?.Connections != null)
-                {
-                    var resolved = new List<WebPubSubServiceAccess>(attrResolved.Connections.Length);
-                    foreach (var sectionName in attrResolved.Connections)
-                    {
-                        if (!_accessFactory.TryCreateFromSectionName(sectionName, out var access) || access == null)
-                        {
-                            throw new InvalidOperationException($"Unable to resolve Web PubSub connection from configuration section '{sectionName}'.");
-                        }
-                        resolved.Add(access);
-                    }
-                    accesses = [.. resolved];
-                }
-
-                accesses ??= _options.WebPubSubAccess != null ? [_options.WebPubSubAccess] : null;
-                var validator = new RequestValidator(accesses);
+                var accesses = _accessFactory.ResolveAccessesOrDefault(attrResolved?.Connections, _options.WebPubSubAccess);
+                var validator = new RequestValidator(accesses, _logger);
                 var serviceRequest = await request.ReadWebPubSubRequestAsync(validator).ConfigureAwait(false);
 
                 switch (serviceRequest)

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubContextBindingProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubContextBindingProvider.cs
@@ -21,11 +21,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 
         public WebPubSubContextBindingProvider(INameResolver nameResolver, IConfiguration configuration, WebPubSubServiceAccessOptions options, WebPubSubServiceAccessFactory accessFactory, ILogger logger)
         {
-            _nameResolver = nameResolver;
-            _configuration = configuration;
-            _options = options;
-            _accessFactory = accessFactory;
-            _logger = logger;
+            _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _accessFactory = accessFactory ?? throw new ArgumentNullException(nameof(accessFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public Task<IBinding> TryCreateAsync(BindingProviderContext context)

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubContextBindingProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Bindings/WebPubSubContextBindingProvider.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 {
@@ -16,13 +17,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         private readonly IConfiguration _configuration;
         private readonly WebPubSubServiceAccessOptions _options;
         private readonly WebPubSubServiceAccessFactory _accessFactory;
+        private readonly ILogger _logger;
 
-        public WebPubSubContextBindingProvider(INameResolver nameResolver, IConfiguration configuration, WebPubSubServiceAccessOptions options, WebPubSubServiceAccessFactory accessFactory)
+        public WebPubSubContextBindingProvider(INameResolver nameResolver, IConfiguration configuration, WebPubSubServiceAccessOptions options, WebPubSubServiceAccessFactory accessFactory, ILogger logger)
         {
             _nameResolver = nameResolver;
             _configuration = configuration;
             _options = options;
             _accessFactory = accessFactory;
+            _logger = logger;
         }
 
         public Task<IBinding> TryCreateAsync(BindingProviderContext context)
@@ -39,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
                 return Task.FromResult<IBinding>(null);
             }
 
-            return Task.FromResult<IBinding>(new WebPubSubContextBinding(context, _configuration, _nameResolver, _options, _accessFactory));
+            return Task.FromResult<IBinding>(new WebPubSubContextBinding(context, _configuration, _nameResolver, _options, _accessFactory, _logger));
         }
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/RequestValidator.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/RequestValidator.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Azure.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub;
@@ -21,9 +23,37 @@ internal class RequestValidator
     private readonly Dictionary<string, WebPubSubServiceAccess> _allowedHosts;
     private readonly bool _skipValidation;
 
-    public RequestValidator(WebPubSubServiceAccess[]? accesses)
+    public RequestValidator(WebPubSubServiceAccess[]? accesses, ILogger? logger = null)
     {
         var normalizedAccesses = accesses ?? [];
+
+        // Defensive validation: every access and its endpoint must be non-null before
+        // we run any LINQ that dereferences them. A null slipping through produces a
+        // confusing NullReferenceException deep inside GroupBy/ToDictionary; convert
+        // it into an explicit ArgumentException that names the offending index.
+        for (var i = 0; i < normalizedAccesses.Length; i++)
+        {
+            var access = normalizedAccesses[i];
+            if (access is null)
+            {
+                throw new ArgumentException(
+                    $"Element at index {i} of accesses is null.",
+                    nameof(accesses));
+            }
+            if (access.ServiceEndpoint is null)
+            {
+                throw new ArgumentException(
+                    $"Element at index {i} of accesses has a null ServiceEndpoint.",
+                    nameof(accesses));
+            }
+            if (access.ServiceEndpoint.Host is null)
+            {
+                throw new ArgumentException(
+                    $"Element at index {i} of accesses has a ServiceEndpoint with a null Host.",
+                    nameof(accesses));
+            }
+        }
+
         // Explicitly validate for duplicate hosts to provide a clear error message
         var duplicateHostGroup = normalizedAccesses
             .GroupBy(a => a.ServiceEndpoint.Host)
@@ -36,6 +66,15 @@ internal class RequestValidator
         }
         _allowedHosts = normalizedAccesses.ToDictionary(a => a.ServiceEndpoint.Host, a => a);
         _skipValidation = _allowedHosts.Count == 0;
+
+        if (_skipValidation)
+        {
+            (logger ?? NullLogger.Instance).LogWarning(
+                "No Web PubSub connection is configured for signature / abuse-protection validation. " +
+                "All upstream requests will be accepted without verification. " +
+                "Configure '{DefaultSection}' or set the 'Connections' property on the trigger / context binding to enable validation.",
+                Constants.WebPubSubConnectionStringName);
+        }
     }
 
     public static bool IsValidationRequest(string? method, StringValues originHeader, out List<string>? requestHosts)

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/RequestValidator.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/RequestValidator.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub;
 /// </summary>
 internal class RequestValidator
 {
+    private static bool _noConnectionWarningLogged;
     private readonly Dictionary<string, WebPubSubServiceAccess> _allowedHosts;
     private readonly bool _skipValidation;
 
@@ -67,8 +68,9 @@ internal class RequestValidator
         _allowedHosts = normalizedAccesses.ToDictionary(a => a.ServiceEndpoint.Host, a => a);
         _skipValidation = _allowedHosts.Count == 0;
 
-        if (_skipValidation)
+        if (_skipValidation && !_noConnectionWarningLogged)
         {
+            _noConnectionWarningLogged = true;
             (logger ?? NullLogger.Instance).LogWarning(
                 "No Web PubSub connection is configured for signature / abuse-protection validation. " +
                 "All upstream requests will be accepted without verification. " +

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
             _nameResolver = nameResolver;
             _configuration = configuration;
             _accessOptions = accessOptions;
-            _dispatcher = new WebPubSubTriggerDispatcher(_logger, _accessOptions.CurrentValue);
+            _dispatcher = new WebPubSubTriggerDispatcher(_logger);
             _clientFactory = clientFactory;
             _accessFactory = accessFactory;
         }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubConfigProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 
             // Trigger binding
             context.AddBindingRule<WebPubSubTriggerAttribute>()
-                .BindToTrigger(new WebPubSubTriggerBindingProvider(_dispatcher, _nameResolver, _accessOptions.CurrentValue, webhookException, _accessFactory));
+                .BindToTrigger(new WebPubSubTriggerBindingProvider(_dispatcher, _nameResolver, _accessOptions.CurrentValue, webhookException, _accessFactory, _logger));
 
             // Input binding
             var webpubsubConnectionAttributeRule = context.AddBindingRule<WebPubSubConnectionAttribute>();
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
             webpubsubConnectionAttributeRule.BindToInput(GetClientConnection);
 
             var webPubSubRequestAttributeRule = context.AddBindingRule<WebPubSubContextAttribute>();
-            webPubSubRequestAttributeRule.Bind(new WebPubSubContextBindingProvider(_nameResolver, _configuration, _accessOptions.CurrentValue, _accessFactory));
+            webPubSubRequestAttributeRule.Bind(new WebPubSubContextBindingProvider(_nameResolver, _configuration, _accessOptions.CurrentValue, _accessFactory, _logger));
 
             // Output binding
             var webPubSubAttributeRule = context.AddBindingRule<WebPubSubAttribute>();

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceClientFactory.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceClientFactory.cs
@@ -21,11 +21,11 @@ internal class WebPubSubServiceClientFactory(
     /// <summary>
     /// Creates a WebPubSubServiceClient with fallback connection and hub resolution.
     /// Priority for connection:
-    ///   1. attributeConnection (can be connection string or config section name)
+    ///   1. attributeConnection (config section name)
     ///   2. options (identity-based connection prioritized over connection string)
     /// Priority for hub: attributeHub > options.Hub.
     /// </summary>
-    /// <param name="attributeConnection">Connection from the attribute (can be connection string or config section name).</param>
+    /// <param name="attributeConnection">Connection from the attribute （config section name).</param>
     /// <param name="attributeHub">Hub from the attribute (highest priority).</param>
     /// <returns>A configured WebPubSubServiceClient instance.</returns>
     public WebPubSubServiceClient Create(string attributeConnection, string attributeHub)

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceClientFactory.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Config/WebPubSubServiceClientFactory.cs
@@ -25,7 +25,7 @@ internal class WebPubSubServiceClientFactory(
     ///   2. options (identity-based connection prioritized over connection string)
     /// Priority for hub: attributeHub > options.Hub.
     /// </summary>
-    /// <param name="attributeConnection">Connection from the attribute （config section name).</param>
+    /// <param name="attributeConnection">Connection from the attribute (config section name).</param>
     /// <param name="attributeHub">Hub from the attribute (highest priority).</param>
     /// <returns>A configured WebPubSubServiceClient instance.</returns>
     public WebPubSubServiceClient Create(string attributeConnection, string attributeHub)

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Microsoft.Azure.WebJobs.Extensions.WebPubSub.csproj
@@ -5,7 +5,7 @@
     <PackageId>Microsoft.Azure.WebJobs.Extensions.WebPubSub</PackageId>
     <PackageTags>Azure, WebPubSub</PackageTags>
     <Description>Azure Functions extension for the WebPubSub service</Description>
-    <Version>1.11.0-beta.1</Version>
+    <Version>1.10.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.10.0</ApiCompatVersion>
     <NoWarn>$(NoWarn);CS8632;CA1056;CA2227</NoWarn>

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBinding.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBinding.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -13,6 +14,7 @@ using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Azure.WebPubSub.Common;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
@@ -24,14 +26,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         private readonly IWebPubSubTriggerDispatcher _dispatcher;
         private readonly WebPubSubServiceAccessOptions _options;
         private readonly WebPubSubServiceAccessFactory _accessFactory;
+        private readonly ILogger _logger;
 
-        public WebPubSubTriggerBinding(ParameterInfo parameterInfo, WebPubSubTriggerAttribute attribute, WebPubSubServiceAccessOptions options, IWebPubSubTriggerDispatcher dispatcher, WebPubSubServiceAccessFactory accessFactory)
+        public WebPubSubTriggerBinding(ParameterInfo parameterInfo, WebPubSubTriggerAttribute attribute, WebPubSubServiceAccessOptions options, IWebPubSubTriggerDispatcher dispatcher, WebPubSubServiceAccessFactory accessFactory, ILogger logger)
         {
             _parameterInfo = parameterInfo ?? throw new ArgumentNullException(nameof(parameterInfo));
             _attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
             _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _accessFactory = accessFactory ?? throw new ArgumentNullException(nameof(accessFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             BindingDataContract = CreateBindingContract(parameterInfo);
         }
@@ -73,27 +77,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
             var attributeName = Utilities.GetFunctionKey(hub, _attribute.EventType, _attribute.EventName, _attribute.ClientProtocols);
             var listernerKey = attributeName;
 
-            WebPubSubServiceAccess[]? accesses = null;
-            if (_attribute.Connections != null)
-            {
-                var resolved = new List<WebPubSubServiceAccess>(_attribute.Connections.Length);
-                foreach (var sectionName in _attribute.Connections)
-                {
-                    if (string.IsNullOrEmpty(sectionName))
-                    {
-                        throw new InvalidOperationException("Web PubSub connection section name cannot be null or empty.");
-                    }
-                    if (!_accessFactory.TryCreateFromSectionName(sectionName, out var access) && access != null)
-                    {
-                        throw new InvalidOperationException($"Unable to resolve Web PubSub connection from configuration section '{sectionName}'.");
-                    }
-                    resolved.Add(access);
-                }
-                accesses = [.. resolved];
-            }
+            _logger.LogInformation(
+                "[WebPubSubTriggerBinding] hub='{Hub}' eventType='{EventType}' eventName='{EventName}' Connections={Connections}",
+                hub,
+                _attribute.EventType,
+                _attribute.EventName,
+                _attribute.Connections == null ? "<null>" : "[" + string.Join(",", _attribute.Connections.Select(c => c ?? "<null>")) + "]");
 
-            accesses ??= _options.WebPubSubAccess != null ? [_options.WebPubSubAccess] : null;
-            var validator = new RequestValidator(accesses);
+            var accesses = _accessFactory.ResolveAccessesOrDefault(_attribute.Connections, _options.WebPubSubAccess);
+            var validator = new RequestValidator(accesses, _logger);
 
             return Task.FromResult<IListener>(new WebPubSubListener(context.Executor, listernerKey, _dispatcher, validator));
         }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBindingProvider.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerBindingProvider.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 {
@@ -16,14 +17,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         private readonly WebPubSubServiceAccessOptions _options;
         private readonly Exception _webhookException;
         private readonly WebPubSubServiceAccessFactory _accessFactory;
+        private readonly ILogger _logger;
 
-        public WebPubSubTriggerBindingProvider(IWebPubSubTriggerDispatcher dispatcher, INameResolver nameResolver, WebPubSubServiceAccessOptions options, Exception webhookException, WebPubSubServiceAccessFactory accessFactory)
+        public WebPubSubTriggerBindingProvider(IWebPubSubTriggerDispatcher dispatcher, INameResolver nameResolver, WebPubSubServiceAccessOptions options, Exception webhookException, WebPubSubServiceAccessFactory accessFactory, ILogger logger)
         {
             _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
             _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _webhookException = webhookException;
             _accessFactory = accessFactory ?? throw new ArgumentNullException(nameof(accessFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
@@ -44,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
                 throw new NotSupportedException($"WebPubSubTrigger is disabled due to 'AzureWebJobsStorage' connection string is not set or invalid. {_webhookException}");
             }
 
-            return Task.FromResult<ITriggerBinding>(new WebPubSubTriggerBinding(parameterInfo, GetResolvedAttribute(attribute), _options, _dispatcher, _accessFactory));
+            return Task.FromResult<ITriggerBinding>(new WebPubSubTriggerBinding(parameterInfo, GetResolvedAttribute(attribute), _options, _dispatcher, _accessFactory, _logger));
         }
 
         internal WebPubSubTriggerAttribute GetResolvedAttribute(WebPubSubTriggerAttribute attribute)

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerDispatcher.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerDispatcher.cs
@@ -21,12 +21,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
     {
         private readonly Dictionary<string, WebPubSubListener> _listeners = new(StringComparer.InvariantCultureIgnoreCase);
         private readonly ILogger _logger;
-        private readonly WebPubSubServiceAccessOptions _options;
 
-        public WebPubSubTriggerDispatcher(ILogger logger, WebPubSubServiceAccessOptions options)
+        public WebPubSubTriggerDispatcher(ILogger logger)
         {
             _logger = logger;
-            _options = options;
         }
 
         public void AddListener(string key, WebPubSubListener listener)

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerDispatcher.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerDispatcher.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -19,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 {
     internal class WebPubSubTriggerDispatcher : IWebPubSubTriggerDispatcher
     {
-        private readonly Dictionary<string, WebPubSubListener> _listeners = new(StringComparer.InvariantCultureIgnoreCase);
+        private readonly ConcurrentDictionary<string, WebPubSubListener> _listeners = new(StringComparer.InvariantCultureIgnoreCase);
         private readonly ILogger _logger;
 
         public WebPubSubTriggerDispatcher(ILogger logger)
@@ -29,11 +30,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 
         public void AddListener(string key, WebPubSubListener listener)
         {
-            if (_listeners.ContainsKey(key))
+            if (!_listeners.TryAdd(key, listener))
             {
                 throw new ArgumentException($"Duplicated binding attribute find: {string.Join(",", key.Split('.'))}");
             }
-            _listeners.Add(key, listener);
         }
 
         public async Task<HttpResponseMessage> ExecuteAsync(HttpRequestMessage req,

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerDispatcher.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/Trigger/WebPubSubTriggerDispatcher.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
         {
             if (req.IsValidationRequest(out var requestHosts))
             {
-                return RespondToServiceAbuseCheck(requestHosts, new RequestValidator([_options.WebPubSubAccess]));
+                return RespondToServiceAbuseCheck(requestHosts);
             }
 
             if (!TryParseCloudEvents(req, out var context))
@@ -261,10 +261,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
             return false;
         }
 
-        private static HttpResponseMessage RespondToServiceAbuseCheck(IList<string> requestHosts, RequestValidator validator)
+        private HttpResponseMessage RespondToServiceAbuseCheck(IList<string> requestHosts)
         {
             var response = new HttpResponseMessage();
-            if (validator.IsValidHost(requestHosts))
+            if (IsValidAbuseProtectionOrigin(requestHosts))
             {
                 response.Headers.Add(Constants.Headers.WebHookAllowedOrigin, Constants.AllowedAllOrigins);
                 return response;
@@ -272,6 +272,27 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub
 
             response.StatusCode = HttpStatusCode.BadRequest;
             return response;
+        }
+
+        /// <summary>
+        /// Checks whether the abuse-protection origin matches any registered listener's
+        /// allowed hosts. Each listener's validator is built from either its trigger
+        /// attribute's <c>Connections</c>, or the extension-level default access
+        /// (<see cref="WebPubSubServiceAccessOptions.WebPubSubAccess"/>) when the trigger
+        /// has none. A validator with no restrictions accepts any origin, matching the
+        /// per-listener signature-validation semantics.
+        /// </summary>
+        private bool IsValidAbuseProtectionOrigin(IList<string> requestHosts)
+        {
+            foreach (var listener in _listeners.Values)
+            {
+                if (listener.Validator.IsValidHost(requestHosts))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/WebPubSubServiceAccessFactory.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/src/WebPubSubServiceAccessFactory.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub;
+
+#nullable enable
 
 internal class WebPubSubServiceAccessFactory
 {
@@ -29,5 +32,40 @@ internal class WebPubSubServiceAccessFactory
             _configuration.GetSection(sectionName),
             _azureComponentFactory,
             out access);
+    }
+
+    /// <summary>
+    /// Resolves a list of configuration section names to <see cref="WebPubSubServiceAccess"/> instances.
+    /// Falls back to <paramref name="defaultAccess"/> when <paramref name="sectionNames"/> is null or empty.
+    /// Returns null when neither is configured (signals "no signature/abuse validation"); a one-time
+    /// warning is logged in that case.
+    /// </summary>
+    public WebPubSubServiceAccess[]? ResolveAccessesOrDefault(IList<string>? sectionNames, WebPubSubServiceAccess? defaultAccess)
+    {
+        if (sectionNames != null && sectionNames.Count > 0)
+        {
+            var resolved = new List<WebPubSubServiceAccess>(sectionNames.Count);
+            foreach (var sectionName in sectionNames)
+            {
+                if (string.IsNullOrEmpty(sectionName))
+                {
+                    throw new InvalidOperationException("Web PubSub connection section name cannot be null or empty.");
+                }
+                if (!TryCreateFromSectionName(sectionName, out var access) || access == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Unable to resolve Web PubSub connection from configuration section '{sectionName}'.");
+                }
+                resolved.Add(access);
+            }
+            return resolved.ToArray();
+        }
+
+        if (defaultAccess != null)
+        {
+            return new[] { defaultAccess };
+        }
+
+        return null;
     }
 }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubRequestBindingProviderTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubRequestBindingProviderTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebPubSub.Common;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             var mockResolver = new Mock<INameResolver>(MockBehavior.Strict);
             var options = new WebPubSubServiceAccessOptions();
             var accessFactory = new WebPubSubServiceAccessFactory(_configuration, TestAzureComponentFactory.Instance);
-            _provider = new WebPubSubContextBindingProvider(mockResolver.Object, _configuration, options, accessFactory);
+            _provider = new WebPubSubContextBindingProvider(mockResolver.Object, _configuration, options, accessFactory, NullLogger.Instance);
         }
 
         [TestCase]

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerBindingProviderTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerBindingProviderTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Azure.WebPubSub.Common;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 
@@ -30,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             var mockDispater = new Mock<IWebPubSubTriggerDispatcher>(MockBehavior.Strict);
             var options = new WebPubSubServiceAccessOptions();
             var accessFactory = new WebPubSubServiceAccessFactory(_configuration, TestAzureComponentFactory.Instance);
-            _provider = new WebPubSubTriggerBindingProvider(mockDispater.Object, resolver, options, null, accessFactory);
+            _provider = new WebPubSubTriggerBindingProvider(mockDispater.Object, resolver, options, null, accessFactory, NullLogger.Instance);
         }
 
         [TestCase]
@@ -70,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
         }
 
         public static void TestFunc(
-            [WebPubSubTrigger("%testhub%", WebPubSubEventType.System, "testevent")]WebPubSubConnectionContext context)
+            [WebPubSubTrigger("%testhub%", WebPubSubEventType.System, "testevent")] WebPubSubConnectionContext context)
         {
         }
     }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerDispatcherTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerDispatcherTests.cs
@@ -106,6 +106,93 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
+        // Regression: customer repro. No default WebPubSubAccess configured (and listener
+        // also has no restriction). Abuse-protection OPTIONS must not NullReferenceException
+        // on new RequestValidator([null]); it should accept any origin because nothing is
+        // restricted.
+        [TestCase]
+        public async Task TestProcessRequest_AbuseProtection_NoDefaultAccess_NoListenerRestriction_Accepts()
+        {
+            var dispatcher = SetupDispatcher(connectionString: null);
+            var request = TestHelpers.CreateHttpRequestMessage(TestHub, TestType, TestEvent, TestKey.ConnectionId, ValidSignature, httpMethod: "OPTIONS", origin: new string[] { "any.example.com" });
+            var response = await dispatcher.ExecuteAsync(request);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        // Regression: customer repro. No default WebPubSubAccess, but the listener was
+        // built from the trigger attribute's Connections and has restrictions. The origin
+        // matches the listener's allowed host → accept.
+        [TestCase]
+        public async Task TestProcessRequest_AbuseProtection_NoDefaultAccess_ListenerRestrictionMatches_Accepts()
+        {
+            var triggerHost = "trigger.example.com";
+            var dispatcher = SetupDispatcherWithListenerOnlyAccess(triggerHost);
+            var request = TestHelpers.CreateHttpRequestMessage(TestHub, TestType, TestEvent, TestKey.ConnectionId, ValidSignature, httpMethod: "OPTIONS", origin: new string[] { triggerHost });
+            var response = await dispatcher.ExecuteAsync(request);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        // No default access, listener has restrictions, origin does not match any of them.
+        [TestCase]
+        public async Task TestProcessRequest_AbuseProtection_NoDefaultAccess_ListenerRestrictionNoMatch_Rejects()
+        {
+            var dispatcher = SetupDispatcherWithListenerOnlyAccess("trigger.example.com");
+            var request = TestHelpers.CreateHttpRequestMessage(TestHub, TestType, TestEvent, TestKey.ConnectionId, ValidSignature, httpMethod: "OPTIONS", origin: new string[] { "stranger.example.com" });
+            var response = await dispatcher.ExecuteAsync(request);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        // Default access host does NOT match origin, but the listener was built from
+        // trigger Connections (local access) which does match → accept.
+        // The listener uses ONLY local access; global default is not consulted.
+        [TestCase]
+        public async Task TestProcessRequest_AbuseProtection_ListenerUsesLocalAccess_OriginMatchesLocal_Accepts()
+        {
+            var defaultHost = "default.example.com";
+            var triggerHost = "trigger.example.com";
+            var dispatcher = SetupDispatcherWithLocalAccess(defaultHost, triggerHost);
+            var request = TestHelpers.CreateHttpRequestMessage(TestHub, TestType, TestEvent, TestKey.ConnectionId, ValidSignature, httpMethod: "OPTIONS", origin: new string[] { triggerHost });
+            var response = await dispatcher.ExecuteAsync(request);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        // Listener has local access (triggerHost). Origin matches the global default host
+        // but NOT the local access → reject. Proves that global default is NOT consulted
+        // when the listener has its own Connections.
+        [TestCase]
+        public async Task TestProcessRequest_AbuseProtection_ListenerUsesLocalAccess_OriginMatchesGlobalOnly_Rejects()
+        {
+            var defaultHost = "default.example.com";
+            var triggerHost = "trigger.example.com";
+            var dispatcher = SetupDispatcherWithLocalAccess(defaultHost, triggerHost);
+            var request = TestHelpers.CreateHttpRequestMessage(TestHub, TestType, TestEvent, TestKey.ConnectionId, ValidSignature, httpMethod: "OPTIONS", origin: new string[] { defaultHost });
+            var response = await dispatcher.ExecuteAsync(request);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        // Listener has no Connections, so it falls back to global default access.
+        // Origin matches the global default → accept.
+        [TestCase]
+        public async Task TestProcessRequest_AbuseProtection_ListenerFallsBackToGlobal_OriginMatchesGlobal_Accepts()
+        {
+            var defaultHost = "default.example.com";
+            var dispatcher = SetupDispatcherWithGlobalFallback(defaultHost);
+            var request = TestHelpers.CreateHttpRequestMessage(TestHub, TestType, TestEvent, TestKey.ConnectionId, ValidSignature, httpMethod: "OPTIONS", origin: new string[] { defaultHost });
+            var response = await dispatcher.ExecuteAsync(request);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        // Listener falls back to global default access. Origin does not match → reject.
+        [TestCase]
+        public async Task TestProcessRequest_AbuseProtection_ListenerFallsBackToGlobal_OriginMismatch_Rejects()
+        {
+            var defaultHost = "default.example.com";
+            var dispatcher = SetupDispatcherWithGlobalFallback(defaultHost);
+            var request = TestHelpers.CreateHttpRequestMessage(TestHub, TestType, TestEvent, TestKey.ConnectionId, ValidSignature, httpMethod: "OPTIONS", origin: new string[] { "stranger.example.com" });
+            var response = await dispatcher.ExecuteAsync(request);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
         [TestCase("sha256=something,sha256=7767effcb3946f3e1de039df4b986ef02c110b1469d02c0a06f41b3b727ab561")]
         [TestCase("sha256=something, sha256=7767effcb3946f3e1de039df4b986ef02c110b1469d02c0a06f41b3b727ab561")]
         [TestCase("sha256=7767effcb3946f3e1de039df4b986ef02c110b1469d02c0a06f41b3b727ab561, sha256=something")]
@@ -326,6 +413,65 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
 
             dispatcher.AddListener(funcName, listener);
 
+            return dispatcher;
+        }
+
+        // No default WebPubSubAccess; the listener is built from a RequestValidator that
+        // restricts allowed hosts to triggerHost (simulates a trigger with explicit
+        // Connections but no default WebPubSubConnection app setting).
+        private static WebPubSubTriggerDispatcher SetupDispatcherWithListenerOnlyAccess(string triggerHost)
+        {
+            var funcName = Utilities.GetFunctionKey(TestHub, TestType, TestEvent, WebPubSubTriggerAcceptedClientProtocols.All).ToLower();
+            var options = new WebPubSubServiceAccessOptions { WebPubSubAccess = null, Hub = TestHub };
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, options);
+            var executor = new Mock<ITriggeredFunctionExecutor>();
+            executor.Setup(f => f.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new FunctionResult(true)));
+            var triggerAccess = WebPubSubServiceAccessUtil.CreateFromConnectionString(
+                $"Endpoint=http://{triggerHost};Port=8080;AccessKey={TestKey.AccessKey};Version=1.0;");
+            var validator = new RequestValidator([triggerAccess]);
+            var listener = new WebPubSubListener(executor.Object, funcName, dispatcher, validator);
+            dispatcher.AddListener(funcName, listener);
+            return dispatcher;
+        }
+
+        // Default WebPubSubAccess is set (scoped to defaultHost), but the listener has
+        // its own local access (scoped to triggerHost). The listener uses ONLY local
+        // access — global default is NOT consulted for this listener.
+        private static WebPubSubTriggerDispatcher SetupDispatcherWithLocalAccess(string defaultHost, string triggerHost)
+        {
+            var funcName = Utilities.GetFunctionKey(TestHub, TestType, TestEvent, WebPubSubTriggerAcceptedClientProtocols.All).ToLower();
+            var defaultAccess = WebPubSubServiceAccessUtil.CreateFromConnectionString(
+                $"Endpoint=http://{defaultHost};Port=8080;AccessKey={TestKey.AccessKey};Version=1.0;");
+            var options = new WebPubSubServiceAccessOptions { WebPubSubAccess = defaultAccess, Hub = TestHub };
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, options);
+            var executor = new Mock<ITriggeredFunctionExecutor>();
+            executor.Setup(f => f.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new FunctionResult(true)));
+            var triggerAccess = WebPubSubServiceAccessUtil.CreateFromConnectionString(
+                $"Endpoint=http://{triggerHost};Port=8080;AccessKey={TestKey.AccessKey};Version=1.0;");
+            var validator = new RequestValidator([triggerAccess]);
+            var listener = new WebPubSubListener(executor.Object, funcName, dispatcher, validator);
+            dispatcher.AddListener(funcName, listener);
+            return dispatcher;
+        }
+
+        // Default WebPubSubAccess is set (scoped to defaultHost). The listener has no
+        // explicit Connections, so its validator falls back to the global default.
+        private static WebPubSubTriggerDispatcher SetupDispatcherWithGlobalFallback(string defaultHost)
+        {
+            var funcName = Utilities.GetFunctionKey(TestHub, TestType, TestEvent, WebPubSubTriggerAcceptedClientProtocols.All).ToLower();
+            var defaultAccess = WebPubSubServiceAccessUtil.CreateFromConnectionString(
+                $"Endpoint=http://{defaultHost};Port=8080;AccessKey={TestKey.AccessKey};Version=1.0;");
+            var options = new WebPubSubServiceAccessOptions { WebPubSubAccess = defaultAccess, Hub = TestHub };
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, options);
+            var executor = new Mock<ITriggeredFunctionExecutor>();
+            executor.Setup(f => f.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new FunctionResult(true)));
+            // Listener falls back to global default access (no local Connections)
+            var validator = new RequestValidator([defaultAccess]);
+            var listener = new WebPubSubListener(executor.Object, funcName, dispatcher, validator);
+            dispatcher.AddListener(funcName, listener);
             return dispatcher;
         }
     }

--- a/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerDispatcherTests.cs
+++ b/sdk/webpubsub/Microsoft.Azure.WebJobs.Extensions.WebPubSub/tests/WebPubSubTriggerDispatcherTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             var connectHttpRequest = TestHelpers.CreateHttpRequestMessage(TestHub, WebPubSubEventType.System, "connect", "clientId", ValidSignature, origin: new string[] { TestOrigin }, subProtocols: new string[] { "mqtt" }, clientProtocol: WebPubSubClientProtocol.Mqtt, payload: Encoding.UTF8.GetBytes(payload));
             connectHttpRequest.Headers.Add(Constants.Headers.CloudEvents.MqttPhysicalConnectionId, "physicalConnectionId");
 
-            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, new() { Hub = TestHub });
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance);
             var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
             var wpsListener = new WebPubSubListener(mockExecutor.Object, Utilities.GetFunctionKey(TestHub, WebPubSubEventType.System, "connect", WebPubSubTriggerAcceptedClientProtocols.Mqtt), dispatcher, null);
             await wpsListener.StartAsync(default);
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             var connectHttpRequest = TestHelpers.CreateHttpRequestMessage(TestHub, WebPubSubEventType.System, "connect", "clientId", ValidSignature, origin: new string[] { TestOrigin }, subProtocols: new string[] { "mqtt" }, clientProtocol: WebPubSubClientProtocol.Mqtt, payload: Encoding.UTF8.GetBytes(payload));
             connectHttpRequest.Headers.Add(Constants.Headers.CloudEvents.MqttPhysicalConnectionId, "physicalConnectionId");
 
-            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, new() { Hub = TestHub });
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance);
             var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
             var wpsListener = new WebPubSubListener(mockExecutor.Object, Utilities.GetFunctionKey(TestHub, WebPubSubEventType.System, "connect", WebPubSubTriggerAcceptedClientProtocols.Mqtt), dispatcher, null);
             await wpsListener.StartAsync(default);
@@ -315,7 +315,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             var connectedRequest = TestHelpers.CreateHttpRequestMessage(TestHub, WebPubSubEventType.System, "connected", "clientId", ValidSignature, origin: new string[] { TestOrigin }, subProtocols: new string[] { "mqtt" }, clientProtocol: WebPubSubClientProtocol.Mqtt);
             connectedRequest.Headers.Add(Constants.Headers.CloudEvents.MqttPhysicalConnectionId, "physicalConnectionId");
             connectedRequest.Headers.Add(Constants.Headers.CloudEvents.MqttSessionId, "sessionId");
-            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, new() { Hub = TestHub });
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance);
             var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
             var wpsListener = new WebPubSubListener(mockExecutor.Object, Utilities.GetFunctionKey(TestHub, WebPubSubEventType.System, "connected", WebPubSubTriggerAcceptedClientProtocols.Mqtt), dispatcher, null);
             await wpsListener.StartAsync(default);
@@ -353,7 +353,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             var disconnectedRequest = TestHelpers.CreateHttpRequestMessage(TestHub, WebPubSubEventType.System, "disconnected", "clientId", ValidSignature, origin: new string[] { TestOrigin }, subProtocols: new string[] { "mqtt" }, clientProtocol: WebPubSubClientProtocol.Mqtt, payload: Encoding.UTF8.GetBytes(body));
             disconnectedRequest.Headers.Add(Constants.Headers.CloudEvents.MqttPhysicalConnectionId, "physicalConnectionId");
             disconnectedRequest.Headers.Add(Constants.Headers.CloudEvents.MqttSessionId, "sessionId");
-            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, new() { Hub = TestHub });
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance);
             var mockExecutor = new Mock<ITriggeredFunctionExecutor>();
             var wpsListener = new WebPubSubListener(mockExecutor.Object, Utilities.GetFunctionKey(TestHub, WebPubSubEventType.System, "disconnected", WebPubSubTriggerAcceptedClientProtocols.Mqtt), dispatcher, null);
             await wpsListener.StartAsync(default);
@@ -395,14 +395,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
         private static WebPubSubTriggerDispatcher SetupDispatcher(string hub = TestHub, WebPubSubEventType type = TestType, string eventName = TestEvent, string connectionString = null, WebPubSubTriggerAcceptedClientProtocols clientProtocol = WebPubSubTriggerAcceptedClientProtocols.All)
         {
             var funcName = Utilities.GetFunctionKey(hub, type, eventName, clientProtocol).ToLower();
-            var options = new WebPubSubServiceAccessOptions
-            {
-                WebPubSubAccess = string.IsNullOrEmpty(connectionString)
-                    ? null
-                    : WebPubSubServiceAccessUtil.CreateFromConnectionString(connectionString),
-                Hub = hub,
-            };
-            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, options);
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance);
             var executor = new Mock<ITriggeredFunctionExecutor>();
             executor.Setup(f => f.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new FunctionResult(true)));
@@ -422,8 +415,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
         private static WebPubSubTriggerDispatcher SetupDispatcherWithListenerOnlyAccess(string triggerHost)
         {
             var funcName = Utilities.GetFunctionKey(TestHub, TestType, TestEvent, WebPubSubTriggerAcceptedClientProtocols.All).ToLower();
-            var options = new WebPubSubServiceAccessOptions { WebPubSubAccess = null, Hub = TestHub };
-            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, options);
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance);
             var executor = new Mock<ITriggeredFunctionExecutor>();
             executor.Setup(f => f.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new FunctionResult(true)));
@@ -443,8 +435,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             var funcName = Utilities.GetFunctionKey(TestHub, TestType, TestEvent, WebPubSubTriggerAcceptedClientProtocols.All).ToLower();
             var defaultAccess = WebPubSubServiceAccessUtil.CreateFromConnectionString(
                 $"Endpoint=http://{defaultHost};Port=8080;AccessKey={TestKey.AccessKey};Version=1.0;");
-            var options = new WebPubSubServiceAccessOptions { WebPubSubAccess = defaultAccess, Hub = TestHub };
-            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, options);
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance);
             var executor = new Mock<ITriggeredFunctionExecutor>();
             executor.Setup(f => f.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new FunctionResult(true)));
@@ -463,8 +454,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.WebPubSub.Tests
             var funcName = Utilities.GetFunctionKey(TestHub, TestType, TestEvent, WebPubSubTriggerAcceptedClientProtocols.All).ToLower();
             var defaultAccess = WebPubSubServiceAccessUtil.CreateFromConnectionString(
                 $"Endpoint=http://{defaultHost};Port=8080;AccessKey={TestKey.AccessKey};Version=1.0;");
-            var options = new WebPubSubServiceAccessOptions { WebPubSubAccess = defaultAccess, Hub = TestHub };
-            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance, options);
+            var dispatcher = new WebPubSubTriggerDispatcher(NullLogger.Instance);
             var executor = new Mock<ITriggeredFunctionExecutor>();
             executor.Setup(f => f.TryExecuteAsync(It.IsAny<TriggeredFunctionData>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(new FunctionResult(true)));


### PR DESCRIPTION
# Fix NRE with custom connection name

## Root Cause

The dispatcher's abuse protection path (`ExecuteAsync` → `RespondToServiceAbuseCheck`) wrapped `_options.WebPubSubAccess` — which is `null` when no default `WebPubSubConnectionString` app setting exists — into a single-element array `[null]`. The `RequestValidator` constructor then dereferenced the null element via `GroupBy(a => a.ServiceEndpoint.Host)`, causing a `NullReferenceException`.

## Changes

- **Centralized connection resolution** — New `WebPubSubServiceAccessFactory.ResolveAccessesOrDefault()` replaces duplicated resolution logic across trigger and context bindings, fixing the original logic error (`&& access != null` → `|| access == null`)
- **Redesigned dispatcher abuse protection** — Validates origins against registered listeners' validators instead of the global default, correctly supporting per-trigger custom connections
- **Defensive null validation in `RequestValidator`** — Explicit null-element and null-endpoint checks with clear `ArgumentException` messages
- **7 regression tests** — Covers no-default-access, local-vs-global access, listener-with-restriction, and fallback scenarios
- **`ILogger` plumbing** — Added through binding providers for diagnostics

## Impact

- Extension Bundle 4.33.1 with WebPubSub 1.10.0
- **Any app** using a non-default connection name for WebPubSub triggers is affected
- **Workaround until fix release**: Pin extension bundle to 4.32.0 (WebPubSub 1.9.0) in `host.json`
