### PR TITLE
AzureDeveloperCliCredential: parse new auth error formats

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `AzureDeveloperCliCredential` to correctly parse error messages from Azure Developer CLI v1.23.7 and later, which previously caused raw JSON to surface in `AuthenticationFailedException` instead of the underlying error text.
+
 ### Other Changes
 
 ## 1.54.0 (2026-04-23)

--- a/sdk/core/Azure.Core/src/Identity/Credentials/AzureDeveloperCliCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/AzureDeveloperCliCredential.cs
@@ -292,7 +292,7 @@ namespace Azure.Identity
                 return rawCliError;
             }
 
-            string fallback = null;
+            string parsedMessage = null;
 
             foreach (string rawLine in rawCliError.Split('\n'))
             {
@@ -317,7 +317,7 @@ namespace Azure.Identity
                         }
                     }
 
-                    if (fallback == null &&
+                    if (parsedMessage == null &&
                         root.TryGetProperty("data", out JsonElement dataObj) &&
                         dataObj.TryGetProperty("message", out JsonElement msgObj) &&
                         msgObj.ValueKind == JsonValueKind.String)
@@ -325,7 +325,7 @@ namespace Azure.Identity
                         string msgText = msgObj.GetString();
                         if (!string.IsNullOrWhiteSpace(msgText))
                         {
-                            fallback = msgText.Trim();
+                            parsedMessage = msgText.Trim();
                         }
                     }
                 }
@@ -335,7 +335,7 @@ namespace Azure.Identity
                 }
             }
 
-            return fallback ?? rawCliError;
+            return parsedMessage ?? rawCliError;
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/AzureDeveloperCliCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/AzureDeveloperCliCredential.cs
@@ -279,36 +279,63 @@ namespace Azure.Identity
             return new AccessToken(accessToken, expiresOn);
         }
 
+        // Extracts a human-readable error from azd's stderr JSON output. Three formats are supported:
+        //   pre-v1.23.7        : {"type":"consoleMessage","data":{"message":"..."}}
+        //   v1.23.7 - v1.23.15 : empty consoleMessage line followed by {"error":"...","message":"...","suggestion":"..."}
+        //   v1.24.0+           : {"error":"...","message":"...","suggestion":"..."}
+        // Prefers the structured "error" field; falls back to the first non-empty consoleMessage data.message;
+        // returns the raw text if neither is found.
         private static string ProcessCliErrorForDisplay(string rawCliError)
         {
-            // Strategy: Try to parse azd JSON format {"type":"...","data":{"message":"..."}}, extract message, fallback to raw
-            // Guard: skip processing if null/empty or doesn't start with brace
-            string trimmedError = rawCliError?.TrimStart();
-            bool skipParsing = string.IsNullOrEmpty(trimmedError) || trimmedError[0] != '{';
-            if (skipParsing)
-                return rawCliError;
-
-            try
+            if (string.IsNullOrWhiteSpace(rawCliError))
             {
-                using JsonDocument jsonDoc = JsonDocument.Parse(rawCliError);
-                JsonElement root = jsonDoc.RootElement;
+                return rawCliError;
+            }
 
-                if (root.TryGetProperty("data", out JsonElement dataObj) &&
-                    dataObj.TryGetProperty("message", out JsonElement msgObj))
+            string fallback = null;
+
+            foreach (string rawLine in rawCliError.Split('\n'))
+            {
+                string line = rawLine.Trim();
+                if (line.Length == 0 || line[0] != '{')
                 {
-                    string msgText = msgObj.GetString();
-                    if (!string.IsNullOrWhiteSpace(msgText))
+                    continue;
+                }
+
+                try
+                {
+                    using JsonDocument jsonDoc = JsonDocument.Parse(line);
+                    JsonElement root = jsonDoc.RootElement;
+
+                    if (root.TryGetProperty("error", out JsonElement errorObj) &&
+                        errorObj.ValueKind == JsonValueKind.String)
                     {
-                        return msgText.Trim();
+                        string errorText = errorObj.GetString();
+                        if (!string.IsNullOrWhiteSpace(errorText))
+                        {
+                            return errorText.Trim();
+                        }
+                    }
+
+                    if (fallback == null &&
+                        root.TryGetProperty("data", out JsonElement dataObj) &&
+                        dataObj.TryGetProperty("message", out JsonElement msgObj) &&
+                        msgObj.ValueKind == JsonValueKind.String)
+                    {
+                        string msgText = msgObj.GetString();
+                        if (!string.IsNullOrWhiteSpace(msgText))
+                        {
+                            fallback = msgText.Trim();
+                        }
                     }
                 }
-            }
-            catch (JsonException)
-            {
-                // Parsing failed, keep original output
+                catch (JsonException)
+                {
+                    // Not valid JSON on this line; continue.
+                }
             }
 
-            return rawCliError;
+            return fallback ?? rawCliError;
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/Identity/AzureDeveloperCliCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/AzureDeveloperCliCredentialTests.cs
@@ -439,5 +439,96 @@ namespace Azure.Core.Tests.Identity
             Assert.That(ex.Message, Does.Contain(AzureDeveloperCliCredential.AzdNotLogIn));
             Assert.That(ex.Message, Does.Not.Contain("{\"type\":\"consoleMessage\""));
         }
+
+        [Test]
+        public void AzdJsonErrorOutput_StructuredError_ExtractsErrorField()
+        {
+            // azd v1.24.0+ writes a single-line structured error to stderr.
+            string aadError = "fetching token: failed to authenticate:\\n(invalid_tenant) AADSTS90002: Tenant 'test' not found";
+            string rawJsonError = "{\"error\":\"" + aadError + "\",\"links\":[{\"title\":\"azd auth login reference\",\"url\":\"https://example.com\"}],\"message\":\"Authentication with Azure failed.\",\"suggestion\":\"Run 'azd auth login' to sign in again.\"}";
+            var testProcess = new TestProcess { Error = rawJsonError };
+            var credential = CreateCredential(new TestProcessService(testProcess));
+
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(false),
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+
+            // Should extract the "error" field, not the wrapping JSON or the friendly "message"/"suggestion"
+            Assert.That(ex.Message, Does.Contain("AADSTS90002"));
+            Assert.That(ex.Message, Does.Not.Contain("\"error\":"));
+            Assert.That(ex.Message, Does.Not.Contain("\"suggestion\":"));
+            Assert.That(ex.Message, Does.Not.Contain("Authentication with Azure failed."));
+        }
+
+        [Test]
+        public void AzdJsonErrorOutput_StructuredErrorPrecededByEmptyConsoleMessage_PrefersStructuredError()
+        {
+            // azd v1.23.7 - v1.23.15 emits an empty consoleMessage line preceding the structured error.
+            string aadError = "fetching token: failed to authenticate";
+            string rawJsonError =
+                "{\"type\":\"consoleMessage\",\"timestamp\":\"2026-04-13T17:43:24.7558297-07:00\",\"data\":{\"message\":\"\\n\"}}\n" +
+                "{\"error\":\"" + aadError + "\",\"message\":\"Authentication with Azure failed.\",\"suggestion\":\"Run 'azd auth login' to sign in again.\"}";
+            var testProcess = new TestProcess { Error = rawJsonError };
+            var credential = CreateCredential(new TestProcessService(testProcess));
+
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(false),
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+
+            Assert.That(ex.Message, Does.Contain(aadError));
+            Assert.That(ex.Message, Does.Not.Contain("{\"type\":\"consoleMessage\""));
+            Assert.That(ex.Message, Does.Not.Contain("{\"error\":"));
+        }
+
+        [Test]
+        public void AzdJsonErrorOutput_StructuredErrorWithConsoleMessage_PrefersStructuredError()
+        {
+            // The structured "error" line carries the actionable failure and should win over the consoleMessage
+            string aadError = "AADSTS70008: Refresh token expired";
+            string rawJsonError =
+                "{\"type\":\"consoleMessage\",\"timestamp\":\"...\",\"data\":{\"message\":\"some informational console output\"}}\n" +
+                "{\"error\":\"" + aadError + "\",\"message\":\"Authentication with Azure failed.\"}";
+            var testProcess = new TestProcess { Error = rawJsonError };
+            var credential = CreateCredential(new TestProcessService(testProcess));
+
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(false),
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+
+            Assert.That(ex.Message, Does.Contain(aadError));
+            Assert.That(ex.Message, Does.Not.Contain("some informational console output"));
+        }
+
+        [Test]
+        public void AzdJsonErrorOutput_MultipleConsoleMessageLines_UsesFirstNonEmpty()
+        {
+            // Multi-line legacy output should fall back to the first non-empty data.message
+            string firstMessage = "ERROR: fetching token: interactive login needed";
+            string rawJsonError =
+                "{\"type\":\"consoleMessage\",\"data\":{\"message\":\"\\n\"}}\n" +
+                "{\"type\":\"consoleMessage\",\"data\":{\"message\":\"" + firstMessage + "\"}}\n" +
+                "{\"type\":\"consoleMessage\",\"data\":{\"message\":\"trailing detail\"}}";
+            var testProcess = new TestProcess { Error = rawJsonError };
+            var credential = CreateCredential(new TestProcessService(testProcess));
+
+            var ex = Assert.ThrowsAsync(GetExpectedExceptionType(false),
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+
+            Assert.That(ex.Message, Does.Contain(firstMessage));
+            Assert.That(ex.Message, Does.Not.Contain("{\"type\":\"consoleMessage\""));
+        }
+
+        [Test]
+        public void AzdJsonErrorOutput_StructuredAadStsError_SurfacesAsAuthFailed()
+        {
+            // The "azd auth login" text lives in the ignored "suggestion" field, so the AADSTS error
+            // should surface as AuthenticationFailedException rather than CredentialUnavailableException.
+            string structuredError = "{\"error\":\"AADSTS50076: Multi-factor authentication required\",\"message\":\"Authentication with Azure failed.\",\"suggestion\":\"Run 'azd auth login' to sign in again.\"}";
+            var testProcess = new TestProcess { Error = structuredError };
+            var credential = CreateCredential(new TestProcessService(testProcess));
+
+            var ex = Assert.ThrowsAsync<AuthenticationFailedException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(MockScopes.Default), default));
+
+            Assert.That(ex.Message, Does.Contain("AADSTS50076"));
+            Assert.That(ex.Message, Does.Not.Contain("\"suggestion\":"));
+        }
     }
 }


### PR DESCRIPTION
Fixes Azure/azure-dev#7858 (parent: Azure/azure-dev#7728)

Related: https://github.com/Azure/azure-sdk-for-go/pull/26590


### Description

Starting with [azd v1.23.7](https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.23.7) (PR [Azure/azure-dev#6827](https://github.com/Azure/azure-dev/pull/6827)), `azd auth token` changed its stderr error format from the legacy `consoleMessage` JSON to a structured `{"error":"..."}` JSON object. The stderr output may also include an extraneous empty `consoleMessage` line preceding the error (fixed in v1.24.0 via [Azure/azure-dev#7701](https://github.com/Azure/azure-dev/pull/7701)).

This PR updates `AzureDeveloperCliCredential` error parsing to handle all three formats:

| azd version | stderr format |
|---|---|
| pre-v1.23.7 | `{"type":"consoleMessage","data":{"message":"..."}}` |
| v1.23.7 – v1.23.15 | `{"type":"consoleMessage",...}\n{"error":"..."}` (two lines) |
| v1.24.0+ | `{"error":"..."}` (single line) |

`ProcessCliErrorForDisplay` now splits stderr by newline and scans for the structured `{"error":"..."}` format first. If not found, it falls back to extracting the first non-empty `data.message` from a legacy `consoleMessage` line. If neither is found the raw text is returned unchanged, preserving existing behavior for plain-text and malformed output.

Without this change, callers using azd v1.23.7+ see the raw JSON blob in `AuthenticationFailedException.Message` instead of the underlying AAD error.

### Testing

Added unit tests in `AzureDeveloperCliCredentialTests` covering each format, the `error`-over-`consoleMessage` precedence, and the multi-line legacy fallback. Existing tests for the legacy format and downstream error classification (login-required, AADSTS, etc.) continue to pass.

Validated manually against multiple versions of `azd` with a small test program:

```csharp
var credential = new AzureDeveloperCliCredential(new AzureDeveloperCliCredentialOptions
{
    TenantId = "tenant-id", // invalid to induce error
});
var token = await credential.GetTokenAsync(
    new TokenRequestContext(new[] { "https://management.azure.com/.default" }),
    CancellationToken.None);
```

**Without changes - v1.23.15:**

```
Failed: AuthenticationFailedException: Azure Developer CLI authentication failed due to an unknown error. Please visit https://aka.ms/azure-dev for installation instructions and then, once installed, authenticate to your Azure account using 'azd auth login'. {"type":"consoleMessage","timestamp":"2026-04-23T16:02:49.7674347-07:00","data":{"message":"\n"}}
{"error":"fetching token: failed to authenticate:\n(invalid_tenant) AADSTS90002: Tenant 'invalid-tenant' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant. Trace ID: <redacted> Correlation ID: <redacted> Timestamp: 2026-04-23 23:02:49Z\n","links":[{"title":"azd auth login reference","url":"https://learn.microsoft.com/azure/developer/azure-developer-cli/reference#azd-auth-login"}],"message":"Authentication with Azure failed.","suggestion":"Run 'azd auth login' to sign in again."}
```

**Without changes - v1.24.1:**

```
Requesting token for scopes: https://management.azure.com/.default
Failed: AuthenticationFailedException: Azure Developer CLI authentication failed due to an unknown error. Please visit https://aka.ms/azure-dev for installation instructions and then, once installed, authenticate to your Azure account using 'azd auth login'. {"error":"fetching token: failed to authenticate:\n(invalid_tenant) AADSTS90002: Tenant 'invalid-tenant' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant. Trace ID: <redacted> Correlation ID: <redacted> Timestamp: 2026-04-23 23:00:53Z\n","links":[{"title":"azd auth login reference","url":"https://learn.microsoft.com/azure/developer/azure-developer-cli/reference#azd-auth-login"}],"message":"Authentication with Azure failed.","suggestion":"Run 'azd auth login' to sign in again."}
```

**With changes - v1.23.15, v1.24.1:**

```
Failed: AuthenticationFailedException: Azure Developer CLI authentication failed due to an unknown error. Please visit https://aka.ms/azure-dev for installation instructions and then, once installed, authenticate to your Azure account using 'azd auth login'. fetching token: failed to authenticate:
(invalid_tenant) AADSTS90002: Tenant 'invalid-tenant' not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant. Trace ID: <redacted> Correlation ID: <redacted> Timestamp: 2026-04-23 23:22:48Z
```