### PR TITLE
Add @m-nash and azure-sdk-write-net-core as Core/ClientModel owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,12 +39,14 @@
 # ######## Core Libraries ########
 
 # PRLabel: %Azure.Core
-/sdk/core/                                                         @Azure/azure-sdk-write-net-core
+/sdk/core/                                                         @m-nash @Azure/azure-sdk-write-net-core
 
 # ServiceLabel: %Azure.Core
+# ServiceOwners:                                                   @m-nash @Azure/azure-sdk-write-net-core
 # AzureSdkOwners:                                                  @m-nash
 
 # ServiceLabel: %System.ClientModel
+# ServiceOwners:                                                   @m-nash @Azure/azure-sdk-write-net-core
 # AzureSdkOwners:                                                  @m-nash
 
 # PRLabel: %Azure.Identity


### PR DESCRIPTION
Adds `@m-nash` and `@Azure/azure-sdk-write-net-core` as owners for the `Azure.Core` and `System.ClientModel` ServiceLabel blocks in `.github/CODEOWNERS`, and adds `@m-nash` to the `/sdk/core/` PR ownership line.

Fixes a release pipeline failure where validation requires both an individual `AzureSdkOwners` and a `ServiceOwners` entry for these ServiceLabel blocks.

Reference: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6201487&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=c6642a37-b24b-5443-7452-ff95456b7c94&l=20