### PR TITLE
Migrate communication service packages from NUnit 3 to NUnit 4

### DIFF
--- a/common/ManagementTestShared/Redesign/InheritanceCheckTests.cs
+++ b/common/ManagementTestShared/Redesign/InheritanceCheckTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,7 +25,7 @@ namespace Azure.ResourceManager.TestFramework
         {
             var testAssembly = Assembly.GetExecutingAssembly();
             var assemblyName = testAssembly.GetName().Name;
-            Assert.IsTrue(assemblyName.EndsWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
+            ClassicAssert.IsTrue(assemblyName.EndsWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
             var rpNamespace = assemblyName.Substring(0, assemblyName.Length - TestAssemblySuffix.Length);
 
             if (rpNamespace == TestFrameworkAssembly)
@@ -41,7 +42,7 @@ namespace Azure.ResourceManager.TestFramework
 
             var sdkAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == rpNamespace) ?? Assembly.Load(rpNamespace);
 
-            Assert.IsNotNull(sdkAssembly, $"The SDK assembly {rpNamespace} not found");
+            ClassicAssert.IsNotNull(sdkAssembly, $"The SDK assembly {rpNamespace} not found");
 
             // Verify all class end with `Resource` & `Collection`
             HashSet<string> exceptionList = ExceptionList == null ? new HashSet<string>() : new HashSet<string>(ExceptionList);
@@ -69,8 +70,8 @@ namespace Azure.ResourceManager.TestFramework
                 }
             }
 
-            Assert.IsEmpty(exceptionList, "InheritanceCheck exception list have values which is not included in current package, please check: " + string.Join(",", exceptionList));
-            Assert.IsEmpty(errorList, "InheritanceCheck failed with Type: " + string.Join(",", errorList));
+            ClassicAssert.IsEmpty(exceptionList, "InheritanceCheck exception list have values which is not included in current package, please check: " + string.Join(",", exceptionList));
+            ClassicAssert.IsEmpty(errorList, "InheritanceCheck failed with Type: " + string.Join(",", errorList));
         }
     }
 }

--- a/common/ManagementTestShared/Redesign/ManagementMockingPatternTests.cs
+++ b/common/ManagementTestShared/Redesign/ManagementMockingPatternTests.cs
@@ -4,6 +4,7 @@
 using Moq;
 using Moq.Language;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -29,7 +30,7 @@ namespace Azure.ResourceManager.TestFramework
         {
             var testAssembly = Assembly.GetExecutingAssembly();
             var assemblyName = testAssembly.GetName().Name;
-            Assert.IsTrue(assemblyName.EndsWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
+            ClassicAssert.IsTrue(assemblyName.EndsWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
             var rpNamespace = assemblyName.Substring(0, assemblyName.Length - TestAssemblySuffix.Length);
 
             if (rpNamespace == ResourceManagerAssemblyName || rpNamespace == TestFrameworkAssembly)
@@ -48,7 +49,7 @@ namespace Azure.ResourceManager.TestFramework
             // find the SDK assembly by filtering the assemblies in current domain, or load it if not found (when there is no test case)
             var sdkAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == rpNamespace) ?? Assembly.Load(rpNamespace);
 
-            Assert.IsNotNull(sdkAssembly, $"The SDK assembly {rpNamespace} not found");
+            ClassicAssert.IsNotNull(sdkAssembly, $"The SDK assembly {rpNamespace} not found");
 
             // find the extension class
             foreach (var type in sdkAssembly.GetTypes())
@@ -75,7 +76,7 @@ namespace Azure.ResourceManager.TestFramework
             var rpNamespace = extensionType.Namespace;
             var rpName = GetRPName(rpNamespace);
 
-            Assert.IsNotNull(extensionType);
+            ClassicAssert.IsNotNull(extensionType);
 
             foreach (var method in extensionType.GetMethods(BindingFlags.Public | BindingFlags.Static))
             {
@@ -109,19 +110,19 @@ namespace Azure.ResourceManager.TestFramework
             var mockingExtensionTypeName = GetMockableResourceTypeName(rpNamespace, rpName, extendedType.Name);
 
             var mockingExtensionType = assembly.GetType(mockingExtensionTypeName);
-            Assert.IsNotNull(mockingExtensionType, $"The mocking extension class {mockingExtensionTypeName} must exist");
-            Assert.IsTrue(mockingExtensionType.IsPublic, $"The mocking extension class {mockingExtensionType} must be public");
+            ClassicAssert.IsNotNull(mockingExtensionType, $"The mocking extension class {mockingExtensionTypeName} must exist");
+            ClassicAssert.IsTrue(mockingExtensionType.IsPublic, $"The mocking extension class {mockingExtensionType} must be public");
 
             // validate the mocking extension class has a method with the exact name and parameter list
             var expectedTypes = parameters.Skip(1).Select(p => p.ParameterType).ToArray();
             var methodOnExtension = mockingExtensionType.GetMethod(method.Name, parameters.Skip(1).Select(p => p.ParameterType).ToArray());
 
-            Assert.IsNotNull(methodOnExtension, $"The class {mockingExtensionType} must have method {method}");
-            Assert.IsTrue(methodOnExtension.IsVirtual, $"The method on {mockingExtensionType} must be virtual");
-            Assert.IsTrue(methodOnExtension.IsPublic, $"The method on {mockingExtensionType} must be public");
+            ClassicAssert.IsNotNull(methodOnExtension, $"The class {mockingExtensionType} must have method {method}");
+            ClassicAssert.IsTrue(methodOnExtension.IsVirtual, $"The method on {mockingExtensionType} must be virtual");
+            ClassicAssert.IsTrue(methodOnExtension.IsPublic, $"The method on {mockingExtensionType} must be public");
 
             // validate they should both have or both not have the EditorBrowsable(Never) attribute
-            Assert.AreEqual(method.IsDefined(typeof(EditorBrowsableAttribute)), methodOnExtension.IsDefined(typeof(EditorBrowsableAttribute)), $"The method {method} and {methodOnExtension} should both have or neither have the EditorBrowsableAttribute on them");
+            ClassicAssert.AreEqual(method.IsDefined(typeof(EditorBrowsableAttribute)), methodOnExtension.IsDefined(typeof(EditorBrowsableAttribute)), $"The method {method} and {methodOnExtension} should both have or neither have the EditorBrowsableAttribute on them");
 
             ValidateMocking(extendedType, mockingExtensionType, method, methodOnExtension);
         }
@@ -151,7 +152,7 @@ namespace Azure.ResourceManager.TestFramework
             {
                 var result = extensionMethod.Invoke(null, arguments.ToArray());
 
-                Assert.IsNotNull(result, $"Mocking of extension method {extensionMethod} is not working properly, please check the implementation to ensure it to call the method with same name and parameter list in {mockingExtensionType}");
+                ClassicAssert.IsNotNull(result, $"Mocking of extension method {extensionMethod} is not working properly, please check the implementation to ensure it to call the method with same name and parameter list in {mockingExtensionType}");
             }
             catch (Exception)
             {

--- a/common/ManagementTestShared/Temp/ModelReaderWriterImplementationValidation.cs
+++ b/common/ManagementTestShared/Temp/ModelReaderWriterImplementationValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.ResourceManager.TestFramework
 {
@@ -25,7 +26,7 @@ namespace Azure.ResourceManager.TestFramework
         {
             var testAssembly = Assembly.GetExecutingAssembly();
             var assemblyName = testAssembly.GetName().Name;
-            Assert.IsTrue(assemblyName.EndsWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
+            ClassicAssert.IsTrue(assemblyName.EndsWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
             var rpNamespace = assemblyName.Substring(0, assemblyName.Length - TestAssemblySuffix.Length);
 
             TestContext.WriteLine($"Testing assembly {rpNamespace}");
@@ -39,7 +40,7 @@ namespace Azure.ResourceManager.TestFramework
             // find the SDK assembly by filtering the assemblies in the current domain, or load it if not found (when there is no test case)
             var sdkAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == rpNamespace) ?? Assembly.Load(rpNamespace);
 
-            Assert.IsNotNull(sdkAssembly, $"The SDK assembly {rpNamespace} not found");
+            ClassicAssert.IsNotNull(sdkAssembly, $"The SDK assembly {rpNamespace} not found");
 
             List<Type> violatedTypes = new();
             var exceptionList = ExceptionList == null ? new HashSet<string>() : new HashSet<string>(ExceptionList);

--- a/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
+++ b/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
@@ -48,18 +48,6 @@
         $(MSBuildProjectName) == 'Azure.Analytics.Purview.Sharing.Tests' or
         $(MSBuildProjectName) == 'Azure.Analytics.Purview.Workflows.Tests' or
         $(MSBuildProjectName) == 'Azure.Analytics.Synapse.Artifacts.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.AlphaIds.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.CallAutomation.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Chat.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Common.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Email.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Identity.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.JobRouter.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Messages.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.PhoneNumbers.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Rooms.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.ShortCodes.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Sms.Tests' or
         $(MSBuildProjectName) == 'Azure.Compute.Batch.Tests' or
         $(MSBuildProjectName) == 'Azure.Containers.ContainerRegistry.Tests' or
         $(MSBuildProjectName) == 'Azure.Core.Amqp.Tests' or
@@ -126,7 +114,6 @@
         $(MSBuildProjectName) == 'Azure.Provisioning.Batch.Tests' or
         $(MSBuildProjectName) == 'Azure.Provisioning.Cdn.Tests' or
         $(MSBuildProjectName) == 'Azure.Provisioning.CognitiveServices.Tests' or
-        $(MSBuildProjectName) == 'Azure.Provisioning.Communication.Tests' or
         $(MSBuildProjectName) == 'Azure.Provisioning.Compute.Tests' or
         $(MSBuildProjectName) == 'Azure.Provisioning.ContainerRegistry.Tests' or
         $(MSBuildProjectName) == 'Azure.Provisioning.ContainerService.Tests' or
@@ -192,7 +179,6 @@
         $(MSBuildProjectName) == 'Azure.ResourceManager.Chaos.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.CloudHealth.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.CognitiveServices.Tests' or
-        $(MSBuildProjectName) == 'Azure.ResourceManager.Communication.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Compute.Recommender.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Compute.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.ComputeFleet.Tests' or

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientAutomatedLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 {
@@ -45,11 +46,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    ClassicAssert.IsNotNull(incomingCallContext);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -57,20 +58,20 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(connectedEvent);
+                    ClassicAssert.IsTrue(connectedEvent is CallConnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    ClassicAssert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
 
                     // try hangup
                     await response.CallConnection.HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
                     callConnectionId = null;
                 }
                 catch (Exception)
@@ -117,23 +118,23 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                         new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    ClassicAssert.IsNotNull(incomingCallContext);
 
                     // answer the call
                     var rejectCallOptions = new RejectCallOptions(incomingCallContext);
                     Response rejectResponse = await client.RejectCallAsync(rejectCallOptions);
 
                     // check reject response
-                    Assert.IsFalse(rejectResponse.IsError);
+                    ClassicAssert.IsFalse(rejectResponse.IsError);
 
                     var createCallFailedEvent = await WaitForEvent<CreateCallFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(createCallFailedEvent);
-                    Assert.IsTrue(createCallFailedEvent is CreateCallFailed);
-                    Assert.AreEqual(callConnectionId, ((CreateCallFailed)createCallFailedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(createCallFailedEvent);
+                    ClassicAssert.IsTrue(createCallFailedEvent is CreateCallFailed);
+                    ClassicAssert.AreEqual(callConnectionId, ((CreateCallFailed)createCallFailedEvent!).CallConnectionId);
 
                     try
                     {
@@ -195,11 +196,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    ClassicAssert.IsNotNull(incomingCallContext);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -207,9 +208,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(connectedEvent);
+                    ClassicAssert.IsTrue(connectedEvent is CallConnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
 
                     // server call locator for connect call.
                     CallLocator callLocator = new ServerCallLocator(connectedEvent.ServerCallId);
@@ -220,22 +221,22 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for connect call connected.
                     var connectCallConnectedEvent = await WaitForEvent<CallConnected>(connectCallConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectCallConnectedEvent);
-                    Assert.IsTrue(connectCallConnectedEvent is CallConnected);
-                    Assert.AreEqual(connectCallConnectionId, ((CallConnected)connectCallConnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(connectCallConnectedEvent);
+                    ClassicAssert.IsTrue(connectCallConnectedEvent is CallConnected);
+                    ClassicAssert.AreEqual(connectCallConnectionId, ((CallConnected)connectCallConnectedEvent!).CallConnectionId);
 
                     CallConnection ConnectCallConnection = connectCallResult.CallConnection;
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await ConnectCallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    ClassicAssert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
 
                     // try hangup
                     await connectCallResult.CallConnection.HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(connectCallConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(connectCallConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(connectCallConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
                     connectCallConnectionId = null;
 
                     // try hangup
@@ -245,7 +246,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                     }
                     catch (RequestFailedException ex)
                     {
-                        Assert.AreEqual(ex.Status, 404);
+                        ClassicAssert.AreEqual(ex.Status, 404);
                     }
 
                     callConnectionId = null;
@@ -296,11 +297,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    ClassicAssert.IsNotNull(incomingCallContext);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -308,9 +309,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(connectedEvent);
+                    ClassicAssert.IsTrue(connectedEvent is CallConnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
 
                     // server call locator for connect call.
                     CallLocator callLocator = new ServerCallLocator(connectedEvent.ServerCallId);
@@ -321,30 +322,30 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for connect call connected.
                     var connectCallConnectedEvent = await WaitForEvent<CallConnected>(connectCallConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectCallConnectedEvent);
-                    Assert.IsTrue(connectCallConnectedEvent is CallConnected);
-                    Assert.AreEqual(connectCallConnectionId, ((CallConnected)connectCallConnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(connectCallConnectedEvent);
+                    ClassicAssert.IsTrue(connectCallConnectedEvent is CallConnected);
+                    ClassicAssert.AreEqual(connectCallConnectionId, ((CallConnected)connectCallConnectedEvent!).CallConnectionId);
 
                     CallConnection ConnectCallConnection = connectCallResult.CallConnection;
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await ConnectCallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    ClassicAssert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
 
                     // try hangup
                     await connectCallResult.CallConnection.HangUpAsync(false).ConfigureAwait(false);
                     var disconnectedConnectEvent = await WaitForEvent<CallDisconnected>(connectCallConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedConnectEvent);
-                    Assert.IsTrue(disconnectedConnectEvent is CallDisconnected);
-                    Assert.AreEqual(connectCallConnectionId, ((CallDisconnected)disconnectedConnectEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedConnectEvent);
+                    ClassicAssert.IsTrue(disconnectedConnectEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(connectCallConnectionId, ((CallDisconnected)disconnectedConnectEvent!).CallConnectionId);
                     connectCallConnectionId = null;
 
                     // try to hangup for anwercall
                     await answerResponse.CallConnection.HangUpAsync(false).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
                     callConnectionId = null;
                 }
                 catch (Exception)

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 {
@@ -29,12 +30,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(200, CreateOrAnswerCallOrGetCallConnectionPayload);
 
             var response = await callAutomationClient.AnswerCallAsync(incomingCallContext, callbackUri).ConfigureAwait(false);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(response.Value.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -43,12 +44,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(200, CreateOrAnswerCallOrGetCallConnectionPayload);
 
             var response = callAutomationClient.AnswerCall(incomingCallContext, callbackUri);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(response.Value.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -63,12 +64,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             };
 
             var response = await callAutomationClient.AnswerCallAsync(options).ConfigureAwait(false);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(response.Value.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -82,12 +83,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             };
 
             var response = callAutomationClient.AnswerCall(options);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(response.Value.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -95,9 +96,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(401);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.AnswerCallAsync(incomingCallContext, callbackUri).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.AnswerCallAsync(incomingCallContext, callbackUri).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 401);
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -105,9 +106,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(401);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.AnswerCall(incomingCallContext, callbackUri));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callAutomationClient.AnswerCall(incomingCallContext, callbackUri));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 401);
         }
 
         [TestCaseSource(nameof(TestData_RedirectCall))]
@@ -116,8 +117,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(204);
 
             var response = await callAutomationClient.RedirectCallAsync(incomingCallContext, callInvite).ConfigureAwait(false);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
         }
 
         [TestCaseSource(nameof(TestData_RedirectCall))]
@@ -126,8 +127,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(204);
 
             var response = callAutomationClient.RedirectCall(incomingCallContext, callInvite);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
         }
 
         [TestCaseSource(nameof(TestData_RedirectCall))]
@@ -135,9 +136,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.RedirectCallAsync(incomingCallContext, callInvite).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.RedirectCallAsync(incomingCallContext, callInvite).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_RedirectCall))]
@@ -145,9 +146,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.RedirectCall(incomingCallContext, callInvite));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callAutomationClient.RedirectCall(incomingCallContext, callInvite));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_RejectCall))]
@@ -159,8 +160,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             rejectOption.CallRejectReason = reason;
 
             var response = await callAutomationClient.RejectCallAsync(rejectOption).ConfigureAwait(false);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
         }
 
         [TestCaseSource(nameof(TestData_RejectCall))]
@@ -172,8 +173,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             rejectOption.CallRejectReason = reason;
 
             var response = callAutomationClient.RejectCall(rejectOption);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
         }
 
         [TestCaseSource(nameof(TestData_RejectCall))]
@@ -184,9 +185,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             RejectCallOptions rejectOption = new RejectCallOptions(incomingCallContext);
             rejectOption.CallRejectReason = reason;
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.RejectCallAsync(rejectOption).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.RejectCallAsync(rejectOption).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_RejectCall))]
@@ -197,9 +198,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             RejectCallOptions rejectOption = new RejectCallOptions(incomingCallContext);
             rejectOption.CallRejectReason = reason;
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.RejectCall(rejectOption));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callAutomationClient.RejectCall(rejectOption));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -210,12 +211,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new CreateCallOptions(target, callbackUri);
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -226,12 +227,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new CreateCallOptions(target, callbackUri);
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -248,12 +249,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -270,12 +271,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -291,10 +292,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyOPSCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -310,10 +311,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyOPSCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -321,9 +322,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.CreateCallAsync(new CreateCallOptions(target, callbackUri)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.CreateCallAsync(new CreateCallOptions(target, callbackUri)).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -334,18 +335,18 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new CreateCallOptions(target, callbackUri);
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(target.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(target.Target);
             var teamsApp = target.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -356,18 +357,18 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new CreateCallOptions(target, callbackUri);
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(target.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(target.Target);
             var teamsApp = target.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -385,17 +386,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
 
             // Verify all optional properties can be set
-            Assert.AreEqual("teams-app-context", options.OperationContext);
-            Assert.IsNotNull(options.MediaStreamingOptions);
-            Assert.IsNotNull(options.TranscriptionOptions);
+            ClassicAssert.AreEqual("teams-app-context", options.OperationContext);
+            ClassicAssert.IsNotNull(options.MediaStreamingOptions);
+            ClassicAssert.IsNotNull(options.TranscriptionOptions);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -413,17 +414,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
 
             // Verify all optional properties can be set
-            Assert.AreEqual("teams-app-context", options.OperationContext);
-            Assert.IsNotNull(options.MediaStreamingOptions);
-            Assert.IsNotNull(options.TranscriptionOptions);
+            ClassicAssert.AreEqual("teams-app-context", options.OperationContext);
+            ClassicAssert.IsNotNull(options.MediaStreamingOptions);
+            ClassicAssert.IsNotNull(options.TranscriptionOptions);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -431,9 +432,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.CreateCallAsync(new CreateCallOptions(target, callbackUri)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.CreateCallAsync(new CreateCallOptions(target, callbackUri)).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -441,9 +442,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.CreateCall(new CreateCallOptions(target, callbackUri)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callAutomationClient.CreateCall(new CreateCallOptions(target, callbackUri)));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_ConnectCall))]
@@ -453,10 +454,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.ConnectCallAsync(callLocator, callbackUri).ConfigureAwait(false);
             ConnectCallResult result = (ConnectCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties, isConnectApi: true);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_ConnectCall))]
@@ -466,10 +467,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = callAutomationClient.ConnectCall(callLocator, callbackUri);
             ConnectCallResult result = (ConnectCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties, isConnectApi: true);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_ConnectCall))]
@@ -480,10 +481,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new ConnectCallOptions(callLocator, callbackUri);
             var response = await callAutomationClient.ConnectCallAsync(options).ConfigureAwait(false);
             ConnectCallResult result = (ConnectCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties, isConnectApi: true);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_ConnectCall))]
@@ -494,10 +495,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new ConnectCallOptions(callLocator, callbackUri);
             var response = callAutomationClient.ConnectCall(options);
             ConnectCallResult result = (ConnectCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties, isConnectApi: true);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_GetCallConnection))]
@@ -505,15 +506,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
         {
             var response = new CallAutomationClient(ConnectionString).GetCallConnection(callConnectionId);
             CallConnection result = (CallConnection)response;
-            Assert.NotNull(result);
-            Assert.AreEqual(callConnectionId, result.CallConnectionId);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual(callConnectionId, result.CallConnectionId);
         }
 
         [Test]
         public void GetCallRecording()
         {
             var response = new CallAutomationClient(ConnectionString).GetCallRecording();
-            Assert.NotNull(response);
+            ClassicAssert.NotNull(response);
         }
 
         [TestCaseSource(nameof(TestData_CreateGroupCall))]
@@ -531,38 +532,38 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.CreateGroupCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            ClassicAssert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
+            ClassicAssert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
         }
 
         private static void ValidateCreateCallResult(CreateCallResult createCallResult)
         {
-            Assert.NotNull(createCallResult);
-            Assert.NotNull(createCallResult.CallConnection);
-            Assert.AreEqual("callConnectionId", createCallResult.CallConnection.CallConnectionId);
+            ClassicAssert.NotNull(createCallResult);
+            ClassicAssert.NotNull(createCallResult.CallConnection);
+            ClassicAssert.AreEqual("callConnectionId", createCallResult.CallConnection.CallConnectionId);
             ValidateCallConnectionProperties(createCallResult.CallConnectionProperties);
         }
 
         private static void ValidateAnswerCallResult(AnswerCallResult answerCallResult)
         {
-            Assert.NotNull(answerCallResult);
-            Assert.NotNull(answerCallResult.CallConnection);
-            Assert.AreEqual("callConnectionId", answerCallResult.CallConnection.CallConnectionId);
+            ClassicAssert.NotNull(answerCallResult);
+            ClassicAssert.NotNull(answerCallResult.CallConnection);
+            ClassicAssert.AreEqual("callConnectionId", answerCallResult.CallConnection.CallConnectionId);
             ValidateCallConnectionProperties(answerCallResult.CallConnectionProperties);
         }
 
         private static void ValidateCallConnectionProperties(CallConnectionProperties properties)
         {
-            Assert.NotNull(properties);
-            Assert.AreEqual("callConnectionId", properties.CallConnectionId);
-            Assert.AreEqual(CallConnectionState.Connecting, properties.CallConnectionState);
-            Assert.AreEqual("dummySourceUser", properties.Source.RawId);
-            Assert.AreEqual("serverCallId", properties.ServerCallId);
-            Assert.AreEqual(1, properties.Targets.Count);
+            ClassicAssert.NotNull(properties);
+            ClassicAssert.AreEqual("callConnectionId", properties.CallConnectionId);
+            ClassicAssert.AreEqual(CallConnectionState.Connecting, properties.CallConnectionState);
+            ClassicAssert.AreEqual("dummySourceUser", properties.Source.RawId);
+            ClassicAssert.AreEqual("serverCallId", properties.ServerCallId);
+            ClassicAssert.AreEqual(1, properties.Targets.Count);
         }
 
         // exceptions

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionAutomatedLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallConnections
 {
@@ -45,11 +46,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    ClassicAssert.IsNotNull(incomingCallContext);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -57,18 +58,18 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(connectedEvent);
+                    ClassicAssert.IsTrue(connectedEvent is CallConnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
 
                     // wait for participants updated
                     var participantsUpdatedEvent1 = await WaitForEvent<ParticipantsUpdated>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(participantsUpdatedEvent1);
-                    Assert.AreEqual(2, ((ParticipantsUpdated)participantsUpdatedEvent1!).Participants.Count);
+                    ClassicAssert.IsNotNull(participantsUpdatedEvent1);
+                    ClassicAssert.AreEqual(2, ((ParticipantsUpdated)participantsUpdatedEvent1!).Participants.Count);
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    ClassicAssert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
 
                     // try RemoveParticipants
                     string operationContext1 = "MyTestOperationcontext";
@@ -77,15 +78,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                         OperationContext = operationContext1,
                     };
                     Response<RemoveParticipantResult> removePartResponse = await response.CallConnection.RemoveParticipantAsync(removeParticipantsOptions);
-                    Assert.IsTrue(!removePartResponse.GetRawResponse().IsError);
+                    ClassicAssert.IsTrue(!removePartResponse.GetRawResponse().IsError);
                     string expectedOperationContext = Mode == RecordedTestMode.Playback ? "Sanitized" : operationContext1;
-                    Assert.AreEqual(expectedOperationContext, removePartResponse.Value.OperationContext);
+                    ClassicAssert.AreEqual(expectedOperationContext, removePartResponse.Value.OperationContext);
 
                     // call should be disconnected after removing participant
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
                     callConnectionId = null;
                 }
                 catch (Exception)
@@ -133,11 +134,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                 var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                 // wait for incomingcall context
                 string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(incomingCallContext);
+                ClassicAssert.IsNotNull(incomingCallContext);
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -145,9 +146,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
                 // wait for callConnected
                 var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(connectedEvent);
-                Assert.IsTrue(connectedEvent is CallConnected);
-                Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                ClassicAssert.IsNotNull(connectedEvent);
+                ClassicAssert.IsTrue(connectedEvent is CallConnected);
+                ClassicAssert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
 
                 // add participant
                 var callConnection = response.CallConnection;
@@ -160,8 +161,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                 var addParticipantResponse = await callConnection.AddParticipantAsync(addParticipantOptions);
 
                 string expectedOperationContext = Mode == RecordedTestMode.Playback ? "Sanitized" : operationContext;
-                Assert.AreEqual(expectedOperationContext, addParticipantResponse.Value.OperationContext);
-                Assert.IsNotNull(addParticipantResponse.Value.InvitationId);
+                ClassicAssert.AreEqual(expectedOperationContext, addParticipantResponse.Value.OperationContext);
+                ClassicAssert.IsNotNull(addParticipantResponse.Value.InvitationId);
 
                 // ensure invitation has arrived
                 await Task.Delay(3000);
@@ -175,9 +176,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
                 // wait for cancel event
                 var CancelAddParticipantSucceededEvent = await WaitForEvent<CancelAddParticipantSucceeded>(callConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(CancelAddParticipantSucceededEvent);
-                Assert.IsTrue(CancelAddParticipantSucceededEvent is CancelAddParticipantSucceeded);
-                Assert.AreEqual(((CancelAddParticipantSucceeded)CancelAddParticipantSucceededEvent!).InvitationId, addParticipantResponse.Value.InvitationId);
+                ClassicAssert.IsNotNull(CancelAddParticipantSucceededEvent);
+                ClassicAssert.IsTrue(CancelAddParticipantSucceededEvent is CancelAddParticipantSucceeded);
+                ClassicAssert.AreEqual(((CancelAddParticipantSucceeded)CancelAddParticipantSucceededEvent!).InvitationId, addParticipantResponse.Value.InvitationId);
             }
             catch (Exception ex)
             {

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallConnections
 {
@@ -48,8 +49,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
             var response = await callConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
 
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(response);
         }
 
@@ -60,8 +61,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
             var response = callConnection.GetCallConnectionProperties();
 
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.NotNull(response);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyCallConnectionProperties(response);
         }
         [Test]
@@ -69,9 +70,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
@@ -79,9 +80,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.GetCallConnectionProperties());
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callConnection.GetCallConnectionProperties());
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
@@ -90,7 +91,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(204);
 
             var response = await callConnection.HangUpAsync(false).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
         }
 
         [Test]
@@ -99,7 +100,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(204);
 
             var response = callConnection.HangUp(false);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
         }
 
         [Test]
@@ -107,9 +108,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.HangUpAsync(false).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callConnection.HangUpAsync(false).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
@@ -117,9 +118,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.HangUp(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callConnection.HangUp(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant))]
@@ -128,7 +129,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
         }
 
@@ -137,7 +138,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
         }
 
@@ -146,7 +147,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
         }
 
@@ -156,7 +157,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.TransferCallToParticipantAsync(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
         }
 
@@ -168,7 +169,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             options.Transferee = new CommunicationUserIdentifier("transfereeid");
 
             var response = await callConnection.TransferCallToParticipantAsync(options).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
         }
 
@@ -178,7 +179,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.TransferCallToParticipant(callInvite.Target);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
         }
 
@@ -188,7 +189,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier));
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
         }
 
@@ -200,7 +201,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             options.Transferee = new CommunicationUserIdentifier("transfereeid");
 
             var response = callConnection.TransferCallToParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
         }
 
@@ -209,9 +210,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.TransferCallToParticipantAsync(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callConnection.TransferCallToParticipantAsync(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier)).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant))]
@@ -219,9 +220,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier)));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -231,7 +232,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callInvite = new CallInvite((CommunicationUserIdentifier)participantToAdd);
 
             var response = await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyAddParticipantsResult(response);
         }
 
@@ -242,7 +243,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callInvite = new CallInvite((CommunicationUserIdentifier)participantToAdd);
 
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyAddParticipantsResult(response);
         }
 
@@ -252,14 +253,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
             var response = await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyAddParticipantsResult(response);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsApp))]
@@ -268,14 +269,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyAddParticipantsResult(response);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsAppWithCloud))]
@@ -284,15 +285,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
             var response = await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyAddParticipantsResult(response);
 
             // Verify the target maintains the correct cloud environment
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
-            Assert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Dod ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Gcch);
         }
@@ -303,15 +304,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyAddParticipantsResult(response);
 
             // Verify the target maintains the correct cloud environment
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
-            Assert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Dod ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Gcch);
         }
@@ -329,13 +330,13 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             };
 
             var response = await callConnection.AddParticipantAsync(options).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyAddParticipantsResult(response);
 
             // Verify all optional properties can be set
-            Assert.AreEqual("custom-context", options.OperationContext);
-            Assert.AreEqual(60, options.InvitationTimeoutInSeconds);
-            Assert.IsNotNull(options.OperationCallbackUri);
+            ClassicAssert.AreEqual("custom-context", options.OperationContext);
+            ClassicAssert.AreEqual(60, options.InvitationTimeoutInSeconds);
+            ClassicAssert.IsNotNull(options.OperationCallbackUri);
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsApp))]
@@ -351,13 +352,13 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             };
 
             var response = callConnection.AddParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyAddParticipantsResult(response);
 
             // Verify all optional properties can be set
-            Assert.AreEqual("custom-context", options.OperationContext);
-            Assert.AreEqual(60, options.InvitationTimeoutInSeconds);
-            Assert.IsNotNull(options.OperationCallbackUri);
+            ClassicAssert.AreEqual("custom-context", options.OperationContext);
+            ClassicAssert.AreEqual(60, options.InvitationTimeoutInSeconds);
+            ClassicAssert.IsNotNull(options.OperationCallbackUri);
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsApp))]
@@ -365,9 +366,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsApp))]
@@ -375,9 +376,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.AddParticipant(new AddParticipantOptions(callInvite)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callConnection.AddParticipant(new AddParticipantOptions(callInvite)));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
@@ -386,9 +387,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
             CallInvite? nullCallInvite = null;
 
-            ArgumentNullException? ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(nullCallInvite!)).ConfigureAwait(false));
-            Assert.IsNotNull(ex);
-            Assert.IsTrue(ex!.Message.Contains("Value cannot be null"));
+            ArgumentNullException? ex = ClassicAssert.ThrowsAsync<ArgumentNullException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(nullCallInvite!)).ConfigureAwait(false));
+            ClassicAssert.IsNotNull(ex);
+            ClassicAssert.IsTrue(ex!.Message.Contains("Value cannot be null"));
         }
 
         [Test]
@@ -397,9 +398,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
             CallInvite? nullCallInvite = null;
 
-            ArgumentNullException? ex = Assert.Throws<ArgumentNullException>(() => callConnection.AddParticipant(new AddParticipantOptions(nullCallInvite!)));
-            Assert.IsNotNull(ex);
-            Assert.IsTrue(ex!.Message.Contains("Value cannot be null"));
+            ArgumentNullException? ex = ClassicAssert.Throws<ArgumentNullException>(() => callConnection.AddParticipant(new AddParticipantOptions(nullCallInvite!)));
+            ClassicAssert.IsNotNull(ex);
+            ClassicAssert.IsTrue(ex!.Message.Contains("Value cannot be null"));
         }
 
         [Test]
@@ -407,9 +408,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
-            ArgumentNullException? ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(null)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.True(ex?.Message.Contains("Value cannot be null."));
+            ArgumentNullException? ex = ClassicAssert.ThrowsAsync<ArgumentNullException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(null)).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.True(ex?.Message.Contains("Value cannot be null."));
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -418,9 +419,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
             var callInvite = new CallInvite((CommunicationUserIdentifier)participantToAdd);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -429,9 +430,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
             var callInvite = new CallInvite((CommunicationUserIdentifier)participantToAdd);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.AddParticipant(new AddParticipantOptions(callInvite)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callConnection.AddParticipant(new AddParticipantOptions(callInvite)));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_GetParticipant))]
@@ -441,7 +442,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var participantIdentifier = new CommunicationUserIdentifier(participantMri);
 
             var response = await callConnection.GetParticipantAsync(participantIdentifier).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyGetParticipantResult(response);
         }
 
@@ -452,7 +453,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var participantIdentifier = new CommunicationUserIdentifier(participantMri);
 
             var response = callConnection.GetParticipant(participantIdentifier);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyGetParticipantResult(response);
         }
 
@@ -462,9 +463,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
             var participantIdentifier = new CommunicationUserIdentifier(participantMri);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.GetParticipantAsync(participantIdentifier).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callConnection.GetParticipantAsync(participantIdentifier).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_GetParticipant))]
@@ -473,9 +474,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
             var participantIdentifier = new CommunicationUserIdentifier(participantMri);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.GetParticipant(participantIdentifier));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callConnection.GetParticipant(participantIdentifier));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
@@ -484,7 +485,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, GetParticipantsPayload);
 
             var response = await callConnection.GetParticipantsAsync().ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyGetParticipantsResult(response.Value);
         }
 
@@ -494,7 +495,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, GetParticipantsPayload);
 
             var response = callConnection.GetParticipants();
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
             verifyGetParticipantsResult(response.Value);
         }
 
@@ -503,9 +504,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.GetParticipantsAsync().ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callConnection.GetParticipantsAsync().ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
@@ -513,9 +514,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.GetParticipants());
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callConnection.GetParticipants());
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -524,8 +525,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.RemoveParticipantAsync(participantToRemove).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
-            Assert.AreEqual(OperationContext, response.Value.OperationContext);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(OperationContext, response.Value.OperationContext);
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -534,8 +535,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.RemoveParticipant(participantToRemove);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
-            Assert.AreEqual(OperationContext, response.Value.OperationContext);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(OperationContext, response.Value.OperationContext);
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -543,9 +544,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.RemoveParticipantAsync(participantToRemove).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callConnection.RemoveParticipantAsync(participantToRemove).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -553,9 +554,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.RemoveParticipant(participantToRemove));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callConnection.RemoveParticipant(participantToRemove));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
@@ -565,8 +566,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, null, connectionId);
 
             var response = callConnection.GetCallMedia();
-            Assert.IsNotNull(response);
-            Assert.AreEqual(connectionId, response.CallConnectionId);
+            ClassicAssert.IsNotNull(response);
+            ClassicAssert.AreEqual(connectionId, response.CallConnectionId);
         }
 
         [TestCaseSource(nameof(TestData_MuteParticipant))]
@@ -575,7 +576,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, OperationContextPayload);
 
             var response = callConnection.MuteParticipant(participant);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_MuteParticipant))]
@@ -587,8 +588,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                 OperationContext = OperationContext
             };
             var response = callConnection.MuteParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
-            Assert.AreEqual(OperationContext, response.Value.OperationContext);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(OperationContext, response.Value.OperationContext);
         }
 
         [TestCaseSource(nameof(TestData_MuteParticipant))]
@@ -597,7 +598,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, OperationContextPayload);
 
             var response = await callConnection.MuteParticipantAsync(participant);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
         }
 
         [Test]
@@ -605,7 +606,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(400);
             var participant = new PhoneNumberIdentifier("+15559501234");
-            Assert.ThrowsAsync(typeof(RequestFailedException), async () => await callConnection.MuteParticipantAsync(participant));
+            ClassicAssert.ThrowsAsync(typeof(RequestFailedException), async () => await callConnection.MuteParticipantAsync(participant));
         }
 
         [TestCaseSource(nameof(TestData_MuteParticipant))]
@@ -618,8 +619,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             };
 
             var response = await callConnection.MuteParticipantAsync(options);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
-            Assert.AreEqual(OperationContext, response.Value.OperationContext);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(OperationContext, response.Value.OperationContext);
         }
 
         [TestCaseSource(nameof(TestData_MuteParticipant))]
@@ -631,7 +632,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                 OperationContext = OperationContext,
             };
 
-            Assert.ThrowsAsync(typeof(RequestFailedException), async () => await callConnection.MuteParticipantAsync(options));
+            ClassicAssert.ThrowsAsync(typeof(RequestFailedException), async () => await callConnection.MuteParticipantAsync(options));
         }
 
         [Test]
@@ -641,8 +642,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var invitationId = "invitationId";
 
             var response = await callConnection.CancelAddParticipantOperationAsync(invitationId).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
-            Assert.AreEqual(invitationId, response.Value.InvitationId);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(invitationId, response.Value.InvitationId);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -651,14 +652,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -667,14 +668,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.TransferCallToParticipant(callInvite.Target);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -685,14 +686,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var options = new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier);
 
             var response = await callConnection.TransferCallToParticipantAsync(options).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
 
             // Verify the options were created correctly
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(options.Target);
-            Assert.IsNotNull(options.CustomCallingContext);
-            Assert.IsEmpty(options.CustomCallingContext.SipHeaders);
-            Assert.IsNotNull(options.CustomCallingContext.VoipHeaders);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(options.Target);
+            ClassicAssert.IsNotNull(options.CustomCallingContext);
+            ClassicAssert.IsEmpty(options.CustomCallingContext.SipHeaders);
+            ClassicAssert.IsNotNull(options.CustomCallingContext.VoipHeaders);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -703,14 +704,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var options = new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier);
 
             var response = callConnection.TransferCallToParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
 
             // Verify the options were created correctly
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(options.Target);
-            Assert.IsNotNull(options.CustomCallingContext);
-            Assert.IsEmpty(options.CustomCallingContext.SipHeaders);
-            Assert.IsNotNull(options.CustomCallingContext.VoipHeaders);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(options.Target);
+            ClassicAssert.IsNotNull(options.CustomCallingContext);
+            ClassicAssert.IsEmpty(options.CustomCallingContext.SipHeaders);
+            ClassicAssert.IsNotNull(options.CustomCallingContext.VoipHeaders);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsAppWithCloud))]
@@ -719,15 +720,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
 
             // Verify the target maintains the correct cloud environment
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
-            Assert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Dod ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Gcch);
         }
@@ -738,15 +739,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.TransferCallToParticipant(callInvite.Target);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
 
             // Verify the target maintains the correct cloud environment
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            ClassicAssert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
-            Assert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
+            ClassicAssert.IsNotNull(teamsApp);
+            ClassicAssert.AreEqual("testAppId", teamsApp!.AppId);
+            ClassicAssert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Dod ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Gcch);
         }
@@ -762,14 +763,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             options.SourceCallerIdNumber = new PhoneNumberIdentifier("+14255551234");
 
             var response = await callConnection.TransferCallToParticipantAsync(options).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
 
             // Verify all optional properties can be set
-            Assert.IsNotNull(options.Transferee);
-            Assert.IsNotNull(options.OperationCallbackUri);
-            Assert.IsNotNull(options.SourceCallerIdNumber);
-            Assert.AreEqual("custom-context", options.OperationContext);
+            ClassicAssert.IsNotNull(options.Transferee);
+            ClassicAssert.IsNotNull(options.OperationCallbackUri);
+            ClassicAssert.IsNotNull(options.SourceCallerIdNumber);
+            ClassicAssert.AreEqual("custom-context", options.OperationContext);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -783,14 +784,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             options.SourceCallerIdNumber = new PhoneNumberIdentifier("+14255551234");
 
             var response = callConnection.TransferCallToParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
             verifyOperationContext(response);
 
             // Verify all optional properties can be set
-            Assert.IsNotNull(options.Transferee);
-            Assert.IsNotNull(options.OperationCallbackUri);
-            Assert.IsNotNull(options.SourceCallerIdNumber);
-            Assert.AreEqual("custom-context", options.OperationContext);
+            ClassicAssert.IsNotNull(options.Transferee);
+            ClassicAssert.IsNotNull(options.OperationCallbackUri);
+            ClassicAssert.IsNotNull(options.SourceCallerIdNumber);
+            ClassicAssert.AreEqual("custom-context", options.OperationContext);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -798,9 +799,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.TransferCallToParticipantAsync(new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await callConnection.TransferCallToParticipantAsync(new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier)).ConfigureAwait(false));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -808,9 +809,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier)));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
@@ -819,9 +820,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
             MicrosoftTeamsAppIdentifier? nullTeamsAppIdentifier = null;
 
-            ArgumentNullException? ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await callConnection.TransferCallToParticipantAsync(nullTeamsAppIdentifier!).ConfigureAwait(false));
-            Assert.IsNotNull(ex);
-            Assert.AreEqual("targetParticipant", ex!.ParamName);
+            ArgumentNullException? ex = ClassicAssert.ThrowsAsync<ArgumentNullException>(async () => await callConnection.TransferCallToParticipantAsync(nullTeamsAppIdentifier!).ConfigureAwait(false));
+            ClassicAssert.IsNotNull(ex);
+            ClassicAssert.AreEqual("targetParticipant", ex!.ParamName);
         }
 
         [Test]
@@ -830,9 +831,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
             MicrosoftTeamsAppIdentifier? nullTeamsAppIdentifier = null;
 
-            ArgumentNullException? ex = Assert.Throws<ArgumentNullException>(() => callConnection.TransferCallToParticipant(nullTeamsAppIdentifier!));
-            Assert.IsNotNull(ex);
-            Assert.AreEqual("targetParticipant", ex!.ParamName);
+            ArgumentNullException? ex = ClassicAssert.Throws<ArgumentNullException>(() => callConnection.TransferCallToParticipant(nullTeamsAppIdentifier!));
+            ClassicAssert.IsNotNull(ex);
+            ClassicAssert.AreEqual("targetParticipant", ex!.ParamName);
         }
 
         private CallConnection CreateMockCallConnection(int responseCode, string? responseContent = null, string callConnectionId = "9ec7da16-30be-4e74-a941-285cfc4bffc5")
@@ -977,33 +978,33 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
         private void verifyOperationContext(TransferCallToParticipantResult result)
         {
-            Assert.AreEqual(OperationContext, result.OperationContext);
+            ClassicAssert.AreEqual(OperationContext, result.OperationContext);
         }
 
         private void verifyAddParticipantsResult(AddParticipantResult result)
         {
             var identifier = (CommunicationUserIdentifier)result.Participant.Identifier;
-            Assert.AreEqual(ParticipantUserId, identifier.Id);
-            Assert.IsFalse(result.Participant.IsMuted);
-            Assert.AreEqual(OperationContext, result.OperationContext);
+            ClassicAssert.AreEqual(ParticipantUserId, identifier.Id);
+            ClassicAssert.IsFalse(result.Participant.IsMuted);
+            ClassicAssert.AreEqual(OperationContext, result.OperationContext);
         }
 
         private void verifyGetParticipantResult(CallParticipant participant)
         {
             var identifier = (CommunicationUserIdentifier)participant.Identifier;
-            Assert.AreEqual(ParticipantUserId, identifier.Id);
-            Assert.IsFalse(participant.IsMuted);
+            ClassicAssert.AreEqual(ParticipantUserId, identifier.Id);
+            ClassicAssert.IsFalse(participant.IsMuted);
         }
 
         private void verifyGetParticipantsResult(IReadOnlyList<CallParticipant> participants)
         {
-            Assert.AreEqual(2, participants.Count);
+            ClassicAssert.AreEqual(2, participants.Count);
             var identifier = (CommunicationUserIdentifier)participants[0].Identifier;
-            Assert.AreEqual(ParticipantUserId, identifier.Id);
-            Assert.IsFalse(participants[0].IsMuted);
+            ClassicAssert.AreEqual(ParticipantUserId, identifier.Id);
+            ClassicAssert.IsFalse(participants[0].IsMuted);
             var identifier2 = (PhoneNumberIdentifier)participants[1].Identifier;
-            Assert.AreEqual(PhoneNumber, identifier2.PhoneNumber);
-            Assert.IsTrue(participants[1].IsMuted);
+            ClassicAssert.AreEqual(PhoneNumber, identifier2.PhoneNumber);
+            ClassicAssert.IsTrue(participants[1].IsMuted);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaAutomatedLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,6 +9,7 @@ using Azure.Communication.PhoneNumbers;
 using Azure.Core.TestFramework;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallMedias
 {
@@ -73,11 +74,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             CreateCallResult response = await client.CreateCallAsync(invite, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
 
             string callConnectionId = response.CallConnectionProperties.CallConnectionId;
-            Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+            ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
             // wait for incomingcall context
             string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(incomingCallContext);
+            ClassicAssert.IsNotNull(incomingCallContext);
 
             // answer the call
             var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
@@ -86,51 +87,51 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // wait for callConnected
             var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(connectedEvent);
-            Assert.IsTrue(connectedEvent is CallConnected);
-            Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+            ClassicAssert.IsNotNull(connectedEvent);
+            ClassicAssert.IsTrue(connectedEvent is CallConnected);
+            ClassicAssert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
 
             // test get properties
             Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+            ClassicAssert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
 
             try
             {
                 // start continuous dtmf recognition
                 var startContinuousDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().StartContinuousDtmfRecognitionAsync(target);
-                Assert.AreEqual(StatusCodes.Status200OK, startContinuousDtmfResponse.Status);
+                ClassicAssert.AreEqual(StatusCodes.Status200OK, startContinuousDtmfResponse.Status);
 
                 // again start continuous dtmf recognition and expect success
                 startContinuousDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().StartContinuousDtmfRecognitionAsync(target);
-                Assert.AreEqual(startContinuousDtmfResponse.Status, StatusCodes.Status200OK);
+                ClassicAssert.AreEqual(startContinuousDtmfResponse.Status, StatusCodes.Status200OK);
 
                 // send dtmf tones to the target user
                 var tones = new DtmfTone[] { DtmfTone.One };
                 var sendDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().SendDtmfTonesAsync(tones, target);
-                Assert.AreEqual(StatusCodes.Status202Accepted, sendDtmfResponse.GetRawResponse().Status);
+                ClassicAssert.AreEqual(StatusCodes.Status202Accepted, sendDtmfResponse.GetRawResponse().Status);
 
                 // wait for ContinuousDtmfRecognitionToneReceived event
                 var continuousDtmfRecognitionToneReceived = await WaitForEvent<ContinuousDtmfRecognitionToneReceived>(targetCallConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(continuousDtmfRecognitionToneReceived);
-                Assert.IsTrue(continuousDtmfRecognitionToneReceived is ContinuousDtmfRecognitionToneReceived);
+                ClassicAssert.IsNotNull(continuousDtmfRecognitionToneReceived);
+                ClassicAssert.IsTrue(continuousDtmfRecognitionToneReceived is ContinuousDtmfRecognitionToneReceived);
 
                 // wait for SendDtmfCompleted event
                 var sendDtmfCompletedEvent = await WaitForEvent<SendDtmfTonesCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(sendDtmfCompletedEvent);
-                Assert.IsTrue(sendDtmfCompletedEvent is SendDtmfTonesCompleted);
+                ClassicAssert.IsNotNull(sendDtmfCompletedEvent);
+                ClassicAssert.IsTrue(sendDtmfCompletedEvent is SendDtmfTonesCompleted);
 
                 // stop continuous dtmf recognition
                 var stopContinuousDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().StopContinuousDtmfRecognitionAsync(target);
-                Assert.AreEqual(StatusCodes.Status200OK, stopContinuousDtmfResponse.Status);
+                ClassicAssert.AreEqual(StatusCodes.Status200OK, stopContinuousDtmfResponse.Status);
 
                 // wait for ContinuousDtmfRecognitionStopped event
                 var continuousDtmfRecognitionStopped = await WaitForEvent<ContinuousDtmfRecognitionStopped>(callConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(continuousDtmfRecognitionStopped);
-                Assert.IsTrue(continuousDtmfRecognitionStopped is ContinuousDtmfRecognitionStopped);
+                ClassicAssert.IsNotNull(continuousDtmfRecognitionStopped);
+                ClassicAssert.IsTrue(continuousDtmfRecognitionStopped is ContinuousDtmfRecognitionStopped);
 
                 // again call stop coninuous recognition and expect success
                 stopContinuousDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().StopContinuousDtmfRecognitionAsync(target);
-                Assert.AreEqual(StatusCodes.Status200OK, stopContinuousDtmfResponse.Status);
+                ClassicAssert.AreEqual(StatusCodes.Status200OK, stopContinuousDtmfResponse.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -174,16 +175,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple File Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(playCompletedEvent);
+                    ClassicAssert.IsTrue(playCompletedEvent is PlayCompleted);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -246,16 +247,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple File Sources
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(playCompletedEvent);
+                    ClassicAssert.IsTrue(playCompletedEvent is PlayCompleted);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -318,16 +319,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(playCompletedEvent);
+                    ClassicAssert.IsTrue(playCompletedEvent is PlayCompleted);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -390,16 +391,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(playCompletedEvent);
+                    ClassicAssert.IsTrue(playCompletedEvent is PlayCompleted);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -461,16 +462,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(playCompletedEvent);
+                    ClassicAssert.IsTrue(playCompletedEvent is PlayCompleted);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -532,16 +533,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(playCompletedEvent);
+                    ClassicAssert.IsTrue(playCompletedEvent is PlayCompleted);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -602,17 +603,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playFailedEvent = await WaitForEvent<PlayFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playFailedEvent);
-                    Assert.IsTrue(playFailedEvent is PlayFailed);
-                    Assert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
-                    Assert.AreEqual(0, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
+                    ClassicAssert.IsNotNull(playFailedEvent);
+                    ClassicAssert.IsTrue(playFailedEvent is PlayFailed);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
+                    ClassicAssert.AreEqual(0, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -674,17 +675,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playFailedEvent = await WaitForEvent<PlayFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playFailedEvent);
-                    Assert.IsTrue(playFailedEvent is PlayFailed);
-                    Assert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
-                    Assert.AreEqual(1, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
+                    ClassicAssert.IsNotNull(playFailedEvent);
+                    ClassicAssert.IsTrue(playFailedEvent is PlayFailed);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
+                    ClassicAssert.AreEqual(1, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -745,17 +746,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with invalid file source
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playFailedEvent = await WaitForEvent<PlayFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playFailedEvent);
-                    Assert.IsTrue(playFailedEvent is PlayFailed);
-                    Assert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
-                    Assert.AreEqual(0, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
+                    ClassicAssert.IsNotNull(playFailedEvent);
+                    ClassicAssert.IsTrue(playFailedEvent is PlayFailed);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
+                    ClassicAssert.AreEqual(0, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -817,17 +818,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playFailedEvent = await WaitForEvent<PlayFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playFailedEvent);
-                    Assert.IsTrue(playFailedEvent is PlayFailed);
-                    Assert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
-                    Assert.AreEqual(1, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
+                    ClassicAssert.IsNotNull(playFailedEvent);
+                    ClassicAssert.IsTrue(playFailedEvent is PlayFailed);
+                    ClassicAssert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
+                    ClassicAssert.AreEqual(1, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -891,9 +892,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -958,9 +959,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1025,9 +1026,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1090,9 +1091,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1156,9 +1157,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1222,9 +1223,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1289,9 +1290,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1356,9 +1357,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1421,9 +1422,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1487,9 +1488,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1553,9 +1554,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1620,9 +1621,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1687,9 +1688,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1752,9 +1753,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1818,9 +1819,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1884,9 +1885,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -1951,9 +1952,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -2018,9 +2019,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -2083,9 +2084,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -2149,9 +2150,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -2204,16 +2205,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
                     // wait for callConnected
                     var addParticipantSucceededEvent = await WaitForEvent<ParticipantsUpdated>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(addParticipantSucceededEvent);
-                    Assert.IsTrue(addParticipantSucceededEvent is ParticipantsUpdated);
-                    Assert.IsTrue(((ParticipantsUpdated)addParticipantSucceededEvent!).CallConnectionId == callConnectionId);
+                    ClassicAssert.IsNotNull(addParticipantSucceededEvent);
+                    ClassicAssert.IsTrue(addParticipantSucceededEvent is ParticipantsUpdated);
+                    ClassicAssert.IsTrue(((ParticipantsUpdated)addParticipantSucceededEvent!).CallConnectionId == callConnectionId);
 
                     // Assert the participant hold
                     await callConnection.GetCallMedia().HoldAsync(target).ConfigureAwait(false);
                     await Task.Delay(1000);
                     var participantResult = await callConnection.GetParticipantAsync(target).ConfigureAwait(false);
-                    Assert.IsNotNull(participantResult);
-                    Assert.IsTrue(participantResult.Value.IsOnHold);
+                    ClassicAssert.IsNotNull(participantResult);
+                    ClassicAssert.IsTrue(participantResult.Value.IsOnHold);
 
                     // Assert the participant unhold
                     await callConnection.GetCallMedia().UnholdAsync(target).ConfigureAwait(false);
@@ -2221,15 +2222,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     await Task.Delay(1000);
 
                     participantResult = await callConnection.GetParticipantAsync(target).ConfigureAwait(false);
-                    Assert.IsNotNull(participantResult);
-                    Assert.IsFalse(participantResult.Value.IsOnHold);
+                    ClassicAssert.IsNotNull(participantResult);
+                    ClassicAssert.IsFalse(participantResult.Value.IsOnHold);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
 
                     try
                     {
@@ -2586,11 +2587,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 }
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 var callerCallConnectionId = response.CallConnectionProperties.CallConnectionId;
-                Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                 // wait for incomingcall context
                 string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(incomingCallContext);
+                ClassicAssert.IsNotNull(incomingCallContext);
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
@@ -2600,9 +2601,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 // wait for callConnected
 
                 var connectedEvent = await WaitForEvent<CallConnected>(targetCallConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(connectedEvent);
-                Assert.IsTrue(connectedEvent is CallConnected);
-                Assert.AreEqual(targetCallConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                ClassicAssert.IsNotNull(connectedEvent);
+                ClassicAssert.IsTrue(connectedEvent is CallConnected);
+                ClassicAssert.AreEqual(targetCallConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
                 return (callerCallConnectionId, targetCallConnectionId);
             }
             catch (Exception)
@@ -2641,11 +2642,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 }
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 var callerCallConnectionId = response.CallConnectionProperties.CallConnectionId;
-                Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                 // wait for incomingcall context
                 string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(incomingCallContext);
+                ClassicAssert.IsNotNull(incomingCallContext);
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
@@ -2670,9 +2671,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 // wait for callConnected
 
                 var connectedEvent = await WaitForEvent<CallConnected>(targetCallConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(connectedEvent);
-                Assert.IsTrue(connectedEvent is CallConnected);
-                Assert.AreEqual(targetCallConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                ClassicAssert.IsNotNull(connectedEvent);
+                ClassicAssert.IsTrue(connectedEvent is CallConnected);
+                ClassicAssert.AreEqual(targetCallConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
                 return (callerCallConnectionId, targetCallConnectionId);
             }
             catch (Exception)
@@ -2695,14 +2696,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // wait for callConnected
             var mediaStreamingStartedEvent = await WaitForEvent<MediaStreamingStarted>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(mediaStreamingStartedEvent);
-            Assert.IsTrue(mediaStreamingStartedEvent is MediaStreamingStarted);
+            ClassicAssert.IsNotNull(mediaStreamingStartedEvent);
+            ClassicAssert.IsTrue(mediaStreamingStartedEvent is MediaStreamingStarted);
 
             // Assert call connection properties
             var connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.MediaStreamingSubscription);
-            Assert.AreEqual(connectionProperties.Value.MediaStreamingSubscription.State, MediaStreamingSubscriptionState.Active);
+            ClassicAssert.IsNotNull(connectionProperties);
+            ClassicAssert.IsNotNull(connectionProperties.Value.MediaStreamingSubscription);
+            ClassicAssert.AreEqual(connectionProperties.Value.MediaStreamingSubscription.State, MediaStreamingSubscriptionState.Active);
 
             //Stop media streaming
             StopMediaStreamingOptions stopMediaStreamingOptions = new StopMediaStreamingOptions();
@@ -2711,21 +2712,21 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // wait for callConnected
             var stopMediaStreamingEvent = await WaitForEvent<MediaStreamingStopped>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(stopMediaStreamingEvent);
-            Assert.IsTrue(stopMediaStreamingEvent is MediaStreamingStopped);
+            ClassicAssert.IsNotNull(stopMediaStreamingEvent);
+            ClassicAssert.IsTrue(stopMediaStreamingEvent is MediaStreamingStopped);
 
             // Assert call connection properties
             connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.MediaStreamingSubscription);
-            Assert.AreEqual(connectionProperties.Value.MediaStreamingSubscription.State, MediaStreamingSubscriptionState.Inactive);
+            ClassicAssert.IsNotNull(connectionProperties);
+            ClassicAssert.IsNotNull(connectionProperties.Value.MediaStreamingSubscription);
+            ClassicAssert.AreEqual(connectionProperties.Value.MediaStreamingSubscription.State, MediaStreamingSubscriptionState.Inactive);
 
             // try hangup
             await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
             var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(disconnectedEvent);
-            Assert.IsTrue(disconnectedEvent is CallDisconnected);
-            Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+            ClassicAssert.IsNotNull(disconnectedEvent);
+            ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+            ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
         }
 
         private async Task VerifyTranscription(CallAutomationClient client, string callConnectionId)
@@ -2740,8 +2741,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             var callerMedia = client.GetCallConnection(callConnectionId).GetCallMedia();
             var startTranscriptionResponse = await callerMedia.StartTranscriptionAsync(startTranscriptionOptions);
             var startTranscriptionEvent = await WaitForEvent<TranscriptionStarted>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(startTranscriptionEvent);
-            Assert.IsTrue(startTranscriptionEvent is TranscriptionStarted);
+            ClassicAssert.IsNotNull(startTranscriptionEvent);
+            ClassicAssert.IsTrue(startTranscriptionEvent is TranscriptionStarted);
 
             var source = new TextSource("Hello, this is live test", "en-US-ElizabethNeural");
             var options = new PlayToAllOptions(source) { OperationContext = "playalloptionduringtranscription" };
@@ -2749,41 +2750,41 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // test get properties
             var connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.TranscriptionSubscription);
-            Assert.AreEqual(connectionProperties.Value.TranscriptionSubscription.State, TranscriptionSubscriptionState.Active);
+            ClassicAssert.IsNotNull(connectionProperties);
+            ClassicAssert.IsNotNull(connectionProperties.Value.TranscriptionSubscription);
+            ClassicAssert.AreEqual(connectionProperties.Value.TranscriptionSubscription.State, TranscriptionSubscriptionState.Active);
 
             // Update Transcription
             UpdateTranscriptionOptions updateTranscriptionOptions = new UpdateTranscriptionOptions("en-US") { OperationContext = "UpdateTranscription" };
             var updateTranscriptionResponse = await callerMedia.UpdateTranscriptionAsync(updateTranscriptionOptions);
             var updateTranscriptionEvent = await WaitForEvent<TranscriptionUpdated>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(updateTranscriptionEvent);
-            Assert.IsTrue(updateTranscriptionEvent is TranscriptionUpdated);
+            ClassicAssert.IsNotNull(updateTranscriptionEvent);
+            ClassicAssert.IsTrue(updateTranscriptionEvent is TranscriptionUpdated);
 
             connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.TranscriptionSubscription);
-            Assert.AreEqual(connectionProperties.Value.TranscriptionSubscription.State, TranscriptionSubscriptionState.Active);
+            ClassicAssert.IsNotNull(connectionProperties);
+            ClassicAssert.IsNotNull(connectionProperties.Value.TranscriptionSubscription);
+            ClassicAssert.AreEqual(connectionProperties.Value.TranscriptionSubscription.State, TranscriptionSubscriptionState.Active);
 
             //Stop Transcription
             StopTranscriptionOptions stopTranscriptionOptions = new StopTranscriptionOptions() { OperationContext = "StopTranscription" };
             var stopTranscriptionResponse = await callerMedia.StopTranscriptionAsync(stopTranscriptionOptions);
 
             var stopTranscriptionEvent = await WaitForEvent<TranscriptionStopped>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(stopTranscriptionEvent);
-            Assert.IsTrue(stopTranscriptionEvent is TranscriptionStopped);
+            ClassicAssert.IsNotNull(stopTranscriptionEvent);
+            ClassicAssert.IsTrue(stopTranscriptionEvent is TranscriptionStopped);
 
             connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.TranscriptionSubscription);
-            Assert.AreEqual(connectionProperties.Value.TranscriptionSubscription.State, TranscriptionSubscriptionState.Inactive);
+            ClassicAssert.IsNotNull(connectionProperties);
+            ClassicAssert.IsNotNull(connectionProperties.Value.TranscriptionSubscription);
+            ClassicAssert.AreEqual(connectionProperties.Value.TranscriptionSubscription.State, TranscriptionSubscriptionState.Inactive);
 
             // try hangup
             await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
             var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(disconnectedEvent);
-            Assert.IsTrue(disconnectedEvent is CallDisconnected);
-            Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+            ClassicAssert.IsNotNull(disconnectedEvent);
+            ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+            ClassicAssert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
         }
 
         private async Task VerifyRecognizeFailedEventForMultipleSources(string callConnectionId,
@@ -2796,7 +2797,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             // Assert the playall with multiple Text Sources
             var recognizeOptions = GetRecognizeOptions(playMultipleSources, target, recognizeInputType, playSource);
-            Assert.IsNotNull(recognizeOptions);
+            ClassicAssert.IsNotNull(recognizeOptions);
 
             var callConnection = client.GetCallConnection(callConnectionId);
 
@@ -2817,22 +2818,22 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // Assert the playall with multiple Text Sources
             var recognizeFailedEvent = await WaitForEvent<RecognizeFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(recognizeFailedEvent);
-            Assert.IsTrue(recognizeFailedEvent is RecognizeFailed);
-            Assert.AreEqual(callConnectionId, ((RecognizeFailed)recognizeFailedEvent!).CallConnectionId);
+            ClassicAssert.IsNotNull(recognizeFailedEvent);
+            ClassicAssert.IsTrue(recognizeFailedEvent is RecognizeFailed);
+            ClassicAssert.AreEqual(callConnectionId, ((RecognizeFailed)recognizeFailedEvent!).CallConnectionId);
             if (expectedBadRequestCheck)
             {
-                Assert.AreEqual(MediaEventReasonCode.PlayInvalidFileFormat, ((RecognizeFailed)recognizeFailedEvent!).ReasonCode);
+                ClassicAssert.AreEqual(MediaEventReasonCode.PlayInvalidFileFormat, ((RecognizeFailed)recognizeFailedEvent!).ReasonCode);
             }
             else if (isInvalidSourceCheck)
             {
-                Assert.AreEqual(0, ((RecognizeFailed)recognizeFailedEvent!).FailedPlaySourceIndex);
+                ClassicAssert.AreEqual(0, ((RecognizeFailed)recognizeFailedEvent!).FailedPlaySourceIndex);
             }
             else
             {
-                Assert.AreEqual(MediaEventReasonCode.RecognizeInitialSilenceTimedOut, ((RecognizeFailed)recognizeFailedEvent!).ReasonCode);
+                ClassicAssert.AreEqual(MediaEventReasonCode.RecognizeInitialSilenceTimedOut, ((RecognizeFailed)recognizeFailedEvent!).ReasonCode);
                 if (recognizeInputType != RecognizeInputType.Dtmf)
-                    Assert.IsNull(((RecognizeFailed)recognizeFailedEvent!).FailedPlaySourceIndex);
+                    ClassicAssert.IsNull(((RecognizeFailed)recognizeFailedEvent!).FailedPlaySourceIndex);
             }
         }
 

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallMedias
 {
@@ -236,8 +237,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_CancelOperationsAsync))]
@@ -245,8 +246,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperationsAsync))]
@@ -254,8 +255,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_SendDtmfOperationsAsync))]
@@ -263,8 +264,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202, "{ \"operationContext\": \"operationContext\" }");
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_StartContinuousRecognitionOperationsAsync))]
@@ -272,8 +273,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StopContinuousRecognitionOperationsAsync))]
@@ -281,8 +282,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StartTranscriptionOperationsAsync))]
@@ -290,8 +291,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StopTranscriptionOperationsAsync))]
@@ -299,8 +300,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_UpdateTranscriptionOperationsAsync))]
@@ -308,8 +309,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StartMediaStreamingOperationsAsync))]
@@ -317,8 +318,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StopMediaStreamingOperationsAsync))]
@@ -326,8 +327,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_PlayOperations))]
@@ -335,8 +336,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_PlayOperations_WithBargeIn))]
@@ -344,8 +345,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_CancelOperations))]
@@ -353,8 +354,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperations))]
@@ -362,8 +363,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_SendDtmfOperations))]
@@ -371,8 +372,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202, "{ \"operationContext\": \"operationContext\" }");
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
         }
 
         [TestCaseSource(nameof(TestData_StartContinuousRecognitionOperations))]
@@ -380,8 +381,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StopContinuousRecognitionOperations))]
@@ -389,8 +390,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StartTranscriptionOperations))]
@@ -398,8 +399,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StopTranscriptionOperations))]
@@ -407,8 +408,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_UpdateTranscriptionOperations))]
@@ -416,8 +417,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StartMediaStreamingOperations))]
@@ -425,8 +426,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StopMediaStreamingOperations))]
@@ -434,218 +435,218 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_PlayOperationsAsync))]
         public void PlayOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response<PlayResult>>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_CancelOperationsAsync))]
         public void CancelOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response<CancelAllMediaOperationsResult>>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperationsAsync))]
         public void RecognizeOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response<StartRecognizingCallMediaResult>>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_SendDtmfOperationsAsync))]
         public void SendDtmfOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response<SendDtmfTonesResult>>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StartContinuousRecognitionOperationsAsync))]
         public void StartContinuousRecognitionOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StopContinuousRecognitionOperationsAsync))]
         public void StopContinuousRecognitionOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StartTranscriptionOperationsAsync))]
         public void StartTranscriptionOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_UpdateTranscriptionOperationsAsync))]
         public void UpdateTranscriptionOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StopTranscriptionOperationsAsync))]
         public void StopTranscriptionOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StartMediaStreamingOperationsAsync))]
         public void StartMediaStreamingOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StopMediaStreamingOperationsAsync))]
         public void StopMediaStreamingOperationsAsync_Return404NotFound(Func<CallMedia, Task<Response>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_PlayOperations))]
         public void PlayOperations_Return404NotFound(Func<CallMedia, Response<PlayResult>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperations))]
         public void RecognizeOperations_Return404NotFound(Func<CallMedia, Response<StartRecognizingCallMediaResult>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_SendDtmfOperations))]
         public void SendDtmfOperations_Return404NotFound(Func<CallMedia, Response<SendDtmfTonesResult>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_CancelOperations))]
         public void CancelOperations_Return404NotFound(Func<CallMedia, Response<CancelAllMediaOperationsResult>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperations))]
         public void MediaOperations_Return404NotFound(Func<CallMedia, Response<StartRecognizingCallMediaResult>> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StartContinuousRecognitionOperations))]
         public void StartContinuousRecognitionOperations_Return404NotFound(Func<CallMedia, Response> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StopContinuousRecognitionOperations))]
         public void StopContinuousRecognizeOperations_Return404NotFound(Func<CallMedia, Response> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StartTranscriptionOperations))]
         public void StartTranscriptionOperations_Return404NotFound(Func<CallMedia, Response> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StopTranscriptionOperations))]
         public void StopTranscriptionOperations_Return404NotFound(Func<CallMedia, Response> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_UpdateTranscriptionOperations))]
         public void UpdateTranscriptionOperations_Return404NotFound(Func<CallMedia, Response> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_HoldOperationsAsync))]
@@ -653,8 +654,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_HoldOperations))]
@@ -662,28 +663,28 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, result.Status);
         }
 
         [TestCaseSource(nameof(TestData_StartMediaStreamingOperations))]
         public void StartMediaStreamingOperations_Return404NotFound(Func<CallMedia, Response> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_StopMediaStreamingOperations))]
         public void StopMediaStreamingOperations_Return404NotFound(Func<CallMedia, Response> operation)
         {
             _callMedia = GetCallMedia(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         private static IEnumerable<object?[]> TestData_PlayOperationsAsync()

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingAutomatedLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,7 @@ using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 {
@@ -34,26 +35,26 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
             CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
             string callConnectionId = response.CallConnectionProperties.CallConnectionId;
-            Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+            ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
             // wait for incomingcall context
             string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(incomingCallContext);
+            ClassicAssert.IsNotNull(incomingCallContext);
 
             // answer the call
             var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
             var answerResponse = await targetClient.AnswerCallAsync(answerCallOptions);
-            Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
+            ClassicAssert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
 
             // wait for callConnected
             var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(connectedEvent);
-            Assert.IsTrue(connectedEvent is CallConnected);
-            Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+            ClassicAssert.IsNotNull(connectedEvent);
+            ClassicAssert.IsTrue(connectedEvent is CallConnected);
+            ClassicAssert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
 
             // test get properties
             Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+            ClassicAssert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
 
             var serverCallId = properties.Value.ServerCallId;
 
@@ -63,30 +64,30 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                 RecordingStateCallbackUri = new Uri(TestEnvironment.DispatcherCallback),
             };
             var recordingResponse = await callRecording.StartAsync(recordingOptions).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
+            ClassicAssert.NotNull(recordingResponse.Value);
 
             var recordingId = recordingResponse.Value.RecordingId;
-            Assert.NotNull(recordingId);
+            ClassicAssert.NotNull(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
 
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
+            ClassicAssert.NotNull(recordingResponse.Value);
+            ClassicAssert.NotNull(recordingResponse.Value.RecordingState);
+            ClassicAssert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
 
             await callRecording.PauseAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Inactive);
+            ClassicAssert.NotNull(recordingResponse.Value);
+            ClassicAssert.NotNull(recordingResponse.Value.RecordingState);
+            ClassicAssert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Inactive);
 
             await callRecording.ResumeAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
+            ClassicAssert.NotNull(recordingResponse.Value);
+            ClassicAssert.NotNull(recordingResponse.Value.RecordingState);
+            ClassicAssert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
 
             await callRecording.StopAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
@@ -143,26 +144,26 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    ClassicAssert.IsNotNull(incomingCallContext);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
                     var answerResponse = await targetClient.AnswerCallAsync(answerCallOptions);
-                    Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
+                    ClassicAssert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+                    ClassicAssert.IsNotNull(connectedEvent);
+                    ClassicAssert.IsTrue(connectedEvent is CallConnected);
+                    ClassicAssert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    ClassicAssert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
 
                     // try start recording unmixed audio - no channel affinity
                     var startRecordingResponse = await client.GetCallRecording().StartAsync(
@@ -173,25 +174,25 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                             RecordingFormat = RecordingFormat.Wav,
                             RecordingStateCallbackUri = new Uri(TestEnvironment.DispatcherCallback),
                         });
-                    Assert.AreEqual(StatusCodes.Status200OK, startRecordingResponse.GetRawResponse().Status);
-                    Assert.NotNull(startRecordingResponse.Value.RecordingId);
+                    ClassicAssert.AreEqual(StatusCodes.Status200OK, startRecordingResponse.GetRawResponse().Status);
+                    ClassicAssert.NotNull(startRecordingResponse.Value.RecordingId);
 
                     // try stop recording
                     var stopRecordingResponse = await client.GetCallRecording().StopAsync(startRecordingResponse.Value.RecordingId);
-                    Assert.AreEqual(StatusCodes.Status204NoContent, stopRecordingResponse.Status);
+                    ClassicAssert.AreEqual(StatusCodes.Status204NoContent, stopRecordingResponse.Status);
 
                     // wait for CallRecordingStateChanged event TODO: Figure out why this event not being received
                     // var recordingStartedEvent = await WaitForEvent<CallRecordingStateChanged>(callConnectionId, TimeSpan.FromSeconds(20));
-                    // Assert.IsNotNull(recordingStartedEvent);
-                    // Assert.IsTrue(recordingStartedEvent is CallRecordingStateChanged);
-                    // Assert.IsTrue(((CallRecordingStateChanged)recordingStartedEvent!).CallConnectionId == callConnectionId);
+                    // ClassicAssert.IsNotNull(recordingStartedEvent);
+                    // ClassicAssert.IsTrue(recordingStartedEvent is CallRecordingStateChanged);
+                    // ClassicAssert.IsTrue(((CallRecordingStateChanged)recordingStartedEvent!).CallConnectionId == callConnectionId);
 
                     // try hangup
                     await response.CallConnection.HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.IsTrue(((CallDisconnected)disconnectedEvent!).CallConnectionId == callConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.IsTrue(((CallDisconnected)disconnectedEvent!).CallConnectionId == callConnectionId);
                     callConnectionId = null;
                 }
                 catch (Exception)
@@ -239,26 +240,26 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    ClassicAssert.IsNotNull(incomingCallContext);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
                     var answerResponse = await targetClient.AnswerCallAsync(answerCallOptions);
-                    Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
+                    ClassicAssert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+                    ClassicAssert.IsNotNull(connectedEvent);
+                    ClassicAssert.IsTrue(connectedEvent is CallConnected);
+                    ClassicAssert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    ClassicAssert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
 
                     // try start recording unmixed audio with channel affinity
                     var startRecordingOptions =
@@ -272,25 +273,25 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                     startRecordingOptions.AudioChannelParticipantOrdering.Add(user);
                     startRecordingOptions.AudioChannelParticipantOrdering.Add(target);
                     var startRecordingResponse = await client.GetCallRecording().StartAsync(startRecordingOptions);
-                    Assert.AreEqual(StatusCodes.Status200OK, startRecordingResponse.GetRawResponse().Status);
-                    Assert.NotNull(startRecordingResponse.Value.RecordingId);
+                    ClassicAssert.AreEqual(StatusCodes.Status200OK, startRecordingResponse.GetRawResponse().Status);
+                    ClassicAssert.NotNull(startRecordingResponse.Value.RecordingId);
 
                     // try stop recording
                     var stopRecordingResponse = await client.GetCallRecording().StopAsync(startRecordingResponse.Value.RecordingId);
-                    Assert.AreEqual(StatusCodes.Status204NoContent, stopRecordingResponse.Status);
+                    ClassicAssert.AreEqual(StatusCodes.Status204NoContent, stopRecordingResponse.Status);
 
                     // wait for CallRecordingStateChanged event TODO: Figure out why event not received
                     // var recordingStartedEvent = await WaitForEvent<CallRecordingStateChanged>(callConnectionId, TimeSpan.FromSeconds(20));
-                    // Assert.IsNotNull(recordingStartedEvent);
-                    // Assert.IsTrue(recordingStartedEvent is CallRecordingStateChanged);
-                    // Assert.IsTrue(((CallRecordingStateChanged)recordingStartedEvent!).CallConnectionId == callConnectionId);
+                    // ClassicAssert.IsNotNull(recordingStartedEvent);
+                    // ClassicAssert.IsTrue(recordingStartedEvent is CallRecordingStateChanged);
+                    // ClassicAssert.IsTrue(((CallRecordingStateChanged)recordingStartedEvent!).CallConnectionId == callConnectionId);
 
                     // try hangup
                     await response.CallConnection.HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.IsTrue(((CallDisconnected)disconnectedEvent!).CallConnectionId == callConnectionId);
+                    ClassicAssert.IsNotNull(disconnectedEvent);
+                    ClassicAssert.IsTrue(disconnectedEvent is CallDisconnected);
+                    ClassicAssert.IsTrue(((CallDisconnected)disconnectedEvent!).CallConnectionId == callConnectionId);
                     callConnectionId = null;
                 }
                 catch (Exception)
@@ -326,26 +327,26 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
             CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
             string callConnectionId = response.CallConnectionProperties.CallConnectionId;
-            Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+            ClassicAssert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
 
             // wait for incomingcall context
             string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(incomingCallContext);
+            ClassicAssert.IsNotNull(incomingCallContext);
 
             // answer the call
             var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
             var answerResponse = await targetClient.AnswerCallAsync(answerCallOptions);
-            Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
+            ClassicAssert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
 
             // wait for callConnected
             var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(connectedEvent);
-            Assert.IsTrue(connectedEvent is CallConnected);
-            Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+            ClassicAssert.IsNotNull(connectedEvent);
+            ClassicAssert.IsTrue(connectedEvent is CallConnected);
+            ClassicAssert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
 
             // test get properties
             Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+            ClassicAssert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
 
             var serverCallId = properties.Value.ServerCallId;
 
@@ -355,30 +356,30 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                 RecordingStateCallbackUri = new Uri(TestEnvironment.DispatcherCallback)
             };
             var recordingResponse = await callRecording.StartAsync(recordingOptions).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
+            ClassicAssert.NotNull(recordingResponse.Value);
 
             var recordingId = recordingResponse.Value.RecordingId;
-            Assert.NotNull(recordingId);
+            ClassicAssert.NotNull(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
 
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
+            ClassicAssert.NotNull(recordingResponse.Value);
+            ClassicAssert.NotNull(recordingResponse.Value.RecordingState);
+            ClassicAssert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
 
             await callRecording.PauseAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Inactive);
+            ClassicAssert.NotNull(recordingResponse.Value);
+            ClassicAssert.NotNull(recordingResponse.Value.RecordingState);
+            ClassicAssert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Inactive);
 
             await callRecording.ResumeAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
+            ClassicAssert.NotNull(recordingResponse.Value);
+            ClassicAssert.NotNull(recordingResponse.Value.RecordingState);
+            ClassicAssert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
 
             await callRecording.StopAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,6 +9,7 @@ using Azure;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 {
@@ -31,8 +32,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(200, responseContent: DummyRecordingStatusResponse);
 
             RecordingStateResult result = operation(callRecording);
-            Assert.AreEqual("dummyRecordingId", result.RecordingId);
-            Assert.AreEqual(RecordingState.Active, result.RecordingState);
+            ClassicAssert.AreEqual("dummyRecordingId", result.RecordingId);
+            ClassicAssert.AreEqual(RecordingState.Active, result.RecordingState);
         }
 
         [TestCaseSource(nameof(TestData_OperationsAsyncWithStatus))]
@@ -41,8 +42,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(200, responseContent: DummyRecordingStatusResponse);
 
             Response<RecordingStateResult> result = await operation(callRecording);
-            Assert.AreEqual("dummyRecordingId", result.Value.RecordingId);
-            Assert.AreEqual(RecordingState.Active, result.Value.RecordingState);
+            ClassicAssert.AreEqual("dummyRecordingId", result.Value.RecordingId);
+            ClassicAssert.AreEqual(RecordingState.Active, result.Value.RecordingState);
         }
 
         [TestCaseSource(nameof(TestData_OperationsWithCallConnectionIdWithStatus))]
@@ -51,8 +52,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(200, responseContent: DummyRecordingStatusResponse);
 
             RecordingStateResult result = operation(callRecording);
-            Assert.AreEqual("dummyRecordingId", result.RecordingId);
-            Assert.AreEqual(RecordingState.Active, result.RecordingState);
+            ClassicAssert.AreEqual("dummyRecordingId", result.RecordingId);
+            ClassicAssert.AreEqual(RecordingState.Active, result.RecordingState);
         }
 
         [TestCaseSource(nameof(TestData_OperationsAsyncWithCallConnectionIdWithStatus))]
@@ -61,8 +62,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(200, responseContent: DummyRecordingStatusResponse);
 
             Response<RecordingStateResult> result = await operation(callRecording);
-            Assert.AreEqual("dummyRecordingId", result.Value.RecordingId);
-            Assert.AreEqual(RecordingState.Active, result.Value.RecordingState);
+            ClassicAssert.AreEqual("dummyRecordingId", result.Value.RecordingId);
+            ClassicAssert.AreEqual(RecordingState.Active, result.Value.RecordingState);
         }
 
         [TestCaseSource(nameof(TestData_OperationsSuccess))]
@@ -71,7 +72,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(expectedStatusCode);
 
             Response response = operation(callRecording);
-            Assert.AreEqual(expectedStatusCode, response.Status);
+            ClassicAssert.AreEqual(expectedStatusCode, response.Status);
         }
 
         [TestCaseSource(nameof(TestData_OperationsAsyncSuccess))]
@@ -80,16 +81,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(expectedStatusCode);
 
             Response response = await operation(callRecording);
-            Assert.AreEqual(expectedStatusCode, response.Status);
+            ClassicAssert.AreEqual(expectedStatusCode, response.Status);
         }
 
         [TestCaseSource(nameof(TestData_Operations404))]
         public void RecordingOperation_Returns404NotFound(Func<CallRecording, TestDelegate> operation)
         {
             CallRecording callRecording = getMockCallRecording(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(operation(callRecording));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(operation(callRecording));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [TestCaseSource(nameof(TestData_OperationsAsync404))]
@@ -97,9 +98,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallRecording callRecording = getMockCallRecording(404);
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(operation(callRecording));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(operation(callRecording));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         private CallRecording getMockCallRecording(int statusCode, string? responseContent = null)

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/ContentDownloadTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/ContentDownloadTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -11,6 +11,7 @@ using Azure.Core;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 {
@@ -124,7 +125,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             Stream destination = new MemoryStream();
             _callAutomationClient.GetCallRecording().DownloadTo(_dummyRecordingLocation, destination, options);
 
-            Assert.AreEqual(10, destination.Length);
+            ClassicAssert.AreEqual(10, destination.Length);
         }
 
         [Test]
@@ -151,47 +152,47 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                 MaximumTransferSize = 5
             };
 
-            Assert.AreNotEqual(options.GetHashCode(), options_updated.GetHashCode());
-            Assert.AreEqual(options.GetHashCode(), options_copy.GetHashCode());
-            Assert.True(options.Equals(options_copy));
-            Assert.True(options.Equals((object)options_copy));
-            Assert.False(options.Equals(options_updated));
+            ClassicAssert.AreNotEqual(options.GetHashCode(), options_updated.GetHashCode());
+            ClassicAssert.AreEqual(options.GetHashCode(), options_copy.GetHashCode());
+            ClassicAssert.True(options.Equals(options_copy));
+            ClassicAssert.True(options.Equals((object)options_copy));
+            ClassicAssert.False(options.Equals(options_updated));
         }
 
         [Test]
         public void DownloadNotExistentContent_Failure_Test()
         {
             CallAutomationClient _callAutomationClient = CreateMockCallAutomationClient(404);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => _callAutomationClient.GetCallRecording().DownloadStreaming(_dummyMetadataLocation));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => _callAutomationClient.GetCallRecording().DownloadStreaming(_dummyMetadataLocation));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
         public void DownloadNotExistentContentAsync_Failure_Test()
         {
             CallAutomationClient _callAutomationClient = CreateMockCallAutomationClient(404);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await _callAutomationClient.GetCallRecording().DownloadStreamingAsync(_dummyMetadataLocation));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await _callAutomationClient.GetCallRecording().DownloadStreamingAsync(_dummyMetadataLocation));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
         public void AccessDenied_Failure_Test()
         {
             CallAutomationClient _callAutomationClient = CreateMockCallAutomationClient(401);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => _callAutomationClient.GetCallRecording().DownloadStreaming(_dummyMetadataLocation));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => _callAutomationClient.GetCallRecording().DownloadStreaming(_dummyMetadataLocation));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 401);
         }
 
         [Test]
         public void AccessDeniedAsync_Failure_Test()
         {
             CallAutomationClient _callAutomationClient = CreateMockCallAutomationClient(401);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await _callAutomationClient.GetCallRecording().DownloadStreamingAsync(_dummyMetadataLocation));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await _callAutomationClient.GetCallRecording().DownloadStreamingAsync(_dummyMetadataLocation));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 401);
         }
 
         [Test]
@@ -218,7 +219,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             Stream destination = new MemoryStream();
             _callAutomationClient.GetCallRecording().DownloadTo(_dummyRecordingLocation, destination, options);
 
-            Assert.AreEqual(10, destination.Length);
+            ClassicAssert.AreEqual(10, destination.Length);
         }
 
         [Test]
@@ -245,22 +246,22 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             Stream destination = new MemoryStream();
             await _callAutomationClient.GetCallRecording().DownloadToAsync(_dummyRecordingLocation, destination, options);
 
-            Assert.AreEqual(10, destination.Length);
+            ClassicAssert.AreEqual(10, destination.Length);
         }
 
         private static void VerifyExpectedMetadata(Stream metadata)
         {
-            Assert.IsNotNull(metadata);
+            ClassicAssert.IsNotNull(metadata);
             JsonElement expected = JsonDocument.Parse(DummyRecordingMetadata).RootElement;
             JsonElement actual = JsonDocument.Parse(metadata).RootElement;
-            Assert.AreEqual(expected.GetProperty("chunkDocumentId").GetString(), actual.GetProperty("chunkDocumentId").GetString());
+            ClassicAssert.AreEqual(expected.GetProperty("chunkDocumentId").GetString(), actual.GetProperty("chunkDocumentId").GetString());
         }
 
         private static void VerifyExpectedRecording(Response<Stream> recording, int recordingLength)
         {
-            Assert.IsNotNull(recording.Value);
-            Assert.IsTrue(recording.Value.GetType().Name.Contains(typeof(RetriableStream).Name));
-            Assert.AreEqual(recordingLength, recording.Value.Length);
+            ClassicAssert.IsNotNull(recording.Value);
+            ClassicAssert.IsTrue(recording.Value.GetType().Name.Contains(typeof(RetriableStream).Name));
+            ClassicAssert.AreEqual(recordingLength, recording.Value.Length);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/DeleteRecordingTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/DeleteRecordingTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.CallRecordings
 {
@@ -18,7 +19,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(200);
             var response = callAutomationClient.GetCallRecording().Delete(new Uri(AmsDeleteUrl));
-            Assert.AreEqual((int)HttpStatusCode.OK, response.Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.Status);
         }
 
         [Test]
@@ -26,7 +27,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(200);
             var response = await callAutomationClient.GetCallRecording().DeleteAsync(new Uri(AmsDeleteUrl)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, response.Status);
         }
 
         [Test]
@@ -34,18 +35,18 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.GetCallRecording().Delete(new Uri(AmsDeleteUrl)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callAutomationClient.GetCallRecording().Delete(new Uri(AmsDeleteUrl)));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
         }
 
         [Test]
         public void DeleteRecording_Returns401Unauthorized()
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(401);
-            RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.GetCallRecording().Delete(new Uri(AmsDeleteUrl)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            RequestFailedException? ex = ClassicAssert.Throws<RequestFailedException>(() => callAutomationClient.GetCallRecording().Delete(new Uri(AmsDeleteUrl)));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 401);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/AttachEventProcessorTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/AttachEventProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 {
@@ -28,7 +29,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
 
             // Assert if the delegate was also called
-            Assert.AreEqual(CallConnectionId, callConnectionIdPassedFromOngoingEventProcessor);
+            ClassicAssert.AreEqual(CallConnectionId, callConnectionIdPassedFromOngoingEventProcessor);
         }
 
         [Test]
@@ -49,7 +50,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
 
             // Assert if the delegate didnt get called
-            Assert.AreEqual(ServerCallId, callConnectionIdPassedFromOngoingEventProcessor);
+            ClassicAssert.AreEqual(ServerCallId, callConnectionIdPassedFromOngoingEventProcessor);
         }
 
         [Test]
@@ -69,7 +70,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
 
             // Assert if the delegate was also called
-            Assert.AreEqual(CallConnectionId, callConnectionIdPassedFromOngoingEventProcessor);
+            ClassicAssert.AreEqual(CallConnectionId, callConnectionIdPassedFromOngoingEventProcessor);
         }
 
         [Test]
@@ -88,7 +89,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallTransferAccepted(internalEvent));
 
             // Assert if the delegate was never called
-            Assert.AreEqual(ServerCallId, callConnectionIdPassedFromOngoingEventProcessor);
+            ClassicAssert.AreEqual(ServerCallId, callConnectionIdPassedFromOngoingEventProcessor);
         }
 
         [Test]
@@ -108,7 +109,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
 
             // Assert if the delegate was never called
-            Assert.AreEqual(ServerCallId, callConnectionIdPassedFromOngoingEventProcessor);
+            ClassicAssert.AreEqual(ServerCallId, callConnectionIdPassedFromOngoingEventProcessor);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/EventProcessorAsyncTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/EventProcessorAsyncTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 {
@@ -31,9 +32,9 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventBase returnedBaseEvent = await baseEventTask;
 
             // Assert
-            Assert.NotNull(returnedBaseEvent);
-            Assert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
-            Assert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
+            ClassicAssert.NotNull(returnedBaseEvent);
+            ClassicAssert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
         }
 
         [Test]
@@ -52,9 +53,9 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
                 && ev.GetType() == typeof(CallConnected));
 
             // Assert
-            Assert.NotNull(returnedBaseEvent);
-            Assert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
-            Assert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
+            ClassicAssert.NotNull(returnedBaseEvent);
+            ClassicAssert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
         }
 
         [Test]
@@ -112,9 +113,9 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
                 // assert
                 CallAutomationEventBase returnedBaseEvent = await task;
-                Assert.NotNull(returnedBaseEvent);
-                Assert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
-                Assert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
+                ClassicAssert.NotNull(returnedBaseEvent);
+                ClassicAssert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
+                ClassicAssert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
             }
         }
 
@@ -141,9 +142,9 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             {
                 // Assert
                 CallAutomationEventBase returnedBaseEvent = await eventAwaiter;
-                Assert.NotNull(returnedBaseEvent);
-                Assert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
-                Assert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
+                ClassicAssert.NotNull(returnedBaseEvent);
+                ClassicAssert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
+                ClassicAssert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
 
                 if (i < eventsSent - 1)
                 {

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/ResultWithEventProcessorAsyncTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/ResultWithEventProcessorAsyncTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using Microsoft.Azure.Amqp.Framing;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 {
@@ -28,7 +29,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
 
             var response = callAutomationClient.CreateCall(new CreateCallOptions(CreateMockInvite(), new Uri(CallBackUri)));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -36,11 +37,11 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CreateCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CallConnected), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.AreEqual(typeof(CallConnected), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
         }
 
         [Test]
@@ -54,17 +55,17 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
                 options: new CallAutomationClientOptions() { Source = new CommunicationUserIdentifier("12345") });
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
             var response = callAutomationClient.CreateCall(new CreateCallOptions(CreateMockInvite(), new Uri(CallBackUri)));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
             var createCallFailedInternalEvent = new CreateCallFailedInternal(CallConnectionId, ServerCallId, CorelationId, "mismatchedOperationId", null);
             SendAndProcessEvent(handler, new CreateCallFailed(createCallFailedInternalEvent));
             CreateCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CreateCallFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(false, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.FailureResult);
+            ClassicAssert.IsNull(returnedResult.SuccessResult);
+            ClassicAssert.AreEqual(typeof(CreateCallFailed), returnedResult.FailureResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
         }
 
         [Test]
@@ -80,7 +81,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
 
             var response = callAutomationClient.ConnectCall(new ConnectCallOptions(new ServerCallLocator(ServerCallId), new Uri(CallBackUri)));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -88,11 +89,11 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             ConnectCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CallConnected), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.AreEqual(typeof(CallConnected), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
         }
 
         [Test]
@@ -106,16 +107,16 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
                 options: new CallAutomationClientOptions() { Source = new CommunicationUserIdentifier("12345") });
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
             var response = callAutomationClient.ConnectCall(new ConnectCallOptions(new ServerCallLocator(ServerCallId), new Uri(CallBackUri)));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
             SendAndProcessEvent(handler, new ConnectFailed(CallConnectionId, ServerCallId, CorelationId, "mismatchedOperationId", null));
             ConnectCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(ConnectFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(false, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.FailureResult);
+            ClassicAssert.IsNull(returnedResult.SuccessResult);
+            ClassicAssert.AreEqual(typeof(ConnectFailed), returnedResult.FailureResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
         }
 
         [Test]
@@ -130,7 +131,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
 
             var response = callAutomationClient.AnswerCall("incomingCallContext", new Uri(CallBackUri));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -138,11 +139,11 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             AnswerCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CallConnected), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.AreEqual(typeof(CallConnected), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
         }
 
         [Test]
@@ -155,7 +156,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
             var callInvite = new CallInvite(new CommunicationUserIdentifier(TargetUser));
             var response = callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
             var transferee = new CommunicationIdentifierModel();
             transferee.CommunicationUser = new CommunicationUserIdentifierModel(TransfereeUser);
             transferee.RawId = TransfereeUser;
@@ -171,15 +172,15 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             TransferCallToParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(CallTransferAccepted), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.SuccessResult.OperationContext);
-            Assert.AreEqual(transferee.CommunicationUser.Id, returnedResult.SuccessResult.Transferee.RawId);
-            Assert.AreEqual(transferTarget.CommunicationUser.Id, returnedResult.SuccessResult.TransferTarget.RawId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.IsNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(CallTransferAccepted), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.AreEqual(response.Value.OperationContext, returnedResult.SuccessResult.OperationContext);
+            ClassicAssert.AreEqual(transferee.CommunicationUser.Id, returnedResult.SuccessResult.Transferee.RawId);
+            ClassicAssert.AreEqual(transferTarget.CommunicationUser.Id, returnedResult.SuccessResult.TransferTarget.RawId);
         }
 
         [Test]
@@ -192,7 +193,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
             var callInvite = new CallInvite(new CommunicationUserIdentifier(TargetUser));
             var response = callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new CallTransferFailed(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null));
@@ -200,13 +201,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             TransferCallToParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(CallTransferFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.FailureResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(false, returnedResult.IsSuccess);
+            ClassicAssert.IsNull(returnedResult.SuccessResult);
+            ClassicAssert.NotNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(CallTransferFailed), returnedResult.FailureResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            ClassicAssert.AreEqual(response.Value.OperationContext, returnedResult.FailureResult.OperationContext);
         }
 
         [Test]
@@ -219,7 +220,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             var callInvite = CreateMockInvite();
 
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.AddParticipantSucceeded(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null, callInvite.Target));
@@ -227,13 +228,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             AddParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(AddParticipantSucceeded), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.SuccessResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.IsNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(AddParticipantSucceeded), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.AreEqual(response.Value.OperationContext, returnedResult.SuccessResult.OperationContext);
         }
 
         [Test]
@@ -246,7 +247,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
             var callInvite = CreateMockInvite();
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.AddParticipantFailed(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null, callInvite.Target));
@@ -254,13 +255,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             AddParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(AddParticipantFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.FailureResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(false, returnedResult.IsSuccess);
+            ClassicAssert.IsNull(returnedResult.SuccessResult);
+            ClassicAssert.NotNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(AddParticipantFailed), returnedResult.FailureResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            ClassicAssert.AreEqual(response.Value.OperationContext, returnedResult.FailureResult.OperationContext);
         }
 
         [Test]
@@ -272,7 +273,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().PlayToAll(new PlayToAllOptions(new FileSource(new Uri(CallBackUri))) { OperationContext = OperationContext });
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             var internalEvent = new PlayCompletedInternal(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation() { });
 
@@ -282,13 +283,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             PlayEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(PlayCompleted), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.SuccessResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.IsNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(PlayCompleted), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.AreEqual(OperationContext, returnedResult.SuccessResult.OperationContext);
         }
 
         [Test]
@@ -300,7 +301,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().PlayToAll(new PlayToAllOptions(new FileSource(new Uri(CallBackUri))) { OperationContext = OperationContext });
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             var internalEvent = new PlayFailedInternal(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation() { }, null);
 
@@ -310,13 +311,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             PlayEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(PlayFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.FailureResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(false, returnedResult.IsSuccess);
+            ClassicAssert.IsNull(returnedResult.SuccessResult);
+            ClassicAssert.NotNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(PlayFailed), returnedResult.FailureResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            ClassicAssert.AreEqual(OperationContext, returnedResult.FailureResult.OperationContext);
         }
 
         [Test]
@@ -328,7 +329,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().CancelAllMediaOperations();
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new PlayCanceled(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -336,12 +337,12 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CancelAllMediaOperationsEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.PlayCanceledSucessEvent);
-            Assert.IsNull(returnedResult.RecognizeCanceledSucessEvent);
-            Assert.AreEqual(typeof(PlayCanceled), returnedResult.PlayCanceledSucessEvent.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.PlayCanceledSucessEvent.CallConnectionId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.PlayCanceledSucessEvent);
+            ClassicAssert.IsNull(returnedResult.RecognizeCanceledSucessEvent);
+            ClassicAssert.AreEqual(typeof(PlayCanceled), returnedResult.PlayCanceledSucessEvent.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.PlayCanceledSucessEvent.CallConnectionId);
         }
 
         [Test]
@@ -353,7 +354,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().CancelAllMediaOperations();
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new RecognizeCanceled(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -361,12 +362,12 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CancelAllMediaOperationsEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.RecognizeCanceledSucessEvent);
-            Assert.IsNull(returnedResult.PlayCanceledSucessEvent);
-            Assert.AreEqual(typeof(RecognizeCanceled), returnedResult.RecognizeCanceledSucessEvent.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.RecognizeCanceledSucessEvent.CallConnectionId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.RecognizeCanceledSucessEvent);
+            ClassicAssert.IsNull(returnedResult.PlayCanceledSucessEvent);
+            ClassicAssert.AreEqual(typeof(RecognizeCanceled), returnedResult.RecognizeCanceledSucessEvent.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.RecognizeCanceledSucessEvent.CallConnectionId);
         }
 
         [Test]
@@ -378,7 +379,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().StartRecognizing(new CallMediaRecognizeDtmfOptions(new CommunicationUserIdentifier(TargetId), 1) { OperationContext = OperationContext });
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new RecognizeCompleted(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation(), CallMediaRecognitionType.Dtmf, null));
@@ -386,13 +387,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             StartRecognizingEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(RecognizeCompleted), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.SuccessResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.IsNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(RecognizeCompleted), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.AreEqual(OperationContext, returnedResult.SuccessResult.OperationContext);
         }
 
         [Test]
@@ -404,7 +405,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().StartRecognizing(new CallMediaRecognizeDtmfOptions(new CommunicationUserIdentifier(TargetId), 1) { OperationContext = OperationContext });
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             var internalEvent = new RecognizeFailedInternal(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation() { }, null);
 
@@ -414,13 +415,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             StartRecognizingEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(RecognizeFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.FailureResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(false, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.FailureResult);
+            ClassicAssert.IsNull(returnedResult.SuccessResult);
+            ClassicAssert.AreEqual(typeof(RecognizeFailed), returnedResult.FailureResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            ClassicAssert.AreEqual(OperationContext, returnedResult.FailureResult.OperationContext);
         }
 
         [Test]
@@ -433,7 +434,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             var callInvite = CreateMockInvite();
 
             var response = callConnection.RemoveParticipant(new RemoveParticipantOptions(callInvite.Target));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.RemoveParticipantSucceeded(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null, callInvite.Target));
@@ -441,13 +442,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             RemoveParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(RemoveParticipantSucceeded), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.SuccessResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.IsNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(RemoveParticipantSucceeded), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.AreEqual(response.Value.OperationContext, returnedResult.SuccessResult.OperationContext);
         }
 
         [Test]
@@ -460,7 +461,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
             var callInvite = CreateMockInvite();
             var response = callConnection.RemoveParticipant(new RemoveParticipantOptions(callInvite.Target));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.RemoveParticipantFailed(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null, callInvite.Target));
@@ -468,13 +469,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             RemoveParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(RemoveParticipantFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.FailureResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(false, returnedResult.IsSuccess);
+            ClassicAssert.IsNull(returnedResult.SuccessResult);
+            ClassicAssert.NotNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(RemoveParticipantFailed), returnedResult.FailureResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            ClassicAssert.AreEqual(response.Value.OperationContext, returnedResult.FailureResult.OperationContext);
         }
 
         [Test]
@@ -489,7 +490,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             dtmfOption.OperationContext = OperationContext;
 
             var response = callConnection.GetCallMedia().SendDtmfTones(dtmfOption);
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.SendDtmfTonesCompleted(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation()));
@@ -497,13 +498,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendDtmfTonesEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(SendDtmfTonesCompleted), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.SuccessResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.IsNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(SendDtmfTonesCompleted), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.AreEqual(OperationContext, returnedResult.SuccessResult.OperationContext);
         }
 
         [Test]
@@ -518,7 +519,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             dtmfOption.OperationContext = OperationContext;
 
             var response = callConnection.GetCallMedia().SendDtmfTones(dtmfOption);
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(successCode, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.SendDtmfTonesFailed(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation()));
@@ -526,13 +527,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendDtmfTonesEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(SendDtmfTonesFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.FailureResult.OperationContext);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(false, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.FailureResult);
+            ClassicAssert.IsNull(returnedResult.SuccessResult);
+            ClassicAssert.AreEqual(typeof(SendDtmfTonesFailed), returnedResult.FailureResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            ClassicAssert.AreEqual(OperationContext, returnedResult.FailureResult.OperationContext);
         }
 
         [Test]
@@ -544,7 +545,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             var callInvite = CreateMockInvite();
             var response = callConnection.CancelAddParticipantOperation(invitationId);
 
-            Assert.AreEqual(202, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(202, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.CancelAddParticipantFailed(
@@ -558,13 +559,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CancelAddParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CancelAddParticipantFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(invitationId, returnedResult.FailureResult.InvitationId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(false, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.FailureResult);
+            ClassicAssert.IsNull(returnedResult.SuccessResult);
+            ClassicAssert.AreEqual(typeof(CancelAddParticipantFailed), returnedResult.FailureResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            ClassicAssert.AreEqual(invitationId, returnedResult.FailureResult.InvitationId);
         }
 
         [Test]
@@ -576,7 +577,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             var callInvite = CreateMockInvite();
             var response = callConnection.CancelAddParticipantOperation(invitationId);
 
-            Assert.AreEqual(202, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(202, response.GetRawResponse().Status);
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.CancelAddParticipantSucceeded(
@@ -589,13 +590,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CancelAddParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(CancelAddParticipantSucceeded), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(invitationId, returnedResult.SuccessResult.InvitationId);
+            ClassicAssert.NotNull(returnedResult);
+            ClassicAssert.AreEqual(true, returnedResult.IsSuccess);
+            ClassicAssert.NotNull(returnedResult.SuccessResult);
+            ClassicAssert.IsNull(returnedResult.FailureResult);
+            ClassicAssert.AreEqual(typeof(CancelAddParticipantSucceeded), returnedResult.SuccessResult.GetType());
+            ClassicAssert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            ClassicAssert.AreEqual(invitationId, returnedResult.SuccessResult.InvitationId);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Events/CallAutomationEventParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Events/CallAutomationEventParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,6 +9,7 @@ using System.Text.Json;
 using Azure.Messaging;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.Events
 {
@@ -30,10 +31,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase callConnected = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.CallConnected");
 
             // assert
-            Assert.AreEqual(callConnected.GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId, callConnected.CallConnectionId);
-            Assert.AreEqual(serverCallId, callConnected.ServerCallId);
-            Assert.AreEqual(correlationId, callConnected.CorrelationId);
+            ClassicAssert.AreEqual(callConnected.GetType(), typeof(CallConnected));
+            ClassicAssert.AreEqual(callConnectionId, callConnected.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, callConnected.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, callConnected.CorrelationId);
         }
 
         [Test]
@@ -57,10 +58,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase callConnected = CallAutomationEventParser.Parse(cloudEvent);
 
             // assert
-            Assert.AreEqual(callConnected.GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId, callConnected.CallConnectionId);
-            Assert.AreEqual(serverCallId, callConnected.ServerCallId);
-            Assert.AreEqual(correlationId, callConnected.CorrelationId);
+            ClassicAssert.AreEqual(callConnected.GetType(), typeof(CallConnected));
+            ClassicAssert.AreEqual(callConnectionId, callConnected.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, callConnected.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, callConnected.CorrelationId);
         }
 
         [Test]
@@ -84,10 +85,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase callConnected = CallAutomationEventParser.Parse(new BinaryData(cloudEvent));
 
             // assert
-            Assert.AreEqual(callConnected.GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId, callConnected.CallConnectionId);
-            Assert.AreEqual(serverCallId, callConnected.ServerCallId);
-            Assert.AreEqual(correlationId, callConnected.CorrelationId);
+            ClassicAssert.AreEqual(callConnected.GetType(), typeof(CallConnected));
+            ClassicAssert.AreEqual(callConnectionId, callConnected.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, callConnected.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, callConnected.CorrelationId);
         }
 
         [Test]
@@ -122,15 +123,15 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase[] callAutomationEvents = CallAutomationEventParser.ParseMany(cloudEvents);
 
             // assert
-            Assert.AreEqual(2, callAutomationEvents.Length);
-            Assert.AreEqual(callAutomationEvents[0].GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId1, callAutomationEvents[0].CallConnectionId);
-            Assert.AreEqual(serverCallId1, callAutomationEvents[0].ServerCallId);
-            Assert.AreEqual(correlationId1, callAutomationEvents[0].CorrelationId);
-            Assert.AreEqual(callAutomationEvents[1].GetType(), typeof(CallDisconnected));
-            Assert.AreEqual(callConnectionId2, callAutomationEvents[1].CallConnectionId);
-            Assert.AreEqual(serverCallId2, callAutomationEvents[1].ServerCallId);
-            Assert.AreEqual(correlationId2, callAutomationEvents[1].CorrelationId);
+            ClassicAssert.AreEqual(2, callAutomationEvents.Length);
+            ClassicAssert.AreEqual(callAutomationEvents[0].GetType(), typeof(CallConnected));
+            ClassicAssert.AreEqual(callConnectionId1, callAutomationEvents[0].CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId1, callAutomationEvents[0].ServerCallId);
+            ClassicAssert.AreEqual(correlationId1, callAutomationEvents[0].CorrelationId);
+            ClassicAssert.AreEqual(callAutomationEvents[1].GetType(), typeof(CallDisconnected));
+            ClassicAssert.AreEqual(callConnectionId2, callAutomationEvents[1].CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId2, callAutomationEvents[1].ServerCallId);
+            ClassicAssert.AreEqual(correlationId2, callAutomationEvents[1].CorrelationId);
         }
 
         [Test]
@@ -165,15 +166,15 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase[] callAutomationEvents = CallAutomationEventParser.ParseMany(new BinaryData(cloudEvents));
 
             // assert
-            Assert.AreEqual(2, callAutomationEvents.Length);
-            Assert.AreEqual(callAutomationEvents[0].GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId1, callAutomationEvents[0].CallConnectionId);
-            Assert.AreEqual(serverCallId1, callAutomationEvents[0].ServerCallId);
-            Assert.AreEqual(correlationId1, callAutomationEvents[0].CorrelationId);
-            Assert.AreEqual(callAutomationEvents[1].GetType(), typeof(CallDisconnected));
-            Assert.AreEqual(callConnectionId2, callAutomationEvents[1].CallConnectionId);
-            Assert.AreEqual(serverCallId2, callAutomationEvents[1].ServerCallId);
-            Assert.AreEqual(correlationId2, callAutomationEvents[1].CorrelationId);
+            ClassicAssert.AreEqual(2, callAutomationEvents.Length);
+            ClassicAssert.AreEqual(callAutomationEvents[0].GetType(), typeof(CallConnected));
+            ClassicAssert.AreEqual(callConnectionId1, callAutomationEvents[0].CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId1, callAutomationEvents[0].ServerCallId);
+            ClassicAssert.AreEqual(correlationId1, callAutomationEvents[0].CorrelationId);
+            ClassicAssert.AreEqual(callAutomationEvents[1].GetType(), typeof(CallDisconnected));
+            ClassicAssert.AreEqual(callConnectionId2, callAutomationEvents[1].CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId2, callAutomationEvents[1].ServerCallId);
+            ClassicAssert.AreEqual(correlationId2, callAutomationEvents[1].CorrelationId);
         }
 
         [Test]
@@ -195,12 +196,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is AddParticipantFailed addParticipantsFailed)
             {
-                Assert.AreEqual(callConnectionId, addParticipantsFailed.CallConnectionId);
-                Assert.AreEqual(serverCallId, addParticipantsFailed.ServerCallId);
-                Assert.AreEqual(correlationId, addParticipantsFailed.CorrelationId);
-                Assert.AreEqual(operationContext, addParticipantsFailed.OperationContext);
-                Assert.AreEqual(403, addParticipantsFailed.ResultInformation?.Code);
-                Assert.AreEqual("8:acs:12345", addParticipantsFailed.Participant.RawId);
+                ClassicAssert.AreEqual(callConnectionId, addParticipantsFailed.CallConnectionId);
+                ClassicAssert.AreEqual(serverCallId, addParticipantsFailed.ServerCallId);
+                ClassicAssert.AreEqual(correlationId, addParticipantsFailed.CorrelationId);
+                ClassicAssert.AreEqual(operationContext, addParticipantsFailed.OperationContext);
+                ClassicAssert.AreEqual(403, addParticipantsFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual("8:acs:12345", addParticipantsFailed.Participant.RawId);
             }
             else
             {
@@ -227,12 +228,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is AddParticipantSucceeded addParticipantsSucceeded)
             {
-                Assert.AreEqual(callConnectionId, addParticipantsSucceeded.CallConnectionId);
-                Assert.AreEqual(serverCallId, addParticipantsSucceeded.ServerCallId);
-                Assert.AreEqual(correlationId, addParticipantsSucceeded.CorrelationId);
-                Assert.AreEqual(operationContext, addParticipantsSucceeded.OperationContext);
-                Assert.AreEqual(200, addParticipantsSucceeded.ResultInformation?.Code);
-                Assert.AreEqual("8:acs:12345", addParticipantsSucceeded.Participant.RawId);
+                ClassicAssert.AreEqual(callConnectionId, addParticipantsSucceeded.CallConnectionId);
+                ClassicAssert.AreEqual(serverCallId, addParticipantsSucceeded.ServerCallId);
+                ClassicAssert.AreEqual(correlationId, addParticipantsSucceeded.CorrelationId);
+                ClassicAssert.AreEqual(operationContext, addParticipantsSucceeded.OperationContext);
+                ClassicAssert.AreEqual(200, addParticipantsSucceeded.ResultInformation?.Code);
+                ClassicAssert.AreEqual("8:acs:12345", addParticipantsSucceeded.Participant.RawId);
             }
             else
             {
@@ -257,11 +258,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is CallConnected calConnected)
             {
-                Assert.AreEqual(callConnectionId, calConnected.CallConnectionId);
-                Assert.AreEqual(serverCallId, calConnected.ServerCallId);
-                Assert.AreEqual(correlationId, calConnected.CorrelationId);
-                Assert.IsNull(calConnected.OperationContext);
-                Assert.IsNull(calConnected.ResultInformation);
+                ClassicAssert.AreEqual(callConnectionId, calConnected.CallConnectionId);
+                ClassicAssert.AreEqual(serverCallId, calConnected.ServerCallId);
+                ClassicAssert.AreEqual(correlationId, calConnected.CorrelationId);
+                ClassicAssert.IsNull(calConnected.OperationContext);
+                ClassicAssert.IsNull(calConnected.ResultInformation);
             }
             else
             {
@@ -286,11 +287,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
         //    // assert
         //    if (parsedEvent is ConnectFailed connectFailed)
         //    {
-        //        Assert.AreEqual(callConnectionId, connectFailed.CallConnectionId);
-        //        Assert.AreEqual(serverCallId, connectFailed.ServerCallId);
-        //        Assert.AreEqual(correlationId, connectFailed.CorrelationId);
-        //        Assert.IsNull(connectFailed.OperationContext);
-        //        Assert.IsNull(connectFailed.ResultInformation);
+        //        ClassicAssert.AreEqual(callConnectionId, connectFailed.CallConnectionId);
+        //        ClassicAssert.AreEqual(serverCallId, connectFailed.ServerCallId);
+        //        ClassicAssert.AreEqual(correlationId, connectFailed.CorrelationId);
+        //        ClassicAssert.IsNull(connectFailed.OperationContext);
+        //        ClassicAssert.IsNull(connectFailed.ResultInformation);
         //    }
         //    else
         //    {
@@ -315,11 +316,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is CallDisconnected callDisconnected)
             {
-                Assert.AreEqual(callConnectionId, callDisconnected.CallConnectionId);
-                Assert.AreEqual(serverCallId, callDisconnected.ServerCallId);
-                Assert.AreEqual(correlationId, callDisconnected.CorrelationId);
-                Assert.IsNull(callDisconnected.OperationContext);
-                Assert.IsNull(callDisconnected.ResultInformation);
+                ClassicAssert.AreEqual(callConnectionId, callDisconnected.CallConnectionId);
+                ClassicAssert.AreEqual(serverCallId, callDisconnected.ServerCallId);
+                ClassicAssert.AreEqual(correlationId, callDisconnected.CorrelationId);
+                ClassicAssert.IsNull(callDisconnected.OperationContext);
+                ClassicAssert.IsNull(callDisconnected.ResultInformation);
             }
             else
             {
@@ -345,11 +346,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is CallTransferAccepted callTransferAccepted)
             {
-                Assert.AreEqual(callConnectionId, callTransferAccepted.CallConnectionId);
-                Assert.AreEqual(serverCallId, callTransferAccepted.ServerCallId);
-                Assert.AreEqual(correlationId, callTransferAccepted.CorrelationId);
-                Assert.AreEqual(operationContext, callTransferAccepted.OperationContext);
-                Assert.AreEqual(202, callTransferAccepted.ResultInformation?.Code);
+                ClassicAssert.AreEqual(callConnectionId, callTransferAccepted.CallConnectionId);
+                ClassicAssert.AreEqual(serverCallId, callTransferAccepted.ServerCallId);
+                ClassicAssert.AreEqual(correlationId, callTransferAccepted.CorrelationId);
+                ClassicAssert.AreEqual(operationContext, callTransferAccepted.OperationContext);
+                ClassicAssert.AreEqual(202, callTransferAccepted.ResultInformation?.Code);
             }
             else
             {
@@ -375,11 +376,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is CallTransferFailed callTransferFailed)
             {
-                Assert.AreEqual(callConnectionId, callTransferFailed.CallConnectionId);
-                Assert.AreEqual(serverCallId, callTransferFailed.ServerCallId);
-                Assert.AreEqual(correlationId, callTransferFailed.CorrelationId);
-                Assert.AreEqual(operationContext, callTransferFailed.OperationContext);
-                Assert.AreEqual(403, callTransferFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual(callConnectionId, callTransferFailed.CallConnectionId);
+                ClassicAssert.AreEqual(serverCallId, callTransferFailed.ServerCallId);
+                ClassicAssert.AreEqual(correlationId, callTransferFailed.CorrelationId);
+                ClassicAssert.AreEqual(operationContext, callTransferFailed.OperationContext);
+                ClassicAssert.AreEqual(403, callTransferFailed.ResultInformation?.Code);
             }
             else
             {
@@ -407,18 +408,18 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is ParticipantsUpdated participantsUpdated)
             {
-                Assert.AreEqual(callConnectionId, participantsUpdated.CallConnectionId);
-                Assert.AreEqual(serverCallId, participantsUpdated.ServerCallId);
-                Assert.AreEqual(correlationId, participantsUpdated.CorrelationId);
-                Assert.IsNull(participantsUpdated.OperationContext);
-                Assert.IsNull(participantsUpdated.ResultInformation);
-                Assert.AreEqual(2, participantsUpdated.Participants.Count);
-                Assert.AreEqual("8:acs:12345", participantsUpdated.Participants[0].Identifier.RawId);
-                Assert.IsFalse(participantsUpdated.Participants[0].IsMuted);
-                Assert.IsFalse(participantsUpdated.Participants[0].IsOnHold);
-                Assert.IsTrue(participantsUpdated.Participants[1].Identifier.RawId.EndsWith("123456789"));
-                Assert.IsFalse(participantsUpdated.Participants[1].IsMuted);
-                Assert.IsTrue(participantsUpdated.Participants[1].IsOnHold);
+                ClassicAssert.AreEqual(callConnectionId, participantsUpdated.CallConnectionId);
+                ClassicAssert.AreEqual(serverCallId, participantsUpdated.ServerCallId);
+                ClassicAssert.AreEqual(correlationId, participantsUpdated.CorrelationId);
+                ClassicAssert.IsNull(participantsUpdated.OperationContext);
+                ClassicAssert.IsNull(participantsUpdated.ResultInformation);
+                ClassicAssert.AreEqual(2, participantsUpdated.Participants.Count);
+                ClassicAssert.AreEqual("8:acs:12345", participantsUpdated.Participants[0].Identifier.RawId);
+                ClassicAssert.IsFalse(participantsUpdated.Participants[0].IsMuted);
+                ClassicAssert.IsFalse(participantsUpdated.Participants[0].IsOnHold);
+                ClassicAssert.IsTrue(participantsUpdated.Participants[1].Identifier.RawId.EndsWith("123456789"));
+                ClassicAssert.IsFalse(participantsUpdated.Participants[1].IsMuted);
+                ClassicAssert.IsTrue(participantsUpdated.Participants[1].IsOnHold);
             }
             else
             {
@@ -441,9 +442,9 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.RecordingStateChanged");
             if (parsedEvent is RecordingStateChanged recordingEvent)
             {
-                Assert.AreEqual("recordingId", recordingEvent.RecordingId);
-                Assert.AreEqual("serverCallId", recordingEvent.ServerCallId);
-                Assert.AreEqual(RecordingState.Active, recordingEvent.State);
+                ClassicAssert.AreEqual("recordingId", recordingEvent.RecordingId);
+                ClassicAssert.AreEqual("serverCallId", recordingEvent.ServerCallId);
+                ClassicAssert.AreEqual(RecordingState.Active, recordingEvent.State);
             }
             else
             {
@@ -465,10 +466,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.PlayCompleted");
             if (parsedEvent is PlayCompleted playCompleted)
             {
-                Assert.AreEqual("correlationId", playCompleted.CorrelationId);
-                Assert.AreEqual("serverCallId", playCompleted.ServerCallId);
-                Assert.AreEqual(200, playCompleted.ResultInformation?.Code);
-                Assert.AreEqual(MediaEventReasonCode.CompletedSuccessfully, playCompleted.ReasonCode);
+                ClassicAssert.AreEqual("correlationId", playCompleted.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", playCompleted.ServerCallId);
+                ClassicAssert.AreEqual(200, playCompleted.ResultInformation?.Code);
+                ClassicAssert.AreEqual(MediaEventReasonCode.CompletedSuccessfully, playCompleted.ReasonCode);
             }
             else
             {
@@ -490,11 +491,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.PlayFailed");
             if (parsedEvent is PlayFailed playFailed)
             {
-                Assert.AreEqual("correlationId", playFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", playFailed.ServerCallId);
-                Assert.AreEqual(400, playFailed.ResultInformation?.Code);
-                //Assert.AreEqual(MediaEventReasonCode.PlayDownloadFailed, playFailed.ResultInformation);
-                Assert.AreEqual(8536, playFailed.ResultInformation?.SubCode);
+                ClassicAssert.AreEqual("correlationId", playFailed.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", playFailed.ServerCallId);
+                ClassicAssert.AreEqual(400, playFailed.ResultInformation?.Code);
+                //ClassicAssert.AreEqual(MediaEventReasonCode.PlayDownloadFailed, playFailed.ResultInformation);
+                ClassicAssert.AreEqual(8536, playFailed.ResultInformation?.SubCode);
             }
             else
             {
@@ -516,9 +517,9 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.PlayStarted");
             if (parsedEvent is PlayStarted playStarted)
             {
-                Assert.AreEqual("correlationId", playStarted.CorrelationId);
-                Assert.AreEqual("serverCallId", playStarted.ServerCallId);
-                Assert.AreEqual(200, playStarted.ResultInformation?.Code);
+                ClassicAssert.AreEqual("correlationId", playStarted.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", playStarted.ServerCallId);
+                ClassicAssert.AreEqual(200, playStarted.ResultInformation?.Code);
             }
             else
             {
@@ -539,8 +540,8 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.PlayCanceled");
             if (parsedEvent is PlayCanceled playCancelled)
             {
-                Assert.AreEqual("correlationId", playCancelled.CorrelationId);
-                Assert.AreEqual("serverCallId", playCancelled.ServerCallId);
+                ClassicAssert.AreEqual("correlationId", playCancelled.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", playCancelled.ServerCallId);
             }
             else
             {
@@ -569,16 +570,16 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             if (parsedEvent is RecognizeCompleted recognizeCompleted)
             {
                 var recognizeResult = recognizeCompleted.RecognizeResult;
-                Assert.AreEqual(recognizeResult is DtmfResult, true);
-                Assert.AreEqual("correlationId", recognizeCompleted.CorrelationId);
-                Assert.AreEqual("serverCallId", recognizeCompleted.ServerCallId);
-                Assert.AreEqual(200, recognizeCompleted.ResultInformation?.Code);
+                ClassicAssert.AreEqual(recognizeResult is DtmfResult, true);
+                ClassicAssert.AreEqual("correlationId", recognizeCompleted.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", recognizeCompleted.ServerCallId);
+                ClassicAssert.AreEqual(200, recognizeCompleted.ResultInformation?.Code);
                 if (recognizeResult is DtmfResult dtmfResultReturned)
                 {
                     string toneResults = dtmfResultReturned.ConvertToString();
-                    Assert.NotZero(dtmfResultReturned.Tones.Count());
-                    Assert.AreEqual(DtmfTone.Five, dtmfResultReturned.Tones.First());
-                    Assert.AreEqual(toneResults, "56#");
+                    ClassicAssert.NotZero(dtmfResultReturned.Tones.Count());
+                    ClassicAssert.AreEqual(DtmfTone.Five, dtmfResultReturned.Tones.First());
+                    ClassicAssert.AreEqual(toneResults, "56#");
                 }
             }
             else
@@ -608,14 +609,14 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             if (parsedEvent is RecognizeCompleted recognizeCompleted)
             {
                 var recognizeResult = recognizeCompleted.RecognizeResult;
-                Assert.AreEqual(recognizeResult is DtmfResult, true);
-                Assert.AreEqual("correlationId", recognizeCompleted.CorrelationId);
-                Assert.AreEqual("serverCallId", recognizeCompleted.ServerCallId);
-                Assert.AreEqual(200, recognizeCompleted.ResultInformation?.Code);
+                ClassicAssert.AreEqual(recognizeResult is DtmfResult, true);
+                ClassicAssert.AreEqual("correlationId", recognizeCompleted.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", recognizeCompleted.ServerCallId);
+                ClassicAssert.AreEqual(200, recognizeCompleted.ResultInformation?.Code);
                 if (recognizeResult is DtmfResult dtmfResultReturned)
                 {
-                    Assert.NotZero(dtmfResultReturned.Tones.Count());
-                    Assert.AreEqual(DtmfTone.Five, dtmfResultReturned.Tones.First());
+                    ClassicAssert.NotZero(dtmfResultReturned.Tones.Count());
+                    ClassicAssert.AreEqual(DtmfTone.Five, dtmfResultReturned.Tones.First());
                 }
             }
             else
@@ -638,10 +639,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.RecognizeFailed");
             if (parsedEvent is RecognizeFailed recognizeFailed)
             {
-                Assert.AreEqual("correlationId", recognizeFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", recognizeFailed.ServerCallId);
-                Assert.AreEqual(400, recognizeFailed.ResultInformation?.Code);
-                Assert.AreEqual(MediaEventReasonCode.RecognizeInitialSilenceTimedOut.ToString(), recognizeFailed.ResultInformation?.SubCode.ToString());
+                ClassicAssert.AreEqual("correlationId", recognizeFailed.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", recognizeFailed.ServerCallId);
+                ClassicAssert.AreEqual(400, recognizeFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual(MediaEventReasonCode.RecognizeInitialSilenceTimedOut.ToString(), recognizeFailed.ResultInformation?.SubCode.ToString());
             }
             else
             {
@@ -662,8 +663,8 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.RecognizeCanceled");
             if (parsedEvent is RecognizeCanceled recognizeCancelled)
             {
-                Assert.AreEqual("correlationId", recognizeCancelled.CorrelationId);
-                Assert.AreEqual("serverCallId", recognizeCancelled.ServerCallId);
+                ClassicAssert.AreEqual("correlationId", recognizeCancelled.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", recognizeCancelled.ServerCallId);
             }
             else
             {
@@ -687,12 +688,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
 
             if (parsedEvent is RemoveParticipantSucceeded addParticipantsSucceeded)
             {
-                Assert.AreEqual(callConnectionId, addParticipantsSucceeded.CallConnectionId);
-                Assert.AreEqual(serverCallId, addParticipantsSucceeded.ServerCallId);
-                Assert.AreEqual(correlationId, addParticipantsSucceeded.CorrelationId);
-                Assert.AreEqual(operationContext, addParticipantsSucceeded.OperationContext);
-                Assert.AreEqual(200, addParticipantsSucceeded.ResultInformation?.Code);
-                Assert.AreEqual("8:acs:12345", addParticipantsSucceeded.Participant.RawId);
+                ClassicAssert.AreEqual(callConnectionId, addParticipantsSucceeded.CallConnectionId);
+                ClassicAssert.AreEqual(serverCallId, addParticipantsSucceeded.ServerCallId);
+                ClassicAssert.AreEqual(correlationId, addParticipantsSucceeded.CorrelationId);
+                ClassicAssert.AreEqual(operationContext, addParticipantsSucceeded.OperationContext);
+                ClassicAssert.AreEqual(200, addParticipantsSucceeded.ResultInformation?.Code);
+                ClassicAssert.AreEqual("8:acs:12345", addParticipantsSucceeded.Participant.RawId);
             }
             else
             {
@@ -716,12 +717,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
 
             if (parsedEvent is RemoveParticipantFailed addParticipantsSucceeded)
             {
-                Assert.AreEqual(callConnectionId, addParticipantsSucceeded.CallConnectionId);
-                Assert.AreEqual(serverCallId, addParticipantsSucceeded.ServerCallId);
-                Assert.AreEqual(correlationId, addParticipantsSucceeded.CorrelationId);
-                Assert.AreEqual(operationContext, addParticipantsSucceeded.OperationContext);
-                Assert.AreEqual(200, addParticipantsSucceeded.ResultInformation?.Code);
-                Assert.AreEqual("8:acs:12345", addParticipantsSucceeded.Participant.RawId);
+                ClassicAssert.AreEqual(callConnectionId, addParticipantsSucceeded.CallConnectionId);
+                ClassicAssert.AreEqual(serverCallId, addParticipantsSucceeded.ServerCallId);
+                ClassicAssert.AreEqual(correlationId, addParticipantsSucceeded.CorrelationId);
+                ClassicAssert.AreEqual(operationContext, addParticipantsSucceeded.OperationContext);
+                ClassicAssert.AreEqual(200, addParticipantsSucceeded.ResultInformation?.Code);
+                ClassicAssert.AreEqual("8:acs:12345", addParticipantsSucceeded.Participant.RawId);
             }
             else
             {
@@ -745,13 +746,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.ContinuousDtmfRecognitionToneReceived");
             if (parsedEvent is ContinuousDtmfRecognitionToneReceived continuousDtmfRecognitionToneReceived)
             {
-                Assert.AreEqual(DtmfTone.A, continuousDtmfRecognitionToneReceived.Tone);
-                Assert.AreEqual(1, continuousDtmfRecognitionToneReceived.SequenceId);
-                Assert.AreEqual("callConnectionId", continuousDtmfRecognitionToneReceived.CallConnectionId);
-                Assert.AreEqual("correlationId", continuousDtmfRecognitionToneReceived.CorrelationId);
-                Assert.AreEqual("serverCallId", continuousDtmfRecognitionToneReceived.ServerCallId);
-                Assert.AreEqual("operationContext", continuousDtmfRecognitionToneReceived.OperationContext);
-                Assert.AreEqual(200, continuousDtmfRecognitionToneReceived.ResultInformation?.Code);
+                ClassicAssert.AreEqual(DtmfTone.A, continuousDtmfRecognitionToneReceived.Tone);
+                ClassicAssert.AreEqual(1, continuousDtmfRecognitionToneReceived.SequenceId);
+                ClassicAssert.AreEqual("callConnectionId", continuousDtmfRecognitionToneReceived.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", continuousDtmfRecognitionToneReceived.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", continuousDtmfRecognitionToneReceived.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", continuousDtmfRecognitionToneReceived.OperationContext);
+                ClassicAssert.AreEqual(200, continuousDtmfRecognitionToneReceived.ResultInformation?.Code);
             }
             else
             {
@@ -773,11 +774,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.ContinuousDtmfRecognitionToneFailed");
             if (parsedEvent is ContinuousDtmfRecognitionToneFailed continuousDtmfRecognitionToneFailed)
             {
-                Assert.AreEqual("callConnectionId", continuousDtmfRecognitionToneFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", continuousDtmfRecognitionToneFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", continuousDtmfRecognitionToneFailed.ServerCallId);
-                Assert.AreEqual("operationContext", continuousDtmfRecognitionToneFailed.OperationContext);
-                Assert.AreEqual(400, continuousDtmfRecognitionToneFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual("callConnectionId", continuousDtmfRecognitionToneFailed.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", continuousDtmfRecognitionToneFailed.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", continuousDtmfRecognitionToneFailed.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", continuousDtmfRecognitionToneFailed.OperationContext);
+                ClassicAssert.AreEqual(400, continuousDtmfRecognitionToneFailed.ResultInformation?.Code);
             }
             else
             {
@@ -799,11 +800,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.ContinuousDtmfRecognitionStopped");
             if (parsedEvent is ContinuousDtmfRecognitionStopped continuousDtmfRecognitionStopped)
             {
-                Assert.AreEqual("callConnectionId", continuousDtmfRecognitionStopped.CallConnectionId);
-                Assert.AreEqual("correlationId", continuousDtmfRecognitionStopped.CorrelationId);
-                Assert.AreEqual("serverCallId", continuousDtmfRecognitionStopped.ServerCallId);
-                Assert.AreEqual("operationContext", continuousDtmfRecognitionStopped.OperationContext);
-                Assert.AreEqual(200, continuousDtmfRecognitionStopped.ResultInformation?.Code);
+                ClassicAssert.AreEqual("callConnectionId", continuousDtmfRecognitionStopped.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", continuousDtmfRecognitionStopped.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", continuousDtmfRecognitionStopped.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", continuousDtmfRecognitionStopped.OperationContext);
+                ClassicAssert.AreEqual(200, continuousDtmfRecognitionStopped.ResultInformation?.Code);
             }
             else
             {
@@ -825,11 +826,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.SendDtmfTonesCompleted");
             if (parsedEvent is SendDtmfTonesCompleted SendDtmfCompleted)
             {
-                Assert.AreEqual("callConnectionId", SendDtmfCompleted.CallConnectionId);
-                Assert.AreEqual("operationContext", SendDtmfCompleted.OperationContext);
-                Assert.AreEqual("correlationId", SendDtmfCompleted.CorrelationId);
-                Assert.AreEqual("serverCallId", SendDtmfCompleted.ServerCallId);
-                Assert.AreEqual(200, SendDtmfCompleted.ResultInformation?.Code);
+                ClassicAssert.AreEqual("callConnectionId", SendDtmfCompleted.CallConnectionId);
+                ClassicAssert.AreEqual("operationContext", SendDtmfCompleted.OperationContext);
+                ClassicAssert.AreEqual("correlationId", SendDtmfCompleted.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", SendDtmfCompleted.ServerCallId);
+                ClassicAssert.AreEqual(200, SendDtmfCompleted.ResultInformation?.Code);
             }
             else
             {
@@ -851,11 +852,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.SendDtmfTonesFailed");
             if (parsedEvent is SendDtmfTonesFailed sendDtmfFailed)
             {
-                Assert.AreEqual("operationContext", sendDtmfFailed.OperationContext);
-                Assert.AreEqual("callConnectionId", sendDtmfFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", sendDtmfFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", sendDtmfFailed.ServerCallId);
-                Assert.AreEqual(400, sendDtmfFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual("operationContext", sendDtmfFailed.OperationContext);
+                ClassicAssert.AreEqual("callConnectionId", sendDtmfFailed.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", sendDtmfFailed.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", sendDtmfFailed.ServerCallId);
+                ClassicAssert.AreEqual(400, sendDtmfFailed.ResultInformation?.Code);
             }
             else
             {
@@ -878,11 +879,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
 
             if (parsedEvent is CancelAddParticipantSucceeded CancelAddParticipantSucceeded)
             {
-                Assert.AreEqual("operationContext", CancelAddParticipantSucceeded.OperationContext);
-                Assert.AreEqual("callConnectionId", CancelAddParticipantSucceeded.CallConnectionId);
-                Assert.AreEqual("correlationId", CancelAddParticipantSucceeded.CorrelationId);
-                Assert.AreEqual("serverCallId", CancelAddParticipantSucceeded.ServerCallId);
-                Assert.AreEqual("invitationId", CancelAddParticipantSucceeded.InvitationId);
+                ClassicAssert.AreEqual("operationContext", CancelAddParticipantSucceeded.OperationContext);
+                ClassicAssert.AreEqual("callConnectionId", CancelAddParticipantSucceeded.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", CancelAddParticipantSucceeded.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", CancelAddParticipantSucceeded.ServerCallId);
+                ClassicAssert.AreEqual("invitationId", CancelAddParticipantSucceeded.InvitationId);
             }
             else
             {
@@ -906,12 +907,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
 
             if (parsedEvent is CancelAddParticipantFailed cancelAddParticipantFailed)
             {
-                Assert.AreEqual("operationContext", cancelAddParticipantFailed.OperationContext);
-                Assert.AreEqual("callConnectionId", cancelAddParticipantFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", cancelAddParticipantFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", cancelAddParticipantFailed.ServerCallId);
-                Assert.AreEqual("invitationId", cancelAddParticipantFailed.InvitationId);
-                Assert.AreEqual(400, cancelAddParticipantFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual("operationContext", cancelAddParticipantFailed.OperationContext);
+                ClassicAssert.AreEqual("callConnectionId", cancelAddParticipantFailed.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", cancelAddParticipantFailed.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", cancelAddParticipantFailed.ServerCallId);
+                ClassicAssert.AreEqual("invitationId", cancelAddParticipantFailed.InvitationId);
+                ClassicAssert.AreEqual(400, cancelAddParticipantFailed.ResultInformation?.Code);
             }
             else
             {
@@ -933,11 +934,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.CreateCallFailed");
             if (parsedEvent is CreateCallFailed createCallFailed)
             {
-                Assert.AreEqual("operationContext", createCallFailed.OperationContext);
-                Assert.AreEqual("callConnectionId", createCallFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", createCallFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", createCallFailed.ServerCallId);
-                Assert.AreEqual(400, createCallFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual("operationContext", createCallFailed.OperationContext);
+                ClassicAssert.AreEqual("callConnectionId", createCallFailed.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", createCallFailed.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", createCallFailed.ServerCallId);
+                ClassicAssert.AreEqual(400, createCallFailed.ResultInformation?.Code);
             }
             else
             {
@@ -960,13 +961,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.TranscriptionStarted");
             if (parsedEvent is TranscriptionStarted transcriptionStarted)
             {
-                Assert.AreEqual("callConnectionId", transcriptionStarted.CallConnectionId);
-                Assert.AreEqual("correlationId", transcriptionStarted.CorrelationId);
-                Assert.AreEqual("serverCallId", transcriptionStarted.ServerCallId);
-                Assert.AreEqual("operationContext", transcriptionStarted.OperationContext);
-                Assert.AreEqual(200, transcriptionStarted.ResultInformation?.Code);
-                Assert.AreEqual(TranscriptionStatus.TranscriptionStarted, transcriptionStarted.TranscriptionUpdate.TranscriptionStatus);
-                Assert.AreEqual(TranscriptionStatusDetails.SubscriptionStarted, transcriptionStarted.TranscriptionUpdate.TranscriptionStatusDetails);
+                ClassicAssert.AreEqual("callConnectionId", transcriptionStarted.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", transcriptionStarted.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", transcriptionStarted.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", transcriptionStarted.OperationContext);
+                ClassicAssert.AreEqual(200, transcriptionStarted.ResultInformation?.Code);
+                ClassicAssert.AreEqual(TranscriptionStatus.TranscriptionStarted, transcriptionStarted.TranscriptionUpdate.TranscriptionStatus);
+                ClassicAssert.AreEqual(TranscriptionStatusDetails.SubscriptionStarted, transcriptionStarted.TranscriptionUpdate.TranscriptionStatusDetails);
             }
             else
             {
@@ -989,13 +990,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.TranscriptionUpdated");
             if (parsedEvent is TranscriptionUpdated transcriptionUpdated)
             {
-                Assert.AreEqual("callConnectionId", transcriptionUpdated.CallConnectionId);
-                Assert.AreEqual("correlationId", transcriptionUpdated.CorrelationId);
-                Assert.AreEqual("serverCallId", transcriptionUpdated.ServerCallId);
-                Assert.AreEqual("operationContext", transcriptionUpdated.OperationContext);
-                Assert.AreEqual(200, transcriptionUpdated.ResultInformation?.Code);
-                Assert.AreEqual(TranscriptionStatus.TranscriptionUpdated, transcriptionUpdated.TranscriptionUpdate.TranscriptionStatus);
-                Assert.AreEqual(TranscriptionStatusDetails.StreamConnectionReestablished, transcriptionUpdated.TranscriptionUpdate.TranscriptionStatusDetails);
+                ClassicAssert.AreEqual("callConnectionId", transcriptionUpdated.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", transcriptionUpdated.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", transcriptionUpdated.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", transcriptionUpdated.OperationContext);
+                ClassicAssert.AreEqual(200, transcriptionUpdated.ResultInformation?.Code);
+                ClassicAssert.AreEqual(TranscriptionStatus.TranscriptionUpdated, transcriptionUpdated.TranscriptionUpdate.TranscriptionStatus);
+                ClassicAssert.AreEqual(TranscriptionStatusDetails.StreamConnectionReestablished, transcriptionUpdated.TranscriptionUpdate.TranscriptionStatusDetails);
             }
             else
             {
@@ -1018,13 +1019,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.TranscriptionStopped");
             if (parsedEvent is TranscriptionStopped transcriptionStopped)
             {
-                Assert.AreEqual("callConnectionId", transcriptionStopped.CallConnectionId);
-                Assert.AreEqual("correlationId", transcriptionStopped.CorrelationId);
-                Assert.AreEqual("serverCallId", transcriptionStopped.ServerCallId);
-                Assert.AreEqual("operationContext", transcriptionStopped.OperationContext);
-                Assert.AreEqual(200, transcriptionStopped.ResultInformation?.Code);
-                Assert.AreEqual(TranscriptionStatus.TranscriptionStopped, transcriptionStopped.TranscriptionUpdate.TranscriptionStatus);
-                Assert.AreEqual(TranscriptionStatusDetails.SubscriptionStopped, transcriptionStopped.TranscriptionUpdate.TranscriptionStatusDetails);
+                ClassicAssert.AreEqual("callConnectionId", transcriptionStopped.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", transcriptionStopped.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", transcriptionStopped.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", transcriptionStopped.OperationContext);
+                ClassicAssert.AreEqual(200, transcriptionStopped.ResultInformation?.Code);
+                ClassicAssert.AreEqual(TranscriptionStatus.TranscriptionStopped, transcriptionStopped.TranscriptionUpdate.TranscriptionStatus);
+                ClassicAssert.AreEqual(TranscriptionStatusDetails.SubscriptionStopped, transcriptionStopped.TranscriptionUpdate.TranscriptionStatusDetails);
             }
             else
             {
@@ -1047,13 +1048,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.TranscriptionFailed");
             if (parsedEvent is TranscriptionFailed transcriptionFailed)
             {
-                Assert.AreEqual("callConnectionId", transcriptionFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", transcriptionFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", transcriptionFailed.ServerCallId);
-                Assert.AreEqual("operationContext", transcriptionFailed.OperationContext);
-                Assert.AreEqual(200, transcriptionFailed.ResultInformation?.Code);
-                Assert.AreEqual(TranscriptionStatus.TranscriptionFailed, transcriptionFailed.TranscriptionUpdate.TranscriptionStatus);
-                Assert.AreEqual(TranscriptionStatusDetails.UnspecifiedError, transcriptionFailed.TranscriptionUpdate.TranscriptionStatusDetails);
+                ClassicAssert.AreEqual("callConnectionId", transcriptionFailed.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", transcriptionFailed.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", transcriptionFailed.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", transcriptionFailed.OperationContext);
+                ClassicAssert.AreEqual(200, transcriptionFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual(TranscriptionStatus.TranscriptionFailed, transcriptionFailed.TranscriptionUpdate.TranscriptionStatus);
+                ClassicAssert.AreEqual(TranscriptionStatusDetails.UnspecifiedError, transcriptionFailed.TranscriptionUpdate.TranscriptionStatusDetails);
             }
             else
             {
@@ -1075,11 +1076,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.HoldFailed");
             if (parsedEvent is HoldFailed holdFailed)
             {
-                Assert.AreEqual("correlationId", holdFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", holdFailed.ServerCallId);
-                Assert.AreEqual(400, holdFailed.ResultInformation?.Code);
-                Assert.AreEqual(MediaEventReasonCode.PlayDownloadFailed, holdFailed.ReasonCode);
-                Assert.AreEqual(8536, holdFailed.ReasonCode.GetReasonCodeValue());
+                ClassicAssert.AreEqual("correlationId", holdFailed.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", holdFailed.ServerCallId);
+                ClassicAssert.AreEqual(400, holdFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual(MediaEventReasonCode.PlayDownloadFailed, holdFailed.ReasonCode);
+                ClassicAssert.AreEqual(8536, holdFailed.ReasonCode.GetReasonCodeValue());
             }
             else
             {
@@ -1102,13 +1103,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.MediaStreamingStarted");
             if (parsedEvent is MediaStreamingStarted mediaStreamingStarted)
             {
-                Assert.AreEqual("callConnectionId", mediaStreamingStarted.CallConnectionId);
-                Assert.AreEqual("correlationId", mediaStreamingStarted.CorrelationId);
-                Assert.AreEqual("serverCallId", mediaStreamingStarted.ServerCallId);
-                Assert.AreEqual("operationContext", mediaStreamingStarted.OperationContext);
-                Assert.AreEqual(200, mediaStreamingStarted.ResultInformation?.Code);
-                Assert.AreEqual(MediaStreamingStatus.MediaStreamingStarted, mediaStreamingStarted.MediaStreamingUpdate.MediaStreamingStatus);
-                Assert.AreEqual(MediaStreamingStatusDetails.SubscriptionStarted, mediaStreamingStarted.MediaStreamingUpdate.MediaStreamingStatusDetails);
+                ClassicAssert.AreEqual("callConnectionId", mediaStreamingStarted.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", mediaStreamingStarted.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", mediaStreamingStarted.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", mediaStreamingStarted.OperationContext);
+                ClassicAssert.AreEqual(200, mediaStreamingStarted.ResultInformation?.Code);
+                ClassicAssert.AreEqual(MediaStreamingStatus.MediaStreamingStarted, mediaStreamingStarted.MediaStreamingUpdate.MediaStreamingStatus);
+                ClassicAssert.AreEqual(MediaStreamingStatusDetails.SubscriptionStarted, mediaStreamingStarted.MediaStreamingUpdate.MediaStreamingStatusDetails);
             }
             else
             {
@@ -1131,13 +1132,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.MediaStreamingStopped");
             if (parsedEvent is MediaStreamingStopped mediaStreamingStopped)
             {
-                Assert.AreEqual("callConnectionId", mediaStreamingStopped.CallConnectionId);
-                Assert.AreEqual("correlationId", mediaStreamingStopped.CorrelationId);
-                Assert.AreEqual("serverCallId", mediaStreamingStopped.ServerCallId);
-                Assert.AreEqual("operationContext", mediaStreamingStopped.OperationContext);
-                Assert.AreEqual(200, mediaStreamingStopped.ResultInformation?.Code);
-                Assert.AreEqual(MediaStreamingStatus.MediaStreamingStarted, mediaStreamingStopped.MediaStreamingUpdate.MediaStreamingStatus);
-                Assert.AreEqual(MediaStreamingStatusDetails.SubscriptionStarted, mediaStreamingStopped.MediaStreamingUpdate.MediaStreamingStatusDetails);
+                ClassicAssert.AreEqual("callConnectionId", mediaStreamingStopped.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", mediaStreamingStopped.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", mediaStreamingStopped.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", mediaStreamingStopped.OperationContext);
+                ClassicAssert.AreEqual(200, mediaStreamingStopped.ResultInformation?.Code);
+                ClassicAssert.AreEqual(MediaStreamingStatus.MediaStreamingStarted, mediaStreamingStopped.MediaStreamingUpdate.MediaStreamingStatus);
+                ClassicAssert.AreEqual(MediaStreamingStatusDetails.SubscriptionStarted, mediaStreamingStopped.MediaStreamingUpdate.MediaStreamingStatusDetails);
             }
             else
             {
@@ -1160,13 +1161,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.MediaStreamingFailed");
             if (parsedEvent is MediaStreamingFailed mediaStreamingFailed)
             {
-                Assert.AreEqual("callConnectionId", mediaStreamingFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", mediaStreamingFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", mediaStreamingFailed.ServerCallId);
-                Assert.AreEqual("operationContext", mediaStreamingFailed.OperationContext);
-                Assert.AreEqual(200, mediaStreamingFailed.ResultInformation?.Code);
-                Assert.AreEqual(MediaStreamingStatus.MediaStreamingStarted, mediaStreamingFailed.MediaStreamingUpdate.MediaStreamingStatus);
-                Assert.AreEqual(MediaStreamingStatusDetails.SubscriptionStarted, mediaStreamingFailed.MediaStreamingUpdate.MediaStreamingStatusDetails);
+                ClassicAssert.AreEqual("callConnectionId", mediaStreamingFailed.CallConnectionId);
+                ClassicAssert.AreEqual("correlationId", mediaStreamingFailed.CorrelationId);
+                ClassicAssert.AreEqual("serverCallId", mediaStreamingFailed.ServerCallId);
+                ClassicAssert.AreEqual("operationContext", mediaStreamingFailed.OperationContext);
+                ClassicAssert.AreEqual(200, mediaStreamingFailed.ResultInformation?.Code);
+                ClassicAssert.AreEqual(MediaStreamingStatus.MediaStreamingStarted, mediaStreamingFailed.MediaStreamingUpdate.MediaStreamingStatus);
+                ClassicAssert.AreEqual(MediaStreamingStatusDetails.SubscriptionStarted, mediaStreamingFailed.MediaStreamingUpdate.MediaStreamingStatusDetails);
             }
             else
             {

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationTestBase.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using Azure.Core;
 using Azure.Core.TestFramework;
 using Microsoft.Azure.Amqp.Framing;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.Infrastructure
 {
@@ -134,34 +135,34 @@ namespace Azure.Communication.CallAutomation.Tests.Infrastructure
 
         protected void verifyCallConnectionProperties(CallConnectionProperties callConnectionProperties, bool isConnectApi = false)
         {
-            Assert.AreEqual(CallConnectionId, callConnectionProperties.CallConnectionId);
-            Assert.AreEqual(ServerCallId, callConnectionProperties.ServerCallId);
+            ClassicAssert.AreEqual(CallConnectionId, callConnectionProperties.CallConnectionId);
+            ClassicAssert.AreEqual(ServerCallId, callConnectionProperties.ServerCallId);
             if (!isConnectApi)
             {
                 var sourceUser = (CommunicationUserIdentifier)callConnectionProperties.Source;
-                Assert.AreEqual(SourceId, sourceUser.Id);
-                Assert.AreEqual(callConnectionProperties.Targets.Count, 1);
+                ClassicAssert.AreEqual(SourceId, sourceUser.Id);
+                ClassicAssert.AreEqual(callConnectionProperties.Targets.Count, 1);
                 var targetUser = (CommunicationUserIdentifier)callConnectionProperties.Targets[0];
-                Assert.AreEqual(TargetId, targetUser.Id);
-                Assert.AreEqual(DisplayName, callConnectionProperties.SourceDisplayName);
+                ClassicAssert.AreEqual(TargetId, targetUser.Id);
+                ClassicAssert.AreEqual(DisplayName, callConnectionProperties.SourceDisplayName);
             }
 
-            Assert.AreEqual(CallConnectionState.Connecting, callConnectionProperties.CallConnectionState);
-            Assert.AreEqual(CallBackUri, callConnectionProperties.CallbackUri.ToString());
+            ClassicAssert.AreEqual(CallConnectionState.Connecting, callConnectionProperties.CallConnectionState);
+            ClassicAssert.AreEqual(CallBackUri, callConnectionProperties.CallbackUri.ToString());
         }
 
         protected void verifyOPSCallConnectionProperties(CallConnectionProperties callConnectionProperties)
         {
-            Assert.AreEqual(CallConnectionId, callConnectionProperties.CallConnectionId);
-            Assert.AreEqual(ServerCallId, callConnectionProperties.ServerCallId);
+            ClassicAssert.AreEqual(CallConnectionId, callConnectionProperties.CallConnectionId);
+            ClassicAssert.AreEqual(ServerCallId, callConnectionProperties.ServerCallId);
             var teamsAppSourceUser = (MicrosoftTeamsAppIdentifier)callConnectionProperties.Source;
-            Assert.AreEqual(SourceId, teamsAppSourceUser.AppId);
-            Assert.AreEqual(callConnectionProperties.Targets.Count, 1);
+            ClassicAssert.AreEqual(SourceId, teamsAppSourceUser.AppId);
+            ClassicAssert.AreEqual(callConnectionProperties.Targets.Count, 1);
             var targetUser = (CommunicationUserIdentifier)callConnectionProperties.Targets[0];
-            Assert.AreEqual(TargetId, targetUser.Id);
-            Assert.AreEqual(CallConnectionState.Connecting, callConnectionProperties.CallConnectionState);
-            Assert.AreEqual(CallBackUri, callConnectionProperties.CallbackUri.ToString());
-            Assert.AreEqual(DisplayName, callConnectionProperties.SourceDisplayName);
+            ClassicAssert.AreEqual(TargetId, targetUser.Id);
+            ClassicAssert.AreEqual(CallConnectionState.Connecting, callConnectionProperties.CallConnectionState);
+            ClassicAssert.AreEqual(CallBackUri, callConnectionProperties.CallbackUri.ToString());
+            ClassicAssert.AreEqual(DisplayName, callConnectionProperties.SourceDisplayName);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Models/CallAutomationModelFactoryTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Models/CallAutomationModelFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Azure.Communication.CallAutomation.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.Models
 {
@@ -29,10 +30,10 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var audioData = CallAutomationModelFactory.AudioData(data, timestamp, participantId, silent);
 
-            Assert.AreEqual(data, Convert.ToBase64String(audioData.Data.ToArray()));
-            Assert.AreEqual(timestamp, audioData.Timestamp.DateTime);
-            Assert.AreEqual(participantId, audioData.Participant.RawId);
-            Assert.AreEqual(silent, audioData.IsSilent);
+            ClassicAssert.AreEqual(data, Convert.ToBase64String(audioData.Data.ToArray()));
+            ClassicAssert.AreEqual(timestamp, audioData.Timestamp.DateTime);
+            ClassicAssert.AreEqual(participantId, audioData.Participant.RawId);
+            ClassicAssert.AreEqual(silent, audioData.IsSilent);
         }
 
         [Test]
@@ -46,10 +47,10 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var audioMetadata = CallAutomationModelFactory.AudioMetadata(mediaSubscriptionId, encoding, sampleRate, channels, length);
 
-            Assert.AreEqual(mediaSubscriptionId, audioMetadata.MediaSubscriptionId);
-            Assert.AreEqual(encoding, audioMetadata.Encoding);
-            Assert.AreEqual(sampleRate, audioMetadata.SampleRate);
-            Assert.AreEqual(AudioChannel.Mono, audioMetadata.Channels);
+            ClassicAssert.AreEqual(mediaSubscriptionId, audioMetadata.MediaSubscriptionId);
+            ClassicAssert.AreEqual(encoding, audioMetadata.Encoding);
+            ClassicAssert.AreEqual(sampleRate, audioMetadata.SampleRate);
+            ClassicAssert.AreEqual(AudioChannel.Mono, audioMetadata.Channels);
         }
 
         [Test]
@@ -66,15 +67,15 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var transcriptionData = CallAutomationModelFactory.TranscriptionData(text, format, confidence, offset, duration, words, participantRawID, resultState);
 
-            Assert.AreEqual(text, transcriptionData.Text);
-            Assert.AreEqual(format, transcriptionData.Format);
-            Assert.AreEqual(confidence, transcriptionData.Confidence);
-            Assert.AreEqual(TimeSpan.FromTicks(offset), transcriptionData.Offset);
-            Assert.AreEqual(TimeSpan.FromTicks(duration), transcriptionData.Duration);
-            Assert.AreEqual(CommunicationIdentifier.FromRawId(participantRawID), transcriptionData.Participant);
-            Assert.AreEqual(resultState, transcriptionData.ResultState);
-            Assert.IsNotNull(transcriptionData.Words);
-            Assert.AreEqual(1, transcriptionData.Words.Count());
+            ClassicAssert.AreEqual(text, transcriptionData.Text);
+            ClassicAssert.AreEqual(format, transcriptionData.Format);
+            ClassicAssert.AreEqual(confidence, transcriptionData.Confidence);
+            ClassicAssert.AreEqual(TimeSpan.FromTicks(offset), transcriptionData.Offset);
+            ClassicAssert.AreEqual(TimeSpan.FromTicks(duration), transcriptionData.Duration);
+            ClassicAssert.AreEqual(CommunicationIdentifier.FromRawId(participantRawID), transcriptionData.Participant);
+            ClassicAssert.AreEqual(resultState, transcriptionData.ResultState);
+            ClassicAssert.IsNotNull(transcriptionData.Words);
+            ClassicAssert.AreEqual(1, transcriptionData.Words.Count());
         }
 
         [Test]
@@ -86,9 +87,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var wordData = CallAutomationModelFactory.WordData(text, offset, duration);
 
-            Assert.AreEqual(text, wordData.Text);
-            Assert.AreEqual(TimeSpan.FromTicks(offset), wordData.Offset);
-            Assert.AreEqual(TimeSpan.FromTicks(duration), wordData.Duration);
+            ClassicAssert.AreEqual(text, wordData.Text);
+            ClassicAssert.AreEqual(TimeSpan.FromTicks(offset), wordData.Offset);
+            ClassicAssert.AreEqual(TimeSpan.FromTicks(duration), wordData.Duration);
         }
 
         [Test]
@@ -98,7 +99,7 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var outStreamingData = CallAutomationModelFactory.OutStreamingData(kind);
 
-            Assert.AreEqual(kind, outStreamingData.Kind);
+            ClassicAssert.AreEqual(kind, outStreamingData.Kind);
         }
 
         [Test]
@@ -110,9 +111,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.AddParticipantsResult(participant, operationContext, invitationId);
 
-            Assert.AreEqual(participant, result.Participant);
-            Assert.AreEqual(operationContext, result.OperationContext);
-            Assert.AreEqual(invitationId, result.InvitationId);
+            ClassicAssert.AreEqual(participant, result.Participant);
+            ClassicAssert.AreEqual(operationContext, result.OperationContext);
+            ClassicAssert.AreEqual(invitationId, result.InvitationId);
         }
 
         [Test]
@@ -125,8 +126,8 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.AnswerCallResult(callConnection, callConnectionProperties);
 
-            Assert.AreEqual(callConnection, result.CallConnection);
-            Assert.AreEqual(callConnectionProperties, result.CallConnectionProperties);
+            ClassicAssert.AreEqual(callConnection, result.CallConnection);
+            ClassicAssert.AreEqual(callConnectionProperties, result.CallConnectionProperties);
         }
 
         [Test]
@@ -146,16 +147,16 @@ namespace Azure.Communication.CallAutomation.Tests.Models
                 callConnectionId, serverCallId, targets, callConnectionState, callbackUri,
                 sourceIdentity, sourceCallerIdNumber, sourceDisplayName, answeredBy);
 
-            Assert.AreEqual(callConnectionId, properties.CallConnectionId);
-            Assert.AreEqual(serverCallId, properties.ServerCallId);
-            Assert.AreNotSame(targets, properties.Targets);
-            Assert.AreEqual(targets, properties.Targets);
-            Assert.AreEqual(callConnectionState, properties.CallConnectionState);
-            Assert.AreEqual(callbackUri, properties.CallbackUri);
-            Assert.AreEqual(sourceIdentity, properties.Source);
-            Assert.AreEqual(sourceCallerIdNumber, properties.SourceCallerIdNumber);
-            Assert.AreEqual(sourceDisplayName, properties.SourceDisplayName);
-            Assert.AreEqual(answeredBy, properties.AnsweredBy);
+            ClassicAssert.AreEqual(callConnectionId, properties.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, properties.ServerCallId);
+            ClassicAssert.AreNotSame(targets, properties.Targets);
+            ClassicAssert.AreEqual(targets, properties.Targets);
+            ClassicAssert.AreEqual(callConnectionState, properties.CallConnectionState);
+            ClassicAssert.AreEqual(callbackUri, properties.CallbackUri);
+            ClassicAssert.AreEqual(sourceIdentity, properties.Source);
+            ClassicAssert.AreEqual(sourceCallerIdNumber, properties.SourceCallerIdNumber);
+            ClassicAssert.AreEqual(sourceDisplayName, properties.SourceDisplayName);
+            ClassicAssert.AreEqual(answeredBy, properties.AnsweredBy);
         }
 
         [Test]
@@ -167,9 +168,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var participant = CallAutomationModelFactory.CallParticipant(identifier, isMuted, isOnHold);
 
-            Assert.AreEqual(identifier, participant.Identifier);
-            Assert.AreEqual(isMuted, participant.IsMuted);
-            Assert.AreEqual(isOnHold, participant.IsOnHold);
+            ClassicAssert.AreEqual(identifier, participant.Identifier);
+            ClassicAssert.AreEqual(isMuted, participant.IsMuted);
+            ClassicAssert.AreEqual(isOnHold, participant.IsOnHold);
         }
 
         [Test]
@@ -182,8 +183,8 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.CreateCallResult(callConnection, callConnectionProperties);
 
-            Assert.AreEqual(callConnection, result.CallConnection);
-            Assert.AreEqual(callConnectionProperties, result.CallConnectionProperties);
+            ClassicAssert.AreEqual(callConnection, result.CallConnection);
+            ClassicAssert.AreEqual(callConnectionProperties, result.CallConnectionProperties);
         }
 
         [Test]
@@ -193,7 +194,7 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.RemoveParticipantResult(operationContext);
 
-            Assert.AreEqual(operationContext, result.OperationContext);
+            ClassicAssert.AreEqual(operationContext, result.OperationContext);
         }
 
         [Test]
@@ -204,8 +205,8 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.CancelAddParticipantResult(invitationId, operationContext);
 
-            Assert.AreEqual(invitationId, result.InvitationId);
-            Assert.AreEqual(operationContext, result.OperationContext);
+            ClassicAssert.AreEqual(invitationId, result.InvitationId);
+            ClassicAssert.AreEqual(operationContext, result.OperationContext);
         }
 
         [Test]
@@ -221,12 +222,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.AddParticipantFailed(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, participant);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(participant, eventResult.Participant);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(participant, eventResult.Participant);
         }
 
         [Test]
@@ -242,12 +243,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.AddParticipantSucceeded(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, participant);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(participant, eventResult.Participant);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(participant, eventResult.Participant);
         }
 
         [Test]
@@ -266,13 +267,13 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.ParticipantsUpdated(
                 callConnectionId, serverCallId, correlationId, participants, sequenceNumber, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(sequenceNumber, eventResult.SequenceNumber);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.IsNotNull(eventResult.Participants);
-            Assert.AreEqual(1, eventResult.Participants.Count());
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(sequenceNumber, eventResult.SequenceNumber);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.IsNotNull(eventResult.Participants);
+            ClassicAssert.AreEqual(1, eventResult.Participants.Count());
         }
 
         [Test]
@@ -288,12 +289,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.RecognizeCompleted(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, recognitionType);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(recognitionType, eventResult.RecognitionType);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(recognitionType, eventResult.RecognitionType);
         }
 
         [Test]
@@ -310,13 +311,13 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.CallTransferAccepted(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, transferee, transferTarget);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(transferee, eventResult.Transferee);
-            Assert.AreEqual(transferTarget, eventResult.TransferTarget);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(transferee, eventResult.Transferee);
+            ClassicAssert.AreEqual(transferTarget, eventResult.TransferTarget);
         }
 
         [Test]
@@ -331,11 +332,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.CallConnected(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
         }
 
         [Test]
@@ -350,11 +351,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.CallDisconnected(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
         }
 
         [Test]
@@ -369,11 +370,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.PlayCompleted(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
         }
 
         [Test]
@@ -389,12 +390,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.PlayFailed(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, failedPlaySourceIndex);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(failedPlaySourceIndex, eventResult.FailedPlaySourceIndex);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(failedPlaySourceIndex, eventResult.FailedPlaySourceIndex);
         }
 
         [Test]
@@ -411,13 +412,13 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.ContinuousDtmfRecognitionToneReceived(
                 sequenceId, tone, callConnectionId, serverCallId, correlationId, resultInformation, operationContext);
 
-            Assert.AreEqual(sequenceId, eventResult.SequenceId);
-            Assert.AreEqual(tone, eventResult.Tone);
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(sequenceId, eventResult.SequenceId);
+            ClassicAssert.AreEqual(tone, eventResult.Tone);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
         }
 
         [Test]
@@ -435,14 +436,14 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.RecordingStateChanged(
                 callConnectionId, serverCallId, correlationId, recordingId, state, startDateTime, recordingKind, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(recordingId, eventResult.RecordingId);
-            Assert.AreEqual(state, eventResult.State);
-            Assert.AreEqual(startDateTime, eventResult.StartDateTime);
-            Assert.AreEqual(recordingKind, eventResult.RecordingKind);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(recordingId, eventResult.RecordingId);
+            ClassicAssert.AreEqual(state, eventResult.State);
+            ClassicAssert.AreEqual(startDateTime, eventResult.StartDateTime);
+            ClassicAssert.AreEqual(recordingKind, eventResult.RecordingKind);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
         }
 
         [Test]
@@ -454,9 +455,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.RecordingStateResult(recordingId, recordingState, recordingKind);
 
-            Assert.AreEqual(recordingId, result.RecordingId);
-            Assert.AreEqual(recordingState, result.RecordingState);
-            Assert.AreEqual(recordingKind, result.RecordingKind);
+            ClassicAssert.AreEqual(recordingId, result.RecordingId);
+            ClassicAssert.AreEqual(recordingState, result.RecordingState);
+            ClassicAssert.AreEqual(recordingKind, result.RecordingKind);
         }
 
         [Test]
@@ -471,11 +472,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.SendDtmfTonesCompleted(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
         }
 
         [Test]
@@ -490,11 +491,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.CreateCallFailed(
                 callConnectionId, serverCallId, correlationId, resultInformation, operationContext);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
+            ClassicAssert.AreEqual(callConnectionId, eventResult.CallConnectionId);
+            ClassicAssert.AreEqual(serverCallId, eventResult.ServerCallId);
+            ClassicAssert.AreEqual(correlationId, eventResult.CorrelationId);
+            ClassicAssert.AreEqual(resultInformation, eventResult.ResultInformation);
+            ClassicAssert.AreEqual(operationContext, eventResult.OperationContext);
         }
 
         [Test]
@@ -504,8 +505,8 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var properties = CallAutomationModelFactory.CallConnectionProperties(
                 targets: null);
 
-            Assert.IsNotNull(properties.Targets);
-            Assert.AreEqual(0, properties.Targets.Count);
+            ClassicAssert.IsNotNull(properties.Targets);
+            ClassicAssert.AreEqual(0, properties.Targets.Count);
         }
 
         [Test]
@@ -514,9 +515,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             // Test that default parameter values work correctly
             var participant = CallAutomationModelFactory.CallParticipant();
 
-            Assert.IsNull(participant.Identifier);
-            Assert.IsFalse(participant.IsMuted);
-            Assert.IsFalse(participant.IsOnHold);
+            ClassicAssert.IsNull(participant.Identifier);
+            ClassicAssert.IsFalse(participant.IsMuted);
+            ClassicAssert.IsFalse(participant.IsOnHold);
         }
 
         [Test]
@@ -526,12 +527,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var originalTargets = new List<CommunicationIdentifier> { _testUser };
             var properties = CallAutomationModelFactory.CallConnectionProperties(targets: originalTargets);
 
-            Assert.AreNotSame(originalTargets, properties.Targets);
-            Assert.AreEqual(originalTargets, properties.Targets);
+            ClassicAssert.AreNotSame(originalTargets, properties.Targets);
+            ClassicAssert.AreEqual(originalTargets, properties.Targets);
 
             // Modifying original should not affect the created instance
             originalTargets.Add(_testPhoneNumber);
-            Assert.AreEqual(1, properties.Targets.Count);
+            ClassicAssert.AreEqual(1, properties.Targets.Count);
         }
 
         private CallConnection CreateMockCallConnection(int responseCode, string? responseContent = null, string callConnectionId = "9ec7da16-30be-4e74-a941-285cfc4bffc5")

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Streaming/StreamingDataParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Streaming/StreamingDataParserTests.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
 {
@@ -48,21 +49,21 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
 
         private static void ValidateAudioMetadata(AudioMetadata streamingAudioMetadata)
         {
-            Assert.IsNotNull(streamingAudioMetadata);
-            Assert.AreEqual("subscriptionId", streamingAudioMetadata.MediaSubscriptionId);
-            Assert.AreEqual("encodingType", streamingAudioMetadata.Encoding);
-            Assert.AreEqual(8, streamingAudioMetadata.SampleRate);
-            Assert.AreEqual(2, (int)streamingAudioMetadata.Channels);
+            ClassicAssert.IsNotNull(streamingAudioMetadata);
+            ClassicAssert.AreEqual("subscriptionId", streamingAudioMetadata.MediaSubscriptionId);
+            ClassicAssert.AreEqual("encodingType", streamingAudioMetadata.Encoding);
+            ClassicAssert.AreEqual(8, streamingAudioMetadata.SampleRate);
+            ClassicAssert.AreEqual(2, (int)streamingAudioMetadata.Channels);
         }
 
         private static void ValidateAudioData(AudioData streamingAudio)
         {
-            Assert.IsNotNull(streamingAudio);
+            ClassicAssert.IsNotNull(streamingAudio);
             CollectionAssert.AreEqual(Convert.FromBase64String("AQIDBAU="), streamingAudio.Data.ToArray());
-            Assert.AreEqual(2022, streamingAudio.Timestamp.Year);
-            Assert.IsTrue(streamingAudio.Participant is CommunicationIdentifier);
-            Assert.AreEqual("participantId", streamingAudio.Participant.RawId);
-            Assert.IsFalse(streamingAudio.IsSilent);
+            ClassicAssert.AreEqual(2022, streamingAudio.Timestamp.Year);
+            ClassicAssert.IsTrue(streamingAudio.Participant is CommunicationIdentifier);
+            ClassicAssert.AreEqual("participantId", streamingAudio.Participant.RawId);
+            ClassicAssert.IsFalse(streamingAudio.IsSilent);
         }
         #endregion
 
@@ -82,8 +83,8 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
         }
         private static void ValidateDtmfData(DtmfData streamingDtmf)
         {
-            Assert.IsNotNull(streamingDtmf);
-            Assert.AreEqual("5", streamingDtmf.Data);
+            ClassicAssert.IsNotNull(streamingDtmf);
+            ClassicAssert.AreEqual("5", streamingDtmf.Data);
         }
         #endregion
 
@@ -162,51 +163,51 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
 
         private static void ValidateTranscriptionMetadata(TranscriptionMetadata transcriptionMetadata)
         {
-            Assert.IsNotNull(transcriptionMetadata);
-            Assert.AreEqual("subscriptionId", transcriptionMetadata.TranscriptionSubscriptionId);
-            Assert.AreEqual("en-US", transcriptionMetadata.Locale);
-            Assert.AreEqual("callConnectionId", transcriptionMetadata.CallConnectionId);
-            Assert.AreEqual("correlationId", transcriptionMetadata.CorrelationId);
-            Assert.AreEqual("speechRecognitionModelEndpointId", transcriptionMetadata.SpeechRecognitionModelEndpointId);
+            ClassicAssert.IsNotNull(transcriptionMetadata);
+            ClassicAssert.AreEqual("subscriptionId", transcriptionMetadata.TranscriptionSubscriptionId);
+            ClassicAssert.AreEqual("en-US", transcriptionMetadata.Locale);
+            ClassicAssert.AreEqual("callConnectionId", transcriptionMetadata.CallConnectionId);
+            ClassicAssert.AreEqual("correlationId", transcriptionMetadata.CorrelationId);
+            ClassicAssert.AreEqual("speechRecognitionModelEndpointId", transcriptionMetadata.SpeechRecognitionModelEndpointId);
         }
 
         private static void ValidateTranscriptionDataWithWordsNull(TranscriptionData transcription)
         {
-            Assert.IsNotNull(transcription);
-            Assert.AreEqual("store hours", transcription.Text);
-            Assert.AreEqual("display", transcription.Format);
-            Assert.AreEqual(49876484, transcription.Offset.Ticks);
-            Assert.AreEqual(9200000, transcription.Duration.Ticks);
+            ClassicAssert.IsNotNull(transcription);
+            ClassicAssert.AreEqual("store hours", transcription.Text);
+            ClassicAssert.AreEqual("display", transcription.Format);
+            ClassicAssert.AreEqual(49876484, transcription.Offset.Ticks);
+            ClassicAssert.AreEqual(9200000, transcription.Duration.Ticks);
 
-            Assert.IsTrue(transcription.Participant is CommunicationIdentifier);
-            Assert.AreEqual("abc12345", transcription.Participant.RawId);
+            ClassicAssert.IsTrue(transcription.Participant is CommunicationIdentifier);
+            ClassicAssert.AreEqual("abc12345", transcription.Participant.RawId);
             Console.WriteLine(transcription.ResultState.ToString());
-            Assert.AreEqual(TranscriptionResultState.Intermediate, transcription.ResultState);
+            ClassicAssert.AreEqual(TranscriptionResultState.Intermediate, transcription.ResultState);
         }
 
         private static void ValidateTranscriptionData(TranscriptionData transcription)
         {
-            Assert.IsNotNull(transcription);
-            Assert.AreEqual("Hello World!", transcription.Text);
-            Assert.AreEqual("display", transcription.Format);
-            Assert.AreEqual(0.98d, transcription.Confidence);
-            Assert.AreEqual(1, transcription.Offset.Ticks);
-            Assert.AreEqual(2, transcription.Duration.Ticks);
+            ClassicAssert.IsNotNull(transcription);
+            ClassicAssert.AreEqual("Hello World!", transcription.Text);
+            ClassicAssert.AreEqual("display", transcription.Format);
+            ClassicAssert.AreEqual(0.98d, transcription.Confidence);
+            ClassicAssert.AreEqual(1, transcription.Offset.Ticks);
+            ClassicAssert.AreEqual(2, transcription.Duration.Ticks);
 
             // validate individual words
             IList<WordData> words = transcription.Words.ToList();
-            Assert.AreEqual(2, words.Count);
-            Assert.AreEqual("Hello", words[0].Text);
-            Assert.AreEqual(1, words[0].Offset.Ticks);
-            Assert.AreEqual(1, words[0].Duration.Ticks);
-            Assert.AreEqual("World", words[1].Text);
-            Assert.AreEqual(6, words[1].Offset.Ticks);
-            Assert.AreEqual(1, words[1].Duration.Ticks);
+            ClassicAssert.AreEqual(2, words.Count);
+            ClassicAssert.AreEqual("Hello", words[0].Text);
+            ClassicAssert.AreEqual(1, words[0].Offset.Ticks);
+            ClassicAssert.AreEqual(1, words[0].Duration.Ticks);
+            ClassicAssert.AreEqual("World", words[1].Text);
+            ClassicAssert.AreEqual(6, words[1].Offset.Ticks);
+            ClassicAssert.AreEqual(1, words[1].Duration.Ticks);
 
-            Assert.IsTrue(transcription.Participant is CommunicationIdentifier);
-            Assert.AreEqual("abc12345", transcription.Participant.RawId);
+            ClassicAssert.IsTrue(transcription.Participant is CommunicationIdentifier);
+            ClassicAssert.AreEqual("abc12345", transcription.Participant.RawId);
             Console.WriteLine(transcription.ResultState.ToString());
-            Assert.AreEqual(TranscriptionResultState.Final, transcription.ResultState);
+            ClassicAssert.AreEqual(TranscriptionResultState.Final, transcription.ResultState);
         }
         #endregion
     }

--- a/sdk/communication/Azure.Communication.Chat/tests/ChatClients/ChatClientsLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Chat/tests/ChatClients/ChatClientsLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -10,6 +10,7 @@ using Azure.Communication.Identity;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Chat.Tests
 {
@@ -75,15 +76,15 @@ namespace Azure.Communication.Chat.Tests
             ChatThreadClient chatThreadClient = GetInstrumentedChatThreadClient(chatClient, createChatThreadResult.ChatThread.Id);
             var threadId = chatThreadClient.Id;
 
-            Assert.IsNotNull(createChatThreadResult.ChatThread.Metadata);
-            Assert.AreEqual("MetaValue1", createChatThreadResult.ChatThread.Metadata["MetaKey1"]);
-            Assert.AreEqual("MetaValue2", createChatThreadResult.ChatThread.Metadata["MetaKey2"]);
+            ClassicAssert.IsNotNull(createChatThreadResult.ChatThread.Metadata);
+            ClassicAssert.AreEqual("MetaValue1", createChatThreadResult.ChatThread.Metadata["MetaKey1"]);
+            ClassicAssert.AreEqual("MetaValue2", createChatThreadResult.ChatThread.Metadata["MetaKey2"]);
 
-            Assert.IsNotNull(createChatThreadResult.ChatThread.RetentionPolicy);
+            ClassicAssert.IsNotNull(createChatThreadResult.ChatThread.RetentionPolicy);
             var threadCreationDateRetentionPolicy = createChatThreadResult.ChatThread.RetentionPolicy as ThreadCreationDateRetentionPolicy;
-            Assert.IsNotNull(threadCreationDateRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.ThreadCreationDate, threadCreationDateRetentionPolicy?.Kind);
-            Assert.AreEqual(60, threadCreationDateRetentionPolicy?.DeleteThreadAfterDays);
+            ClassicAssert.IsNotNull(threadCreationDateRetentionPolicy);
+            ClassicAssert.AreEqual(RetentionPolicyKind.ThreadCreationDate, threadCreationDateRetentionPolicy?.Kind);
+            ClassicAssert.AreEqual(60, threadCreationDateRetentionPolicy?.DeleteThreadAfterDays);
 
             var participants = new List<ChatParticipant>
             {
@@ -100,8 +101,8 @@ namespace Azure.Communication.Chat.Tests
             var chatParticipantsOnCreationCount = chatParticipantsOnCreationList.Count;
 
             var chatParticipant1 = chatParticipantsOnCreationList.FirstOrDefault(x => x.User == user1);
-            Assert.AreEqual("ParticipantMetaValue1", chatParticipant1?.Metadata["ParticipantMetaKey1"]);
-            Assert.AreEqual("ParticipantMetaValue2", chatParticipant1?.Metadata["ParticipantMetaKey2"]);
+            ClassicAssert.AreEqual("ParticipantMetaValue1", chatParticipant1?.Metadata["ParticipantMetaKey1"]);
+            ClassicAssert.AreEqual("ParticipantMetaValue2", chatParticipant1?.Metadata["ParticipantMetaKey2"]);
 
             var updatedTopic = "Updated topic - C# sdk";
             await chatThreadClient.UpdateTopicAsync(updatedTopic);
@@ -229,58 +230,58 @@ namespace Azure.Communication.Chat.Tests
             await chatClient.DeleteChatThreadAsync(threadId);
 
             //assert
-            Assert.AreEqual(updatedTopic, chatThread.Topic);
-            Assert.AreEqual(3, chatParticipantsOnCreationCount);
-            Assert.AreEqual(messageContent, message.Content.Message);
-            Assert.AreEqual(displayNameMessage, message.SenderDisplayName);
-            Assert.AreEqual(updatedMessageContent, actualUpdateMessage.Value.Content.Message);
-            Assert.AreEqual(ChatMessageType.Text, message.Type);
+            ClassicAssert.AreEqual(updatedTopic, chatThread.Topic);
+            ClassicAssert.AreEqual(3, chatParticipantsOnCreationCount);
+            ClassicAssert.AreEqual(messageContent, message.Content.Message);
+            ClassicAssert.AreEqual(displayNameMessage, message.SenderDisplayName);
+            ClassicAssert.AreEqual(updatedMessageContent, actualUpdateMessage.Value.Content.Message);
+            ClassicAssert.AreEqual(ChatMessageType.Text, message.Type);
 
-            Assert.AreEqual(ChatMessageType.Html, message2.Type);
-            Assert.AreEqual(ChatMessageType.Text, message3.Type);
-            Assert.AreEqual(ChatMessageType.Html, message4.Type);
-            Assert.AreEqual(ChatMessageType.Text, message5.Type);
-            Assert.AreEqual(ChatMessageType.Html, message6.Type);
+            ClassicAssert.AreEqual(ChatMessageType.Html, message2.Type);
+            ClassicAssert.AreEqual(ChatMessageType.Text, message3.Type);
+            ClassicAssert.AreEqual(ChatMessageType.Html, message4.Type);
+            ClassicAssert.AreEqual(ChatMessageType.Text, message5.Type);
+            ClassicAssert.AreEqual(ChatMessageType.Html, message6.Type);
 
-            Assert.AreEqual(messageContent2, message2.Content.Message);
-            Assert.AreEqual(messageContent3, message3.Content.Message);
-            Assert.AreEqual(messageContent4, message4.Content.Message);
-            Assert.AreEqual(messageContent5, message5.Content.Message);
-            Assert.AreEqual(messageContent6, message6.Content.Message);
+            ClassicAssert.AreEqual(messageContent2, message2.Content.Message);
+            ClassicAssert.AreEqual(messageContent3, message3.Content.Message);
+            ClassicAssert.AreEqual(messageContent4, message4.Content.Message);
+            ClassicAssert.AreEqual(messageContent5, message5.Content.Message);
+            ClassicAssert.AreEqual(messageContent6, message6.Content.Message);
 
-            Assert.AreEqual(sendChatMessageOptions7.MessageType, message7.Type);
-            Assert.AreEqual(sendChatMessageOptions7.SenderDisplayName, message7.SenderDisplayName);
-            Assert.AreEqual(sendChatMessageOptions7.Content, message7.Content.Message);
+            ClassicAssert.AreEqual(sendChatMessageOptions7.MessageType, message7.Type);
+            ClassicAssert.AreEqual(sendChatMessageOptions7.SenderDisplayName, message7.SenderDisplayName);
+            ClassicAssert.AreEqual(sendChatMessageOptions7.Content, message7.Content.Message);
             CollectionAssert.AreEquivalent(sendChatMessageOptions7.Metadata, message7.Metadata);
 
-            Assert.AreEqual(sendChatMessageOptions7.MessageType, actualUpdatedMessage7.Value.Type);
-            Assert.AreEqual(sendChatMessageOptions7.SenderDisplayName, actualUpdatedMessage7.Value.SenderDisplayName);
-            Assert.AreEqual(updateChatMessageOptions7.Content, actualUpdatedMessage7.Value.Content.Message);
-            Assert.AreEqual(4, actualUpdatedMessage7.Value.Metadata.Count);
-            Assert.AreEqual(updateChatMessageOptions7.Metadata["deliveryMode"], actualUpdatedMessage7.Value.Metadata["deliveryMode"]);
-            Assert.AreEqual(updateChatMessageOptions7.Metadata["onedriveReferences"], actualUpdatedMessage7.Value.Metadata["onedriveReferences"]);
-            Assert.AreEqual(updateChatMessageOptions7.Metadata["amsreferences"], actualUpdatedMessage7.Value.Metadata["amsreferences"]);
-            Assert.AreEqual(updateChatMessageOptions7.Metadata["key"], actualUpdatedMessage7.Value.Metadata["key"]);
-            Assert.AreEqual(2, threadsCount);
-            Assert.AreEqual(9, getMessagesCount); //Including all types : 6 text message, 3 control messages
-            Assert.AreEqual(3, getMessagesCount2); //Including all types : 1 text message, 2 control messages
+            ClassicAssert.AreEqual(sendChatMessageOptions7.MessageType, actualUpdatedMessage7.Value.Type);
+            ClassicAssert.AreEqual(sendChatMessageOptions7.SenderDisplayName, actualUpdatedMessage7.Value.SenderDisplayName);
+            ClassicAssert.AreEqual(updateChatMessageOptions7.Content, actualUpdatedMessage7.Value.Content.Message);
+            ClassicAssert.AreEqual(4, actualUpdatedMessage7.Value.Metadata.Count);
+            ClassicAssert.AreEqual(updateChatMessageOptions7.Metadata["deliveryMode"], actualUpdatedMessage7.Value.Metadata["deliveryMode"]);
+            ClassicAssert.AreEqual(updateChatMessageOptions7.Metadata["onedriveReferences"], actualUpdatedMessage7.Value.Metadata["onedriveReferences"]);
+            ClassicAssert.AreEqual(updateChatMessageOptions7.Metadata["amsreferences"], actualUpdatedMessage7.Value.Metadata["amsreferences"]);
+            ClassicAssert.AreEqual(updateChatMessageOptions7.Metadata["key"], actualUpdatedMessage7.Value.Metadata["key"]);
+            ClassicAssert.AreEqual(2, threadsCount);
+            ClassicAssert.AreEqual(9, getMessagesCount); //Including all types : 6 text message, 3 control messages
+            ClassicAssert.AreEqual(3, getMessagesCount2); //Including all types : 1 text message, 2 control messages
 
-            Assert.AreEqual(1, participantAddedMessage.Content.Participants.Count);
-            Assert.AreEqual(user5.Id, CommunicationIdentifierSerializer.Serialize(participantAddedMessage.Content.Participants[0].User).CommunicationUser.Id);
-            Assert.AreEqual("user5", participantAddedMessage.Content.Participants[0].DisplayName);
+            ClassicAssert.AreEqual(1, participantAddedMessage.Content.Participants.Count);
+            ClassicAssert.AreEqual(user5.Id, CommunicationIdentifierSerializer.Serialize(participantAddedMessage.Content.Participants[0].User).CommunicationUser.Id);
+            ClassicAssert.AreEqual("user5", participantAddedMessage.Content.Participants[0].DisplayName);
 
-            Assert.AreEqual(1, participantRemovedMessage.Content.Participants.Count);
-            Assert.AreEqual(user4.Id, CommunicationIdentifierSerializer.Serialize(participantRemovedMessage.Content.Participants[0].User).CommunicationUser.Id);
-            Assert.AreEqual("user4", participantRemovedMessage.Content.Participants[0].DisplayName);
+            ClassicAssert.AreEqual(1, participantRemovedMessage.Content.Participants.Count);
+            ClassicAssert.AreEqual(user4.Id, CommunicationIdentifierSerializer.Serialize(participantRemovedMessage.Content.Participants[0].User).CommunicationUser.Id);
+            ClassicAssert.AreEqual("user4", participantRemovedMessage.Content.Participants[0].DisplayName);
 
-            Assert.IsTrue(deletedChatMessage.DeletedOn.HasValue);
-            Assert.AreEqual(3, chatParticipantsCount);
-            Assert.AreEqual(5, chatParticipantsAfterTwoOneAddedCount);
-            Assert.AreEqual(4, chatParticipantAfterOneDeletedCount);
-            Assert.AreEqual(0, addChatParticipantsResult.InvalidParticipants.Count);
-            Assert.AreEqual((int)HttpStatusCode.Created, addChatParticipantResult.Status);
-            Assert.AreEqual((int)HttpStatusCode.OK, typingNotificationResponse.Status);
-            Assert.AreEqual((int)HttpStatusCode.OK, typingNotificationWithOptionsResponse.Status);
+            ClassicAssert.IsTrue(deletedChatMessage.DeletedOn.HasValue);
+            ClassicAssert.AreEqual(3, chatParticipantsCount);
+            ClassicAssert.AreEqual(5, chatParticipantsAfterTwoOneAddedCount);
+            ClassicAssert.AreEqual(4, chatParticipantAfterOneDeletedCount);
+            ClassicAssert.AreEqual(0, addChatParticipantsResult.InvalidParticipants.Count);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, addChatParticipantResult.Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, typingNotificationResponse.Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, typingNotificationWithOptionsResponse.Status);
         }
 
         /// <summary>
@@ -312,20 +313,20 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsChangeTopic);
 
             var updateResponseUpdateTopic = await chatThreadClient.GetPropertiesAsync();
-            Assert.AreEqual("updated thread topic", updateResponseUpdateTopic.Value.Topic);
+            ClassicAssert.AreEqual("updated thread topic", updateResponseUpdateTopic.Value.Topic);
 
             var noneRetentionPolicy = updateResponseUpdateTopic.Value.RetentionPolicy as NoneRetentionPolicy;
-            Assert.IsNotNull(noneRetentionPolicy);
+            ClassicAssert.IsNotNull(noneRetentionPolicy);
 
             // Update properties, not setting options. Topic not changed.
             var updateOptionsWithSameProperties = new UpdateChatThreadPropertiesOptions();
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithSameProperties);
 
             var updateResponseWithSameProperties = await chatThreadClient.GetPropertiesAsync();
-            Assert.AreEqual("updated thread topic", updateResponseWithSameProperties.Value.Topic);
+            ClassicAssert.AreEqual("updated thread topic", updateResponseWithSameProperties.Value.Topic);
 
             noneRetentionPolicy = updateResponseWithSameProperties.Value.RetentionPolicy as NoneRetentionPolicy;
-            Assert.IsNotNull(noneRetentionPolicy);
+            ClassicAssert.IsNotNull(noneRetentionPolicy);
 
             // Update properties adding metadata
             var updateOptionsWithNewMetadata = new UpdateChatThreadPropertiesOptions();
@@ -335,11 +336,11 @@ namespace Azure.Communication.Chat.Tests
 
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewMetadata);
             var updateResponseWithNewMetadata = await chatThreadClient.GetPropertiesAsync();
-            Assert.AreEqual("Update properties adding metadata", updateResponseWithNewMetadata.Value.Topic);
+            ClassicAssert.AreEqual("Update properties adding metadata", updateResponseWithNewMetadata.Value.Topic);
 
-            Assert.IsNotNull(updateResponseWithNewMetadata.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew2"]);
+            ClassicAssert.IsNotNull(updateResponseWithNewMetadata.Value.Metadata);
+            ClassicAssert.AreEqual("MetaValueNew1", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew1"]);
+            ClassicAssert.AreEqual("MetaValueNew2", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew2"]);
 
             // Update properties adding retention policy deleteAfterDays
             var updateOptionsWithNewRetentionPolicy = new UpdateChatThreadPropertiesOptions();
@@ -348,12 +349,12 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewRetentionPolicy);
             var updateResponseWithNewRetentionPolicy = await chatThreadClient.GetPropertiesAsync();
             var newDataRetentionPolicy = updateResponseWithNewRetentionPolicy.Value.RetentionPolicy as ThreadCreationDateRetentionPolicy;
-            Assert.IsNotNull(newDataRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.ThreadCreationDate, newDataRetentionPolicy?.Kind);
-            Assert.AreEqual(40, newDataRetentionPolicy?.DeleteThreadAfterDays);
-            Assert.IsNotNull(updateResponseWithNewRetentionPolicy.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
+            ClassicAssert.IsNotNull(newDataRetentionPolicy);
+            ClassicAssert.AreEqual(RetentionPolicyKind.ThreadCreationDate, newDataRetentionPolicy?.Kind);
+            ClassicAssert.AreEqual(40, newDataRetentionPolicy?.DeleteThreadAfterDays);
+            ClassicAssert.IsNotNull(updateResponseWithNewRetentionPolicy.Value.Metadata);
+            ClassicAssert.AreEqual("MetaValueNew1", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
+            ClassicAssert.AreEqual("MetaValueNew2", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
 
             // Update properties changing retention policy deleteAfterDays
             updateOptionsWithNewRetentionPolicy = new UpdateChatThreadPropertiesOptions();
@@ -362,12 +363,12 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewRetentionPolicy);
             updateResponseWithNewRetentionPolicy = await chatThreadClient.GetPropertiesAsync();
             newDataRetentionPolicy = updateResponseWithNewRetentionPolicy.Value.RetentionPolicy as ThreadCreationDateRetentionPolicy;
-            Assert.IsNotNull(newDataRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.ThreadCreationDate, newDataRetentionPolicy?.Kind);
-            Assert.AreEqual(50, newDataRetentionPolicy?.DeleteThreadAfterDays);
-            Assert.IsNotNull(updateResponseWithNewRetentionPolicy.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
+            ClassicAssert.IsNotNull(newDataRetentionPolicy);
+            ClassicAssert.AreEqual(RetentionPolicyKind.ThreadCreationDate, newDataRetentionPolicy?.Kind);
+            ClassicAssert.AreEqual(50, newDataRetentionPolicy?.DeleteThreadAfterDays);
+            ClassicAssert.IsNotNull(updateResponseWithNewRetentionPolicy.Value.Metadata);
+            ClassicAssert.AreEqual("MetaValueNew1", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
+            ClassicAssert.AreEqual("MetaValueNew2", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
 
             // Update properties updating tetention policy to NoneRetentionPolicy
             var updateOptionsWithNoneRetentionPolicy = new UpdateChatThreadPropertiesOptions();
@@ -376,12 +377,12 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNoneRetentionPolicy);
             var updateResponseWithNoneRetentionPolicy = await chatThreadClient.GetPropertiesAsync();
             var noneDataRetentionPolicy = updateResponseWithNoneRetentionPolicy.Value.RetentionPolicy as NoneRetentionPolicy;
-            Assert.IsNotNull(noneDataRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.None, noneDataRetentionPolicy?.Kind);
+            ClassicAssert.IsNotNull(noneDataRetentionPolicy);
+            ClassicAssert.AreEqual(RetentionPolicyKind.None, noneDataRetentionPolicy?.Kind);
 
-            Assert.IsNotNull(updateResponseWithNoneRetentionPolicy.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNoneRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNoneRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
+            ClassicAssert.IsNotNull(updateResponseWithNoneRetentionPolicy.Value.Metadata);
+            ClassicAssert.AreEqual("MetaValueNew1", updateResponseWithNoneRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
+            ClassicAssert.AreEqual("MetaValueNew2", updateResponseWithNoneRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
 
             // Set retention policy to null and change topic
             var updateOptionsWithNullRetentionPolicyOptions = new UpdateChatThreadPropertiesOptions
@@ -392,14 +393,14 @@ namespace Azure.Communication.Chat.Tests
 
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNullRetentionPolicyOptions);
             var updateResponseWithNullRetentionPolicy = await chatThreadClient.GetPropertiesAsync();
-            Assert.AreEqual(updateOptionsWithNullRetentionPolicyOptions.Topic, updateResponseWithNullRetentionPolicy.Value.Topic);
+            ClassicAssert.AreEqual(updateOptionsWithNullRetentionPolicyOptions.Topic, updateResponseWithNullRetentionPolicy.Value.Topic);
             var nullDataRetentionPolicy = updateResponseWithNullRetentionPolicy.Value.RetentionPolicy as NoneRetentionPolicy;
-            Assert.IsNotNull(nullDataRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.None, nullDataRetentionPolicy?.Kind);
+            ClassicAssert.IsNotNull(nullDataRetentionPolicy);
+            ClassicAssert.AreEqual(RetentionPolicyKind.None, nullDataRetentionPolicy?.Kind);
 
-            Assert.IsNotNull(updateResponseWithNullRetentionPolicy.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNullRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNullRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
+            ClassicAssert.IsNotNull(updateResponseWithNullRetentionPolicy.Value.Metadata);
+            ClassicAssert.AreEqual("MetaValueNew1", updateResponseWithNullRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
+            ClassicAssert.AreEqual("MetaValueNew2", updateResponseWithNullRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
 
             // Change values of metadata
             updateOptionsWithNewMetadata = new UpdateChatThreadPropertiesOptions();
@@ -409,10 +410,10 @@ namespace Azure.Communication.Chat.Tests
 
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewMetadata);
             updateResponseWithNewMetadata = await chatThreadClient.GetPropertiesAsync();
-            Assert.IsNotNull(updateResponseWithNewMetadata.Value.Metadata);
-            Assert.AreEqual("MetaValueChangedValue1", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueChangedValue2", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew2"]);
-            Assert.AreEqual("MetaValueNew3", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew3"]);
+            ClassicAssert.IsNotNull(updateResponseWithNewMetadata.Value.Metadata);
+            ClassicAssert.AreEqual("MetaValueChangedValue1", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew1"]);
+            ClassicAssert.AreEqual("MetaValueChangedValue2", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew2"]);
+            ClassicAssert.AreEqual("MetaValueNew3", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew3"]);
 
             // Set metadata to empty dictionary. Previous metadata will be kept.
             var updateOptionsWithEmptyMetadata = new UpdateChatThreadPropertiesOptions
@@ -426,11 +427,11 @@ namespace Azure.Communication.Chat.Tests
             var updateResponseWithEmptyMetadata = await chatThreadClient.GetPropertiesAsync();
 
             // Expect all previous metadata to be kept
-            Assert.IsNotNull(updateResponseWithEmptyMetadata.Value.Metadata);
-            Assert.AreEqual(3, updateResponseWithEmptyMetadata.Value.Metadata.Count);
-            Assert.AreEqual("MetaValueChangedValue1", updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueChangedValue2", updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew2"]);
-            Assert.AreEqual("MetaValueNew3", updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew3"]);
+            ClassicAssert.IsNotNull(updateResponseWithEmptyMetadata.Value.Metadata);
+            ClassicAssert.AreEqual(3, updateResponseWithEmptyMetadata.Value.Metadata.Count);
+            ClassicAssert.AreEqual("MetaValueChangedValue1", updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew1"]);
+            ClassicAssert.AreEqual("MetaValueChangedValue2", updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew2"]);
+            ClassicAssert.AreEqual("MetaValueNew3", updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew3"]);
 
             // Update topic, metadata and retention policy in one call
             var fullUpdateOptions = new UpdateChatThreadPropertiesOptions
@@ -444,9 +445,9 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(fullUpdateOptions);
             var result = await chatThreadClient.GetPropertiesAsync();
 
-            Assert.AreEqual("Full update topic", result.Value.Topic);
-            Assert.AreEqual("ValueA", result.Value.Metadata["KeyA"]);
-            Assert.AreEqual(90, ((ThreadCreationDateRetentionPolicy)result.Value.RetentionPolicy).DeleteThreadAfterDays);
+            ClassicAssert.AreEqual("Full update topic", result.Value.Topic);
+            ClassicAssert.AreEqual("ValueA", result.Value.Metadata["KeyA"]);
+            ClassicAssert.AreEqual(90, ((ThreadCreationDateRetentionPolicy)result.Value.RetentionPolicy).DeleteThreadAfterDays);
         }
 
         [Test]
@@ -492,8 +493,8 @@ namespace Azure.Communication.Chat.Tests
             await chatClient.DeleteChatThreadAsync(threadId);
 
             //assert
-            Assert.AreEqual(2, readReceiptsCount);
-            Assert.AreEqual(2, readReceiptsCount2);
+            ClassicAssert.AreEqual(2, readReceiptsCount);
+            ClassicAssert.AreEqual(2, readReceiptsCount2);
         }
 
         #region Support functions
@@ -532,11 +533,11 @@ namespace Azure.Communication.Chat.Tests
                         actualTotalResources++;
                     }
                     continuationToken = page.ContinuationToken;
-                    Assert.GreaterOrEqual(expectedPageSize, actualPageSize);
+                    ClassicAssert.GreaterOrEqual(expectedPageSize, actualPageSize);
                 }
-                Assert.IsNull(continuationToken);
-                Assert.AreEqual(expectedTotalResources, actualTotalResources);
-                Assert.AreEqual(expectedRoundTrips, actualRoundTrips);
+                ClassicAssert.IsNull(continuationToken);
+                ClassicAssert.AreEqual(expectedTotalResources, actualTotalResources);
+                ClassicAssert.AreEqual(expectedRoundTrips, actualRoundTrips);
             }
 
             public static async Task AssertPaginationAsync(AsyncPageable<T> enumerableResource, int expectedPageSize, int expectedTotalResources)
@@ -554,11 +555,11 @@ namespace Azure.Communication.Chat.Tests
                         actualTotalResources++;
                     }
                     continuationToken = page.ContinuationToken;
-                    Assert.GreaterOrEqual(expectedPageSize, actualPageSize);
+                    ClassicAssert.GreaterOrEqual(expectedPageSize, actualPageSize);
                 }
-                Assert.IsNull(continuationToken);
-                Assert.AreEqual(expectedTotalResources, actualTotalResources);
-                Assert.AreEqual(expectedRoundTrips, actualRoundTrips);
+                ClassicAssert.IsNull(continuationToken);
+                ClassicAssert.AreEqual(expectedTotalResources, actualTotalResources);
+                ClassicAssert.AreEqual(expectedRoundTrips, actualRoundTrips);
             }
         }
         #endregion

--- a/sdk/communication/Azure.Communication.Chat/tests/ChatClients/ChatClientsTests.cs
+++ b/sdk/communication/Azure.Communication.Chat/tests/ChatClients/ChatClientsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Chat.Tests.ChatClients
 {
@@ -67,16 +68,16 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             await foreach (ChatMessage message in allMessages)
             {
                 idCounter++;
-                Assert.AreEqual($"{idCounter}", message.Id);
-                Assert.AreEqual($"{idCounter}", message.Version);
+                ClassicAssert.AreEqual($"{idCounter}", message.Id);
+                ClassicAssert.AreEqual($"{idCounter}", message.Version);
                 if (message.Type == "text")
                 {
                     textMessagesCounter++;
-                    Assert.AreEqual($"Content for async message{idCounter}", message.Content.Message);
+                    ClassicAssert.AreEqual($"Content for async message{idCounter}", message.Content.Message);
                 }
             }
-            Assert.AreEqual(8, idCounter);
-            Assert.AreEqual(5, textMessagesCounter);
+            ClassicAssert.AreEqual(8, idCounter);
+            ClassicAssert.AreEqual(5, textMessagesCounter);
         }
 
         [Test]
@@ -114,18 +115,18 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 foreach (ChatMessage message in page.Values)
                 {
                     idCounter++;
-                    Assert.AreEqual($"{idCounter}", message.Id);
-                    Assert.AreEqual($"{idCounter}", message.Version);
+                    ClassicAssert.AreEqual($"{idCounter}", message.Id);
+                    ClassicAssert.AreEqual($"{idCounter}", message.Version);
                     if (message.Type == "text")
                     {
                         textMessagesCounter++;
-                        Assert.AreEqual($"Content for async message{idCounter}", message.Content.Message);
+                        ClassicAssert.AreEqual($"Content for async message{idCounter}", message.Content.Message);
                     }
                 }
             }
-            Assert.AreEqual(2, pages);
-            Assert.AreEqual(8, idCounter);
-            Assert.AreEqual(5, textMessagesCounter);
+            ClassicAssert.AreEqual(2, pages);
+            ClassicAssert.AreEqual(8, idCounter);
+            ClassicAssert.AreEqual(5, textMessagesCounter);
         }
 
         [Test]
@@ -144,11 +145,11 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             await foreach (ChatMessageReadReceipt readReceipt in allReadReceipts)
             {
                 idCounter++;
-                Assert.AreEqual($"{idCounter}", readReceipt.ChatMessageId);
-                Assert.AreEqual($"{baseSenderId}{idCounter}", ((UnknownIdentifier)readReceipt.Sender).Id);
-                Assert.AreEqual(baseReadOnDate.AddSeconds(idCounter), readReceipt.ReadOn);
+                ClassicAssert.AreEqual($"{idCounter}", readReceipt.ChatMessageId);
+                ClassicAssert.AreEqual($"{baseSenderId}{idCounter}", ((UnknownIdentifier)readReceipt.Sender).Id);
+                ClassicAssert.AreEqual(baseReadOnDate.AddSeconds(idCounter), readReceipt.ReadOn);
             }
-            Assert.AreEqual(5, idCounter);
+            ClassicAssert.AreEqual(5, idCounter);
         }
 
         [Test]
@@ -167,11 +168,11 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             foreach (ChatMessageReadReceipt readReceipt in allReadReceipts)
             {
                 idCounter++;
-                Assert.AreEqual($"{idCounter}", readReceipt.ChatMessageId);
-                Assert.AreEqual($"{baseSenderId}{idCounter}", ((UnknownIdentifier)readReceipt.Sender).Id);
-                Assert.AreEqual(baseReadOnDate.AddSeconds(idCounter), readReceipt.ReadOn);
+                ClassicAssert.AreEqual($"{idCounter}", readReceipt.ChatMessageId);
+                ClassicAssert.AreEqual($"{baseSenderId}{idCounter}", ((UnknownIdentifier)readReceipt.Sender).Id);
+                ClassicAssert.AreEqual(baseReadOnDate.AddSeconds(idCounter), readReceipt.ReadOn);
             }
-            Assert.AreEqual(5, idCounter);
+            ClassicAssert.AreEqual(5, idCounter);
         }
         [Test]
         public async Task OrderInGetReadReceiptsIteratorIsNotAlteredByPaging()
@@ -209,14 +210,14 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 foreach (ChatMessageReadReceipt readReceipt in page.Values)
                 {
                     idCounter++;
-                    Assert.AreEqual($"{idCounter}", readReceipt.ChatMessageId);
-                    Assert.AreEqual($"{baseSenderId}{idCounter}", ((UnknownIdentifier)readReceipt.Sender).Id);
-                    Assert.AreEqual(baseReadOnDate.AddSeconds(idCounter), readReceipt.ReadOn);
+                    ClassicAssert.AreEqual($"{idCounter}", readReceipt.ChatMessageId);
+                    ClassicAssert.AreEqual($"{baseSenderId}{idCounter}", ((UnknownIdentifier)readReceipt.Sender).Id);
+                    ClassicAssert.AreEqual(baseReadOnDate.AddSeconds(idCounter), readReceipt.ReadOn);
                 }
                 //continuationToken = page.ContinuationToken;
             }
-            Assert.AreEqual(2, pages);
-            Assert.AreEqual(5, idCounter);
+            ClassicAssert.AreEqual(2, pages);
+            ClassicAssert.AreEqual(5, idCounter);
         }
 
         [Test]
@@ -228,9 +229,9 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             CreateChatThreadResult createChatThreadResult = await chatClient.CreateChatThreadAsync("", new List<ChatParticipant>() { chatParticipant });
 
             //assert
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).CommunicationUser.Id);
-            Assert.AreEqual("Topic for testing success", createChatThreadResult.ChatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
+            ClassicAssert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).CommunicationUser.Id);
+            ClassicAssert.AreEqual("Topic for testing success", createChatThreadResult.ChatThread.Topic);
+            ClassicAssert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
         }
 
         [Test]
@@ -242,9 +243,9 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             CreateChatThreadResult createChatThreadResult = chatClient.CreateChatThread("", new List<ChatParticipant>() { chatParticipant });
 
             //assert
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).CommunicationUser.Id);
-            Assert.AreEqual("Topic for testing success", createChatThreadResult.ChatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
+            ClassicAssert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).CommunicationUser.Id);
+            ClassicAssert.AreEqual("Topic for testing success", createChatThreadResult.ChatThread.Topic);
+            ClassicAssert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
         }
 
         [Test]
@@ -257,7 +258,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             SendChatMessageResult sendChatMessageResult = await chatThreadClient.SendMessageAsync("Send Message Test");
 
             //assert
-            Assert.AreEqual("1", sendChatMessageResult.Id);
+            ClassicAssert.AreEqual("1", sendChatMessageResult.Id);
         }
 
         [Test]
@@ -275,7 +276,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -294,7 +295,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -309,7 +310,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             SendChatMessageResult sendChatMessageResult = await chatThreadClient.SendMessageAsync(sendChatMessageOptions);
 
             //assert
-            Assert.AreEqual("1", sendChatMessageResult.Id);
+            ClassicAssert.AreEqual("1", sendChatMessageResult.Id);
         }
 
         [Test]
@@ -322,7 +323,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response typingNotificationResponse = await chatThreadClient.SendTypingNotificationAsync();
 
             //assert
-            Assert.AreEqual(200, typingNotificationResponse.Status);
+            ClassicAssert.AreEqual(200, typingNotificationResponse.Status);
         }
 
         [Test]
@@ -339,7 +340,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -357,7 +358,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -372,7 +373,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response typingNotificationResponse = await chatThreadClient.SendTypingNotificationAsync(options);
 
             //assert
-            Assert.AreEqual(200, typingNotificationResponse.Status);
+            ClassicAssert.AreEqual(200, typingNotificationResponse.Status);
         }
 
         [Test]
@@ -386,7 +387,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response readReceiptResponse = await chatThreadClient.SendReadReceiptAsync(messageId);
 
             //assert
-            Assert.AreEqual(200, readReceiptResponse.Status);
+            ClassicAssert.AreEqual(200, readReceiptResponse.Status);
         }
 
         [Test]
@@ -400,7 +401,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response readReceiptResponse = chatThreadClient.SendReadReceipt(messageId);
 
             //assert
-            Assert.AreEqual(200, readReceiptResponse.Status);
+            ClassicAssert.AreEqual(200, readReceiptResponse.Status);
         }
 
         [Test]
@@ -418,7 +419,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -437,7 +438,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -452,7 +453,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             var response = await chatThreadClient.DeleteMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(204, response.Status);
+            ClassicAssert.AreEqual(204, response.Status);
         }
 
         [Test]
@@ -466,7 +467,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             var response = chatThreadClient.DeleteMessage(messageId);
 
             //assert
-            Assert.AreEqual(204, response.Status);
+            ClassicAssert.AreEqual(204, response.Status);
         }
 
         [Test]
@@ -484,7 +485,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -503,7 +504,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -519,7 +520,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response updateMessageResponse = await chatThreadClient.UpdateMessageAsync(messageId, content);
 
             //assert
-            Assert.AreEqual(204, updateMessageResponse.Status);
+            ClassicAssert.AreEqual(204, updateMessageResponse.Status);
         }
 
         [Test]
@@ -538,7 +539,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -558,7 +559,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -574,7 +575,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response updateMessageResponse = chatThreadClient.UpdateMessage(messageId, content);
 
             //assert
-            Assert.AreEqual(204, updateMessageResponse.Status);
+            ClassicAssert.AreEqual(204, updateMessageResponse.Status);
         }
 
         [Test]
@@ -588,12 +589,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = await chatThreadClient.GetMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.Text, message.Type);
-            Assert.AreEqual("1", message.Id);
-            Assert.AreEqual("Test Message", message.Content.Message);
-            Assert.AreEqual("DisplayName for Test Message", message.SenderDisplayName);
-            Assert.NotNull(message.Sender);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Sender!).CommunicationUser.Id);
+            ClassicAssert.AreEqual(ChatMessageType.Text, message.Type);
+            ClassicAssert.AreEqual("1", message.Id);
+            ClassicAssert.AreEqual("Test Message", message.Content.Message);
+            ClassicAssert.AreEqual("DisplayName for Test Message", message.SenderDisplayName);
+            ClassicAssert.NotNull(message.Sender);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Sender!).CommunicationUser.Id);
         }
 
         [Test]
@@ -611,7 +612,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -630,7 +631,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -645,12 +646,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = chatThreadClient.GetMessage(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.Text, message.Type);
-            Assert.AreEqual("1", message.Id);
-            Assert.AreEqual("Test Message", message.Content.Message);
-            Assert.AreEqual("DisplayName for Test Message", message.SenderDisplayName);
-            Assert.NotNull(message.Sender);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Sender!).CommunicationUser.Id);
+            ClassicAssert.AreEqual(ChatMessageType.Text, message.Type);
+            ClassicAssert.AreEqual("1", message.Id);
+            ClassicAssert.AreEqual("Test Message", message.Content.Message);
+            ClassicAssert.AreEqual("DisplayName for Test Message", message.SenderDisplayName);
+            ClassicAssert.NotNull(message.Sender);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Sender!).CommunicationUser.Id);
         }
         [Test]
         public async Task GetTopicUpdatedMessageAsyncShouldSucceed()
@@ -663,12 +664,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = await chatThreadClient.GetMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.TopicUpdated, message.Type);
-            Assert.AreEqual("2", message.Id);
-            Assert.AreEqual("TopicUpdateTest", message.Content.Topic);
-            Assert.AreEqual("2", message.Version);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
+            ClassicAssert.AreEqual(ChatMessageType.TopicUpdated, message.Type);
+            ClassicAssert.AreEqual("2", message.Id);
+            ClassicAssert.AreEqual("TopicUpdateTest", message.Content.Topic);
+            ClassicAssert.AreEqual("2", message.Version);
+            ClassicAssert.NotNull(message.Content.Initiator);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
         }
 
         [Test]
@@ -682,12 +683,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = chatThreadClient.GetMessage(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.TopicUpdated, message.Type);
-            Assert.AreEqual("2", message.Id);
-            Assert.AreEqual("TopicUpdateTest", message.Content.Topic);
-            Assert.AreEqual("2", message.Version);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
+            ClassicAssert.AreEqual(ChatMessageType.TopicUpdated, message.Type);
+            ClassicAssert.AreEqual("2", message.Id);
+            ClassicAssert.AreEqual("TopicUpdateTest", message.Content.Topic);
+            ClassicAssert.AreEqual("2", message.Version);
+            ClassicAssert.NotNull(message.Content.Initiator);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
         }
 
         [Test]
@@ -701,16 +702,16 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = await chatThreadClient.GetMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.ParticipantAdded, message.Type);
-            Assert.AreEqual("3", message.Id);
-            Assert.AreEqual("3", message.Version);
-            Assert.AreEqual(2, message.Content.Participants.Count);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.NotNull(message.Content.Participants[0].User);
-            Assert.NotNull(message.Content.Participants[1].User);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[1].User!).RawId);
+            ClassicAssert.AreEqual(ChatMessageType.ParticipantAdded, message.Type);
+            ClassicAssert.AreEqual("3", message.Id);
+            ClassicAssert.AreEqual("3", message.Version);
+            ClassicAssert.AreEqual(2, message.Content.Participants.Count);
+            ClassicAssert.NotNull(message.Content.Initiator);
+            ClassicAssert.NotNull(message.Content.Participants[0].User);
+            ClassicAssert.NotNull(message.Content.Participants[1].User);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[1].User!).RawId);
         }
 
         [Test]
@@ -724,16 +725,16 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = chatThreadClient.GetMessage(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.ParticipantAdded, message.Type);
-            Assert.AreEqual("3", message.Id);
-            Assert.AreEqual("3", message.Version);
-            Assert.AreEqual(2, message.Content.Participants.Count);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.NotNull(message.Content.Participants[0].User);
-            Assert.NotNull(message.Content.Participants[1].User);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[1].User!).RawId);
+            ClassicAssert.AreEqual(ChatMessageType.ParticipantAdded, message.Type);
+            ClassicAssert.AreEqual("3", message.Id);
+            ClassicAssert.AreEqual("3", message.Version);
+            ClassicAssert.AreEqual(2, message.Content.Participants.Count);
+            ClassicAssert.NotNull(message.Content.Initiator);
+            ClassicAssert.NotNull(message.Content.Participants[0].User);
+            ClassicAssert.NotNull(message.Content.Participants[1].User);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[1].User!).RawId);
         }
 
         [Test]
@@ -747,14 +748,14 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = await chatThreadClient.GetMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.ParticipantRemoved, message.Type);
-            Assert.AreEqual("4", message.Id);
-            Assert.AreEqual("4", message.Version);
-            Assert.AreEqual(1, message.Content.Participants.Count);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.NotNull(message.Content.Participants[0].User);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
+            ClassicAssert.AreEqual(ChatMessageType.ParticipantRemoved, message.Type);
+            ClassicAssert.AreEqual("4", message.Id);
+            ClassicAssert.AreEqual("4", message.Version);
+            ClassicAssert.AreEqual(1, message.Content.Participants.Count);
+            ClassicAssert.NotNull(message.Content.Initiator);
+            ClassicAssert.NotNull(message.Content.Participants[0].User);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
         }
 
         public void GetParticipantRemovedMessageShouldSucceed()
@@ -767,14 +768,14 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = chatThreadClient.GetMessage(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.ParticipantRemoved, message.Type);
-            Assert.AreEqual("4", message.Id);
-            Assert.AreEqual("4", message.Version);
-            Assert.AreEqual(1, message.Content.Participants.Count);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.NotNull(message.Content.Participants[0].User);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
+            ClassicAssert.AreEqual(ChatMessageType.ParticipantRemoved, message.Type);
+            ClassicAssert.AreEqual("4", message.Id);
+            ClassicAssert.AreEqual("4", message.Version);
+            ClassicAssert.AreEqual(1, message.Content.Participants.Count);
+            ClassicAssert.NotNull(message.Content.Initiator);
+            ClassicAssert.NotNull(message.Content.Participants[0].User);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
         }
         [Test]
         public async Task GetThreadShouldSucceed()
@@ -787,9 +788,9 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatThreadProperties chatThread = await chatThreadClient.GetPropertiesAsync();
 
             //assert
-            Assert.AreEqual(threadId, chatThread.Id);
-            Assert.AreEqual("Test Thread", chatThread.Topic);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id);
+            ClassicAssert.AreEqual(threadId, chatThread.Id);
+            ClassicAssert.AreEqual("Test Thread", chatThread.Topic);
+            ClassicAssert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id);
         }
 
         [Test]
@@ -807,7 +808,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -826,7 +827,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -841,7 +842,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response UpdateTopiceResponse = await chatThreadClient.UpdateTopicAsync(topic);
 
             //assert
-            Assert.AreEqual(204, UpdateTopiceResponse.Status);
+            ClassicAssert.AreEqual(204, UpdateTopiceResponse.Status);
         }
 
         [Test]
@@ -859,7 +860,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -878,7 +879,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -894,7 +895,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            ClassicAssert.AreEqual(204, response.Status);
         }
 
         [Test]
@@ -908,7 +909,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewMetadata);
 
-            Assert.AreEqual(204, response.Status);
+            ClassicAssert.AreEqual(204, response.Status);
         }
 
         [Test]
@@ -923,7 +924,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            ClassicAssert.AreEqual(204, response.Status);
         }
 
         [Test]
@@ -936,7 +937,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            ClassicAssert.AreEqual(204, response.Status);
         }
 
         [Test]
@@ -953,7 +954,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            ClassicAssert.AreEqual(204, response.Status);
         }
 
         [Test]
@@ -972,7 +973,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            ClassicAssert.AreEqual(204, response.Status);
         }
 
         [Test]
@@ -995,10 +996,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 {
                     continue;
                 }
-                Assert.AreEqual($"{idCounter}", chatThread.Id);
-                Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                ClassicAssert.AreEqual($"{idCounter}", chatThread.Id);
+                ClassicAssert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
             }
-            Assert.AreEqual(5, idCounter);
+            ClassicAssert.AreEqual(5, idCounter);
         }
 
         [Test]
@@ -1028,12 +1029,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 foreach (ChatThreadItem chatThread in page.Values)
                 {
                     idCounter++;
-                    Assert.AreEqual($"{idCounter}", chatThread.Id);
-                    Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                    ClassicAssert.AreEqual($"{idCounter}", chatThread.Id);
+                    ClassicAssert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
                 }
             }
-            Assert.AreEqual(2, pages);
-            Assert.AreEqual(6, idCounter);
+            ClassicAssert.AreEqual(2, pages);
+            ClassicAssert.AreEqual(6, idCounter);
         }
 
         [Test]
@@ -1063,12 +1064,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 foreach (ChatThreadItem chatThread in page.Values)
                 {
                     idCounter++;
-                    Assert.AreEqual($"{idCounter}", chatThread.Id);
-                    Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                    ClassicAssert.AreEqual($"{idCounter}", chatThread.Id);
+                    ClassicAssert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
                 }
             }
-            Assert.AreEqual(2, pages);
-            Assert.AreEqual(6, idCounter);
+            ClassicAssert.AreEqual(2, pages);
+            ClassicAssert.AreEqual(6, idCounter);
         }
 
         [Test]
@@ -1090,10 +1091,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 {
                     continue;
                 }
-                Assert.AreEqual($"{idCounter}", chatThread.Id);
-                Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                ClassicAssert.AreEqual($"{idCounter}", chatThread.Id);
+                ClassicAssert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
             }
-            Assert.AreEqual(5, idCounter);
+            ClassicAssert.AreEqual(5, idCounter);
         }
 
         [Test]
@@ -1115,10 +1116,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 {
                     continue;
                 }
-                Assert.AreEqual($"{idCounter}", chatThread.Id);
-                Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                ClassicAssert.AreEqual($"{idCounter}", chatThread.Id);
+                ClassicAssert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
             }
-            Assert.AreEqual(5, idCounter);
+            ClassicAssert.AreEqual(5, idCounter);
         }
 
         [Test]
@@ -1140,7 +1141,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.IsTrue(ex.Message.Contains("401"));
+                ClassicAssert.IsTrue(ex.Message.Contains("401"));
             }
         }
 
@@ -1158,7 +1159,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.IsTrue(ex.Message.Contains("401"));
+                ClassicAssert.IsTrue(ex.Message.Contains("401"));
             }
         }
 
@@ -1176,7 +1177,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.IsTrue(ex.Message.Contains("401"));
+                ClassicAssert.IsTrue(ex.Message.Contains("401"));
             }
         }
 
@@ -1194,10 +1195,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             await foreach (ChatParticipant chatParticipant in chatParticipants)
             {
                 idCounter++;
-                Assert.AreEqual($"{idCounter}", CommunicationIdentifierSerializer.Serialize(chatParticipant.User).CommunicationUser.Id);
-                Assert.AreEqual($"Display Name {idCounter}", chatParticipant.DisplayName);
+                ClassicAssert.AreEqual($"{idCounter}", CommunicationIdentifierSerializer.Serialize(chatParticipant.User).CommunicationUser.Id);
+                ClassicAssert.AreEqual($"Display Name {idCounter}", chatParticipant.DisplayName);
             }
-            Assert.AreEqual(2, idCounter);
+            ClassicAssert.AreEqual(2, idCounter);
         }
 
         [Test]
@@ -1212,7 +1213,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response RemoveParticipantResponse = chatThreadClient.RemoveParticipant(identifier);
 
             //assert
-            Assert.AreEqual(204, RemoveParticipantResponse.Status);
+            ClassicAssert.AreEqual(204, RemoveParticipantResponse.Status);
         }
 
         [Test]
@@ -1227,7 +1228,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response RemoveParticipantResponse = await chatThreadClient.RemoveParticipantAsync(identifier);
 
             //assert
-            Assert.AreEqual(204, RemoveParticipantResponse.Status);
+            ClassicAssert.AreEqual(204, RemoveParticipantResponse.Status);
         }
 
         [Test]
@@ -1242,7 +1243,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response AddParticipantResponse = chatThreadClient.AddParticipant(chatParticipant);
 
             //assert
-            Assert.AreEqual(201, AddParticipantResponse.Status);
+            ClassicAssert.AreEqual(201, AddParticipantResponse.Status);
         }
 
         [Test]
@@ -1257,7 +1258,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response AddParticipantResponse = await chatThreadClient.AddParticipantAsync(chatParticipant);
 
             //assert
-            Assert.AreEqual(201, AddParticipantResponse.Status);
+            ClassicAssert.AreEqual(201, AddParticipantResponse.Status);
         }
 
         [Test]
@@ -1270,7 +1271,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AddChatParticipantsResult AddParticipantsResponse = await chatThreadClient.AddParticipantsAsync(new List<ChatParticipant>());
 
             //assert
-            Assert.AreEqual(0, AddParticipantsResponse.InvalidParticipants.Count);
+            ClassicAssert.AreEqual(0, AddParticipantsResponse.InvalidParticipants.Count);
         }
 
         [Test]
@@ -1283,7 +1284,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AddChatParticipantsResult AddParticipantsResponse = chatThreadClient.AddParticipants(new List<ChatParticipant>());
 
             //assert
-            Assert.AreEqual(0, AddParticipantsResponse.InvalidParticipants.Count);
+            ClassicAssert.AreEqual(0, AddParticipantsResponse.InvalidParticipants.Count);
         }
 
         [Test]
@@ -1297,7 +1298,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response deleteChatThreadResponse = await chatClient.DeleteChatThreadAsync(threadId);
 
             //assert
-            Assert.AreEqual(204, deleteChatThreadResponse.Status);
+            ClassicAssert.AreEqual(204, deleteChatThreadResponse.Status);
         }
 
         [Test]
@@ -1311,7 +1312,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response deleteChatThreadResponse = chatClient.DeleteChatThread(threadId);
 
             //assert
-            Assert.AreEqual(204, deleteChatThreadResponse.Status);
+            ClassicAssert.AreEqual(204, deleteChatThreadResponse.Status);
         }
 
         [Test]
@@ -1329,7 +1330,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.True(ex.Message.Contains("401"));
             }
         }
 
@@ -1348,10 +1349,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AsssertParticipantError(createChatThreadResult.InvalidParticipants.First(x => x.Code == "403"), "Permissions check failed", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345679");
             AsssertParticipantError(createChatThreadResult.InvalidParticipants.First(x => x.Code == "404"), "Not found", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345677");
 
-            Assert.AreEqual(3, createChatThreadResult.InvalidParticipants.Count);
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).RawId);
-            Assert.AreEqual("Topic for testing errors", createChatThreadResult.ChatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
+            ClassicAssert.AreEqual(3, createChatThreadResult.InvalidParticipants.Count);
+            ClassicAssert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).RawId);
+            ClassicAssert.AreEqual("Topic for testing errors", createChatThreadResult.ChatThread.Topic);
+            ClassicAssert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
         }
 
         [Test]
@@ -1364,14 +1365,14 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             //assert
             var chatThread = createChatThreadResult.ChatThread;
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id);
-            Assert.AreEqual("Topic for testing success", chatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", chatThread.Id);
+            ClassicAssert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id);
+            ClassicAssert.AreEqual("Topic for testing success", chatThread.Topic);
+            ClassicAssert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", chatThread.Id);
 
             var threadCreationDateRetentionPolicy = chatThread.RetentionPolicy as ThreadCreationDateRetentionPolicy;
 
-            Assert.IsNotNull(threadCreationDateRetentionPolicy);
-            Assert.AreEqual(40, threadCreationDateRetentionPolicy?.DeleteThreadAfterDays);
+            ClassicAssert.IsNotNull(threadCreationDateRetentionPolicy);
+            ClassicAssert.AreEqual(40, threadCreationDateRetentionPolicy?.DeleteThreadAfterDays);
         }
 
         [Test]
@@ -1384,13 +1385,13 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             //assert
             var chatThread = createChatThreadResult.ChatThread;
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id);
-            Assert.AreEqual("Topic for testing success", chatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", chatThread.Id);
+            ClassicAssert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id);
+            ClassicAssert.AreEqual("Topic for testing success", chatThread.Topic);
+            ClassicAssert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", chatThread.Id);
 
             var noneRetentionPolicy = chatThread.RetentionPolicy as NoneRetentionPolicy;
 
-            Assert.IsNotNull(noneRetentionPolicy);
+            ClassicAssert.IsNotNull(noneRetentionPolicy);
         }
 
         [Test]
@@ -1408,10 +1409,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AsssertParticipantError(createChatThreadResult.InvalidParticipants.First(x => x.Code == "403"), "Permissions check failed", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345679");
             AsssertParticipantError(createChatThreadResult.InvalidParticipants.First(x => x.Code == "404"), "Not found", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345677");
 
-            Assert.AreEqual(3, createChatThreadResult.InvalidParticipants.Count);
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).RawId);
-            Assert.AreEqual("Topic for testing errors", createChatThreadResult.ChatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
+            ClassicAssert.AreEqual(3, createChatThreadResult.InvalidParticipants.Count);
+            ClassicAssert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).RawId);
+            ClassicAssert.AreEqual("Topic for testing errors", createChatThreadResult.ChatThread.Topic);
+            ClassicAssert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
         }
 
         [Test]
@@ -1427,7 +1428,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AsssertParticipantError(addChatParticipantsResult.InvalidParticipants.First(x => x.Code == "401"), "Authentication failed", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345678");
             AsssertParticipantError(addChatParticipantsResult.InvalidParticipants.First(x => x.Code == "403"), "Permissions check failed", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345679");
             AsssertParticipantError(addChatParticipantsResult.InvalidParticipants.First(x => x.Code == "404"), "Not found", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345677");
-            Assert.AreEqual(3, addChatParticipantsResult.InvalidParticipants.Count);
+            ClassicAssert.AreEqual(3, addChatParticipantsResult.InvalidParticipants.Count);
         }
 
         [Test]
@@ -1445,7 +1446,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (RequestFailedException requestFailedException)
             {
                 //assert
-                Assert.AreEqual(401, requestFailedException.Status);
+                ClassicAssert.AreEqual(401, requestFailedException.Status);
             }
         }
 
@@ -1453,35 +1454,35 @@ namespace Azure.Communication.Chat.Tests.ChatClients
         public void TestMockingModels()
         {
             var chatThreadProperties = ChatModelFactory.ChatThreadProperties("id", "topic", It.IsAny<DateTimeOffset>(), It.IsAny<CommunicationIdentifier>(), It.IsAny<DateTimeOffset>());
-            Assert.IsNotNull(chatThreadProperties);
+            ClassicAssert.IsNotNull(chatThreadProperties);
 
             var createChatThreadResult = ChatModelFactory.CreateChatThreadResult(chatThreadProperties, It.IsAny<IEnumerable<ChatError>>());
-            Assert.IsNotNull(createChatThreadResult);
+            ClassicAssert.IsNotNull(createChatThreadResult);
 
             var sendChatMessageResult = ChatModelFactory.SendChatMessageResult("id");
-            Assert.IsNotNull(sendChatMessageResult);
+            ClassicAssert.IsNotNull(sendChatMessageResult);
 
             var innerChatError = new ChatError("innerErrorCode", "InnerCodeMessage");
             var chatErrorDetails = new List<ChatError>() { new ChatError("detailsErrorCode", "DetailsCodeMessage") };
             var chatError = ChatModelFactory.ChatError("code", "message", "target", chatErrorDetails, innerChatError);
-            Assert.IsNotNull(chatError);
-            Assert.AreEqual(chatError.Details, chatErrorDetails);
-            Assert.AreEqual(chatError.InnerError, innerChatError);
+            ClassicAssert.IsNotNull(chatError);
+            ClassicAssert.AreEqual(chatError.Details, chatErrorDetails);
+            ClassicAssert.AreEqual(chatError.InnerError, innerChatError);
 
             var chatParticipant = ChatModelFactory.ChatParticipant(It.IsAny<CommunicationIdentifier>(), It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<IDictionary<string, string>>());
-            Assert.IsNotNull(chatParticipant);
+            ClassicAssert.IsNotNull(chatParticipant);
 
             var addChatParticipantsResult = ChatModelFactory.AddChatParticipantsResult(It.IsAny<IEnumerable<ChatError>>());
-            Assert.IsNotNull(addChatParticipantsResult);
+            ClassicAssert.IsNotNull(addChatParticipantsResult);
 
             var addChatParticipantsResultEmpty = new AddChatParticipantsResult();
-            Assert.IsNotNull(addChatParticipantsResultEmpty);
+            ClassicAssert.IsNotNull(addChatParticipantsResultEmpty);
 
             var chatThreadItem = ChatModelFactory.ChatThreadItem("id", "topic", It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>());
-            Assert.IsNotNull(chatThreadItem);
+            ClassicAssert.IsNotNull(chatThreadItem);
 
             var chatMessageContent = ChatModelFactory.ChatMessageContent("id", "topic", It.IsAny<CommunicationUserIdentifier>(), It.IsAny<IEnumerable<ChatParticipant>>(), It.IsAny<IReadOnlyList<ChatAttachment>>());
-            Assert.IsNotNull(chatMessageContent);
+            ClassicAssert.IsNotNull(chatMessageContent);
 
             try
             {
@@ -1489,24 +1490,24 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.IsNotNull(ex);
+                ClassicAssert.IsNotNull(ex);
             }
 
             var chatMessageReceipt = ChatModelFactory.ChatMessageReadReceipt(It.IsAny<CommunicationUserIdentifier>(), "messageId", It.IsAny<DateTimeOffset>());
-            Assert.IsNotNull(chatMessageReceipt);
+            ClassicAssert.IsNotNull(chatMessageReceipt);
         }
 
         [Test]
         public void TestChatClientOptions()
         {
             var options = new ChatClientOptions(ChatClientOptions.ServiceVersion.V2021_09_07);
-            Assert.IsNotNull(options);
+            ClassicAssert.IsNotNull(options);
         }
 
         private void AsssertParticipantError(ChatError chatParticipantError, string expectedMessage, string expectedTarget)
         {
-            Assert.AreEqual(expectedMessage, chatParticipantError.Message);
-            Assert.AreEqual(expectedTarget, chatParticipantError.Target);
+            ClassicAssert.AreEqual(expectedMessage, chatParticipantError.Message);
+            ClassicAssert.AreEqual(expectedTarget, chatParticipantError.Target);
         }
 
         private ChatClient CreateMockChatClient(int responseCode, string? responseContent = null)

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication
 {
@@ -14,86 +15,86 @@ namespace Azure.Communication
         public void RawIdTakesPrecendenceInEqualityCheck()
         {
             // Teams users
-            Assert.AreEqual(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true), new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true));
-            Assert.AreNotEqual(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Raw Id"), new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Another Raw Id"));
+            ClassicAssert.AreEqual(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true), new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true));
+            ClassicAssert.AreNotEqual(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Raw Id"), new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Another Raw Id"));
 
-            Assert.AreEqual(new MicrosoftTeamsUserIdentifier("override", isAnonymous: true, rawId: "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true));
-            Assert.AreEqual(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true), new MicrosoftTeamsUserIdentifier("override", isAnonymous: true, rawId: "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+            ClassicAssert.AreEqual(new MicrosoftTeamsUserIdentifier("override", isAnonymous: true, rawId: "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true));
+            ClassicAssert.AreEqual(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true), new MicrosoftTeamsUserIdentifier("override", isAnonymous: true, rawId: "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"));
 
             // Phone numbers
-            Assert.AreEqual(new PhoneNumberIdentifier("+14255550123"), new PhoneNumberIdentifier("+14255550123"));
-            Assert.AreNotEqual(new PhoneNumberIdentifier("+14255550123", "Raw Id"), new PhoneNumberIdentifier("+14255550123", "Another Raw Id"));
+            ClassicAssert.AreEqual(new PhoneNumberIdentifier("+14255550123"), new PhoneNumberIdentifier("+14255550123"));
+            ClassicAssert.AreNotEqual(new PhoneNumberIdentifier("+14255550123", "Raw Id"), new PhoneNumberIdentifier("+14255550123", "Another Raw Id"));
 
-            Assert.AreEqual(new PhoneNumberIdentifier("+override", "4:14255550123"), new PhoneNumberIdentifier("14255550123"));
-            Assert.AreEqual(new PhoneNumberIdentifier("14255550123"), new PhoneNumberIdentifier("+override", "4:14255550123"));
+            ClassicAssert.AreEqual(new PhoneNumberIdentifier("+override", "4:14255550123"), new PhoneNumberIdentifier("14255550123"));
+            ClassicAssert.AreEqual(new PhoneNumberIdentifier("14255550123"), new PhoneNumberIdentifier("+override", "4:14255550123"));
 
             // Teams app
-            Assert.AreEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"));
-            Assert.AreEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Public));
-            Assert.AreNotEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Dod));
-            Assert.AreNotEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Gcch));
+            ClassicAssert.AreEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"));
+            ClassicAssert.AreEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Public));
+            ClassicAssert.AreNotEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Dod));
+            ClassicAssert.AreNotEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Gcch));
 
-            Assert.AreNotEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("override"));
+            ClassicAssert.AreNotEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("override"));
 
             // Teams extension user
-            Assert.AreEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"));
-            Assert.AreEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Public));
-            Assert.AreNotEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Gcch));
-            Assert.AreNotEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Dod));
+            ClassicAssert.AreEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"));
+            ClassicAssert.AreEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Public));
+            ClassicAssert.AreNotEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Gcch));
+            ClassicAssert.AreNotEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Dod));
         }
 
         [Test]
         public void InitializeIdentifierWithNullOrEmptyParameters()
         {
-            Assert.Throws<ArgumentException>(() => new CommunicationUserIdentifier(string.Empty));
-            Assert.Throws<ArgumentException>(() => new MicrosoftTeamsUserIdentifier(string.Empty));
-            Assert.Throws<ArgumentException>(() => new PhoneNumberIdentifier(string.Empty));
-            Assert.Throws<ArgumentException>(() => new MicrosoftTeamsAppIdentifier(string.Empty));
-            Assert.Throws<ArgumentException>(() => new TeamsExtensionUserIdentifier(string.Empty, string.Empty, string.Empty));
+            ClassicAssert.Throws<ArgumentException>(() => new CommunicationUserIdentifier(string.Empty));
+            ClassicAssert.Throws<ArgumentException>(() => new MicrosoftTeamsUserIdentifier(string.Empty));
+            ClassicAssert.Throws<ArgumentException>(() => new PhoneNumberIdentifier(string.Empty));
+            ClassicAssert.Throws<ArgumentException>(() => new MicrosoftTeamsAppIdentifier(string.Empty));
+            ClassicAssert.Throws<ArgumentException>(() => new TeamsExtensionUserIdentifier(string.Empty, string.Empty, string.Empty));
 
-            Assert.Throws<ArgumentNullException>(() => new CommunicationUserIdentifier(null));
-            Assert.Throws<ArgumentNullException>(() => new MicrosoftTeamsUserIdentifier(null));
-            Assert.Throws<ArgumentNullException>(() => new PhoneNumberIdentifier(null));
-            Assert.Throws<ArgumentNullException>(() => new MicrosoftTeamsAppIdentifier(null));
-            Assert.Throws<ArgumentNullException>(() => new TeamsExtensionUserIdentifier(null, "b", "c"));
-            Assert.Throws<ArgumentNullException>(() => new TeamsExtensionUserIdentifier("a", null, "c"));
-            Assert.Throws<ArgumentNullException>(() => new TeamsExtensionUserIdentifier("a", "b", null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new CommunicationUserIdentifier(null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new MicrosoftTeamsUserIdentifier(null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new PhoneNumberIdentifier(null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new MicrosoftTeamsAppIdentifier(null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new TeamsExtensionUserIdentifier(null, "b", "c"));
+            ClassicAssert.Throws<ArgumentNullException>(() => new TeamsExtensionUserIdentifier("a", null, "c"));
+            ClassicAssert.Throws<ArgumentNullException>(() => new TeamsExtensionUserIdentifier("a", "b", null));
         }
 
         [Test]
         public void DefaultCloudIsPublic()
         {
-            Assert.AreEqual(CommunicationCloudEnvironment.Public, new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Raw Id").Cloud);
-            Assert.AreEqual(CommunicationCloudEnvironment.Public, new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130").Cloud);
-            Assert.AreEqual(CommunicationCloudEnvironment.Public, new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd").Cloud);
+            ClassicAssert.AreEqual(CommunicationCloudEnvironment.Public, new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Raw Id").Cloud);
+            ClassicAssert.AreEqual(CommunicationCloudEnvironment.Public, new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130").Cloud);
+            ClassicAssert.AreEqual(CommunicationCloudEnvironment.Public, new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd").Cloud);
         }
 
         [Test]
         public void PhoneNumberIdentifier_ComputedProperties()
         {
-            Assert.AreEqual(false, new PhoneNumberIdentifier("14255550123").IsAnonymous);
-            Assert.AreEqual(true, new PhoneNumberIdentifier("anonymous").IsAnonymous);
-            Assert.AreEqual(true, new PhoneNumberIdentifier("override", "4:anonymous").IsAnonymous);
-            Assert.AreEqual(false, new PhoneNumberIdentifier("override", "4:anonymous123").IsAnonymous);
-            Assert.AreEqual(false, new PhoneNumberIdentifier("override", "4:_anonymous").IsAnonymous);
+            ClassicAssert.AreEqual(false, new PhoneNumberIdentifier("14255550123").IsAnonymous);
+            ClassicAssert.AreEqual(true, new PhoneNumberIdentifier("anonymous").IsAnonymous);
+            ClassicAssert.AreEqual(true, new PhoneNumberIdentifier("override", "4:anonymous").IsAnonymous);
+            ClassicAssert.AreEqual(false, new PhoneNumberIdentifier("override", "4:anonymous123").IsAnonymous);
+            ClassicAssert.AreEqual(false, new PhoneNumberIdentifier("override", "4:_anonymous").IsAnonymous);
 
-            Assert.AreEqual(null, new PhoneNumberIdentifier("14255550121").AssertedId);
-            Assert.AreEqual(null, new PhoneNumberIdentifier("14255550121.123").AssertedId);
-            Assert.AreEqual(null, new PhoneNumberIdentifier("14255550121-123").AssertedId);
-            Assert.AreEqual("123", new PhoneNumberIdentifier("14255550121_123").AssertedId);
-            Assert.AreEqual("123", new PhoneNumberIdentifier("14255550121", "4:14255550121_123").AssertedId);
-            Assert.AreEqual("456", new PhoneNumberIdentifier("14255550121_123_456").AssertedId);
-            Assert.AreEqual("456", new PhoneNumberIdentifier("14255550121", "4:14255550121_123_456").AssertedId);
+            ClassicAssert.AreEqual(null, new PhoneNumberIdentifier("14255550121").AssertedId);
+            ClassicAssert.AreEqual(null, new PhoneNumberIdentifier("14255550121.123").AssertedId);
+            ClassicAssert.AreEqual(null, new PhoneNumberIdentifier("14255550121-123").AssertedId);
+            ClassicAssert.AreEqual("123", new PhoneNumberIdentifier("14255550121_123").AssertedId);
+            ClassicAssert.AreEqual("123", new PhoneNumberIdentifier("14255550121", "4:14255550121_123").AssertedId);
+            ClassicAssert.AreEqual("456", new PhoneNumberIdentifier("14255550121_123_456").AssertedId);
+            ClassicAssert.AreEqual("456", new PhoneNumberIdentifier("14255550121", "4:14255550121_123_456").AssertedId);
 
             var staticPhoneNumberIdentifier = new PhoneNumberIdentifier("14255550121_123");
-            Assert.AreEqual("123", staticPhoneNumberIdentifier.AssertedId); // first use: compute assertedId
-            Assert.AreEqual("123", staticPhoneNumberIdentifier.AssertedId); // second use: reuse previously computed assertedId
+            ClassicAssert.AreEqual("123", staticPhoneNumberIdentifier.AssertedId); // first use: compute assertedId
+            ClassicAssert.AreEqual("123", staticPhoneNumberIdentifier.AssertedId); // second use: reuse previously computed assertedId
         }
 
         [Test]
         public void GetRawIdOfIdentifier()
         {
-            static void AssertRawId(CommunicationIdentifier identifier, string expectedRawId) => Assert.AreEqual(expectedRawId, identifier.RawId);
+            static void AssertRawId(CommunicationIdentifier identifier, string expectedRawId) => ClassicAssert.AreEqual(expectedRawId, identifier.RawId);
 
             AssertRawId(new CommunicationUserIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"), "8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
             AssertRawId(new CommunicationUserIdentifier("8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"), "8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
@@ -127,10 +128,10 @@ namespace Azure.Communication
         {
             static void AssertIdentifier(string rawId, CommunicationIdentifier expectedIdentifier)
             {
-                Assert.AreEqual(expectedIdentifier, CommunicationIdentifier.FromRawId(rawId));
-                Assert.AreEqual(expectedIdentifier.GetHashCode(), CommunicationIdentifier.FromRawId(rawId).GetHashCode());
-                Assert.IsTrue(CommunicationIdentifier.FromRawId(rawId) == expectedIdentifier);
-                Assert.IsFalse(CommunicationIdentifier.FromRawId(rawId) != expectedIdentifier);
+                ClassicAssert.AreEqual(expectedIdentifier, CommunicationIdentifier.FromRawId(rawId));
+                ClassicAssert.AreEqual(expectedIdentifier.GetHashCode(), CommunicationIdentifier.FromRawId(rawId).GetHashCode());
+                ClassicAssert.IsTrue(CommunicationIdentifier.FromRawId(rawId) == expectedIdentifier);
+                ClassicAssert.IsFalse(CommunicationIdentifier.FromRawId(rawId) != expectedIdentifier);
             }
 
             AssertIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130", new CommunicationUserIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
@@ -160,13 +161,13 @@ namespace Azure.Communication
             AssertIdentifier("8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130_207ffef6-9444-41fb-92ab-20eacaae2768", new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Gcch));
             AssertIdentifier("8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130_207ffef6-9444-41fb-92ab-20eacaae2768", new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Dod));
 
-            Assert.Throws<ArgumentNullException>(() => CommunicationIdentifier.FromRawId(null));
+            ClassicAssert.Throws<ArgumentNullException>(() => CommunicationIdentifier.FromRawId(null));
         }
 
         [Test]
         public void RawIdStaysTheSameAfterConversionToIdentifierAndBack()
         {
-            static void AssertRoundtrip(string rawId) => Assert.AreEqual(rawId, CommunicationIdentifier.FromRawId(rawId).RawId);
+            static void AssertRoundtrip(string rawId) => ClassicAssert.AreEqual(rawId, CommunicationIdentifier.FromRawId(rawId).RawId);
 
             AssertRoundtrip("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
             AssertRoundtrip("8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
@@ -196,7 +197,7 @@ namespace Azure.Communication
             IEnumerable<Type>? implementations = baseType.Assembly.GetTypes().Where(type => type.IsSubclassOf(typeof(CommunicationIdentifier)));
             foreach (Type implementation in implementations)
             {
-                Assert.AreNotEqual(baseType, implementation.GetProperty(nameof(CommunicationIdentifier.RawId))?.DeclaringType);
+                ClassicAssert.AreNotEqual(baseType, implementation.GetProperty(nameof(CommunicationIdentifier.RawId))?.DeclaringType);
             }
         }
 
@@ -264,31 +265,31 @@ namespace Azure.Communication
             var otherTypeIdentifier = new MicrosoftTeamsUserIdentifier("123");
             CommunicationIdentifier? nullIdentifier = null;
 
-            Assert.False(identifier == null);
-            Assert.False(null == identifier);
-            Assert.True(identifier != null);
-            Assert.True(null != identifier);
+            ClassicAssert.False(identifier == null);
+            ClassicAssert.False(null == identifier);
+            ClassicAssert.True(identifier != null);
+            ClassicAssert.True(null != identifier);
 
-            Assert.True(null as CommunicationIdentifier == null as CommunicationIdentifier);
-            Assert.False(identifier == null as CommunicationIdentifier);
-            Assert.False(null as CommunicationIdentifier == identifier);
-            Assert.True(identifier != null as CommunicationIdentifier);
-            Assert.True(null as CommunicationIdentifier != identifier);
+            ClassicAssert.True(null as CommunicationIdentifier == null as CommunicationIdentifier);
+            ClassicAssert.False(identifier == null as CommunicationIdentifier);
+            ClassicAssert.False(null as CommunicationIdentifier == identifier);
+            ClassicAssert.True(identifier != null as CommunicationIdentifier);
+            ClassicAssert.True(null as CommunicationIdentifier != identifier);
 
-            Assert.True(null == nullIdentifier);
-            Assert.False(nullIdentifier == identifier);
+            ClassicAssert.True(null == nullIdentifier);
+            ClassicAssert.False(nullIdentifier == identifier);
 
 #pragma warning disable CS1718 // Comparison made to same variable
-            Assert.True(identifier == identifier);
+            ClassicAssert.True(identifier == identifier);
 #pragma warning restore CS1718 // Comparison made to same variable
-            Assert.True(identifier == sameIdentifier);
-            Assert.False(identifier != sameIdentifier);
-            Assert.True(sameIdentifier == identifier);
-            Assert.False(sameIdentifier != identifier);
-            Assert.False(identifier == otherIdentifier);
-            Assert.True(identifier != otherIdentifier);
-            Assert.False(identifier == otherTypeIdentifier);
-            Assert.True(identifier != otherTypeIdentifier);
+            ClassicAssert.True(identifier == sameIdentifier);
+            ClassicAssert.False(identifier != sameIdentifier);
+            ClassicAssert.True(sameIdentifier == identifier);
+            ClassicAssert.False(sameIdentifier != identifier);
+            ClassicAssert.False(identifier == otherIdentifier);
+            ClassicAssert.True(identifier != otherIdentifier);
+            ClassicAssert.False(identifier == otherTypeIdentifier);
+            ClassicAssert.True(identifier != otherTypeIdentifier);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationUserIdentifierTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationUserIdentifierTests.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication
 {
@@ -13,8 +14,8 @@ namespace Azure.Communication
         [Test]
         public void constructWithNullOrEmptyIdShouldThrow()
         {
-            Assert.Throws<ArgumentNullException>(() => { new CommunicationUserIdentifier(null); }, "The initialization parameter [id] cannot be null");
-            Assert.Throws<ArgumentException>(() => { new CommunicationUserIdentifier(""); }, "The initialization parameter [id] cannot be empty");
+            ClassicAssert.Throws<ArgumentNullException>(() => { new CommunicationUserIdentifier(null); }, "The initialization parameter [id] cannot be null");
+            ClassicAssert.Throws<ArgumentException>(() => { new CommunicationUserIdentifier(""); }, "The initialization parameter [id] cannot be empty");
         }
 
         [Test]
@@ -23,8 +24,8 @@ namespace Azure.Communication
             CommunicationUserIdentifier identifier1 = new(_id);
             CommunicationUserIdentifier identifier2 = new(_id);
 
-            Assert.True(identifier1.Equals(identifier1));
-            Assert.True(identifier1.Equals(identifier2));
+            ClassicAssert.True(identifier1.Equals(identifier1));
+            ClassicAssert.True(identifier1.Equals(identifier2));
         }
 
         [Test]
@@ -32,15 +33,15 @@ namespace Azure.Communication
         {
             CommunicationUserIdentifier identifier1 = new(_id);
             object identifier2 = new();
-            Assert.False(identifier1.Equals(identifier2));
+            ClassicAssert.False(identifier1.Equals(identifier2));
         }
 
         [Test]
         public void constructWithValidId()
         {
             CommunicationUserIdentifier result = new(_id);
-            Assert.NotNull(result.Id);
-            Assert.NotNull(result.GetHashCode());
+            ClassicAssert.NotNull(result.Id);
+            ClassicAssert.NotNull(result.GetHashCode());
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Identity
 {
@@ -71,7 +72,7 @@ namespace Azure.Communication.Identity
                     AsyncTokenRefresher = cancellationToken => FetchTokenForUserFromMyServerAsync("bob@contoso.com", cancellationToken)
                 });
             var accessToken = await tokenCredential.GetTokenAsync();
-            Assert.AreEqual(SampleToken, accessToken.Token);
+            ClassicAssert.AreEqual(SampleToken, accessToken.Token);
         }
 
         [Test]
@@ -105,8 +106,8 @@ namespace Azure.Communication.Identity
             using var tokenCredential = new CommunicationTokenCredential(token);
             AccessToken accessToken = await tokenCredential.GetTokenAsync();
 
-            Assert.AreEqual(token, accessToken.Token);
-            Assert.AreEqual(expectedExpiryUnixTimeSeconds, accessToken.ExpiresOn.ToUnixTimeSeconds());
+            ClassicAssert.AreEqual(token, accessToken.Token);
+            ClassicAssert.AreEqual(expectedExpiryUnixTimeSeconds, accessToken.ExpiresOn.ToUnixTimeSeconds());
         }
 
         [Test]
@@ -114,11 +115,11 @@ namespace Azure.Communication.Identity
         [TestCase("foo.bar")]
         [TestCase("foo.bar.foobar")]
         public void CommunicationTokenCredential_ThrowsIfInvalidToken(string token)
-            => Assert.Throws<FormatException>(() => new CommunicationTokenCredential(token));
+            => ClassicAssert.Throws<FormatException>(() => new CommunicationTokenCredential(token));
 
         [Test]
         public void CommunicationTokenCredential_ThrowsIfTokenIsNull()
-            => Assert.Throws<ArgumentNullException>(() => new CommunicationTokenCredential(token: null!));
+            => ClassicAssert.Throws<ArgumentNullException>(() => new CommunicationTokenCredential(token: null!));
 
         [Test]
         [TestCase(false)]
@@ -128,7 +129,7 @@ namespace Azure.Communication.Identity
             using var tokenCredential = new CommunicationTokenCredential(ExpiredToken);
 
             AccessToken token = async ? await tokenCredential.GetTokenAsync() : tokenCredential.GetToken();
-            Assert.AreEqual(ExpiredToken, token.Token);
+            ClassicAssert.AreEqual(ExpiredToken, token.Token);
         }
 
         [Test]
@@ -150,7 +151,7 @@ namespace Azure.Communication.Identity
                 });
 
             AccessToken token = async ? await tokenCredential.GetTokenAsync(cancellationToken) : tokenCredential.GetToken(cancellationToken);
-            Assert.AreEqual(cancellationToken, actualCancellationToken);
+            ClassicAssert.AreEqual(cancellationToken, actualCancellationToken);
 
             string RefreshToken(CancellationToken token)
             {
@@ -173,9 +174,9 @@ namespace Azure.Communication.Identity
                 _ => throw new NotImplementedException(),
                 expiredToken);
 
-            Assert.AreEqual(1, testClock.ScheduledActions.Count());
+            ClassicAssert.AreEqual(1, testClock.ScheduledActions.Count());
             testClock.Tick();
-            Assert.AreEqual(1, refreshCallCount);
+            ClassicAssert.AreEqual(1, refreshCallCount);
 
             string RefreshToken(CancellationToken _)
             {
@@ -197,14 +198,14 @@ namespace Azure.Communication.Identity
                 _ => new ValueTask<string>(token),
                 initialToken: ExpiredToken);
 
-            Assert.AreEqual(0, testClock.ScheduledActions.Count());
+            ClassicAssert.AreEqual(0, testClock.ScheduledActions.Count());
 
             AccessToken accessToken = async
                 ? await tokenCredential.GetTokenAsync()
                 : tokenCredential.GetToken();
 
-            Assert.AreEqual(token, accessToken.Token);
-            Assert.AreEqual(expectedExpiryUnixTimeSeconds, accessToken.ExpiresOn.ToUnixTimeSeconds());
+            ClassicAssert.AreEqual(token, accessToken.Token);
+            ClassicAssert.AreEqual(expectedExpiryUnixTimeSeconds, accessToken.ExpiresOn.ToUnixTimeSeconds());
         }
 
         [Test]
@@ -224,9 +225,9 @@ namespace Azure.Communication.Identity
             tokenCredential.Dispose();
 
             if (async)
-                Assert.ThrowsAsync<ObjectDisposedException>(async () => await tokenCredential.GetTokenAsync());
+                ClassicAssert.ThrowsAsync<ObjectDisposedException>(async () => await tokenCredential.GetTokenAsync());
             else
-                Assert.Throws<ObjectDisposedException>(() => tokenCredential.GetToken());
+                ClassicAssert.Throws<ObjectDisposedException>(() => tokenCredential.GetToken());
         }
 
         [Test]
@@ -239,9 +240,9 @@ namespace Azure.Communication.Identity
             tokenCredential.Dispose();
 
             if (async)
-                Assert.ThrowsAsync<ObjectDisposedException>(async () => await tokenCredential.GetTokenAsync());
+                ClassicAssert.ThrowsAsync<ObjectDisposedException>(async () => await tokenCredential.GetTokenAsync());
             else
-                Assert.Throws<ObjectDisposedException>(() => tokenCredential.GetToken());
+                ClassicAssert.Throws<ObjectDisposedException>(() => tokenCredential.GetToken());
         }
 
         [Test]
@@ -254,10 +255,10 @@ namespace Azure.Communication.Identity
                 _ => SampleToken,
                 _ => new ValueTask<string>(SampleToken));
 
-            Assert.AreEqual(1, testClock.ScheduledActions.Count());
+            ClassicAssert.AreEqual(1, testClock.ScheduledActions.Count());
             tokenCredential.Dispose();
 
-            Assert.AreEqual(0, testClock.ScheduledActions.Count());
+            ClassicAssert.AreEqual(0, testClock.ScheduledActions.Count());
         }
 
         [Test]
@@ -285,12 +286,12 @@ namespace Azure.Communication.Identity
 
             testClock.Tick(TimeSpan.FromMinutes(tokenValidForMinutes - ThreadSafeRefreshableAccessTokenCache.ProactiveRefreshIntervalInMinutes + 0.5));
 
-            Assert.AreEqual(1, refreshCallCount);
+            ClassicAssert.AreEqual(1, refreshCallCount);
 
             AccessToken afterRefreshToken = tokenCredential.GetToken();
 
-            Assert.AreEqual(inCriticalExpiryWindow ? newToken : initialToken, token.Token);
-            Assert.AreEqual(newToken, afterRefreshToken.Token);
+            ClassicAssert.AreEqual(inCriticalExpiryWindow ? newToken : initialToken, token.Token);
+            ClassicAssert.AreEqual(newToken, afterRefreshToken.Token);
 
             string RefreshToken(CancellationToken _)
             {
@@ -312,7 +313,7 @@ namespace Azure.Communication.Identity
                     InitialToken = expiredToken
                 });
 
-            Assert.Throws<ArithmeticException>(() => tokenCredential.GetToken());
+            ClassicAssert.Throws<ArithmeticException>(() => tokenCredential.GetToken());
 
             static string RefreshToken(CancellationToken _) => throw new ArithmeticException("Refresh token failed");
         }
@@ -330,14 +331,14 @@ namespace Azure.Communication.Identity
                 _ => throw new NotImplementedException(),
                 twentyMinToken);
 
-            Assert.AreEqual(1, testClock.ScheduledActions.Count());
+            ClassicAssert.AreEqual(1, testClock.ScheduledActions.Count());
             ThreadSafeRefreshableAccessTokenCache.IScheduledAction? firstTimer = testClock.ScheduledActions.First();
             // Go into the soon-to-expire window
             testClock.Tick(TimeSpan.FromMinutes(20 - ThreadSafeRefreshableAccessTokenCache.ProactiveRefreshIntervalInMinutes + 0.5));
 
-            Assert.AreEqual(1, testClock.ScheduledActions.Count());
+            ClassicAssert.AreEqual(1, testClock.ScheduledActions.Count());
             ThreadSafeRefreshableAccessTokenCache.IScheduledAction? secondTimer = testClock.ScheduledActions.First();
-            Assert.AreNotEqual(firstTimer, secondTimer);
+            ClassicAssert.AreNotEqual(firstTimer, secondTimer);
         }
 
         [Test]
@@ -367,7 +368,7 @@ namespace Azure.Communication.Identity
                     tokenCredential.GetToken();
             }
 
-            Assert.AreEqual(1, refreshCallCount);
+            ClassicAssert.AreEqual(1, refreshCallCount);
 
             string RefreshToken(CancellationToken _)
             {
@@ -398,7 +399,7 @@ namespace Azure.Communication.Identity
             AccessToken refreshedToken = tokenCredential.GetToken();
 
             // Expect the token to be refreshed only once within the first 10 minutes
-            Assert.AreEqual(expectedTotalCallCounts, refreshCallCount);
+            ClassicAssert.AreEqual(expectedTotalCallCounts, refreshCallCount);
 
             // iterate until the penultimate millisecond of the token expiration
             // to prevent an exception being thrown due to the token being expired
@@ -410,7 +411,7 @@ namespace Azure.Communication.Identity
                 testClock.Tick(TimeSpan.FromMilliseconds(soonToExpireMs));
                 expectedTotalCallCounts++;
             }
-            Assert.AreEqual(expectedTotalCallCounts, refreshCallCount);
+            ClassicAssert.AreEqual(expectedTotalCallCounts, refreshCallCount);
 
             string RefreshToken(CancellationToken _)
             {
@@ -433,7 +434,7 @@ namespace Azure.Communication.Identity
                     InitialToken = expiredToken
                 });
 
-            InvalidOperationException? ex = Assert.Throws<InvalidOperationException>(() => tokenCredential.GetToken());
+            InvalidOperationException? ex = ClassicAssert.Throws<InvalidOperationException>(() => tokenCredential.GetToken());
             Assert.That(ex?.Message, Is.EqualTo("The token returned from the tokenRefresher is expired."));
             string RefreshToken(CancellationToken _)
             {

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
@@ -10,6 +10,7 @@ using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Identity
 {
@@ -58,21 +59,21 @@ namespace Azure.Communication.Identity
         [Test, TestCaseSource(nameof(validScopes))]
         public void EntraCommunicationTokenCredentialOptions_Init_ThrowsErrorWithNulls(string[] scopes)
         {
-            Assert.Throws<ArgumentNullException>(() => new EntraCommunicationTokenCredentialOptions(
+            ClassicAssert.Throws<ArgumentNullException>(() => new EntraCommunicationTokenCredentialOptions(
                 null,
                 _mockTokenCredential.Object)
             {
                 Scopes = scopes
             });
 
-            Assert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
+            ClassicAssert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
                 "",
                 _mockTokenCredential.Object)
             {
                 Scopes = scopes
             });
 
-            Assert.Throws<ArgumentNullException>(() => new EntraCommunicationTokenCredentialOptions(
+            ClassicAssert.Throws<ArgumentNullException>(() => new EntraCommunicationTokenCredentialOptions(
                 _resourceEndpoint,
                 null)
             {
@@ -83,13 +84,13 @@ namespace Azure.Communication.Identity
         [Test]
         public void EntraCommunicationTokenCredentialOptions_NullOrEmptyScopes_ThrowsError()
         {
-            Assert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
+            ClassicAssert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
                 _resourceEndpoint,
                 _mockTokenCredential.Object)
             {
                 Scopes = null
             });
-            Assert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
+            ClassicAssert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
                 _resourceEndpoint,
                 _mockTokenCredential.Object)
             {
@@ -100,7 +101,7 @@ namespace Azure.Communication.Identity
         [Test, TestCaseSource(nameof(invalidScopes))]
         public void EntraCommunicationTokenCredentialOptions_InvalidScopes_ThrowsForInvalidScopes(string[] scopes)
         {
-            Assert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
+            ClassicAssert.Throws<ArgumentException>(() => new EntraCommunicationTokenCredentialOptions(
                 _resourceEndpoint,
                 _mockTokenCredential.Object)
             {
@@ -115,7 +116,7 @@ namespace Azure.Communication.Identity
                 _resourceEndpoint,
                 _mockTokenCredential.Object);
             var scopes = new[] { "https://communication.azure.com/clients/.default" };
-            Assert.AreEqual(credential.Scopes, scopes);
+            ClassicAssert.AreEqual(credential.Scopes, scopes);
         }
 
         [Test]
@@ -124,7 +125,7 @@ namespace Azure.Communication.Identity
             // Arrange
             var mockTransport = CreateMockTransport(new[] { CreateMockResponse(200, TokenResponse) });
             // Assert
-            Assert.Throws<ArgumentNullException>(() => new EntraTokenCredential(null, mockTransport));
+            ClassicAssert.Throws<ArgumentNullException>(() => new EntraTokenCredential(null, mockTransport));
         }
 
         [Test, TestCaseSource(nameof(validScopes))]
@@ -152,15 +153,15 @@ namespace Azure.Communication.Identity
             var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
 
             // Assert
-            Assert.AreEqual(SampleToken, token.Token);
-            Assert.AreEqual(token.ExpiresOn, expiryTime);
+            ClassicAssert.AreEqual(SampleToken, token.Token);
+            ClassicAssert.AreEqual(token.ExpiresOn, expiryTime);
             if (scopes.Contains(teamsExtensionScope))
             {
-                Assert.AreEqual(teamsExtensionEndpoint, mockTransport.SingleRequest.Uri.Path);
+                ClassicAssert.AreEqual(teamsExtensionEndpoint, mockTransport.SingleRequest.Uri.Path);
             }
             else
             {
-                Assert.AreEqual(communicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
+                ClassicAssert.AreEqual(communicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
             }
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -178,9 +179,9 @@ namespace Azure.Communication.Identity
             var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
 
             // Assert
-            Assert.AreEqual(SampleToken, token.Token);
-            Assert.AreEqual(token.ExpiresOn, expiryTime);
-            Assert.AreEqual(communicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
+            ClassicAssert.AreEqual(SampleToken, token.Token);
+            ClassicAssert.AreEqual(token.ExpiresOn, expiryTime);
+            ClassicAssert.AreEqual(communicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -206,7 +207,7 @@ namespace Azure.Communication.Identity
             var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
 
             // Assert for cached tokens are updated
-            Assert.AreEqual(newToken, token.Token);
+            ClassicAssert.AreEqual(newToken, token.Token);
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
@@ -225,7 +226,7 @@ namespace Azure.Communication.Identity
                 token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
             }
             // Assert
-            Assert.AreEqual(SampleToken, token.Token);
+            ClassicAssert.AreEqual(SampleToken, token.Token);
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -244,7 +245,7 @@ namespace Azure.Communication.Identity
             var entraTokenCredential = new EntraTokenCredential(options, mockTransport);
 
             // Act & Assert
-            Assert.ThrowsAsync<RequestFailedException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
+            ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
         }
 
         [Test, TestCaseSource(nameof(validScopes))]
@@ -263,7 +264,7 @@ namespace Azure.Communication.Identity
             var entraTokenCredential = new EntraTokenCredential(options, mockTransport);
 
             // Act & Assert
-            Assert.ThrowsAsync<RequestFailedException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
+            ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
         }
 
         [Test, TestCaseSource(nameof(validScopes))]
@@ -289,8 +290,8 @@ namespace Azure.Communication.Identity
             var entraTokenCredential = new EntraTokenCredential(options, mockTransport);
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<RequestFailedException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
-            StringAssert.Contains(lastRetryErrorMessage, ex?.Message);
+            var ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
+            StringAssert.Contains(lastRetryErrorMessage, ex?.Message ?? string.Empty);
         }
 
         [Test, TestCaseSource(nameof(invalidScopes))]
@@ -312,8 +313,8 @@ namespace Azure.Communication.Identity
             var entraTokenCredential = new EntraTokenCredential(options, mockTransport);
 
             // Act & Assert
-            var ex = Assert.ThrowsAsync<ArgumentException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
-            StringAssert.Contains("Scopes validation failed. Ensure all scopes start with either", ex?.Message);
+            var ex = ClassicAssert.ThrowsAsync<ArgumentException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
+            StringAssert.Contains("Scopes validation failed. Ensure all scopes start with either", ex?.Message ?? string.Empty);
         }
 
         [Test]
@@ -344,7 +345,7 @@ namespace Azure.Communication.Identity
             var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
 
             // Assert for cached tokens are updated
-            Assert.AreEqual(newToken, token.Token);
+            ClassicAssert.AreEqual(newToken, token.Token);
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 

--- a/sdk/communication/Azure.Communication.Common/tests/Pipeline/CommunicationBearerTokenCredentialTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Pipeline/CommunicationBearerTokenCredentialTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Azure.Communication.Identity;
 using Azure.Core;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Pipeline
 {
@@ -76,8 +77,8 @@ namespace Azure.Communication.Pipeline
 
             var accessToken = await communicationBearerTokenCredential.GetTokenAsync(MockTokenRequestContext(), CancellationToken.None);
 
-            Assert.AreEqual(initialToken, accessToken.Token);
-            Assert.AreEqual(SampleTokenExpiry, accessToken.ExpiresOn.ToUnixTimeSeconds());
+            ClassicAssert.AreEqual(initialToken, accessToken.Token);
+            ClassicAssert.AreEqual(SampleTokenExpiry, accessToken.ExpiresOn.ToUnixTimeSeconds());
         }
 
         [Test]
@@ -87,7 +88,7 @@ namespace Azure.Communication.Pipeline
             var communicationBearerTokenCredential = new CommunicationBearerTokenCredential(tokenCredential);
 
             var accessToken = communicationBearerTokenCredential.GetToken(MockTokenRequestContext(), CancellationToken.None);
-            Assert.AreEqual(ExpiredToken, accessToken.Token);
+            ClassicAssert.AreEqual(ExpiredToken, accessToken.Token);
         }
 
         [Test]
@@ -97,7 +98,7 @@ namespace Azure.Communication.Pipeline
             var communicationBearerTokenCredential = new CommunicationBearerTokenCredential(tokenCredential);
 
             var accessToken = await communicationBearerTokenCredential.GetTokenAsync(MockTokenRequestContext(), CancellationToken.None);
-            Assert.AreEqual(ExpiredToken, accessToken.Token);
+            ClassicAssert.AreEqual(ExpiredToken, accessToken.Token);
         }
 
         [Test]
@@ -118,7 +119,7 @@ namespace Azure.Communication.Pipeline
                 });
             var communicationBearerTokenCredential = new CommunicationBearerTokenCredential(tokenCredential);
             var accessToken = communicationBearerTokenCredential.GetToken(MockTokenRequestContext(), cancellationToken);
-            Assert.AreEqual(cancellationToken.GetHashCode(), actualCancellationToken.GetHashCode());
+            ClassicAssert.AreEqual(cancellationToken.GetHashCode(), actualCancellationToken.GetHashCode());
 
             string RefreshToken(CancellationToken token)
             {
@@ -146,7 +147,7 @@ namespace Azure.Communication.Pipeline
 
             var communicationBearerTokenCredential = new CommunicationBearerTokenCredential(tokenCredential);
             var accessToken = await communicationBearerTokenCredential.GetTokenAsync(MockTokenRequestContext(), cancellationToken);
-            Assert.AreEqual(cancellationToken.GetHashCode(), actualCancellationToken.GetHashCode());
+            ClassicAssert.AreEqual(cancellationToken.GetHashCode(), actualCancellationToken.GetHashCode());
 
             string RefreshToken(CancellationToken token)
             {

--- a/sdk/communication/Azure.Communication.Common/tests/Pipeline/EntraTokenGuardPolicyTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Pipeline/EntraTokenGuardPolicyTests.cs
@@ -8,6 +8,7 @@ using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Pipeline
 {
@@ -179,7 +180,7 @@ namespace Azure.Communication.Pipeline
                 policy.Process(_httpMessage, pipelines);
                 _httpPipelinePolicyMock.Verify(p => p.Process(_httpMessage, It.IsAny<ReadOnlyMemory<HttpPipelinePolicy>>()), Times.Once);
             }
-            Assert.AreEqual(successfullResponse, _httpMessage.Response);
+            ClassicAssert.AreEqual(successfullResponse, _httpMessage.Response);
         }
 
         private class CustomRequest : MockRequest

--- a/sdk/communication/Azure.Communication.Common/tests/Pipeline/HMACAuthenticationPolicyTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Pipeline/HMACAuthenticationPolicyTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using NUnit.Framework.Internal;
 
 namespace Azure.Communication.Pipeline
@@ -22,16 +23,16 @@ namespace Azure.Communication.Pipeline
             await SendGetRequest(transport, authPolicy);
             var headers = transport.SingleRequest.Headers;
 
-            Assert.True(headers.Contains("x-ms-date"));
-            Assert.True(headers.Contains("Authorization"));
+            ClassicAssert.True(headers.Contains("x-ms-date"));
+            ClassicAssert.True(headers.Contains("Authorization"));
 
-            Assert.True(headers.TryGetValue("x-ms-content-sha256", out var shaValue));
-            Assert.AreEqual(expectedShaValue, shaValue);
+            ClassicAssert.True(headers.TryGetValue("x-ms-content-sha256", out var shaValue));
+            ClassicAssert.AreEqual(expectedShaValue, shaValue);
 
             var expectedAuthHeader = "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256";
-            Assert.True(headers.TryGetValue("Authorization", out var authValue));
-            Assert.NotNull(authValue);
-            Assert.True(authValue!.Contains(expectedAuthHeader));
+            ClassicAssert.True(headers.TryGetValue("Authorization", out var authValue));
+            ClassicAssert.NotNull(authValue);
+            ClassicAssert.True(authValue!.Contains(expectedAuthHeader));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/tests/Pipeline/PolicyTestBase.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Pipeline/PolicyTestBase.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Pipeline
 {
@@ -13,7 +14,7 @@ namespace Azure.Communication.Pipeline
     {
         protected static async Task<Response> SendGetRequest(HttpPipelineTransport transport, HttpPipelinePolicy policy, ResponseClassifier? responseClassifier = null)
         {
-            Assert.IsInstanceOf<HttpPipelinePolicy>(policy, "Use HttpPipelinePolicy base type for policies");
+            ClassicAssert.IsInstanceOf<HttpPipelinePolicy>(policy, "Use HttpPipelinePolicy base type for policies");
 
             using (Request request = transport.CreateRequest())
             {

--- a/sdk/communication/Azure.Communication.Common/tests/UnknownIdentifierTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/UnknownIdentifierTests.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication
 {
@@ -12,8 +13,8 @@ namespace Azure.Communication
         [Test]
         public void constructWithNullOrEmptyIdShouldThrow()
         {
-            Assert.Throws<ArgumentNullException>(() => { new UnknownIdentifier(null); }, "The initialization parameter [id] cannot be null");
-            Assert.Throws<ArgumentException>(() => { new UnknownIdentifier(""); }, "The initialization parameter [id] cannot be empty");
+            ClassicAssert.Throws<ArgumentNullException>(() => { new UnknownIdentifier(null); }, "The initialization parameter [id] cannot be null");
+            ClassicAssert.Throws<ArgumentException>(() => { new UnknownIdentifier(""); }, "The initialization parameter [id] cannot be empty");
         }
 
         [Test]
@@ -22,8 +23,8 @@ namespace Azure.Communication
             UnknownIdentifier identifier1 = new(_id);
             UnknownIdentifier identifier2 = new(_id);
 
-            Assert.True(identifier1.Equals(identifier1));
-            Assert.True(identifier1.Equals(identifier2));
+            ClassicAssert.True(identifier1.Equals(identifier1));
+            ClassicAssert.True(identifier1.Equals(identifier2));
         }
 
         [Test]
@@ -31,15 +32,15 @@ namespace Azure.Communication
         {
             UnknownIdentifier identifier1 = new(_id);
             object identifier2 = new();
-            Assert.False(identifier1.Equals(identifier2));
+            ClassicAssert.False(identifier1.Equals(identifier2));
         }
 
         [Test]
         public void constructWithValidId()
         {
             UnknownIdentifier result = new(_id);
-            Assert.NotNull(result.Id);
-            Assert.NotNull(result.GetHashCode());
+            ClassicAssert.NotNull(result.Id);
+            ClassicAssert.NotNull(result.GetHashCode());
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Email/tests/EmailClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/EmailClientLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 #nullable enable
 
@@ -29,7 +30,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = await SendEmailAndWaitForExistingOperationAsync(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }
@@ -46,7 +47,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = SendEmailAndWaitForExistingOperation(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }
@@ -61,7 +62,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = await SendEmailAndWaitForStatusWithManualPollingAsync(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }
@@ -78,7 +79,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = await SendEmailAndWaitForStatusWithAutomaticPollingAsync(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }
@@ -95,7 +96,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = SendEmailAndWaitForStatusWithAutomaticPolling(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }

--- a/sdk/communication/Azure.Communication.Email/tests/EmailClientTests.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/EmailClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 #nullable enable
 
@@ -26,10 +27,10 @@ namespace Azure.Communication.Email.Tests
         [Test]
         public void Constructor_InvalidParamsThrows()
         {
-            Assert.Throws<ArgumentNullException>(() => new EmailClient(null));
-            Assert.Throws<ArgumentException>(() => new EmailClient(string.Empty));
-            Assert.Throws<InvalidOperationException>(() => new EmailClient(" "));
-            Assert.Throws<InvalidOperationException>(() => new EmailClient("mumbojumbo"));
+            ClassicAssert.Throws<ArgumentNullException>(() => new EmailClient(null));
+            ClassicAssert.Throws<ArgumentException>(() => new EmailClient(string.Empty));
+            ClassicAssert.Throws<InvalidOperationException>(() => new EmailClient(" "));
+            ClassicAssert.Throws<InvalidOperationException>(() => new EmailClient("mumbojumbo"));
         }
 
         [Test]
@@ -39,11 +40,11 @@ namespace Azure.Communication.Email.Tests
 
             if (IsAsync)
             {
-                Assert.ThrowsAsync<ArgumentNullException>(async () => await emailClient.SendAsync(WaitUntil.Started, null));
+                ClassicAssert.ThrowsAsync<ArgumentNullException>(async () => await emailClient.SendAsync(WaitUntil.Started, null));
             }
             else
             {
-                Assert.Throws<ArgumentNullException>(() => emailClient.Send(WaitUntil.Started, null));
+                ClassicAssert.Throws<ArgumentNullException>(() => emailClient.Send(WaitUntil.Started, null));
             }
         }
 
@@ -77,22 +78,22 @@ namespace Azure.Communication.Email.Tests
             {
                 if (invalidStringValue == null)
                 {
-                    Assert.ThrowsAsync<ArgumentNullException>(asyncCode);
+                    ClassicAssert.ThrowsAsync<ArgumentNullException>(asyncCode);
                 }
                 else
                 {
-                    Assert.ThrowsAsync<ArgumentException>(asyncCode);
+                    ClassicAssert.ThrowsAsync<ArgumentException>(asyncCode);
                 }
             }
             else
             {
                 if (invalidStringValue == null)
                 {
-                    Assert.Throws<ArgumentNullException>(code);
+                    ClassicAssert.Throws<ArgumentNullException>(code);
                 }
                 else
                 {
-                    Assert.Throws<ArgumentException>(code);
+                    ClassicAssert.Throws<ArgumentException>(code);
                 }
             }
         }
@@ -154,7 +155,7 @@ namespace Azure.Communication.Email.Tests
 
             if (IsAsync)
             {
-                Assert.ThrowsAsync<ArgumentException>(async () => await emailClient.SendAsync(
+                ClassicAssert.ThrowsAsync<ArgumentException>(async () => await emailClient.SendAsync(
                     WaitUntil.Started,
                     emailMessage.SenderAddress,
                     emailMessage.Recipients.To.First().Address,
@@ -164,7 +165,7 @@ namespace Azure.Communication.Email.Tests
             }
             else
             {
-                Assert.Throws<ArgumentException>(() => emailClient.Send(
+                ClassicAssert.Throws<ArgumentException>(() => emailClient.Send(
                     WaitUntil.Started,
                     emailMessage.SenderAddress,
                     emailMessage.Recipients.To.First().Address,
@@ -238,7 +239,7 @@ namespace Azure.Communication.Email.Tests
 
             if (IsAsync)
             {
-                Assert.ThrowsAsync<ArgumentException>(async () => await emailClient.SendAsync(
+                ClassicAssert.ThrowsAsync<ArgumentException>(async () => await emailClient.SendAsync(
                     WaitUntil.Started,
                     emailMessage.SenderAddress,
                     emailMessage.Recipients.To.First().Address,
@@ -249,7 +250,7 @@ namespace Azure.Communication.Email.Tests
             }
             else
             {
-                Assert.Throws<ArgumentException>(() => emailClient.Send(
+                ClassicAssert.Throws<ArgumentException>(() => emailClient.Send(
                     WaitUntil.Started,
                     emailMessage.SenderAddress,
                     emailMessage.Recipients.To.First().Address,
@@ -270,13 +271,13 @@ namespace Azure.Communication.Email.Tests
             RequestFailedException? exception = null;
             if (IsAsync)
             {
-                exception = Assert.ThrowsAsync<RequestFailedException>(async () => await emailClient.SendAsync(WaitUntil.Started, emailMessage));
+                exception = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await emailClient.SendAsync(WaitUntil.Started, emailMessage));
             }
             else
             {
-                exception = Assert.Throws<RequestFailedException>(() => emailClient.Send(WaitUntil.Started, emailMessage));
+                exception = ClassicAssert.Throws<RequestFailedException>(() => emailClient.Send(WaitUntil.Started, emailMessage));
             }
-            Assert.AreEqual((int)HttpStatusCode.BadRequest, exception?.Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.BadRequest, exception?.Status);
         }
 
         [Test]
@@ -288,13 +289,13 @@ namespace Azure.Communication.Email.Tests
             ArgumentException? exception = null;
             if (IsAsync)
             {
-                exception = Assert.ThrowsAsync<ArgumentException>(async () => await emailClient.SendAsync(WaitUntil.Started, emailMessage));
+                exception = ClassicAssert.ThrowsAsync<ArgumentException>(async () => await emailClient.SendAsync(WaitUntil.Started, emailMessage));
             }
             else
             {
-                exception = Assert.Throws<ArgumentException>(() => emailClient.Send(WaitUntil.Started, emailMessage));
+                exception = ClassicAssert.Throws<ArgumentException>(() => emailClient.Send(WaitUntil.Started, emailMessage));
             }
-            Assert.IsTrue(exception?.Message.Contains(errorMessage));
+            ClassicAssert.IsTrue(exception?.Message.Contains(errorMessage));
         }
 
         [Test]
@@ -306,13 +307,13 @@ namespace Azure.Communication.Email.Tests
             RequestFailedException? exception = null;
             if (IsAsync)
             {
-                exception = Assert.ThrowsAsync<RequestFailedException>(async () => await emailClient.SendAsync(WaitUntil.Started, emailMessage));
+                exception = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await emailClient.SendAsync(WaitUntil.Started, emailMessage));
             }
             else
             {
-                exception = Assert.Throws<RequestFailedException>(() => emailClient.Send(WaitUntil.Started, emailMessage));
+                exception = ClassicAssert.Throws<RequestFailedException>(() => emailClient.Send(WaitUntil.Started, emailMessage));
             }
-            Assert.AreEqual((int)HttpStatusCode.BadRequest, exception?.Status);
+            ClassicAssert.AreEqual((int)HttpStatusCode.BadRequest, exception?.Status);
         }
 
         [Test]
@@ -334,10 +335,10 @@ namespace Azure.Communication.Email.Tests
                 Thread.Sleep(1000);
             }
 
-            Assert.IsTrue(emailSendOperation.HasCompleted);
-            Assert.IsTrue(emailSendOperation.HasValue);
-            Assert.IsNotNull(emailSendOperation.Id);
-            Assert.AreEqual(EmailSendStatus.Succeeded, emailSendOperation.Value.Status);
+            ClassicAssert.IsTrue(emailSendOperation.HasCompleted);
+            ClassicAssert.IsTrue(emailSendOperation.HasValue);
+            ClassicAssert.IsNotNull(emailSendOperation.Id);
+            ClassicAssert.AreEqual(EmailSendStatus.Succeeded, emailSendOperation.Value.Status);
         }
 
         [Test]
@@ -359,10 +360,10 @@ namespace Azure.Communication.Email.Tests
                 Thread.Sleep(1000);
             }
 
-            Assert.IsTrue(emailSendOperation.HasCompleted);
-            Assert.IsTrue(emailSendOperation.HasValue);
-            Assert.IsNotNull(emailSendOperation.Id);
-            Assert.AreEqual(EmailSendStatus.Succeeded, emailSendOperation.Value.Status);
+            ClassicAssert.IsTrue(emailSendOperation.HasCompleted);
+            ClassicAssert.IsTrue(emailSendOperation.HasValue);
+            ClassicAssert.IsNotNull(emailSendOperation.Id);
+            ClassicAssert.AreEqual(EmailSendStatus.Succeeded, emailSendOperation.Value.Status);
         }
 
         [Test]
@@ -374,7 +375,7 @@ namespace Azure.Communication.Email.Tests
 
             EmailSendOperation emailSendOperation = emailClient.Send(WaitUntil.Started, emailMessage);
 
-            RequestFailedException? exception = Assert.Throws<RequestFailedException>(() =>
+            RequestFailedException? exception = ClassicAssert.Throws<RequestFailedException>(() =>
             {
                 while (true)
                 {
@@ -387,10 +388,10 @@ namespace Azure.Communication.Email.Tests
                 }
             });
 
-            Assert.AreEqual((int)HttpStatusCode.OK, exception?.Status);
-            Assert.IsTrue(emailSendOperation.HasCompleted);
-            Assert.IsFalse(emailSendOperation.HasValue);
-            Assert.IsNotNull(emailSendOperation.Id);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, exception?.Status);
+            ClassicAssert.IsTrue(emailSendOperation.HasCompleted);
+            ClassicAssert.IsFalse(emailSendOperation.HasValue);
+            ClassicAssert.IsNotNull(emailSendOperation.Id);
         }
 
         [Test]
@@ -402,7 +403,7 @@ namespace Azure.Communication.Email.Tests
 
             EmailSendOperation emailSendOperation = await emailClient.SendAsync(WaitUntil.Started, emailMessage);
 
-            RequestFailedException? exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
+            RequestFailedException? exception = ClassicAssert.ThrowsAsync<RequestFailedException>(async () =>
             {
                 while (true)
                 {
@@ -415,10 +416,10 @@ namespace Azure.Communication.Email.Tests
                 }
             });
 
-            Assert.AreEqual((int)HttpStatusCode.OK, exception?.Status);
-            Assert.IsTrue(emailSendOperation.HasCompleted);
-            Assert.IsFalse(emailSendOperation.HasValue);
-            Assert.IsNotNull(emailSendOperation.Id);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, exception?.Status);
+            ClassicAssert.IsTrue(emailSendOperation.HasCompleted);
+            ClassicAssert.IsFalse(emailSendOperation.HasValue);
+            ClassicAssert.IsNotNull(emailSendOperation.Id);
         }
 
         private EmailClient CreateEmailClient(HttpStatusCode statusCode = HttpStatusCode.OK)

--- a/sdk/communication/Azure.Communication.Email/tests/EmailRecipientsTests.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/EmailRecipientsTests.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
 using System.Linq;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Email.Tests
 {
@@ -27,9 +28,9 @@ namespace Azure.Communication.Email.Tests
         {
             var recipients = new EmailRecipients(DefaultRecipients(toCount), DefaultRecipients(ccCount), DefaultRecipients(bccCount));
 
-            Assert.AreEqual(recipients.CC.Count, ccCount);
-            Assert.AreEqual(recipients.BCC.Count, bccCount);
-            Assert.AreEqual(recipients.To.Count, toCount);
+            ClassicAssert.AreEqual(recipients.CC.Count, ccCount);
+            ClassicAssert.AreEqual(recipients.BCC.Count, bccCount);
+            ClassicAssert.AreEqual(recipients.To.Count, toCount);
         }
 
         private static List<EmailAddress> DefaultRecipients(int count = 1)

--- a/sdk/communication/Azure.Communication.Email/tests/Samples/Sample1_EmailClient.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/Samples/Sample1_EmailClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 #endregion Snippet:Azure_Communication_Email_UsingStatements
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System.Net.Mime;
 using System.Threading;
 
@@ -49,7 +50,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_Simple_AutoPolling
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            ClassicAssert.False(string.IsNullOrEmpty(operationId));
         }
 
         [Test]
@@ -92,7 +93,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_With_MoreOptions
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            ClassicAssert.False(string.IsNullOrEmpty(operationId));
         }
 
         [Test]
@@ -179,7 +180,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_Multiple_Recipients
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            ClassicAssert.False(string.IsNullOrEmpty(operationId));
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.Email/tests/Samples/Sample1_EmailClientAsync.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/Samples/Sample1_EmailClientAsync.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,7 @@ using System.Net.Mime;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Email.Tests.Samples
 {
@@ -46,7 +47,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_Simple_AutoPolling_Async
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            ClassicAssert.False(string.IsNullOrEmpty(operationId));
         }
 
         [RecordedTest]
@@ -136,7 +137,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_With_MoreOptions_Async
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            ClassicAssert.False(string.IsNullOrEmpty(operationId));
         }
 
         [Test]
@@ -223,7 +224,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_Multiple_Recipients_Async
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            ClassicAssert.False(string.IsNullOrEmpty(operationId));
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.Identity/tests/CommunicationIdentityClient/CommunicationIdentityClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Identity/tests/CommunicationIdentityClient/CommunicationIdentityClientLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -11,6 +11,7 @@ using Azure.Communication.Tests;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using static Azure.Communication.Identity.CommunicationIdentityClientOptions;
 
 namespace Azure.Communication.Identity.Tests
@@ -70,8 +71,8 @@ namespace Azure.Communication.Identity.Tests
 
             Response<CommunicationUserIdentifier> userResponse = await client.CreateUserAsync();
             Response<AccessToken> tokenResponse = await client.GetTokenAsync(userResponse.Value, scopes: scopes.Select(x => new CommunicationTokenScope(x)));
-            Assert.IsNotNull(tokenResponse.Value);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(tokenResponse.Value.Token));
+            ClassicAssert.IsNotNull(tokenResponse.Value);
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(tokenResponse.Value.Token));
             ValidateScopesIfNotSanitized();
 
             void ValidateScopesIfNotSanitized()
@@ -99,8 +100,8 @@ namespace Azure.Communication.Identity.Tests
             Response<CommunicationUserIdentifier> userResponse = await client.CreateUserAsync();
             Response<AccessToken> tokenResponse = await client.GetTokenAsync(userResponse.Value, scopes: scopes.Select(x => new CommunicationTokenScope(x)));
 
-            Assert.IsNotNull(tokenResponse.Value);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(tokenResponse.Value.Token));
+            ClassicAssert.IsNotNull(tokenResponse.Value);
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(tokenResponse.Value.Token));
             ValidateScopesIfNotSanitized();
 
             void ValidateScopesIfNotSanitized()
@@ -123,7 +124,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (NullReferenceException ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -141,7 +142,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("scopes", ex.ParamName);
+                ClassicAssert.AreEqual("scopes", ex.ParamName);
                 return;
             }
             Assert.Fail("RevokeTokensAsync should have thrown an exception.");
@@ -162,8 +163,8 @@ namespace Azure.Communication.Identity.Tests
             CommunicationIdentityClient client = CreateClient();
             Response<CommunicationUserIdentifierAndToken> accessToken = await client.CreateUserAndTokenAsync(scopes: scopes.Select(x => new CommunicationTokenScope(x)));
 
-            Assert.IsNotNull(accessToken.Value.AccessToken);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(accessToken.Value.AccessToken.Token));
+            ClassicAssert.IsNotNull(accessToken.Value.AccessToken);
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(accessToken.Value.AccessToken.Token));
             ValidateScopesIfNotSanitized();
 
             void ValidateScopesIfNotSanitized()
@@ -186,14 +187,14 @@ namespace Azure.Communication.Identity.Tests
             CommunicationIdentityClient client = CreateClient();
             Response<CommunicationUserIdentifierAndToken> accessToken = await client.CreateUserAndTokenAsync(scopes: new[] { CommunicationTokenScope.Chat }, tokenExpiresIn: tokenExpiresIn);
 
-            Assert.IsNotNull(accessToken.Value.AccessToken);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(accessToken.Value.AccessToken.Token));
+            ClassicAssert.IsNotNull(accessToken.Value.AccessToken);
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(accessToken.Value.AccessToken.Token));
 
             if (Mode == RecordedTestMode.Live)
             {
                 TimeSpan tokenTimeSpan;
                 var tokenExpirationWithinAllowedDeviation = TokenExpirationWithinAllowedDeviation(tokenExpiresIn, accessToken.Value.AccessToken.ExpiresOn, TOKEN_EXPIRATION_ALLOWED_DEVIATION, out tokenTimeSpan);
-                Assert.True(tokenExpirationWithinAllowedDeviation,
+                ClassicAssert.True(tokenExpirationWithinAllowedDeviation,
                     $"Token expiration is outside of allowed {TOKEN_EXPIRATION_ALLOWED_DEVIATION * 100}% deviation." +
                     $"Expected minutes: {tokenExpiresIn.TotalMinutes}, actual minutes: {tokenTimeSpan.TotalMinutes:0.##}.");
             }
@@ -212,7 +213,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -231,8 +232,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains(TOKEN_EXPIRATION_OVERFLOW_MESSAGE));
+                ClassicAssert.NotNull(ex.Message);
+                ClassicAssert.True(ex.Message.Contains(TOKEN_EXPIRATION_OVERFLOW_MESSAGE));
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -250,14 +251,14 @@ namespace Azure.Communication.Identity.Tests
             CommunicationUserIdentifier userIdentifier = await client.CreateUserAsync();
             Response<AccessToken> accessToken = await client.GetTokenAsync(communicationUser: userIdentifier, scopes: new[] { CommunicationTokenScope.VoIP }, tokenExpiresIn: tokenExpiresIn);
 
-            Assert.IsNotNull(accessToken.Value);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(accessToken.Value.Token));
+            ClassicAssert.IsNotNull(accessToken.Value);
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(accessToken.Value.Token));
 
             if (Mode == RecordedTestMode.Live)
             {
                 TimeSpan tokenTimeSpan;
                 var tokenExpirationWithinAllowedDeviation = TokenExpirationWithinAllowedDeviation(tokenExpiresIn, accessToken.Value.ExpiresOn, TOKEN_EXPIRATION_ALLOWED_DEVIATION, out tokenTimeSpan);
-                Assert.True(tokenExpirationWithinAllowedDeviation,
+                ClassicAssert.True(tokenExpirationWithinAllowedDeviation,
                     $"Token expiration is outside of allowed {TOKEN_EXPIRATION_ALLOWED_DEVIATION * 100}% deviation." +
                     $"Expected minutes: {tokenExpiresIn.TotalMinutes}, actual minutes: {tokenTimeSpan.TotalMinutes:0.##}.");
             }
@@ -277,7 +278,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -297,8 +298,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains(TOKEN_EXPIRATION_OVERFLOW_MESSAGE));
+                ClassicAssert.NotNull(ex.Message);
+                ClassicAssert.True(ex.Message.Contains(TOKEN_EXPIRATION_OVERFLOW_MESSAGE));
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -315,7 +316,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (NullReferenceException ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -332,7 +333,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (NullReferenceException ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -349,8 +350,8 @@ namespace Azure.Communication.Identity.Tests
 
             CommunicationIdentityClient client = CreateClient();
             Response<AccessToken> tokenResponse = await client.GetTokenForTeamsUserAsync(CTEOptions);
-            Assert.IsNotNull(tokenResponse.Value);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(tokenResponse.Value.Token));
+            ClassicAssert.IsNotNull(tokenResponse.Value);
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(tokenResponse.Value.Token));
         }
 
         [Test]
@@ -370,7 +371,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(paramName, ex.ParamName);
+                ClassicAssert.AreEqual(paramName, ex.ParamName);
                 return;
             }
             Assert.Fail("An exception should have been thrown.");
@@ -388,8 +389,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.NotNull(ex.Message);
+                ClassicAssert.True(ex.Message.Contains("401"));
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -406,8 +407,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("401"));
+                ClassicAssert.NotNull(ex.Message);
+                ClassicAssert.True(ex.Message.Contains("401"));
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -431,8 +432,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("400"));
+                ClassicAssert.NotNull(ex.Message);
+                ClassicAssert.True(ex.Message.Contains("400"));
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -454,8 +455,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("400"));
+                ClassicAssert.NotNull(ex.Message);
+                ClassicAssert.True(ex.Message.Contains("400"));
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -479,8 +480,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("400"));
+                ClassicAssert.NotNull(ex.Message);
+                ClassicAssert.True(ex.Message.Contains("400"));
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -502,8 +503,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("400"));
+                ClassicAssert.NotNull(ex.Message);
+                ClassicAssert.True(ex.Message.Contains("400"));
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -522,7 +523,7 @@ namespace Azure.Communication.Identity.Tests
             {
                 CommunicationIdentityClient client = CreateClient(default, version);
                 CommunicationUserIdentifier userResponse = await client.CreateUserAsync();
-                Assert.IsNotNull(userResponse);
+                ClassicAssert.IsNotNull(userResponse);
             }
             catch (Exception ex)
             {
@@ -537,12 +538,12 @@ namespace Azure.Communication.Identity.Tests
             CommunicationIdentityClient client = CreateClient();
             Response<CommunicationUserIdentifier> createResponse = await client.CreateUserAsync(customId);
 
-            Assert.IsTrue((int)HttpStatusCode.Created == createResponse.GetRawResponse().Status);
-            Assert.IsNotNull(createResponse.Value.Id);
+            ClassicAssert.IsTrue((int)HttpStatusCode.Created == createResponse.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(createResponse.Value.Id);
 
             Response<CommunicationUserIdentifier> createResponse2 = await client.CreateUserAsync(customId);
-            Assert.AreEqual((int)HttpStatusCode.Created, createResponse2.GetRawResponse().Status);
-            Assert.AreEqual(createResponse.Value.Id, createResponse2.Value.Id);
+            ClassicAssert.AreEqual((int)HttpStatusCode.Created, createResponse2.GetRawResponse().Status);
+            ClassicAssert.AreEqual(createResponse.Value.Id, createResponse2.Value.Id);
         }
 
         [Test]
@@ -553,15 +554,15 @@ namespace Azure.Communication.Identity.Tests
             Response<CommunicationUserIdentifierAndToken> createResponse = await client.CreateUserAndTokenAsync(customId,
                 new List<CommunicationTokenScope> { CommunicationTokenScope.VoIP },
                 TimeSpan.FromHours(2));
-            Assert.IsTrue((int)HttpStatusCode.Created == createResponse.GetRawResponse().Status
+            ClassicAssert.IsTrue((int)HttpStatusCode.Created == createResponse.GetRawResponse().Status
                 || (int)HttpStatusCode.OK == createResponse.GetRawResponse().Status);
-            Assert.IsNotNull(createResponse.Value.User);
+            ClassicAssert.IsNotNull(createResponse.Value.User);
 
             Response<CommunicationUserDetail> getResponse = await client.GetUserDetailAsync(createResponse.Value.User);
-            Assert.AreEqual((int)HttpStatusCode.OK, getResponse.GetRawResponse().Status);
-            Assert.AreEqual(createResponse.Value.User.Id, getResponse.Value.User.Id);
-            Assert.AreEqual(customId, getResponse.Value.CustomId);
-            Assert.IsNotNull(getResponse.Value.LastTokenIssuedAt);
+            ClassicAssert.AreEqual((int)HttpStatusCode.OK, getResponse.GetRawResponse().Status);
+            ClassicAssert.AreEqual(createResponse.Value.User.Id, getResponse.Value.User.Id);
+            ClassicAssert.AreEqual(customId, getResponse.Value.CustomId);
+            ClassicAssert.IsNotNull(getResponse.Value.LastTokenIssuedAt);
         }
 
         [Test]
@@ -574,7 +575,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
                 return;
             }
             Assert.Fail("An exception should have been thrown.");

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Infrastructure/RouterLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Infrastructure/RouterLiveTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Core.TestFramework.Models;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.Infrastructure
 {
@@ -161,10 +162,10 @@ namespace Azure.Communication.JobRouter.Tests.Infrastructure
                     Name = distributionPolicyName,
                 });
 
-            Assert.AreEqual(distributionId, createDistributionPolicyResponse.Value.Id);
-            Assert.AreEqual(distributionPolicyName, createDistributionPolicyResponse.Value.Name);
-            Assert.IsNotNull(createDistributionPolicyResponse.Value.Mode);
-            Assert.IsTrue(createDistributionPolicyResponse.Value.Mode.GetType() == typeof(LongestIdleMode));
+            ClassicAssert.AreEqual(distributionId, createDistributionPolicyResponse.Value.Id);
+            ClassicAssert.AreEqual(distributionPolicyName, createDistributionPolicyResponse.Value.Name);
+            ClassicAssert.IsNotNull(createDistributionPolicyResponse.Value.Mode);
+            ClassicAssert.IsTrue(createDistributionPolicyResponse.Value.Mode.GetType() == typeof(LongestIdleMode));
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(createDistributionPolicyResponse.Value.Id)));
             return createDistributionPolicyResponse;
         }
@@ -177,9 +178,9 @@ namespace Azure.Communication.JobRouter.Tests.Infrastructure
         {
             var response = upsertQueueResponse.Value;
 
-            Assert.AreEqual(queueId, response.Id);
-            Assert.AreEqual(queueName, response.Name);
-            Assert.AreEqual(distributionPolicyId, response.DistributionPolicyId);
+            ClassicAssert.AreEqual(queueId, response.Id);
+            ClassicAssert.AreEqual(queueName, response.Name);
+            ClassicAssert.AreEqual(distributionPolicyId, response.DistributionPolicyId);
             if (queueLabels != default)
             {
                 var labelsWithID = queueLabels.ToDictionary(k => k.Key, k => k.Value);
@@ -189,12 +190,12 @@ namespace Azure.Communication.JobRouter.Tests.Infrastructure
                     labelsWithID.Add("Id", new RouterValue(queueId));
                 }
 
-                Assert.AreEqual(labelsWithID.ToDictionary(x => x.Key, x => x.Value?.Value), response.Labels.ToDictionary(x => x.Key, x => x.Value?.Value));
+                ClassicAssert.AreEqual(labelsWithID.ToDictionary(x => x.Key, x => x.Value?.Value), response.Labels.ToDictionary(x => x.Key, x => x.Value?.Value));
             }
 
             if (exceptionPolicyId != default)
             {
-                Assert.AreEqual(exceptionPolicyId, response.ExceptionPolicyId);
+                ClassicAssert.AreEqual(exceptionPolicyId, response.ExceptionPolicyId);
             }
         }
 
@@ -206,26 +207,26 @@ namespace Azure.Communication.JobRouter.Tests.Infrastructure
         {
             var response = routerWorkerResponse.Value;
 
-            Assert.AreEqual(workerId, response.Id);
-            Assert.AreEqual(queues.Count(), response.Queues.Count);
-            Assert.AreEqual(capacity, response.Capacity);
+            ClassicAssert.AreEqual(workerId, response.Id);
+            ClassicAssert.AreEqual(queues.Count(), response.Queues.Count);
+            ClassicAssert.AreEqual(capacity, response.Capacity);
 
             if (workerLabels != default)
             {
                 var labelsWithID = workerLabels.ToDictionary(k => k.Key, k => k.Value);
                 labelsWithID.Add("Id", new RouterValue(workerId));
-                Assert.AreEqual(labelsWithID, response.Labels);
+                ClassicAssert.AreEqual(labelsWithID, response.Labels);
             }
 
             if (workerTags != default)
             {
                 var tags = workerTags.ToDictionary(k => k.Key, k => k.Value);
-                Assert.AreEqual(tags, response.Tags);
+                ClassicAssert.AreEqual(tags, response.Tags);
             }
 
             if (channelsList != default)
             {
-                Assert.AreEqual(channelsList.Count, response.Channels.Count);
+                ClassicAssert.AreEqual(channelsList.Count, response.Channels.Count);
             }
         }
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ClassificationPolicyLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ClassificationPolicyLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Linq;
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Azure.Communication.JobRouter.Tests.Infrastructure;
 using Azure.Core;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -34,35 +35,35 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteClassificationPolicyAsync(classificationPolicyId)));
-            Assert.NotNull(createClassificationPolicyResponse.Value);
+            ClassicAssert.NotNull(createClassificationPolicyResponse.Value);
 
             var createClassificationPolicy = createClassificationPolicyResponse.Value;
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 var queueSelectors = createClassificationPolicy.QueueSelectorAttachments;
-                Assert.AreEqual(queueSelectors.Count, 1);
+                ClassicAssert.AreEqual(queueSelectors.Count, 1);
                 var qs = queueSelectors.First();
-                Assert.IsTrue(qs.GetType() == typeof(StaticQueueSelectorAttachment));
+                ClassicAssert.IsTrue(qs.GetType() == typeof(StaticQueueSelectorAttachment));
                 var staticQSelector = (StaticQueueSelectorAttachment)qs;
-                Assert.AreEqual(staticQSelector.QueueSelector.Key, "Id");
-                Assert.AreEqual(staticQSelector.QueueSelector.LabelOperator, LabelOperator.Equal);
-                Assert.AreEqual(staticQSelector.QueueSelector.Value.Value, createQueueResponse.Value.Id);
+                ClassicAssert.AreEqual(staticQSelector.QueueSelector.Key, "Id");
+                ClassicAssert.AreEqual(staticQSelector.QueueSelector.LabelOperator, LabelOperator.Equal);
+                ClassicAssert.AreEqual(staticQSelector.QueueSelector.Value.Value, createQueueResponse.Value.Id);
             });
-            Assert.AreEqual(1, createClassificationPolicy.WorkerSelectorAttachments.Count);
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.AreEqual(1, createClassificationPolicy.WorkerSelectorAttachments.Count);
+            ClassicAssert.DoesNotThrow(() =>
             {
                 var workerSelectors = createClassificationPolicy.WorkerSelectorAttachments;
-                Assert.AreEqual(workerSelectors.Count, 1);
+                ClassicAssert.AreEqual(workerSelectors.Count, 1);
                 var ws = workerSelectors.First();
-                Assert.IsTrue(ws.GetType() == typeof(StaticWorkerSelectorAttachment));
+                ClassicAssert.IsTrue(ws.GetType() == typeof(StaticWorkerSelectorAttachment));
                 var staticWSelector = (StaticWorkerSelectorAttachment)ws;
-                Assert.AreEqual("key", staticWSelector.WorkerSelector.Key);
-                Assert.AreEqual(LabelOperator.Equal, staticWSelector.WorkerSelector.LabelOperator);
-                Assert.AreEqual("value", staticWSelector.WorkerSelector.Value.Value);
+                ClassicAssert.AreEqual("key", staticWSelector.WorkerSelector.Key);
+                ClassicAssert.AreEqual(LabelOperator.Equal, staticWSelector.WorkerSelector.LabelOperator);
+                ClassicAssert.AreEqual("value", staticWSelector.WorkerSelector.Value.Value);
             });
-            Assert.IsTrue(createClassificationPolicy.PrioritizationRule.GetType() == typeof(StaticRouterRule));
-            Assert.IsTrue(string.IsNullOrWhiteSpace(createClassificationPolicy.FallbackQueueId));
-            Assert.IsTrue(string.IsNullOrWhiteSpace(createClassificationPolicy.Name));
+            ClassicAssert.IsTrue(createClassificationPolicy.PrioritizationRule.GetType() == typeof(StaticRouterRule));
+            ClassicAssert.IsTrue(string.IsNullOrWhiteSpace(createClassificationPolicy.FallbackQueueId));
+            ClassicAssert.IsTrue(string.IsNullOrWhiteSpace(createClassificationPolicy.Name));
 
             var classificationPolicyName = $"{classificationPolicyId}-Name";
 
@@ -76,35 +77,35 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = classificationPolicyName,
                 });
 
-            Assert.NotNull(updateClassificationPolicyResponse.Value);
+            ClassicAssert.NotNull(updateClassificationPolicyResponse.Value);
 
             createClassificationPolicy = updateClassificationPolicyResponse.Value;
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 var queueSelectors = createClassificationPolicy.QueueSelectorAttachments;
-                Assert.AreEqual(queueSelectors.Count, 1);
+                ClassicAssert.AreEqual(queueSelectors.Count, 1);
                 var qs = queueSelectors.First();
-                Assert.IsTrue(qs.GetType() == typeof(StaticQueueSelectorAttachment));
+                ClassicAssert.IsTrue(qs.GetType() == typeof(StaticQueueSelectorAttachment));
                 var staticQSelector = (StaticQueueSelectorAttachment)qs;
-                Assert.AreEqual(staticQSelector.QueueSelector.Key, "Id");
-                Assert.AreEqual(staticQSelector.QueueSelector.LabelOperator, LabelOperator.Equal);
-                Assert.AreEqual(staticQSelector.QueueSelector.Value.Value, createQueueResponse.Value.Id);
+                ClassicAssert.AreEqual(staticQSelector.QueueSelector.Key, "Id");
+                ClassicAssert.AreEqual(staticQSelector.QueueSelector.LabelOperator, LabelOperator.Equal);
+                ClassicAssert.AreEqual(staticQSelector.QueueSelector.Value.Value, createQueueResponse.Value.Id);
             });
-            Assert.AreEqual(1, createClassificationPolicy.WorkerSelectorAttachments.Count);
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.AreEqual(1, createClassificationPolicy.WorkerSelectorAttachments.Count);
+            ClassicAssert.DoesNotThrow(() =>
             {
                 var workerSelectors = createClassificationPolicy.WorkerSelectorAttachments;
-                Assert.AreEqual(workerSelectors.Count, 1);
+                ClassicAssert.AreEqual(workerSelectors.Count, 1);
                 var ws = workerSelectors.First();
-                Assert.IsTrue(ws.GetType() == typeof(StaticWorkerSelectorAttachment));
+                ClassicAssert.IsTrue(ws.GetType() == typeof(StaticWorkerSelectorAttachment));
                 var staticWSelector = (StaticWorkerSelectorAttachment)ws;
-                Assert.AreEqual("key", staticWSelector.WorkerSelector.Key);
-                Assert.AreEqual(LabelOperator.Equal, staticWSelector.WorkerSelector.LabelOperator);
-                Assert.AreEqual("value", staticWSelector.WorkerSelector.Value.Value);
+                ClassicAssert.AreEqual("key", staticWSelector.WorkerSelector.Key);
+                ClassicAssert.AreEqual(LabelOperator.Equal, staticWSelector.WorkerSelector.LabelOperator);
+                ClassicAssert.AreEqual("value", staticWSelector.WorkerSelector.Value.Value);
             });
-            Assert.IsTrue(createClassificationPolicy.PrioritizationRule.GetType() == typeof(StaticRouterRule));
-            Assert.IsTrue(!string.IsNullOrWhiteSpace(createClassificationPolicy.FallbackQueueId) && createClassificationPolicy.FallbackQueueId == createQueueResponse.Value.Id);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(createClassificationPolicy.Name));
+            ClassicAssert.IsTrue(createClassificationPolicy.PrioritizationRule.GetType() == typeof(StaticRouterRule));
+            ClassicAssert.IsTrue(!string.IsNullOrWhiteSpace(createClassificationPolicy.FallbackQueueId) && createClassificationPolicy.FallbackQueueId == createQueueResponse.Value.Id);
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createClassificationPolicy.Name));
 
             updateClassificationPolicyResponse.Value.FallbackQueueId = null;
             updateClassificationPolicyResponse.Value.PrioritizationRule = null;
@@ -116,9 +117,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 updateClassificationPolicyResponse.Value);
 
             var updateClassificationPolicy = updateClassificationPolicyResponse.Value;
-            Assert.IsFalse(updateClassificationPolicy.QueueSelectorAttachments.Any());
-            Assert.IsFalse(updateClassificationPolicy.WorkerSelectorAttachments.Any());
-            Assert.AreEqual(updateClassificationPolicy.Name, $"{classificationPolicyName}-updated");
+            ClassicAssert.IsFalse(updateClassificationPolicy.QueueSelectorAttachments.Any());
+            ClassicAssert.IsFalse(updateClassificationPolicy.WorkerSelectorAttachments.Any());
+            ClassicAssert.AreEqual(updateClassificationPolicy.Name, $"{classificationPolicyName}-updated");
         }
 
         [Test]
@@ -132,11 +133,11 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var getClassificationPolicyResponse =
                 await routerClient.GetClassificationPolicyAsync(classificationPolicyId);
 
-            Assert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
-            Assert.Null(getClassificationPolicyResponse.Value.Name);
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.QueueSelectorAttachments);
-            Assert.Null(getClassificationPolicyResponse.Value.PrioritizationRule);
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.WorkerSelectorAttachments);
+            ClassicAssert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
+            ClassicAssert.Null(getClassificationPolicyResponse.Value.Name);
+            ClassicAssert.IsEmpty(getClassificationPolicyResponse.Value.QueueSelectorAttachments);
+            ClassicAssert.Null(getClassificationPolicyResponse.Value.PrioritizationRule);
+            ClassicAssert.IsEmpty(getClassificationPolicyResponse.Value.WorkerSelectorAttachments);
 
             AddForCleanup(new Task(async () => await routerClient.DeleteClassificationPolicyAsync(classificationPolicyId)));
         }
@@ -160,11 +161,11 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             var getClassificationPolicyResponse = await routerClient.GetClassificationPolicyAsync(classificationPolicyId);
 
-            Assert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
-            Assert.AreEqual(classificationPolicyName, getClassificationPolicyResponse.Value.Name);
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.QueueSelectorAttachments);
-            Assert.IsTrue(getClassificationPolicyResponse.Value.PrioritizationRule.GetType() == typeof(StaticRouterRule));
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.WorkerSelectorAttachments);
+            ClassicAssert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
+            ClassicAssert.AreEqual(classificationPolicyName, getClassificationPolicyResponse.Value.Name);
+            ClassicAssert.IsEmpty(getClassificationPolicyResponse.Value.QueueSelectorAttachments);
+            ClassicAssert.IsTrue(getClassificationPolicyResponse.Value.PrioritizationRule.GetType() == typeof(StaticRouterRule));
+            ClassicAssert.IsEmpty(getClassificationPolicyResponse.Value.WorkerSelectorAttachments);
         }
 
         [Test]
@@ -190,13 +191,13 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             AddForCleanup(new Task(async () => await routerClient.DeleteClassificationPolicyAsync(classificationPolicyId)));
 
             var getClassificationPolicyResponse = await routerClient.GetClassificationPolicyAsync(classificationPolicyId);
-            Assert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
-            Assert.AreEqual(classificationPolicyName, getClassificationPolicyResponse.Value.Name);
-            Assert.AreEqual(1, getClassificationPolicyResponse.Value.QueueSelectorAttachments.Count);
+            ClassicAssert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
+            ClassicAssert.AreEqual(classificationPolicyName, getClassificationPolicyResponse.Value.Name);
+            ClassicAssert.AreEqual(1, getClassificationPolicyResponse.Value.QueueSelectorAttachments.Count);
             var staticQSelector = (StaticQueueSelectorAttachment)getClassificationPolicyResponse.Value.QueueSelectorAttachments.First();
-            Assert.NotNull(staticQSelector);
-            Assert.Null(getClassificationPolicyResponse.Value.PrioritizationRule);
-            Assert.AreEqual(0, getClassificationPolicyResponse.Value.WorkerSelectorAttachments.Count);
+            ClassicAssert.NotNull(staticQSelector);
+            ClassicAssert.Null(getClassificationPolicyResponse.Value.PrioritizationRule);
+            ClassicAssert.AreEqual(0, getClassificationPolicyResponse.Value.WorkerSelectorAttachments.Count);
         }
 
         [Test]
@@ -218,11 +219,11 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var getClassificationPolicyResponse =
                 await routerClient.GetClassificationPolicyAsync(classificationPolicyId);
 
-            Assert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
-            Assert.AreEqual(classificationPolicyName, getClassificationPolicyResponse.Value.Name);
-            Assert.Null(getClassificationPolicyResponse.Value.PrioritizationRule);
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.QueueSelectorAttachments);
-            Assert.AreEqual(1, getClassificationPolicyResponse.Value.WorkerSelectorAttachments.Count);
+            ClassicAssert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
+            ClassicAssert.AreEqual(classificationPolicyName, getClassificationPolicyResponse.Value.Name);
+            ClassicAssert.Null(getClassificationPolicyResponse.Value.PrioritizationRule);
+            ClassicAssert.IsEmpty(getClassificationPolicyResponse.Value.QueueSelectorAttachments);
+            ClassicAssert.AreEqual(1, getClassificationPolicyResponse.Value.WorkerSelectorAttachments.Count);
         }
 
         #endregion Classification Policy Tests

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DateTimeOffsetParserTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DateTimeOffsetParserTests.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -14,8 +15,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var input = "2022-05-13T16:59:04.531199+00:00";
             var sampleAsDateTimeOffset = DateTimeOffsetParser.ParseAndGetDateTimeOffset(input);
 
-            Assert.NotNull(sampleAsDateTimeOffset);
-            Assert.AreEqual(new TimeSpan(0, 0, 0), sampleAsDateTimeOffset.Offset);
+            ClassicAssert.NotNull(sampleAsDateTimeOffset);
+            ClassicAssert.AreEqual(new TimeSpan(0, 0, 0), sampleAsDateTimeOffset.Offset);
         }
 
         [Test]
@@ -24,8 +25,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var input = "2022-05-13T12:30:39.0516617-07:00";
             var sampleAsDateTimeOffset = DateTimeOffsetParser.ParseAndGetDateTimeOffset(input);
 
-            Assert.NotNull(sampleAsDateTimeOffset);
-            Assert.AreEqual(new TimeSpan(0, 0, 0), sampleAsDateTimeOffset.Offset);
+            ClassicAssert.NotNull(sampleAsDateTimeOffset);
+            ClassicAssert.AreEqual(new TimeSpan(0, 0, 0), sampleAsDateTimeOffset.Offset);
         }
 
         [Test]
@@ -34,8 +35,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var input = "2022-05-13T16:59:04.531199Z";
             var sampleAsDateTimeOffset = DateTimeOffsetParser.ParseAndGetDateTimeOffset(input);
 
-            Assert.NotNull(sampleAsDateTimeOffset);
-            Assert.AreEqual(new TimeSpan(0, 0, 0), sampleAsDateTimeOffset.Offset);
+            ClassicAssert.NotNull(sampleAsDateTimeOffset);
+            ClassicAssert.AreEqual(new TimeSpan(0, 0, 0), sampleAsDateTimeOffset.Offset);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DistributionPolicyLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DistributionPolicyLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,6 +9,7 @@ using Azure.Communication.JobRouter.Tests.Infrastructure;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -37,12 +38,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(bestWorkerModeDistributionPolicyId)));
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            ClassicAssert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
 
             var bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            ClassicAssert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
+            ClassicAssert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
+            ClassicAssert.IsFalse(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
 
             bestWorkerModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
                 new DistributionPolicy(bestWorkerModeDistributionPolicyId)
@@ -56,12 +57,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = bestWorkerModeDistributionPolicyName
                 });
 
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            ClassicAssert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
 
             bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsTrue(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            ClassicAssert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
+            ClassicAssert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
+            ClassicAssert.IsTrue(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
 
             bestWorkerModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
                 new DistributionPolicy(bestWorkerModeDistributionPolicyId)
@@ -74,12 +75,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     }
                 });
 
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            ClassicAssert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
 
             bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsTrue(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            ClassicAssert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
+            ClassicAssert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
+            ClassicAssert.IsTrue(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
         }
 
         [Test]
@@ -110,32 +111,32 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 { Name = bestWorkerModeDistributionPolicyName });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(bestWorkerModeDistributionPolicyId)));
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            ClassicAssert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
 
             var bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            ClassicAssert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
+            ClassicAssert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
+            ClassicAssert.IsFalse(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
 
             var paramSelectors = ((BestWorkerMode)bestWorkerModeDistributionPolicy.Mode).ScoringRuleOptions
                 .ScoringParameters;
-            Assert.AreEqual(1, paramSelectors.Count);
-            Assert.AreEqual(ScoringRuleParameterSelector.WorkerSelectors, paramSelectors.First());
+            ClassicAssert.AreEqual(1, paramSelectors.Count);
+            ClassicAssert.AreEqual(ScoringRuleParameterSelector.WorkerSelectors, paramSelectors.First());
 
             var scoringRule = ((BestWorkerMode)bestWorkerModeDistributionPolicy.Mode).ScoringRule;
-            Assert.NotNull(scoringRule);
+            ClassicAssert.NotNull(scoringRule);
             var azureFuncScoringRule = (FunctionRouterRule)scoringRule;
-            // Assert.AreEqual("https://my.function.app/api/myfunction?code=Kg==", azureFuncScoringRule.FunctionAppUrl);
-            Assert.IsNotNull(azureFuncScoringRule.Credential);
+            // ClassicAssert.AreEqual("https://my.function.app/api/myfunction?code=Kg==", azureFuncScoringRule.FunctionAppUrl);
+            ClassicAssert.IsNotNull(azureFuncScoringRule.Credential);
 
             if (Mode != RecordedTestMode.Playback)
             {
                 // any value will be sanitized when recordings are saved
-                Assert.AreEqual("MyAppKey", azureFuncScoringRule.Credential.AppKey);
-                Assert.IsTrue(string.IsNullOrWhiteSpace(azureFuncScoringRule.Credential.FunctionKey));
+                ClassicAssert.AreEqual("MyAppKey", azureFuncScoringRule.Credential.AppKey);
+                ClassicAssert.IsTrue(string.IsNullOrWhiteSpace(azureFuncScoringRule.Credential.FunctionKey));
             }
 
-            Assert.AreEqual("MyClientId", azureFuncScoringRule.Credential.ClientId);
+            ClassicAssert.AreEqual("MyClientId", azureFuncScoringRule.Credential.ClientId);
 
             bestWorkerModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
                 new DistributionPolicy(bestWorkerModeDistributionPolicyId)
@@ -155,28 +156,28 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     }
                 });
 
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            ClassicAssert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
 
             bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            ClassicAssert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
+            ClassicAssert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
+            ClassicAssert.IsFalse(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
 
             paramSelectors = ((BestWorkerMode)bestWorkerModeDistributionPolicy.Mode).ScoringRuleOptions
                 .ScoringParameters;
-            Assert.AreEqual(1, paramSelectors.Count);
-            Assert.AreEqual(ScoringRuleParameterSelector.WorkerSelectors, paramSelectors.First());
+            ClassicAssert.AreEqual(1, paramSelectors.Count);
+            ClassicAssert.AreEqual(ScoringRuleParameterSelector.WorkerSelectors, paramSelectors.First());
 
             scoringRule = ((BestWorkerMode)bestWorkerModeDistributionPolicy.Mode).ScoringRule;
-            Assert.NotNull(scoringRule);
+            ClassicAssert.NotNull(scoringRule);
             azureFuncScoringRule = (FunctionRouterRule)scoringRule;
-            Assert.AreEqual("https://my.function.app/api/myfunction?code=Kg==", azureFuncScoringRule.FunctionUri.ToString());
-            Assert.IsNotNull(azureFuncScoringRule.Credential);
+            ClassicAssert.AreEqual("https://my.function.app/api/myfunction?code=Kg==", azureFuncScoringRule.FunctionUri.ToString());
+            ClassicAssert.IsNotNull(azureFuncScoringRule.Credential);
 
             if (Mode != RecordedTestMode.Playback)
             {
                 // any value will be sanitized when recordings are saved
-                Assert.AreEqual("MyKey", azureFuncScoringRule.Credential.FunctionKey);
+                ClassicAssert.AreEqual("MyKey", azureFuncScoringRule.Credential.FunctionKey);
             }
         }
 
@@ -198,12 +199,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(longestIdleModeDistributionPolicyId)));
-            Assert.NotNull(longestIdleModeDistributionPolicyResponse.Value);
+            ClassicAssert.NotNull(longestIdleModeDistributionPolicyResponse.Value);
 
             var longestIdleModeDistributionPolicy = longestIdleModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(longestIdleModeDistributionPolicy.Mode.BypassSelectors);
+            ClassicAssert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MinConcurrentOffers);
+            ClassicAssert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MaxConcurrentOffers);
+            ClassicAssert.IsFalse(longestIdleModeDistributionPolicy.Mode.BypassSelectors);
 
             // specifying min and max concurrent offers
             longestIdleModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
@@ -217,12 +218,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     },
                 });
 
-            Assert.NotNull(longestIdleModeDistributionPolicyResponse.Value);
+            ClassicAssert.NotNull(longestIdleModeDistributionPolicyResponse.Value);
 
             longestIdleModeDistributionPolicy = longestIdleModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, longestIdleModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsTrue(longestIdleModeDistributionPolicy.Mode.BypassSelectors);
+            ClassicAssert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MinConcurrentOffers);
+            ClassicAssert.AreEqual(2, longestIdleModeDistributionPolicy.Mode.MaxConcurrentOffers);
+            ClassicAssert.IsTrue(longestIdleModeDistributionPolicy.Mode.BypassSelectors);
         }
 
         #endregion longest idle mode constructors
@@ -245,12 +246,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(roundRobinModeDistributionPolicyId)));
-            Assert.NotNull(roundRobinModeDistributionPolicyResponse.Value);
+            ClassicAssert.NotNull(roundRobinModeDistributionPolicyResponse.Value);
 
             var roundRobinModeDistributionPolicy = roundRobinModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(roundRobinModeDistributionPolicy.Mode.BypassSelectors);
+            ClassicAssert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MinConcurrentOffers);
+            ClassicAssert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MaxConcurrentOffers);
+            ClassicAssert.IsFalse(roundRobinModeDistributionPolicy.Mode.BypassSelectors);
 
             // specifying min and max concurrent offers
             roundRobinModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
@@ -264,12 +265,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     },
                 });
 
-            Assert.NotNull(roundRobinModeDistributionPolicyResponse.Value);
+            ClassicAssert.NotNull(roundRobinModeDistributionPolicyResponse.Value);
 
             roundRobinModeDistributionPolicy = roundRobinModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, roundRobinModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsTrue(roundRobinModeDistributionPolicy.Mode.BypassSelectors);
+            ClassicAssert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MinConcurrentOffers);
+            ClassicAssert.AreEqual(2, roundRobinModeDistributionPolicy.Mode.MaxConcurrentOffers);
+            ClassicAssert.IsTrue(roundRobinModeDistributionPolicy.Mode.BypassSelectors);
         }
 
         #endregion round robin mode constructors

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExceptionPolicyLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExceptionPolicyLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Azure.Communication.JobRouter.Tests.Infrastructure;
 using Azure.Core;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -43,27 +44,27 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createExceptionPolicyResponse = await routerClient.CreateExceptionPolicyAsync(new CreateExceptionPolicyOptions(exceptionPolicyId, rules));
             AddForCleanup(new Task(async () => await routerClient.DeleteExceptionPolicyAsync(exceptionPolicyId)));
 
-            Assert.NotNull(createExceptionPolicyResponse.Value);
+            ClassicAssert.NotNull(createExceptionPolicyResponse.Value);
 
             var exceptionPolicy = createExceptionPolicyResponse.Value;
 
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
+            ClassicAssert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
+            ClassicAssert.DoesNotThrow(() =>
             {
                 var exceptionRule = exceptionPolicy.ExceptionRules.First();
 
-                Assert.AreEqual(exceptionRuleId, exceptionRule.Id);
-                Assert.IsTrue(exceptionRule.Trigger.GetType() == typeof(QueueLengthExceptionTrigger));
+                ClassicAssert.AreEqual(exceptionRuleId, exceptionRule.Id);
+                ClassicAssert.IsTrue(exceptionRule.Trigger.GetType() == typeof(QueueLengthExceptionTrigger));
                 var trigger = exceptionRule.Trigger as QueueLengthExceptionTrigger;
-                Assert.NotNull(trigger);
-                Assert.AreEqual(1, trigger!.Threshold);
+                ClassicAssert.NotNull(trigger);
+                ClassicAssert.AreEqual(1, trigger!.Threshold);
 
                 var actions = exceptionRule.Actions;
-                Assert.AreEqual(1, actions.Count);
+                ClassicAssert.AreEqual(1, actions.Count);
                 var cancelAction = actions.FirstOrDefault() as CancelExceptionAction;
-                Assert.NotNull(cancelAction);
-                Assert.AreEqual($"CancelledDueToMaxQueueLengthReached", cancelAction!.DispositionCode);
+                ClassicAssert.NotNull(cancelAction);
+                ClassicAssert.AreEqual($"CancelledDueToMaxQueueLengthReached", cancelAction!.DispositionCode);
             });
 
             // with name
@@ -74,12 +75,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = exceptionPolicyName
                 });
 
-            Assert.NotNull(createExceptionPolicyResponse.Value);
+            ClassicAssert.NotNull(createExceptionPolicyResponse.Value);
 
             exceptionPolicy = createExceptionPolicyResponse.Value;
 
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
-            Assert.AreEqual(exceptionPolicyName, exceptionPolicy.Name);
+            ClassicAssert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
+            ClassicAssert.AreEqual(exceptionPolicyName, exceptionPolicy.Name);
         }
 
         [Test]
@@ -127,32 +128,32 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createExceptionPolicyResponse = await routerClient.CreateExceptionPolicyAsync(new CreateExceptionPolicyOptions(exceptionPolicyId, rules));
 
             AddForCleanup(new Task(async () => await routerClient.DeleteExceptionPolicyAsync(exceptionPolicyId)));
-            Assert.NotNull(createExceptionPolicyResponse.Value);
+            ClassicAssert.NotNull(createExceptionPolicyResponse.Value);
 
             var exceptionPolicy = createExceptionPolicyResponse.Value;
 
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
+            ClassicAssert.DoesNotThrow(() =>
             {
                 var exceptionRule = exceptionPolicy.ExceptionRules.First();
 
-                Assert.AreEqual(exceptionRuleId, exceptionRule.Id);
-                Assert.IsTrue(exceptionRule.Trigger.GetType() == typeof(QueueLengthExceptionTrigger));
+                ClassicAssert.AreEqual(exceptionRuleId, exceptionRule.Id);
+                ClassicAssert.IsTrue(exceptionRule.Trigger.GetType() == typeof(QueueLengthExceptionTrigger));
                 var trigger = exceptionRule.Trigger as QueueLengthExceptionTrigger;
-                Assert.NotNull(trigger);
-                Assert.AreEqual(1, trigger!.Threshold);
+                ClassicAssert.NotNull(trigger);
+                ClassicAssert.AreEqual(1, trigger!.Threshold);
 
                 var actions = exceptionRule.Actions;
-                Assert.AreEqual(2, actions.Count);
+                ClassicAssert.AreEqual(2, actions.Count);
                 var reclassifyExceptionAction = actions.FirstOrDefault() as ReclassifyExceptionAction;
-                Assert.NotNull(reclassifyExceptionAction);
-                Assert.AreEqual(classificationPolicyId, reclassifyExceptionAction?.ClassificationPolicyId);
-                Assert.AreEqual(labelsToUpsert.FirstOrDefault().Key, reclassifyExceptionAction?.LabelsToUpsert.FirstOrDefault().Key);
-                Assert.AreEqual(labelsToUpsert.FirstOrDefault().Value.Value as string, reclassifyExceptionAction?.LabelsToUpsert.FirstOrDefault().Value.Value as string);
+                ClassicAssert.NotNull(reclassifyExceptionAction);
+                ClassicAssert.AreEqual(classificationPolicyId, reclassifyExceptionAction?.ClassificationPolicyId);
+                ClassicAssert.AreEqual(labelsToUpsert.FirstOrDefault().Key, reclassifyExceptionAction?.LabelsToUpsert.FirstOrDefault().Key);
+                ClassicAssert.AreEqual(labelsToUpsert.FirstOrDefault().Value.Value as string, reclassifyExceptionAction?.LabelsToUpsert.FirstOrDefault().Value.Value as string);
                 var manualReclassifyExceptionAction = actions.LastOrDefault() as ManualReclassifyExceptionAction;
-                Assert.NotNull(manualReclassifyExceptionAction);
-                Assert.AreEqual(queueId, manualReclassifyExceptionAction?.QueueId);
-                Assert.AreEqual(1, manualReclassifyExceptionAction?.Priority);
+                ClassicAssert.NotNull(manualReclassifyExceptionAction);
+                ClassicAssert.AreEqual(queueId, manualReclassifyExceptionAction?.QueueId);
+                ClassicAssert.AreEqual(1, manualReclassifyExceptionAction?.Priority);
             });
 
             // with name
@@ -163,12 +164,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = exceptionPolicyName
                 });
 
-            Assert.NotNull(createExceptionPolicyResponse.Value);
+            ClassicAssert.NotNull(createExceptionPolicyResponse.Value);
 
             exceptionPolicy = createExceptionPolicyResponse.Value;
 
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
-            Assert.AreEqual(exceptionPolicyName, exceptionPolicy.Name);
+            ClassicAssert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
+            ClassicAssert.AreEqual(exceptionPolicyName, exceptionPolicy.Name);
         }
 
         #endregion Exception Policy Tests

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExpressionRuleTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExpressionRuleTests.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -11,7 +12,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         [Test]
         public void ConstructorWithLanguageDoesNotExists()
         {
-            Assert.Throws<MissingMethodException>(() =>
+            ClassicAssert.Throws<MissingMethodException>(() =>
             {
                 var rule = Activator.CreateInstance(typeof(ExpressionRouterRule), "PowerFx", "expression");
             });
@@ -25,7 +26,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             if (languagePropertyInfo is not null)
             {
                 var getSetMethodForLanguage = languagePropertyInfo.GetSetMethod();
-                Assert.IsNull(getSetMethodForLanguage);
+                ClassicAssert.IsNull(getSetMethodForLanguage);
             }
         }
     }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/FunctionRuleCredentialTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/FunctionRuleCredentialTests.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -13,7 +14,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         [Parallelizable(ParallelScope.All)]
         public void NullFunctionKeyThrowsException(string functionKey)
         {
-            Assert.Throws<ArgumentNullException>(() => new FunctionRouterRuleCredential(functionKey));
+            ClassicAssert.Throws<ArgumentNullException>(() => new FunctionRouterRuleCredential(functionKey));
         }
 
         [Test]
@@ -22,16 +23,16 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         [Parallelizable(ParallelScope.All)]
         public void EmptyFunctionKeyThrowsException(string functionKey)
         {
-            Assert.Throws<ArgumentException>(() => new FunctionRouterRuleCredential(functionKey));
+            ClassicAssert.Throws<ArgumentException>(() => new FunctionRouterRuleCredential(functionKey));
         }
 
         [Test]
         public void NonEmptyFunctionKeyDoesNotThrowsException()
         {
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 var funcCredential = new FunctionRouterRuleCredential("functionKey");
-                Assert.AreEqual("functionKey", funcCredential.FunctionKey);
+                ClassicAssert.AreEqual("functionKey", funcCredential.FunctionKey);
             });
         }
 
@@ -43,7 +44,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         [Parallelizable(ParallelScope.All)]
         public void EmptyAppKeyAndClientIdThrowsException(string appKey, string clientId)
         {
-            Assert.Throws<ArgumentException>(() => new FunctionRouterRuleCredential(appKey, clientId));
+            ClassicAssert.Throws<ArgumentException>(() => new FunctionRouterRuleCredential(appKey, clientId));
         }
 
         [Test]
@@ -53,7 +54,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         [Parallelizable(ParallelScope.All)]
         public void NullAppKeyAndClientIdThrowsException(string appKey, string clientId)
         {
-            Assert.Throws<ArgumentNullException>(() => new FunctionRouterRuleCredential(appKey, clientId));
+            ClassicAssert.Throws<ArgumentNullException>(() => new FunctionRouterRuleCredential(appKey, clientId));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/LabelValueTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/LabelValueTests.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -11,11 +12,11 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         public void LabelValueAcceptsNull()
         {
             var labelValue = new RouterValue(null);
-            Assert.IsNotNull(labelValue);
+            ClassicAssert.IsNotNull(labelValue);
             var testValue1 = new RouterValue(null);
-            Assert.AreEqual(labelValue, testValue1);
+            ClassicAssert.AreEqual(labelValue, testValue1);
             var testValue2 = new RouterValue(null);
-            Assert.AreEqual(labelValue, testValue2);
+            ClassicAssert.AreEqual(labelValue, testValue2);
         }
 
         [Test]
@@ -23,9 +24,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             short input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            ClassicAssert.IsNotNull(labelValue);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            ClassicAssert.AreEqual(labelValue, testValue);
         }
 
         [Test]
@@ -33,9 +34,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             int input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            ClassicAssert.IsNotNull(labelValue);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            ClassicAssert.AreEqual(labelValue, testValue);
         }
 
         [Test]
@@ -43,9 +44,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             long input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            ClassicAssert.IsNotNull(labelValue);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            ClassicAssert.AreEqual(labelValue, testValue);
         }
 
         [Test]
@@ -53,9 +54,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             float input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            ClassicAssert.IsNotNull(labelValue);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            ClassicAssert.AreEqual(labelValue, testValue);
         }
 
         [Test]
@@ -63,9 +64,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             double input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            ClassicAssert.IsNotNull(labelValue);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            ClassicAssert.AreEqual(labelValue, testValue);
         }
 
         [Test]
@@ -73,9 +74,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             decimal input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            ClassicAssert.IsNotNull(labelValue);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            ClassicAssert.AreEqual(labelValue, testValue);
         }
 
         [Test]
@@ -83,9 +84,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             string input = "1";
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            ClassicAssert.IsNotNull(labelValue);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            ClassicAssert.AreEqual(labelValue, testValue);
         }
 
         [Test]
@@ -94,9 +95,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         public void LabelValueAcceptsBoolean(bool input)
         {
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            ClassicAssert.IsNotNull(labelValue);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            ClassicAssert.AreEqual(labelValue, testValue);
         }
 
         [Test]
@@ -104,7 +105,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             string input = "1";
             var labelValue = new RouterValue(input);
-            Assert.AreEqual(labelValue.ToString(), labelValue.Value.ToString());
+            ClassicAssert.AreEqual(labelValue.ToString(), labelValue.Value.ToString());
         }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterClientCrudTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterClientCrudTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -26,7 +27,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -43,7 +44,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -59,7 +60,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -75,7 +76,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -91,7 +92,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -107,7 +108,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -128,7 +129,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -145,7 +146,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -161,7 +162,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -177,7 +178,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -193,7 +194,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -209,7 +210,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -230,7 +231,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -247,7 +248,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -263,7 +264,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -279,7 +280,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -295,7 +296,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -311,7 +312,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -340,7 +341,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -361,7 +362,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -377,7 +378,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -393,7 +394,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -409,7 +410,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -425,7 +426,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -446,7 +447,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -463,7 +464,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -479,7 +480,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 
@@ -495,7 +496,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                ClassicAssert.AreEqual(exceptionType, e.GetType());
             }
         }
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterJobLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterJobLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,6 +9,7 @@ using Azure.Communication.JobRouter.Tests.Infrastructure;
 using Azure.Core;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -65,8 +66,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
             }
 
-            Assert.IsNotEmpty(updatedJob1Response.Notes);
-            Assert.IsTrue(updatedJob1Response.Notes.Count == 1);
+            ClassicAssert.IsNotEmpty(updatedJob1Response.Notes);
+            ClassicAssert.IsTrue(updatedJob1Response.Notes.Count == 1);
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -103,7 +104,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 job => job.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, job1Result.Value.Status);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job1Result.Value.Status);
 
             // cancel job 1
             var cancelJob1Response = await routerClient.CancelJobAsync(new CancelJobOptions(createJob1.Id));
@@ -122,7 +123,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 job => job.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, job2Result.Value.Status);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job2Result.Value.Status);
 
             // test get jobs
             var getJobsResponse = routerClient.GetJobsAsync(channelId: channelId, queueId: createQueue.Id, status: null, classificationPolicyId: null, scheduledBefore: null, scheduledAfter: null, cancellationToken: default);
@@ -136,8 +137,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 }
             }
 
-            Assert.IsTrue(allJobs.Contains(createJob1.Id));
-            Assert.IsTrue(allJobs.Contains(createJob2.Id));
+            ClassicAssert.IsTrue(allJobs.Contains(createJob1.Id));
+            ClassicAssert.IsTrue(allJobs.Contains(createJob2.Id));
 
             // in-test cleanup
             await routerClient.CancelJobAsync(new CancelJobOptions(jobId2)); // other wise queue deletion will throw error
@@ -178,7 +179,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 }
             }
 
-            Assert.IsTrue(allJobs.Contains(createJob1.Id));
+            ClassicAssert.IsTrue(allJobs.Contains(createJob1.Id));
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -234,10 +235,10 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
-            Assert.AreEqual(createJob.Id, queuedJob.Value.Id);
-            Assert.AreEqual(10, queuedJob.Value.Priority); // from classification policy
-            Assert.AreEqual(createQueue.Id, queuedJob.Value.QueueId); // from direct queue assignment
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
+            ClassicAssert.AreEqual(createJob.Id, queuedJob.Value.Id);
+            ClassicAssert.AreEqual(10, queuedJob.Value.Priority); // from classification policy
+            ClassicAssert.AreEqual(createQueue.Id, queuedJob.Value.QueueId); // from direct queue assignment
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -287,10 +288,10 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
-            Assert.AreEqual(createJob.Id, queuedJob.Value.Id);
-            // Assert.AreEqual(1, queuedJob.Value.Priority); // default value TODO: Should be 0 or 1?
-            Assert.AreEqual(createQueue2.Id, queuedJob.Value.QueueId); // from queue selector in classification policy
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
+            ClassicAssert.AreEqual(createJob.Id, queuedJob.Value.Id);
+            // ClassicAssert.AreEqual(1, queuedJob.Value.Priority); // default value TODO: Should be 0 or 1?
+            ClassicAssert.AreEqual(createQueue2.Id, queuedJob.Value.QueueId); // from queue selector in classification policy
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -341,9 +342,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
-            Assert.AreEqual(1, queuedJob.Value.Priority); // default priority value
-            Assert.AreEqual(createQueue2.Id, queuedJob.Value.QueueId); // from fallback queue of classification policy
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
+            ClassicAssert.AreEqual(1, queuedJob.Value.Priority); // default priority value
+            ClassicAssert.AreEqual(createQueue2.Id, queuedJob.Value.QueueId); // from fallback queue of classification policy
 
             // in-test cleanup
             await routerClient.CancelJobAsync(new CancelJobOptions(createJob.Id)); // other wise queue deletion will throw error
@@ -389,10 +390,10 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
-            Assert.AreEqual(createJob.Id, queuedJob.Value.Id);
-            Assert.AreEqual(1, queuedJob.Value.Priority); // default value
-            Assert.AreEqual(createQueue1.Id, queuedJob.Value.QueueId); // from queue selector in classification policy
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
+            ClassicAssert.AreEqual(createJob.Id, queuedJob.Value.Id);
+            ClassicAssert.AreEqual(1, queuedJob.Value.Priority); // default value
+            ClassicAssert.AreEqual(createQueue1.Id, queuedJob.Value.QueueId); // from queue selector in classification policy
 
             // in-test cleanup
             await routerClient.CancelJobAsync(new CancelJobOptions(createJob.Id)); // other wise queue deletion will throw error
@@ -421,7 +422,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createJob1 = createJob1Response.Value;
             AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(createJob1.Id)));
 
-            Assert.IsTrue(createJob1.MatchingMode.GetType() == typeof(QueueAndMatchMode));
+            ClassicAssert.IsTrue(createJob1.MatchingMode.GetType() == typeof(QueueAndMatchMode));
 
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob1.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
@@ -456,7 +457,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createJob1 = createJob1Response.Value;
             AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(createJob1.Id)));
 
-            Assert.IsTrue(createJob1.MatchingMode.GetType() == typeof(SuspendMode));
+            ClassicAssert.IsTrue(createJob1.MatchingMode.GetType() == typeof(SuspendMode));
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -489,7 +490,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createJob1 = createJob1Response.Value;
             AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(createJob1.Id)));
 
-            Assert.IsTrue(createJob1.MatchingMode.GetType() == typeof(ScheduleAndSuspendMode));
+            ClassicAssert.IsTrue(createJob1.MatchingMode.GetType() == typeof(ScheduleAndSuspendMode));
 
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob1.Id),
                 job => job.Value.Status == RouterJobStatus.Scheduled, TimeSpan.FromSeconds(10));
@@ -550,12 +551,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             var updateJobResponse = await routerClient.UpdateJobAsync(updateOptions);
 
-            Assert.AreEqual(updateJobResponse.Value.Labels, new Dictionary<string, RouterValue?>
+            ClassicAssert.AreEqual(updateJobResponse.Value.Labels, new Dictionary<string, RouterValue?>
             {
                 ["Label_3"] = new RouterValue("Value_Updated_3"),
                 ["Label_4"] = new RouterValue("Value_4")
             });
-            Assert.AreEqual(updateJobResponse.Value.Tags, new Dictionary<string, RouterValue?>
+            ClassicAssert.AreEqual(updateJobResponse.Value.Tags, new Dictionary<string, RouterValue?>
             {
                 ["Tag_3"] = new RouterValue("Value_Updated_3"),
                 ["Tag_4"] = new RouterValue("Value_4")
@@ -605,7 +606,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             await routerClient.ReclassifyJobAsync(jobId1, CancellationToken.None);
 
-            Assert.AreEqual(createJob1.QueueId, createQueue.Id);
+            ClassicAssert.AreEqual(createJob1.QueueId, createQueue.Id);
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterWorkerLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterWorkerLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Azure.Communication.JobRouter.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -55,7 +56,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
             AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(workerId)));
 
-            Assert.NotNull(routerWorkerResponse.Value);
+            ClassicAssert.NotNull(routerWorkerResponse.Value);
             AssertRegisteredWorkerIsValid(routerWorkerResponse, workerId, queues,
                 capacity, workerLabels, channels);
 
@@ -77,7 +78,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var routerWorkerResponse = await routerClient.CreateWorkerAsync(new CreateWorkerOptions(workerId, capacity) { AvailableForOffers = true });
             AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(workerId)));
 
-            Assert.NotNull(routerWorkerResponse.Value);
+            ClassicAssert.NotNull(routerWorkerResponse.Value);
 
             routerWorkerResponse.Value.AvailableForOffers = false;
             await routerClient.UpdateWorkerAsync(routerWorkerResponse);
@@ -165,7 +166,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var getWorkersResponse = routerClient.GetWorkersAsync(new GetWorkersOptions() { ChannelId = "Voip" });
             await foreach (var workerPage in getWorkersResponse.AsPages(pageSizeHint: 1))
             {
-                Assert.AreEqual(1, workerPage.Values.Count);
+                ClassicAssert.AreEqual(1, workerPage.Values.Count);
                 foreach (var worker in workerPage.Values)
                 {
                     if (channel2Workers.Contains(worker.Id))
@@ -174,14 +175,14 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     }
                 }
             }
-            Assert.IsEmpty(channel2Workers);
+            ClassicAssert.IsEmpty(channel2Workers);
 
             // Query all workers with queue filter
             var queue2Workers = new HashSet<string>() { workerId2, workerId3 };
             getWorkersResponse = routerClient.GetWorkersAsync(new GetWorkersOptions() { QueueId = createQueue2.Id });
             await foreach (var workerPage in getWorkersResponse.AsPages(pageSizeHint: 1))
             {
-                Assert.AreEqual(1, workerPage.Values.Count);
+                ClassicAssert.AreEqual(1, workerPage.Values.Count);
                 foreach (var worker in workerPage.Values)
                 {
                     if (queue2Workers.Contains(worker.Id))
@@ -190,14 +191,14 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     }
                 }
             }
-            Assert.IsEmpty(queue2Workers);
+            ClassicAssert.IsEmpty(queue2Workers);
 
             // Query all workers with channel + hasCapacity filter
             var channel1Workers = new HashSet<string>() { workerId1, workerId2, workerId3, workerId4 }; // no worker is expected to get any job
             getWorkersResponse = routerClient.GetWorkersAsync(new GetWorkersOptions() { ChannelId = "WebChat", HasCapacity = true});
             await foreach (var workerPage in getWorkersResponse.AsPages(pageSizeHint: 1))
             {
-                Assert.AreEqual(1, workerPage.Values.Count);
+                ClassicAssert.AreEqual(1, workerPage.Values.Count);
                 foreach (var worker in workerPage.Values)
                 {
                     if (channel1Workers.Contains(worker.Id))
@@ -206,7 +207,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     }
                 }
             }
-            Assert.IsEmpty(channel1Workers);
+            ClassicAssert.IsEmpty(channel1Workers);
 
             // Deregister worker1
             await routerClient.UpdateWorkerAsync(new RouterWorker(workerId1) { AvailableForOffers = false});
@@ -214,36 +215,36 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var checkWorker1Status = await Poll(async () => await routerClient.GetWorkerAsync(workerId1),
                 w => w.Value.State == RouterWorkerState.Inactive, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterWorkerState.Inactive, checkWorker1Status.Value.State);
+            ClassicAssert.AreEqual(RouterWorkerState.Inactive, checkWorker1Status.Value.State);
 
             // Query all workers with status: active
             var activeWorkers = new HashSet<string>();
             getWorkersResponse = routerClient.GetWorkersAsync(new GetWorkersOptions() { ChannelId = "WebChat", State = RouterWorkerStateSelector.Active});
             await foreach (var workerPage in getWorkersResponse.AsPages(pageSizeHint: 1))
             {
-                Assert.AreEqual(1, workerPage.Values.Count);
+                ClassicAssert.AreEqual(1, workerPage.Values.Count);
                 foreach (var worker in workerPage.Values)
                 {
                     activeWorkers.Add(worker.Id);
                 }
             }
 
-            Assert.IsTrue(activeWorkers.Contains(workerId2));
-            Assert.IsTrue(activeWorkers.Contains(workerId3));
-            Assert.IsTrue(activeWorkers.Contains(workerId4));
+            ClassicAssert.IsTrue(activeWorkers.Contains(workerId2));
+            ClassicAssert.IsTrue(activeWorkers.Contains(workerId3));
+            ClassicAssert.IsTrue(activeWorkers.Contains(workerId4));
 
             // Query all workers with status: inactive
             var inactiveWorkers = new HashSet<string>();
             getWorkersResponse = routerClient.GetWorkersAsync(new GetWorkersOptions() { ChannelId = "WebChat", State = RouterWorkerStateSelector.Inactive });
             await foreach (var workerPage in getWorkersResponse.AsPages(pageSizeHint: 1))
             {
-                Assert.AreEqual(1, workerPage.Values.Count);
+                ClassicAssert.AreEqual(1, workerPage.Values.Count);
                 foreach (var worker in workerPage.Values)
                 {
                     inactiveWorkers.Add(worker.Id);
                 }
             }
-            Assert.IsTrue(inactiveWorkers.Contains(workerId1));
+            ClassicAssert.IsTrue(inactiveWorkers.Contains(workerId1));
 
             // in-test cleanup workers before deleting queue and channel
             await routerClient.DeleteWorkerAsync(expectedWorkerIds[0]);
@@ -293,7 +294,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var routerWorkerResponse = await routerClient.CreateWorkerAsync(createWorkerOptions);
             AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(workerId)));
 
-            Assert.NotNull(routerWorkerResponse.Value);
+            ClassicAssert.NotNull(routerWorkerResponse.Value);
             AssertRegisteredWorkerIsValid(routerWorkerResponse, workerId, queues,
                 capacity, workerLabels, channels, workerTags);
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/StaticRuleTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/StaticRuleTests.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.RouterClients
 {
@@ -16,10 +17,10 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         [Parallelizable(ParallelScope.All)]
         public void RouterRuleAcceptsValueInConstructor(object input)
         {
-            Assert.DoesNotThrow(() =>
+            ClassicAssert.DoesNotThrow(() =>
             {
                 var rule = new StaticRouterRule(new RouterValue(input));
-                Assert.AreEqual(input, rule.Value.Value);
+                ClassicAssert.AreEqual(input, rule.Value.Value);
             });
         }
     }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/AssignmentScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/AssignmentScenario.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Azure.Communication.JobRouter.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.Scenarios
 {
@@ -62,18 +63,18 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
                 w => w.Value.Offers.Any(x => x.JobId == createJob.Value.Id),
                 TimeSpan.FromSeconds(10));
 
-            Assert.IsTrue(worker.Value.Offers.Any(x => x.JobId == createJob.Value.Id));
+            ClassicAssert.IsTrue(worker.Value.Offers.Any(x => x.JobId == createJob.Value.Id));
 
             var offer = worker.Value.Offers.Single(x => x.JobId == createJob.Value.Id);
-            Assert.AreEqual(1, offer.CapacityCost);
-            Assert.IsNotNull(offer.OfferedAt);
-            Assert.IsNotNull(offer.ExpiresAt);
+            ClassicAssert.AreEqual(1, offer.CapacityCost);
+            ClassicAssert.IsNotNull(offer.OfferedAt);
+            ClassicAssert.IsNotNull(offer.ExpiresAt);
 
             var accept = await client.AcceptJobOfferAsync(worker.Value.Id, offer.OfferId);
-            Assert.AreEqual(createJob.Value.Id, accept.Value.JobId);
-            Assert.AreEqual(worker.Value.Id, accept.Value.WorkerId);
+            ClassicAssert.AreEqual(createJob.Value.Id, accept.Value.JobId);
+            ClassicAssert.AreEqual(worker.Value.Id, accept.Value.WorkerId);
 
-            Assert.ThrowsAsync<RequestFailedException>(async () =>
+            ClassicAssert.ThrowsAsync<RequestFailedException>(async () =>
                 await client.DeclineJobOfferAsync(
                     new DeclineJobOfferOptions(worker.Value.Id, offer.OfferId)
                     {
@@ -84,21 +85,21 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             {
                 Note = $"Job completed by {workerId1}"
             });
-            Assert.AreEqual(200, complete.Status);
+            ClassicAssert.AreEqual(200, complete.Status);
 
             var close = await client.CloseJobAsync(new CloseJobOptions(createJob.Value.Id, accept.Value.AssignmentId)
             {
                 Note = $"Job closed by {workerId1}"
             });
-            Assert.AreEqual(200, complete.Status);
+            ClassicAssert.AreEqual(200, complete.Status);
 
             var finalJobState = await client.GetJobAsync(createJob.Value.Id);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].AssignedAt);
-            Assert.AreEqual(worker.Value.Id, finalJobState.Value.Assignments[accept.Value.AssignmentId].WorkerId);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].CompletedAt);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].ClosedAt);
-            Assert.IsNotEmpty(finalJobState.Value.Notes);
-            Assert.IsTrue(finalJobState.Value.Notes.Count == 2);
+            ClassicAssert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].AssignedAt);
+            ClassicAssert.AreEqual(worker.Value.Id, finalJobState.Value.Assignments[accept.Value.AssignmentId].WorkerId);
+            ClassicAssert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].CompletedAt);
+            ClassicAssert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].ClosedAt);
+            ClassicAssert.IsNotEmpty(finalJobState.Value.Notes);
+            ClassicAssert.IsTrue(finalJobState.Value.Notes.Count == 2);
 
             // in-test cleanup
             worker.Value.AvailableForOffers = false;

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/CancellationScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/CancellationScenario.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using System.Threading.Tasks;
 using Azure.Communication.JobRouter.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.Scenarios
 {
@@ -53,7 +54,7 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
 
             await client.CancelJobAsync(new CancelJobOptions(job.Value.Id)
             {
@@ -61,8 +62,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             });
 
             var finalJobState = await client.GetJobAsync(createJob.Value.Id);
-            Assert.AreEqual(RouterJobStatus.Cancelled, finalJobState.Value.Status);
-            Assert.AreEqual(dispositionCode, finalJobState.Value.DispositionCode);
+            ClassicAssert.AreEqual(RouterJobStatus.Cancelled, finalJobState.Value.Status);
+            ClassicAssert.AreEqual(dispositionCode, finalJobState.Value.DispositionCode);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/LimitConcurrentOffersToWorkerScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/LimitConcurrentOffersToWorkerScenario.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Azure.Communication.JobRouter.Tests.Infrastructure;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.Scenarios
 {
@@ -72,7 +73,7 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var queriedWorker = await Poll(async () => await client.GetWorkerAsync(workerId1),
                 x => x.Value.Offers.Any(offer => offer.JobId == jobId1 || offer.JobId == jobId2),
                 TimeSpan.FromSeconds(30));
-            Assert.IsTrue(queriedWorker.Value.Offers.Count == 1);
+            ClassicAssert.IsTrue(queriedWorker.Value.Offers.Count == 1);
 
             var offer1 = queriedWorker.Value.Offers.First(offer => offer.JobId == jobId1 || offer.JobId == jobId2);
             var jobWithOffer = offer1.JobId;
@@ -83,7 +84,7 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             queriedWorker = await Poll(async () => await client.GetWorkerAsync(workerId1),
                 x => x.Value.Offers.Any(newOffer => newOffer.JobId == jobWithoutOffer),
                 TimeSpan.FromSeconds(30));
-            Assert.IsTrue(queriedWorker.Value.Offers.Count == 1);
+            ClassicAssert.IsTrue(queriedWorker.Value.Offers.Count == 1);
 
             var offer2 = queriedWorker.Value.Offers.First(newOffer => newOffer.JobId == jobWithoutOffer);
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/QueueScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/QueueScenario.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Communication.JobRouter.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.Scenarios
 {
@@ -45,7 +46,7 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
         }
 
         [Test]
@@ -81,8 +82,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
-            Assert.AreEqual(job.Value.QueueId, queueResponse.Value.Id);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
+            ClassicAssert.AreEqual(job.Value.QueueId, queueResponse.Value.Id);
         }
 
         [Test]
@@ -118,8 +119,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
-            Assert.AreEqual(job.Value.QueueId, fallbackQueueResponse.Value.Id);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
+            ClassicAssert.AreEqual(job.Value.QueueId, fallbackQueueResponse.Value.Id);
         }
 
         [Test]
@@ -170,8 +171,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
-            Assert.AreEqual(job.Value.QueueId, queueResponse.Value.Id);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
+            ClassicAssert.AreEqual(job.Value.QueueId, queueResponse.Value.Id);
         }
 
         [Test]
@@ -234,8 +235,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
-            Assert.AreEqual(job.Value.QueueId, queueResponse.Value.Id);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
+            ClassicAssert.AreEqual(job.Value.QueueId, queueResponse.Value.Id);
         }
 
         [Test]
@@ -342,10 +343,10 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, job1.Value.Status);
-            Assert.AreEqual(RouterJobStatus.Queued, job2.Value.Status);
-            Assert.AreEqual(job1.Value.QueueId, queue1Response.Value.Id);
-            Assert.AreEqual(job2.Value.QueueId, queue2Response.Value.Id);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job1.Value.Status);
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, job2.Value.Status);
+            ClassicAssert.AreEqual(job1.Value.QueueId, queue1Response.Value.Id);
+            ClassicAssert.AreEqual(job2.Value.QueueId, queue2Response.Value.Id);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/SchedulingScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/SchedulingScenario.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Azure.Communication.JobRouter.Tests.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.JobRouter.Tests.Scenarios
 {
@@ -62,8 +63,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.WaitingForActivation,
                 TimeSpan.FromSeconds(30));
-            Assert.AreEqual(RouterJobStatus.WaitingForActivation, job.Value.Status);
-            Assert.NotNull(job.Value.ScheduledAt);
+            ClassicAssert.AreEqual(RouterJobStatus.WaitingForActivation, job.Value.Status);
+            ClassicAssert.NotNull(job.Value.ScheduledAt);
             Assert.That(job.Value.ScheduledAt, Is.EqualTo(timeToEnqueueJob).Within(30).Seconds);
 
             var updateJobToStartMatching =
@@ -72,25 +73,25 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
                     MatchingMode = new QueueAndMatchMode()
                 });
 
-            Assert.AreEqual(RouterJobStatus.Queued, updateJobToStartMatching.Value.Status);
-            Assert.NotNull(updateJobToStartMatching.Value.ScheduledAt);
-            Assert.AreEqual(typeof(QueueAndMatchMode), updateJobToStartMatching.Value.MatchingMode.GetType());
+            ClassicAssert.AreEqual(RouterJobStatus.Queued, updateJobToStartMatching.Value.Status);
+            ClassicAssert.NotNull(updateJobToStartMatching.Value.ScheduledAt);
+            ClassicAssert.AreEqual(typeof(QueueAndMatchMode), updateJobToStartMatching.Value.MatchingMode.GetType());
 
             var worker = await Poll(async () => await client.GetWorkerAsync(registerWorker.Value.Id),
                 w => w.Value.Offers.Any(x => x.JobId == updateJobToStartMatching.Value.Id),
                 TimeSpan.FromSeconds(10));
-            Assert.IsTrue(worker.Value.Offers.Any(x => x.JobId == updateJobToStartMatching.Value.Id), "Offers should be sent to worker");
+            ClassicAssert.IsTrue(worker.Value.Offers.Any(x => x.JobId == updateJobToStartMatching.Value.Id), "Offers should be sent to worker");
 
             var offer = worker.Value.Offers.Single(x => x.JobId == updateJobToStartMatching.Value.Id);
-            Assert.AreEqual(1, offer.CapacityCost);
-            Assert.IsNotNull(offer.OfferedAt);
-            Assert.IsNotNull(offer.ExpiresAt);
+            ClassicAssert.AreEqual(1, offer.CapacityCost);
+            ClassicAssert.IsNotNull(offer.OfferedAt);
+            ClassicAssert.IsNotNull(offer.ExpiresAt);
 
             var accept = await client.AcceptJobOfferAsync(worker.Value.Id, offer.OfferId);
-            Assert.AreEqual(createJob.Value.Id, accept.Value.JobId);
-            Assert.AreEqual(worker.Value.Id, accept.Value.WorkerId);
+            ClassicAssert.AreEqual(createJob.Value.Id, accept.Value.JobId);
+            ClassicAssert.AreEqual(worker.Value.Id, accept.Value.WorkerId);
 
-            Assert.ThrowsAsync<RequestFailedException>(async () =>
+            ClassicAssert.ThrowsAsync<RequestFailedException>(async () =>
                 await client.DeclineJobOfferAsync(
                     new DeclineJobOfferOptions(worker.Value.Id, offer.OfferId)
                     {
@@ -101,22 +102,22 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             {
                 Note = $"Job completed by {workerId1}"
             });
-            Assert.AreEqual(200, complete.Status);
+            ClassicAssert.AreEqual(200, complete.Status);
 
             var close = await client.CloseJobAsync(new CloseJobOptions(createJob.Value.Id, accept.Value.AssignmentId)
             {
                 Note = $"Job closed by {workerId1}"
             });
-            Assert.AreEqual(200, complete.Status);
+            ClassicAssert.AreEqual(200, complete.Status);
 
             var finalJobState = await client.GetJobAsync(createJob.Value.Id);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].AssignedAt);
-            Assert.AreEqual(worker.Value.Id, finalJobState.Value.Assignments[accept.Value.AssignmentId].WorkerId);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].CompletedAt);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].ClosedAt);
-            Assert.IsNotEmpty(finalJobState.Value.Notes);
-            Assert.IsTrue(finalJobState.Value.Notes.Count == 2);
-            Assert.NotNull(finalJobState.Value.ScheduledAt);
+            ClassicAssert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].AssignedAt);
+            ClassicAssert.AreEqual(worker.Value.Id, finalJobState.Value.Assignments[accept.Value.AssignmentId].WorkerId);
+            ClassicAssert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].CompletedAt);
+            ClassicAssert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].ClosedAt);
+            ClassicAssert.IsNotEmpty(finalJobState.Value.Notes);
+            ClassicAssert.IsTrue(finalJobState.Value.Notes.Count == 2);
+            ClassicAssert.NotNull(finalJobState.Value.ScheduledAt);
 
             // delete worker for straggling offers if any
             await client.UpdateWorkerAsync(new RouterWorker(workerId1) { AvailableForOffers = false });

--- a/sdk/communication/Azure.Communication.Messages/tests/NotificationMessagesClient/NotificationMessagesClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Messages/tests/NotificationMessagesClient/NotificationMessagesClientLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Azure.Communication.Messages.Models.Channels;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Messages.Tests
 {
@@ -560,11 +561,11 @@ namespace Azure.Communication.Messages.Tests
                 new List<string> { TestEnvironment.RecipientIdentifier }, string.Empty);
 
             // Act and Assert
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
+            RequestFailedException ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
 
             // Assert the expected error code and message
-            Assert.AreEqual(400, ex.Status);
-            Assert.AreEqual("BadRequest", ex.ErrorCode);
+            ClassicAssert.AreEqual(400, ex.Status);
+            ClassicAssert.AreEqual("BadRequest", ex.ErrorCode);
 
             return Task.CompletedTask;
         }
@@ -583,12 +584,12 @@ namespace Azure.Communication.Messages.Tests
             NotificationContent content = new TemplateNotificationContent(channelRegistrationId, recipients, template);
 
             // Act and Assert
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
+            RequestFailedException ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
 
             // Assert the expected error code and message
-            Assert.AreEqual(404, ex.Status);
-            Assert.AreEqual("TemplateNotFound", ex.ErrorCode);
-            Assert.IsTrue(ex.Message.Contains("Template does not exist"));
+            ClassicAssert.AreEqual(404, ex.Status);
+            ClassicAssert.AreEqual("TemplateNotFound", ex.ErrorCode);
+            ClassicAssert.IsTrue(ex.Message.Contains("Template does not exist"));
             return Task.CompletedTask;
         }
 
@@ -601,7 +602,7 @@ namespace Azure.Communication.Messages.Tests
                 new List<string> { "InvalidRecipient" }, "LiveTest");
 
             // Act and Assert
-            Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
+            ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
             return Task.CompletedTask;
         }
 
@@ -621,12 +622,12 @@ namespace Azure.Communication.Messages.Tests
                 superLongText);
 
             // Act and Assert
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
+            RequestFailedException ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
 
             // Assert the expected error code and message
-            Assert.AreEqual(400, ex.Status);
-            Assert.AreEqual("BadRequest", ex.ErrorCode);
-            Assert.IsTrue(ex.Message.Contains("InvalidParameter: (#100) Param text['body'] must be at most 4096 characters long."));
+            ClassicAssert.AreEqual(400, ex.Status);
+            ClassicAssert.AreEqual("BadRequest", ex.ErrorCode);
+            ClassicAssert.IsTrue(ex.Message.Contains("InvalidParameter: (#100) Param text['body'] must be at most 4096 characters long."));
 
             return Task.CompletedTask;
         }
@@ -643,7 +644,7 @@ namespace Azure.Communication.Messages.Tests
 
             // Assert
             mediaStream.Position = 0; // Reset stream position for reading
-            Assert.IsTrue(mediaStream.Length > 0);
+            ClassicAssert.IsTrue(mediaStream.Length > 0);
         }
 
         [Test]
@@ -653,12 +654,12 @@ namespace Azure.Communication.Messages.Tests
             NotificationMessagesClient notificationMessagesClient = CreateInstrumentedNotificationMessagesClient();
 
             // Act & Assert
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await notificationMessagesClient.DownloadMediaAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(async () => await notificationMessagesClient.DownloadMediaAsync(string.Empty));
-            Assert.ThrowsAsync<ArgumentException>(async () => await notificationMessagesClient.DownloadMediaAsync(""));
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.DownloadMediaAsync("  "));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 400);
+            ClassicAssert.ThrowsAsync<ArgumentNullException>(async () => await notificationMessagesClient.DownloadMediaAsync(null));
+            ClassicAssert.ThrowsAsync<ArgumentException>(async () => await notificationMessagesClient.DownloadMediaAsync(string.Empty));
+            ClassicAssert.ThrowsAsync<ArgumentException>(async () => await notificationMessagesClient.DownloadMediaAsync(""));
+            RequestFailedException ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.DownloadMediaAsync("  "));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 400);
         }
 
         [Test]
@@ -668,10 +669,10 @@ namespace Azure.Communication.Messages.Tests
             NotificationMessagesClient notificationMessagesClient = CreateInstrumentedNotificationMessagesClient();
 
             // Act & Assert
-            RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.DownloadMediaAsync("test"));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
-            Assert.AreEqual(ex?.ErrorCode, "MediaNotFound");
+            RequestFailedException ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.DownloadMediaAsync("test"));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(ex?.Status, 404);
+            ClassicAssert.AreEqual(ex?.ErrorCode, "MediaNotFound");
         }
 
         [Test]
@@ -686,9 +687,9 @@ namespace Azure.Communication.Messages.Tests
             Response downloadResponse = await notificationMessagesClient.DownloadMediaToAsync(mediaContentId, destinationStream);
 
             // Assert
-            Assert.AreEqual(200, downloadResponse.Status);
+            ClassicAssert.AreEqual(200, downloadResponse.Status);
             destinationStream.Position = 0; // Reset stream position for reading
-            Assert.IsTrue(destinationStream.Length > 0);
+            ClassicAssert.IsTrue(destinationStream.Length > 0);
         }
 
         [Test]
@@ -703,16 +704,16 @@ namespace Azure.Communication.Messages.Tests
             Response downloadResponse = await notificationMessagesClient.DownloadMediaToAsync(mediaContentId, destinationPath);
 
             // Assert
-            Assert.AreEqual(200, downloadResponse.Status);
-            Assert.IsTrue(File.Exists(destinationPath));
+            ClassicAssert.AreEqual(200, downloadResponse.Status);
+            ClassicAssert.IsTrue(File.Exists(destinationPath));
         }
 
         private void validateResponse(Response<SendMessageResult> response)
         {
-            Assert.AreEqual(202, response.GetRawResponse().Status);
-            Assert.IsNotNull(response.Value.Receipts[0].MessageId);
-            Assert.IsNotNull(response.Value.Receipts[0].To);
-            Assert.AreEqual(TestEnvironment.RecipientIdentifier, response.Value.Receipts[0].To);
+            ClassicAssert.AreEqual(202, response.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(response.Value.Receipts[0].MessageId);
+            ClassicAssert.IsNotNull(response.Value.Receipts[0].To);
+            ClassicAssert.AreEqual(TestEnvironment.RecipientIdentifier, response.Value.Receipts[0].To);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Messages/tests/NotificationMessagesClient/NotificationMessagesClientTests.cs
+++ b/sdk/communication/Azure.Communication.Messages/tests/NotificationMessagesClient/NotificationMessagesClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Messages.Tests
 {
@@ -22,11 +23,11 @@ namespace Azure.Communication.Messages.Tests
         [Test]
         public void Constructor_InvalidConnectionString_ShouldThrow()
         {
-            Assert.Throws<ArgumentNullException>(() => new NotificationMessagesClient((string)null));
-            Assert.Throws<ArgumentException>(() => new NotificationMessagesClient(string.Empty));
-            Assert.Throws<ArgumentException>(() => new NotificationMessagesClient(""));
-            Assert.Throws<InvalidOperationException>(() => new NotificationMessagesClient("  "));
-            Assert.Throws<InvalidOperationException>(() => new NotificationMessagesClient("test"));
+            ClassicAssert.Throws<ArgumentNullException>(() => new NotificationMessagesClient((string)null));
+            ClassicAssert.Throws<ArgumentException>(() => new NotificationMessagesClient(string.Empty));
+            ClassicAssert.Throws<ArgumentException>(() => new NotificationMessagesClient(""));
+            ClassicAssert.Throws<InvalidOperationException>(() => new NotificationMessagesClient("  "));
+            ClassicAssert.Throws<InvalidOperationException>(() => new NotificationMessagesClient("test"));
         }
 
         [Test]
@@ -37,7 +38,7 @@ namespace Azure.Communication.Messages.Tests
             AzureKeyCredential credential = new AzureKeyCredential("ZHVtbXlhY2Nlc3NrZXk=");
 
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => new NotificationMessagesClient(endpoint, credential));
+            ClassicAssert.Throws<ArgumentNullException>(() => new NotificationMessagesClient(endpoint, credential));
         }
 
         [Test]
@@ -47,9 +48,9 @@ namespace Azure.Communication.Messages.Tests
             var validEndpoint = new Uri("https://contoso.azure.com/");
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>(() => new NotificationMessagesClient(validEndpoint, new AzureKeyCredential(null)));
-            Assert.Throws<ArgumentException>(() => new NotificationMessagesClient(validEndpoint, new AzureKeyCredential(string.Empty)));
-            Assert.Throws<ArgumentException>(() => new NotificationMessagesClient(validEndpoint, new AzureKeyCredential("")));
+            ClassicAssert.Throws<ArgumentNullException>(() => new NotificationMessagesClient(validEndpoint, new AzureKeyCredential(null)));
+            ClassicAssert.Throws<ArgumentException>(() => new NotificationMessagesClient(validEndpoint, new AzureKeyCredential(string.Empty)));
+            ClassicAssert.Throws<ArgumentException>(() => new NotificationMessagesClient(validEndpoint, new AzureKeyCredential("")));
         }
 
         [Test]
@@ -63,10 +64,10 @@ namespace Azure.Communication.Messages.Tests
             SendMessageResult sendMessageResult = await notificationMessagesClient.SendAsync(content);
 
             //assert
-            Assert.IsNotNull(sendMessageResult.Receipts[0].MessageId);
-            Assert.IsNotNull(sendMessageResult.Receipts[0].To);
-            Assert.AreEqual("d53605de-2f6e-437d-9e40-8d83b2111cb8", sendMessageResult.Receipts[0].MessageId);
-            Assert.AreEqual("+1(123)456-7890", sendMessageResult.Receipts[0].To);
+            ClassicAssert.IsNotNull(sendMessageResult.Receipts[0].MessageId);
+            ClassicAssert.IsNotNull(sendMessageResult.Receipts[0].To);
+            ClassicAssert.AreEqual("d53605de-2f6e-437d-9e40-8d83b2111cb8", sendMessageResult.Receipts[0].MessageId);
+            ClassicAssert.AreEqual("+1(123)456-7890", sendMessageResult.Receipts[0].To);
         }
 
         [Test]
@@ -76,7 +77,7 @@ namespace Azure.Communication.Messages.Tests
             NotificationMessagesClient notificationMessagesClient = CreateMockNotificationMessagesClient();
 
             //act & assert
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await notificationMessagesClient.SendAsync((NotificationContent)null));
+            ClassicAssert.ThrowsAsync<ArgumentNullException>(async () => await notificationMessagesClient.SendAsync((NotificationContent)null));
         }
 
         [Test]
@@ -94,7 +95,7 @@ namespace Azure.Communication.Messages.Tests
             catch (RequestFailedException requestFailedException)
             {
                 //assert
-                Assert.AreEqual(400, requestFailedException.Status);
+                ClassicAssert.AreEqual(400, requestFailedException.Status);
             }
         }
 

--- a/sdk/communication/Azure.Communication.Messages/tests/TemplateClient/MessageTemplateClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Messages/tests/TemplateClient/MessageTemplateClientLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Azure.Communication.Messages.Models.Channels;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Messages.Tests
 {
@@ -28,14 +29,14 @@ namespace Azure.Communication.Messages.Tests
             AsyncPageable<MessageTemplateItem> templates = messageTemplateClient.GetTemplatesAsync(channelRegistrationId);
 
             // Assert
-            Assert.IsNotNull(templates);
+            ClassicAssert.IsNotNull(templates);
             List<MessageTemplateItem> templatesEnumerable = templates.ToEnumerableAsync().Result;
-            Assert.IsNotEmpty(templatesEnumerable);
+            ClassicAssert.IsNotEmpty(templatesEnumerable);
             foreach (WhatsAppMessageTemplateItem template in templatesEnumerable.Cast<WhatsAppMessageTemplateItem>())
             {
-                Assert.IsNotNull(template.Name);
-                Assert.IsNotNull(template.Language);
-                Assert.IsNotNull(template.Content);
+                ClassicAssert.IsNotNull(template.Name);
+                ClassicAssert.IsNotNull(template.Language);
+                ClassicAssert.IsNotNull(template.Content);
             }
 
             return Task.CompletedTask;
@@ -52,14 +53,14 @@ namespace Azure.Communication.Messages.Tests
             AsyncPageable<MessageTemplateItem> templates = messageTemplateClient.GetTemplatesAsync(channelRegistrationId);
 
             // Assert
-            Assert.IsNotNull(templates);
+            ClassicAssert.IsNotNull(templates);
             List<MessageTemplateItem> templatesEnumerable = templates.ToEnumerableAsync().Result;
-            Assert.IsNotEmpty(templatesEnumerable);
+            ClassicAssert.IsNotEmpty(templatesEnumerable);
             foreach (WhatsAppMessageTemplateItem template in templatesEnumerable.Cast<WhatsAppMessageTemplateItem>())
             {
-                Assert.IsNotNull(template.Name);
-                Assert.IsNotNull(template.Language);
-                Assert.IsNotNull(template.Content);
+                ClassicAssert.IsNotNull(template.Name);
+                ClassicAssert.IsNotNull(template.Language);
+                ClassicAssert.IsNotNull(template.Content);
             }
 
             return Task.CompletedTask;

--- a/sdk/communication/Azure.Communication.Messages/tests/TemplateClient/MessageTemplateClientTests.cs
+++ b/sdk/communication/Azure.Communication.Messages/tests/TemplateClient/MessageTemplateClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using Azure.Communication.Messages.Models.Channels;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Messages.Tests
 {
@@ -26,17 +27,17 @@ namespace Azure.Communication.Messages.Tests
             AzureKeyCredential credential = new AzureKeyCredential("ZHVtbXlhY2Nlc3NrZXk=");
 
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => new MessageTemplateClient(endpoint, credential));
+            ClassicAssert.Throws<ArgumentNullException>(() => new MessageTemplateClient(endpoint, credential));
         }
 
         [Test]
         public void Constructor_InvalidConnectionString_ShouldThrow()
         {
-            Assert.Throws<ArgumentNullException>(() => new MessageTemplateClient((string)null));
-            Assert.Throws<ArgumentException>(() => new MessageTemplateClient(string.Empty));
-            Assert.Throws<ArgumentException>(() => new MessageTemplateClient(""));
-            Assert.Throws<InvalidOperationException>(() => new MessageTemplateClient("  "));
-            Assert.Throws<InvalidOperationException>(() => new MessageTemplateClient("test"));
+            ClassicAssert.Throws<ArgumentNullException>(() => new MessageTemplateClient((string)null));
+            ClassicAssert.Throws<ArgumentException>(() => new MessageTemplateClient(string.Empty));
+            ClassicAssert.Throws<ArgumentException>(() => new MessageTemplateClient(""));
+            ClassicAssert.Throws<InvalidOperationException>(() => new MessageTemplateClient("  "));
+            ClassicAssert.Throws<InvalidOperationException>(() => new MessageTemplateClient("test"));
         }
 
         [Test]
@@ -55,7 +56,7 @@ namespace Azure.Communication.Messages.Tests
             catch (RequestFailedException requestFailedException)
             {
                 //assert
-                Assert.AreEqual(400, requestFailedException.Status);
+                ClassicAssert.AreEqual(400, requestFailedException.Status);
             }
 
             return Task.CompletedTask;
@@ -74,10 +75,10 @@ namespace Azure.Communication.Messages.Tests
             //assert
             await foreach (MessageTemplateItem template in templates)
             {
-                Assert.IsNotNull(template.Name);
-                Assert.IsNotNull(template.Language);
-                Assert.IsNotNull(template.Status);
-                Assert.IsTrue(template is WhatsAppMessageTemplateItem);
+                ClassicAssert.IsNotNull(template.Name);
+                ClassicAssert.IsNotNull(template.Language);
+                ClassicAssert.IsNotNull(template.Status);
+                ClassicAssert.IsTrue(template is WhatsAppMessageTemplateItem);
             }
         }
 
@@ -88,7 +89,7 @@ namespace Azure.Communication.Messages.Tests
             MessageTemplateClient messageTemplateClient = CreateMockMessageTemplateClient();
 
             //act & assert
-            Assert.Throws<FormatException>(() => messageTemplateClient.GetTemplatesAsync(new Guid(string.Empty)));
+            ClassicAssert.Throws<FormatException>(() => messageTemplateClient.GetTemplatesAsync(new Guid(string.Empty)));
         }
 
         private static MessageTemplateClient CreateMockMessageTemplateClient(int responseCode = 200, string responseContent = null)

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Azure.Communication.Tests;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.PhoneNumbers.Tests
 {
@@ -39,7 +40,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var numbersPagable = client.GetPurchasedPhoneNumbersAsync();
             var numbers = await numbersPagable.ToEnumerableAsync();
 
-            Assert.IsNotNull(numbers);
+            ClassicAssert.IsNotNull(numbers);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPurchasedPhoneNumbersUsingConnectionString")]
@@ -53,7 +54,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var numbersPagable = client.GetPurchasedPhoneNumbers();
             var numbers = numbersPagable.AsPages().ToList();
 
-            Assert.IsNotNull(numbers);
+            ClassicAssert.IsNotNull(numbers);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPhoneNumberUsingConnectionString")]
@@ -67,9 +68,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var client = CreateClient(authMethod);
             var phoneNumber = await client.GetPurchasedPhoneNumberAsync(number);
 
-            Assert.IsNotNull(phoneNumber);
-            Assert.IsNotNull(phoneNumber.Value);
-            Assert.AreEqual(number, phoneNumber.Value.PhoneNumber);
+            ClassicAssert.IsNotNull(phoneNumber);
+            ClassicAssert.IsNotNull(phoneNumber.Value);
+            ClassicAssert.AreEqual(number, phoneNumber.Value.PhoneNumber);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPhoneNumberUsingConnectionString")]
@@ -83,9 +84,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var client = CreateClient(authMethod);
             var phoneNumber = client.GetPurchasedPhoneNumber(number);
 
-            Assert.IsNotNull(phoneNumber);
-            Assert.IsNotNull(phoneNumber.Value);
-            Assert.AreEqual(number, phoneNumber.Value.PhoneNumber);
+            ClassicAssert.IsNotNull(phoneNumber);
+            ClassicAssert.IsNotNull(phoneNumber.Value);
+            ClassicAssert.AreEqual(number, phoneNumber.Value.PhoneNumber);
         }
 
         [Test]
@@ -100,7 +101,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("phoneNumber", ex.ParamName);
+                ClassicAssert.AreEqual("phoneNumber", ex.ParamName);
                 return;
             }
 
@@ -119,7 +120,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("phoneNumber", ex.ParamName);
+                ClassicAssert.AreEqual("phoneNumber", ex.ParamName);
                 return;
             }
 
@@ -138,7 +139,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("phoneNumber", ex.ParamName);
+                ClassicAssert.AreEqual("phoneNumber", ex.ParamName);
                 return;
             }
 
@@ -157,7 +158,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("phoneNumber", ex.ParamName);
+                ClassicAssert.AreEqual("phoneNumber", ex.ParamName);
                 return;
             }
 
@@ -178,7 +179,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
                 return;
             }
 
@@ -199,7 +200,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
                 return;
             }
 
@@ -218,7 +219,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("twoLetterIsoCountryName", ex.ParamName);
+                ClassicAssert.AreEqual("twoLetterIsoCountryName", ex.ParamName);
                 return;
             }
 
@@ -237,7 +238,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("twoLetterIsoCountryName", ex.ParamName);
+                ClassicAssert.AreEqual("twoLetterIsoCountryName", ex.ParamName);
                 return;
             }
 
@@ -258,22 +259,22 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             await searchOperation.WaitForCompletionAsync();
 
-            Assert.IsTrue(searchOperation.HasCompleted);
-            Assert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
+            ClassicAssert.IsTrue(searchOperation.HasCompleted);
+            ClassicAssert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
+            ClassicAssert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
+            ClassicAssert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
 
             var searchId = searchOperation.Value.SearchId;
 
             var response = await client.GetPhoneNumberSearchResultAsync(searchId);
 
-            Assert.AreEqual(1, response.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, response.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, response.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, response.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, response.Value.PhoneNumberType);
+            ClassicAssert.AreEqual(1, response.Value.PhoneNumbers.Count);
+            ClassicAssert.AreEqual(PhoneNumberAssignmentType.Application, response.Value.AssignmentType);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.Outbound, response.Value.Capabilities.Calling);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.None, response.Value.Capabilities.Sms);
+            ClassicAssert.AreEqual(PhoneNumberType.TollFree, response.Value.PhoneNumberType);
         }
 
         [Test]
@@ -294,22 +295,22 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 searchOperation.UpdateStatus();
             }
 
-            Assert.IsTrue(searchOperation.HasCompleted);
-            Assert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
+            ClassicAssert.IsTrue(searchOperation.HasCompleted);
+            ClassicAssert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
+            ClassicAssert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
+            ClassicAssert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
 
             var searchId = searchOperation.Value.SearchId;
 
             var response = client.GetPhoneNumberSearchResult(searchId);
 
-            Assert.AreEqual(1, response.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, response.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, response.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, response.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, response.Value.PhoneNumberType);
+            ClassicAssert.AreEqual(1, response.Value.PhoneNumbers.Count);
+            ClassicAssert.AreEqual(PhoneNumberAssignmentType.Application, response.Value.AssignmentType);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.Outbound, response.Value.Capabilities.Calling);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.None, response.Value.Capabilities.Sms);
+            ClassicAssert.AreEqual(PhoneNumberType.TollFree, response.Value.PhoneNumberType);
         }
 
         [Test]
@@ -323,7 +324,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -338,7 +339,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -353,8 +354,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -369,8 +370,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -385,8 +386,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -401,8 +402,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -417,7 +418,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -432,7 +433,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -447,7 +448,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -462,7 +463,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -477,8 +478,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -493,8 +494,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -515,12 +516,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             await searchOperation.WaitForCompletionAsync();
 
-            Assert.IsTrue(searchOperation.HasCompleted);
-            Assert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
+            ClassicAssert.IsTrue(searchOperation.HasCompleted);
+            ClassicAssert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
+            ClassicAssert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
+            ClassicAssert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
 
             var searchId = searchOperation.Value.SearchId;
 
@@ -530,8 +531,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -556,12 +557,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 searchOperation.UpdateStatus();
             }
 
-            Assert.IsTrue(searchOperation.HasCompleted);
-            Assert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
+            ClassicAssert.IsTrue(searchOperation.HasCompleted);
+            ClassicAssert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
+            ClassicAssert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
+            ClassicAssert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
 
             var searchId = searchOperation.Value.SearchId;
 
@@ -571,8 +572,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -588,7 +589,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 Console.WriteLine("phone " + purchasedPhone.PhoneNumber);
             }
 
-            Assert.NotNull(purchasedPhoneNumbers);
+            ClassicAssert.NotNull(purchasedPhoneNumbers);
         }
 
         [Test]
@@ -603,7 +604,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 Console.WriteLine("phone " + purchasedPhone.PhoneNumber);
             }
 
-            Assert.NotNull(purchasedPhoneNumbers);
+            ClassicAssert.NotNull(purchasedPhoneNumbers);
         }
 
         [Test]
@@ -632,7 +633,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -640,7 +641,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(phoneNumbersCount, actual);
+            ClassicAssert.AreEqual(phoneNumbersCount, actual);
         }
 
         [Test]
@@ -669,7 +670,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -677,7 +678,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(phoneNumbersCount, actual);
+            ClassicAssert.AreEqual(phoneNumbersCount, actual);
         }
 
         [Test]
@@ -698,10 +699,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var updateOperation = await client.StartUpdateCapabilitiesAsync(number, callingCapabilityType, smsCapabilityType);
             await updateOperation.WaitForCompletionAsync();
 
-            Assert.IsTrue(updateOperation.HasCompleted);
-            Assert.IsNotNull(updateOperation.Value);
-            Assert.AreEqual(number, updateOperation.Value.PhoneNumber);
-            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status), $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
+            ClassicAssert.IsTrue(updateOperation.HasCompleted);
+            ClassicAssert.IsNotNull(updateOperation.Value);
+            ClassicAssert.AreEqual(number, updateOperation.Value.PhoneNumber);
+            ClassicAssert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status), $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
         }
 
         [Test]
@@ -727,10 +728,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 updateOperation.UpdateStatus();
             }
 
-            Assert.IsTrue(updateOperation.HasCompleted);
-            Assert.IsNotNull(updateOperation.Value);
-            Assert.AreEqual(number, updateOperation.Value.PhoneNumber);
-            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status), $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
+            ClassicAssert.IsTrue(updateOperation.HasCompleted);
+            ClassicAssert.IsNotNull(updateOperation.Value);
+            ClassicAssert.AreEqual(number, updateOperation.Value.PhoneNumber);
+            ClassicAssert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status), $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
         }
 
         [Test]
@@ -744,8 +745,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -760,8 +761,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.NotNull(ex.Message);
             }
         }
 
@@ -775,9 +776,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var areaCodes = client.GetAvailableAreaCodesTollFreeAsync("US");
             await foreach (PhoneNumberAreaCode areaCode in areaCodes)
             {
-                Assert.Contains(areaCode.AreaCode, expectedAreaCodes);
+                ClassicAssert.Contains(areaCode.AreaCode, expectedAreaCodes);
             }
-            Assert.IsNotNull(areaCodes);
+            ClassicAssert.IsNotNull(areaCodes);
         }
 
         [Test]
@@ -790,9 +791,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var areaCodes = client.GetAvailableAreaCodesTollFree("US");
             foreach (PhoneNumberAreaCode areaCode in areaCodes)
             {
-                Assert.Contains(areaCode.AreaCode, expectedAreaCodes);
+                ClassicAssert.Contains(areaCode.AreaCode, expectedAreaCodes);
             }
-            Assert.IsNotNull(areaCodes);
+            ClassicAssert.IsNotNull(areaCodes);
         }
 
         [Test]
@@ -820,7 +821,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -828,7 +829,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(areaCodesCount, actual);
+            ClassicAssert.AreEqual(areaCodesCount, actual);
         }
 
         [Test]
@@ -857,7 +858,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -865,7 +866,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(areaCodesCount, actual);
+            ClassicAssert.AreEqual(areaCodesCount, actual);
         }
 
         [Test]
@@ -881,7 +882,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 {
                     Console.WriteLine("Area Code " + areaCode.AreaCode);
                 }
-                Assert.IsNotNull(areaCodes);
+                ClassicAssert.IsNotNull(areaCodes);
                 break;
             }
         }
@@ -899,7 +900,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 {
                     Console.WriteLine("Area Code " + areaCode.AreaCode);
                 }
-                Assert.IsNotNull(areaCodes);
+                ClassicAssert.IsNotNull(areaCodes);
                 break;
             }
         }
@@ -930,7 +931,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -938,7 +939,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(areaCodesCount, actual);
+            ClassicAssert.AreEqual(areaCodesCount, actual);
         }
 
         [Test]
@@ -968,7 +969,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -976,7 +977,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(areaCodesCount, actual);
+            ClassicAssert.AreEqual(areaCodesCount, actual);
         }
 
         [Test]
@@ -992,7 +993,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 {
                     Console.WriteLine("Mobile Area Code " + areaCode.AreaCode);
                 }
-                Assert.IsNotNull(areaCodes);
+                ClassicAssert.IsNotNull(areaCodes);
                 break;
             }
         }
@@ -1010,7 +1011,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 {
                     Console.WriteLine("Mobile Area Code " + areaCode.AreaCode);
                 }
-                Assert.IsNotNull(areaCodes);
+                ClassicAssert.IsNotNull(areaCodes);
                 break;
             }
         }
@@ -1031,9 +1032,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             foreach (string country in expectedCountries)
             {
-                Assert.Contains(country, countriesResponse);
+                ClassicAssert.Contains(country, countriesResponse);
             }
-            Assert.IsNotNull(countries);
+            ClassicAssert.IsNotNull(countries);
         }
 
         [Test]
@@ -1052,9 +1053,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             foreach (string country in expectedCountries)
             {
-                Assert.Contains(country, countriesResponse);
+                ClassicAssert.Contains(country, countriesResponse);
             }
-            Assert.IsNotNull(countries);
+            ClassicAssert.IsNotNull(countries);
         }
 
         [Test]
@@ -1083,7 +1084,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1091,7 +1092,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(countriesCount, actual);
+            ClassicAssert.AreEqual(countriesCount, actual);
         }
 
         [Test]
@@ -1120,7 +1121,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1128,7 +1129,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(countriesCount, actual);
+            ClassicAssert.AreEqual(countriesCount, actual);
         }
 
         [Test]
@@ -1142,7 +1143,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Locality " + locality.LocalizedName);
             }
-            Assert.IsNotNull(localities);
+            ClassicAssert.IsNotNull(localities);
         }
 
         [Test]
@@ -1156,7 +1157,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Locality " + locality.LocalizedName);
             }
-            Assert.IsNotNull(localities);
+            ClassicAssert.IsNotNull(localities);
         }
 
         [Test]
@@ -1170,7 +1171,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Locality " + locality.LocalizedName);
             }
-            Assert.IsNotNull(localities);
+            ClassicAssert.IsNotNull(localities);
         }
 
         [Test]
@@ -1184,7 +1185,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Locality " + locality.LocalizedName);
             }
-            Assert.IsNotNull(localities);
+            ClassicAssert.IsNotNull(localities);
         }
 
         [Test]
@@ -1210,7 +1211,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1218,7 +1219,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(localitiesCount, actual);
+            ClassicAssert.AreEqual(localitiesCount, actual);
         }
 
         [Test]
@@ -1244,7 +1245,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1252,7 +1253,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(localitiesCount, actual);
+            ClassicAssert.AreEqual(localitiesCount, actual);
         }
 
         [Test]
@@ -1280,7 +1281,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1288,7 +1289,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(localitiesCount, actual);
+            ClassicAssert.AreEqual(localitiesCount, actual);
         }
 
         [Test]
@@ -1316,7 +1317,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1324,7 +1325,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(localitiesCount, actual);
+            ClassicAssert.AreEqual(localitiesCount, actual);
         }
 
         [Test]
@@ -1339,9 +1340,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 await foreach (PhoneNumberLocality locality in localities)
                 {
                     Console.WriteLine("Locality " + locality.LocalizedName);
-                    Assert.AreEqual(locality.AdministrativeDivision.AbbreviatedName, firstLocality.AdministrativeDivision.AbbreviatedName);
+                    ClassicAssert.AreEqual(locality.AdministrativeDivision.AbbreviatedName, firstLocality.AdministrativeDivision.AbbreviatedName);
                 }
-                Assert.IsNotNull(localities);
+                ClassicAssert.IsNotNull(localities);
                 break;
             }
         }
@@ -1358,9 +1359,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 foreach (PhoneNumberLocality locality in localities)
                 {
                     Console.WriteLine("Locality " + locality.LocalizedName);
-                    Assert.AreEqual(locality.AdministrativeDivision.AbbreviatedName, firstLocality.AdministrativeDivision.AbbreviatedName);
+                    ClassicAssert.AreEqual(locality.AdministrativeDivision.AbbreviatedName, firstLocality.AdministrativeDivision.AbbreviatedName);
                 }
-                Assert.IsNotNull(localities);
+                ClassicAssert.IsNotNull(localities);
                 break;
             }
         }
@@ -1376,7 +1377,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Offering " + offering.ToString());
             }
-            Assert.IsNotNull(offerings);
+            ClassicAssert.IsNotNull(offerings);
         }
 
         [Test]
@@ -1390,7 +1391,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Offering " + offering.ToString());
             }
-            Assert.IsNotNull(offerings);
+            ClassicAssert.IsNotNull(offerings);
         }
 
         [Test]
@@ -1418,7 +1419,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1426,7 +1427,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(offeringsCount, actual);
+            ClassicAssert.AreEqual(offeringsCount, actual);
         }
 
         [Test]
@@ -1454,7 +1455,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    ClassicAssert.AreEqual(expectedPageSize, page.Values.Count);
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1462,7 +1463,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(offeringsCount, actual);
+            ClassicAssert.AreEqual(offeringsCount, actual);
         }
 
         [Test]
@@ -1476,7 +1477,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Offering " + offering.ToString());
             }
-            Assert.IsNotNull(offerings);
+            ClassicAssert.IsNotNull(offerings);
         }
 
         [Test]
@@ -1490,7 +1491,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Offering " + offering.ToString());
             }
-            Assert.IsNotNull(offerings);
+            ClassicAssert.IsNotNull(offerings);
         }
 
         [Test]
@@ -1503,7 +1504,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var client = CreateClient();
 
             var results = await client.SearchOperatorInformationAsync(phoneNumbers);
-            Assert.AreEqual(phoneNumber, results.Value.Values[0].PhoneNumber);
+            ClassicAssert.AreEqual(phoneNumber, results.Value.Values[0].PhoneNumber);
         }
 
         [Test]
@@ -1516,7 +1517,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var client = CreateClient();
 
             var results = client.SearchOperatorInformation(phoneNumbers);
-            Assert.AreEqual(phoneNumber, results.Value.Values[0].PhoneNumber);
+            ClassicAssert.AreEqual(phoneNumber, results.Value.Values[0].PhoneNumber);
         }
 
         [Test]
@@ -1534,7 +1535,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
                 return;
             }
 
@@ -1556,7 +1557,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                ClassicAssert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
                 return;
             }
 
@@ -1574,19 +1575,19 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var results = await client.SearchOperatorInformationAsync(phoneNumbers, new OperatorInformationOptions() { IncludeAdditionalOperatorDetails = false });
             var operatorInformation = results.Value.Values[0];
-            Assert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
-            Assert.IsNotNull(operatorInformation.InternationalFormat);
-            Assert.IsNotNull(operatorInformation.NationalFormat);
-            Assert.IsNull(operatorInformation.IsoCountryCode);
-            Assert.IsNull(operatorInformation.OperatorDetails);
+            ClassicAssert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
+            ClassicAssert.IsNotNull(operatorInformation.InternationalFormat);
+            ClassicAssert.IsNotNull(operatorInformation.NationalFormat);
+            ClassicAssert.IsNull(operatorInformation.IsoCountryCode);
+            ClassicAssert.IsNull(operatorInformation.OperatorDetails);
 
             results = await client.SearchOperatorInformationAsync(phoneNumbers, new OperatorInformationOptions() { IncludeAdditionalOperatorDetails = true });
             operatorInformation = results.Value.Values[0];
-            Assert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
-            Assert.IsNotNull(operatorInformation.InternationalFormat);
-            Assert.IsNotNull(operatorInformation.NationalFormat);
-            Assert.IsNotNull(operatorInformation.IsoCountryCode);
-            Assert.IsNotNull(operatorInformation.OperatorDetails);
+            ClassicAssert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
+            ClassicAssert.IsNotNull(operatorInformation.InternationalFormat);
+            ClassicAssert.IsNotNull(operatorInformation.NationalFormat);
+            ClassicAssert.IsNotNull(operatorInformation.IsoCountryCode);
+            ClassicAssert.IsNotNull(operatorInformation.OperatorDetails);
         }
 
         [Test]
@@ -1600,19 +1601,19 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var results = client.SearchOperatorInformation(phoneNumbers, new OperatorInformationOptions() { IncludeAdditionalOperatorDetails = false });
             var operatorInformation = results.Value.Values[0];
-            Assert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
-            Assert.IsNotNull(operatorInformation.InternationalFormat);
-            Assert.IsNotNull(operatorInformation.NationalFormat);
-            Assert.IsNull(operatorInformation.IsoCountryCode);
-            Assert.IsNull(operatorInformation.OperatorDetails);
+            ClassicAssert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
+            ClassicAssert.IsNotNull(operatorInformation.InternationalFormat);
+            ClassicAssert.IsNotNull(operatorInformation.NationalFormat);
+            ClassicAssert.IsNull(operatorInformation.IsoCountryCode);
+            ClassicAssert.IsNull(operatorInformation.OperatorDetails);
 
             results = client.SearchOperatorInformation(phoneNumbers, new OperatorInformationOptions() { IncludeAdditionalOperatorDetails = true });
             operatorInformation = results.Value.Values[0];
-            Assert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
-            Assert.IsNotNull(operatorInformation.InternationalFormat);
-            Assert.IsNotNull(operatorInformation.NationalFormat);
-            Assert.IsNotNull(operatorInformation.IsoCountryCode);
-            Assert.IsNotNull(operatorInformation.OperatorDetails);
+            ClassicAssert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
+            ClassicAssert.IsNotNull(operatorInformation.InternationalFormat);
+            ClassicAssert.IsNotNull(operatorInformation.NationalFormat);
+            ClassicAssert.IsNotNull(operatorInformation.IsoCountryCode);
+            ClassicAssert.IsNotNull(operatorInformation.OperatorDetails);
         }
 
         private static bool IsSuccess(int statusCode)

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersReservationsTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersReservationsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,6 +9,7 @@ using Azure.Communication.Tests;
 using Azure.Core.TestFramework;
 using Azure.Core.TestFramework.Models;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.PhoneNumbers.Tests
 {
@@ -66,14 +67,14 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = await client.CreateOrUpdateReservationAsync(request).ConfigureAwait(false);
 
             // The response should be a 201 Created.
-            Assert.AreEqual(201, reservationResponse.GetRawResponse().Status);
-            Assert.IsNotNull(reservationResponse.Value);
-            Assert.AreEqual(reservationId, reservationResponse.Value.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationResponse.Value.Status);
-            Assert.IsEmpty(reservationResponse.Value.PhoneNumbers);
+            ClassicAssert.AreEqual(201, reservationResponse.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(reservationResponse.Value);
+            ClassicAssert.AreEqual(reservationId, reservationResponse.Value.Id);
+            ClassicAssert.AreEqual(ReservationStatus.Active, reservationResponse.Value.Status);
+            ClassicAssert.IsEmpty(reservationResponse.Value.PhoneNumbers);
             if (Mode != RecordedTestMode.Playback)
             {
-                Assert.Greater(reservationResponse.Value.ExpiresAt, DateTimeOffset.UtcNow);
+                ClassicAssert.Greater(reservationResponse.Value.ExpiresAt, DateTimeOffset.UtcNow);
             }
 
             _initialReservationState = reservationResponse.Value;
@@ -91,14 +92,14 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = client.CreateOrUpdateReservation(request);
 
             // The response should be a 201 Created.
-            Assert.AreEqual(201, reservationResponse.GetRawResponse().Status);
-            Assert.IsNotNull(reservationResponse.Value);
-            Assert.AreEqual(reservationId, reservationResponse.Value.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationResponse.Value.Status);
-            Assert.IsEmpty(reservationResponse.Value.PhoneNumbers);
+            ClassicAssert.AreEqual(201, reservationResponse.GetRawResponse().Status);
+            ClassicAssert.IsNotNull(reservationResponse.Value);
+            ClassicAssert.AreEqual(reservationId, reservationResponse.Value.Id);
+            ClassicAssert.AreEqual(ReservationStatus.Active, reservationResponse.Value.Status);
+            ClassicAssert.IsEmpty(reservationResponse.Value.PhoneNumbers);
             if (Mode != RecordedTestMode.Playback)
             {
-                Assert.Greater(reservationResponse.Value.ExpiresAt, DateTimeOffset.UtcNow);
+                ClassicAssert.Greater(reservationResponse.Value.ExpiresAt, DateTimeOffset.UtcNow);
             }
 
             _initialReservationState = reservationResponse.Value;
@@ -115,16 +116,16 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var response = await client.BrowseAvailableNumbersAsync(browseRequest);
 
-            Assert.IsNotNull(response.Value);
-            Assert.Greater(response.Value.PhoneNumbers.Count, 0);
+            ClassicAssert.IsNotNull(response.Value);
+            ClassicAssert.Greater(response.Value.PhoneNumbers.Count, 0);
 
             browseRequest = new PhoneNumbersBrowseOptions("IE", PhoneNumberType.Mobile);
 
             response = await client.BrowseAvailableNumbersAsync(browseRequest);
 
-            Assert.IsNotNull(response.Value);
-            Assert.Greater(response.Value.PhoneNumbers.Count, 0);
-            Assert.IsTrue(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.Mobile);
+            ClassicAssert.IsNotNull(response.Value);
+            ClassicAssert.Greater(response.Value.PhoneNumbers.Count, 0);
+            ClassicAssert.IsTrue(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.Mobile);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "BrowseAvailableNumbersUsingConnectionString")]
@@ -138,17 +139,17 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var response = client.BrowseAvailableNumbers(browseRequest);
 
-            Assert.IsNotNull(response.Value);
-            Assert.Greater(response.Value.PhoneNumbers.Count, 0);
-            Assert.IsTrue(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.TollFree);
+            ClassicAssert.IsNotNull(response.Value);
+            ClassicAssert.Greater(response.Value.PhoneNumbers.Count, 0);
+            ClassicAssert.IsTrue(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.TollFree);
 
             browseRequest = new PhoneNumbersBrowseOptions("IE", PhoneNumberType.Mobile);
 
             response = client.BrowseAvailableNumbers(browseRequest);
 
-            Assert.IsNotNull(response.Value);
-            Assert.Greater(response.Value.PhoneNumbers.Count, 0);
-            Assert.IsTrue(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.Mobile);
+            ClassicAssert.IsNotNull(response.Value);
+            ClassicAssert.Greater(response.Value.PhoneNumbers.Count, 0);
+            ClassicAssert.IsTrue(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.Mobile);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPhoneNumbersReservationsAsyncWithConnectionString")]
@@ -163,9 +164,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationsPageable = client.GetReservationsAsync();
             var reservations = await reservationsPageable.ToEnumerableAsync();
 
-            Assert.IsNotNull(reservations);
-            Assert.Greater(reservations.Count, 0);
-            Assert.True(reservations.Any(reservations => reservations.Id == _initialReservationState?.Id));
+            ClassicAssert.IsNotNull(reservations);
+            ClassicAssert.Greater(reservations.Count, 0);
+            ClassicAssert.True(reservations.Any(reservations => reservations.Id == _initialReservationState?.Id));
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPhoneNumbersReservationsWithConnectionString")]
@@ -179,9 +180,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var reservations = client.GetReservations();
 
-            Assert.IsNotNull(reservations);
-            Assert.Greater(reservations.Count(), 0);
-            Assert.True(reservations.Any(reservations => reservations.Id == _initialReservationState?.Id));
+            ClassicAssert.IsNotNull(reservations);
+            ClassicAssert.Greater(reservations.Count(), 0);
+            ClassicAssert.True(reservations.Any(reservations => reservations.Id == _initialReservationState?.Id));
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetReservationAsyncUsingConnectionString")]
@@ -196,10 +197,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = await client.GetReservationAsync((Guid)(_initialReservationState!.Id)!);
             var reservation = reservationResponse.Value;
 
-            Assert.IsNotNull(reservation);
-            Assert.AreEqual(_initialReservationState!.Id, reservation.Id);
-            Assert.AreEqual(_initialReservationState!.ExpiresAt, reservation.ExpiresAt);
-            Assert.AreEqual(_initialReservationState!.Status, reservation.Status);
+            ClassicAssert.IsNotNull(reservation);
+            ClassicAssert.AreEqual(_initialReservationState!.Id, reservation.Id);
+            ClassicAssert.AreEqual(_initialReservationState!.ExpiresAt, reservation.ExpiresAt);
+            ClassicAssert.AreEqual(_initialReservationState!.Status, reservation.Status);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetReservationUsingConnectionString")]
@@ -214,10 +215,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = client.GetReservation((Guid)(_initialReservationState!.Id)!);
             var reservation = reservationResponse.Value;
 
-            Assert.IsNotNull(reservation);
-            Assert.AreEqual(_initialReservationState!.Id, reservation.Id);
-            Assert.AreEqual(_initialReservationState!.ExpiresAt, reservation.ExpiresAt);
-            Assert.AreEqual(_initialReservationState!.Status, reservation.Status);
+            ClassicAssert.IsNotNull(reservation);
+            ClassicAssert.AreEqual(_initialReservationState!.Id, reservation.Id);
+            ClassicAssert.AreEqual(_initialReservationState!.ExpiresAt, reservation.ExpiresAt);
+            ClassicAssert.AreEqual(_initialReservationState!.Status, reservation.Status);
         }
 
         [TestCase(AuthMethod.ConnectionString, "US", "tollFree", TestName = "CreateOrUpdateReservationAsyncTollFreeUsingConnectionString")]
@@ -249,12 +250,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = await client.CreateOrUpdateReservationAsync(updateRequest).ConfigureAwait(false);
             var reservationAfterAdd = reservationResponse.Value;
 
-            Assert.IsNotNull(reservationAfterAdd);
-            Assert.AreEqual(_initialReservationState!.Id, reservationAfterAdd.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationAfterAdd.Status);
-            Assert.Greater(reservationAfterAdd.ExpiresAt, _initialReservationState.ExpiresAt);
-            Assert.IsTrue(reservationAfterAdd.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
-            Assert.IsTrue(reservationAfterAdd.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
+            ClassicAssert.IsNotNull(reservationAfterAdd);
+            ClassicAssert.AreEqual(_initialReservationState!.Id, reservationAfterAdd.Id);
+            ClassicAssert.AreEqual(ReservationStatus.Active, reservationAfterAdd.Status);
+            ClassicAssert.Greater(reservationAfterAdd.ExpiresAt, _initialReservationState.ExpiresAt);
+            ClassicAssert.IsTrue(reservationAfterAdd.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
+            ClassicAssert.IsTrue(reservationAfterAdd.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
 
             // Now remove the reserved number
             var phoneNumberIdToRemove = phoneNumberToReserve.Id;
@@ -266,12 +267,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             reservationResponse = await client.CreateOrUpdateReservationAsync(removeRequest).ConfigureAwait(false);
             var reservationAfterRemove = reservationResponse.Value;
-            Assert.IsNotNull(reservationAfterRemove);
-            Assert.AreEqual(_initialReservationState!.Id, reservationAfterRemove.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationAfterRemove.Status);
-            Assert.Greater(reservationAfterRemove.ExpiresAt, reservationAfterAdd.ExpiresAt);
-            Assert.IsTrue(reservationAfterRemove.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
-            Assert.IsFalse(reservationAfterRemove.PhoneNumbers.ContainsKey(phoneNumberIdToRemove));
+            ClassicAssert.IsNotNull(reservationAfterRemove);
+            ClassicAssert.AreEqual(_initialReservationState!.Id, reservationAfterRemove.Id);
+            ClassicAssert.AreEqual(ReservationStatus.Active, reservationAfterRemove.Status);
+            ClassicAssert.Greater(reservationAfterRemove.ExpiresAt, reservationAfterAdd.ExpiresAt);
+            ClassicAssert.IsTrue(reservationAfterRemove.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
+            ClassicAssert.IsFalse(reservationAfterRemove.PhoneNumbers.ContainsKey(phoneNumberIdToRemove));
         }
 
         [TestCase(AuthMethod.ConnectionString, "US", "tollFree", TestName = "CreateOrUpdateReservationTollFreeUsingConnectionString")]
@@ -303,12 +304,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = client.CreateOrUpdateReservation(updateRequest);
             var reservationAfterAdd = reservationResponse.Value;
 
-            Assert.IsNotNull(reservationAfterAdd);
-            Assert.AreEqual(reservationBeforeAdd.Id, reservationAfterAdd.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationAfterAdd.Status);
-            Assert.Greater(reservationAfterAdd.ExpiresAt, reservationBeforeAdd.ExpiresAt);
-            Assert.IsTrue(reservationAfterAdd.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
-            Assert.IsTrue(reservationAfterAdd.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
+            ClassicAssert.IsNotNull(reservationAfterAdd);
+            ClassicAssert.AreEqual(reservationBeforeAdd.Id, reservationAfterAdd.Id);
+            ClassicAssert.AreEqual(ReservationStatus.Active, reservationAfterAdd.Status);
+            ClassicAssert.Greater(reservationAfterAdd.ExpiresAt, reservationBeforeAdd.ExpiresAt);
+            ClassicAssert.IsTrue(reservationAfterAdd.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
+            ClassicAssert.IsTrue(reservationAfterAdd.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
 
             // Now remove the reserved number
             var phoneNumberIdToRemove = phoneNumberToReserve.Id;
@@ -321,12 +322,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             reservationResponse = client.CreateOrUpdateReservation(removeRequest);
             var reservationAfterRemove = reservationResponse.Value;
 
-            Assert.IsNotNull(reservationAfterRemove);
-            Assert.AreEqual(reservationBeforeRemove.Id, reservationAfterRemove.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationAfterRemove.Status);
-            Assert.Greater(reservationAfterRemove.ExpiresAt, reservationBeforeRemove.ExpiresAt);
-            Assert.IsTrue(reservationAfterRemove.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
-            Assert.IsFalse(reservationAfterRemove.PhoneNumbers.ContainsKey(phoneNumberIdToRemove));
+            ClassicAssert.IsNotNull(reservationAfterRemove);
+            ClassicAssert.AreEqual(reservationBeforeRemove.Id, reservationAfterRemove.Id);
+            ClassicAssert.AreEqual(ReservationStatus.Active, reservationAfterRemove.Status);
+            ClassicAssert.Greater(reservationAfterRemove.ExpiresAt, reservationBeforeRemove.ExpiresAt);
+            ClassicAssert.IsTrue(reservationAfterRemove.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
+            ClassicAssert.IsFalse(reservationAfterRemove.PhoneNumbers.ContainsKey(phoneNumberIdToRemove));
         }
 
         [TestCase]
@@ -338,8 +339,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             await client.DeleteReservationAsync(_initialReservationState!.Id);
 
-            var exception = Assert.ThrowsAsync<RequestFailedException>(async () => await client.GetReservationAsync(_initialReservationState!.Id));
-            Assert.AreEqual(404, exception!.Status);
+            var exception = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await client.GetReservationAsync(_initialReservationState!.Id));
+            ClassicAssert.AreEqual(404, exception!.Status);
         }
 
         [TestCase]
@@ -351,8 +352,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             client.DeleteReservation(_initialReservationState!.Id);
 
-            var exception = Assert.Throws<RequestFailedException>(() => client.GetReservation(_initialReservationState!.Id));
-            Assert.AreEqual(404, exception!.Status);
+            var exception = ClassicAssert.Throws<RequestFailedException>(() => client.GetReservation(_initialReservationState!.Id));
+            ClassicAssert.AreEqual(404, exception!.Status);
         }
 
         [TestCase]
@@ -376,7 +377,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var phoneNumberToReserve = availablePhoneNumbers.First();
 
             // The phone number should require an agreement to not resell.
-            Assert.IsTrue(phoneNumberToReserve.IsAgreementToNotResellRequired);
+            ClassicAssert.IsTrue(phoneNumberToReserve.IsAgreementToNotResellRequired);
 
             var reservationId = GetReservationId();
             var request = new CreateOrUpdateReservationOptions(reservationId)
@@ -387,12 +388,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = await client.CreateOrUpdateReservationAsync(request).ConfigureAwait(false);
 
             // The phone number was successfully reserved.
-            Assert.IsTrue(reservationResponse.Value.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservationResponse.Value.PhoneNumbers[phoneNumberToReserve.Id]);
+            ClassicAssert.IsTrue(reservationResponse.Value.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
+            ClassicAssert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservationResponse.Value.PhoneNumbers[phoneNumberToReserve.Id]);
 
             // The phone number should not be purchasable without agreeing to not resell.
-            var exception = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartPurchaseReservationAsync(reservationId, agreeToNotResell: false));
-            Assert.AreEqual(400, exception!.Status);
+            var exception = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await client.StartPurchaseReservationAsync(reservationId, agreeToNotResell: false));
+            ClassicAssert.AreEqual(400, exception!.Status);
 
             // Clean up the reservation.
             await client.DeleteReservationAsync(reservationId);
@@ -419,7 +420,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var phoneNumberToReserve = availablePhoneNumbers.First();
 
             // The phone number should require an agreement to not resell.
-            Assert.IsTrue(phoneNumberToReserve.IsAgreementToNotResellRequired);
+            ClassicAssert.IsTrue(phoneNumberToReserve.IsAgreementToNotResellRequired);
 
             var reservationId = GetReservationId();
             var request = new CreateOrUpdateReservationOptions(reservationId)
@@ -430,12 +431,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = client.CreateOrUpdateReservation(request);
 
             // The phone number was successfully reserved.
-            Assert.IsTrue(reservationResponse.Value.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservationResponse.Value.PhoneNumbers[phoneNumberToReserve.Id]);
+            ClassicAssert.IsTrue(reservationResponse.Value.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
+            ClassicAssert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservationResponse.Value.PhoneNumbers[phoneNumberToReserve.Id]);
 
             // The phone number should not be purchasable without agreeing to not resell.
-            var exception = Assert.Throws<RequestFailedException>(() => client.StartPurchaseReservation(reservationId, agreeToNotResell: false));
-            Assert.AreEqual(400, exception!.Status);
+            var exception = ClassicAssert.Throws<RequestFailedException>(() => client.StartPurchaseReservation(reservationId, agreeToNotResell: false));
+            ClassicAssert.AreEqual(400, exception!.Status);
 
             // Clean up the reservation.
             client.DeleteReservation(reservationId);

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumberSearchResultErrorTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumberSearchResultErrorTests.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.PhoneNumbers.Tests
 {
@@ -11,7 +12,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
         [Test]
         public void Constructor_ThrowsArgumentNullException_WhenValueIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new PhoneNumberSearchResultError(null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new PhoneNumberSearchResultError(null));
         }
 
         [TestCase("NoError")]
@@ -34,7 +35,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
         public void Constructor_SetsValue_WhenValueIsNotNull(string value)
         {
             var error = new PhoneNumberSearchResultError(value);
-            Assert.AreEqual(value, error.ToString());
+            ClassicAssert.AreEqual(value, error.ToString());
         }
 
         [Test]
@@ -43,7 +44,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("NoError");
 
-            Assert.IsTrue(error1 == error2);
+            ClassicAssert.IsTrue(error1 == error2);
         }
 
         [Test]
@@ -52,14 +53,14 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("UnknownErrorCode");
 
-            Assert.IsTrue(error1 != error2);
+            ClassicAssert.IsTrue(error1 != error2);
         }
 
         [Test]
         public void ImplicitConversion_ReturnsCorrectError()
         {
             PhoneNumberSearchResultError error = "NoError";
-            Assert.AreEqual("NoError", error.ToString());
+            ClassicAssert.AreEqual("NoError", error.ToString());
         }
 
         [Test]
@@ -68,7 +69,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("NoError");
 
-            Assert.IsTrue(error1.Equals(error2));
+            ClassicAssert.IsTrue(error1.Equals(error2));
         }
 
         [Test]
@@ -77,7 +78,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("UnknownErrorCode");
 
-            Assert.IsFalse(error1.Equals(error2));
+            ClassicAssert.IsFalse(error1.Equals(error2));
         }
 
         [Test]
@@ -86,14 +87,14 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("NoError");
 
-            Assert.AreEqual(error1.GetHashCode(), error2.GetHashCode());
+            ClassicAssert.AreEqual(error1.GetHashCode(), error2.GetHashCode());
         }
 
         [Test]
         public void ToString_ReturnsCorrectValue()
         {
             var error = new PhoneNumberSearchResultError("NoError");
-            Assert.AreEqual("NoError", error.ToString());
+            ClassicAssert.AreEqual("NoError", error.ToString());
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumbersModelFactoryTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumbersModelFactoryTests.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.PhoneNumbers.Tests
 {
@@ -13,17 +14,17 @@ namespace Azure.Communication.PhoneNumbers.Tests
         public void PhoneNumberAreaCode_ShouldReturnInstanceOfPhoneNumberAreaCode()
         {
             var result = PhoneNumbersModelFactory.PhoneNumberAreaCode("123");
-            Assert.IsNotNull(result);
-            Assert.AreEqual("123", result.AreaCode);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual("123", result.AreaCode);
         }
 
         [Test]
         public void PhoneNumberCountry_WhenLocalizedAndCountryCodeNotNull_ShouldReturnInstanceOfPhoneNumberCountry()
         {
             var result = PhoneNumbersModelFactory.PhoneNumberCountry("USA", "US");
-            Assert.IsNotNull(result);
-            Assert.AreEqual("USA", result.LocalizedName);
-            Assert.AreEqual("US", result.CountryCode);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual("USA", result.LocalizedName);
+            ClassicAssert.AreEqual("US", result.CountryCode);
         }
 
         [Test]
@@ -31,18 +32,18 @@ namespace Azure.Communication.PhoneNumbers.Tests
         {
             var administrativeDivision = PhoneNumbersModelFactory.PhoneNumberAdministrativeDivision("Washington", "WA");
             var result = PhoneNumbersModelFactory.PhoneNumberLocality("Seattle", administrativeDivision);
-            Assert.IsNotNull(result);
-            Assert.AreEqual("Seattle", result.LocalizedName);
-            Assert.AreEqual(administrativeDivision, result.AdministrativeDivision);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual("Seattle", result.LocalizedName);
+            ClassicAssert.AreEqual(administrativeDivision, result.AdministrativeDivision);
         }
 
         [Test]
         public void PhoneNumberAdministrativeDivision_WhenLocalizedAndAbbreviatedNameNotNull_ShouldReturnInstanceOfPhoneNumberAdministrativeDivision()
         {
             var result = PhoneNumbersModelFactory.PhoneNumberAdministrativeDivision("Washington", "WA");
-            Assert.IsNotNull(result);
-            Assert.AreEqual("Washington", result.LocalizedName);
-            Assert.AreEqual("WA", result.AbbreviatedName);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual("Washington", result.LocalizedName);
+            ClassicAssert.AreEqual("WA", result.AbbreviatedName);
         }
 
         [Test]
@@ -51,21 +52,21 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var capabilities = new PhoneNumberCapabilities(PhoneNumberCapabilityType.Inbound, PhoneNumberCapabilityType.Inbound);
             var cost = PhoneNumbersModelFactory.PhoneNumberCost(10, "USD", BillingFrequency.Monthly);
             var result = PhoneNumbersModelFactory.PhoneNumberOffering(PhoneNumberType.Geographic, PhoneNumberAssignmentType.Application, capabilities, cost);
-            Assert.IsNotNull(result);
-            Assert.AreEqual(PhoneNumberType.Geographic, result.PhoneNumberType);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, result.AssignmentType);
-            Assert.AreEqual(capabilities, result.AvailableCapabilities);
-            Assert.AreEqual(cost, result.Cost);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual(PhoneNumberType.Geographic, result.PhoneNumberType);
+            ClassicAssert.AreEqual(PhoneNumberAssignmentType.Application, result.AssignmentType);
+            ClassicAssert.AreEqual(capabilities, result.AvailableCapabilities);
+            ClassicAssert.AreEqual(cost, result.Cost);
         }
 
         [Test]
         public void PhoneNumberCost_WhenIsoCurrencySymbolNotNull_ShouldReturnInstanceOfPhoneNumberCost()
         {
             var result = PhoneNumbersModelFactory.PhoneNumberCost(10, "USD", BillingFrequency.Monthly);
-            Assert.IsNotNull(result);
-            Assert.AreEqual(10, result.Amount);
-            Assert.AreEqual("USD", result.IsoCurrencySymbol);
-            Assert.AreEqual(BillingFrequency.Monthly, result.BillingFrequency);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual(10, result.Amount);
+            ClassicAssert.AreEqual("USD", result.IsoCurrencySymbol);
+            ClassicAssert.AreEqual(BillingFrequency.Monthly, result.BillingFrequency);
         }
 
         [Test]
@@ -77,15 +78,15 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error = PhoneNumberSearchResultError.NoError;
 
             var result = PhoneNumbersModelFactory.PhoneNumberSearchResult("search1", phoneNumbers, PhoneNumberType.Geographic, PhoneNumberAssignmentType.Application, capabilities, cost, DateTimeOffset.Now, 0, error);
-            Assert.IsNotNull(result);
-            Assert.AreEqual("search1", result.SearchId);
-            Assert.AreEqual(phoneNumbers, result.PhoneNumbers);
-            Assert.AreEqual(PhoneNumberType.Geographic, result.PhoneNumberType);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, result.AssignmentType);
-            Assert.AreEqual(capabilities, result.Capabilities);
-            Assert.AreEqual(cost, result.Cost);
-            Assert.AreEqual(0, result.ErrorCode);
-            Assert.AreEqual(error, result.Error);
+            ClassicAssert.IsNotNull(result);
+            ClassicAssert.AreEqual("search1", result.SearchId);
+            ClassicAssert.AreEqual(phoneNumbers, result.PhoneNumbers);
+            ClassicAssert.AreEqual(PhoneNumberType.Geographic, result.PhoneNumberType);
+            ClassicAssert.AreEqual(PhoneNumberAssignmentType.Application, result.AssignmentType);
+            ClassicAssert.AreEqual(capabilities, result.Capabilities);
+            ClassicAssert.AreEqual(cost, result.Cost);
+            ClassicAssert.AreEqual(0, result.ErrorCode);
+            ClassicAssert.AreEqual(error, result.Error);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 {
@@ -37,8 +38,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         public async Task ClearConfiguration()
         {
             var client = CreateClient();
-            Assert.AreEqual(200, (await client.SetRoutesAsync(new List<SipTrunkRoute>())).Status);
-            Assert.AreEqual(200, (await client.SetTrunksAsync(new List<SipTrunk>())).Status);
+            ClassicAssert.AreEqual(200, (await client.SetRoutesAsync(new List<SipTrunkRoute>())).Status);
+            ClassicAssert.AreEqual(200, (await client.SetTrunksAsync(new List<SipTrunk>())).Status);
         }
 
         [Test]
@@ -52,7 +53,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var client = CreateClientWithTokenCredential();
 
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
-            Assert.AreEqual(200, response.GetRawResponse().Status);
+            ClassicAssert.AreEqual(200, response.GetRawResponse().Status);
         }
 
         [Test]
@@ -66,7 +67,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var client = CreateClientWithTokenCredential();
 
             var response = await client.SetTrunkAsync(new SipTrunk(TestData!.TrunkList[0].Fqdn, 5555)).ConfigureAwait(false);
-            Assert.AreEqual(200, response.Status);
+            ClassicAssert.AreEqual(200, response.Status);
         }
 
         [Test]
@@ -81,10 +82,10 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
             var trunks = response.Value;
 
-            Assert.IsNotNull(trunks);
-            Assert.AreEqual(TestData!.TrunkList.Count, trunks.Count());
-            Assert.IsTrue(TrunkAreEqual(TestData!.TrunkList[0], trunks[0]));
-            Assert.IsTrue(TrunkAreEqual(TestData!.TrunkList[1], trunks[1]));
+            ClassicAssert.IsNotNull(trunks);
+            ClassicAssert.AreEqual(TestData!.TrunkList.Count, trunks.Count());
+            ClassicAssert.IsTrue(TrunkAreEqual(TestData!.TrunkList[0], trunks[0]));
+            ClassicAssert.IsTrue(TrunkAreEqual(TestData!.TrunkList[1], trunks[1]));
         }
 
         [Test]
@@ -100,9 +101,9 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetRoutesAsync().ConfigureAwait(false);
             var routes = response.Value;
 
-            Assert.IsNotNull(routes);
-            Assert.AreEqual(1, routes.Count());
-            Assert.IsTrue(RouteAreEqual(TestData!.RuleWithoutTrunks, routes[0]));
+            ClassicAssert.IsNotNull(routes);
+            ClassicAssert.AreEqual(1, routes.Count());
+            ClassicAssert.IsTrue(RouteAreEqual(TestData!.RuleWithoutTrunks, routes[0]));
         }
 
         [Test]
@@ -117,8 +118,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.SetTrunkAsync(TestData!.NewTrunk).ConfigureAwait(false);
             var actualTrunks = await client.GetTrunksAsync().ConfigureAwait(false);
 
-            Assert.AreEqual(3, actualTrunks.Value.Count());
-            Assert.IsNotNull(actualTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.NewTrunk.Fqdn));
+            ClassicAssert.AreEqual(3, actualTrunks.Value.Count());
+            ClassicAssert.IsNotNull(actualTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.NewTrunk.Fqdn));
         }
 
         [Test]
@@ -134,7 +135,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             await client.SetTrunkAsync(modifiedTrunk).ConfigureAwait(false);
 
             var actualTrunk = await client.GetTrunkAsync(TestData!.TrunkList[0].Fqdn).ConfigureAwait(false);
-            Assert.AreEqual(modifiedTrunk.SipSignalingPort, actualTrunk.Value.SipSignalingPort);
+            ClassicAssert.AreEqual(modifiedTrunk.SipSignalingPort, actualTrunk.Value.SipSignalingPort);
         }
 
         [Test]
@@ -147,13 +148,13 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var client = InitializeTest();
             var initialTrunks = await client.GetTrunksAsync().ConfigureAwait(false);
-            Assert.AreEqual(TestData!.TrunkList.Count, initialTrunks.Value.Count());
+            ClassicAssert.AreEqual(TestData!.TrunkList.Count, initialTrunks.Value.Count());
 
             await client.DeleteTrunkAsync(TestData!.TrunkList[1].Fqdn).ConfigureAwait(false);
 
             var finalTrunks = await client.GetTrunksAsync().ConfigureAwait(false);
-            Assert.AreEqual(TestData!.TrunkList.Count - 1, finalTrunks.Value.Count());
-            Assert.IsNull(finalTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.TrunkList[1].Fqdn));
+            ClassicAssert.AreEqual(TestData!.TrunkList.Count - 1, finalTrunks.Value.Count());
+            ClassicAssert.IsNull(finalTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.TrunkList[1].Fqdn));
         }
 
         [Test]
@@ -169,8 +170,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetTrunkAsync(TestData!.TrunkList[1].Fqdn).ConfigureAwait(false);
 
             var trunk = response.Value;
-            Assert.IsNotNull(trunk);
-            Assert.IsTrue(TrunkAreEqual(TestData!.TrunkList[1], trunk));
+            ClassicAssert.IsNotNull(trunk);
+            ClassicAssert.IsTrue(TrunkAreEqual(TestData!.TrunkList[1], trunk));
         }
 
         [Test]
@@ -188,9 +189,9 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetRoutesAsync().ConfigureAwait(false);
 
             var newRoutes = response.Value;
-            Assert.IsNotNull(newRoutes);
-            Assert.AreEqual(1, newRoutes.Count);
-            Assert.IsTrue(RouteAreEqual(TestData!.RuleWithoutTrunks2, newRoutes[0]));
+            ClassicAssert.IsNotNull(newRoutes);
+            ClassicAssert.AreEqual(1, newRoutes.Count);
+            ClassicAssert.IsTrue(RouteAreEqual(TestData!.RuleWithoutTrunks2, newRoutes[0]));
         }
 
         [Test]
@@ -207,9 +208,9 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
 
             var newTrunks = response.Value;
-            Assert.IsNotNull(newTrunks);
-            Assert.AreEqual(1, newTrunks.Count);
-            Assert.IsTrue(TrunkAreEqual(TestData!.NewTrunk, newTrunks[0]));
+            ClassicAssert.IsNotNull(newTrunks);
+            ClassicAssert.AreEqual(1, newTrunks.Count);
+            ClassicAssert.IsTrue(TrunkAreEqual(TestData!.NewTrunk, newTrunks[0]));
         }
 
         [Test]
@@ -227,8 +228,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
             var newTrunks = response.Value;
-            Assert.IsNotNull(newTrunks);
-            Assert.IsEmpty(newTrunks);
+            ClassicAssert.IsNotNull(newTrunks);
+            ClassicAssert.IsEmpty(newTrunks);
         }
 
         [Test]
@@ -246,8 +247,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
             var newTrunks = response.Value;
-            Assert.IsNotNull(newTrunks);
-            Assert.IsEmpty(newTrunks);
+            ClassicAssert.IsNotNull(newTrunks);
+            ClassicAssert.IsEmpty(newTrunks);
         }
 
         [Test]
@@ -265,8 +266,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var response = await client.GetRoutesAsync().ConfigureAwait(false);
             var newRoutes = response.Value;
-            Assert.IsNotNull(newRoutes);
-            Assert.IsEmpty(newRoutes);
+            ClassicAssert.IsNotNull(newRoutes);
+            ClassicAssert.IsEmpty(newRoutes);
         }
 
         [Test]
@@ -284,8 +285,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var response = await client.GetRoutesAsync().ConfigureAwait(false);
             var newRoutes = response.Value;
-            Assert.IsNotNull(newRoutes);
-            Assert.IsEmpty(newRoutes);
+            ClassicAssert.IsNotNull(newRoutes);
+            ClassicAssert.IsEmpty(newRoutes);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_PhoneNumbersClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_PhoneNumbersClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using Azure.Communication.Tests;
 using Azure.Core.TestFramework;
 using Azure.Core.TestFramework.Models;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.PhoneNumbers.Tests.Samples
 {
@@ -77,7 +78,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             #endregion Snippet:StartPurchaseSearchAsync
 
             await WaitForCompletionResponseAsync(purchaseOperation!);
-            Assert.AreEqual(purchaseOperation.GetRawResponse().Status, 200);
+            ClassicAssert.AreEqual(purchaseOperation.GetRawResponse().Status, 200);
 
             #region Snippet:GetPurchasedPhoneNumbersAsync
             var purchasedPhoneNumbers = client.GetPurchasedPhoneNumbersAsync();
@@ -99,8 +100,8 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             #endregion Snippet:UpdateCapabilitiesNumbersAsync
 
             await WaitForCompletionAsync(updateCapabilitiesOperation);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, updateCapabilitiesOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.InboundOutbound, updateCapabilitiesOperation.Value.Capabilities.Sms);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.Outbound, updateCapabilitiesOperation.Value.Capabilities.Calling);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.InboundOutbound, updateCapabilitiesOperation.Value.Capabilities.Sms);
 
             #region Snippet:ReleasePhoneNumbersAsync
 
@@ -122,7 +123,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             {
                 purchasedPhoneNumbersAfterReleaseStatus = e.ErrorCode;
             }
-            Assert.AreEqual("NotFound", purchasedPhoneNumbersAfterReleaseStatus);
+            ClassicAssert.AreEqual("NotFound", purchasedPhoneNumbersAfterReleaseStatus);
         }
 
         private ValueTask<Response<T>> WaitForCompletionAsync<T>(Operation<T> operation) where T : notnull
@@ -186,7 +187,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:StartPurchaseSearch
 
-            Assert.AreEqual(purchaseOperation.GetRawResponse().Status, 200);
+            ClassicAssert.AreEqual(purchaseOperation.GetRawResponse().Status, 200);
 
             #region Snippet:GetPurchasedPhoneNumbers
             var purchasedPhoneNumbers = client.GetPurchasedPhoneNumbers();
@@ -212,8 +213,8 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:UpdateCapabilitiesNumbers
 
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, updateCapabilitiesOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.InboundOutbound, updateCapabilitiesOperation.Value.Capabilities.Sms);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.Outbound, updateCapabilitiesOperation.Value.Capabilities.Calling);
+            ClassicAssert.AreEqual(PhoneNumberCapabilityType.InboundOutbound, updateCapabilitiesOperation.Value.Capabilities.Sms);
 
             #region Snippet:ReleasePhoneNumbers
             //@@var purchasedPhoneNumber = "<purchased_phone_number>";
@@ -239,7 +240,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             {
                 purchasedPhoneNumbersAfterReleaseStatus = e.ErrorCode;
             }
-            Assert.AreEqual("NotFound", purchasedPhoneNumbersAfterReleaseStatus);
+            ClassicAssert.AreEqual("NotFound", purchasedPhoneNumbersAfterReleaseStatus);
         }
 
         [TestCase]
@@ -280,9 +281,9 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:CreateReservationAsync
 
-            Assert.IsTrue(phoneNumbersToReserve.All(n => reservation.PhoneNumbers.ContainsKey(n.Id)));
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.First().Id]);
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.Last().Id]);
+            ClassicAssert.IsTrue(phoneNumbersToReserve.All(n => reservation.PhoneNumbers.ContainsKey(n.Id)));
+            ClassicAssert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.First().Id]);
+            ClassicAssert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.Last().Id]);
 
             #region Snippet:CheckForPartialFailure
             var phoneNumbersWithError = reservation.PhoneNumbers.Values
@@ -330,7 +331,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:ValidateReservationPurchaseAsync
 
-            Assert.IsTrue(purchasedReservation.PhoneNumbers.All(n => n.Value.Status == PhoneNumberAvailabilityStatus.Purchased));
+            ClassicAssert.IsTrue(purchasedReservation.PhoneNumbers.All(n => n.Value.Status == PhoneNumberAvailabilityStatus.Purchased));
 
             // Release the number to prevent additional costs.
             foreach (var phoneNumberToReserve in phoneNumbersToReserve)
@@ -382,9 +383,9 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:CreateReservation
 
-            Assert.IsTrue(phoneNumbersToReserve.All(n => reservation.PhoneNumbers.ContainsKey(n.Id)));
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.First().Id]);
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.Last().Id]);
+            ClassicAssert.IsTrue(phoneNumbersToReserve.All(n => reservation.PhoneNumbers.ContainsKey(n.Id)));
+            ClassicAssert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.First().Id]);
+            ClassicAssert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.Last().Id]);
 
             var phoneNumbersWithError = reservation
                 .PhoneNumbers
@@ -431,7 +432,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:ValidateReservationPurchase
 
-            Assert.IsTrue(purchasedReservation.PhoneNumbers.All(n => n.Value.Status == PhoneNumberAvailabilityStatus.Purchased));
+            ClassicAssert.IsTrue(purchasedReservation.PhoneNumbers.All(n => n.Value.Status == PhoneNumberAvailabilityStatus.Purchased));
 
             // Release the number to prevent additional costs.
             foreach (var phoneNumberToReserve in phoneNumbersToReserve)

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_SipRoutingClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_SipRoutingClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,6 +8,7 @@ using Azure.Communication.PhoneNumbers.SipRouting;
 using Azure.Communication.PhoneNumbers.SipRouting.Tests;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.PhoneNumbers.Tests.Samples
 {
@@ -60,10 +61,10 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             var routesResponse = client.GetRoutes();
             #endregion Snippet:RetrieveList
 
-            Assert.AreEqual(1, trunksResponse.Value.Count);
-            Assert.IsTrue(TrunkAreEqual(TestData.NewTrunk, trunksResponse.Value[0]));
-            Assert.AreEqual(1, routesResponse.Value.Count);
-            Assert.IsTrue(RouteAreEqual(TestData.RuleNavigateToNewTrunk, routesResponse.Value[0]));
+            ClassicAssert.AreEqual(1, trunksResponse.Value.Count);
+            ClassicAssert.IsTrue(TrunkAreEqual(TestData.NewTrunk, trunksResponse.Value[0]));
+            ClassicAssert.AreEqual(1, routesResponse.Value.Count);
+            ClassicAssert.IsTrue(RouteAreEqual(TestData.RuleNavigateToNewTrunk, routesResponse.Value[0]));
 
             var fqdnToRetrieve = TestData.NewTrunk.Fqdn;
 
@@ -94,9 +95,9 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             var trunksFinalResponse = client.GetTrunks();
             var routesFinalResponse = client.GetRoutes();
 
-            Assert.AreEqual(1, trunksFinalResponse.Value.Count);
-            Assert.IsTrue(TrunkAreEqual(trunkToSet, trunksFinalResponse.Value[0]));
-            Assert.AreEqual(1, routesFinalResponse.Value.Count);
+            ClassicAssert.AreEqual(1, trunksFinalResponse.Value.Count);
+            ClassicAssert.IsTrue(TrunkAreEqual(trunkToSet, trunksFinalResponse.Value[0]));
+            ClassicAssert.AreEqual(1, routesFinalResponse.Value.Count);
         }
 
         [Test]
@@ -124,10 +125,10 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             var routesResponse = await client.GetRoutesAsync();
             #endregion Snippet:RetrieveListAsync
 
-            Assert.AreEqual(1, trunksResponse.Value.Count);
-            Assert.IsTrue(TrunkAreEqual(TestData.NewTrunk, trunksResponse.Value[0]));
-            Assert.AreEqual(1, routesResponse.Value.Count);
-            Assert.IsTrue(RouteAreEqual(TestData.RuleNavigateToNewTrunk, routesResponse.Value[0]));
+            ClassicAssert.AreEqual(1, trunksResponse.Value.Count);
+            ClassicAssert.IsTrue(TrunkAreEqual(TestData.NewTrunk, trunksResponse.Value[0]));
+            ClassicAssert.AreEqual(1, routesResponse.Value.Count);
+            ClassicAssert.IsTrue(RouteAreEqual(TestData.RuleNavigateToNewTrunk, routesResponse.Value[0]));
 
             var fqdnToRetrieve = TestData.NewTrunk.Fqdn;
 
@@ -158,9 +159,9 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             var trunksFinalResponse = client.GetTrunksAsync();
             var routesFinalResponse = client.GetRoutesAsync();
 
-            Assert.AreEqual(1, trunksFinalResponse.Result.Value.Count);
-            Assert.IsTrue(TrunkAreEqual(trunkToSet, trunksFinalResponse.Result.Value[0]));
-            Assert.AreEqual(1, routesFinalResponse.Result.Value.Count);
+            ClassicAssert.AreEqual(1, trunksFinalResponse.Result.Value.Count);
+            ClassicAssert.IsTrue(TrunkAreEqual(trunkToSet, trunksFinalResponse.Result.Value[0]));
+            ClassicAssert.AreEqual(1, routesFinalResponse.Result.Value.Count);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomClientPstnDialOutLiveTest.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomClientPstnDialOutLiveTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -13,6 +13,7 @@ using Azure.Communication.Rooms.Tests;
 using Azure.Communication.Tests;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using static Azure.Communication.Rooms.RoomsClientOptions;
 
 namespace Azure.Communication.Rooms.Test
@@ -69,8 +70,8 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                ClassicAssert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
                 ValidateRoom(createCommunicationRoom);
                 var createdRoomId = createCommunicationRoom.Id;
 
@@ -79,8 +80,8 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, getCommunicationRoom.Id);
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(createdRoomId, getCommunicationRoom.Id);
+                ClassicAssert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(getCommunicationRoom);
 
                 // Act: Update Room
@@ -96,15 +97,15 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, updateCommunicationRoom.Id);
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(createdRoomId, updateCommunicationRoom.Id);
+                ClassicAssert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(updateCommunicationRoom);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert:
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -141,8 +142,8 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                ClassicAssert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
                 ValidateRoom(createCommunicationRoom, roomCreateOptions);
 
                 // Act: Get Room
@@ -151,8 +152,8 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, getCommunicationRoom.Id);
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(createdRoomId, getCommunicationRoom.Id);
+                ClassicAssert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(getCommunicationRoom, roomCreateOptions);
 
                 // Act: Update Room
@@ -169,15 +170,15 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, updateCommunicationRoom.Id);
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(createdRoomId, updateCommunicationRoom.Id);
+                ClassicAssert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert:
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -226,7 +227,7 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                ClassicAssert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
                 ValidateRoom(createCommunicationRoom);
 
                 var createdRoomId = createCommunicationRoom.Id;
@@ -236,7 +237,7 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(getCommunicationRoom);
 
                 // Act Update Room
@@ -252,19 +253,19 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(updateCommunicationRoom);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
 
                 // Get Deleted Room
-                RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-                Assert.NotNull(ex);
-                Assert.AreEqual(404, ex?.Status);
+                RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
+                ClassicAssert.NotNull(ex);
+                ClassicAssert.AreEqual(404, ex?.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -316,7 +317,7 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                ClassicAssert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
                 ValidateRoom(createCommunicationRoom, roomCreateOptions);
 
                 // Act: Get Room
@@ -325,7 +326,7 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(getCommunicationRoom, roomCreateOptions);
 
                 // Act Update Room
@@ -343,19 +344,19 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
 
                 // Get Deleted Room
-                RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-                Assert.NotNull(ex);
-                Assert.AreEqual(404, ex?.Status);
+                RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
+                ClassicAssert.NotNull(ex);
+                ClassicAssert.AreEqual(404, ex?.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -378,7 +379,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(options: null);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value);
         }
 
@@ -392,7 +393,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(new CreateRoomOptions());
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value);
         }
 
@@ -417,7 +418,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value, roomCreateOptions);
         }
 
@@ -442,7 +443,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value);
         }
 
@@ -468,7 +469,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value, roomCreateOptions);
         }
 
@@ -497,7 +498,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value);
         }
 
@@ -527,7 +528,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value, roomCreateOptions);
         }
 
@@ -546,9 +547,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -567,9 +568,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -586,9 +587,9 @@ namespace Azure.Communication.Rooms.Test
                 ValidUntil = validUntil
             };
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -607,9 +608,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -627,9 +628,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -649,9 +650,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -668,9 +669,9 @@ namespace Azure.Communication.Rooms.Test
             var roomsClient = CreateClient(authMethod, apiVersion: apiVersion);
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync("invalid_id"));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync("invalid_id"));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -697,8 +698,8 @@ namespace Azure.Communication.Rooms.Test
             CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
             // Assert:
-            Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
-            Assert.AreEqual(createRoomResponse.Value.Id, updateCommunicationRoom.Id);
+            ClassicAssert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+            ClassicAssert.AreEqual(createRoomResponse.Value.Id, updateCommunicationRoom.Id);
             ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
         }
 
@@ -728,9 +729,9 @@ namespace Azure.Communication.Rooms.Test
             CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
             // Assert:
-            Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
-            Assert.AreEqual(createRoomResponse.Value.Id, updateCommunicationRoom.Id);
-            Assert.AreEqual(updateCommunicationRoom.PstnDialOutEnabled, roomCreateOptions.PstnDialOutEnabled); // PSTN Enabled Dial-Out remains unchanged as in the room create operation
+            ClassicAssert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+            ClassicAssert.AreEqual(createRoomResponse.Value.Id, updateCommunicationRoom.Id);
+            ClassicAssert.AreEqual(updateCommunicationRoom.PstnDialOutEnabled, roomCreateOptions.PstnDialOutEnabled); // PSTN Enabled Dial-Out remains unchanged as in the room create operation
             ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
         }
 
@@ -756,9 +757,9 @@ namespace Azure.Communication.Rooms.Test
             CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
             // Assert:
-            Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
-            Assert.AreEqual(createRoomResponse.Value.Id, updateCommunicationRoom.Id);
-            Assert.AreEqual(updateCommunicationRoom.PstnDialOutEnabled, roomCreateOptions.PstnDialOutEnabled); // PSTN Enabled Dial-Out remains unchanged as in the room create operation
+            ClassicAssert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+            ClassicAssert.AreEqual(createRoomResponse.Value.Id, updateCommunicationRoom.Id);
+            ClassicAssert.AreEqual(updateCommunicationRoom.PstnDialOutEnabled, roomCreateOptions.PstnDialOutEnabled); // PSTN Enabled Dial-Out remains unchanged as in the room create operation
             ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
         }
 
@@ -784,9 +785,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -813,9 +814,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -841,9 +842,9 @@ namespace Azure.Communication.Rooms.Test
                 ValidUntil = validUntil
             };
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -870,9 +871,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -897,9 +898,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync("invalid_id", roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync("invalid_id", roomUpdateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -925,9 +926,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync("invalid_id", roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync("invalid_id", roomUpdateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -952,9 +953,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(404, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -983,9 +984,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(404, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -999,9 +1000,9 @@ namespace Azure.Communication.Rooms.Test
                 new RoomParticipant(new CommunicationUserIdentifier("invalid_mri"))
             };
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.AddOrUpdateParticipantsAsync(createRoomResponse.Value.Id, participants: roomParticipants));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.AddOrUpdateParticipantsAsync(createRoomResponse.Value.Id, participants: roomParticipants));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -1077,7 +1078,7 @@ namespace Azure.Communication.Rooms.Test
                 Response<CommunicationRoom> createRoomResponse = await roomsClient.CreateRoomAsync(roomCreateOptions);
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
 
                 var createdRoomId = createCommunicationRoom.Id;
                 participant2 = new RoomParticipant(communicationUser2) { Role = ParticipantRole.Consumer };
@@ -1092,19 +1093,19 @@ namespace Azure.Communication.Rooms.Test
                 };
 
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                ClassicAssert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Presenter), "Expected participants to contain Presenter");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Consumer), "Expected participants to contain Consumer");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Attendee), "Expected participants to contain Attendee");
+                ClassicAssert.AreEqual(3, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 3");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Presenter), "Expected participants to contain Presenter");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Consumer), "Expected participants to contain Consumer");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Attendee), "Expected participants to contain Attendee");
 
                 // Arrange: Remove participants
                 List<CommunicationIdentifier> toRemoveCommunicationUsers = new List<CommunicationIdentifier>
@@ -1118,13 +1119,13 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(1, removeRoomParticipantsResult.Count, "Expected Room participants count to be 1 after removal");
-                Assert.IsTrue(removeRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.AreEqual(200, removeParticipantsResponse.Status);
+                ClassicAssert.AreEqual(1, removeRoomParticipantsResult.Count, "Expected Room participants count to be 1 after removal");
+                ClassicAssert.IsTrue(removeRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -1187,20 +1188,20 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> roomParticipantsResult = await roomParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, roomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                ClassicAssert.AreEqual(3, roomParticipantsResult.Count, "Expected Room participants count to be 3");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
                     "Expected participant1 to have Presenter role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                     "Expected participant2 to have Attendee role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
                    "Expected participant3 to have Presenter role.");
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
 
                 // Arrange
                 // participant1 should be updated to Attendee which is default
@@ -1219,28 +1220,28 @@ namespace Azure.Communication.Rooms.Test
 
                 // Act
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                ClassicAssert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(4, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 4");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add or update.");
+                ClassicAssert.AreEqual(4, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 4");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add or update.");
 
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                    "Expected participant1 to have Attendee role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Consumer)),
                     "Expected participant2 to have Consumer role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                    "Expected participant4 to have Attendee role.");
 
@@ -1255,22 +1256,22 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> allParticipantsAfterDeleteResult = await allParticipantsAfterDelete.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(2, allParticipantsAfterDeleteResult.Count, "Expected Room participants count to be 2");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add and update.");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                ClassicAssert.AreEqual(200, removeParticipantsResponse.Status);
+                ClassicAssert.AreEqual(2, allParticipantsAfterDeleteResult.Count, "Expected Room participants count to be 2");
+                ClassicAssert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add and update.");
+                ClassicAssert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add and update.");
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add and update.");
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add and update.");
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                    "Expected participant4 to have Attendee role.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -1309,8 +1310,8 @@ namespace Azure.Communication.Rooms.Test
             List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
             // Assert
-            Assert.AreEqual(removeParticipantResponse.Status, 200);
-            Assert.AreEqual(removeRoomParticipantsResult.Count, 0);
+            ClassicAssert.AreEqual(removeParticipantResponse.Status, 200);
+            ClassicAssert.AreEqual(removeRoomParticipantsResult.Count, 0);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -1332,9 +1333,9 @@ namespace Azure.Communication.Rooms.Test
             };
 
             // Act and assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -1349,10 +1350,10 @@ namespace Azure.Communication.Rooms.Test
             Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
             // Assert:
-            Assert.AreEqual(204, deleteRoomResponse.Status);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(404, ex?.Status);
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -1370,9 +1371,9 @@ namespace Azure.Communication.Rooms.Test
             var invalidRoomId = "123";
 
             // Act and Assert:
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(invalidRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(invalidRoomId));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [TestCase(ServiceVersion.V2025_03_13)]
@@ -1419,20 +1420,20 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> roomParticipantsResult = await roomParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, roomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                ClassicAssert.AreEqual(3, roomParticipantsResult.Count, "Expected Room participants count to be 3");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
                     "Expected participant1 to have Presenter role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                     "Expected participant2 to have Attendee role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Collaborator)),
                    "Expected participant3 to have Presenter role.");
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
 
                 // Arrange
                 // participant1 should be updated to Attendee which is default
@@ -1451,28 +1452,28 @@ namespace Azure.Communication.Rooms.Test
 
                 // Act
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                ClassicAssert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(4, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 4");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add or update.");
+                ClassicAssert.AreEqual(4, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 4");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add or update.");
 
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                    "Expected participant1 to have Attendee role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Collaborator)),
                     "Expected participant2 to have Consumer role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Collaborator)),
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                    "Expected participant4 to have Attendee role.");
 
@@ -1487,22 +1488,22 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> allParticipantsAfterDeleteResult = await allParticipantsAfterDelete.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(2, allParticipantsAfterDeleteResult.Count, "Expected Room participants count to be 2");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add and update.");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                ClassicAssert.AreEqual(200, removeParticipantsResponse.Status);
+                ClassicAssert.AreEqual(2, allParticipantsAfterDeleteResult.Count, "Expected Room participants count to be 2");
+                ClassicAssert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add and update.");
+                ClassicAssert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add and update.");
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add and update.");
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add and update.");
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Collaborator)),
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                    "Expected participant4 to have Attendee role.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -1517,22 +1518,22 @@ namespace Azure.Communication.Rooms.Test
 
         private void ValidateRoom(CommunicationRoom? room)
         {
-            Assert.NotNull(room);
-            Assert.NotNull(room?.Id);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.ValidFrom);
-            Assert.NotNull(room?.ValidUntil);
-            Assert.NotNull(room?.PstnDialOutEnabled);
+            ClassicAssert.NotNull(room);
+            ClassicAssert.NotNull(room?.Id);
+            ClassicAssert.NotNull(room?.CreatedAt);
+            ClassicAssert.NotNull(room?.ValidFrom);
+            ClassicAssert.NotNull(room?.ValidUntil);
+            ClassicAssert.NotNull(room?.PstnDialOutEnabled);
         }
 
         private void ValidateRoom(CommunicationRoom? room, CreateRoomOptions roomCreateOptions)
         {
-            Assert.NotNull(room);
-            Assert.NotNull(room?.Id);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.ValidFrom);
-            Assert.NotNull(room?.ValidUntil);
-            Assert.AreEqual(room?.PstnDialOutEnabled, roomCreateOptions.PstnDialOutEnabled.HasValue ? roomCreateOptions?.PstnDialOutEnabled : false);
+            ClassicAssert.NotNull(room);
+            ClassicAssert.NotNull(room?.Id);
+            ClassicAssert.NotNull(room?.CreatedAt);
+            ClassicAssert.NotNull(room?.ValidFrom);
+            ClassicAssert.NotNull(room?.ValidUntil);
+            ClassicAssert.AreEqual(room?.PstnDialOutEnabled, roomCreateOptions.PstnDialOutEnabled.HasValue ? roomCreateOptions?.PstnDialOutEnabled : false);
             Console.Write("Room Id: " + room?.Id);
             Console.Write("CreatedAt: " + room?.CreatedAt);
             Console.Write("ValidFrom: " + room?.ValidFrom);
@@ -1542,12 +1543,12 @@ namespace Azure.Communication.Rooms.Test
 
         private void ValidateRoom(CommunicationRoom? room, UpdateRoomOptions roomUpdateOptions)
         {
-            Assert.NotNull(room);
-            Assert.NotNull(room?.Id);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.ValidFrom);
-            Assert.AreEqual(room?.PstnDialOutEnabled, roomUpdateOptions.PstnDialOutEnabled.HasValue ? roomUpdateOptions.PstnDialOutEnabled : room?.PstnDialOutEnabled);
+            ClassicAssert.NotNull(room);
+            ClassicAssert.NotNull(room?.Id);
+            ClassicAssert.NotNull(room?.CreatedAt);
+            ClassicAssert.NotNull(room?.CreatedAt);
+            ClassicAssert.NotNull(room?.ValidFrom);
+            ClassicAssert.AreEqual(room?.PstnDialOutEnabled, roomUpdateOptions.PstnDialOutEnabled.HasValue ? roomUpdateOptions.PstnDialOutEnabled : room?.PstnDialOutEnabled);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -10,6 +10,7 @@ using Azure.Communication.Rooms;
 using Azure.Communication.Tests;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Rooms.Tests
 {
@@ -36,8 +37,8 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                ClassicAssert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
                 ValidateRoom(createCommunicationRoom);
                 var createdRoomId = createCommunicationRoom.Id;
 
@@ -46,8 +47,8 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, getCommunicationRoom.Id);
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(createdRoomId, getCommunicationRoom.Id);
+                ClassicAssert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(getCommunicationRoom);
 
                 // Act: Update Room
@@ -57,15 +58,15 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, updateCommunicationRoom.Id);
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(createdRoomId, updateCommunicationRoom.Id);
+                ClassicAssert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(updateCommunicationRoom);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert:
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -109,7 +110,7 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                ClassicAssert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
                 ValidateRoom(createCommunicationRoom);
 
                 var createdRoomId = createCommunicationRoom.Id;
@@ -119,7 +120,7 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(getCommunicationRoom);
 
                 // Act Update Room
@@ -130,19 +131,19 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                ClassicAssert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
                 ValidateRoom(updateCommunicationRoom);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
 
                 // Get Deleted Room
-                RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-                Assert.NotNull(ex);
-                Assert.AreEqual(404, ex?.Status);
+                RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
+                ClassicAssert.NotNull(ex);
+                ClassicAssert.AreEqual(404, ex?.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -165,7 +166,7 @@ namespace Azure.Communication.Rooms.Tests
             var createdRoom = await roomsClient.CreateRoomAsync();
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value);
         }
 
@@ -185,7 +186,7 @@ namespace Azure.Communication.Rooms.Tests
             var createdRoom = await roomsClient.CreateRoomAsync(participants: roomParticipants);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value);
         }
 
@@ -207,7 +208,7 @@ namespace Azure.Communication.Rooms.Tests
             var createdRoom = await roomsClient.CreateRoomAsync(participants: roomParticipants, validFrom: validFrom, validUntil: validUntil);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            ClassicAssert.AreEqual(createdRoom.GetRawResponse().Status, 201);
             ValidateRoom(createdRoom.Value);
         }
 
@@ -220,9 +221,9 @@ namespace Azure.Communication.Rooms.Tests
             var roomsClient = CreateInstrumentedRoomsClient(RoomsClientOptions.ServiceVersion.V2023_06_14);
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(validFrom: validFrom, validUntil: validUntil));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [Test]
@@ -234,9 +235,9 @@ namespace Azure.Communication.Rooms.Tests
             var validUntil = validFrom.AddDays(-20);
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(validFrom: validFrom, validUntil: validUntil));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [Test]
@@ -250,9 +251,9 @@ namespace Azure.Communication.Rooms.Tests
             var roomsClient = CreateInstrumentedRoomsClient(RoomsClientOptions.ServiceVersion.V2023_06_14);
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(participants: roomParticipants));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(participants: roomParticipants));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [Test]
@@ -262,9 +263,9 @@ namespace Azure.Communication.Rooms.Tests
             var roomsClient = CreateInstrumentedRoomsClient(RoomsClientOptions.ServiceVersion.V2023_06_14);
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync("invalid_id"));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync("invalid_id"));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [Test]
@@ -278,9 +279,9 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and Assert
             validUntil = validFrom.AddDays(200);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, validFrom: validFrom, validUntil: validUntil));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [Test]
@@ -294,9 +295,9 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and Assert
             validUntil = validFrom.AddDays(-20);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, validFrom: validFrom, validUntil: validUntil));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [Test]
@@ -308,9 +309,9 @@ namespace Azure.Communication.Rooms.Tests
             var roomsClient = CreateInstrumentedRoomsClient(RoomsClientOptions.ServiceVersion.V2023_06_14);
 
             // Act and Assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync("invalid_id", validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync("invalid_id", validFrom: validFrom, validUntil: validUntil));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [Test]
@@ -324,9 +325,9 @@ namespace Azure.Communication.Rooms.Tests
             await roomsClient.DeleteRoomAsync(createRoomResponse.Value.Id);
 
             // Act and assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, validFrom: validFrom, validUntil: validUntil));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(404, ex?.Status);
         }
 
         [Test]
@@ -340,9 +341,9 @@ namespace Azure.Communication.Rooms.Tests
                 new RoomParticipant(new CommunicationUserIdentifier("invalid_mri"))
             };
 
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.AddOrUpdateParticipantsAsync(createRoomResponse.Value.Id, participants: roomParticipants));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.AddOrUpdateParticipantsAsync(createRoomResponse.Value.Id, participants: roomParticipants));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [Test]
@@ -404,7 +405,7 @@ namespace Azure.Communication.Rooms.Tests
                 Response<CommunicationRoom> createRoomResponse = await roomsClient.CreateRoomAsync(validFrom, validUntil, createRoomParticipants);
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
 
                 var createdRoomId = createCommunicationRoom.Id;
                 participant2 = new RoomParticipant(communicationUser2) { Role = ParticipantRole.Consumer };
@@ -419,19 +420,19 @@ namespace Azure.Communication.Rooms.Tests
                 };
 
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                ClassicAssert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Presenter), "Expected participants to contain Presenter");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Consumer), "Expected participants to contain Consumer");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Attendee), "Expected participants to contain Attendee");
+                ClassicAssert.AreEqual(3, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 3");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Presenter), "Expected participants to contain Presenter");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Consumer), "Expected participants to contain Consumer");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Attendee), "Expected participants to contain Attendee");
 
                 // Arrange: Remove participants
                 List<CommunicationIdentifier> toRemoveCommunicationUsers = new List<CommunicationIdentifier>
@@ -445,13 +446,13 @@ namespace Azure.Communication.Rooms.Tests
                 List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(1, removeRoomParticipantsResult.Count, "Expected Room participants count to be 1 after removal");
-                Assert.IsTrue(removeRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.AreEqual(200, removeParticipantsResponse.Status);
+                ClassicAssert.AreEqual(1, removeRoomParticipantsResult.Count, "Expected Room participants count to be 1 after removal");
+                ClassicAssert.IsTrue(removeRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -501,20 +502,20 @@ namespace Azure.Communication.Rooms.Tests
                 List<RoomParticipant> roomParticipantsResult = await roomParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, roomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                ClassicAssert.AreEqual(3, roomParticipantsResult.Count, "Expected Room participants count to be 3");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
                     "Expected participant1 to have Presenter role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                     "Expected participant2 to have Attendee role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                ClassicAssert.IsTrue(roomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
                    "Expected participant3 to have Presenter role.");
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
 
                 // Arrange
                 // participant1 should be updated to Attendee which is default
@@ -533,28 +534,28 @@ namespace Azure.Communication.Rooms.Tests
 
                 // Act
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                ClassicAssert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(4, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 4");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add or update.");
+                ClassicAssert.AreEqual(4, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 4");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add or update.");
 
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                    "Expected participant1 to have Attendee role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Consumer)),
                     "Expected participant2 to have Consumer role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                ClassicAssert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                    "Expected participant4 to have Attendee role.");
 
@@ -569,22 +570,22 @@ namespace Azure.Communication.Rooms.Tests
                 List<RoomParticipant> allParticipantsAfterDeleteResult = await allParticipantsAfterDelete.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(2, allParticipantsAfterDeleteResult.Count, "Expected Room participants count to be 2");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add and update.");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                ClassicAssert.AreEqual(200, removeParticipantsResponse.Status);
+                ClassicAssert.AreEqual(2, allParticipantsAfterDeleteResult.Count, "Expected Room participants count to be 2");
+                ClassicAssert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add and update.");
+                ClassicAssert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add and update.");
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add and update.");
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add and update.");
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                ClassicAssert.IsTrue(allParticipantsAfterDeleteResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
                    "Expected participant4 to have Attendee role.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
             }
             catch (RequestFailedException ex)
             {
@@ -616,8 +617,8 @@ namespace Azure.Communication.Rooms.Tests
             List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
             // Assert
-            Assert.AreEqual(removeParticipantResponse.Status, 200);
-            Assert.AreEqual(removeRoomParticipantsResult.Count, 0);
+            ClassicAssert.AreEqual(removeParticipantResponse.Status, 200);
+            ClassicAssert.AreEqual(removeRoomParticipantsResult.Count, 0);
         }
 
         [Test]
@@ -632,9 +633,9 @@ namespace Azure.Communication.Rooms.Tests
             };
 
             // Act and assert
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         [Test]
@@ -649,10 +650,10 @@ namespace Azure.Communication.Rooms.Tests
             Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
             // Assert:
-            Assert.AreEqual(204, deleteRoomResponse.Status);
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(404, ex?.Status);
         }
 
         [Test]
@@ -663,18 +664,18 @@ namespace Azure.Communication.Rooms.Tests
             var ivnalidRoomId = "123";
 
             // Act and Assert:
-            RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(ivnalidRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            RequestFailedException? ex = ClassicAssert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(ivnalidRoomId));
+            ClassicAssert.NotNull(ex);
+            ClassicAssert.AreEqual(400, ex?.Status);
         }
 
         private void ValidateRoom(CommunicationRoom? room)
         {
-            Assert.NotNull(room);
-            Assert.NotNull(room?.Id);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.ValidFrom);
-            Assert.NotNull(room?.ValidUntil);
+            ClassicAssert.NotNull(room);
+            ClassicAssert.NotNull(room?.Id);
+            ClassicAssert.NotNull(room?.CreatedAt);
+            ClassicAssert.NotNull(room?.ValidFrom);
+            ClassicAssert.NotNull(room?.ValidUntil);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientTest.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Rooms.Tests
 {
@@ -44,7 +45,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.CreateRoomAsync(validFrom, validUntil, createRoomParticipants, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.CreateRoomAsync(validFrom, validUntil, createRoomParticipants, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Theory]
@@ -89,7 +90,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.CreateRoomAsync(createRoomOptions, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.CreateRoomAsync(createRoomOptions, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -114,7 +115,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.CreateRoom(validFrom, validUntil, createRoomParticipants, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.CreateRoom(validFrom, validUntil, createRoomParticipants, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Theory]
@@ -150,7 +151,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.CreateRoom(createRoomOptions, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.CreateRoom(createRoomOptions, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -170,7 +171,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.UpdateRoomAsync(roomId, validFrom, validUntil, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.UpdateRoomAsync(roomId, validFrom, validUntil, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Theory]
@@ -199,7 +200,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.UpdateRoomAsync(roomId, roomUpdateOptions, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.UpdateRoomAsync(roomId, roomUpdateOptions, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -220,7 +221,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.UpdateRoom(roomId, validFrom, validUntil, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.UpdateRoom(roomId, validFrom, validUntil, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Theory]
@@ -248,7 +249,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.UpdateRoom(roomId, roomUpdateOptions, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.UpdateRoom(roomId, roomUpdateOptions, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -266,7 +267,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.GetRoomAsync(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetRoomAsync(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -284,7 +285,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.GetRoom(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetRoom(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -301,7 +302,7 @@ namespace Azure.Communication.Rooms.Tests
             AsyncPageable<CommunicationRoom> actualResponse = mockRoomsClient.Object.GetRoomsAsync(cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetRoomsAsync(cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -318,7 +319,7 @@ namespace Azure.Communication.Rooms.Tests
             Pageable<CommunicationRoom> actualResponse = mockRoomsClient.Object.GetRooms(cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetRooms(cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -336,7 +337,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = await mockRoomsClient.Object.DeleteRoomAsync(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.DeleteRoomAsync(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -354,7 +355,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = mockRoomsClient.Object.DeleteRoom(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.DeleteRoom(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -389,7 +390,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = await mockRoomsClient.Object.AddOrUpdateParticipantsAsync(roomId, participants, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.AddOrUpdateParticipantsAsync(roomId, participants, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedResult, actualResponse);
+            ClassicAssert.AreEqual(expectedResult, actualResponse);
         }
 
         [Test]
@@ -425,7 +426,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = mockRoomsClient.Object.AddOrUpdateParticipants(roomId, communicationUsers, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.AddOrUpdateParticipants(roomId, communicationUsers, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
         [Test]
         public async Task RemoveParticipantsAsyncShouldSucceed()
@@ -450,7 +451,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = await mockRoomsClient.Object.RemoveParticipantsAsync(roomId, communicationUsers, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.RemoveParticipantsAsync(roomId, communicationUsers, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedResult, actualResponse);
+            ClassicAssert.AreEqual(expectedResult, actualResponse);
         }
 
         [Test]
@@ -474,7 +475,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = mockRoomsClient.Object.RemoveParticipants(roomId, communicationUsers, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.RemoveParticipants(roomId, communicationUsers, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedResult, actualResponse);
+            ClassicAssert.AreEqual(expectedResult, actualResponse);
         }
 
         [Test]
@@ -492,7 +493,7 @@ namespace Azure.Communication.Rooms.Tests
             AsyncPageable<RoomParticipant> actualResponse = mockRoomsClient.Object.GetParticipantsAsync(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetParticipantsAsync(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
 
         [Test]
@@ -511,7 +512,7 @@ namespace Azure.Communication.Rooms.Tests
             Pageable<RoomParticipant> actualResponse = mockRoomsClient.Object.GetParticipants(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetParticipants(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            ClassicAssert.AreEqual(expectedRoomResult, actualResponse);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/Samples/Sample1_RoomsClient.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/Samples/Sample1_RoomsClient.cs
@@ -8,6 +8,7 @@ using Azure.Communication;
 using Azure.Communication.Identity;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Rooms.Tests.samples
 {
@@ -64,7 +65,7 @@ namespace Azure.Communication.Rooms.Tests.samples
 
             #endregion Snippet:Azure_Communication_Rooms_Tests_Samples_CreateRoomAsync
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
 
             string createdRoomId = createCommunicationRoom.Id;
 
@@ -86,14 +87,14 @@ namespace Azure.Communication.Rooms.Tests.samples
 
             #endregion Snippet:Azure_Communication_Rooms_Tests_Samples_UpdateRoomAsync
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(updateCommunicationRoom.Id));
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(updateCommunicationRoom.Id));
 
             #region Snippet:Azure_Communication_Rooms_Tests_Samples_GetRoomAsync
             Response<CommunicationRoom> getRoomResponse = await roomsClient.GetRoomAsync(createdRoomId);
             CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
             #endregion Snippet:Azure_Communication_Rooms_Tests_Samples_GetRoomAsync
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(getCommunicationRoom.Id));
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(getCommunicationRoom.Id));
 
             #region Snippet:Azure_Communication_Rooms_Tests_Samples_GetRoomsAsync
 
@@ -120,7 +121,7 @@ namespace Azure.Communication.Rooms.Tests.samples
             Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
             #endregion Snippet:Azure_Communication_Rooms_Tests_Samples_DeleteRoomAsync
 
-            Assert.AreEqual(204, deleteRoomResponse.Status);
+            ClassicAssert.AreEqual(204, deleteRoomResponse.Status);
         }
 
         [Test]
@@ -142,7 +143,7 @@ namespace Azure.Communication.Rooms.Tests.samples
             Response<CommunicationRoom> createRoomResponse = await roomsClient.CreateRoomAsync(validFrom, validUntil, createRoomParticipants);
             CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
 
             string createdRoomId = createCommunicationRoom.Id;
 

--- a/sdk/communication/Azure.Communication.ShortCodes/tests/ShortCodesClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.ShortCodes/tests/ShortCodesClientLiveTests.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
 using System.Threading.Tasks;
 using Azure.Core.TestFramework;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.ShortCodes.Tests
 {
@@ -37,7 +38,7 @@ namespace Azure.Communication.ShortCodes.Tests
             }
             #endregion Snippet:GetShortCodes
 
-            Assert.NotNull(shortCodes);
+            ClassicAssert.NotNull(shortCodes);
         }
 
         [Test]
@@ -52,7 +53,7 @@ namespace Azure.Communication.ShortCodes.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("body", ex.ParamName);
+                ClassicAssert.AreEqual("body", ex.ParamName);
                 return;
             }
 
@@ -66,7 +67,7 @@ namespace Azure.Communication.ShortCodes.Tests
             var client = CreateClient();
             var response = await client.DeleteUSProgramBriefAsync(programBriefId);
 
-            Assert.AreEqual(204, response.Status);
+            ClassicAssert.AreEqual(204, response.Status);
         }
 
         [Test]
@@ -81,7 +82,7 @@ namespace Azure.Communication.ShortCodes.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                ClassicAssert.AreEqual(404, ex.Status);
                 return;
             }
 
@@ -95,7 +96,7 @@ namespace Azure.Communication.ShortCodes.Tests
             var pageable = client.GetUSProgramBriefsAsync();
             var programBriefs = await pageable.ToEnumerableAsync();
 
-            Assert.NotNull(programBriefs);
+            ClassicAssert.NotNull(programBriefs);
         }
 
         [Test]
@@ -110,7 +111,7 @@ namespace Azure.Communication.ShortCodes.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                ClassicAssert.AreEqual(404, ex.Status);
                 return;
             }
 

--- a/sdk/communication/Azure.Communication.Sms/tests/OptOutsClientTest.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/OptOutsClientTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -10,6 +10,7 @@ using Azure.Communication.Sms.Models;
 using Azure.Core.Pipeline;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Sms.Tests
 {
@@ -21,7 +22,7 @@ namespace Azure.Communication.Sms.Tests
             var httpPipeline = HttpPipelineBuilder.Build(new SmsClientOptions());
             var uri = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new OptOutsClient(null, httpPipeline, uri));
+            ClassicAssert.Throws<ArgumentNullException>(() => new OptOutsClient(null, httpPipeline, uri));
         }
 
         [Test]
@@ -30,7 +31,7 @@ namespace Azure.Communication.Sms.Tests
             var clientDiagnostics = new ClientDiagnostics(new SmsClientOptions());
             var uri = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new OptOutsClient(clientDiagnostics, null, uri));
+            ClassicAssert.Throws<ArgumentNullException>(() => new OptOutsClient(clientDiagnostics, null, uri));
         }
 
         [Test]
@@ -39,7 +40,7 @@ namespace Azure.Communication.Sms.Tests
             var clientDiagnostics = new ClientDiagnostics(new SmsClientOptions());
             var httpPipeline = HttpPipelineBuilder.Build(new SmsClientOptions());
 
-            Assert.Throws<ArgumentNullException>(() => new OptOutsClient(clientDiagnostics, httpPipeline, null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new OptOutsClient(clientDiagnostics, httpPipeline, null));
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -54,16 +55,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .ReturnsAsync((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    ClassicAssert.AreEqual(expectedFrom, from);
+                    ClassicAssert.AreEqual(expectedTo, to);
+                    ClassicAssert.AreEqual(cancellationToken, token);
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutResponseItem>> actualResponse = await mockClient.Object.CheckAsync(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            ClassicAssert.AreEqual(expectedResponse, actualResponse);
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -78,16 +79,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .Returns((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    ClassicAssert.AreEqual(expectedFrom, from);
+                    ClassicAssert.AreEqual(expectedTo, to);
+                    ClassicAssert.AreEqual(cancellationToken, token);
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutResponseItem>> actualResponse = mockClient.Object.Check(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            ClassicAssert.AreEqual(expectedResponse, actualResponse);
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -102,16 +103,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .ReturnsAsync((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    ClassicAssert.AreEqual(expectedFrom, from);
+                    ClassicAssert.AreEqual(expectedTo, to);
+                    ClassicAssert.AreEqual(cancellationToken, token);
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutAddResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutAddResponseItem>> actualResponse = await mockClient.Object.AddAsync(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            ClassicAssert.AreEqual(expectedResponse, actualResponse);
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -126,16 +127,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .Returns((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    ClassicAssert.AreEqual(expectedFrom, from);
+                    ClassicAssert.AreEqual(expectedTo, to);
+                    ClassicAssert.AreEqual(cancellationToken, token);
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutAddResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutAddResponseItem>> actualResponse = mockClient.Object.Add(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            ClassicAssert.AreEqual(expectedResponse, actualResponse);
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -150,16 +151,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .ReturnsAsync((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    ClassicAssert.AreEqual(expectedFrom, from);
+                    ClassicAssert.AreEqual(expectedTo, to);
+                    ClassicAssert.AreEqual(cancellationToken, token);
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutRemoveResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutRemoveResponseItem>> actualResponse = await mockClient.Object.RemoveAsync(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            ClassicAssert.AreEqual(expectedResponse, actualResponse);
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -174,16 +175,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .Returns((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    ClassicAssert.AreEqual(expectedFrom, from);
+                    ClassicAssert.AreEqual(expectedTo, to);
+                    ClassicAssert.AreEqual(cancellationToken, token);
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutRemoveResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutRemoveResponseItem>> actualResponse = mockClient.Object.Remove(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            ClassicAssert.AreEqual(expectedResponse, actualResponse);
         }
 
         private static IEnumerable<object> TestData()

--- a/sdk/communication/Azure.Communication.Sms/tests/OptOutsRestClientTests.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/OptOutsRestClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Azure.Communication.Sms.Models;
 using Azure.Core.Pipeline;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Sms.Tests
 {
@@ -18,7 +19,7 @@ namespace Azure.Communication.Sms.Tests
             var httpPipeline = HttpPipelineBuilder.Build(new SmsClientOptions());
             var uri = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new OptOutsRestClient(null, httpPipeline, uri));
+            ClassicAssert.Throws<ArgumentNullException>(() => new OptOutsRestClient(null, httpPipeline, uri));
         }
 
         [Test]
@@ -27,7 +28,7 @@ namespace Azure.Communication.Sms.Tests
             var clientDiagnostics = new ClientDiagnostics(new SmsClientOptions());
             var endpoint = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new OptOutsRestClient(clientDiagnostics, null, endpoint));
+            ClassicAssert.Throws<ArgumentNullException>(() => new OptOutsRestClient(clientDiagnostics, null, endpoint));
         }
 
         [Test]
@@ -36,7 +37,7 @@ namespace Azure.Communication.Sms.Tests
             var clientDiagnostics = new ClientDiagnostics(new SmsClientOptions());
             var httpPipeline = HttpPipelineBuilder.Build(new SmsClientOptions());
 
-            Assert.Throws<ArgumentNullException>(() => new OptOutsRestClient(clientDiagnostics, httpPipeline, null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new OptOutsRestClient(clientDiagnostics, httpPipeline, null));
         }
 
         [Test]
@@ -47,7 +48,7 @@ namespace Azure.Communication.Sms.Tests
             var httpPipeline = HttpPipelineBuilder.Build(clientOptions);
             var uri = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new OptOutsRestClient(clientDiagnostics, httpPipeline, uri, null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new OptOutsRestClient(clientDiagnostics, httpPipeline, uri, null));
         }
 
         [Test]
@@ -63,7 +64,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
         }
@@ -81,7 +82,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                ClassicAssert.AreEqual("recipients", ex.ParamName);
                 return;
             }
         }
@@ -99,7 +100,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
         }
@@ -117,7 +118,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                ClassicAssert.AreEqual("recipients", ex.ParamName);
                 return;
             }
         }
@@ -135,7 +136,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
         }
@@ -153,7 +154,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                ClassicAssert.AreEqual("recipients", ex.ParamName);
                 return;
             }
         }
@@ -171,7 +172,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
         }
@@ -189,7 +190,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                ClassicAssert.AreEqual("recipients", ex.ParamName);
                 return;
             }
         }
@@ -207,7 +208,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
         }
@@ -225,7 +226,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                ClassicAssert.AreEqual("recipients", ex.ParamName);
                 return;
             }
         }
@@ -243,7 +244,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
         }
@@ -261,7 +262,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                ClassicAssert.AreEqual("recipients", ex.ParamName);
                 return;
             }
         }

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #region Snippet:Azure_Communication_Sms_Tests_UsingStatements
@@ -10,6 +10,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using Azure.Communication.Sms.Models;
 
 namespace Azure.Communication.Sms.Tests
@@ -86,8 +87,8 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsNotEmpty(ex.Message);
-                Assert.True(ex.Message.Contains("401")); // Unauthorized
+                ClassicAssert.IsNotEmpty(ex.Message);
+                ClassicAssert.True(ex.Message.Contains("401")); // Unauthorized
                 Console.WriteLine(ex.Message);
             }
             catch (Exception ex)
@@ -150,7 +151,7 @@ namespace Azure.Communication.Sms.Tests
                 SmsSendResult firstMessageResult = firstMessageResponse.Value;
                 SmsSendResult secondMessageResult = secondMessageResponse.Value;
 
-                Assert.AreNotEqual(firstMessageResult.MessageId, secondMessageResult.MessageId);
+                ClassicAssert.AreNotEqual(firstMessageResult.MessageId, secondMessageResult.MessageId);
                 AssertSmsSendingHappyPath(firstMessageResult);
                 AssertSmsSendingHappyPath(secondMessageResult);
             }
@@ -178,7 +179,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
             Assert.Fail("SendAsync should have thrown an exception.");
@@ -201,7 +202,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.ApiKey).ToLower(), ex.ParamName?.ToLower());
+                ClassicAssert.AreEqual(nameof(MessagingConnectOptions.ApiKey).ToLower(), ex.ParamName?.ToLower());
                 return;
             }
             Assert.Fail("SendAsync should have thrown an exception.");
@@ -224,7 +225,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.Partner).ToLower(), ex.ParamName?.ToLower());
+                ClassicAssert.AreEqual(nameof(MessagingConnectOptions.Partner).ToLower(), ex.ParamName?.ToLower());
                 return;
             }
             Assert.Fail("SendAsync should have thrown an exception.");
@@ -244,7 +245,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                ClassicAssert.AreEqual("to", ex.ParamName);
                 return;
             }
             Assert.Fail("SendAsync should have thrown an exception.");
@@ -263,7 +264,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
             Assert.Fail("CheckAsync should have thrown an exception.");
@@ -282,7 +283,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                ClassicAssert.AreEqual("to", ex.ParamName);
                 return;
             }
             Assert.Fail("CheckAsync should have thrown an exception.");
@@ -308,7 +309,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                ClassicAssert.AreEqual("to", ex.ParamName);
                 return;
             }
             Assert.Fail("CheckAsync should have thrown an exception.");
@@ -348,7 +349,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
             Assert.Fail("AddAsync should have thrown an exception.");
@@ -367,7 +368,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                ClassicAssert.AreEqual("to", ex.ParamName);
                 return;
             }
             Assert.Fail("AddAsync should have thrown an exception.");
@@ -393,7 +394,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                ClassicAssert.AreEqual("to", ex.ParamName);
                 return;
             }
             Assert.Fail("AddAsync should have thrown an exception.");
@@ -433,7 +434,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
             Assert.Fail("RemoveAsync should have thrown an exception.");
@@ -452,7 +453,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                ClassicAssert.AreEqual("to", ex.ParamName);
                 return;
             }
             Assert.Fail("RemoveAsync should have thrown an exception.");
@@ -478,7 +479,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                ClassicAssert.AreEqual("to", ex.ParamName);
                 return;
             }
             Assert.Fail("RemoveAsync should have thrown an exception.");
@@ -521,7 +522,7 @@ namespace Azure.Communication.Sms.Tests
                   from: TestEnvironment.FromPhoneNumber,
                   to: to);
 
-                Assert.IsTrue(checkResult.Value[0].IsOptedOut);
+                ClassicAssert.IsTrue(checkResult.Value[0].IsOptedOut);
             }
             catch (Exception ex)
             {
@@ -551,7 +552,7 @@ namespace Azure.Communication.Sms.Tests
                     from: TestEnvironment.FromPhoneNumber,
                     to: to);
 
-                Assert.IsFalse(checkResult.Value[0].IsOptedOut);
+                ClassicAssert.IsFalse(checkResult.Value[0].IsOptedOut);
             }
             catch (Exception ex)
             {
@@ -577,8 +578,8 @@ namespace Azure.Communication.Sms.Tests
                   from: TestEnvironment.FromPhoneNumber,
                   to: to);
 
-                Assert.IsTrue(checkResult.Value[0].IsOptedOut);
-                Assert.IsTrue(checkResult.Value[1].IsOptedOut);
+                ClassicAssert.IsTrue(checkResult.Value[0].IsOptedOut);
+                ClassicAssert.IsTrue(checkResult.Value[1].IsOptedOut);
             }
             catch (Exception ex)
             {
@@ -608,7 +609,7 @@ namespace Azure.Communication.Sms.Tests
                     from: TestEnvironment.FromPhoneNumber,
                     to: to);
 
-                Assert.IsFalse(checkResult.Value[0].IsOptedOut);
+                ClassicAssert.IsFalse(checkResult.Value[0].IsOptedOut);
             }
             catch (Exception ex)
             {
@@ -620,9 +621,9 @@ namespace Azure.Communication.Sms.Tests
 
         private void AssertSmsSendingHappyPath(SmsSendResult sendResult)
         {
-            Assert.True(sendResult.Successful);
-            Assert.AreEqual(202, sendResult.HttpStatusCode);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(sendResult.MessageId));
+            ClassicAssert.True(sendResult.Successful);
+            ClassicAssert.AreEqual(202, sendResult.HttpStatusCode);
+            ClassicAssert.IsFalse(string.IsNullOrWhiteSpace(sendResult.MessageId));
         }
 
         private void AssertSmsSendingRawResponseHappyPath(Stream contentStream)
@@ -632,7 +633,7 @@ namespace Azure.Communication.Sms.Tests
                 StreamReader streamReader = new StreamReader(contentStream);
                 streamReader.BaseStream.Seek(0, SeekOrigin.Begin);
                 string rawResponse = streamReader.ReadToEnd();
-                Assert.True(rawResponse.Contains("\"repeatabilityResult\":\"accepted\""));
+                ClassicAssert.True(rawResponse.Contains("\"repeatabilityResult\":\"accepted\""));
                 return;
             }
             Assert.Fail("Response content stream is empty.");

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsClientTest.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsClientTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -11,6 +11,7 @@ using Azure.Core;
 using Azure.Core.TestFramework;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Sms.Tests
 {
@@ -24,7 +25,7 @@ namespace Azure.Communication.Sms.Tests
             AzureKeyCredential? nullCredential = null;
             Uri uri = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new SmsClient(uri, nullCredential));
+            ClassicAssert.Throws<ArgumentNullException>(() => new SmsClient(uri, nullCredential));
         }
 
         [Test]
@@ -32,7 +33,7 @@ namespace Azure.Communication.Sms.Tests
         {
             AzureKeyCredential mockCredential = new AzureKeyCredential("mockKey");
 
-            Assert.Throws<ArgumentNullException>(() => new SmsClient(null, mockCredential));
+            ClassicAssert.Throws<ArgumentNullException>(() => new SmsClient(null, mockCredential));
         }
 
         [Test]
@@ -41,7 +42,7 @@ namespace Azure.Communication.Sms.Tests
             AzureKeyCredential mockCredential = new AzureKeyCredential("mockKey");
             Uri uri = new Uri("http://localhost");
 
-            Assert.DoesNotThrow(() => new SmsClient(uri, mockCredential));
+            ClassicAssert.DoesNotThrow(() => new SmsClient(uri, mockCredential));
         }
 
         [Test]
@@ -50,14 +51,14 @@ namespace Azure.Communication.Sms.Tests
             TokenCredential mockCredential = new MockCredential();
             Uri endpoint = new Uri("http://localhost");
 
-            Assert.DoesNotThrow(() => new SmsClient(endpoint, mockCredential, null));
+            ClassicAssert.DoesNotThrow(() => new SmsClient(endpoint, mockCredential, null));
         }
 
         [Test]
         public void SmsClient_ThrowsWithNullOrEmptyConnectionString()
         {
-            Assert.Throws<ArgumentException>(() => new SmsClient(string.Empty));
-            Assert.Throws<ArgumentNullException>(() => new SmsClient(null));
+            ClassicAssert.Throws<ArgumentException>(() => new SmsClient(string.Empty));
+            ClassicAssert.Throws<ArgumentNullException>(() => new SmsClient(null));
         }
 
         [Test]
@@ -65,7 +66,7 @@ namespace Azure.Communication.Sms.Tests
         {
             var invalidServiceVersion = (SmsClientOptions.ServiceVersion)99;
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => new SmsClientOptions(invalidServiceVersion));
+            ClassicAssert.Throws<ArgumentOutOfRangeException>(() => new SmsClientOptions(invalidServiceVersion));
         }
 
         [Test]
@@ -73,7 +74,7 @@ namespace Azure.Communication.Sms.Tests
         {
             var smsClient = new SmsClient(TestConnectionString);
 
-            Assert.NotNull(smsClient.OptOuts);
+            ClassicAssert.NotNull(smsClient.OptOuts);
         }
 
         [Test]
@@ -81,7 +82,7 @@ namespace Azure.Communication.Sms.Tests
         {
             var smsClient = new SmsClient(TestConnectionString, new SmsClientOptions(SmsClientOptions.ServiceVersion.V2021_03_07));
 
-            Assert.NotNull(smsClient.OptOuts);
+            ClassicAssert.NotNull(smsClient.OptOuts);
         }
 
         [Test]
@@ -91,7 +92,7 @@ namespace Azure.Communication.Sms.Tests
             Uri endpoint = new Uri("http://localhost");
             var smsClient = new SmsClient(endpoint, mockCredential, new SmsClientOptions(SmsClientOptions.ServiceVersion.V2021_03_07));
 
-            Assert.NotNull(smsClient.OptOuts);
+            ClassicAssert.NotNull(smsClient.OptOuts);
         }
 
         [Test]
@@ -101,7 +102,7 @@ namespace Azure.Communication.Sms.Tests
             Uri endpoint = new Uri("http://localhost");
             var smsClient = new SmsClient(endpoint, mockCredential, new SmsClientOptions(SmsClientOptions.ServiceVersion.V2021_03_07));
 
-            Assert.NotNull(smsClient.OptOuts);
+            ClassicAssert.NotNull(smsClient.OptOuts);
         }
 
         [TestCaseSource(nameof(TestDataForSingleSms))]
@@ -116,18 +117,18 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .ReturnsAsync((string from, string to, string message, SmsSendOptions options, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(expectedMessage, message);
-                    Assert.AreEqual(cancellationToken, token);
-                    Assert.AreEqual(expectedOptions, options);
+                    ClassicAssert.AreEqual(expectedFrom, from);
+                    ClassicAssert.AreEqual(expectedTo, to);
+                    ClassicAssert.AreEqual(expectedMessage, message);
+                    ClassicAssert.AreEqual(cancellationToken, token);
+                    ClassicAssert.AreEqual(expectedOptions, options);
                     return expectedResponse = new Mock<Response<SmsSendResult>>().Object;
                 });
 
             Response<SmsSendResult> actualResponse = await mockClient.Object.SendAsync(expectedFrom, expectedTo, expectedMessage, expectedOptions, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            ClassicAssert.AreEqual(expectedResponse, actualResponse);
         }
 
         [TestCaseSource(nameof(TestDataForSingleSms))]
@@ -142,18 +143,18 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .Returns((string from, string to, string message, SmsSendOptions options, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(expectedMessage, message);
-                    Assert.AreEqual(cancellationToken, token);
-                    Assert.AreEqual(expectedOptions, options);
+                    ClassicAssert.AreEqual(expectedFrom, from);
+                    ClassicAssert.AreEqual(expectedTo, to);
+                    ClassicAssert.AreEqual(expectedMessage, message);
+                    ClassicAssert.AreEqual(cancellationToken, token);
+                    ClassicAssert.AreEqual(expectedOptions, options);
                     return expectedResponse = new Mock<Response<SmsSendResult>>().Object;
                 });
 
             Response<SmsSendResult> actualResponse = mockClient.Object.Send(expectedFrom, expectedTo, expectedMessage, expectedOptions, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            ClassicAssert.AreEqual(expectedResponse, actualResponse);
         }
 
         private static IEnumerable<object?[]> TestDataForSingleSms()

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsRestClientTest.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsRestClientTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Azure.Communication.Sms.Models;
 using Azure.Core.Pipeline;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication.Sms.Tests
 {
@@ -18,7 +19,7 @@ namespace Azure.Communication.Sms.Tests
             var httpPipeline = HttpPipelineBuilder.Build(new SmsClientOptions());
             var uri = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new SmsRestClient(null, httpPipeline, uri));
+            ClassicAssert.Throws<ArgumentNullException>(() => new SmsRestClient(null, httpPipeline, uri));
         }
 
         [Test]
@@ -27,7 +28,7 @@ namespace Azure.Communication.Sms.Tests
             var clientDiagnostics = new ClientDiagnostics(new SmsClientOptions());
             var endpoint = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new SmsRestClient(clientDiagnostics, null, endpoint));
+            ClassicAssert.Throws<ArgumentNullException>(() => new SmsRestClient(clientDiagnostics, null, endpoint));
         }
 
         [Test]
@@ -36,7 +37,7 @@ namespace Azure.Communication.Sms.Tests
             var clientDiagnostics = new ClientDiagnostics(new SmsClientOptions());
             var httpPipeline = HttpPipelineBuilder.Build(new SmsClientOptions());
 
-            Assert.Throws<ArgumentNullException>(() => new SmsRestClient(clientDiagnostics, httpPipeline, null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new SmsRestClient(clientDiagnostics, httpPipeline, null));
         }
 
         [Test]
@@ -47,7 +48,7 @@ namespace Azure.Communication.Sms.Tests
             var httpPipeline = HttpPipelineBuilder.Build(clientOptions);
             var uri = new Uri("http://localhost");
 
-            Assert.Throws<ArgumentNullException>(() => new SmsRestClient(clientDiagnostics, httpPipeline, uri, null));
+            ClassicAssert.Throws<ArgumentNullException>(() => new SmsRestClient(clientDiagnostics, httpPipeline, uri, null));
         }
 
         [Test]
@@ -64,7 +65,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
         }
@@ -83,7 +84,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("smsRecipients", ex.ParamName);
+                ClassicAssert.AreEqual("smsRecipients", ex.ParamName);
                 return;
             }
         }
@@ -102,7 +103,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("message", ex.ParamName);
+                ClassicAssert.AreEqual("message", ex.ParamName);
                 return;
             }
         }
@@ -125,7 +126,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.Partner).ToLower(), ex.ParamName?.ToLower());
+                ClassicAssert.AreEqual(nameof(MessagingConnectOptions.Partner).ToLower(), ex.ParamName?.ToLower());
                 return;
             }
         }
@@ -148,7 +149,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.ApiKey).ToLower(), ex.ParamName?.ToLower());
+                ClassicAssert.AreEqual(nameof(MessagingConnectOptions.ApiKey).ToLower(), ex.ParamName?.ToLower());
                 return;
             }
         }
@@ -167,7 +168,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                ClassicAssert.AreEqual("from", ex.ParamName);
                 return;
             }
         }
@@ -186,7 +187,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("smsRecipients", ex.ParamName);
+                ClassicAssert.AreEqual("smsRecipients", ex.ParamName);
                 return;
             }
         }
@@ -205,7 +206,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("message", ex.ParamName);
+                ClassicAssert.AreEqual("message", ex.ParamName);
                 return;
             }
         }
@@ -228,7 +229,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.ApiKey).ToLower(), ex.ParamName?.ToLower());
+                ClassicAssert.AreEqual(nameof(MessagingConnectOptions.ApiKey).ToLower(), ex.ParamName?.ToLower());
                 return;
             }
         }
@@ -251,7 +252,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.Partner).ToLower(), ex.ParamName?.ToLower());
+                ClassicAssert.AreEqual(nameof(MessagingConnectOptions.Partner).ToLower(), ex.ParamName?.ToLower());
                 return;
             }
         }

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/CommunicationServiceTests.cs
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/CommunicationServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -11,6 +11,7 @@ using Azure.ResourceManager.Communication.Models;
 using Azure.ResourceManager.Models;
 using Azure.ResourceManager.Resources;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.ResourceManager.Communication.Tests
 {
@@ -74,8 +75,8 @@ namespace Azure.ResourceManager.Communication.Tests
             await communication.AddTagAsync("testkey", "testvalue");
             communication = await collection.GetAsync(communicationServiceName);
             var tagValue = communication.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            ClassicAssert.AreEqual(tagValue.Key, "testkey");
+            ClassicAssert.AreEqual(tagValue.Value, "testvalue");
         }
 
         [TestCase(null)]
@@ -90,12 +91,12 @@ namespace Azure.ResourceManager.Communication.Tests
             await communication.AddTagAsync("testkey", "testvalue");
             communication = await collection.GetAsync(communicationServiceName);
             var tagValue = communication.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            ClassicAssert.AreEqual(tagValue.Key, "testkey");
+            ClassicAssert.AreEqual(tagValue.Value, "testvalue");
             await communication.RemoveTagAsync("testkey");
             communication = await collection.GetAsync(communicationServiceName);
             var tag = communication.Data.Tags;
-            Assert.IsTrue(tag.Count == 0);
+            ClassicAssert.IsTrue(tag.Count == 0);
         }
 
         [TestCase(null)]
@@ -110,15 +111,15 @@ namespace Azure.ResourceManager.Communication.Tests
             await communication.AddTagAsync("testkey", "testvalue");
             communication = await collection.GetAsync(communicationServiceName);
             var tagValue = communication.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            ClassicAssert.AreEqual(tagValue.Key, "testkey");
+            ClassicAssert.AreEqual(tagValue.Value, "testvalue");
             var tag = new Dictionary<string, string>() { { "newtestkey", "newtestvalue" } };
             await communication.SetTagsAsync(tag);
             communication = await collection.GetAsync(communicationServiceName);
             tagValue = communication.Data.Tags.FirstOrDefault();
-            Assert.IsTrue(communication.Data.Tags.Count == 1);
-            Assert.AreEqual(tagValue.Key, "newtestkey");
-            Assert.AreEqual(tagValue.Value, "newtestvalue");
+            ClassicAssert.IsTrue(communication.Data.Tags.Count == 1);
+            ClassicAssert.AreEqual(tagValue.Key, "newtestkey");
+            ClassicAssert.AreEqual(tagValue.Value, "newtestvalue");
         }
 
         [Test]
@@ -135,7 +136,7 @@ namespace Azure.ResourceManager.Communication.Tests
             string communicationServiceName = Recording.GenerateAssetName("communication-service-");
             var communicationServiceLro = await _resourceGroup.GetCommunicationServiceResources().CreateOrUpdateAsync(WaitUntil.Completed, communicationServiceName, data);
             var resource = communicationServiceLro.Value;
-            Assert.AreEqual(resource.Data.Identity.ManagedServiceIdentityType, ManagedServiceIdentityType.SystemAssignedUserAssigned);
+            ClassicAssert.AreEqual(resource.Data.Identity.ManagedServiceIdentityType, ManagedServiceIdentityType.SystemAssignedUserAssigned);
         }
 
         [Test]
@@ -145,10 +146,10 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetCommunicationServiceResources();
             var communication = await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             var keys = await communication.GetKeysAsync();
-            Assert.NotNull(keys.Value.PrimaryKey);
-            Assert.NotNull(keys.Value.SecondaryKey);
-            Assert.NotNull(keys.Value.PrimaryConnectionString);
-            Assert.NotNull(keys.Value.SecondaryConnectionString);
+            ClassicAssert.NotNull(keys.Value.PrimaryKey);
+            ClassicAssert.NotNull(keys.Value.SecondaryKey);
+            ClassicAssert.NotNull(keys.Value.PrimaryConnectionString);
+            ClassicAssert.NotNull(keys.Value.SecondaryConnectionString);
         }
 
         // [Test]
@@ -164,12 +165,12 @@ namespace Azure.ResourceManager.Communication.Tests
             string secondaryConnectionString = keys.Value.SecondaryConnectionString;
             var parameter = new RegenerateCommunicationServiceKeyContent() { KeyType = CommunicationServiceKeyType.Primary };
             var newkeys = await communication.RegenerateKeyAsync(parameter);
-            Assert.AreEqual(primaryKey, newkeys.Value.PrimaryKey);
-            Assert.NotNull(primaryConnectionString, keys.Value.PrimaryConnectionString);
+            ClassicAssert.AreEqual(primaryKey, newkeys.Value.PrimaryKey);
+            ClassicAssert.NotNull(primaryConnectionString, keys.Value.PrimaryConnectionString);
             parameter = new RegenerateCommunicationServiceKeyContent() { KeyType = CommunicationServiceKeyType.Secondary };
             newkeys = await communication.RegenerateKeyAsync(parameter);
-            Assert.NotNull(secondaryKey, keys.Value.SecondaryKey);
-            Assert.NotNull(secondaryConnectionString, keys.Value.SecondaryConnectionString);
+            ClassicAssert.NotNull(secondaryKey, keys.Value.SecondaryKey);
+            ClassicAssert.NotNull(secondaryConnectionString, keys.Value.SecondaryConnectionString);
         }
 
         [Test]
@@ -182,7 +183,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var parameter = new LinkNotificationHubContent(new ResourceIdentifier(((CommunicationManagementTestEnvironment)TestEnvironment).NotificationHubsResourceId),
                 ((CommunicationManagementTestEnvironment)TestEnvironment).NotificationHubsConnectionString);
             var hub = await communication.LinkNotificationHubAsync(parameter);
-            Assert.NotNull(hub.Value.ResourceId);
+            ClassicAssert.NotNull(hub.Value.ResourceId);
         }
 
         [Test]
@@ -192,7 +193,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetCommunicationServiceResources();
             await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             bool exists = await collection.ExistsAsync(communicationServiceName);
-            Assert.IsTrue(exists);
+            ClassicAssert.IsTrue(exists);
         }
 
         [Test]
@@ -200,10 +201,10 @@ namespace Azure.ResourceManager.Communication.Tests
         {
             string communicationServiceName = Recording.GenerateAssetName("communication-service-");
             var communicationService = await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
-            Assert.IsNotNull(communicationService);
-            Assert.AreEqual(communicationServiceName, communicationService.Data.Name);
-            Assert.AreEqual(_location.ToString(), communicationService.Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), communicationService.Data.DataLocation.ToString());
+            ClassicAssert.IsNotNull(communicationService);
+            ClassicAssert.AreEqual(communicationServiceName, communicationService.Data.Name);
+            ClassicAssert.AreEqual(_location.ToString(), communicationService.Data.Location.ToString());
+            ClassicAssert.AreEqual(_dataLocation.ToString(), communicationService.Data.DataLocation.ToString());
         }
 
         [Test]
@@ -216,9 +217,9 @@ namespace Azure.ResourceManager.Communication.Tests
                 Tags = { { "newtag", "newvalue" } }
             };
             var communication2 = (await communication1.UpdateAsync(patch)).Value;
-            Assert.IsNotNull(communication2);
-            Assert.AreEqual("newtag", communication2.Data.Tags.FirstOrDefault().Key);
-            Assert.AreEqual(communication1.Data.Name, communication2.Data.Name);
+            ClassicAssert.IsNotNull(communication2);
+            ClassicAssert.AreEqual("newtag", communication2.Data.Tags.FirstOrDefault().Key);
+            ClassicAssert.AreEqual(communication1.Data.Name, communication2.Data.Name);
         }
 
         [Test]
@@ -229,7 +230,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var communicationService = await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             await communicationService.DeleteAsync(WaitUntil.Completed);
             bool exists = await collection.ExistsAsync(communicationServiceName);
-            Assert.IsFalse(exists);
+            ClassicAssert.IsFalse(exists);
         }
 
         [Test]
@@ -239,10 +240,10 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetCommunicationServiceResources();
             await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             var communicationService = await collection.GetAsync(communicationServiceName);
-            Assert.IsNotNull(communicationService);
-            Assert.AreEqual(communicationServiceName, communicationService.Value.Data.Name);
-            Assert.AreEqual(_location.ToString(), communicationService.Value.Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), communicationService.Value.Data.DataLocation.ToString());
+            ClassicAssert.IsNotNull(communicationService);
+            ClassicAssert.AreEqual(communicationServiceName, communicationService.Value.Data.Name);
+            ClassicAssert.AreEqual(_location.ToString(), communicationService.Value.Data.Location.ToString());
+            ClassicAssert.AreEqual(_dataLocation.ToString(), communicationService.Value.Data.DataLocation.ToString());
         }
 
         [Test]
@@ -251,10 +252,10 @@ namespace Azure.ResourceManager.Communication.Tests
             string communicationServiceName = Recording.GenerateAssetName("communication-service-");
             await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             var list = await _resourceGroup.GetCommunicationServiceResources().GetAllAsync().ToEnumerableAsync();
-            Assert.IsNotEmpty(list);
-            Assert.AreEqual(communicationServiceName, list.FirstOrDefault().Data.Name);
-            Assert.AreEqual(_location.ToString(), list.FirstOrDefault().Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), list.FirstOrDefault().Data.DataLocation.ToString());
+            ClassicAssert.IsNotEmpty(list);
+            ClassicAssert.AreEqual(communicationServiceName, list.FirstOrDefault().Data.Name);
+            ClassicAssert.AreEqual(_location.ToString(), list.FirstOrDefault().Data.Location.ToString());
+            ClassicAssert.AreEqual(_dataLocation.ToString(), list.FirstOrDefault().Data.DataLocation.ToString());
         }
     }
 }

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/DomainTests.cs
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/DomainTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -9,6 +9,7 @@ using Azure.Core.TestFramework;
 using Azure.ResourceManager.Communication.Models;
 using Azure.ResourceManager.Resources;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.ResourceManager.Communication.Tests
 {
@@ -68,8 +69,8 @@ namespace Azure.ResourceManager.Communication.Tests
             await domain.AddTagAsync("testkey", "testvalue");
             domain = await collection.GetAsync(domainName);
             var tagValue = domain.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            ClassicAssert.AreEqual(tagValue.Key, "testkey");
+            ClassicAssert.AreEqual(tagValue.Value, "testvalue");
         }
 
         [TestCase(null)]
@@ -84,12 +85,12 @@ namespace Azure.ResourceManager.Communication.Tests
             await domain.AddTagAsync("testkey", "testvalue");
             domain = await collection.GetAsync(domainName);
             var tagValue = domain.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            ClassicAssert.AreEqual(tagValue.Key, "testkey");
+            ClassicAssert.AreEqual(tagValue.Value, "testvalue");
             await domain.RemoveTagAsync("testkey");
             domain = await collection.GetAsync(domainName);
             var tag = domain.Data.Tags;
-            Assert.IsTrue(tag.Count == 0);
+            ClassicAssert.IsTrue(tag.Count == 0);
         }
 
         [TestCase(null)]
@@ -104,15 +105,15 @@ namespace Azure.ResourceManager.Communication.Tests
             await domain.AddTagAsync("testkey", "testvalue");
             domain = await collection.GetAsync(domainName);
             var tagValue = domain.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            ClassicAssert.AreEqual(tagValue.Key, "testkey");
+            ClassicAssert.AreEqual(tagValue.Value, "testvalue");
             var tag = new Dictionary<string, string>() { { "newtestkey", "newtestvalue" } };
             await domain.SetTagsAsync(tag);
             domain = await collection.GetAsync(domainName);
             tagValue = domain.Data.Tags.FirstOrDefault();
-            Assert.IsTrue(domain.Data.Tags.Count == 1);
-            Assert.AreEqual(tagValue.Key, "newtestkey");
-            Assert.AreEqual(tagValue.Value, "newtestvalue");
+            ClassicAssert.IsTrue(domain.Data.Tags.Count == 1);
+            ClassicAssert.AreEqual(tagValue.Key, "newtestkey");
+            ClassicAssert.AreEqual(tagValue.Value, "newtestvalue");
         }
 
         [Test]
@@ -122,7 +123,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _emailService.GetCommunicationDomainResources();
             await CreateDefaultDomain(domainName, _emailService);
             bool exists = await collection.ExistsAsync(domainName);
-            Assert.IsTrue(exists);
+            ClassicAssert.IsTrue(exists);
         }
 
         [Test]
@@ -130,10 +131,10 @@ namespace Azure.ResourceManager.Communication.Tests
         {
             string domainName = Recording.GenerateAssetName("domain-") + ".com";
             var domain = await CreateDefaultDomain(domainName, _emailService);
-            Assert.IsNotNull(domain);
-            Assert.AreEqual(domainName, domain.Data.Name);
-            Assert.AreEqual(_location.ToString().ToLower(), domain.Data.Location.ToString().ToLower());
-            Assert.AreEqual(_dataLocation.ToString().ToLower(), domain.Data.DataLocation.ToString().ToLower());
+            ClassicAssert.IsNotNull(domain);
+            ClassicAssert.AreEqual(domainName, domain.Data.Name);
+            ClassicAssert.AreEqual(_location.ToString().ToLower(), domain.Data.Location.ToString().ToLower());
+            ClassicAssert.AreEqual(_dataLocation.ToString().ToLower(), domain.Data.DataLocation.ToString().ToLower());
         }
 
         [Test]
@@ -146,8 +147,8 @@ namespace Azure.ResourceManager.Communication.Tests
                 UserEngagementTracking = UserEngagementTracking.Enabled
             };
             var domain2 = (await domain1.UpdateAsync(WaitUntil.Completed, patch)).Value;
-            Assert.IsNotNull(domain2);
-            Assert.AreEqual(domain1.Data.Name, domain2.Data.Name);
+            ClassicAssert.IsNotNull(domain2);
+            ClassicAssert.AreEqual(domain1.Data.Name, domain2.Data.Name);
         }
 
         [Test]
@@ -158,7 +159,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var domain = await CreateDefaultDomain(domainName, _emailService);
             await domain.DeleteAsync(WaitUntil.Completed);
             bool exists = await collection.ExistsAsync(domainName);
-            Assert.IsFalse(exists);
+            ClassicAssert.IsFalse(exists);
         }
 
         [Test]
@@ -168,10 +169,10 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _emailService.GetCommunicationDomainResources();
             await CreateDefaultDomain(domainName, _emailService);
             var domain = await collection.GetAsync(domainName);
-            Assert.IsNotNull(domain);
-            Assert.AreEqual(domainName, domain.Value.Data.Name);
-            Assert.AreEqual(_location.ToString().ToLower(), domain.Value.Data.Location.ToString().ToLower());
-            Assert.AreEqual(_dataLocation.ToString().ToLower(), domain.Value.Data.DataLocation.ToString().ToLower());
+            ClassicAssert.IsNotNull(domain);
+            ClassicAssert.AreEqual(domainName, domain.Value.Data.Name);
+            ClassicAssert.AreEqual(_location.ToString().ToLower(), domain.Value.Data.Location.ToString().ToLower());
+            ClassicAssert.AreEqual(_dataLocation.ToString().ToLower(), domain.Value.Data.DataLocation.ToString().ToLower());
         }
 
         [Test]
@@ -180,10 +181,10 @@ namespace Azure.ResourceManager.Communication.Tests
             string domainName = Recording.GenerateAssetName("domain-") + ".com";
             await CreateDefaultDomain(domainName, _emailService);
             var list = await _emailService.GetCommunicationDomainResources().GetAllAsync().ToEnumerableAsync();
-            Assert.IsNotEmpty(list);
-            Assert.AreEqual(domainName, list.FirstOrDefault().Data.Name);
-            Assert.AreEqual(_location.ToString().ToLower(), list.FirstOrDefault().Data.Location.ToString().ToLower());
-            Assert.AreEqual(_dataLocation.ToString().ToLower(), list.FirstOrDefault().Data.DataLocation.ToString().ToLower());
+            ClassicAssert.IsNotEmpty(list);
+            ClassicAssert.AreEqual(domainName, list.FirstOrDefault().Data.Name);
+            ClassicAssert.AreEqual(_location.ToString().ToLower(), list.FirstOrDefault().Data.Location.ToString().ToLower());
+            ClassicAssert.AreEqual(_dataLocation.ToString().ToLower(), list.FirstOrDefault().Data.DataLocation.ToString().ToLower());
         }
 
         [Test]

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/EmailServiceTests.cs
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/EmailServiceTests.cs
@@ -9,6 +9,7 @@ using Azure.Core.TestFramework;
 using Azure.ResourceManager.Communication.Models;
 using Azure.ResourceManager.Resources;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.ResourceManager.Communication.Tests
 {
@@ -68,8 +69,8 @@ namespace Azure.ResourceManager.Communication.Tests
             await email.AddTagAsync("testkey", "testvalue");
             email = await collection.GetAsync(emailServiceName);
             var tagValue = email.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            ClassicAssert.AreEqual(tagValue.Key, "testkey");
+            ClassicAssert.AreEqual(tagValue.Value, "testvalue");
         }
 
         [TestCase(null)]
@@ -84,12 +85,12 @@ namespace Azure.ResourceManager.Communication.Tests
             await email.AddTagAsync("testkey", "testvalue");
             email = await collection.GetAsync(emailServiceName);
             var tagValue = email.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            ClassicAssert.AreEqual(tagValue.Key, "testkey");
+            ClassicAssert.AreEqual(tagValue.Value, "testvalue");
             await email.RemoveTagAsync("testkey");
             email = await collection.GetAsync(emailServiceName);
             var tag = email.Data.Tags;
-            Assert.IsTrue(tag.Count == 0);
+            ClassicAssert.IsTrue(tag.Count == 0);
         }
 
         [TestCase(null)]
@@ -104,15 +105,15 @@ namespace Azure.ResourceManager.Communication.Tests
             await email.AddTagAsync("testkey", "testvalue");
             email = await collection.GetAsync(emailServiceName);
             var tagValue = email.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            ClassicAssert.AreEqual(tagValue.Key, "testkey");
+            ClassicAssert.AreEqual(tagValue.Value, "testvalue");
             var tag = new Dictionary<string, string>() { { "newtestkey", "newtestvalue" } };
             await email.SetTagsAsync(tag);
             email = await collection.GetAsync(emailServiceName);
             tagValue = email.Data.Tags.FirstOrDefault();
-            Assert.IsTrue(email.Data.Tags.Count == 1);
-            Assert.AreEqual(tagValue.Key, "newtestkey");
-            Assert.AreEqual(tagValue.Value, "newtestvalue");
+            ClassicAssert.IsTrue(email.Data.Tags.Count == 1);
+            ClassicAssert.AreEqual(tagValue.Key, "newtestkey");
+            ClassicAssert.AreEqual(tagValue.Value, "newtestvalue");
         }
 
         [Test]
@@ -122,7 +123,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetEmailServiceResources();
             await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             bool exists = await collection.ExistsAsync(emailServiceName);
-            Assert.IsTrue(exists);
+            ClassicAssert.IsTrue(exists);
         }
 
         [Test]
@@ -130,10 +131,10 @@ namespace Azure.ResourceManager.Communication.Tests
         {
             string emailServiceName = Recording.GenerateAssetName("email-service-");
             var emailService = await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
-            Assert.IsNotNull(emailService);
-            Assert.AreEqual(emailServiceName, emailService.Data.Name);
-            Assert.AreEqual(_location.ToString(), emailService.Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), emailService.Data.DataLocation.ToString());
+            ClassicAssert.IsNotNull(emailService);
+            ClassicAssert.AreEqual(emailServiceName, emailService.Data.Name);
+            ClassicAssert.AreEqual(_location.ToString(), emailService.Data.Location.ToString());
+            ClassicAssert.AreEqual(_dataLocation.ToString(), emailService.Data.DataLocation.ToString());
         }
 
         [Test]
@@ -143,8 +144,8 @@ namespace Azure.ResourceManager.Communication.Tests
             var emailService1 = await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             var patch = new EmailServiceResourcePatch();
             var emailService2 = (await emailService1.UpdateAsync(WaitUntil.Completed, patch)).Value;
-            Assert.IsNotNull(emailService2);
-            Assert.AreEqual(emailService1.Data.Name, emailService2.Data.Name);
+            ClassicAssert.IsNotNull(emailService2);
+            ClassicAssert.AreEqual(emailService1.Data.Name, emailService2.Data.Name);
         }
 
         [Test]
@@ -155,7 +156,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var emailService = await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             await emailService.DeleteAsync(WaitUntil.Completed);
             bool exists = await collection.ExistsAsync(emailServiceName);
-            Assert.IsFalse(exists);
+            ClassicAssert.IsFalse(exists);
         }
 
         [Test]
@@ -165,10 +166,10 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetEmailServiceResources();
             await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             var emailService = await collection.GetAsync(emailServiceName);
-            Assert.IsNotNull(emailService);
-            Assert.AreEqual(emailServiceName, emailService.Value.Data.Name);
-            Assert.AreEqual(_location.ToString(), emailService.Value.Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), emailService.Value.Data.DataLocation.ToString());
+            ClassicAssert.IsNotNull(emailService);
+            ClassicAssert.AreEqual(emailServiceName, emailService.Value.Data.Name);
+            ClassicAssert.AreEqual(_location.ToString(), emailService.Value.Data.Location.ToString());
+            ClassicAssert.AreEqual(_dataLocation.ToString(), emailService.Value.Data.DataLocation.ToString());
         }
 
         [Test]
@@ -177,10 +178,10 @@ namespace Azure.ResourceManager.Communication.Tests
             string emailServiceName = Recording.GenerateAssetName("email-service-");
             await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             var list = await _resourceGroup.GetEmailServiceResources().GetAllAsync().ToEnumerableAsync();
-            Assert.IsNotEmpty(list);
-            Assert.AreEqual(emailServiceName, list.FirstOrDefault().Data.Name);
-            Assert.AreEqual(_location.ToString(), list.FirstOrDefault().Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), list.FirstOrDefault().Data.DataLocation.ToString());
+            ClassicAssert.IsNotEmpty(list);
+            ClassicAssert.AreEqual(emailServiceName, list.FirstOrDefault().Data.Name);
+            ClassicAssert.AreEqual(_location.ToString(), list.FirstOrDefault().Data.Location.ToString());
+            ClassicAssert.AreEqual(_dataLocation.ToString(), list.FirstOrDefault().Data.DataLocation.ToString());
         }
     }
 }

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/SenderUsernameTests.cs
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/SenderUsernameTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -10,6 +10,7 @@ using Azure.Core.TestFramework;
 using Azure.ResourceManager.Communication.Models;
 using Azure.ResourceManager.Resources;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.ResourceManager.Communication.Tests
 {
@@ -77,7 +78,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _domainResource.GetSenderUsernameResources();
             await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
             bool exists = await collection.ExistsAsync(username);
-            Assert.IsTrue(exists);
+            ClassicAssert.IsTrue(exists);
         }
 
         [Test]
@@ -88,9 +89,9 @@ namespace Azure.ResourceManager.Communication.Tests
 
             var senderUsername = await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
 
-            Assert.IsNotNull(senderUsername);
-            Assert.AreEqual(username, senderUsername.Data.Username);
-            Assert.AreEqual(displayName, senderUsername.Data.DisplayName);
+            ClassicAssert.IsNotNull(senderUsername);
+            ClassicAssert.AreEqual(username, senderUsername.Data.Username);
+            ClassicAssert.AreEqual(displayName, senderUsername.Data.DisplayName);
         }
 
         // todo: follow up on update bug. Updating a record with the same name results in 400 error a username already exists.
@@ -111,10 +112,10 @@ namespace Azure.ResourceManager.Communication.Tests
         //    };
         //    var senderUsername2 = (await senderUsername1.UpdateAsync(WaitUntil.Completed, patch)).Value;
 
-        //    Assert.IsNotNull(senderUsername2);
-        //    Assert.AreEqual(senderUsername1.Data.Name, senderUsername2.Data.Name);
-        //    Assert.AreNotEqual(senderUsername1.Data.Username, senderUsername2.Data.Username);
-        //    Assert.AreNotEqual(senderUsername1.Data.DisplayName, senderUsername2.Data.DisplayName);
+        //    ClassicAssert.IsNotNull(senderUsername2);
+        //    ClassicAssert.AreEqual(senderUsername1.Data.Name, senderUsername2.Data.Name);
+        //    ClassicAssert.AreNotEqual(senderUsername1.Data.Username, senderUsername2.Data.Username);
+        //    ClassicAssert.AreNotEqual(senderUsername1.Data.DisplayName, senderUsername2.Data.DisplayName);
         //}
 
         [Test]
@@ -127,7 +128,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var senderUsername = await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
             await senderUsername.DeleteAsync(WaitUntil.Completed);
             bool exists = await collection.ExistsAsync(username);
-            Assert.IsFalse(exists);
+            ClassicAssert.IsFalse(exists);
         }
 
         [Test]
@@ -140,9 +141,9 @@ namespace Azure.ResourceManager.Communication.Tests
             await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
 
             var actualSenderUsername = await collection.GetAsync(username);
-            Assert.IsNotNull(actualSenderUsername);
-            Assert.AreEqual(actualSenderUsername.Value.Data.Username, username);
-            Assert.AreEqual(actualSenderUsername.Value.Data.DisplayName, displayName);
+            ClassicAssert.IsNotNull(actualSenderUsername);
+            ClassicAssert.AreEqual(actualSenderUsername.Value.Data.Username, username);
+            ClassicAssert.AreEqual(actualSenderUsername.Value.Data.DisplayName, displayName);
         }
 
         [Test]
@@ -154,9 +155,9 @@ namespace Azure.ResourceManager.Communication.Tests
             await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
 
             var list = await _domainResource.GetSenderUsernameResources().GetAllAsync().ToEnumerableAsync();
-            Assert.IsNotEmpty(list);
-            Assert.IsTrue(list.Any(s => s.HasData && s.Data.Username == username));
-            Assert.IsTrue(list.Any(s => s.HasData && s.Data.DisplayName == displayName));
+            ClassicAssert.IsNotEmpty(list);
+            ClassicAssert.IsTrue(list.Any(s => s.HasData && s.Data.Username == username));
+            ClassicAssert.IsTrue(list.Any(s => s.HasData && s.Data.DisplayName == displayName));
         }
     }
 }

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/SuppressionListTests.cs
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/SuppressionListTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -12,6 +12,7 @@ using Azure.Core.Tests.TestFramework;
 // using Azure.Core.TestFramework;
 using Azure.ResourceManager.Resources;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.ResourceManager.Communication.Tests
 {
@@ -75,23 +76,23 @@ namespace Azure.ResourceManager.Communication.Tests
     //        var listName = "donotreply";
     //        var suppressionList = await CreateDefaultSuppressionListResource(_domainResource, listName);
 
-    //        Assert.IsNotNull(suppressionList);
-    //        Assert.AreEqual(listName, suppressionList.Data.ListName);
+    //        ClassicAssert.IsNotNull(suppressionList);
+    //        ClassicAssert.AreEqual(listName, suppressionList.Data.ListName);
     //        var collection = _domainResource.GetSuppressionListResources();
 
     //        var exists = await collection.ExistsAsync(suppressionList.Id.Name);
-    //        Assert.IsTrue(exists);
+    //        ClassicAssert.IsTrue(exists);
 
     //        suppressionList = await collection.GetAsync(suppressionList.Data.Name);
 
-    //        Assert.IsNotNull(suppressionList);
-    //        Assert.AreEqual(suppressionList.Data.ListName, listName);
+    //        ClassicAssert.IsNotNull(suppressionList);
+    //        ClassicAssert.AreEqual(suppressionList.Data.ListName, listName);
 
     //        await suppressionList.DeleteAsync(WaitUntil.Completed);
 
     //        collection = _domainResource.GetSuppressionListResources();
     //        exists = await collection.ExistsAsync(suppressionList.Id.Name);
-    //        Assert.IsFalse(exists);
+    //        ClassicAssert.IsFalse(exists);
     //    }
 
     //    [Test]
@@ -115,14 +116,14 @@ namespace Azure.ResourceManager.Communication.Tests
     //        await foreach (var page in collection.GetAllAsync().AsPages())
     //        {
     //            pageCount++;
-    //            Assert.IsTrue(page.Values.Count == listNames.Length);
+    //            ClassicAssert.IsTrue(page.Values.Count == listNames.Length);
     //            foreach (var resource in page.Values)
     //            {
-    //                Assert.IsTrue(resourceNames[resource.Data.Name] == resource.Data.ListName);
+    //                ClassicAssert.IsTrue(resourceNames[resource.Data.Name] == resource.Data.ListName);
     //                listsToDelete.Add(resource);
     //            }
     //        }
-    //        Assert.AreEqual(expectedPageCount, pageCount);
+    //        ClassicAssert.AreEqual(expectedPageCount, pageCount);
 
     //        foreach (var list in listsToDelete)
     //        {
@@ -135,7 +136,7 @@ namespace Azure.ResourceManager.Communication.Tests
     //    {
     //        var listName = Recording.Random.NewGuid().ToString();
     //        var suppressionList = await CreateDefaultSuppressionListResource(_domainResource, listName);
-    //        Assert.IsNotNull(suppressionList);
+    //        ClassicAssert.IsNotNull(suppressionList);
 
     //        var addressesToDelete = new List<SuppressionListAddressResource>();
     //        var addresses = new string[] { "user1@email.com", "user2@email.com", "user3@email.com" };
@@ -155,7 +156,7 @@ namespace Azure.ResourceManager.Communication.Tests
     //        await foreach (var resource in collection.GetAllAsync())
     //        {
     //            count++;
-    //            Assert.AreEqual(resourceNames[resource.Data.Name], resource.Data.Email);
+    //            ClassicAssert.AreEqual(resourceNames[resource.Data.Name], resource.Data.Email);
 
     //            if (count == expectedCount)
     //            {
@@ -179,7 +180,7 @@ namespace Azure.ResourceManager.Communication.Tests
     //        var listName = Recording.Random.NewGuid().ToString();
     //        var suppressionList = await CreateDefaultSuppressionListResource(_domainResource, listName);
 
-    //        Assert.IsNotNull(suppressionList);
+    //        ClassicAssert.IsNotNull(suppressionList);
 
     //        var addressesToDelete = new List<SuppressionListAddressResource>();
     //        var resourceNames = new Dictionary<string, string>();
@@ -199,7 +200,7 @@ namespace Azure.ResourceManager.Communication.Tests
     //        {
     //            count++;
 
-    //            Assert.AreEqual(resourceNames[resource.Data.Name], resource.Data.Email);
+    //            ClassicAssert.AreEqual(resourceNames[resource.Data.Name], resource.Data.Email);
     //            addressesToDelete.Add(resource);
 
     //            if (count == expectedCount)
@@ -223,7 +224,7 @@ namespace Azure.ResourceManager.Communication.Tests
     //        var listName = Recording.Random.NewGuid().ToString();
     //        var suppressionList = await CreateDefaultSuppressionListResource(_domainResource, listName);
 
-    //        Assert.IsNotNull(suppressionList);
+    //        ClassicAssert.IsNotNull(suppressionList);
 
     //        var email = "superuser@email.com";
     //        var created = await CreateDefaultSuppressionListAddressResource(suppressionList, email, "firstName", "lastName", "notes");
@@ -240,12 +241,12 @@ namespace Azure.ResourceManager.Communication.Tests
     //            .GetSuppressionListAddressResources()
     //            .CreateOrUpdateAsync(WaitUntil.Completed, created.Id.Name, data);
 
-    //        Assert.IsNotNull(updated);
-    //        Assert.AreEqual(created.Data.Id, updated.Value.Data.Id);
-    //        Assert.AreEqual(created.Data.Email, updated.Value.Data.Email);
-    //        Assert.AreNotEqual(created.Data.FirstName, updated.Value.Data.FirstName);
-    //        Assert.AreNotEqual(created.Data.LastName, updated.Value.Data.LastName);
-    //        Assert.AreEqual(created.Data.Notes, updated.Value.Data.Notes);
+    //        ClassicAssert.IsNotNull(updated);
+    //        ClassicAssert.AreEqual(created.Data.Id, updated.Value.Data.Id);
+    //        ClassicAssert.AreEqual(created.Data.Email, updated.Value.Data.Email);
+    //        ClassicAssert.AreNotEqual(created.Data.FirstName, updated.Value.Data.FirstName);
+    //        ClassicAssert.AreNotEqual(created.Data.LastName, updated.Value.Data.LastName);
+    //        ClassicAssert.AreEqual(created.Data.Notes, updated.Value.Data.Notes);
 
     //        await created.DeleteAsync(WaitUntil.Started);
     //        await suppressionList.DeleteAsync(WaitUntil.Started);
@@ -257,7 +258,7 @@ namespace Azure.ResourceManager.Communication.Tests
     //        var listName = Recording.Random.NewGuid().ToString();
     //        var suppressionList = await CreateDefaultSuppressionListResource(_domainResource, listName);
 
-    //        Assert.IsNotNull(suppressionList);
+    //        ClassicAssert.IsNotNull(suppressionList);
 
     //        var email = "superuser@email.com";
     //        var addressResource = await CreateDefaultSuppressionListAddressResource(suppressionList, email, "firstName", "lastName", "notes");
@@ -265,14 +266,14 @@ namespace Azure.ResourceManager.Communication.Tests
     //        var collection = suppressionList.GetSuppressionListAddressResources();
 
     //        var exists = await collection.ExistsAsync(addressResource.Id.Name);
-    //        Assert.IsTrue(exists);
+    //        ClassicAssert.IsTrue(exists);
 
     //        await addressResource.DeleteAsync(WaitUntil.Completed);
 
     //        // // todo: follow up on this issue. getting item after being deleted should return 404 not found instead of 500.
     //        // collection = suppressionList.GetSuppressionListAddressResources();
     //        // exists = await collection.ExistsAsync(addressResource.Id.Name);
-    //        // Assert.IsFalse(exists);
+    //        // ClassicAssert.IsFalse(exists);
 
     //        await suppressionList.DeleteAsync(WaitUntil.Started);
     //    }

--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Text.Json;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 namespace Azure.Communication
 {
@@ -60,7 +61,7 @@ namespace Azure.Communication
             };
 
             foreach (CommunicationIdentifierModel item in modelsWithTooManyNestedObjects)
-                Assert.Throws<JsonException>(() => CommunicationIdentifierSerializer.Deserialize(item));
+                ClassicAssert.Throws<JsonException>(() => CommunicationIdentifierSerializer.Deserialize(item));
         }
 
         [Test]
@@ -75,7 +76,7 @@ namespace Azure.Communication
             };
 
             foreach (CommunicationIdentifierModel item in modelsWithMissingMandatoryProperty)
-                Assert.Throws<JsonException>(() => CommunicationIdentifierSerializer.Deserialize(item));
+                ClassicAssert.Throws<JsonException>(() => CommunicationIdentifierSerializer.Deserialize(item));
         }
 
         [Test]
@@ -83,7 +84,7 @@ namespace Azure.Communication
         {
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(new CommunicationUserIdentifier(TestUserId));
 
-            Assert.AreEqual(TestUserId, model.CommunicationUser.Id);
+            ClassicAssert.AreEqual(TestUserId, model.CommunicationUser.Id);
         }
 
         [Test]
@@ -98,8 +99,8 @@ namespace Azure.Communication
 
             CommunicationUserIdentifier expectedIdentifier = new(TestUserId);
 
-            Assert.AreEqual(expectedIdentifier.Id, identifier.Id);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.Id, identifier.Id);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -115,8 +116,8 @@ namespace Azure.Communication
 
             CommunicationUserIdentifier expectedIdentifier = new(TestUserId);
 
-            Assert.AreEqual(expectedIdentifier.Id, identifier.Id);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.Id, identifier.Id);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -131,8 +132,8 @@ namespace Azure.Communication
 
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -140,7 +141,7 @@ namespace Azure.Communication
         {
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(new UnknownIdentifier(TestRawId));
 
-            Assert.AreEqual(TestRawId, model.RawId);
+            ClassicAssert.AreEqual(TestRawId, model.RawId);
         }
 
         [Test]
@@ -153,8 +154,8 @@ namespace Azure.Communication
                 });
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.Id, identifier.Id);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.Id, identifier.Id);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -164,8 +165,8 @@ namespace Azure.Communication
         {
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(new PhoneNumberIdentifier(TestPhoneNumber, rawId));
 
-            Assert.AreEqual(TestPhoneNumber, model.PhoneNumber.Value);
-            Assert.AreEqual(TestPhoneNumberRawId, model.RawId);
+            ClassicAssert.AreEqual(TestPhoneNumber, model.PhoneNumber.Value);
+            ClassicAssert.AreEqual(TestPhoneNumberRawId, model.RawId);
         }
 
         [Test]
@@ -180,9 +181,9 @@ namespace Azure.Communication
 
             PhoneNumberIdentifier expectedIdentifier = new(TestPhoneNumber, TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.PhoneNumber, identifier.PhoneNumber);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.PhoneNumber, identifier.PhoneNumber);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -198,9 +199,9 @@ namespace Azure.Communication
 
             PhoneNumberIdentifier expectedIdentifier = new(TestPhoneNumber, TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.PhoneNumber, identifier.PhoneNumber);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.PhoneNumber, identifier.PhoneNumber);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -215,8 +216,8 @@ namespace Azure.Communication
 
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -229,10 +230,10 @@ namespace Azure.Communication
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(
                 new MicrosoftTeamsUserIdentifier(TestTeamsUserId, isAnonymous, CommunicationCloudEnvironment.Dod, rawId));
 
-            Assert.AreEqual(TestTeamsUserId, model.MicrosoftTeamsUser.UserId);
-            Assert.AreEqual(CommunicationCloudEnvironmentModel.Dod, model.MicrosoftTeamsUser.Cloud);
-            Assert.AreEqual(isAnonymous, model.MicrosoftTeamsUser.IsAnonymous);
-            Assert.AreEqual(rawId ?? $"8:{(isAnonymous ? "teamsvisitor" : "dod")}:{TestTeamsUserId}", model.RawId);
+            ClassicAssert.AreEqual(TestTeamsUserId, model.MicrosoftTeamsUser.UserId);
+            ClassicAssert.AreEqual(CommunicationCloudEnvironmentModel.Dod, model.MicrosoftTeamsUser.Cloud);
+            ClassicAssert.AreEqual(isAnonymous, model.MicrosoftTeamsUser.IsAnonymous);
+            ClassicAssert.AreEqual(rawId ?? $"8:{(isAnonymous ? "teamsvisitor" : "dod")}:{TestTeamsUserId}", model.RawId);
         }
 
         [Test]
@@ -253,11 +254,11 @@ namespace Azure.Communication
 
             MicrosoftTeamsUserIdentifier expectedIdentifier = new(TestTeamsUserId, isAnonymous, CommunicationCloudEnvironment.Gcch, TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.UserId, identifier.UserId);
-            Assert.AreEqual(expectedIdentifier.IsAnonymous, identifier.IsAnonymous);
-            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.UserId, identifier.UserId);
+            ClassicAssert.AreEqual(expectedIdentifier.IsAnonymous, identifier.IsAnonymous);
+            ClassicAssert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -277,11 +278,11 @@ namespace Azure.Communication
 
             MicrosoftTeamsUserIdentifier expectedIdentifier = new(TestTeamsUserId, false, CommunicationCloudEnvironment.Gcch, TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.UserId, identifier.UserId);
-            Assert.AreEqual(expectedIdentifier.IsAnonymous, identifier.IsAnonymous);
-            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.UserId, identifier.UserId);
+            ClassicAssert.AreEqual(expectedIdentifier.IsAnonymous, identifier.IsAnonymous);
+            ClassicAssert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -296,8 +297,8 @@ namespace Azure.Communication
 
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -306,9 +307,9 @@ namespace Azure.Communication
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(
                 new MicrosoftTeamsAppIdentifier(TestTeamsAppId, CommunicationCloudEnvironment.Dod));
 
-            Assert.AreEqual(TestTeamsAppId, model.MicrosoftTeamsApp.AppId);
-            Assert.AreEqual(CommunicationCloudEnvironmentModel.Dod, model.MicrosoftTeamsApp.Cloud);
-            Assert.AreEqual($"28:dod:{TestTeamsAppId}", model.RawId);
+            ClassicAssert.AreEqual(TestTeamsAppId, model.MicrosoftTeamsApp.AppId);
+            ClassicAssert.AreEqual(CommunicationCloudEnvironmentModel.Dod, model.MicrosoftTeamsApp.Cloud);
+            ClassicAssert.AreEqual($"28:dod:{TestTeamsAppId}", model.RawId);
         }
 
         [Test]
@@ -326,10 +327,10 @@ namespace Azure.Communication
 
             MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, CommunicationCloudEnvironment.Gcch);
 
-            Assert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
-            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
+            ClassicAssert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -348,10 +349,10 @@ namespace Azure.Communication
 
             MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, CommunicationCloudEnvironment.Gcch);
 
-            Assert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
-            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
+            ClassicAssert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
 
         [Test]
@@ -366,8 +367,8 @@ namespace Azure.Communication
 
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            ClassicAssert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
+            ClassicAssert.AreEqual(expectedIdentifier, identifier);
         }
     }
 }


### PR DESCRIPTION
Migrate all 14 communication test projects to NUnit 4.4.0 by removing them from the NUnit 3 baseline in Directory.NUnit3Baseline.Packages.props.

Migrated packages:
- Azure.Communication.AlphaIds.Tests
- Azure.Communication.CallAutomation.Tests
- Azure.Communication.Chat.Tests
- Azure.Communication.Common.Tests
- Azure.Communication.Email.Tests
- Azure.Communication.Identity.Tests
- Azure.Communication.JobRouter.Tests
- Azure.Communication.Messages.Tests
- Azure.Communication.PhoneNumbers.Tests
- Azure.Communication.Rooms.Tests
- Azure.Communication.ShortCodes.Tests
- Azure.Communication.Sms.Tests
- Azure.Provisioning.Communication.Tests
- Azure.ResourceManager.Communication.Tests

Code changes:
- Replace Assert.* with ClassicAssert.* (NUnit.Framework.Legacy)
- Add 'using NUnit.Framework.Legacy' where needed
- Fix nullable reference in EntraTokenCredentialTest.cs
- Update shared test files (communication/Shared, ManagementTestShared)

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
