### PR TITLE
Migrate communication test projects from NUnit 3 to NUnit 4

### DIFF
--- a/common/ManagementTestShared/Temp/ModelReaderWriterImplementationValidation.cs
+++ b/common/ManagementTestShared/Temp/ModelReaderWriterImplementationValidation.cs
@@ -25,7 +25,7 @@ namespace Azure.ResourceManager.TestFramework
         {
             var testAssembly = Assembly.GetExecutingAssembly();
             var assemblyName = testAssembly.GetName().Name;
-            Assert.IsTrue(assemblyName.EndsWith(TestAssemblySuffix), $"The test assembly should end with {TestAssemblySuffix}");
+            Assert.That(assemblyName.EndsWith(TestAssemblySuffix), Is.True, $"The test assembly should end with {TestAssemblySuffix}");
             var rpNamespace = assemblyName.Substring(0, assemblyName.Length - TestAssemblySuffix.Length);
 
             TestContext.WriteLine($"Testing assembly {rpNamespace}");
@@ -39,7 +39,7 @@ namespace Azure.ResourceManager.TestFramework
             // find the SDK assembly by filtering the assemblies in the current domain, or load it if not found (when there is no test case)
             var sdkAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == rpNamespace) ?? Assembly.Load(rpNamespace);
 
-            Assert.IsNotNull(sdkAssembly, $"The SDK assembly {rpNamespace} not found");
+            Assert.That(sdkAssembly, Is.Not.Null, $"The SDK assembly {rpNamespace} not found");
 
             List<Type> violatedTypes = new();
             var exceptionList = ExceptionList == null ? new HashSet<string>() : new HashSet<string>(ExceptionList);

--- a/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
+++ b/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
@@ -48,18 +48,6 @@
         $(MSBuildProjectName) == 'Azure.Analytics.Purview.Sharing.Tests' or
         $(MSBuildProjectName) == 'Azure.Analytics.Purview.Workflows.Tests' or
         $(MSBuildProjectName) == 'Azure.Analytics.Synapse.Artifacts.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.AlphaIds.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.CallAutomation.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Chat.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Common.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Email.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Identity.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.JobRouter.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Messages.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.PhoneNumbers.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Rooms.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.ShortCodes.Tests' or
-        $(MSBuildProjectName) == 'Azure.Communication.Sms.Tests' or
         $(MSBuildProjectName) == 'Azure.Compute.Batch.Tests' or
         $(MSBuildProjectName) == 'Azure.Containers.ContainerRegistry.Tests' or
         $(MSBuildProjectName) == 'Azure.Core.Amqp.Tests' or
@@ -152,7 +140,6 @@
         $(MSBuildProjectName) == 'Azure.ResourceManager.Chaos.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.CloudHealth.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.CognitiveServices.Tests' or
-        $(MSBuildProjectName) == 'Azure.ResourceManager.Communication.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Compute.Recommender.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Compute.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.ComputeFleet.Tests' or

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientAutomatedLiveTests.cs
@@ -45,11 +45,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    Assert.That(incomingCallContext, Is.Not.Null);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -57,20 +57,20 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                    Assert.That(connectedEvent, Is.Not.Null);
+                    Assert.That(connectedEvent is CallConnected, Is.True);
+                    Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    Assert.That(properties.Value.CallConnectionState, Is.EqualTo(CallConnectionState.Connected));
 
                     // try hangup
                     await response.CallConnection.HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
                     callConnectionId = null;
                 }
                 catch (Exception)
@@ -117,23 +117,23 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                         new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    Assert.That(incomingCallContext, Is.Not.Null);
 
                     // answer the call
                     var rejectCallOptions = new RejectCallOptions(incomingCallContext);
                     Response rejectResponse = await client.RejectCallAsync(rejectCallOptions);
 
                     // check reject response
-                    Assert.IsFalse(rejectResponse.IsError);
+                    Assert.That(rejectResponse.IsError, Is.False);
 
                     var createCallFailedEvent = await WaitForEvent<CreateCallFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(createCallFailedEvent);
-                    Assert.IsTrue(createCallFailedEvent is CreateCallFailed);
-                    Assert.AreEqual(callConnectionId, ((CreateCallFailed)createCallFailedEvent!).CallConnectionId);
+                    Assert.That(createCallFailedEvent, Is.Not.Null);
+                    Assert.That(createCallFailedEvent is CreateCallFailed, Is.True);
+                    Assert.That(((CreateCallFailed)createCallFailedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -195,11 +195,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    Assert.That(incomingCallContext, Is.Not.Null);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -207,9 +207,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                    Assert.That(connectedEvent, Is.Not.Null);
+                    Assert.That(connectedEvent is CallConnected, Is.True);
+                    Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // server call locator for connect call.
                     CallLocator callLocator = new ServerCallLocator(connectedEvent.ServerCallId);
@@ -220,22 +220,22 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for connect call connected.
                     var connectCallConnectedEvent = await WaitForEvent<CallConnected>(connectCallConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectCallConnectedEvent);
-                    Assert.IsTrue(connectCallConnectedEvent is CallConnected);
-                    Assert.AreEqual(connectCallConnectionId, ((CallConnected)connectCallConnectedEvent!).CallConnectionId);
+                    Assert.That(connectCallConnectedEvent, Is.Not.Null);
+                    Assert.That(connectCallConnectedEvent is CallConnected, Is.True);
+                    Assert.That(((CallConnected)connectCallConnectedEvent!).CallConnectionId, Is.EqualTo(connectCallConnectionId));
 
                     CallConnection ConnectCallConnection = connectCallResult.CallConnection;
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await ConnectCallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    Assert.That(properties.Value.CallConnectionState, Is.EqualTo(CallConnectionState.Connected));
 
                     // try hangup
                     await connectCallResult.CallConnection.HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(connectCallConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(connectCallConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(connectCallConnectionId));
                     connectCallConnectionId = null;
 
                     // try hangup
@@ -245,7 +245,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                     }
                     catch (RequestFailedException ex)
                     {
-                        Assert.AreEqual(ex.Status, 404);
+                        Assert.That(ex.Status, Is.EqualTo(404));
                     }
 
                     callConnectionId = null;
@@ -296,11 +296,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    Assert.That(incomingCallContext, Is.Not.Null);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -308,9 +308,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                    Assert.That(connectedEvent, Is.Not.Null);
+                    Assert.That(connectedEvent is CallConnected, Is.True);
+                    Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // server call locator for connect call.
                     CallLocator callLocator = new ServerCallLocator(connectedEvent.ServerCallId);
@@ -321,30 +321,30 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
                     // wait for connect call connected.
                     var connectCallConnectedEvent = await WaitForEvent<CallConnected>(connectCallConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectCallConnectedEvent);
-                    Assert.IsTrue(connectCallConnectedEvent is CallConnected);
-                    Assert.AreEqual(connectCallConnectionId, ((CallConnected)connectCallConnectedEvent!).CallConnectionId);
+                    Assert.That(connectCallConnectedEvent, Is.Not.Null);
+                    Assert.That(connectCallConnectedEvent is CallConnected, Is.True);
+                    Assert.That(((CallConnected)connectCallConnectedEvent!).CallConnectionId, Is.EqualTo(connectCallConnectionId));
 
                     CallConnection ConnectCallConnection = connectCallResult.CallConnection;
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await ConnectCallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    Assert.That(properties.Value.CallConnectionState, Is.EqualTo(CallConnectionState.Connected));
 
                     // try hangup
                     await connectCallResult.CallConnection.HangUpAsync(false).ConfigureAwait(false);
                     var disconnectedConnectEvent = await WaitForEvent<CallDisconnected>(connectCallConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedConnectEvent);
-                    Assert.IsTrue(disconnectedConnectEvent is CallDisconnected);
-                    Assert.AreEqual(connectCallConnectionId, ((CallDisconnected)disconnectedConnectEvent!).CallConnectionId);
+                    Assert.That(disconnectedConnectEvent, Is.Not.Null);
+                    Assert.That(disconnectedConnectEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedConnectEvent!).CallConnectionId, Is.EqualTo(connectCallConnectionId));
                     connectCallConnectionId = null;
 
                     // try to hangup for anwercall
                     await answerResponse.CallConnection.HangUpAsync(false).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
                     callConnectionId = null;
                 }
                 catch (Exception)

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallAutomationClients/CallAutomationClientTests.cs
@@ -29,12 +29,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(200, CreateOrAnswerCallOrGetCallConnectionPayload);
 
             var response = await callAutomationClient.AnswerCallAsync(incomingCallContext, callbackUri).ConfigureAwait(false);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(response.Value.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Null);
+            Assert.That(response.Value.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -43,12 +43,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(200, CreateOrAnswerCallOrGetCallConnectionPayload);
 
             var response = callAutomationClient.AnswerCall(incomingCallContext, callbackUri);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(response.Value.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Null);
+            Assert.That(response.Value.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -63,12 +63,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             };
 
             var response = await callAutomationClient.AnswerCallAsync(options).ConfigureAwait(false);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(response.Value.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            Assert.That(response.Value.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Not.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -82,12 +82,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             };
 
             var response = callAutomationClient.AnswerCall(options);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(response.Value.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, response.Value.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            Assert.That(response.Value.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Not.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -96,8 +96,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(401);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.AnswerCallAsync(incomingCallContext, callbackUri).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(401));
         }
 
         [TestCaseSource(nameof(TestData_AnswerCall))]
@@ -106,8 +106,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(401);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.AnswerCall(incomingCallContext, callbackUri));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(401));
         }
 
         [TestCaseSource(nameof(TestData_RedirectCall))]
@@ -116,8 +116,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(204);
 
             var response = await callAutomationClient.RedirectCallAsync(incomingCallContext, callInvite).ConfigureAwait(false);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Status, Is.EqualTo((int)HttpStatusCode.NoContent));
         }
 
         [TestCaseSource(nameof(TestData_RedirectCall))]
@@ -126,8 +126,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(204);
 
             var response = callAutomationClient.RedirectCall(incomingCallContext, callInvite);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Status, Is.EqualTo((int)HttpStatusCode.NoContent));
         }
 
         [TestCaseSource(nameof(TestData_RedirectCall))]
@@ -136,8 +136,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.RedirectCallAsync(incomingCallContext, callInvite).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_RedirectCall))]
@@ -146,8 +146,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.RedirectCall(incomingCallContext, callInvite));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_RejectCall))]
@@ -159,8 +159,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             rejectOption.CallRejectReason = reason;
 
             var response = await callAutomationClient.RejectCallAsync(rejectOption).ConfigureAwait(false);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Status, Is.EqualTo((int)HttpStatusCode.NoContent));
         }
 
         [TestCaseSource(nameof(TestData_RejectCall))]
@@ -172,8 +172,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             rejectOption.CallRejectReason = reason;
 
             var response = callAutomationClient.RejectCall(rejectOption);
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Status, Is.EqualTo((int)HttpStatusCode.NoContent));
         }
 
         [TestCaseSource(nameof(TestData_RejectCall))]
@@ -185,8 +185,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             rejectOption.CallRejectReason = reason;
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.RejectCallAsync(rejectOption).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_RejectCall))]
@@ -198,8 +198,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             rejectOption.CallRejectReason = reason;
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.RejectCall(rejectOption));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -210,12 +210,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new CreateCallOptions(target, callbackUri);
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Null);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -226,12 +226,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new CreateCallOptions(target, callbackUri);
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Null);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -248,12 +248,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Not.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -270,12 +270,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Not.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -291,10 +291,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyOPSCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -310,10 +310,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyOPSCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_CreateCall))]
@@ -322,8 +322,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.CreateCallAsync(new CreateCallOptions(target, callbackUri)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -334,18 +334,18 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new CreateCallOptions(target, callbackUri);
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Null);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(target.Target);
+            Assert.That(target.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = target.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -356,18 +356,18 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new CreateCallOptions(target, callbackUri);
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.Null(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.Null(response.Value.CallConnectionProperties.TranscriptionSubscription);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Null);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(target.Target);
+            Assert.That(target.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = target.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -385,17 +385,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.CreateCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Not.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Not.Null);
 
             // Verify all optional properties can be set
-            Assert.AreEqual("teams-app-context", options.OperationContext);
-            Assert.IsNotNull(options.MediaStreamingOptions);
-            Assert.IsNotNull(options.TranscriptionOptions);
+            Assert.That(options.OperationContext, Is.EqualTo("teams-app-context"));
+            Assert.That(options.MediaStreamingOptions, Is.Not.Null);
+            Assert.That(options.TranscriptionOptions, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -413,17 +413,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = callAutomationClient.CreateCall(options);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Not.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Not.Null);
 
             // Verify all optional properties can be set
-            Assert.AreEqual("teams-app-context", options.OperationContext);
-            Assert.IsNotNull(options.MediaStreamingOptions);
-            Assert.IsNotNull(options.TranscriptionOptions);
+            Assert.That(options.OperationContext, Is.EqualTo("teams-app-context"));
+            Assert.That(options.MediaStreamingOptions, Is.Not.Null);
+            Assert.That(options.TranscriptionOptions, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -432,8 +432,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callAutomationClient.CreateCallAsync(new CreateCallOptions(target, callbackUri)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_CreateCall_MicrosoftTeamsApp))]
@@ -442,8 +442,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.CreateCall(new CreateCallOptions(target, callbackUri)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_ConnectCall))]
@@ -453,10 +453,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.ConnectCallAsync(callLocator, callbackUri).ConfigureAwait(false);
             ConnectCallResult result = (ConnectCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(result.CallConnectionProperties, isConnectApi: true);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_ConnectCall))]
@@ -466,10 +466,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = callAutomationClient.ConnectCall(callLocator, callbackUri);
             ConnectCallResult result = (ConnectCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(result.CallConnectionProperties, isConnectApi: true);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_ConnectCall))]
@@ -480,10 +480,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new ConnectCallOptions(callLocator, callbackUri);
             var response = await callAutomationClient.ConnectCallAsync(options).ConfigureAwait(false);
             ConnectCallResult result = (ConnectCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(result.CallConnectionProperties, isConnectApi: true);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_ConnectCall))]
@@ -494,10 +494,10 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
             var options = new ConnectCallOptions(callLocator, callbackUri);
             var response = callAutomationClient.ConnectCall(options);
             ConnectCallResult result = (ConnectCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(result.CallConnectionProperties, isConnectApi: true);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [TestCaseSource(nameof(TestData_GetCallConnection))]
@@ -505,15 +505,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
         {
             var response = new CallAutomationClient(ConnectionString).GetCallConnection(callConnectionId);
             CallConnection result = (CallConnection)response;
-            Assert.NotNull(result);
-            Assert.AreEqual(callConnectionId, result.CallConnectionId);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.CallConnectionId, Is.EqualTo(callConnectionId));
         }
 
         [Test]
         public void GetCallRecording()
         {
             var response = new CallAutomationClient(ConnectionString).GetCallRecording();
-            Assert.NotNull(response);
+            Assert.That(response, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_CreateGroupCall))]
@@ -531,38 +531,38 @@ namespace Azure.Communication.CallAutomation.Tests.CallAutomationClients
 
             var response = await callAutomationClient.CreateGroupCallAsync(options).ConfigureAwait(false);
             CreateCallResult result = (CreateCallResult)response;
-            Assert.NotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
             verifyCallConnectionProperties(result.CallConnectionProperties);
-            Assert.AreEqual(CallConnectionId, result.CallConnection.CallConnectionId);
-            Assert.NotNull(response.Value.CallConnectionProperties.MediaStreamingSubscription);
-            Assert.NotNull(response.Value.CallConnectionProperties.TranscriptionSubscription);
+            Assert.That(result.CallConnection.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(response.Value.CallConnectionProperties.MediaStreamingSubscription, Is.Not.Null);
+            Assert.That(response.Value.CallConnectionProperties.TranscriptionSubscription, Is.Not.Null);
         }
 
         private static void ValidateCreateCallResult(CreateCallResult createCallResult)
         {
-            Assert.NotNull(createCallResult);
-            Assert.NotNull(createCallResult.CallConnection);
-            Assert.AreEqual("callConnectionId", createCallResult.CallConnection.CallConnectionId);
+            Assert.That(createCallResult, Is.Not.Null);
+            Assert.That(createCallResult.CallConnection, Is.Not.Null);
+            Assert.That(createCallResult.CallConnection.CallConnectionId, Is.EqualTo("callConnectionId"));
             ValidateCallConnectionProperties(createCallResult.CallConnectionProperties);
         }
 
         private static void ValidateAnswerCallResult(AnswerCallResult answerCallResult)
         {
-            Assert.NotNull(answerCallResult);
-            Assert.NotNull(answerCallResult.CallConnection);
-            Assert.AreEqual("callConnectionId", answerCallResult.CallConnection.CallConnectionId);
+            Assert.That(answerCallResult, Is.Not.Null);
+            Assert.That(answerCallResult.CallConnection, Is.Not.Null);
+            Assert.That(answerCallResult.CallConnection.CallConnectionId, Is.EqualTo("callConnectionId"));
             ValidateCallConnectionProperties(answerCallResult.CallConnectionProperties);
         }
 
         private static void ValidateCallConnectionProperties(CallConnectionProperties properties)
         {
-            Assert.NotNull(properties);
-            Assert.AreEqual("callConnectionId", properties.CallConnectionId);
-            Assert.AreEqual(CallConnectionState.Connecting, properties.CallConnectionState);
-            Assert.AreEqual("dummySourceUser", properties.Source.RawId);
-            Assert.AreEqual("serverCallId", properties.ServerCallId);
-            Assert.AreEqual(1, properties.Targets.Count);
+            Assert.That(properties, Is.Not.Null);
+            Assert.That(properties.CallConnectionId, Is.EqualTo("callConnectionId"));
+            Assert.That(properties.CallConnectionState, Is.EqualTo(CallConnectionState.Connecting));
+            Assert.That(properties.Source.RawId, Is.EqualTo("dummySourceUser"));
+            Assert.That(properties.ServerCallId, Is.EqualTo("serverCallId"));
+            Assert.That(properties.Targets.Count, Is.EqualTo(1));
         }
 
         // exceptions

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionAutomatedLiveTests.cs
@@ -45,11 +45,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    Assert.That(incomingCallContext, Is.Not.Null);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -57,18 +57,18 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                    Assert.That(connectedEvent, Is.Not.Null);
+                    Assert.That(connectedEvent is CallConnected, Is.True);
+                    Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // wait for participants updated
                     var participantsUpdatedEvent1 = await WaitForEvent<ParticipantsUpdated>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(participantsUpdatedEvent1);
-                    Assert.AreEqual(2, ((ParticipantsUpdated)participantsUpdatedEvent1!).Participants.Count);
+                    Assert.That(participantsUpdatedEvent1, Is.Not.Null);
+                    Assert.That(((ParticipantsUpdated)participantsUpdatedEvent1!).Participants.Count, Is.EqualTo(2));
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    Assert.That(properties.Value.CallConnectionState, Is.EqualTo(CallConnectionState.Connected));
 
                     // try RemoveParticipants
                     string operationContext1 = "MyTestOperationcontext";
@@ -77,15 +77,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                         OperationContext = operationContext1,
                     };
                     Response<RemoveParticipantResult> removePartResponse = await response.CallConnection.RemoveParticipantAsync(removeParticipantsOptions);
-                    Assert.IsTrue(!removePartResponse.GetRawResponse().IsError);
+                    Assert.That(!removePartResponse.GetRawResponse().IsError, Is.True);
                     string expectedOperationContext = Mode == RecordedTestMode.Playback ? "Sanitized" : operationContext1;
-                    Assert.AreEqual(expectedOperationContext, removePartResponse.Value.OperationContext);
+                    Assert.That(removePartResponse.Value.OperationContext, Is.EqualTo(expectedOperationContext));
 
                     // call should be disconnected after removing participant
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
                     callConnectionId = null;
                 }
                 catch (Exception)
@@ -133,11 +133,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                 var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                 // wait for incomingcall context
                 string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(incomingCallContext);
+                Assert.That(incomingCallContext, Is.Not.Null);
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
@@ -145,9 +145,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
                 // wait for callConnected
                 var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(connectedEvent);
-                Assert.IsTrue(connectedEvent is CallConnected);
-                Assert.AreEqual(callConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                Assert.That(connectedEvent, Is.Not.Null);
+                Assert.That(connectedEvent is CallConnected, Is.True);
+                Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                 // add participant
                 var callConnection = response.CallConnection;
@@ -160,8 +160,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                 var addParticipantResponse = await callConnection.AddParticipantAsync(addParticipantOptions);
 
                 string expectedOperationContext = Mode == RecordedTestMode.Playback ? "Sanitized" : operationContext;
-                Assert.AreEqual(expectedOperationContext, addParticipantResponse.Value.OperationContext);
-                Assert.IsNotNull(addParticipantResponse.Value.InvitationId);
+                Assert.That(addParticipantResponse.Value.OperationContext, Is.EqualTo(expectedOperationContext));
+                Assert.That(addParticipantResponse.Value.InvitationId, Is.Not.Null);
 
                 // ensure invitation has arrived
                 await Task.Delay(3000);
@@ -175,9 +175,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
                 // wait for cancel event
                 var CancelAddParticipantSucceededEvent = await WaitForEvent<CancelAddParticipantSucceeded>(callConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(CancelAddParticipantSucceededEvent);
-                Assert.IsTrue(CancelAddParticipantSucceededEvent is CancelAddParticipantSucceeded);
-                Assert.AreEqual(((CancelAddParticipantSucceeded)CancelAddParticipantSucceededEvent!).InvitationId, addParticipantResponse.Value.InvitationId);
+                Assert.That(CancelAddParticipantSucceededEvent, Is.Not.Null);
+                Assert.That(CancelAddParticipantSucceededEvent is CancelAddParticipantSucceeded, Is.True);
+                Assert.That(addParticipantResponse.Value.InvitationId, Is.EqualTo(((CancelAddParticipantSucceeded)CancelAddParticipantSucceededEvent!).InvitationId));
             }
             catch (Exception ex)
             {

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallConnections/CallConnectionTests.cs
@@ -48,8 +48,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
             var response = await callConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
 
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(response);
         }
 
@@ -60,8 +60,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
             var response = callConnection.GetCallConnectionProperties();
 
-            Assert.NotNull(response);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyCallConnectionProperties(response);
         }
         [Test]
@@ -70,8 +70,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -80,8 +80,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.GetCallConnectionProperties());
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(204);
 
             var response = await callConnection.HangUpAsync(false).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            Assert.That(response.Status, Is.EqualTo((int)HttpStatusCode.NoContent));
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(204);
 
             var response = callConnection.HangUp(false);
-            Assert.AreEqual((int)HttpStatusCode.NoContent, response.Status);
+            Assert.That(response.Status, Is.EqualTo((int)HttpStatusCode.NoContent));
         }
 
         [Test]
@@ -108,8 +108,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.HangUpAsync(false).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -118,8 +118,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.HangUp(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant))]
@@ -128,7 +128,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
         }
 
@@ -137,7 +137,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
         }
 
@@ -146,7 +146,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
         {
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
         }
 
@@ -156,7 +156,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.TransferCallToParticipantAsync(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
         }
 
@@ -168,7 +168,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             options.Transferee = new CommunicationUserIdentifier("transfereeid");
 
             var response = await callConnection.TransferCallToParticipantAsync(options).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
         }
 
@@ -178,7 +178,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.TransferCallToParticipant(callInvite.Target);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
         }
 
@@ -188,7 +188,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier));
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
         }
 
@@ -200,7 +200,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             options.Transferee = new CommunicationUserIdentifier("transfereeid");
 
             var response = callConnection.TransferCallToParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
         }
 
@@ -210,8 +210,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.TransferCallToParticipantAsync(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant))]
@@ -220,8 +220,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -231,7 +231,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callInvite = new CallInvite((CommunicationUserIdentifier)participantToAdd);
 
             var response = await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyAddParticipantsResult(response);
         }
 
@@ -242,7 +242,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callInvite = new CallInvite((CommunicationUserIdentifier)participantToAdd);
 
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyAddParticipantsResult(response);
         }
 
@@ -252,14 +252,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
             var response = await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyAddParticipantsResult(response);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            Assert.That(callInvite.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsApp))]
@@ -268,14 +268,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyAddParticipantsResult(response);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            Assert.That(callInvite.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsAppWithCloud))]
@@ -284,17 +284,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
             var response = await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyAddParticipantsResult(response);
 
             // Verify the target maintains the correct cloud environment
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            Assert.That(callInvite.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
-            Assert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
+            Assert.That(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Dod ||
-                         teamsApp.Cloud == CommunicationCloudEnvironment.Gcch);
+                         teamsApp.Cloud == CommunicationCloudEnvironment.Gcch, Is.True);
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsAppWithCloud))]
@@ -303,17 +303,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyAddParticipantsResult(response);
 
             // Verify the target maintains the correct cloud environment
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            Assert.That(callInvite.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
-            Assert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
+            Assert.That(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Dod ||
-                         teamsApp.Cloud == CommunicationCloudEnvironment.Gcch);
+                         teamsApp.Cloud == CommunicationCloudEnvironment.Gcch, Is.True);
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsApp))]
@@ -329,13 +329,13 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             };
 
             var response = await callConnection.AddParticipantAsync(options).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyAddParticipantsResult(response);
 
             // Verify all optional properties can be set
-            Assert.AreEqual("custom-context", options.OperationContext);
-            Assert.AreEqual(60, options.InvitationTimeoutInSeconds);
-            Assert.IsNotNull(options.OperationCallbackUri);
+            Assert.That(options.OperationContext, Is.EqualTo("custom-context"));
+            Assert.That(options.InvitationTimeoutInSeconds, Is.EqualTo(60));
+            Assert.That(options.OperationCallbackUri, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsApp))]
@@ -351,13 +351,13 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             };
 
             var response = callConnection.AddParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyAddParticipantsResult(response);
 
             // Verify all optional properties can be set
-            Assert.AreEqual("custom-context", options.OperationContext);
-            Assert.AreEqual(60, options.InvitationTimeoutInSeconds);
-            Assert.IsNotNull(options.OperationCallbackUri);
+            Assert.That(options.OperationContext, Is.EqualTo("custom-context"));
+            Assert.That(options.InvitationTimeoutInSeconds, Is.EqualTo(60));
+            Assert.That(options.OperationCallbackUri, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsApp))]
@@ -366,8 +366,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_AddParticipant_MicrosoftTeamsApp))]
@@ -376,8 +376,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.AddParticipant(new AddParticipantOptions(callInvite)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -387,8 +387,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             CallInvite? nullCallInvite = null;
 
             ArgumentNullException? ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(nullCallInvite!)).ConfigureAwait(false));
-            Assert.IsNotNull(ex);
-            Assert.IsTrue(ex!.Message.Contains("Value cannot be null"));
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex!.Message.Contains("Value cannot be null"), Is.True);
         }
 
         [Test]
@@ -398,8 +398,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             CallInvite? nullCallInvite = null;
 
             ArgumentNullException? ex = Assert.Throws<ArgumentNullException>(() => callConnection.AddParticipant(new AddParticipantOptions(nullCallInvite!)));
-            Assert.IsNotNull(ex);
-            Assert.IsTrue(ex!.Message.Contains("Value cannot be null"));
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex!.Message.Contains("Value cannot be null"), Is.True);
         }
 
         [Test]
@@ -408,8 +408,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, AddParticipantPayload);
 
             ArgumentNullException? ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(null)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.True(ex?.Message.Contains("Value cannot be null."));
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Message.Contains("Value cannot be null."), Is.True);
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -419,8 +419,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callInvite = new CallInvite((CommunicationUserIdentifier)participantToAdd);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.AddParticipantAsync(new AddParticipantOptions(callInvite)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -430,8 +430,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callInvite = new CallInvite((CommunicationUserIdentifier)participantToAdd);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.AddParticipant(new AddParticipantOptions(callInvite)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_GetParticipant))]
@@ -441,7 +441,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var participantIdentifier = new CommunicationUserIdentifier(participantMri);
 
             var response = await callConnection.GetParticipantAsync(participantIdentifier).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyGetParticipantResult(response);
         }
 
@@ -452,7 +452,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var participantIdentifier = new CommunicationUserIdentifier(participantMri);
 
             var response = callConnection.GetParticipant(participantIdentifier);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyGetParticipantResult(response);
         }
 
@@ -463,8 +463,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var participantIdentifier = new CommunicationUserIdentifier(participantMri);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.GetParticipantAsync(participantIdentifier).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_GetParticipant))]
@@ -474,8 +474,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var participantIdentifier = new CommunicationUserIdentifier(participantMri);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.GetParticipant(participantIdentifier));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -484,7 +484,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, GetParticipantsPayload);
 
             var response = await callConnection.GetParticipantsAsync().ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyGetParticipantsResult(response.Value);
         }
 
@@ -494,7 +494,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, GetParticipantsPayload);
 
             var response = callConnection.GetParticipants();
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
             verifyGetParticipantsResult(response.Value);
         }
 
@@ -504,8 +504,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.GetParticipantsAsync().ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -514,8 +514,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.GetParticipants());
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -524,8 +524,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.RemoveParticipantAsync(participantToRemove).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
-            Assert.AreEqual(OperationContext, response.Value.OperationContext);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
+            Assert.That(response.Value.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -534,8 +534,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.RemoveParticipant(participantToRemove);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
-            Assert.AreEqual(OperationContext, response.Value.OperationContext);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
+            Assert.That(response.Value.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -544,8 +544,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.RemoveParticipantAsync(participantToRemove).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_AddOrRemoveParticipant))]
@@ -554,8 +554,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.RemoveParticipant(participantToRemove));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -565,8 +565,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, null, connectionId);
 
             var response = callConnection.GetCallMedia();
-            Assert.IsNotNull(response);
-            Assert.AreEqual(connectionId, response.CallConnectionId);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.CallConnectionId, Is.EqualTo(connectionId));
         }
 
         [TestCaseSource(nameof(TestData_MuteParticipant))]
@@ -575,7 +575,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, OperationContextPayload);
 
             var response = callConnection.MuteParticipant(participant);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [TestCaseSource(nameof(TestData_MuteParticipant))]
@@ -587,8 +587,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
                 OperationContext = OperationContext
             };
             var response = callConnection.MuteParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
-            Assert.AreEqual(OperationContext, response.Value.OperationContext);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
+            Assert.That(response.Value.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [TestCaseSource(nameof(TestData_MuteParticipant))]
@@ -597,7 +597,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(200, OperationContextPayload);
 
             var response = await callConnection.MuteParticipantAsync(participant);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [Test]
@@ -618,8 +618,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             };
 
             var response = await callConnection.MuteParticipantAsync(options);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.GetRawResponse().Status);
-            Assert.AreEqual(OperationContext, response.Value.OperationContext);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
+            Assert.That(response.Value.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [TestCaseSource(nameof(TestData_MuteParticipant))]
@@ -641,8 +641,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var invitationId = "invitationId";
 
             var response = await callConnection.CancelAddParticipantOperationAsync(invitationId).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
-            Assert.AreEqual(invitationId, response.Value.InvitationId);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
+            Assert.That(response.Value.InvitationId, Is.EqualTo(invitationId));
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -651,14 +651,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            Assert.That(callInvite.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -667,14 +667,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.TransferCallToParticipant(callInvite.Target);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
 
             // Verify the target is correctly typed as MicrosoftTeamsAppIdentifier
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            Assert.That(callInvite.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -685,14 +685,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var options = new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier);
 
             var response = await callConnection.TransferCallToParticipantAsync(options).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
 
             // Verify the options were created correctly
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(options.Target);
-            Assert.IsNotNull(options.CustomCallingContext);
-            Assert.IsEmpty(options.CustomCallingContext.SipHeaders);
-            Assert.IsNotNull(options.CustomCallingContext.VoipHeaders);
+            Assert.That(options.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
+            Assert.That(options.CustomCallingContext, Is.Not.Null);
+            Assert.That(options.CustomCallingContext.SipHeaders, Is.Empty);
+            Assert.That(options.CustomCallingContext.VoipHeaders, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -703,14 +703,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var options = new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier);
 
             var response = callConnection.TransferCallToParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
 
             // Verify the options were created correctly
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(options.Target);
-            Assert.IsNotNull(options.CustomCallingContext);
-            Assert.IsEmpty(options.CustomCallingContext.SipHeaders);
-            Assert.IsNotNull(options.CustomCallingContext.VoipHeaders);
+            Assert.That(options.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
+            Assert.That(options.CustomCallingContext, Is.Not.Null);
+            Assert.That(options.CustomCallingContext.SipHeaders, Is.Empty);
+            Assert.That(options.CustomCallingContext.VoipHeaders, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsAppWithCloud))]
@@ -719,17 +719,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = await callConnection.TransferCallToParticipantAsync(callInvite.Target).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
 
             // Verify the target maintains the correct cloud environment
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            Assert.That(callInvite.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
-            Assert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
+            Assert.That(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Dod ||
-                         teamsApp.Cloud == CommunicationCloudEnvironment.Gcch);
+                         teamsApp.Cloud == CommunicationCloudEnvironment.Gcch, Is.True);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsAppWithCloud))]
@@ -738,17 +738,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(202, OperationContextPayload);
 
             var response = callConnection.TransferCallToParticipant(callInvite.Target);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
 
             // Verify the target maintains the correct cloud environment
-            Assert.IsInstanceOf<MicrosoftTeamsAppIdentifier>(callInvite.Target);
+            Assert.That(callInvite.Target, Is.InstanceOf<MicrosoftTeamsAppIdentifier>());
             var teamsApp = callInvite.Target as MicrosoftTeamsAppIdentifier;
-            Assert.IsNotNull(teamsApp);
-            Assert.AreEqual("testAppId", teamsApp!.AppId);
-            Assert.IsTrue(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
+            Assert.That(teamsApp, Is.Not.Null);
+            Assert.That(teamsApp!.AppId, Is.EqualTo("testAppId"));
+            Assert.That(teamsApp.Cloud == CommunicationCloudEnvironment.Public ||
                          teamsApp.Cloud == CommunicationCloudEnvironment.Dod ||
-                         teamsApp.Cloud == CommunicationCloudEnvironment.Gcch);
+                         teamsApp.Cloud == CommunicationCloudEnvironment.Gcch, Is.True);
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -762,14 +762,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             options.SourceCallerIdNumber = new PhoneNumberIdentifier("+14255551234");
 
             var response = await callConnection.TransferCallToParticipantAsync(options).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
 
             // Verify all optional properties can be set
-            Assert.IsNotNull(options.Transferee);
-            Assert.IsNotNull(options.OperationCallbackUri);
-            Assert.IsNotNull(options.SourceCallerIdNumber);
-            Assert.AreEqual("custom-context", options.OperationContext);
+            Assert.That(options.Transferee, Is.Not.Null);
+            Assert.That(options.OperationCallbackUri, Is.Not.Null);
+            Assert.That(options.SourceCallerIdNumber, Is.Not.Null);
+            Assert.That(options.OperationContext, Is.EqualTo("custom-context"));
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -783,14 +783,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             options.SourceCallerIdNumber = new PhoneNumberIdentifier("+14255551234");
 
             var response = callConnection.TransferCallToParticipant(options);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
             verifyOperationContext(response);
 
             // Verify all optional properties can be set
-            Assert.IsNotNull(options.Transferee);
-            Assert.IsNotNull(options.OperationCallbackUri);
-            Assert.IsNotNull(options.SourceCallerIdNumber);
-            Assert.AreEqual("custom-context", options.OperationContext);
+            Assert.That(options.Transferee, Is.Not.Null);
+            Assert.That(options.OperationCallbackUri, Is.Not.Null);
+            Assert.That(options.SourceCallerIdNumber, Is.Not.Null);
+            Assert.That(options.OperationContext, Is.EqualTo("custom-context"));
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -799,8 +799,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await callConnection.TransferCallToParticipantAsync(new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier)).ConfigureAwait(false));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_TransferCallToParticipant_MicrosoftTeamsApp))]
@@ -809,8 +809,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             var callConnection = CreateMockCallConnection(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as MicrosoftTeamsAppIdentifier)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -820,8 +820,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             MicrosoftTeamsAppIdentifier? nullTeamsAppIdentifier = null;
 
             ArgumentNullException? ex = Assert.ThrowsAsync<ArgumentNullException>(async () => await callConnection.TransferCallToParticipantAsync(nullTeamsAppIdentifier!).ConfigureAwait(false));
-            Assert.IsNotNull(ex);
-            Assert.AreEqual("targetParticipant", ex!.ParamName);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex!.ParamName, Is.EqualTo("targetParticipant"));
         }
 
         [Test]
@@ -831,8 +831,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
             MicrosoftTeamsAppIdentifier? nullTeamsAppIdentifier = null;
 
             ArgumentNullException? ex = Assert.Throws<ArgumentNullException>(() => callConnection.TransferCallToParticipant(nullTeamsAppIdentifier!));
-            Assert.IsNotNull(ex);
-            Assert.AreEqual("targetParticipant", ex!.ParamName);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex!.ParamName, Is.EqualTo("targetParticipant"));
         }
 
         private CallConnection CreateMockCallConnection(int responseCode, string? responseContent = null, string callConnectionId = "9ec7da16-30be-4e74-a941-285cfc4bffc5")
@@ -977,33 +977,33 @@ namespace Azure.Communication.CallAutomation.Tests.CallConnections
 
         private void verifyOperationContext(TransferCallToParticipantResult result)
         {
-            Assert.AreEqual(OperationContext, result.OperationContext);
+            Assert.That(result.OperationContext, Is.EqualTo(OperationContext));
         }
 
         private void verifyAddParticipantsResult(AddParticipantResult result)
         {
             var identifier = (CommunicationUserIdentifier)result.Participant.Identifier;
-            Assert.AreEqual(ParticipantUserId, identifier.Id);
-            Assert.IsFalse(result.Participant.IsMuted);
-            Assert.AreEqual(OperationContext, result.OperationContext);
+            Assert.That(identifier.Id, Is.EqualTo(ParticipantUserId));
+            Assert.That(result.Participant.IsMuted, Is.False);
+            Assert.That(result.OperationContext, Is.EqualTo(OperationContext));
         }
 
         private void verifyGetParticipantResult(CallParticipant participant)
         {
             var identifier = (CommunicationUserIdentifier)participant.Identifier;
-            Assert.AreEqual(ParticipantUserId, identifier.Id);
-            Assert.IsFalse(participant.IsMuted);
+            Assert.That(identifier.Id, Is.EqualTo(ParticipantUserId));
+            Assert.That(participant.IsMuted, Is.False);
         }
 
         private void verifyGetParticipantsResult(IReadOnlyList<CallParticipant> participants)
         {
-            Assert.AreEqual(2, participants.Count);
+            Assert.That(participants.Count, Is.EqualTo(2));
             var identifier = (CommunicationUserIdentifier)participants[0].Identifier;
-            Assert.AreEqual(ParticipantUserId, identifier.Id);
-            Assert.IsFalse(participants[0].IsMuted);
+            Assert.That(identifier.Id, Is.EqualTo(ParticipantUserId));
+            Assert.That(participants[0].IsMuted, Is.False);
             var identifier2 = (PhoneNumberIdentifier)participants[1].Identifier;
-            Assert.AreEqual(PhoneNumber, identifier2.PhoneNumber);
-            Assert.IsTrue(participants[1].IsMuted);
+            Assert.That(identifier2.PhoneNumber, Is.EqualTo(PhoneNumber));
+            Assert.That(participants[1].IsMuted, Is.True);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaAutomatedLiveTests.cs
@@ -73,11 +73,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             CreateCallResult response = await client.CreateCallAsync(invite, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
 
             string callConnectionId = response.CallConnectionProperties.CallConnectionId;
-            Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+            Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
             // wait for incomingcall context
             string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(incomingCallContext);
+            Assert.That(incomingCallContext, Is.Not.Null);
 
             // answer the call
             var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
@@ -86,51 +86,51 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // wait for callConnected
             var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(connectedEvent);
-            Assert.IsTrue(connectedEvent is CallConnected);
-            Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+            Assert.That(connectedEvent, Is.Not.Null);
+            Assert.That(connectedEvent is CallConnected, Is.True);
+            Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
             // test get properties
             Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+            Assert.That(properties.Value.CallConnectionState, Is.EqualTo(CallConnectionState.Connected));
 
             try
             {
                 // start continuous dtmf recognition
                 var startContinuousDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().StartContinuousDtmfRecognitionAsync(target);
-                Assert.AreEqual(StatusCodes.Status200OK, startContinuousDtmfResponse.Status);
+                Assert.That(startContinuousDtmfResponse.Status, Is.EqualTo(StatusCodes.Status200OK));
 
                 // again start continuous dtmf recognition and expect success
                 startContinuousDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().StartContinuousDtmfRecognitionAsync(target);
-                Assert.AreEqual(startContinuousDtmfResponse.Status, StatusCodes.Status200OK);
+                Assert.That(startContinuousDtmfResponse.Status, Is.EqualTo(StatusCodes.Status200OK));
 
                 // send dtmf tones to the target user
                 var tones = new DtmfTone[] { DtmfTone.One };
                 var sendDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().SendDtmfTonesAsync(tones, target);
-                Assert.AreEqual(StatusCodes.Status202Accepted, sendDtmfResponse.GetRawResponse().Status);
+                Assert.That(sendDtmfResponse.GetRawResponse().Status, Is.EqualTo(StatusCodes.Status202Accepted));
 
                 // wait for ContinuousDtmfRecognitionToneReceived event
                 var continuousDtmfRecognitionToneReceived = await WaitForEvent<ContinuousDtmfRecognitionToneReceived>(targetCallConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(continuousDtmfRecognitionToneReceived);
-                Assert.IsTrue(continuousDtmfRecognitionToneReceived is ContinuousDtmfRecognitionToneReceived);
+                Assert.That(continuousDtmfRecognitionToneReceived, Is.Not.Null);
+                Assert.That(continuousDtmfRecognitionToneReceived is ContinuousDtmfRecognitionToneReceived, Is.True);
 
                 // wait for SendDtmfCompleted event
                 var sendDtmfCompletedEvent = await WaitForEvent<SendDtmfTonesCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(sendDtmfCompletedEvent);
-                Assert.IsTrue(sendDtmfCompletedEvent is SendDtmfTonesCompleted);
+                Assert.That(sendDtmfCompletedEvent, Is.Not.Null);
+                Assert.That(sendDtmfCompletedEvent is SendDtmfTonesCompleted, Is.True);
 
                 // stop continuous dtmf recognition
                 var stopContinuousDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().StopContinuousDtmfRecognitionAsync(target);
-                Assert.AreEqual(StatusCodes.Status200OK, stopContinuousDtmfResponse.Status);
+                Assert.That(stopContinuousDtmfResponse.Status, Is.EqualTo(StatusCodes.Status200OK));
 
                 // wait for ContinuousDtmfRecognitionStopped event
                 var continuousDtmfRecognitionStopped = await WaitForEvent<ContinuousDtmfRecognitionStopped>(callConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(continuousDtmfRecognitionStopped);
-                Assert.IsTrue(continuousDtmfRecognitionStopped is ContinuousDtmfRecognitionStopped);
+                Assert.That(continuousDtmfRecognitionStopped, Is.Not.Null);
+                Assert.That(continuousDtmfRecognitionStopped is ContinuousDtmfRecognitionStopped, Is.True);
 
                 // again call stop coninuous recognition and expect success
                 stopContinuousDtmfResponse = await client.GetCallConnection(callConnectionId).GetCallMedia().StopContinuousDtmfRecognitionAsync(target);
-                Assert.AreEqual(StatusCodes.Status200OK, stopContinuousDtmfResponse.Status);
+                Assert.That(stopContinuousDtmfResponse.Status, Is.EqualTo(StatusCodes.Status200OK));
             }
             catch (RequestFailedException ex)
             {
@@ -174,16 +174,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple File Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    Assert.That(playCompletedEvent, Is.Not.Null);
+                    Assert.That(playCompletedEvent is PlayCompleted, Is.True);
+                    Assert.That(((PlayCompleted)playCompletedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -246,16 +246,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple File Sources
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    Assert.That(playCompletedEvent, Is.Not.Null);
+                    Assert.That(playCompletedEvent is PlayCompleted, Is.True);
+                    Assert.That(((PlayCompleted)playCompletedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -318,16 +318,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    Assert.That(playCompletedEvent, Is.Not.Null);
+                    Assert.That(playCompletedEvent is PlayCompleted, Is.True);
+                    Assert.That(((PlayCompleted)playCompletedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -390,16 +390,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    Assert.That(playCompletedEvent, Is.Not.Null);
+                    Assert.That(playCompletedEvent is PlayCompleted, Is.True);
+                    Assert.That(((PlayCompleted)playCompletedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -461,16 +461,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    Assert.That(playCompletedEvent, Is.Not.Null);
+                    Assert.That(playCompletedEvent is PlayCompleted, Is.True);
+                    Assert.That(((PlayCompleted)playCompletedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -532,16 +532,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playCompletedEvent = await WaitForEvent<PlayCompleted>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playCompletedEvent);
-                    Assert.IsTrue(playCompletedEvent is PlayCompleted);
-                    Assert.AreEqual(callConnectionId, ((PlayCompleted)playCompletedEvent!).CallConnectionId);
+                    Assert.That(playCompletedEvent, Is.Not.Null);
+                    Assert.That(playCompletedEvent is PlayCompleted, Is.True);
+                    Assert.That(((PlayCompleted)playCompletedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -602,17 +602,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playFailedEvent = await WaitForEvent<PlayFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playFailedEvent);
-                    Assert.IsTrue(playFailedEvent is PlayFailed);
-                    Assert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
-                    Assert.AreEqual(0, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
+                    Assert.That(playFailedEvent, Is.Not.Null);
+                    Assert.That(playFailedEvent is PlayFailed, Is.True);
+                    Assert.That(((PlayFailed)playFailedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
+                    Assert.That(((PlayFailed)playFailedEvent!).FailedPlaySourceIndex, Is.EqualTo(0));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -674,17 +674,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayAsync(options).ConfigureAwait(false);
                     var playFailedEvent = await WaitForEvent<PlayFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playFailedEvent);
-                    Assert.IsTrue(playFailedEvent is PlayFailed);
-                    Assert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
-                    Assert.AreEqual(1, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
+                    Assert.That(playFailedEvent, Is.Not.Null);
+                    Assert.That(playFailedEvent is PlayFailed, Is.True);
+                    Assert.That(((PlayFailed)playFailedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
+                    Assert.That(((PlayFailed)playFailedEvent!).FailedPlaySourceIndex, Is.EqualTo(1));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -745,17 +745,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with invalid file source
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playFailedEvent = await WaitForEvent<PlayFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playFailedEvent);
-                    Assert.IsTrue(playFailedEvent is PlayFailed);
-                    Assert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
-                    Assert.AreEqual(0, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
+                    Assert.That(playFailedEvent, Is.Not.Null);
+                    Assert.That(playFailedEvent is PlayFailed, Is.True);
+                    Assert.That(((PlayFailed)playFailedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
+                    Assert.That(((PlayFailed)playFailedEvent!).FailedPlaySourceIndex, Is.EqualTo(0));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -817,17 +817,17 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // Assert the Play with multiple Text Sources
                     await callConnection.GetCallMedia().PlayToAllAsync(options).ConfigureAwait(false);
                     var playFailedEvent = await WaitForEvent<PlayFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(playFailedEvent);
-                    Assert.IsTrue(playFailedEvent is PlayFailed);
-                    Assert.AreEqual(callConnectionId, ((PlayFailed)playFailedEvent!).CallConnectionId);
-                    Assert.AreEqual(1, ((PlayFailed)playFailedEvent!).FailedPlaySourceIndex);
+                    Assert.That(playFailedEvent, Is.Not.Null);
+                    Assert.That(playFailedEvent is PlayFailed, Is.True);
+                    Assert.That(((PlayFailed)playFailedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
+                    Assert.That(((PlayFailed)playFailedEvent!).FailedPlaySourceIndex, Is.EqualTo(1));
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -891,9 +891,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -958,9 +958,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1025,9 +1025,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1090,9 +1090,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1156,9 +1156,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1222,9 +1222,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1289,9 +1289,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1356,9 +1356,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1421,9 +1421,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1487,9 +1487,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1553,9 +1553,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1620,9 +1620,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1687,9 +1687,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1752,9 +1752,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1818,9 +1818,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1884,9 +1884,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -1951,9 +1951,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -2018,9 +2018,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -2083,9 +2083,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -2149,9 +2149,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -2204,16 +2204,16 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
                     // wait for callConnected
                     var addParticipantSucceededEvent = await WaitForEvent<ParticipantsUpdated>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(addParticipantSucceededEvent);
-                    Assert.IsTrue(addParticipantSucceededEvent is ParticipantsUpdated);
-                    Assert.IsTrue(((ParticipantsUpdated)addParticipantSucceededEvent!).CallConnectionId == callConnectionId);
+                    Assert.That(addParticipantSucceededEvent, Is.Not.Null);
+                    Assert.That(addParticipantSucceededEvent is ParticipantsUpdated, Is.True);
+                    Assert.That(((ParticipantsUpdated)addParticipantSucceededEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // Assert the participant hold
                     await callConnection.GetCallMedia().HoldAsync(target).ConfigureAwait(false);
                     await Task.Delay(1000);
                     var participantResult = await callConnection.GetParticipantAsync(target).ConfigureAwait(false);
-                    Assert.IsNotNull(participantResult);
-                    Assert.IsTrue(participantResult.Value.IsOnHold);
+                    Assert.That(participantResult, Is.Not.Null);
+                    Assert.That(participantResult.Value.IsOnHold, Is.True);
 
                     // Assert the participant unhold
                     await callConnection.GetCallMedia().UnholdAsync(target).ConfigureAwait(false);
@@ -2221,15 +2221,15 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                     await Task.Delay(1000);
 
                     participantResult = await callConnection.GetParticipantAsync(target).ConfigureAwait(false);
-                    Assert.IsNotNull(participantResult);
-                    Assert.IsFalse(participantResult.Value.IsOnHold);
+                    Assert.That(participantResult, Is.Not.Null);
+                    Assert.That(participantResult.Value.IsOnHold, Is.False);
 
                     // try hangup
                     await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     try
                     {
@@ -2586,11 +2586,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 }
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 var callerCallConnectionId = response.CallConnectionProperties.CallConnectionId;
-                Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                 // wait for incomingcall context
                 string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(incomingCallContext);
+                Assert.That(incomingCallContext, Is.Not.Null);
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
@@ -2600,9 +2600,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 // wait for callConnected
 
                 var connectedEvent = await WaitForEvent<CallConnected>(targetCallConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(connectedEvent);
-                Assert.IsTrue(connectedEvent is CallConnected);
-                Assert.AreEqual(targetCallConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                Assert.That(connectedEvent, Is.Not.Null);
+                Assert.That(connectedEvent is CallConnected, Is.True);
+                Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(targetCallConnectionId));
                 return (callerCallConnectionId, targetCallConnectionId);
             }
             catch (Exception)
@@ -2641,11 +2641,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 }
                 CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                 var callerCallConnectionId = response.CallConnectionProperties.CallConnectionId;
-                Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                 // wait for incomingcall context
                 string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(incomingCallContext);
+                Assert.That(incomingCallContext, Is.Not.Null);
 
                 // answer the call
                 var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
@@ -2670,9 +2670,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
                 // wait for callConnected
 
                 var connectedEvent = await WaitForEvent<CallConnected>(targetCallConnectionId, TimeSpan.FromSeconds(20));
-                Assert.IsNotNull(connectedEvent);
-                Assert.IsTrue(connectedEvent is CallConnected);
-                Assert.AreEqual(targetCallConnectionId, ((CallConnected)connectedEvent!).CallConnectionId);
+                Assert.That(connectedEvent, Is.Not.Null);
+                Assert.That(connectedEvent is CallConnected, Is.True);
+                Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(targetCallConnectionId));
                 return (callerCallConnectionId, targetCallConnectionId);
             }
             catch (Exception)
@@ -2695,14 +2695,14 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // wait for callConnected
             var mediaStreamingStartedEvent = await WaitForEvent<MediaStreamingStarted>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(mediaStreamingStartedEvent);
-            Assert.IsTrue(mediaStreamingStartedEvent is MediaStreamingStarted);
+            Assert.That(mediaStreamingStartedEvent, Is.Not.Null);
+            Assert.That(mediaStreamingStartedEvent is MediaStreamingStarted, Is.True);
 
             // Assert call connection properties
             var connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.MediaStreamingSubscription);
-            Assert.AreEqual(connectionProperties.Value.MediaStreamingSubscription.State, MediaStreamingSubscriptionState.Active);
+            Assert.That(connectionProperties, Is.Not.Null);
+            Assert.That(connectionProperties.Value.MediaStreamingSubscription, Is.Not.Null);
+            Assert.That(MediaStreamingSubscriptionState.Active, Is.EqualTo(connectionProperties.Value.MediaStreamingSubscription.State));
 
             //Stop media streaming
             StopMediaStreamingOptions stopMediaStreamingOptions = new StopMediaStreamingOptions();
@@ -2711,21 +2711,21 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // wait for callConnected
             var stopMediaStreamingEvent = await WaitForEvent<MediaStreamingStopped>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(stopMediaStreamingEvent);
-            Assert.IsTrue(stopMediaStreamingEvent is MediaStreamingStopped);
+            Assert.That(stopMediaStreamingEvent, Is.Not.Null);
+            Assert.That(stopMediaStreamingEvent is MediaStreamingStopped, Is.True);
 
             // Assert call connection properties
             connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.MediaStreamingSubscription);
-            Assert.AreEqual(connectionProperties.Value.MediaStreamingSubscription.State, MediaStreamingSubscriptionState.Inactive);
+            Assert.That(connectionProperties, Is.Not.Null);
+            Assert.That(connectionProperties.Value.MediaStreamingSubscription, Is.Not.Null);
+            Assert.That(MediaStreamingSubscriptionState.Inactive, Is.EqualTo(connectionProperties.Value.MediaStreamingSubscription.State));
 
             // try hangup
             await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
             var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(disconnectedEvent);
-            Assert.IsTrue(disconnectedEvent is CallDisconnected);
-            Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+            Assert.That(disconnectedEvent, Is.Not.Null);
+            Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+            Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
         }
 
         private async Task VerifyTranscription(CallAutomationClient client, string callConnectionId)
@@ -2740,8 +2740,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             var callerMedia = client.GetCallConnection(callConnectionId).GetCallMedia();
             var startTranscriptionResponse = await callerMedia.StartTranscriptionAsync(startTranscriptionOptions);
             var startTranscriptionEvent = await WaitForEvent<TranscriptionStarted>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(startTranscriptionEvent);
-            Assert.IsTrue(startTranscriptionEvent is TranscriptionStarted);
+            Assert.That(startTranscriptionEvent, Is.Not.Null);
+            Assert.That(startTranscriptionEvent is TranscriptionStarted, Is.True);
 
             var source = new TextSource("Hello, this is live test", "en-US-ElizabethNeural");
             var options = new PlayToAllOptions(source) { OperationContext = "playalloptionduringtranscription" };
@@ -2749,41 +2749,41 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // test get properties
             var connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.TranscriptionSubscription);
-            Assert.AreEqual(connectionProperties.Value.TranscriptionSubscription.State, TranscriptionSubscriptionState.Active);
+            Assert.That(connectionProperties, Is.Not.Null);
+            Assert.That(connectionProperties.Value.TranscriptionSubscription, Is.Not.Null);
+            Assert.That(TranscriptionSubscriptionState.Active, Is.EqualTo(connectionProperties.Value.TranscriptionSubscription.State));
 
             // Update Transcription
             UpdateTranscriptionOptions updateTranscriptionOptions = new UpdateTranscriptionOptions("en-US") { OperationContext = "UpdateTranscription" };
             var updateTranscriptionResponse = await callerMedia.UpdateTranscriptionAsync(updateTranscriptionOptions);
             var updateTranscriptionEvent = await WaitForEvent<TranscriptionUpdated>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(updateTranscriptionEvent);
-            Assert.IsTrue(updateTranscriptionEvent is TranscriptionUpdated);
+            Assert.That(updateTranscriptionEvent, Is.Not.Null);
+            Assert.That(updateTranscriptionEvent is TranscriptionUpdated, Is.True);
 
             connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.TranscriptionSubscription);
-            Assert.AreEqual(connectionProperties.Value.TranscriptionSubscription.State, TranscriptionSubscriptionState.Active);
+            Assert.That(connectionProperties, Is.Not.Null);
+            Assert.That(connectionProperties.Value.TranscriptionSubscription, Is.Not.Null);
+            Assert.That(TranscriptionSubscriptionState.Active, Is.EqualTo(connectionProperties.Value.TranscriptionSubscription.State));
 
             //Stop Transcription
             StopTranscriptionOptions stopTranscriptionOptions = new StopTranscriptionOptions() { OperationContext = "StopTranscription" };
             var stopTranscriptionResponse = await callerMedia.StopTranscriptionAsync(stopTranscriptionOptions);
 
             var stopTranscriptionEvent = await WaitForEvent<TranscriptionStopped>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(stopTranscriptionEvent);
-            Assert.IsTrue(stopTranscriptionEvent is TranscriptionStopped);
+            Assert.That(stopTranscriptionEvent, Is.Not.Null);
+            Assert.That(stopTranscriptionEvent is TranscriptionStopped, Is.True);
 
             connectionProperties = await client.GetCallConnection(callConnectionId).GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.IsNotNull(connectionProperties);
-            Assert.IsNotNull(connectionProperties.Value.TranscriptionSubscription);
-            Assert.AreEqual(connectionProperties.Value.TranscriptionSubscription.State, TranscriptionSubscriptionState.Inactive);
+            Assert.That(connectionProperties, Is.Not.Null);
+            Assert.That(connectionProperties.Value.TranscriptionSubscription, Is.Not.Null);
+            Assert.That(TranscriptionSubscriptionState.Inactive, Is.EqualTo(connectionProperties.Value.TranscriptionSubscription.State));
 
             // try hangup
             await client.GetCallConnection(callConnectionId).HangUpAsync(true).ConfigureAwait(false);
             var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(disconnectedEvent);
-            Assert.IsTrue(disconnectedEvent is CallDisconnected);
-            Assert.AreEqual(callConnectionId, ((CallDisconnected)disconnectedEvent!).CallConnectionId);
+            Assert.That(disconnectedEvent, Is.Not.Null);
+            Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+            Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
         }
 
         private async Task VerifyRecognizeFailedEventForMultipleSources(string callConnectionId,
@@ -2796,7 +2796,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             // Assert the playall with multiple Text Sources
             var recognizeOptions = GetRecognizeOptions(playMultipleSources, target, recognizeInputType, playSource);
-            Assert.IsNotNull(recognizeOptions);
+            Assert.That(recognizeOptions, Is.Not.Null);
 
             var callConnection = client.GetCallConnection(callConnectionId);
 
@@ -2817,22 +2817,22 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
 
             // Assert the playall with multiple Text Sources
             var recognizeFailedEvent = await WaitForEvent<RecognizeFailed>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(recognizeFailedEvent);
-            Assert.IsTrue(recognizeFailedEvent is RecognizeFailed);
-            Assert.AreEqual(callConnectionId, ((RecognizeFailed)recognizeFailedEvent!).CallConnectionId);
+            Assert.That(recognizeFailedEvent, Is.Not.Null);
+            Assert.That(recognizeFailedEvent is RecognizeFailed, Is.True);
+            Assert.That(((RecognizeFailed)recognizeFailedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
             if (expectedBadRequestCheck)
             {
-                Assert.AreEqual(MediaEventReasonCode.PlayInvalidFileFormat, ((RecognizeFailed)recognizeFailedEvent!).ReasonCode);
+                Assert.That(((RecognizeFailed)recognizeFailedEvent!).ReasonCode, Is.EqualTo(MediaEventReasonCode.PlayInvalidFileFormat));
             }
             else if (isInvalidSourceCheck)
             {
-                Assert.AreEqual(0, ((RecognizeFailed)recognizeFailedEvent!).FailedPlaySourceIndex);
+                Assert.That(((RecognizeFailed)recognizeFailedEvent!).FailedPlaySourceIndex, Is.EqualTo(0));
             }
             else
             {
-                Assert.AreEqual(MediaEventReasonCode.RecognizeInitialSilenceTimedOut, ((RecognizeFailed)recognizeFailedEvent!).ReasonCode);
+                Assert.That(((RecognizeFailed)recognizeFailedEvent!).ReasonCode, Is.EqualTo(MediaEventReasonCode.RecognizeInitialSilenceTimedOut));
                 if (recognizeInputType != RecognizeInputType.Dtmf)
-                    Assert.IsNull(((RecognizeFailed)recognizeFailedEvent!).FailedPlaySourceIndex);
+                    Assert.That(((RecognizeFailed)recognizeFailedEvent!).FailedPlaySourceIndex, Is.Null);
             }
         }
 

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallMedias/CallMediaTests.cs
@@ -236,8 +236,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_CancelOperationsAsync))]
@@ -245,8 +245,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperationsAsync))]
@@ -254,8 +254,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_SendDtmfOperationsAsync))]
@@ -263,8 +263,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202, "{ \"operationContext\": \"operationContext\" }");
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_StartContinuousRecognitionOperationsAsync))]
@@ -272,8 +272,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [TestCaseSource(nameof(TestData_StopContinuousRecognitionOperationsAsync))]
@@ -281,8 +281,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [TestCaseSource(nameof(TestData_StartTranscriptionOperationsAsync))]
@@ -290,8 +290,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_StopTranscriptionOperationsAsync))]
@@ -299,8 +299,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_UpdateTranscriptionOperationsAsync))]
@@ -308,8 +308,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_StartMediaStreamingOperationsAsync))]
@@ -317,8 +317,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_StopMediaStreamingOperationsAsync))]
@@ -326,8 +326,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_PlayOperations))]
@@ -335,8 +335,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_PlayOperations_WithBargeIn))]
@@ -344,8 +344,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_CancelOperations))]
@@ -353,8 +353,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperations))]
@@ -362,8 +362,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_SendDtmfOperations))]
@@ -371,8 +371,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202, "{ \"operationContext\": \"operationContext\" }");
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.GetRawResponse().Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_StartContinuousRecognitionOperations))]
@@ -380,8 +380,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [TestCaseSource(nameof(TestData_StopContinuousRecognitionOperations))]
@@ -389,8 +389,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [TestCaseSource(nameof(TestData_StartTranscriptionOperations))]
@@ -398,8 +398,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_StopTranscriptionOperations))]
@@ -407,8 +407,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_UpdateTranscriptionOperations))]
@@ -416,8 +416,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_StartMediaStreamingOperations))]
@@ -425,8 +425,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_StopMediaStreamingOperations))]
@@ -434,8 +434,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(202);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.Accepted, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.Accepted));
         }
 
         [TestCaseSource(nameof(TestData_PlayOperationsAsync))]
@@ -444,8 +444,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_CancelOperationsAsync))]
@@ -454,8 +454,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperationsAsync))]
@@ -464,8 +464,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_SendDtmfOperationsAsync))]
@@ -474,8 +474,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StartContinuousRecognitionOperationsAsync))]
@@ -484,8 +484,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StopContinuousRecognitionOperationsAsync))]
@@ -494,8 +494,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StartTranscriptionOperationsAsync))]
@@ -504,8 +504,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_UpdateTranscriptionOperationsAsync))]
@@ -514,8 +514,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StopTranscriptionOperationsAsync))]
@@ -524,8 +524,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StartMediaStreamingOperationsAsync))]
@@ -534,8 +534,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StopMediaStreamingOperationsAsync))]
@@ -544,8 +544,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(
                 async () => await operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_PlayOperations))]
@@ -554,8 +554,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperations))]
@@ -564,8 +564,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_SendDtmfOperations))]
@@ -574,8 +574,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_CancelOperations))]
@@ -584,8 +584,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_RecognizeOperations))]
@@ -594,8 +594,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StartContinuousRecognitionOperations))]
@@ -604,8 +604,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StopContinuousRecognitionOperations))]
@@ -614,8 +614,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StartTranscriptionOperations))]
@@ -624,8 +624,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StopTranscriptionOperations))]
@@ -634,8 +634,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_UpdateTranscriptionOperations))]
@@ -644,8 +644,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_HoldOperationsAsync))]
@@ -653,8 +653,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = await operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [TestCaseSource(nameof(TestData_HoldOperations))]
@@ -662,8 +662,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
         {
             _callMedia = GetCallMedia(200);
             var result = operation(_callMedia);
-            Assert.IsNotNull(result);
-            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [TestCaseSource(nameof(TestData_StartMediaStreamingOperations))]
@@ -672,8 +672,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_StopMediaStreamingOperations))]
@@ -682,8 +682,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallMedias
             _callMedia = GetCallMedia(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(
                 () => operation(_callMedia));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         private static IEnumerable<object?[]> TestData_PlayOperationsAsync()

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingAutomatedLiveTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingAutomatedLiveTests.cs
@@ -34,26 +34,26 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
             CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
             string callConnectionId = response.CallConnectionProperties.CallConnectionId;
-            Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+            Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
             // wait for incomingcall context
             string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(incomingCallContext);
+            Assert.That(incomingCallContext, Is.Not.Null);
 
             // answer the call
             var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
             var answerResponse = await targetClient.AnswerCallAsync(answerCallOptions);
-            Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
+            Assert.That(answerResponse.GetRawResponse().Status, Is.EqualTo(StatusCodes.Status200OK));
 
             // wait for callConnected
             var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(connectedEvent);
-            Assert.IsTrue(connectedEvent is CallConnected);
-            Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+            Assert.That(connectedEvent, Is.Not.Null);
+            Assert.That(connectedEvent is CallConnected, Is.True);
+            Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
             // test get properties
             Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+            Assert.That(properties.Value.CallConnectionState, Is.EqualTo(CallConnectionState.Connected));
 
             var serverCallId = properties.Value.ServerCallId;
 
@@ -63,30 +63,30 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                 RecordingStateCallbackUri = new Uri(TestEnvironment.DispatcherCallback),
             };
             var recordingResponse = await callRecording.StartAsync(recordingOptions).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
+            Assert.That(recordingResponse.Value, Is.Not.Null);
 
             var recordingId = recordingResponse.Value.RecordingId;
-            Assert.NotNull(recordingId);
+            Assert.That(recordingId, Is.Not.Null);
             await WaitForOperationCompletion().ConfigureAwait(false);
 
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
+            Assert.That(recordingResponse.Value, Is.Not.Null);
+            Assert.That(recordingResponse.Value.RecordingState, Is.Not.Null);
+            Assert.That(RecordingState.Active, Is.EqualTo(recordingResponse.Value.RecordingState));
 
             await callRecording.PauseAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Inactive);
+            Assert.That(recordingResponse.Value, Is.Not.Null);
+            Assert.That(recordingResponse.Value.RecordingState, Is.Not.Null);
+            Assert.That(RecordingState.Inactive, Is.EqualTo(recordingResponse.Value.RecordingState));
 
             await callRecording.ResumeAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
+            Assert.That(recordingResponse.Value, Is.Not.Null);
+            Assert.That(recordingResponse.Value.RecordingState, Is.Not.Null);
+            Assert.That(RecordingState.Active, Is.EqualTo(recordingResponse.Value.RecordingState));
 
             await callRecording.StopAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
@@ -143,26 +143,26 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    Assert.That(incomingCallContext, Is.Not.Null);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
                     var answerResponse = await targetClient.AnswerCallAsync(answerCallOptions);
-                    Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
+                    Assert.That(answerResponse.GetRawResponse().Status, Is.EqualTo(StatusCodes.Status200OK));
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+                    Assert.That(connectedEvent, Is.Not.Null);
+                    Assert.That(connectedEvent is CallConnected, Is.True);
+                    Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    Assert.That(properties.Value.CallConnectionState, Is.EqualTo(CallConnectionState.Connected));
 
                     // try start recording unmixed audio - no channel affinity
                     var startRecordingResponse = await client.GetCallRecording().StartAsync(
@@ -173,12 +173,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                             RecordingFormat = RecordingFormat.Wav,
                             RecordingStateCallbackUri = new Uri(TestEnvironment.DispatcherCallback),
                         });
-                    Assert.AreEqual(StatusCodes.Status200OK, startRecordingResponse.GetRawResponse().Status);
-                    Assert.NotNull(startRecordingResponse.Value.RecordingId);
+                    Assert.That(startRecordingResponse.GetRawResponse().Status, Is.EqualTo(StatusCodes.Status200OK));
+                    Assert.That(startRecordingResponse.Value.RecordingId, Is.Not.Null);
 
                     // try stop recording
                     var stopRecordingResponse = await client.GetCallRecording().StopAsync(startRecordingResponse.Value.RecordingId);
-                    Assert.AreEqual(StatusCodes.Status204NoContent, stopRecordingResponse.Status);
+                    Assert.That(stopRecordingResponse.Status, Is.EqualTo(StatusCodes.Status204NoContent));
 
                     // wait for CallRecordingStateChanged event TODO: Figure out why this event not being received
                     // var recordingStartedEvent = await WaitForEvent<CallRecordingStateChanged>(callConnectionId, TimeSpan.FromSeconds(20));
@@ -189,9 +189,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                     // try hangup
                     await response.CallConnection.HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.IsTrue(((CallDisconnected)disconnectedEvent!).CallConnectionId == callConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
                     callConnectionId = null;
                 }
                 catch (Exception)
@@ -239,26 +239,26 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                     var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
                     CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
                     callConnectionId = response.CallConnectionProperties.CallConnectionId;
-                    Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+                    Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
                     // wait for incomingcall context
                     string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(incomingCallContext);
+                    Assert.That(incomingCallContext, Is.Not.Null);
 
                     // answer the call
                     var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
                     var answerResponse = await targetClient.AnswerCallAsync(answerCallOptions);
-                    Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
+                    Assert.That(answerResponse.GetRawResponse().Status, Is.EqualTo(StatusCodes.Status200OK));
 
                     // wait for callConnected
                     var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(connectedEvent);
-                    Assert.IsTrue(connectedEvent is CallConnected);
-                    Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+                    Assert.That(connectedEvent, Is.Not.Null);
+                    Assert.That(connectedEvent is CallConnected, Is.True);
+                    Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
                     // test get properties
                     Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-                    Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+                    Assert.That(properties.Value.CallConnectionState, Is.EqualTo(CallConnectionState.Connected));
 
                     // try start recording unmixed audio with channel affinity
                     var startRecordingOptions =
@@ -272,12 +272,12 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                     startRecordingOptions.AudioChannelParticipantOrdering.Add(user);
                     startRecordingOptions.AudioChannelParticipantOrdering.Add(target);
                     var startRecordingResponse = await client.GetCallRecording().StartAsync(startRecordingOptions);
-                    Assert.AreEqual(StatusCodes.Status200OK, startRecordingResponse.GetRawResponse().Status);
-                    Assert.NotNull(startRecordingResponse.Value.RecordingId);
+                    Assert.That(startRecordingResponse.GetRawResponse().Status, Is.EqualTo(StatusCodes.Status200OK));
+                    Assert.That(startRecordingResponse.Value.RecordingId, Is.Not.Null);
 
                     // try stop recording
                     var stopRecordingResponse = await client.GetCallRecording().StopAsync(startRecordingResponse.Value.RecordingId);
-                    Assert.AreEqual(StatusCodes.Status204NoContent, stopRecordingResponse.Status);
+                    Assert.That(stopRecordingResponse.Status, Is.EqualTo(StatusCodes.Status204NoContent));
 
                     // wait for CallRecordingStateChanged event TODO: Figure out why event not received
                     // var recordingStartedEvent = await WaitForEvent<CallRecordingStateChanged>(callConnectionId, TimeSpan.FromSeconds(20));
@@ -288,9 +288,9 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                     // try hangup
                     await response.CallConnection.HangUpAsync(true).ConfigureAwait(false);
                     var disconnectedEvent = await WaitForEvent<CallDisconnected>(callConnectionId, TimeSpan.FromSeconds(20));
-                    Assert.IsNotNull(disconnectedEvent);
-                    Assert.IsTrue(disconnectedEvent is CallDisconnected);
-                    Assert.IsTrue(((CallDisconnected)disconnectedEvent!).CallConnectionId == callConnectionId);
+                    Assert.That(disconnectedEvent, Is.Not.Null);
+                    Assert.That(disconnectedEvent is CallDisconnected, Is.True);
+                    Assert.That(((CallDisconnected)disconnectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
                     callConnectionId = null;
                 }
                 catch (Exception)
@@ -326,26 +326,26 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             var createCallOptions = new CreateCallOptions(new CallInvite(target), new Uri(TestEnvironment.DispatcherCallback + $"?q={uniqueId}"));
             CreateCallResult response = await client.CreateCallAsync(createCallOptions).ConfigureAwait(false);
             string callConnectionId = response.CallConnectionProperties.CallConnectionId;
-            Assert.IsNotEmpty(response.CallConnectionProperties.CallConnectionId);
+            Assert.That(response.CallConnectionProperties.CallConnectionId, Is.Not.Empty);
 
             // wait for incomingcall context
             string? incomingCallContext = await WaitForIncomingCallContext(uniqueId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(incomingCallContext);
+            Assert.That(incomingCallContext, Is.Not.Null);
 
             // answer the call
             var answerCallOptions = new AnswerCallOptions(incomingCallContext, new Uri(TestEnvironment.DispatcherCallback));
             var answerResponse = await targetClient.AnswerCallAsync(answerCallOptions);
-            Assert.AreEqual(answerResponse.GetRawResponse().Status, StatusCodes.Status200OK);
+            Assert.That(answerResponse.GetRawResponse().Status, Is.EqualTo(StatusCodes.Status200OK));
 
             // wait for callConnected
             var connectedEvent = await WaitForEvent<CallConnected>(callConnectionId, TimeSpan.FromSeconds(20));
-            Assert.IsNotNull(connectedEvent);
-            Assert.IsTrue(connectedEvent is CallConnected);
-            Assert.IsTrue(((CallConnected)connectedEvent!).CallConnectionId == callConnectionId);
+            Assert.That(connectedEvent, Is.Not.Null);
+            Assert.That(connectedEvent is CallConnected, Is.True);
+            Assert.That(((CallConnected)connectedEvent!).CallConnectionId, Is.EqualTo(callConnectionId));
 
             // test get properties
             Response<CallConnectionProperties> properties = await response.CallConnection.GetCallConnectionPropertiesAsync().ConfigureAwait(false);
-            Assert.AreEqual(CallConnectionState.Connected, properties.Value.CallConnectionState);
+            Assert.That(properties.Value.CallConnectionState, Is.EqualTo(CallConnectionState.Connected));
 
             var serverCallId = properties.Value.ServerCallId;
 
@@ -355,30 +355,30 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                 RecordingStateCallbackUri = new Uri(TestEnvironment.DispatcherCallback)
             };
             var recordingResponse = await callRecording.StartAsync(recordingOptions).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
+            Assert.That(recordingResponse.Value, Is.Not.Null);
 
             var recordingId = recordingResponse.Value.RecordingId;
-            Assert.NotNull(recordingId);
+            Assert.That(recordingId, Is.Not.Null);
             await WaitForOperationCompletion().ConfigureAwait(false);
 
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
+            Assert.That(recordingResponse.Value, Is.Not.Null);
+            Assert.That(recordingResponse.Value.RecordingState, Is.Not.Null);
+            Assert.That(RecordingState.Active, Is.EqualTo(recordingResponse.Value.RecordingState));
 
             await callRecording.PauseAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Inactive);
+            Assert.That(recordingResponse.Value, Is.Not.Null);
+            Assert.That(recordingResponse.Value.RecordingState, Is.Not.Null);
+            Assert.That(RecordingState.Inactive, Is.EqualTo(recordingResponse.Value.RecordingState));
 
             await callRecording.ResumeAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);
             recordingResponse = await callRecording.GetStateAsync(recordingId).ConfigureAwait(false);
-            Assert.NotNull(recordingResponse.Value);
-            Assert.NotNull(recordingResponse.Value.RecordingState);
-            Assert.AreEqual(recordingResponse.Value.RecordingState, RecordingState.Active);
+            Assert.That(recordingResponse.Value, Is.Not.Null);
+            Assert.That(recordingResponse.Value.RecordingState, Is.Not.Null);
+            Assert.That(RecordingState.Active, Is.EqualTo(recordingResponse.Value.RecordingState));
 
             await callRecording.StopAsync(recordingId);
             await WaitForOperationCompletion().ConfigureAwait(false);

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/CallRecordingTests.cs
@@ -31,8 +31,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(200, responseContent: DummyRecordingStatusResponse);
 
             RecordingStateResult result = operation(callRecording);
-            Assert.AreEqual("dummyRecordingId", result.RecordingId);
-            Assert.AreEqual(RecordingState.Active, result.RecordingState);
+            Assert.That(result.RecordingId, Is.EqualTo("dummyRecordingId"));
+            Assert.That(result.RecordingState, Is.EqualTo(RecordingState.Active));
         }
 
         [TestCaseSource(nameof(TestData_OperationsAsyncWithStatus))]
@@ -41,8 +41,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(200, responseContent: DummyRecordingStatusResponse);
 
             Response<RecordingStateResult> result = await operation(callRecording);
-            Assert.AreEqual("dummyRecordingId", result.Value.RecordingId);
-            Assert.AreEqual(RecordingState.Active, result.Value.RecordingState);
+            Assert.That(result.Value.RecordingId, Is.EqualTo("dummyRecordingId"));
+            Assert.That(result.Value.RecordingState, Is.EqualTo(RecordingState.Active));
         }
 
         [TestCaseSource(nameof(TestData_OperationsWithCallConnectionIdWithStatus))]
@@ -51,8 +51,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(200, responseContent: DummyRecordingStatusResponse);
 
             RecordingStateResult result = operation(callRecording);
-            Assert.AreEqual("dummyRecordingId", result.RecordingId);
-            Assert.AreEqual(RecordingState.Active, result.RecordingState);
+            Assert.That(result.RecordingId, Is.EqualTo("dummyRecordingId"));
+            Assert.That(result.RecordingState, Is.EqualTo(RecordingState.Active));
         }
 
         [TestCaseSource(nameof(TestData_OperationsAsyncWithCallConnectionIdWithStatus))]
@@ -61,8 +61,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(200, responseContent: DummyRecordingStatusResponse);
 
             Response<RecordingStateResult> result = await operation(callRecording);
-            Assert.AreEqual("dummyRecordingId", result.Value.RecordingId);
-            Assert.AreEqual(RecordingState.Active, result.Value.RecordingState);
+            Assert.That(result.Value.RecordingId, Is.EqualTo("dummyRecordingId"));
+            Assert.That(result.Value.RecordingState, Is.EqualTo(RecordingState.Active));
         }
 
         [TestCaseSource(nameof(TestData_OperationsSuccess))]
@@ -71,7 +71,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(expectedStatusCode);
 
             Response response = operation(callRecording);
-            Assert.AreEqual(expectedStatusCode, response.Status);
+            Assert.That(response.Status, Is.EqualTo(expectedStatusCode));
         }
 
         [TestCaseSource(nameof(TestData_OperationsAsyncSuccess))]
@@ -80,7 +80,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(expectedStatusCode);
 
             Response response = await operation(callRecording);
-            Assert.AreEqual(expectedStatusCode, response.Status);
+            Assert.That(response.Status, Is.EqualTo(expectedStatusCode));
         }
 
         [TestCaseSource(nameof(TestData_Operations404))]
@@ -88,8 +88,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallRecording callRecording = getMockCallRecording(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(operation(callRecording));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(TestData_OperationsAsync404))]
@@ -98,8 +98,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallRecording callRecording = getMockCallRecording(404);
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(operation(callRecording));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         private CallRecording getMockCallRecording(int statusCode, string? responseContent = null)

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/ContentDownloadTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/ContentDownloadTests.cs
@@ -124,7 +124,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             Stream destination = new MemoryStream();
             _callAutomationClient.GetCallRecording().DownloadTo(_dummyRecordingLocation, destination, options);
 
-            Assert.AreEqual(10, destination.Length);
+            Assert.That(destination.Length, Is.EqualTo(10));
         }
 
         [Test]
@@ -151,11 +151,11 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
                 MaximumTransferSize = 5
             };
 
-            Assert.AreNotEqual(options.GetHashCode(), options_updated.GetHashCode());
-            Assert.AreEqual(options.GetHashCode(), options_copy.GetHashCode());
-            Assert.True(options.Equals(options_copy));
-            Assert.True(options.Equals((object)options_copy));
-            Assert.False(options.Equals(options_updated));
+            Assert.That(options_updated.GetHashCode(), Is.Not.EqualTo(options.GetHashCode()));
+            Assert.That(options_copy.GetHashCode(), Is.EqualTo(options.GetHashCode()));
+            Assert.That(options, Is.EqualTo(options_copy));
+            Assert.That(options, Is.EqualTo((object)options_copy));
+            Assert.That(options.Equals(options_updated), Is.False);
         }
 
         [Test]
@@ -163,8 +163,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient _callAutomationClient = CreateMockCallAutomationClient(404);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => _callAutomationClient.GetCallRecording().DownloadStreaming(_dummyMetadataLocation));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -172,8 +172,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient _callAutomationClient = CreateMockCallAutomationClient(404);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await _callAutomationClient.GetCallRecording().DownloadStreamingAsync(_dummyMetadataLocation));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -181,8 +181,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient _callAutomationClient = CreateMockCallAutomationClient(401);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => _callAutomationClient.GetCallRecording().DownloadStreaming(_dummyMetadataLocation));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(401));
         }
 
         [Test]
@@ -190,8 +190,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient _callAutomationClient = CreateMockCallAutomationClient(401);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await _callAutomationClient.GetCallRecording().DownloadStreamingAsync(_dummyMetadataLocation));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(401));
         }
 
         [Test]
@@ -218,7 +218,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             Stream destination = new MemoryStream();
             _callAutomationClient.GetCallRecording().DownloadTo(_dummyRecordingLocation, destination, options);
 
-            Assert.AreEqual(10, destination.Length);
+            Assert.That(destination.Length, Is.EqualTo(10));
         }
 
         [Test]
@@ -245,22 +245,22 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             Stream destination = new MemoryStream();
             await _callAutomationClient.GetCallRecording().DownloadToAsync(_dummyRecordingLocation, destination, options);
 
-            Assert.AreEqual(10, destination.Length);
+            Assert.That(destination.Length, Is.EqualTo(10));
         }
 
         private static void VerifyExpectedMetadata(Stream metadata)
         {
-            Assert.IsNotNull(metadata);
+            Assert.That(metadata, Is.Not.Null);
             JsonElement expected = JsonDocument.Parse(DummyRecordingMetadata).RootElement;
             JsonElement actual = JsonDocument.Parse(metadata).RootElement;
-            Assert.AreEqual(expected.GetProperty("chunkDocumentId").GetString(), actual.GetProperty("chunkDocumentId").GetString());
+            Assert.That(actual.GetProperty("chunkDocumentId").GetString(), Is.EqualTo(expected.GetProperty("chunkDocumentId").GetString()));
         }
 
         private static void VerifyExpectedRecording(Response<Stream> recording, int recordingLength)
         {
-            Assert.IsNotNull(recording.Value);
-            Assert.IsTrue(recording.Value.GetType().Name.Contains(typeof(RetriableStream).Name));
-            Assert.AreEqual(recordingLength, recording.Value.Length);
+            Assert.That(recording.Value, Is.Not.Null);
+            Assert.That(recording.Value.GetType().Name.Contains(typeof(RetriableStream).Name), Is.True);
+            Assert.That(recording.Value.Length, Is.EqualTo(recordingLength));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/DeleteRecordingTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/CallRecordings/DeleteRecordingTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(200);
             var response = callAutomationClient.GetCallRecording().Delete(new Uri(AmsDeleteUrl));
-            Assert.AreEqual((int)HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [Test]
@@ -26,7 +26,7 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(200);
             var response = await callAutomationClient.GetCallRecording().DeleteAsync(new Uri(AmsDeleteUrl)).ConfigureAwait(false);
-            Assert.AreEqual((int)HttpStatusCode.OK, response.Status);
+            Assert.That(response.Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         [Test]
@@ -35,8 +35,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(404);
 
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.GetCallRecording().Delete(new Uri(AmsDeleteUrl)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -44,8 +44,8 @@ namespace Azure.Communication.CallAutomation.Tests.CallRecordings
         {
             CallAutomationClient callAutomationClient = CreateMockCallAutomationClient(401);
             RequestFailedException? ex = Assert.Throws<RequestFailedException>(() => callAutomationClient.GetCallRecording().Delete(new Uri(AmsDeleteUrl)));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 401);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(401));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/AttachEventProcessorTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/AttachEventProcessorTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
 
             // Assert if the delegate was also called
-            Assert.AreEqual(CallConnectionId, callConnectionIdPassedFromOngoingEventProcessor);
+            Assert.That(callConnectionIdPassedFromOngoingEventProcessor, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
 
             // Assert if the delegate didnt get called
-            Assert.AreEqual(ServerCallId, callConnectionIdPassedFromOngoingEventProcessor);
+            Assert.That(callConnectionIdPassedFromOngoingEventProcessor, Is.EqualTo(ServerCallId));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
 
             // Assert if the delegate was also called
-            Assert.AreEqual(CallConnectionId, callConnectionIdPassedFromOngoingEventProcessor);
+            Assert.That(callConnectionIdPassedFromOngoingEventProcessor, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallTransferAccepted(internalEvent));
 
             // Assert if the delegate was never called
-            Assert.AreEqual(ServerCallId, callConnectionIdPassedFromOngoingEventProcessor);
+            Assert.That(callConnectionIdPassedFromOngoingEventProcessor, Is.EqualTo(ServerCallId));
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
 
             // Assert if the delegate was never called
-            Assert.AreEqual(ServerCallId, callConnectionIdPassedFromOngoingEventProcessor);
+            Assert.That(callConnectionIdPassedFromOngoingEventProcessor, Is.EqualTo(ServerCallId));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/EventProcessorAsyncTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/EventProcessorAsyncTests.cs
@@ -31,9 +31,9 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventBase returnedBaseEvent = await baseEventTask;
 
             // Assert
-            Assert.NotNull(returnedBaseEvent);
-            Assert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
-            Assert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
+            Assert.That(returnedBaseEvent, Is.Not.Null);
+            Assert.That(returnedBaseEvent.GetType(), Is.EqualTo(typeof(CallConnected)));
+            Assert.That(returnedBaseEvent.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -52,9 +52,9 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
                 && ev.GetType() == typeof(CallConnected));
 
             // Assert
-            Assert.NotNull(returnedBaseEvent);
-            Assert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
-            Assert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
+            Assert.That(returnedBaseEvent, Is.Not.Null);
+            Assert.That(returnedBaseEvent.GetType(), Is.EqualTo(typeof(CallConnected)));
+            Assert.That(returnedBaseEvent.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -112,9 +112,9 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
                 // assert
                 CallAutomationEventBase returnedBaseEvent = await task;
-                Assert.NotNull(returnedBaseEvent);
-                Assert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
-                Assert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
+                Assert.That(returnedBaseEvent, Is.Not.Null);
+                Assert.That(returnedBaseEvent.GetType(), Is.EqualTo(typeof(CallConnected)));
+                Assert.That(returnedBaseEvent.CallConnectionId, Is.EqualTo(CallConnectionId));
             }
         }
 
@@ -141,9 +141,9 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             {
                 // Assert
                 CallAutomationEventBase returnedBaseEvent = await eventAwaiter;
-                Assert.NotNull(returnedBaseEvent);
-                Assert.AreEqual(typeof(CallConnected), returnedBaseEvent.GetType());
-                Assert.AreEqual(CallConnectionId, returnedBaseEvent.CallConnectionId);
+                Assert.That(returnedBaseEvent, Is.Not.Null);
+                Assert.That(returnedBaseEvent.GetType(), Is.EqualTo(typeof(CallConnected)));
+                Assert.That(returnedBaseEvent.CallConnectionId, Is.EqualTo(CallConnectionId));
 
                 if (i < eventsSent - 1)
                 {

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/ResultWithEventProcessorAsyncTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/EventProcessors/ResultWithEventProcessorAsyncTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
 
             var response = callAutomationClient.CreateCall(new CreateCallOptions(CreateMockInvite(), new Uri(CallBackUri)));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -36,11 +36,11 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CreateCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CallConnected), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(CallConnected)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -54,17 +54,17 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
                 options: new CallAutomationClientOptions() { Source = new CommunicationUserIdentifier("12345") });
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
             var response = callAutomationClient.CreateCall(new CreateCallOptions(CreateMockInvite(), new Uri(CallBackUri)));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
             var createCallFailedInternalEvent = new CreateCallFailedInternal(CallConnectionId, ServerCallId, CorelationId, "mismatchedOperationId", null);
             SendAndProcessEvent(handler, new CreateCallFailed(createCallFailedInternalEvent));
             CreateCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CreateCallFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(false));
+            Assert.That(returnedResult.FailureResult, Is.Not.Null);
+            Assert.That(returnedResult.SuccessResult, Is.Null);
+            Assert.That(returnedResult.FailureResult.GetType(), Is.EqualTo(typeof(CreateCallFailed)));
+            Assert.That(returnedResult.FailureResult.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
 
             var response = callAutomationClient.ConnectCall(new ConnectCallOptions(new ServerCallLocator(ServerCallId), new Uri(CallBackUri)));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -88,11 +88,11 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             ConnectCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CallConnected), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(CallConnected)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -106,16 +106,16 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
                 options: new CallAutomationClientOptions() { Source = new CommunicationUserIdentifier("12345") });
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
             var response = callAutomationClient.ConnectCall(new ConnectCallOptions(new ServerCallLocator(ServerCallId), new Uri(CallBackUri)));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
             SendAndProcessEvent(handler, new ConnectFailed(CallConnectionId, ServerCallId, CorelationId, "mismatchedOperationId", null));
             ConnectCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(ConnectFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(false));
+            Assert.That(returnedResult.FailureResult, Is.Not.Null);
+            Assert.That(returnedResult.SuccessResult, Is.Null);
+            Assert.That(returnedResult.FailureResult.GetType(), Is.EqualTo(typeof(ConnectFailed)));
+            Assert.That(returnedResult.FailureResult.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callAutomationClient.GetEventProcessor();
 
             var response = callAutomationClient.AnswerCall("incomingCallContext", new Uri(CallBackUri));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new CallConnected(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -138,11 +138,11 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             AnswerCallEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CallConnected), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(CallConnected)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
             var callInvite = new CallInvite(new CommunicationUserIdentifier(TargetUser));
             var response = callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
             var transferee = new CommunicationIdentifierModel();
             transferee.CommunicationUser = new CommunicationUserIdentifierModel(TransfereeUser);
             transferee.RawId = TransfereeUser;
@@ -171,15 +171,15 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             TransferCallToParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(CallTransferAccepted), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.SuccessResult.OperationContext);
-            Assert.AreEqual(transferee.CommunicationUser.Id, returnedResult.SuccessResult.Transferee.RawId);
-            Assert.AreEqual(transferTarget.CommunicationUser.Id, returnedResult.SuccessResult.TransferTarget.RawId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult, Is.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(CallTransferAccepted)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.SuccessResult.OperationContext, Is.EqualTo(response.Value.OperationContext));
+            Assert.That(returnedResult.SuccessResult.Transferee.RawId, Is.EqualTo(transferee.CommunicationUser.Id));
+            Assert.That(returnedResult.SuccessResult.TransferTarget.RawId, Is.EqualTo(transferTarget.CommunicationUser.Id));
         }
 
         [Test]
@@ -192,7 +192,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
             var callInvite = new CallInvite(new CommunicationUserIdentifier(TargetUser));
             var response = callConnection.TransferCallToParticipant(new TransferToParticipantOptions(callInvite.Target as CommunicationUserIdentifier));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new CallTransferFailed(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null));
@@ -200,13 +200,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             TransferCallToParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(CallTransferFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.FailureResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(false));
+            Assert.That(returnedResult.SuccessResult, Is.Null);
+            Assert.That(returnedResult.FailureResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult.GetType(), Is.EqualTo(typeof(CallTransferFailed)));
+            Assert.That(returnedResult.FailureResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.FailureResult.OperationContext, Is.EqualTo(response.Value.OperationContext));
         }
 
         [Test]
@@ -219,7 +219,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             var callInvite = CreateMockInvite();
 
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.AddParticipantSucceeded(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null, callInvite.Target));
@@ -227,13 +227,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             AddParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(AddParticipantSucceeded), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.SuccessResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult, Is.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(AddParticipantSucceeded)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.SuccessResult.OperationContext, Is.EqualTo(response.Value.OperationContext));
         }
 
         [Test]
@@ -246,7 +246,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
             var callInvite = CreateMockInvite();
             var response = callConnection.AddParticipant(new AddParticipantOptions(callInvite));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.AddParticipantFailed(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null, callInvite.Target));
@@ -254,13 +254,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             AddParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(AddParticipantFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.FailureResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(false));
+            Assert.That(returnedResult.SuccessResult, Is.Null);
+            Assert.That(returnedResult.FailureResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult.GetType(), Is.EqualTo(typeof(AddParticipantFailed)));
+            Assert.That(returnedResult.FailureResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.FailureResult.OperationContext, Is.EqualTo(response.Value.OperationContext));
         }
 
         [Test]
@@ -272,7 +272,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().PlayToAll(new PlayToAllOptions(new FileSource(new Uri(CallBackUri))) { OperationContext = OperationContext });
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             var internalEvent = new PlayCompletedInternal(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation() { });
 
@@ -282,13 +282,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             PlayEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(PlayCompleted), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.SuccessResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult, Is.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(PlayCompleted)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.SuccessResult.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [Test]
@@ -300,7 +300,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().PlayToAll(new PlayToAllOptions(new FileSource(new Uri(CallBackUri))) { OperationContext = OperationContext });
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             var internalEvent = new PlayFailedInternal(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation() { }, null);
 
@@ -310,13 +310,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             PlayEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(PlayFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.FailureResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(false));
+            Assert.That(returnedResult.SuccessResult, Is.Null);
+            Assert.That(returnedResult.FailureResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult.GetType(), Is.EqualTo(typeof(PlayFailed)));
+            Assert.That(returnedResult.FailureResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.FailureResult.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [Test]
@@ -328,7 +328,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().CancelAllMediaOperations();
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new PlayCanceled(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -336,12 +336,12 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CancelAllMediaOperationsEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.PlayCanceledSucessEvent);
-            Assert.IsNull(returnedResult.RecognizeCanceledSucessEvent);
-            Assert.AreEqual(typeof(PlayCanceled), returnedResult.PlayCanceledSucessEvent.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.PlayCanceledSucessEvent.CallConnectionId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.PlayCanceledSucessEvent, Is.Not.Null);
+            Assert.That(returnedResult.RecognizeCanceledSucessEvent, Is.Null);
+            Assert.That(returnedResult.PlayCanceledSucessEvent.GetType(), Is.EqualTo(typeof(PlayCanceled)));
+            Assert.That(returnedResult.PlayCanceledSucessEvent.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -353,7 +353,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().CancelAllMediaOperations();
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new RecognizeCanceled(CallConnectionId, ServerCallId, CorelationId, null, null));
@@ -361,12 +361,12 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CancelAllMediaOperationsEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.RecognizeCanceledSucessEvent);
-            Assert.IsNull(returnedResult.PlayCanceledSucessEvent);
-            Assert.AreEqual(typeof(RecognizeCanceled), returnedResult.RecognizeCanceledSucessEvent.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.RecognizeCanceledSucessEvent.CallConnectionId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.RecognizeCanceledSucessEvent, Is.Not.Null);
+            Assert.That(returnedResult.PlayCanceledSucessEvent, Is.Null);
+            Assert.That(returnedResult.RecognizeCanceledSucessEvent.GetType(), Is.EqualTo(typeof(RecognizeCanceled)));
+            Assert.That(returnedResult.RecognizeCanceledSucessEvent.CallConnectionId, Is.EqualTo(CallConnectionId));
         }
 
         [Test]
@@ -378,7 +378,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().StartRecognizing(new CallMediaRecognizeDtmfOptions(new CommunicationUserIdentifier(TargetId), 1) { OperationContext = OperationContext });
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, new RecognizeCompleted(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation(), CallMediaRecognitionType.Dtmf, null));
@@ -386,13 +386,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             StartRecognizingEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(RecognizeCompleted), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.SuccessResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult, Is.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(RecognizeCompleted)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.SuccessResult.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [Test]
@@ -404,7 +404,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CallAutomationEventProcessor handler = callConnection.EventProcessor;
 
             var response = callConnection.GetCallMedia().StartRecognizing(new CallMediaRecognizeDtmfOptions(new CommunicationUserIdentifier(TargetId), 1) { OperationContext = OperationContext });
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             var internalEvent = new RecognizeFailedInternal(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation() { }, null);
 
@@ -414,13 +414,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             StartRecognizingEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(RecognizeFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.FailureResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(false));
+            Assert.That(returnedResult.FailureResult, Is.Not.Null);
+            Assert.That(returnedResult.SuccessResult, Is.Null);
+            Assert.That(returnedResult.FailureResult.GetType(), Is.EqualTo(typeof(RecognizeFailed)));
+            Assert.That(returnedResult.FailureResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.FailureResult.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [Test]
@@ -433,7 +433,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             var callInvite = CreateMockInvite();
 
             var response = callConnection.RemoveParticipant(new RemoveParticipantOptions(callInvite.Target));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.RemoveParticipantSucceeded(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null, callInvite.Target));
@@ -441,13 +441,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             RemoveParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(RemoveParticipantSucceeded), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.SuccessResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult, Is.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(RemoveParticipantSucceeded)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.SuccessResult.OperationContext, Is.EqualTo(response.Value.OperationContext));
         }
 
         [Test]
@@ -460,7 +460,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
 
             var callInvite = CreateMockInvite();
             var response = callConnection.RemoveParticipant(new RemoveParticipantOptions(callInvite.Target));
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.RemoveParticipantFailed(CallConnectionId, ServerCallId, CorelationId, response.Value.OperationContext, null, callInvite.Target));
@@ -468,13 +468,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             RemoveParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(RemoveParticipantFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(response.Value.OperationContext, returnedResult.FailureResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(false));
+            Assert.That(returnedResult.SuccessResult, Is.Null);
+            Assert.That(returnedResult.FailureResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult.GetType(), Is.EqualTo(typeof(RemoveParticipantFailed)));
+            Assert.That(returnedResult.FailureResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.FailureResult.OperationContext, Is.EqualTo(response.Value.OperationContext));
         }
 
         [Test]
@@ -489,7 +489,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             dtmfOption.OperationContext = OperationContext;
 
             var response = callConnection.GetCallMedia().SendDtmfTones(dtmfOption);
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.SendDtmfTonesCompleted(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation()));
@@ -497,13 +497,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendDtmfTonesEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(SendDtmfTonesCompleted), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.SuccessResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult, Is.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(SendDtmfTonesCompleted)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.SuccessResult.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [Test]
@@ -518,7 +518,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             dtmfOption.OperationContext = OperationContext;
 
             var response = callConnection.GetCallMedia().SendDtmfTones(dtmfOption);
-            Assert.AreEqual(successCode, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(successCode));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.SendDtmfTonesFailed(CallConnectionId, ServerCallId, CorelationId, OperationContext, new ResultInformation()));
@@ -526,13 +526,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             SendDtmfTonesEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(SendDtmfTonesFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(OperationContext, returnedResult.FailureResult.OperationContext);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(false));
+            Assert.That(returnedResult.FailureResult, Is.Not.Null);
+            Assert.That(returnedResult.SuccessResult, Is.Null);
+            Assert.That(returnedResult.FailureResult.GetType(), Is.EqualTo(typeof(SendDtmfTonesFailed)));
+            Assert.That(returnedResult.FailureResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.FailureResult.OperationContext, Is.EqualTo(OperationContext));
         }
 
         [Test]
@@ -544,7 +544,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             var callInvite = CreateMockInvite();
             var response = callConnection.CancelAddParticipantOperation(invitationId);
 
-            Assert.AreEqual(202, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(202));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.CancelAddParticipantFailed(
@@ -558,13 +558,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CancelAddParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(false, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.FailureResult);
-            Assert.IsNull(returnedResult.SuccessResult);
-            Assert.AreEqual(typeof(CancelAddParticipantFailed), returnedResult.FailureResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.FailureResult.CallConnectionId);
-            Assert.AreEqual(invitationId, returnedResult.FailureResult.InvitationId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(false));
+            Assert.That(returnedResult.FailureResult, Is.Not.Null);
+            Assert.That(returnedResult.SuccessResult, Is.Null);
+            Assert.That(returnedResult.FailureResult.GetType(), Is.EqualTo(typeof(CancelAddParticipantFailed)));
+            Assert.That(returnedResult.FailureResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.FailureResult.InvitationId, Is.EqualTo(invitationId));
         }
 
         [Test]
@@ -576,7 +576,7 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             var callInvite = CreateMockInvite();
             var response = callConnection.CancelAddParticipantOperation(invitationId);
 
-            Assert.AreEqual(202, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(202));
 
             // Create and send event to event processor
             SendAndProcessEvent(handler, CallAutomationModelFactory.CancelAddParticipantSucceeded(
@@ -589,13 +589,13 @@ namespace Azure.Communication.CallAutomation.Tests.EventProcessors
             CancelAddParticipantEventResult returnedResult = await response.Value.WaitForEventProcessorAsync();
 
             // Assert
-            Assert.NotNull(returnedResult);
-            Assert.AreEqual(true, returnedResult.IsSuccess);
-            Assert.NotNull(returnedResult.SuccessResult);
-            Assert.IsNull(returnedResult.FailureResult);
-            Assert.AreEqual(typeof(CancelAddParticipantSucceeded), returnedResult.SuccessResult.GetType());
-            Assert.AreEqual(CallConnectionId, returnedResult.SuccessResult.CallConnectionId);
-            Assert.AreEqual(invitationId, returnedResult.SuccessResult.InvitationId);
+            Assert.That(returnedResult, Is.Not.Null);
+            Assert.That(returnedResult.IsSuccess, Is.EqualTo(true));
+            Assert.That(returnedResult.SuccessResult, Is.Not.Null);
+            Assert.That(returnedResult.FailureResult, Is.Null);
+            Assert.That(returnedResult.SuccessResult.GetType(), Is.EqualTo(typeof(CancelAddParticipantSucceeded)));
+            Assert.That(returnedResult.SuccessResult.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(returnedResult.SuccessResult.InvitationId, Is.EqualTo(invitationId));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Events/CallAutomationEventParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Events/CallAutomationEventParserTests.cs
@@ -30,10 +30,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase callConnected = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.CallConnected");
 
             // assert
-            Assert.AreEqual(callConnected.GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId, callConnected.CallConnectionId);
-            Assert.AreEqual(serverCallId, callConnected.ServerCallId);
-            Assert.AreEqual(correlationId, callConnected.CorrelationId);
+            Assert.That(typeof(CallConnected), Is.EqualTo(callConnected.GetType()));
+            Assert.That(callConnected.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(callConnected.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(callConnected.CorrelationId, Is.EqualTo(correlationId));
         }
 
         [Test]
@@ -57,10 +57,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase callConnected = CallAutomationEventParser.Parse(cloudEvent);
 
             // assert
-            Assert.AreEqual(callConnected.GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId, callConnected.CallConnectionId);
-            Assert.AreEqual(serverCallId, callConnected.ServerCallId);
-            Assert.AreEqual(correlationId, callConnected.CorrelationId);
+            Assert.That(typeof(CallConnected), Is.EqualTo(callConnected.GetType()));
+            Assert.That(callConnected.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(callConnected.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(callConnected.CorrelationId, Is.EqualTo(correlationId));
         }
 
         [Test]
@@ -84,10 +84,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase callConnected = CallAutomationEventParser.Parse(new BinaryData(cloudEvent));
 
             // assert
-            Assert.AreEqual(callConnected.GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId, callConnected.CallConnectionId);
-            Assert.AreEqual(serverCallId, callConnected.ServerCallId);
-            Assert.AreEqual(correlationId, callConnected.CorrelationId);
+            Assert.That(typeof(CallConnected), Is.EqualTo(callConnected.GetType()));
+            Assert.That(callConnected.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(callConnected.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(callConnected.CorrelationId, Is.EqualTo(correlationId));
         }
 
         [Test]
@@ -122,15 +122,15 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase[] callAutomationEvents = CallAutomationEventParser.ParseMany(cloudEvents);
 
             // assert
-            Assert.AreEqual(2, callAutomationEvents.Length);
-            Assert.AreEqual(callAutomationEvents[0].GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId1, callAutomationEvents[0].CallConnectionId);
-            Assert.AreEqual(serverCallId1, callAutomationEvents[0].ServerCallId);
-            Assert.AreEqual(correlationId1, callAutomationEvents[0].CorrelationId);
-            Assert.AreEqual(callAutomationEvents[1].GetType(), typeof(CallDisconnected));
-            Assert.AreEqual(callConnectionId2, callAutomationEvents[1].CallConnectionId);
-            Assert.AreEqual(serverCallId2, callAutomationEvents[1].ServerCallId);
-            Assert.AreEqual(correlationId2, callAutomationEvents[1].CorrelationId);
+            Assert.That(callAutomationEvents.Length, Is.EqualTo(2));
+            Assert.That(typeof(CallConnected), Is.EqualTo(callAutomationEvents[0].GetType()));
+            Assert.That(callAutomationEvents[0].CallConnectionId, Is.EqualTo(callConnectionId1));
+            Assert.That(callAutomationEvents[0].ServerCallId, Is.EqualTo(serverCallId1));
+            Assert.That(callAutomationEvents[0].CorrelationId, Is.EqualTo(correlationId1));
+            Assert.That(typeof(CallDisconnected), Is.EqualTo(callAutomationEvents[1].GetType()));
+            Assert.That(callAutomationEvents[1].CallConnectionId, Is.EqualTo(callConnectionId2));
+            Assert.That(callAutomationEvents[1].ServerCallId, Is.EqualTo(serverCallId2));
+            Assert.That(callAutomationEvents[1].CorrelationId, Is.EqualTo(correlationId2));
         }
 
         [Test]
@@ -165,15 +165,15 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             CallAutomationEventBase[] callAutomationEvents = CallAutomationEventParser.ParseMany(new BinaryData(cloudEvents));
 
             // assert
-            Assert.AreEqual(2, callAutomationEvents.Length);
-            Assert.AreEqual(callAutomationEvents[0].GetType(), typeof(CallConnected));
-            Assert.AreEqual(callConnectionId1, callAutomationEvents[0].CallConnectionId);
-            Assert.AreEqual(serverCallId1, callAutomationEvents[0].ServerCallId);
-            Assert.AreEqual(correlationId1, callAutomationEvents[0].CorrelationId);
-            Assert.AreEqual(callAutomationEvents[1].GetType(), typeof(CallDisconnected));
-            Assert.AreEqual(callConnectionId2, callAutomationEvents[1].CallConnectionId);
-            Assert.AreEqual(serverCallId2, callAutomationEvents[1].ServerCallId);
-            Assert.AreEqual(correlationId2, callAutomationEvents[1].CorrelationId);
+            Assert.That(callAutomationEvents.Length, Is.EqualTo(2));
+            Assert.That(typeof(CallConnected), Is.EqualTo(callAutomationEvents[0].GetType()));
+            Assert.That(callAutomationEvents[0].CallConnectionId, Is.EqualTo(callConnectionId1));
+            Assert.That(callAutomationEvents[0].ServerCallId, Is.EqualTo(serverCallId1));
+            Assert.That(callAutomationEvents[0].CorrelationId, Is.EqualTo(correlationId1));
+            Assert.That(typeof(CallDisconnected), Is.EqualTo(callAutomationEvents[1].GetType()));
+            Assert.That(callAutomationEvents[1].CallConnectionId, Is.EqualTo(callConnectionId2));
+            Assert.That(callAutomationEvents[1].ServerCallId, Is.EqualTo(serverCallId2));
+            Assert.That(callAutomationEvents[1].CorrelationId, Is.EqualTo(correlationId2));
         }
 
         [Test]
@@ -195,12 +195,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is AddParticipantFailed addParticipantsFailed)
             {
-                Assert.AreEqual(callConnectionId, addParticipantsFailed.CallConnectionId);
-                Assert.AreEqual(serverCallId, addParticipantsFailed.ServerCallId);
-                Assert.AreEqual(correlationId, addParticipantsFailed.CorrelationId);
-                Assert.AreEqual(operationContext, addParticipantsFailed.OperationContext);
-                Assert.AreEqual(403, addParticipantsFailed.ResultInformation?.Code);
-                Assert.AreEqual("8:acs:12345", addParticipantsFailed.Participant.RawId);
+                Assert.That(addParticipantsFailed.CallConnectionId, Is.EqualTo(callConnectionId));
+                Assert.That(addParticipantsFailed.ServerCallId, Is.EqualTo(serverCallId));
+                Assert.That(addParticipantsFailed.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(addParticipantsFailed.OperationContext, Is.EqualTo(operationContext));
+                Assert.That(addParticipantsFailed.ResultInformation?.Code, Is.EqualTo(403));
+                Assert.That(addParticipantsFailed.Participant.RawId, Is.EqualTo("8:acs:12345"));
             }
             else
             {
@@ -227,12 +227,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is AddParticipantSucceeded addParticipantsSucceeded)
             {
-                Assert.AreEqual(callConnectionId, addParticipantsSucceeded.CallConnectionId);
-                Assert.AreEqual(serverCallId, addParticipantsSucceeded.ServerCallId);
-                Assert.AreEqual(correlationId, addParticipantsSucceeded.CorrelationId);
-                Assert.AreEqual(operationContext, addParticipantsSucceeded.OperationContext);
-                Assert.AreEqual(200, addParticipantsSucceeded.ResultInformation?.Code);
-                Assert.AreEqual("8:acs:12345", addParticipantsSucceeded.Participant.RawId);
+                Assert.That(addParticipantsSucceeded.CallConnectionId, Is.EqualTo(callConnectionId));
+                Assert.That(addParticipantsSucceeded.ServerCallId, Is.EqualTo(serverCallId));
+                Assert.That(addParticipantsSucceeded.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(addParticipantsSucceeded.OperationContext, Is.EqualTo(operationContext));
+                Assert.That(addParticipantsSucceeded.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(addParticipantsSucceeded.Participant.RawId, Is.EqualTo("8:acs:12345"));
             }
             else
             {
@@ -257,11 +257,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is CallConnected calConnected)
             {
-                Assert.AreEqual(callConnectionId, calConnected.CallConnectionId);
-                Assert.AreEqual(serverCallId, calConnected.ServerCallId);
-                Assert.AreEqual(correlationId, calConnected.CorrelationId);
-                Assert.IsNull(calConnected.OperationContext);
-                Assert.IsNull(calConnected.ResultInformation);
+                Assert.That(calConnected.CallConnectionId, Is.EqualTo(callConnectionId));
+                Assert.That(calConnected.ServerCallId, Is.EqualTo(serverCallId));
+                Assert.That(calConnected.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(calConnected.OperationContext, Is.Null);
+                Assert.That(calConnected.ResultInformation, Is.Null);
             }
             else
             {
@@ -315,11 +315,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is CallDisconnected callDisconnected)
             {
-                Assert.AreEqual(callConnectionId, callDisconnected.CallConnectionId);
-                Assert.AreEqual(serverCallId, callDisconnected.ServerCallId);
-                Assert.AreEqual(correlationId, callDisconnected.CorrelationId);
-                Assert.IsNull(callDisconnected.OperationContext);
-                Assert.IsNull(callDisconnected.ResultInformation);
+                Assert.That(callDisconnected.CallConnectionId, Is.EqualTo(callConnectionId));
+                Assert.That(callDisconnected.ServerCallId, Is.EqualTo(serverCallId));
+                Assert.That(callDisconnected.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(callDisconnected.OperationContext, Is.Null);
+                Assert.That(callDisconnected.ResultInformation, Is.Null);
             }
             else
             {
@@ -345,11 +345,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is CallTransferAccepted callTransferAccepted)
             {
-                Assert.AreEqual(callConnectionId, callTransferAccepted.CallConnectionId);
-                Assert.AreEqual(serverCallId, callTransferAccepted.ServerCallId);
-                Assert.AreEqual(correlationId, callTransferAccepted.CorrelationId);
-                Assert.AreEqual(operationContext, callTransferAccepted.OperationContext);
-                Assert.AreEqual(202, callTransferAccepted.ResultInformation?.Code);
+                Assert.That(callTransferAccepted.CallConnectionId, Is.EqualTo(callConnectionId));
+                Assert.That(callTransferAccepted.ServerCallId, Is.EqualTo(serverCallId));
+                Assert.That(callTransferAccepted.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(callTransferAccepted.OperationContext, Is.EqualTo(operationContext));
+                Assert.That(callTransferAccepted.ResultInformation?.Code, Is.EqualTo(202));
             }
             else
             {
@@ -375,11 +375,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is CallTransferFailed callTransferFailed)
             {
-                Assert.AreEqual(callConnectionId, callTransferFailed.CallConnectionId);
-                Assert.AreEqual(serverCallId, callTransferFailed.ServerCallId);
-                Assert.AreEqual(correlationId, callTransferFailed.CorrelationId);
-                Assert.AreEqual(operationContext, callTransferFailed.OperationContext);
-                Assert.AreEqual(403, callTransferFailed.ResultInformation?.Code);
+                Assert.That(callTransferFailed.CallConnectionId, Is.EqualTo(callConnectionId));
+                Assert.That(callTransferFailed.ServerCallId, Is.EqualTo(serverCallId));
+                Assert.That(callTransferFailed.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(callTransferFailed.OperationContext, Is.EqualTo(operationContext));
+                Assert.That(callTransferFailed.ResultInformation?.Code, Is.EqualTo(403));
             }
             else
             {
@@ -407,18 +407,18 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             // assert
             if (parsedEvent is ParticipantsUpdated participantsUpdated)
             {
-                Assert.AreEqual(callConnectionId, participantsUpdated.CallConnectionId);
-                Assert.AreEqual(serverCallId, participantsUpdated.ServerCallId);
-                Assert.AreEqual(correlationId, participantsUpdated.CorrelationId);
-                Assert.IsNull(participantsUpdated.OperationContext);
-                Assert.IsNull(participantsUpdated.ResultInformation);
-                Assert.AreEqual(2, participantsUpdated.Participants.Count);
-                Assert.AreEqual("8:acs:12345", participantsUpdated.Participants[0].Identifier.RawId);
-                Assert.IsFalse(participantsUpdated.Participants[0].IsMuted);
-                Assert.IsFalse(participantsUpdated.Participants[0].IsOnHold);
-                Assert.IsTrue(participantsUpdated.Participants[1].Identifier.RawId.EndsWith("123456789"));
-                Assert.IsFalse(participantsUpdated.Participants[1].IsMuted);
-                Assert.IsTrue(participantsUpdated.Participants[1].IsOnHold);
+                Assert.That(participantsUpdated.CallConnectionId, Is.EqualTo(callConnectionId));
+                Assert.That(participantsUpdated.ServerCallId, Is.EqualTo(serverCallId));
+                Assert.That(participantsUpdated.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(participantsUpdated.OperationContext, Is.Null);
+                Assert.That(participantsUpdated.ResultInformation, Is.Null);
+                Assert.That(participantsUpdated.Participants.Count, Is.EqualTo(2));
+                Assert.That(participantsUpdated.Participants[0].Identifier.RawId, Is.EqualTo("8:acs:12345"));
+                Assert.That(participantsUpdated.Participants[0].IsMuted, Is.False);
+                Assert.That(participantsUpdated.Participants[0].IsOnHold, Is.False);
+                Assert.That(participantsUpdated.Participants[1].Identifier.RawId.EndsWith("123456789"), Is.True);
+                Assert.That(participantsUpdated.Participants[1].IsMuted, Is.False);
+                Assert.That(participantsUpdated.Participants[1].IsOnHold, Is.True);
             }
             else
             {
@@ -441,9 +441,9 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.RecordingStateChanged");
             if (parsedEvent is RecordingStateChanged recordingEvent)
             {
-                Assert.AreEqual("recordingId", recordingEvent.RecordingId);
-                Assert.AreEqual("serverCallId", recordingEvent.ServerCallId);
-                Assert.AreEqual(RecordingState.Active, recordingEvent.State);
+                Assert.That(recordingEvent.RecordingId, Is.EqualTo("recordingId"));
+                Assert.That(recordingEvent.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(recordingEvent.State, Is.EqualTo(RecordingState.Active));
             }
             else
             {
@@ -465,10 +465,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.PlayCompleted");
             if (parsedEvent is PlayCompleted playCompleted)
             {
-                Assert.AreEqual("correlationId", playCompleted.CorrelationId);
-                Assert.AreEqual("serverCallId", playCompleted.ServerCallId);
-                Assert.AreEqual(200, playCompleted.ResultInformation?.Code);
-                Assert.AreEqual(MediaEventReasonCode.CompletedSuccessfully, playCompleted.ReasonCode);
+                Assert.That(playCompleted.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(playCompleted.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(playCompleted.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(playCompleted.ReasonCode, Is.EqualTo(MediaEventReasonCode.CompletedSuccessfully));
             }
             else
             {
@@ -490,11 +490,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.PlayFailed");
             if (parsedEvent is PlayFailed playFailed)
             {
-                Assert.AreEqual("correlationId", playFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", playFailed.ServerCallId);
-                Assert.AreEqual(400, playFailed.ResultInformation?.Code);
+                Assert.That(playFailed.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(playFailed.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(playFailed.ResultInformation?.Code, Is.EqualTo(400));
                 //Assert.AreEqual(MediaEventReasonCode.PlayDownloadFailed, playFailed.ResultInformation);
-                Assert.AreEqual(8536, playFailed.ResultInformation?.SubCode);
+                Assert.That(playFailed.ResultInformation?.SubCode, Is.EqualTo(8536));
             }
             else
             {
@@ -516,9 +516,9 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.PlayStarted");
             if (parsedEvent is PlayStarted playStarted)
             {
-                Assert.AreEqual("correlationId", playStarted.CorrelationId);
-                Assert.AreEqual("serverCallId", playStarted.ServerCallId);
-                Assert.AreEqual(200, playStarted.ResultInformation?.Code);
+                Assert.That(playStarted.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(playStarted.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(playStarted.ResultInformation?.Code, Is.EqualTo(200));
             }
             else
             {
@@ -539,8 +539,8 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.PlayCanceled");
             if (parsedEvent is PlayCanceled playCancelled)
             {
-                Assert.AreEqual("correlationId", playCancelled.CorrelationId);
-                Assert.AreEqual("serverCallId", playCancelled.ServerCallId);
+                Assert.That(playCancelled.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(playCancelled.ServerCallId, Is.EqualTo("serverCallId"));
             }
             else
             {
@@ -569,16 +569,16 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             if (parsedEvent is RecognizeCompleted recognizeCompleted)
             {
                 var recognizeResult = recognizeCompleted.RecognizeResult;
-                Assert.AreEqual(recognizeResult is DtmfResult, true);
-                Assert.AreEqual("correlationId", recognizeCompleted.CorrelationId);
-                Assert.AreEqual("serverCallId", recognizeCompleted.ServerCallId);
-                Assert.AreEqual(200, recognizeCompleted.ResultInformation?.Code);
+                Assert.That(recognizeResult is DtmfResult, Is.EqualTo(true));
+                Assert.That(recognizeCompleted.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(recognizeCompleted.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(recognizeCompleted.ResultInformation?.Code, Is.EqualTo(200));
                 if (recognizeResult is DtmfResult dtmfResultReturned)
                 {
                     string toneResults = dtmfResultReturned.ConvertToString();
-                    Assert.NotZero(dtmfResultReturned.Tones.Count());
-                    Assert.AreEqual(DtmfTone.Five, dtmfResultReturned.Tones.First());
-                    Assert.AreEqual(toneResults, "56#");
+                    Assert.That(dtmfResultReturned.Tones.Count(), Is.Not.Zero);
+                    Assert.That(dtmfResultReturned.Tones.First(), Is.EqualTo(DtmfTone.Five));
+                    Assert.That(toneResults, Is.EqualTo("56#"));
                 }
             }
             else
@@ -608,14 +608,14 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             if (parsedEvent is RecognizeCompleted recognizeCompleted)
             {
                 var recognizeResult = recognizeCompleted.RecognizeResult;
-                Assert.AreEqual(recognizeResult is DtmfResult, true);
-                Assert.AreEqual("correlationId", recognizeCompleted.CorrelationId);
-                Assert.AreEqual("serverCallId", recognizeCompleted.ServerCallId);
-                Assert.AreEqual(200, recognizeCompleted.ResultInformation?.Code);
+                Assert.That(recognizeResult is DtmfResult, Is.EqualTo(true));
+                Assert.That(recognizeCompleted.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(recognizeCompleted.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(recognizeCompleted.ResultInformation?.Code, Is.EqualTo(200));
                 if (recognizeResult is DtmfResult dtmfResultReturned)
                 {
-                    Assert.NotZero(dtmfResultReturned.Tones.Count());
-                    Assert.AreEqual(DtmfTone.Five, dtmfResultReturned.Tones.First());
+                    Assert.That(dtmfResultReturned.Tones.Count(), Is.Not.Zero);
+                    Assert.That(dtmfResultReturned.Tones.First(), Is.EqualTo(DtmfTone.Five));
                 }
             }
             else
@@ -638,10 +638,10 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.RecognizeFailed");
             if (parsedEvent is RecognizeFailed recognizeFailed)
             {
-                Assert.AreEqual("correlationId", recognizeFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", recognizeFailed.ServerCallId);
-                Assert.AreEqual(400, recognizeFailed.ResultInformation?.Code);
-                Assert.AreEqual(MediaEventReasonCode.RecognizeInitialSilenceTimedOut.ToString(), recognizeFailed.ResultInformation?.SubCode.ToString());
+                Assert.That(recognizeFailed.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(recognizeFailed.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(recognizeFailed.ResultInformation?.Code, Is.EqualTo(400));
+                Assert.That(recognizeFailed.ResultInformation?.SubCode.ToString(), Is.EqualTo(MediaEventReasonCode.RecognizeInitialSilenceTimedOut.ToString()));
             }
             else
             {
@@ -662,8 +662,8 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.RecognizeCanceled");
             if (parsedEvent is RecognizeCanceled recognizeCancelled)
             {
-                Assert.AreEqual("correlationId", recognizeCancelled.CorrelationId);
-                Assert.AreEqual("serverCallId", recognizeCancelled.ServerCallId);
+                Assert.That(recognizeCancelled.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(recognizeCancelled.ServerCallId, Is.EqualTo("serverCallId"));
             }
             else
             {
@@ -687,12 +687,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
 
             if (parsedEvent is RemoveParticipantSucceeded addParticipantsSucceeded)
             {
-                Assert.AreEqual(callConnectionId, addParticipantsSucceeded.CallConnectionId);
-                Assert.AreEqual(serverCallId, addParticipantsSucceeded.ServerCallId);
-                Assert.AreEqual(correlationId, addParticipantsSucceeded.CorrelationId);
-                Assert.AreEqual(operationContext, addParticipantsSucceeded.OperationContext);
-                Assert.AreEqual(200, addParticipantsSucceeded.ResultInformation?.Code);
-                Assert.AreEqual("8:acs:12345", addParticipantsSucceeded.Participant.RawId);
+                Assert.That(addParticipantsSucceeded.CallConnectionId, Is.EqualTo(callConnectionId));
+                Assert.That(addParticipantsSucceeded.ServerCallId, Is.EqualTo(serverCallId));
+                Assert.That(addParticipantsSucceeded.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(addParticipantsSucceeded.OperationContext, Is.EqualTo(operationContext));
+                Assert.That(addParticipantsSucceeded.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(addParticipantsSucceeded.Participant.RawId, Is.EqualTo("8:acs:12345"));
             }
             else
             {
@@ -716,12 +716,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
 
             if (parsedEvent is RemoveParticipantFailed addParticipantsSucceeded)
             {
-                Assert.AreEqual(callConnectionId, addParticipantsSucceeded.CallConnectionId);
-                Assert.AreEqual(serverCallId, addParticipantsSucceeded.ServerCallId);
-                Assert.AreEqual(correlationId, addParticipantsSucceeded.CorrelationId);
-                Assert.AreEqual(operationContext, addParticipantsSucceeded.OperationContext);
-                Assert.AreEqual(200, addParticipantsSucceeded.ResultInformation?.Code);
-                Assert.AreEqual("8:acs:12345", addParticipantsSucceeded.Participant.RawId);
+                Assert.That(addParticipantsSucceeded.CallConnectionId, Is.EqualTo(callConnectionId));
+                Assert.That(addParticipantsSucceeded.ServerCallId, Is.EqualTo(serverCallId));
+                Assert.That(addParticipantsSucceeded.CorrelationId, Is.EqualTo(correlationId));
+                Assert.That(addParticipantsSucceeded.OperationContext, Is.EqualTo(operationContext));
+                Assert.That(addParticipantsSucceeded.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(addParticipantsSucceeded.Participant.RawId, Is.EqualTo("8:acs:12345"));
             }
             else
             {
@@ -745,13 +745,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.ContinuousDtmfRecognitionToneReceived");
             if (parsedEvent is ContinuousDtmfRecognitionToneReceived continuousDtmfRecognitionToneReceived)
             {
-                Assert.AreEqual(DtmfTone.A, continuousDtmfRecognitionToneReceived.Tone);
-                Assert.AreEqual(1, continuousDtmfRecognitionToneReceived.SequenceId);
-                Assert.AreEqual("callConnectionId", continuousDtmfRecognitionToneReceived.CallConnectionId);
-                Assert.AreEqual("correlationId", continuousDtmfRecognitionToneReceived.CorrelationId);
-                Assert.AreEqual("serverCallId", continuousDtmfRecognitionToneReceived.ServerCallId);
-                Assert.AreEqual("operationContext", continuousDtmfRecognitionToneReceived.OperationContext);
-                Assert.AreEqual(200, continuousDtmfRecognitionToneReceived.ResultInformation?.Code);
+                Assert.That(continuousDtmfRecognitionToneReceived.Tone, Is.EqualTo(DtmfTone.A));
+                Assert.That(continuousDtmfRecognitionToneReceived.SequenceId, Is.EqualTo(1));
+                Assert.That(continuousDtmfRecognitionToneReceived.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(continuousDtmfRecognitionToneReceived.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(continuousDtmfRecognitionToneReceived.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(continuousDtmfRecognitionToneReceived.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(continuousDtmfRecognitionToneReceived.ResultInformation?.Code, Is.EqualTo(200));
             }
             else
             {
@@ -773,11 +773,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.ContinuousDtmfRecognitionToneFailed");
             if (parsedEvent is ContinuousDtmfRecognitionToneFailed continuousDtmfRecognitionToneFailed)
             {
-                Assert.AreEqual("callConnectionId", continuousDtmfRecognitionToneFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", continuousDtmfRecognitionToneFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", continuousDtmfRecognitionToneFailed.ServerCallId);
-                Assert.AreEqual("operationContext", continuousDtmfRecognitionToneFailed.OperationContext);
-                Assert.AreEqual(400, continuousDtmfRecognitionToneFailed.ResultInformation?.Code);
+                Assert.That(continuousDtmfRecognitionToneFailed.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(continuousDtmfRecognitionToneFailed.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(continuousDtmfRecognitionToneFailed.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(continuousDtmfRecognitionToneFailed.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(continuousDtmfRecognitionToneFailed.ResultInformation?.Code, Is.EqualTo(400));
             }
             else
             {
@@ -799,11 +799,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.ContinuousDtmfRecognitionStopped");
             if (parsedEvent is ContinuousDtmfRecognitionStopped continuousDtmfRecognitionStopped)
             {
-                Assert.AreEqual("callConnectionId", continuousDtmfRecognitionStopped.CallConnectionId);
-                Assert.AreEqual("correlationId", continuousDtmfRecognitionStopped.CorrelationId);
-                Assert.AreEqual("serverCallId", continuousDtmfRecognitionStopped.ServerCallId);
-                Assert.AreEqual("operationContext", continuousDtmfRecognitionStopped.OperationContext);
-                Assert.AreEqual(200, continuousDtmfRecognitionStopped.ResultInformation?.Code);
+                Assert.That(continuousDtmfRecognitionStopped.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(continuousDtmfRecognitionStopped.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(continuousDtmfRecognitionStopped.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(continuousDtmfRecognitionStopped.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(continuousDtmfRecognitionStopped.ResultInformation?.Code, Is.EqualTo(200));
             }
             else
             {
@@ -825,11 +825,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.SendDtmfTonesCompleted");
             if (parsedEvent is SendDtmfTonesCompleted SendDtmfCompleted)
             {
-                Assert.AreEqual("callConnectionId", SendDtmfCompleted.CallConnectionId);
-                Assert.AreEqual("operationContext", SendDtmfCompleted.OperationContext);
-                Assert.AreEqual("correlationId", SendDtmfCompleted.CorrelationId);
-                Assert.AreEqual("serverCallId", SendDtmfCompleted.ServerCallId);
-                Assert.AreEqual(200, SendDtmfCompleted.ResultInformation?.Code);
+                Assert.That(SendDtmfCompleted.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(SendDtmfCompleted.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(SendDtmfCompleted.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(SendDtmfCompleted.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(SendDtmfCompleted.ResultInformation?.Code, Is.EqualTo(200));
             }
             else
             {
@@ -851,11 +851,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.SendDtmfTonesFailed");
             if (parsedEvent is SendDtmfTonesFailed sendDtmfFailed)
             {
-                Assert.AreEqual("operationContext", sendDtmfFailed.OperationContext);
-                Assert.AreEqual("callConnectionId", sendDtmfFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", sendDtmfFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", sendDtmfFailed.ServerCallId);
-                Assert.AreEqual(400, sendDtmfFailed.ResultInformation?.Code);
+                Assert.That(sendDtmfFailed.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(sendDtmfFailed.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(sendDtmfFailed.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(sendDtmfFailed.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(sendDtmfFailed.ResultInformation?.Code, Is.EqualTo(400));
             }
             else
             {
@@ -878,11 +878,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
 
             if (parsedEvent is CancelAddParticipantSucceeded CancelAddParticipantSucceeded)
             {
-                Assert.AreEqual("operationContext", CancelAddParticipantSucceeded.OperationContext);
-                Assert.AreEqual("callConnectionId", CancelAddParticipantSucceeded.CallConnectionId);
-                Assert.AreEqual("correlationId", CancelAddParticipantSucceeded.CorrelationId);
-                Assert.AreEqual("serverCallId", CancelAddParticipantSucceeded.ServerCallId);
-                Assert.AreEqual("invitationId", CancelAddParticipantSucceeded.InvitationId);
+                Assert.That(CancelAddParticipantSucceeded.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(CancelAddParticipantSucceeded.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(CancelAddParticipantSucceeded.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(CancelAddParticipantSucceeded.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(CancelAddParticipantSucceeded.InvitationId, Is.EqualTo("invitationId"));
             }
             else
             {
@@ -906,12 +906,12 @@ namespace Azure.Communication.CallAutomation.Tests.Events
 
             if (parsedEvent is CancelAddParticipantFailed cancelAddParticipantFailed)
             {
-                Assert.AreEqual("operationContext", cancelAddParticipantFailed.OperationContext);
-                Assert.AreEqual("callConnectionId", cancelAddParticipantFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", cancelAddParticipantFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", cancelAddParticipantFailed.ServerCallId);
-                Assert.AreEqual("invitationId", cancelAddParticipantFailed.InvitationId);
-                Assert.AreEqual(400, cancelAddParticipantFailed.ResultInformation?.Code);
+                Assert.That(cancelAddParticipantFailed.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(cancelAddParticipantFailed.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(cancelAddParticipantFailed.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(cancelAddParticipantFailed.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(cancelAddParticipantFailed.InvitationId, Is.EqualTo("invitationId"));
+                Assert.That(cancelAddParticipantFailed.ResultInformation?.Code, Is.EqualTo(400));
             }
             else
             {
@@ -933,11 +933,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.CreateCallFailed");
             if (parsedEvent is CreateCallFailed createCallFailed)
             {
-                Assert.AreEqual("operationContext", createCallFailed.OperationContext);
-                Assert.AreEqual("callConnectionId", createCallFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", createCallFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", createCallFailed.ServerCallId);
-                Assert.AreEqual(400, createCallFailed.ResultInformation?.Code);
+                Assert.That(createCallFailed.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(createCallFailed.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(createCallFailed.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(createCallFailed.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(createCallFailed.ResultInformation?.Code, Is.EqualTo(400));
             }
             else
             {
@@ -960,13 +960,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.TranscriptionStarted");
             if (parsedEvent is TranscriptionStarted transcriptionStarted)
             {
-                Assert.AreEqual("callConnectionId", transcriptionStarted.CallConnectionId);
-                Assert.AreEqual("correlationId", transcriptionStarted.CorrelationId);
-                Assert.AreEqual("serverCallId", transcriptionStarted.ServerCallId);
-                Assert.AreEqual("operationContext", transcriptionStarted.OperationContext);
-                Assert.AreEqual(200, transcriptionStarted.ResultInformation?.Code);
-                Assert.AreEqual(TranscriptionStatus.TranscriptionStarted, transcriptionStarted.TranscriptionUpdate.TranscriptionStatus);
-                Assert.AreEqual(TranscriptionStatusDetails.SubscriptionStarted, transcriptionStarted.TranscriptionUpdate.TranscriptionStatusDetails);
+                Assert.That(transcriptionStarted.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(transcriptionStarted.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(transcriptionStarted.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(transcriptionStarted.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(transcriptionStarted.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(transcriptionStarted.TranscriptionUpdate.TranscriptionStatus, Is.EqualTo(TranscriptionStatus.TranscriptionStarted));
+                Assert.That(transcriptionStarted.TranscriptionUpdate.TranscriptionStatusDetails, Is.EqualTo(TranscriptionStatusDetails.SubscriptionStarted));
             }
             else
             {
@@ -989,13 +989,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.TranscriptionUpdated");
             if (parsedEvent is TranscriptionUpdated transcriptionUpdated)
             {
-                Assert.AreEqual("callConnectionId", transcriptionUpdated.CallConnectionId);
-                Assert.AreEqual("correlationId", transcriptionUpdated.CorrelationId);
-                Assert.AreEqual("serverCallId", transcriptionUpdated.ServerCallId);
-                Assert.AreEqual("operationContext", transcriptionUpdated.OperationContext);
-                Assert.AreEqual(200, transcriptionUpdated.ResultInformation?.Code);
-                Assert.AreEqual(TranscriptionStatus.TranscriptionUpdated, transcriptionUpdated.TranscriptionUpdate.TranscriptionStatus);
-                Assert.AreEqual(TranscriptionStatusDetails.StreamConnectionReestablished, transcriptionUpdated.TranscriptionUpdate.TranscriptionStatusDetails);
+                Assert.That(transcriptionUpdated.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(transcriptionUpdated.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(transcriptionUpdated.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(transcriptionUpdated.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(transcriptionUpdated.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(transcriptionUpdated.TranscriptionUpdate.TranscriptionStatus, Is.EqualTo(TranscriptionStatus.TranscriptionUpdated));
+                Assert.That(transcriptionUpdated.TranscriptionUpdate.TranscriptionStatusDetails, Is.EqualTo(TranscriptionStatusDetails.StreamConnectionReestablished));
             }
             else
             {
@@ -1018,13 +1018,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.TranscriptionStopped");
             if (parsedEvent is TranscriptionStopped transcriptionStopped)
             {
-                Assert.AreEqual("callConnectionId", transcriptionStopped.CallConnectionId);
-                Assert.AreEqual("correlationId", transcriptionStopped.CorrelationId);
-                Assert.AreEqual("serverCallId", transcriptionStopped.ServerCallId);
-                Assert.AreEqual("operationContext", transcriptionStopped.OperationContext);
-                Assert.AreEqual(200, transcriptionStopped.ResultInformation?.Code);
-                Assert.AreEqual(TranscriptionStatus.TranscriptionStopped, transcriptionStopped.TranscriptionUpdate.TranscriptionStatus);
-                Assert.AreEqual(TranscriptionStatusDetails.SubscriptionStopped, transcriptionStopped.TranscriptionUpdate.TranscriptionStatusDetails);
+                Assert.That(transcriptionStopped.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(transcriptionStopped.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(transcriptionStopped.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(transcriptionStopped.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(transcriptionStopped.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(transcriptionStopped.TranscriptionUpdate.TranscriptionStatus, Is.EqualTo(TranscriptionStatus.TranscriptionStopped));
+                Assert.That(transcriptionStopped.TranscriptionUpdate.TranscriptionStatusDetails, Is.EqualTo(TranscriptionStatusDetails.SubscriptionStopped));
             }
             else
             {
@@ -1047,13 +1047,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.TranscriptionFailed");
             if (parsedEvent is TranscriptionFailed transcriptionFailed)
             {
-                Assert.AreEqual("callConnectionId", transcriptionFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", transcriptionFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", transcriptionFailed.ServerCallId);
-                Assert.AreEqual("operationContext", transcriptionFailed.OperationContext);
-                Assert.AreEqual(200, transcriptionFailed.ResultInformation?.Code);
-                Assert.AreEqual(TranscriptionStatus.TranscriptionFailed, transcriptionFailed.TranscriptionUpdate.TranscriptionStatus);
-                Assert.AreEqual(TranscriptionStatusDetails.UnspecifiedError, transcriptionFailed.TranscriptionUpdate.TranscriptionStatusDetails);
+                Assert.That(transcriptionFailed.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(transcriptionFailed.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(transcriptionFailed.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(transcriptionFailed.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(transcriptionFailed.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(transcriptionFailed.TranscriptionUpdate.TranscriptionStatus, Is.EqualTo(TranscriptionStatus.TranscriptionFailed));
+                Assert.That(transcriptionFailed.TranscriptionUpdate.TranscriptionStatusDetails, Is.EqualTo(TranscriptionStatusDetails.UnspecifiedError));
             }
             else
             {
@@ -1075,11 +1075,11 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.HoldFailed");
             if (parsedEvent is HoldFailed holdFailed)
             {
-                Assert.AreEqual("correlationId", holdFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", holdFailed.ServerCallId);
-                Assert.AreEqual(400, holdFailed.ResultInformation?.Code);
-                Assert.AreEqual(MediaEventReasonCode.PlayDownloadFailed, holdFailed.ReasonCode);
-                Assert.AreEqual(8536, holdFailed.ReasonCode.GetReasonCodeValue());
+                Assert.That(holdFailed.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(holdFailed.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(holdFailed.ResultInformation?.Code, Is.EqualTo(400));
+                Assert.That(holdFailed.ReasonCode, Is.EqualTo(MediaEventReasonCode.PlayDownloadFailed));
+                Assert.That(holdFailed.ReasonCode.GetReasonCodeValue(), Is.EqualTo(8536));
             }
             else
             {
@@ -1102,13 +1102,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.MediaStreamingStarted");
             if (parsedEvent is MediaStreamingStarted mediaStreamingStarted)
             {
-                Assert.AreEqual("callConnectionId", mediaStreamingStarted.CallConnectionId);
-                Assert.AreEqual("correlationId", mediaStreamingStarted.CorrelationId);
-                Assert.AreEqual("serverCallId", mediaStreamingStarted.ServerCallId);
-                Assert.AreEqual("operationContext", mediaStreamingStarted.OperationContext);
-                Assert.AreEqual(200, mediaStreamingStarted.ResultInformation?.Code);
-                Assert.AreEqual(MediaStreamingStatus.MediaStreamingStarted, mediaStreamingStarted.MediaStreamingUpdate.MediaStreamingStatus);
-                Assert.AreEqual(MediaStreamingStatusDetails.SubscriptionStarted, mediaStreamingStarted.MediaStreamingUpdate.MediaStreamingStatusDetails);
+                Assert.That(mediaStreamingStarted.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(mediaStreamingStarted.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(mediaStreamingStarted.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(mediaStreamingStarted.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(mediaStreamingStarted.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(mediaStreamingStarted.MediaStreamingUpdate.MediaStreamingStatus, Is.EqualTo(MediaStreamingStatus.MediaStreamingStarted));
+                Assert.That(mediaStreamingStarted.MediaStreamingUpdate.MediaStreamingStatusDetails, Is.EqualTo(MediaStreamingStatusDetails.SubscriptionStarted));
             }
             else
             {
@@ -1131,13 +1131,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.MediaStreamingStopped");
             if (parsedEvent is MediaStreamingStopped mediaStreamingStopped)
             {
-                Assert.AreEqual("callConnectionId", mediaStreamingStopped.CallConnectionId);
-                Assert.AreEqual("correlationId", mediaStreamingStopped.CorrelationId);
-                Assert.AreEqual("serverCallId", mediaStreamingStopped.ServerCallId);
-                Assert.AreEqual("operationContext", mediaStreamingStopped.OperationContext);
-                Assert.AreEqual(200, mediaStreamingStopped.ResultInformation?.Code);
-                Assert.AreEqual(MediaStreamingStatus.MediaStreamingStarted, mediaStreamingStopped.MediaStreamingUpdate.MediaStreamingStatus);
-                Assert.AreEqual(MediaStreamingStatusDetails.SubscriptionStarted, mediaStreamingStopped.MediaStreamingUpdate.MediaStreamingStatusDetails);
+                Assert.That(mediaStreamingStopped.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(mediaStreamingStopped.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(mediaStreamingStopped.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(mediaStreamingStopped.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(mediaStreamingStopped.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(mediaStreamingStopped.MediaStreamingUpdate.MediaStreamingStatus, Is.EqualTo(MediaStreamingStatus.MediaStreamingStarted));
+                Assert.That(mediaStreamingStopped.MediaStreamingUpdate.MediaStreamingStatusDetails, Is.EqualTo(MediaStreamingStatusDetails.SubscriptionStarted));
             }
             else
             {
@@ -1160,13 +1160,13 @@ namespace Azure.Communication.CallAutomation.Tests.Events
             var parsedEvent = CallAutomationEventParser.Parse(jsonEvent, "Microsoft.Communication.MediaStreamingFailed");
             if (parsedEvent is MediaStreamingFailed mediaStreamingFailed)
             {
-                Assert.AreEqual("callConnectionId", mediaStreamingFailed.CallConnectionId);
-                Assert.AreEqual("correlationId", mediaStreamingFailed.CorrelationId);
-                Assert.AreEqual("serverCallId", mediaStreamingFailed.ServerCallId);
-                Assert.AreEqual("operationContext", mediaStreamingFailed.OperationContext);
-                Assert.AreEqual(200, mediaStreamingFailed.ResultInformation?.Code);
-                Assert.AreEqual(MediaStreamingStatus.MediaStreamingStarted, mediaStreamingFailed.MediaStreamingUpdate.MediaStreamingStatus);
-                Assert.AreEqual(MediaStreamingStatusDetails.SubscriptionStarted, mediaStreamingFailed.MediaStreamingUpdate.MediaStreamingStatusDetails);
+                Assert.That(mediaStreamingFailed.CallConnectionId, Is.EqualTo("callConnectionId"));
+                Assert.That(mediaStreamingFailed.CorrelationId, Is.EqualTo("correlationId"));
+                Assert.That(mediaStreamingFailed.ServerCallId, Is.EqualTo("serverCallId"));
+                Assert.That(mediaStreamingFailed.OperationContext, Is.EqualTo("operationContext"));
+                Assert.That(mediaStreamingFailed.ResultInformation?.Code, Is.EqualTo(200));
+                Assert.That(mediaStreamingFailed.MediaStreamingUpdate.MediaStreamingStatus, Is.EqualTo(MediaStreamingStatus.MediaStreamingStarted));
+                Assert.That(mediaStreamingFailed.MediaStreamingUpdate.MediaStreamingStatusDetails, Is.EqualTo(MediaStreamingStatusDetails.SubscriptionStarted));
             }
             else
             {

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationTestBase.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Infrastructure/CallAutomationTestBase.cs
@@ -134,34 +134,34 @@ namespace Azure.Communication.CallAutomation.Tests.Infrastructure
 
         protected void verifyCallConnectionProperties(CallConnectionProperties callConnectionProperties, bool isConnectApi = false)
         {
-            Assert.AreEqual(CallConnectionId, callConnectionProperties.CallConnectionId);
-            Assert.AreEqual(ServerCallId, callConnectionProperties.ServerCallId);
+            Assert.That(callConnectionProperties.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(callConnectionProperties.ServerCallId, Is.EqualTo(ServerCallId));
             if (!isConnectApi)
             {
                 var sourceUser = (CommunicationUserIdentifier)callConnectionProperties.Source;
-                Assert.AreEqual(SourceId, sourceUser.Id);
-                Assert.AreEqual(callConnectionProperties.Targets.Count, 1);
+                Assert.That(sourceUser.Id, Is.EqualTo(SourceId));
+                Assert.That(callConnectionProperties.Targets.Count, Is.EqualTo(1));
                 var targetUser = (CommunicationUserIdentifier)callConnectionProperties.Targets[0];
-                Assert.AreEqual(TargetId, targetUser.Id);
-                Assert.AreEqual(DisplayName, callConnectionProperties.SourceDisplayName);
+                Assert.That(targetUser.Id, Is.EqualTo(TargetId));
+                Assert.That(callConnectionProperties.SourceDisplayName, Is.EqualTo(DisplayName));
             }
 
-            Assert.AreEqual(CallConnectionState.Connecting, callConnectionProperties.CallConnectionState);
-            Assert.AreEqual(CallBackUri, callConnectionProperties.CallbackUri.ToString());
+            Assert.That(callConnectionProperties.CallConnectionState, Is.EqualTo(CallConnectionState.Connecting));
+            Assert.That(callConnectionProperties.CallbackUri.ToString(), Is.EqualTo(CallBackUri));
         }
 
         protected void verifyOPSCallConnectionProperties(CallConnectionProperties callConnectionProperties)
         {
-            Assert.AreEqual(CallConnectionId, callConnectionProperties.CallConnectionId);
-            Assert.AreEqual(ServerCallId, callConnectionProperties.ServerCallId);
+            Assert.That(callConnectionProperties.CallConnectionId, Is.EqualTo(CallConnectionId));
+            Assert.That(callConnectionProperties.ServerCallId, Is.EqualTo(ServerCallId));
             var teamsAppSourceUser = (MicrosoftTeamsAppIdentifier)callConnectionProperties.Source;
-            Assert.AreEqual(SourceId, teamsAppSourceUser.AppId);
-            Assert.AreEqual(callConnectionProperties.Targets.Count, 1);
+            Assert.That(teamsAppSourceUser.AppId, Is.EqualTo(SourceId));
+            Assert.That(callConnectionProperties.Targets.Count, Is.EqualTo(1));
             var targetUser = (CommunicationUserIdentifier)callConnectionProperties.Targets[0];
-            Assert.AreEqual(TargetId, targetUser.Id);
-            Assert.AreEqual(CallConnectionState.Connecting, callConnectionProperties.CallConnectionState);
-            Assert.AreEqual(CallBackUri, callConnectionProperties.CallbackUri.ToString());
-            Assert.AreEqual(DisplayName, callConnectionProperties.SourceDisplayName);
+            Assert.That(targetUser.Id, Is.EqualTo(TargetId));
+            Assert.That(callConnectionProperties.CallConnectionState, Is.EqualTo(CallConnectionState.Connecting));
+            Assert.That(callConnectionProperties.CallbackUri.ToString(), Is.EqualTo(CallBackUri));
+            Assert.That(callConnectionProperties.SourceDisplayName, Is.EqualTo(DisplayName));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Models/CallAutomationModelFactoryTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Models/CallAutomationModelFactoryTests.cs
@@ -29,10 +29,10 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var audioData = CallAutomationModelFactory.AudioData(data, timestamp, participantId, silent);
 
-            Assert.AreEqual(data, Convert.ToBase64String(audioData.Data.ToArray()));
-            Assert.AreEqual(timestamp, audioData.Timestamp.DateTime);
-            Assert.AreEqual(participantId, audioData.Participant.RawId);
-            Assert.AreEqual(silent, audioData.IsSilent);
+            Assert.That(Convert.ToBase64String(audioData.Data.ToArray()), Is.EqualTo(data));
+            Assert.That(audioData.Timestamp.DateTime, Is.EqualTo(timestamp));
+            Assert.That(audioData.Participant.RawId, Is.EqualTo(participantId));
+            Assert.That(audioData.IsSilent, Is.EqualTo(silent));
         }
 
         [Test]
@@ -46,10 +46,10 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var audioMetadata = CallAutomationModelFactory.AudioMetadata(mediaSubscriptionId, encoding, sampleRate, channels, length);
 
-            Assert.AreEqual(mediaSubscriptionId, audioMetadata.MediaSubscriptionId);
-            Assert.AreEqual(encoding, audioMetadata.Encoding);
-            Assert.AreEqual(sampleRate, audioMetadata.SampleRate);
-            Assert.AreEqual(AudioChannel.Mono, audioMetadata.Channels);
+            Assert.That(audioMetadata.MediaSubscriptionId, Is.EqualTo(mediaSubscriptionId));
+            Assert.That(audioMetadata.Encoding, Is.EqualTo(encoding));
+            Assert.That(audioMetadata.SampleRate, Is.EqualTo(sampleRate));
+            Assert.That(audioMetadata.Channels, Is.EqualTo(AudioChannel.Mono));
         }
 
         [Test]
@@ -66,15 +66,15 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var transcriptionData = CallAutomationModelFactory.TranscriptionData(text, format, confidence, offset, duration, words, participantRawID, resultState);
 
-            Assert.AreEqual(text, transcriptionData.Text);
-            Assert.AreEqual(format, transcriptionData.Format);
-            Assert.AreEqual(confidence, transcriptionData.Confidence);
-            Assert.AreEqual(TimeSpan.FromTicks(offset), transcriptionData.Offset);
-            Assert.AreEqual(TimeSpan.FromTicks(duration), transcriptionData.Duration);
-            Assert.AreEqual(CommunicationIdentifier.FromRawId(participantRawID), transcriptionData.Participant);
-            Assert.AreEqual(resultState, transcriptionData.ResultState);
-            Assert.IsNotNull(transcriptionData.Words);
-            Assert.AreEqual(1, transcriptionData.Words.Count());
+            Assert.That(transcriptionData.Text, Is.EqualTo(text));
+            Assert.That(transcriptionData.Format, Is.EqualTo(format));
+            Assert.That(transcriptionData.Confidence, Is.EqualTo(confidence));
+            Assert.That(transcriptionData.Offset, Is.EqualTo(TimeSpan.FromTicks(offset)));
+            Assert.That(transcriptionData.Duration, Is.EqualTo(TimeSpan.FromTicks(duration)));
+            Assert.That(transcriptionData.Participant, Is.EqualTo(CommunicationIdentifier.FromRawId(participantRawID)));
+            Assert.That(transcriptionData.ResultState, Is.EqualTo(resultState));
+            Assert.That(transcriptionData.Words, Is.Not.Null);
+            Assert.That(transcriptionData.Words.Count(), Is.EqualTo(1));
         }
 
         [Test]
@@ -86,9 +86,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var wordData = CallAutomationModelFactory.WordData(text, offset, duration);
 
-            Assert.AreEqual(text, wordData.Text);
-            Assert.AreEqual(TimeSpan.FromTicks(offset), wordData.Offset);
-            Assert.AreEqual(TimeSpan.FromTicks(duration), wordData.Duration);
+            Assert.That(wordData.Text, Is.EqualTo(text));
+            Assert.That(wordData.Offset, Is.EqualTo(TimeSpan.FromTicks(offset)));
+            Assert.That(wordData.Duration, Is.EqualTo(TimeSpan.FromTicks(duration)));
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var outStreamingData = CallAutomationModelFactory.OutStreamingData(kind);
 
-            Assert.AreEqual(kind, outStreamingData.Kind);
+            Assert.That(outStreamingData.Kind, Is.EqualTo(kind));
         }
 
         [Test]
@@ -110,9 +110,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.AddParticipantsResult(participant, operationContext, invitationId);
 
-            Assert.AreEqual(participant, result.Participant);
-            Assert.AreEqual(operationContext, result.OperationContext);
-            Assert.AreEqual(invitationId, result.InvitationId);
+            Assert.That(result.Participant, Is.EqualTo(participant));
+            Assert.That(result.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(result.InvitationId, Is.EqualTo(invitationId));
         }
 
         [Test]
@@ -125,8 +125,8 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.AnswerCallResult(callConnection, callConnectionProperties);
 
-            Assert.AreEqual(callConnection, result.CallConnection);
-            Assert.AreEqual(callConnectionProperties, result.CallConnectionProperties);
+            Assert.That(result.CallConnection, Is.EqualTo(callConnection));
+            Assert.That(result.CallConnectionProperties, Is.EqualTo(callConnectionProperties));
         }
 
         [Test]
@@ -146,16 +146,16 @@ namespace Azure.Communication.CallAutomation.Tests.Models
                 callConnectionId, serverCallId, targets, callConnectionState, callbackUri,
                 sourceIdentity, sourceCallerIdNumber, sourceDisplayName, answeredBy);
 
-            Assert.AreEqual(callConnectionId, properties.CallConnectionId);
-            Assert.AreEqual(serverCallId, properties.ServerCallId);
-            Assert.AreNotSame(targets, properties.Targets);
-            Assert.AreEqual(targets, properties.Targets);
-            Assert.AreEqual(callConnectionState, properties.CallConnectionState);
-            Assert.AreEqual(callbackUri, properties.CallbackUri);
-            Assert.AreEqual(sourceIdentity, properties.Source);
-            Assert.AreEqual(sourceCallerIdNumber, properties.SourceCallerIdNumber);
-            Assert.AreEqual(sourceDisplayName, properties.SourceDisplayName);
-            Assert.AreEqual(answeredBy, properties.AnsweredBy);
+            Assert.That(properties.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(properties.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(properties.Targets, Is.Not.SameAs(targets));
+            Assert.That(properties.Targets, Is.EqualTo(targets));
+            Assert.That(properties.CallConnectionState, Is.EqualTo(callConnectionState));
+            Assert.That(properties.CallbackUri, Is.EqualTo(callbackUri));
+            Assert.That(properties.Source, Is.EqualTo(sourceIdentity));
+            Assert.That(properties.SourceCallerIdNumber, Is.EqualTo(sourceCallerIdNumber));
+            Assert.That(properties.SourceDisplayName, Is.EqualTo(sourceDisplayName));
+            Assert.That(properties.AnsweredBy, Is.EqualTo(answeredBy));
         }
 
         [Test]
@@ -167,9 +167,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var participant = CallAutomationModelFactory.CallParticipant(identifier, isMuted, isOnHold);
 
-            Assert.AreEqual(identifier, participant.Identifier);
-            Assert.AreEqual(isMuted, participant.IsMuted);
-            Assert.AreEqual(isOnHold, participant.IsOnHold);
+            Assert.That(participant.Identifier, Is.EqualTo(identifier));
+            Assert.That(participant.IsMuted, Is.EqualTo(isMuted));
+            Assert.That(participant.IsOnHold, Is.EqualTo(isOnHold));
         }
 
         [Test]
@@ -182,8 +182,8 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.CreateCallResult(callConnection, callConnectionProperties);
 
-            Assert.AreEqual(callConnection, result.CallConnection);
-            Assert.AreEqual(callConnectionProperties, result.CallConnectionProperties);
+            Assert.That(result.CallConnection, Is.EqualTo(callConnection));
+            Assert.That(result.CallConnectionProperties, Is.EqualTo(callConnectionProperties));
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.RemoveParticipantResult(operationContext);
 
-            Assert.AreEqual(operationContext, result.OperationContext);
+            Assert.That(result.OperationContext, Is.EqualTo(operationContext));
         }
 
         [Test]
@@ -204,8 +204,8 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.CancelAddParticipantResult(invitationId, operationContext);
 
-            Assert.AreEqual(invitationId, result.InvitationId);
-            Assert.AreEqual(operationContext, result.OperationContext);
+            Assert.That(result.InvitationId, Is.EqualTo(invitationId));
+            Assert.That(result.OperationContext, Is.EqualTo(operationContext));
         }
 
         [Test]
@@ -221,12 +221,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.AddParticipantFailed(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, participant);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(participant, eventResult.Participant);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
+            Assert.That(eventResult.Participant, Is.EqualTo(participant));
         }
 
         [Test]
@@ -242,12 +242,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.AddParticipantSucceeded(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, participant);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(participant, eventResult.Participant);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
+            Assert.That(eventResult.Participant, Is.EqualTo(participant));
         }
 
         [Test]
@@ -266,13 +266,13 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.ParticipantsUpdated(
                 callConnectionId, serverCallId, correlationId, participants, sequenceNumber, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(sequenceNumber, eventResult.SequenceNumber);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.IsNotNull(eventResult.Participants);
-            Assert.AreEqual(1, eventResult.Participants.Count());
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.SequenceNumber, Is.EqualTo(sequenceNumber));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
+            Assert.That(eventResult.Participants, Is.Not.Null);
+            Assert.That(eventResult.Participants.Count(), Is.EqualTo(1));
         }
 
         [Test]
@@ -288,12 +288,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.RecognizeCompleted(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, recognitionType);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(recognitionType, eventResult.RecognitionType);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
+            Assert.That(eventResult.RecognitionType, Is.EqualTo(recognitionType));
         }
 
         [Test]
@@ -310,13 +310,13 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.CallTransferAccepted(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, transferee, transferTarget);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(transferee, eventResult.Transferee);
-            Assert.AreEqual(transferTarget, eventResult.TransferTarget);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
+            Assert.That(eventResult.Transferee, Is.EqualTo(transferee));
+            Assert.That(eventResult.TransferTarget, Is.EqualTo(transferTarget));
         }
 
         [Test]
@@ -331,11 +331,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.CallConnected(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
         }
 
         [Test]
@@ -350,11 +350,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.CallDisconnected(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
         }
 
         [Test]
@@ -369,11 +369,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.PlayCompleted(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
         }
 
         [Test]
@@ -389,12 +389,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.PlayFailed(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation, failedPlaySourceIndex);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(failedPlaySourceIndex, eventResult.FailedPlaySourceIndex);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
+            Assert.That(eventResult.FailedPlaySourceIndex, Is.EqualTo(failedPlaySourceIndex));
         }
 
         [Test]
@@ -411,13 +411,13 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.ContinuousDtmfRecognitionToneReceived(
                 sequenceId, tone, callConnectionId, serverCallId, correlationId, resultInformation, operationContext);
 
-            Assert.AreEqual(sequenceId, eventResult.SequenceId);
-            Assert.AreEqual(tone, eventResult.Tone);
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
+            Assert.That(eventResult.SequenceId, Is.EqualTo(sequenceId));
+            Assert.That(eventResult.Tone, Is.EqualTo(tone));
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
         }
 
         [Test]
@@ -435,14 +435,14 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.RecordingStateChanged(
                 callConnectionId, serverCallId, correlationId, recordingId, state, startDateTime, recordingKind, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(recordingId, eventResult.RecordingId);
-            Assert.AreEqual(state, eventResult.State);
-            Assert.AreEqual(startDateTime, eventResult.StartDateTime);
-            Assert.AreEqual(recordingKind, eventResult.RecordingKind);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.RecordingId, Is.EqualTo(recordingId));
+            Assert.That(eventResult.State, Is.EqualTo(state));
+            Assert.That(eventResult.StartDateTime, Is.EqualTo(startDateTime));
+            Assert.That(eventResult.RecordingKind, Is.EqualTo(recordingKind));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
         }
 
         [Test]
@@ -454,9 +454,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
 
             var result = CallAutomationModelFactory.RecordingStateResult(recordingId, recordingState, recordingKind);
 
-            Assert.AreEqual(recordingId, result.RecordingId);
-            Assert.AreEqual(recordingState, result.RecordingState);
-            Assert.AreEqual(recordingKind, result.RecordingKind);
+            Assert.That(result.RecordingId, Is.EqualTo(recordingId));
+            Assert.That(result.RecordingState, Is.EqualTo(recordingState));
+            Assert.That(result.RecordingKind, Is.EqualTo(recordingKind));
         }
 
         [Test]
@@ -471,11 +471,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.SendDtmfTonesCompleted(
                 callConnectionId, serverCallId, correlationId, operationContext, resultInformation);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
         }
 
         [Test]
@@ -490,11 +490,11 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var eventResult = CallAutomationModelFactory.CreateCallFailed(
                 callConnectionId, serverCallId, correlationId, resultInformation, operationContext);
 
-            Assert.AreEqual(callConnectionId, eventResult.CallConnectionId);
-            Assert.AreEqual(serverCallId, eventResult.ServerCallId);
-            Assert.AreEqual(correlationId, eventResult.CorrelationId);
-            Assert.AreEqual(resultInformation, eventResult.ResultInformation);
-            Assert.AreEqual(operationContext, eventResult.OperationContext);
+            Assert.That(eventResult.CallConnectionId, Is.EqualTo(callConnectionId));
+            Assert.That(eventResult.ServerCallId, Is.EqualTo(serverCallId));
+            Assert.That(eventResult.CorrelationId, Is.EqualTo(correlationId));
+            Assert.That(eventResult.ResultInformation, Is.EqualTo(resultInformation));
+            Assert.That(eventResult.OperationContext, Is.EqualTo(operationContext));
         }
 
         [Test]
@@ -504,8 +504,8 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var properties = CallAutomationModelFactory.CallConnectionProperties(
                 targets: null);
 
-            Assert.IsNotNull(properties.Targets);
-            Assert.AreEqual(0, properties.Targets.Count);
+            Assert.That(properties.Targets, Is.Not.Null);
+            Assert.That(properties.Targets.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -514,9 +514,9 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             // Test that default parameter values work correctly
             var participant = CallAutomationModelFactory.CallParticipant();
 
-            Assert.IsNull(participant.Identifier);
-            Assert.IsFalse(participant.IsMuted);
-            Assert.IsFalse(participant.IsOnHold);
+            Assert.That(participant.Identifier, Is.Null);
+            Assert.That(participant.IsMuted, Is.False);
+            Assert.That(participant.IsOnHold, Is.False);
         }
 
         [Test]
@@ -526,12 +526,12 @@ namespace Azure.Communication.CallAutomation.Tests.Models
             var originalTargets = new List<CommunicationIdentifier> { _testUser };
             var properties = CallAutomationModelFactory.CallConnectionProperties(targets: originalTargets);
 
-            Assert.AreNotSame(originalTargets, properties.Targets);
-            Assert.AreEqual(originalTargets, properties.Targets);
+            Assert.That(properties.Targets, Is.Not.SameAs(originalTargets));
+            Assert.That(properties.Targets, Is.EqualTo(originalTargets));
 
             // Modifying original should not affect the created instance
             originalTargets.Add(_testPhoneNumber);
-            Assert.AreEqual(1, properties.Targets.Count);
+            Assert.That(properties.Targets.Count, Is.EqualTo(1));
         }
 
         private CallConnection CreateMockCallConnection(int responseCode, string? responseContent = null, string callConnectionId = "9ec7da16-30be-4e74-a941-285cfc4bffc5")

--- a/sdk/communication/Azure.Communication.CallAutomation/tests/Streaming/StreamingDataParserTests.cs
+++ b/sdk/communication/Azure.Communication.CallAutomation/tests/Streaming/StreamingDataParserTests.cs
@@ -48,21 +48,21 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
 
         private static void ValidateAudioMetadata(AudioMetadata streamingAudioMetadata)
         {
-            Assert.IsNotNull(streamingAudioMetadata);
-            Assert.AreEqual("subscriptionId", streamingAudioMetadata.MediaSubscriptionId);
-            Assert.AreEqual("encodingType", streamingAudioMetadata.Encoding);
-            Assert.AreEqual(8, streamingAudioMetadata.SampleRate);
-            Assert.AreEqual(2, (int)streamingAudioMetadata.Channels);
+            Assert.That(streamingAudioMetadata, Is.Not.Null);
+            Assert.That(streamingAudioMetadata.MediaSubscriptionId, Is.EqualTo("subscriptionId"));
+            Assert.That(streamingAudioMetadata.Encoding, Is.EqualTo("encodingType"));
+            Assert.That(streamingAudioMetadata.SampleRate, Is.EqualTo(8));
+            Assert.That((int)streamingAudioMetadata.Channels, Is.EqualTo(2));
         }
 
         private static void ValidateAudioData(AudioData streamingAudio)
         {
-            Assert.IsNotNull(streamingAudio);
-            CollectionAssert.AreEqual(Convert.FromBase64String("AQIDBAU="), streamingAudio.Data.ToArray());
-            Assert.AreEqual(2022, streamingAudio.Timestamp.Year);
-            Assert.IsTrue(streamingAudio.Participant is CommunicationIdentifier);
-            Assert.AreEqual("participantId", streamingAudio.Participant.RawId);
-            Assert.IsFalse(streamingAudio.IsSilent);
+            Assert.That(streamingAudio, Is.Not.Null);
+            Assert.That(streamingAudio.Data.ToArray(), Is.EqualTo(Convert.FromBase64String("AQIDBAU=")).AsCollection);
+            Assert.That(streamingAudio.Timestamp.Year, Is.EqualTo(2022));
+            Assert.That(streamingAudio.Participant is CommunicationIdentifier, Is.True);
+            Assert.That(streamingAudio.Participant.RawId, Is.EqualTo("participantId"));
+            Assert.That(streamingAudio.IsSilent, Is.False);
         }
         #endregion
 
@@ -82,8 +82,8 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
         }
         private static void ValidateDtmfData(DtmfData streamingDtmf)
         {
-            Assert.IsNotNull(streamingDtmf);
-            Assert.AreEqual("5", streamingDtmf.Data);
+            Assert.That(streamingDtmf, Is.Not.Null);
+            Assert.That(streamingDtmf.Data, Is.EqualTo("5"));
         }
         #endregion
 
@@ -162,51 +162,51 @@ namespace Azure.Communication.CallAutomation.Tests.MediaStreaming
 
         private static void ValidateTranscriptionMetadata(TranscriptionMetadata transcriptionMetadata)
         {
-            Assert.IsNotNull(transcriptionMetadata);
-            Assert.AreEqual("subscriptionId", transcriptionMetadata.TranscriptionSubscriptionId);
-            Assert.AreEqual("en-US", transcriptionMetadata.Locale);
-            Assert.AreEqual("callConnectionId", transcriptionMetadata.CallConnectionId);
-            Assert.AreEqual("correlationId", transcriptionMetadata.CorrelationId);
-            Assert.AreEqual("speechRecognitionModelEndpointId", transcriptionMetadata.SpeechRecognitionModelEndpointId);
+            Assert.That(transcriptionMetadata, Is.Not.Null);
+            Assert.That(transcriptionMetadata.TranscriptionSubscriptionId, Is.EqualTo("subscriptionId"));
+            Assert.That(transcriptionMetadata.Locale, Is.EqualTo("en-US"));
+            Assert.That(transcriptionMetadata.CallConnectionId, Is.EqualTo("callConnectionId"));
+            Assert.That(transcriptionMetadata.CorrelationId, Is.EqualTo("correlationId"));
+            Assert.That(transcriptionMetadata.SpeechRecognitionModelEndpointId, Is.EqualTo("speechRecognitionModelEndpointId"));
         }
 
         private static void ValidateTranscriptionDataWithWordsNull(TranscriptionData transcription)
         {
-            Assert.IsNotNull(transcription);
-            Assert.AreEqual("store hours", transcription.Text);
-            Assert.AreEqual("display", transcription.Format);
-            Assert.AreEqual(49876484, transcription.Offset.Ticks);
-            Assert.AreEqual(9200000, transcription.Duration.Ticks);
+            Assert.That(transcription, Is.Not.Null);
+            Assert.That(transcription.Text, Is.EqualTo("store hours"));
+            Assert.That(transcription.Format, Is.EqualTo("display"));
+            Assert.That(transcription.Offset.Ticks, Is.EqualTo(49876484));
+            Assert.That(transcription.Duration.Ticks, Is.EqualTo(9200000));
 
-            Assert.IsTrue(transcription.Participant is CommunicationIdentifier);
-            Assert.AreEqual("abc12345", transcription.Participant.RawId);
+            Assert.That(transcription.Participant is CommunicationIdentifier, Is.True);
+            Assert.That(transcription.Participant.RawId, Is.EqualTo("abc12345"));
             Console.WriteLine(transcription.ResultState.ToString());
-            Assert.AreEqual(TranscriptionResultState.Intermediate, transcription.ResultState);
+            Assert.That(transcription.ResultState, Is.EqualTo(TranscriptionResultState.Intermediate));
         }
 
         private static void ValidateTranscriptionData(TranscriptionData transcription)
         {
-            Assert.IsNotNull(transcription);
-            Assert.AreEqual("Hello World!", transcription.Text);
-            Assert.AreEqual("display", transcription.Format);
-            Assert.AreEqual(0.98d, transcription.Confidence);
-            Assert.AreEqual(1, transcription.Offset.Ticks);
-            Assert.AreEqual(2, transcription.Duration.Ticks);
+            Assert.That(transcription, Is.Not.Null);
+            Assert.That(transcription.Text, Is.EqualTo("Hello World!"));
+            Assert.That(transcription.Format, Is.EqualTo("display"));
+            Assert.That(transcription.Confidence, Is.EqualTo(0.98d));
+            Assert.That(transcription.Offset.Ticks, Is.EqualTo(1));
+            Assert.That(transcription.Duration.Ticks, Is.EqualTo(2));
 
             // validate individual words
             IList<WordData> words = transcription.Words.ToList();
-            Assert.AreEqual(2, words.Count);
-            Assert.AreEqual("Hello", words[0].Text);
-            Assert.AreEqual(1, words[0].Offset.Ticks);
-            Assert.AreEqual(1, words[0].Duration.Ticks);
-            Assert.AreEqual("World", words[1].Text);
-            Assert.AreEqual(6, words[1].Offset.Ticks);
-            Assert.AreEqual(1, words[1].Duration.Ticks);
+            Assert.That(words.Count, Is.EqualTo(2));
+            Assert.That(words[0].Text, Is.EqualTo("Hello"));
+            Assert.That(words[0].Offset.Ticks, Is.EqualTo(1));
+            Assert.That(words[0].Duration.Ticks, Is.EqualTo(1));
+            Assert.That(words[1].Text, Is.EqualTo("World"));
+            Assert.That(words[1].Offset.Ticks, Is.EqualTo(6));
+            Assert.That(words[1].Duration.Ticks, Is.EqualTo(1));
 
-            Assert.IsTrue(transcription.Participant is CommunicationIdentifier);
-            Assert.AreEqual("abc12345", transcription.Participant.RawId);
+            Assert.That(transcription.Participant is CommunicationIdentifier, Is.True);
+            Assert.That(transcription.Participant.RawId, Is.EqualTo("abc12345"));
             Console.WriteLine(transcription.ResultState.ToString());
-            Assert.AreEqual(TranscriptionResultState.Final, transcription.ResultState);
+            Assert.That(transcription.ResultState, Is.EqualTo(TranscriptionResultState.Final));
         }
         #endregion
     }

--- a/sdk/communication/Azure.Communication.Chat/tests/ChatClients/ChatClientsLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Chat/tests/ChatClients/ChatClientsLiveTests.cs
@@ -75,15 +75,15 @@ namespace Azure.Communication.Chat.Tests
             ChatThreadClient chatThreadClient = GetInstrumentedChatThreadClient(chatClient, createChatThreadResult.ChatThread.Id);
             var threadId = chatThreadClient.Id;
 
-            Assert.IsNotNull(createChatThreadResult.ChatThread.Metadata);
-            Assert.AreEqual("MetaValue1", createChatThreadResult.ChatThread.Metadata["MetaKey1"]);
-            Assert.AreEqual("MetaValue2", createChatThreadResult.ChatThread.Metadata["MetaKey2"]);
+            Assert.That(createChatThreadResult.ChatThread.Metadata, Is.Not.Null);
+            Assert.That(createChatThreadResult.ChatThread.Metadata["MetaKey1"], Is.EqualTo("MetaValue1"));
+            Assert.That(createChatThreadResult.ChatThread.Metadata["MetaKey2"], Is.EqualTo("MetaValue2"));
 
-            Assert.IsNotNull(createChatThreadResult.ChatThread.RetentionPolicy);
+            Assert.That(createChatThreadResult.ChatThread.RetentionPolicy, Is.Not.Null);
             var threadCreationDateRetentionPolicy = createChatThreadResult.ChatThread.RetentionPolicy as ThreadCreationDateRetentionPolicy;
-            Assert.IsNotNull(threadCreationDateRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.ThreadCreationDate, threadCreationDateRetentionPolicy?.Kind);
-            Assert.AreEqual(60, threadCreationDateRetentionPolicy?.DeleteThreadAfterDays);
+            Assert.That(threadCreationDateRetentionPolicy, Is.Not.Null);
+            Assert.That(threadCreationDateRetentionPolicy?.Kind, Is.EqualTo(RetentionPolicyKind.ThreadCreationDate));
+            Assert.That(threadCreationDateRetentionPolicy?.DeleteThreadAfterDays, Is.EqualTo(60));
 
             var participants = new List<ChatParticipant>
             {
@@ -100,8 +100,8 @@ namespace Azure.Communication.Chat.Tests
             var chatParticipantsOnCreationCount = chatParticipantsOnCreationList.Count;
 
             var chatParticipant1 = chatParticipantsOnCreationList.FirstOrDefault(x => x.User == user1);
-            Assert.AreEqual("ParticipantMetaValue1", chatParticipant1?.Metadata["ParticipantMetaKey1"]);
-            Assert.AreEqual("ParticipantMetaValue2", chatParticipant1?.Metadata["ParticipantMetaKey2"]);
+            Assert.That(chatParticipant1?.Metadata["ParticipantMetaKey1"], Is.EqualTo("ParticipantMetaValue1"));
+            Assert.That(chatParticipant1?.Metadata["ParticipantMetaKey2"], Is.EqualTo("ParticipantMetaValue2"));
 
             var updatedTopic = "Updated topic - C# sdk";
             await chatThreadClient.UpdateTopicAsync(updatedTopic);
@@ -229,58 +229,58 @@ namespace Azure.Communication.Chat.Tests
             await chatClient.DeleteChatThreadAsync(threadId);
 
             //assert
-            Assert.AreEqual(updatedTopic, chatThread.Topic);
-            Assert.AreEqual(3, chatParticipantsOnCreationCount);
-            Assert.AreEqual(messageContent, message.Content.Message);
-            Assert.AreEqual(displayNameMessage, message.SenderDisplayName);
-            Assert.AreEqual(updatedMessageContent, actualUpdateMessage.Value.Content.Message);
-            Assert.AreEqual(ChatMessageType.Text, message.Type);
+            Assert.That(chatThread.Topic, Is.EqualTo(updatedTopic));
+            Assert.That(chatParticipantsOnCreationCount, Is.EqualTo(3));
+            Assert.That(message.Content.Message, Is.EqualTo(messageContent));
+            Assert.That(message.SenderDisplayName, Is.EqualTo(displayNameMessage));
+            Assert.That(actualUpdateMessage.Value.Content.Message, Is.EqualTo(updatedMessageContent));
+            Assert.That(message.Type, Is.EqualTo(ChatMessageType.Text));
 
-            Assert.AreEqual(ChatMessageType.Html, message2.Type);
-            Assert.AreEqual(ChatMessageType.Text, message3.Type);
-            Assert.AreEqual(ChatMessageType.Html, message4.Type);
-            Assert.AreEqual(ChatMessageType.Text, message5.Type);
-            Assert.AreEqual(ChatMessageType.Html, message6.Type);
+            Assert.That(message2.Type, Is.EqualTo(ChatMessageType.Html));
+            Assert.That(message3.Type, Is.EqualTo(ChatMessageType.Text));
+            Assert.That(message4.Type, Is.EqualTo(ChatMessageType.Html));
+            Assert.That(message5.Type, Is.EqualTo(ChatMessageType.Text));
+            Assert.That(message6.Type, Is.EqualTo(ChatMessageType.Html));
 
-            Assert.AreEqual(messageContent2, message2.Content.Message);
-            Assert.AreEqual(messageContent3, message3.Content.Message);
-            Assert.AreEqual(messageContent4, message4.Content.Message);
-            Assert.AreEqual(messageContent5, message5.Content.Message);
-            Assert.AreEqual(messageContent6, message6.Content.Message);
+            Assert.That(message2.Content.Message, Is.EqualTo(messageContent2));
+            Assert.That(message3.Content.Message, Is.EqualTo(messageContent3));
+            Assert.That(message4.Content.Message, Is.EqualTo(messageContent4));
+            Assert.That(message5.Content.Message, Is.EqualTo(messageContent5));
+            Assert.That(message6.Content.Message, Is.EqualTo(messageContent6));
 
-            Assert.AreEqual(sendChatMessageOptions7.MessageType, message7.Type);
-            Assert.AreEqual(sendChatMessageOptions7.SenderDisplayName, message7.SenderDisplayName);
-            Assert.AreEqual(sendChatMessageOptions7.Content, message7.Content.Message);
-            CollectionAssert.AreEquivalent(sendChatMessageOptions7.Metadata, message7.Metadata);
+            Assert.That(message7.Type, Is.EqualTo(sendChatMessageOptions7.MessageType));
+            Assert.That(message7.SenderDisplayName, Is.EqualTo(sendChatMessageOptions7.SenderDisplayName));
+            Assert.That(message7.Content.Message, Is.EqualTo(sendChatMessageOptions7.Content));
+            Assert.That(message7.Metadata, Is.EquivalentTo(sendChatMessageOptions7.Metadata));
 
-            Assert.AreEqual(sendChatMessageOptions7.MessageType, actualUpdatedMessage7.Value.Type);
-            Assert.AreEqual(sendChatMessageOptions7.SenderDisplayName, actualUpdatedMessage7.Value.SenderDisplayName);
-            Assert.AreEqual(updateChatMessageOptions7.Content, actualUpdatedMessage7.Value.Content.Message);
-            Assert.AreEqual(4, actualUpdatedMessage7.Value.Metadata.Count);
-            Assert.AreEqual(updateChatMessageOptions7.Metadata["deliveryMode"], actualUpdatedMessage7.Value.Metadata["deliveryMode"]);
-            Assert.AreEqual(updateChatMessageOptions7.Metadata["onedriveReferences"], actualUpdatedMessage7.Value.Metadata["onedriveReferences"]);
-            Assert.AreEqual(updateChatMessageOptions7.Metadata["amsreferences"], actualUpdatedMessage7.Value.Metadata["amsreferences"]);
-            Assert.AreEqual(updateChatMessageOptions7.Metadata["key"], actualUpdatedMessage7.Value.Metadata["key"]);
-            Assert.AreEqual(2, threadsCount);
-            Assert.AreEqual(9, getMessagesCount); //Including all types : 6 text message, 3 control messages
-            Assert.AreEqual(3, getMessagesCount2); //Including all types : 1 text message, 2 control messages
+            Assert.That(actualUpdatedMessage7.Value.Type, Is.EqualTo(sendChatMessageOptions7.MessageType));
+            Assert.That(actualUpdatedMessage7.Value.SenderDisplayName, Is.EqualTo(sendChatMessageOptions7.SenderDisplayName));
+            Assert.That(actualUpdatedMessage7.Value.Content.Message, Is.EqualTo(updateChatMessageOptions7.Content));
+            Assert.That(actualUpdatedMessage7.Value.Metadata.Count, Is.EqualTo(4));
+            Assert.That(actualUpdatedMessage7.Value.Metadata["deliveryMode"], Is.EqualTo(updateChatMessageOptions7.Metadata["deliveryMode"]));
+            Assert.That(actualUpdatedMessage7.Value.Metadata["onedriveReferences"], Is.EqualTo(updateChatMessageOptions7.Metadata["onedriveReferences"]));
+            Assert.That(actualUpdatedMessage7.Value.Metadata["amsreferences"], Is.EqualTo(updateChatMessageOptions7.Metadata["amsreferences"]));
+            Assert.That(actualUpdatedMessage7.Value.Metadata["key"], Is.EqualTo(updateChatMessageOptions7.Metadata["key"]));
+            Assert.That(threadsCount, Is.EqualTo(2));
+            Assert.That(getMessagesCount, Is.EqualTo(9)); //Including all types : 6 text message, 3 control messages
+            Assert.That(getMessagesCount2, Is.EqualTo(3)); //Including all types : 1 text message, 2 control messages
 
-            Assert.AreEqual(1, participantAddedMessage.Content.Participants.Count);
-            Assert.AreEqual(user5.Id, CommunicationIdentifierSerializer.Serialize(participantAddedMessage.Content.Participants[0].User).CommunicationUser.Id);
-            Assert.AreEqual("user5", participantAddedMessage.Content.Participants[0].DisplayName);
+            Assert.That(participantAddedMessage.Content.Participants.Count, Is.EqualTo(1));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(participantAddedMessage.Content.Participants[0].User).CommunicationUser.Id, Is.EqualTo(user5.Id));
+            Assert.That(participantAddedMessage.Content.Participants[0].DisplayName, Is.EqualTo("user5"));
 
-            Assert.AreEqual(1, participantRemovedMessage.Content.Participants.Count);
-            Assert.AreEqual(user4.Id, CommunicationIdentifierSerializer.Serialize(participantRemovedMessage.Content.Participants[0].User).CommunicationUser.Id);
-            Assert.AreEqual("user4", participantRemovedMessage.Content.Participants[0].DisplayName);
+            Assert.That(participantRemovedMessage.Content.Participants.Count, Is.EqualTo(1));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(participantRemovedMessage.Content.Participants[0].User).CommunicationUser.Id, Is.EqualTo(user4.Id));
+            Assert.That(participantRemovedMessage.Content.Participants[0].DisplayName, Is.EqualTo("user4"));
 
-            Assert.IsTrue(deletedChatMessage.DeletedOn.HasValue);
-            Assert.AreEqual(3, chatParticipantsCount);
-            Assert.AreEqual(5, chatParticipantsAfterTwoOneAddedCount);
-            Assert.AreEqual(4, chatParticipantAfterOneDeletedCount);
-            Assert.AreEqual(0, addChatParticipantsResult.InvalidParticipants.Count);
-            Assert.AreEqual((int)HttpStatusCode.Created, addChatParticipantResult.Status);
-            Assert.AreEqual((int)HttpStatusCode.OK, typingNotificationResponse.Status);
-            Assert.AreEqual((int)HttpStatusCode.OK, typingNotificationWithOptionsResponse.Status);
+            Assert.That(deletedChatMessage.DeletedOn.HasValue, Is.True);
+            Assert.That(chatParticipantsCount, Is.EqualTo(3));
+            Assert.That(chatParticipantsAfterTwoOneAddedCount, Is.EqualTo(5));
+            Assert.That(chatParticipantAfterOneDeletedCount, Is.EqualTo(4));
+            Assert.That(addChatParticipantsResult.InvalidParticipants.Count, Is.EqualTo(0));
+            Assert.That(addChatParticipantResult.Status, Is.EqualTo((int)HttpStatusCode.Created));
+            Assert.That(typingNotificationResponse.Status, Is.EqualTo((int)HttpStatusCode.OK));
+            Assert.That(typingNotificationWithOptionsResponse.Status, Is.EqualTo((int)HttpStatusCode.OK));
         }
 
         /// <summary>
@@ -312,20 +312,20 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsChangeTopic);
 
             var updateResponseUpdateTopic = await chatThreadClient.GetPropertiesAsync();
-            Assert.AreEqual("updated thread topic", updateResponseUpdateTopic.Value.Topic);
+            Assert.That(updateResponseUpdateTopic.Value.Topic, Is.EqualTo("updated thread topic"));
 
             var noneRetentionPolicy = updateResponseUpdateTopic.Value.RetentionPolicy as NoneRetentionPolicy;
-            Assert.IsNotNull(noneRetentionPolicy);
+            Assert.That(noneRetentionPolicy, Is.Not.Null);
 
             // Update properties, not setting options. Topic not changed.
             var updateOptionsWithSameProperties = new UpdateChatThreadPropertiesOptions();
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithSameProperties);
 
             var updateResponseWithSameProperties = await chatThreadClient.GetPropertiesAsync();
-            Assert.AreEqual("updated thread topic", updateResponseWithSameProperties.Value.Topic);
+            Assert.That(updateResponseWithSameProperties.Value.Topic, Is.EqualTo("updated thread topic"));
 
             noneRetentionPolicy = updateResponseWithSameProperties.Value.RetentionPolicy as NoneRetentionPolicy;
-            Assert.IsNotNull(noneRetentionPolicy);
+            Assert.That(noneRetentionPolicy, Is.Not.Null);
 
             // Update properties adding metadata
             var updateOptionsWithNewMetadata = new UpdateChatThreadPropertiesOptions();
@@ -335,11 +335,11 @@ namespace Azure.Communication.Chat.Tests
 
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewMetadata);
             var updateResponseWithNewMetadata = await chatThreadClient.GetPropertiesAsync();
-            Assert.AreEqual("Update properties adding metadata", updateResponseWithNewMetadata.Value.Topic);
+            Assert.That(updateResponseWithNewMetadata.Value.Topic, Is.EqualTo("Update properties adding metadata"));
 
-            Assert.IsNotNull(updateResponseWithNewMetadata.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew2"]);
+            Assert.That(updateResponseWithNewMetadata.Value.Metadata, Is.Not.Null);
+            Assert.That(updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew1"], Is.EqualTo("MetaValueNew1"));
+            Assert.That(updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew2"], Is.EqualTo("MetaValueNew2"));
 
             // Update properties adding retention policy deleteAfterDays
             var updateOptionsWithNewRetentionPolicy = new UpdateChatThreadPropertiesOptions();
@@ -348,12 +348,12 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewRetentionPolicy);
             var updateResponseWithNewRetentionPolicy = await chatThreadClient.GetPropertiesAsync();
             var newDataRetentionPolicy = updateResponseWithNewRetentionPolicy.Value.RetentionPolicy as ThreadCreationDateRetentionPolicy;
-            Assert.IsNotNull(newDataRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.ThreadCreationDate, newDataRetentionPolicy?.Kind);
-            Assert.AreEqual(40, newDataRetentionPolicy?.DeleteThreadAfterDays);
-            Assert.IsNotNull(updateResponseWithNewRetentionPolicy.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
+            Assert.That(newDataRetentionPolicy, Is.Not.Null);
+            Assert.That(newDataRetentionPolicy?.Kind, Is.EqualTo(RetentionPolicyKind.ThreadCreationDate));
+            Assert.That(newDataRetentionPolicy?.DeleteThreadAfterDays, Is.EqualTo(40));
+            Assert.That(updateResponseWithNewRetentionPolicy.Value.Metadata, Is.Not.Null);
+            Assert.That(updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew1"], Is.EqualTo("MetaValueNew1"));
+            Assert.That(updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew2"], Is.EqualTo("MetaValueNew2"));
 
             // Update properties changing retention policy deleteAfterDays
             updateOptionsWithNewRetentionPolicy = new UpdateChatThreadPropertiesOptions();
@@ -362,12 +362,12 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewRetentionPolicy);
             updateResponseWithNewRetentionPolicy = await chatThreadClient.GetPropertiesAsync();
             newDataRetentionPolicy = updateResponseWithNewRetentionPolicy.Value.RetentionPolicy as ThreadCreationDateRetentionPolicy;
-            Assert.IsNotNull(newDataRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.ThreadCreationDate, newDataRetentionPolicy?.Kind);
-            Assert.AreEqual(50, newDataRetentionPolicy?.DeleteThreadAfterDays);
-            Assert.IsNotNull(updateResponseWithNewRetentionPolicy.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
+            Assert.That(newDataRetentionPolicy, Is.Not.Null);
+            Assert.That(newDataRetentionPolicy?.Kind, Is.EqualTo(RetentionPolicyKind.ThreadCreationDate));
+            Assert.That(newDataRetentionPolicy?.DeleteThreadAfterDays, Is.EqualTo(50));
+            Assert.That(updateResponseWithNewRetentionPolicy.Value.Metadata, Is.Not.Null);
+            Assert.That(updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew1"], Is.EqualTo("MetaValueNew1"));
+            Assert.That(updateResponseWithNewRetentionPolicy.Value.Metadata["MetaKeyNew2"], Is.EqualTo("MetaValueNew2"));
 
             // Update properties updating tetention policy to NoneRetentionPolicy
             var updateOptionsWithNoneRetentionPolicy = new UpdateChatThreadPropertiesOptions();
@@ -376,12 +376,12 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNoneRetentionPolicy);
             var updateResponseWithNoneRetentionPolicy = await chatThreadClient.GetPropertiesAsync();
             var noneDataRetentionPolicy = updateResponseWithNoneRetentionPolicy.Value.RetentionPolicy as NoneRetentionPolicy;
-            Assert.IsNotNull(noneDataRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.None, noneDataRetentionPolicy?.Kind);
+            Assert.That(noneDataRetentionPolicy, Is.Not.Null);
+            Assert.That(noneDataRetentionPolicy?.Kind, Is.EqualTo(RetentionPolicyKind.None));
 
-            Assert.IsNotNull(updateResponseWithNoneRetentionPolicy.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNoneRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNoneRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
+            Assert.That(updateResponseWithNoneRetentionPolicy.Value.Metadata, Is.Not.Null);
+            Assert.That(updateResponseWithNoneRetentionPolicy.Value.Metadata["MetaKeyNew1"], Is.EqualTo("MetaValueNew1"));
+            Assert.That(updateResponseWithNoneRetentionPolicy.Value.Metadata["MetaKeyNew2"], Is.EqualTo("MetaValueNew2"));
 
             // Set retention policy to null and change topic
             var updateOptionsWithNullRetentionPolicyOptions = new UpdateChatThreadPropertiesOptions
@@ -392,14 +392,14 @@ namespace Azure.Communication.Chat.Tests
 
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNullRetentionPolicyOptions);
             var updateResponseWithNullRetentionPolicy = await chatThreadClient.GetPropertiesAsync();
-            Assert.AreEqual(updateOptionsWithNullRetentionPolicyOptions.Topic, updateResponseWithNullRetentionPolicy.Value.Topic);
+            Assert.That(updateResponseWithNullRetentionPolicy.Value.Topic, Is.EqualTo(updateOptionsWithNullRetentionPolicyOptions.Topic));
             var nullDataRetentionPolicy = updateResponseWithNullRetentionPolicy.Value.RetentionPolicy as NoneRetentionPolicy;
-            Assert.IsNotNull(nullDataRetentionPolicy);
-            Assert.AreEqual(RetentionPolicyKind.None, nullDataRetentionPolicy?.Kind);
+            Assert.That(nullDataRetentionPolicy, Is.Not.Null);
+            Assert.That(nullDataRetentionPolicy?.Kind, Is.EqualTo(RetentionPolicyKind.None));
 
-            Assert.IsNotNull(updateResponseWithNullRetentionPolicy.Value.Metadata);
-            Assert.AreEqual("MetaValueNew1", updateResponseWithNullRetentionPolicy.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueNew2", updateResponseWithNullRetentionPolicy.Value.Metadata["MetaKeyNew2"]);
+            Assert.That(updateResponseWithNullRetentionPolicy.Value.Metadata, Is.Not.Null);
+            Assert.That(updateResponseWithNullRetentionPolicy.Value.Metadata["MetaKeyNew1"], Is.EqualTo("MetaValueNew1"));
+            Assert.That(updateResponseWithNullRetentionPolicy.Value.Metadata["MetaKeyNew2"], Is.EqualTo("MetaValueNew2"));
 
             // Change values of metadata
             updateOptionsWithNewMetadata = new UpdateChatThreadPropertiesOptions();
@@ -409,10 +409,10 @@ namespace Azure.Communication.Chat.Tests
 
             await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewMetadata);
             updateResponseWithNewMetadata = await chatThreadClient.GetPropertiesAsync();
-            Assert.IsNotNull(updateResponseWithNewMetadata.Value.Metadata);
-            Assert.AreEqual("MetaValueChangedValue1", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueChangedValue2", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew2"]);
-            Assert.AreEqual("MetaValueNew3", updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew3"]);
+            Assert.That(updateResponseWithNewMetadata.Value.Metadata, Is.Not.Null);
+            Assert.That(updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew1"], Is.EqualTo("MetaValueChangedValue1"));
+            Assert.That(updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew2"], Is.EqualTo("MetaValueChangedValue2"));
+            Assert.That(updateResponseWithNewMetadata.Value.Metadata["MetaKeyNew3"], Is.EqualTo("MetaValueNew3"));
 
             // Set metadata to empty dictionary. Previous metadata will be kept.
             var updateOptionsWithEmptyMetadata = new UpdateChatThreadPropertiesOptions
@@ -426,11 +426,11 @@ namespace Azure.Communication.Chat.Tests
             var updateResponseWithEmptyMetadata = await chatThreadClient.GetPropertiesAsync();
 
             // Expect all previous metadata to be kept
-            Assert.IsNotNull(updateResponseWithEmptyMetadata.Value.Metadata);
-            Assert.AreEqual(3, updateResponseWithEmptyMetadata.Value.Metadata.Count);
-            Assert.AreEqual("MetaValueChangedValue1", updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew1"]);
-            Assert.AreEqual("MetaValueChangedValue2", updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew2"]);
-            Assert.AreEqual("MetaValueNew3", updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew3"]);
+            Assert.That(updateResponseWithEmptyMetadata.Value.Metadata, Is.Not.Null);
+            Assert.That(updateResponseWithEmptyMetadata.Value.Metadata.Count, Is.EqualTo(3));
+            Assert.That(updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew1"], Is.EqualTo("MetaValueChangedValue1"));
+            Assert.That(updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew2"], Is.EqualTo("MetaValueChangedValue2"));
+            Assert.That(updateResponseWithEmptyMetadata.Value.Metadata["MetaKeyNew3"], Is.EqualTo("MetaValueNew3"));
 
             // Update topic, metadata and retention policy in one call
             var fullUpdateOptions = new UpdateChatThreadPropertiesOptions
@@ -444,9 +444,9 @@ namespace Azure.Communication.Chat.Tests
             await chatThreadClient.UpdatePropertiesAsync(fullUpdateOptions);
             var result = await chatThreadClient.GetPropertiesAsync();
 
-            Assert.AreEqual("Full update topic", result.Value.Topic);
-            Assert.AreEqual("ValueA", result.Value.Metadata["KeyA"]);
-            Assert.AreEqual(90, ((ThreadCreationDateRetentionPolicy)result.Value.RetentionPolicy).DeleteThreadAfterDays);
+            Assert.That(result.Value.Topic, Is.EqualTo("Full update topic"));
+            Assert.That(result.Value.Metadata["KeyA"], Is.EqualTo("ValueA"));
+            Assert.That(((ThreadCreationDateRetentionPolicy)result.Value.RetentionPolicy).DeleteThreadAfterDays, Is.EqualTo(90));
         }
 
         [Test]
@@ -492,8 +492,8 @@ namespace Azure.Communication.Chat.Tests
             await chatClient.DeleteChatThreadAsync(threadId);
 
             //assert
-            Assert.AreEqual(2, readReceiptsCount);
-            Assert.AreEqual(2, readReceiptsCount2);
+            Assert.That(readReceiptsCount, Is.EqualTo(2));
+            Assert.That(readReceiptsCount2, Is.EqualTo(2));
         }
 
         #region Support functions
@@ -532,11 +532,11 @@ namespace Azure.Communication.Chat.Tests
                         actualTotalResources++;
                     }
                     continuationToken = page.ContinuationToken;
-                    Assert.GreaterOrEqual(expectedPageSize, actualPageSize);
+                    Assert.That(expectedPageSize, Is.GreaterThanOrEqualTo(actualPageSize));
                 }
-                Assert.IsNull(continuationToken);
-                Assert.AreEqual(expectedTotalResources, actualTotalResources);
-                Assert.AreEqual(expectedRoundTrips, actualRoundTrips);
+                Assert.That(continuationToken, Is.Null);
+                Assert.That(actualTotalResources, Is.EqualTo(expectedTotalResources));
+                Assert.That(actualRoundTrips, Is.EqualTo(expectedRoundTrips));
             }
 
             public static async Task AssertPaginationAsync(AsyncPageable<T> enumerableResource, int expectedPageSize, int expectedTotalResources)
@@ -554,11 +554,11 @@ namespace Azure.Communication.Chat.Tests
                         actualTotalResources++;
                     }
                     continuationToken = page.ContinuationToken;
-                    Assert.GreaterOrEqual(expectedPageSize, actualPageSize);
+                    Assert.That(expectedPageSize, Is.GreaterThanOrEqualTo(actualPageSize));
                 }
-                Assert.IsNull(continuationToken);
-                Assert.AreEqual(expectedTotalResources, actualTotalResources);
-                Assert.AreEqual(expectedRoundTrips, actualRoundTrips);
+                Assert.That(continuationToken, Is.Null);
+                Assert.That(actualTotalResources, Is.EqualTo(expectedTotalResources));
+                Assert.That(actualRoundTrips, Is.EqualTo(expectedRoundTrips));
             }
         }
         #endregion

--- a/sdk/communication/Azure.Communication.Chat/tests/ChatClients/ChatClientsTests.cs
+++ b/sdk/communication/Azure.Communication.Chat/tests/ChatClients/ChatClientsTests.cs
@@ -67,16 +67,16 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             await foreach (ChatMessage message in allMessages)
             {
                 idCounter++;
-                Assert.AreEqual($"{idCounter}", message.Id);
-                Assert.AreEqual($"{idCounter}", message.Version);
+                Assert.That(message.Id, Is.EqualTo($"{idCounter}"));
+                Assert.That(message.Version, Is.EqualTo($"{idCounter}"));
                 if (message.Type == "text")
                 {
                     textMessagesCounter++;
-                    Assert.AreEqual($"Content for async message{idCounter}", message.Content.Message);
+                    Assert.That(message.Content.Message, Is.EqualTo($"Content for async message{idCounter}"));
                 }
             }
-            Assert.AreEqual(8, idCounter);
-            Assert.AreEqual(5, textMessagesCounter);
+            Assert.That(idCounter, Is.EqualTo(8));
+            Assert.That(textMessagesCounter, Is.EqualTo(5));
         }
 
         [Test]
@@ -114,18 +114,18 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 foreach (ChatMessage message in page.Values)
                 {
                     idCounter++;
-                    Assert.AreEqual($"{idCounter}", message.Id);
-                    Assert.AreEqual($"{idCounter}", message.Version);
+                    Assert.That(message.Id, Is.EqualTo($"{idCounter}"));
+                    Assert.That(message.Version, Is.EqualTo($"{idCounter}"));
                     if (message.Type == "text")
                     {
                         textMessagesCounter++;
-                        Assert.AreEqual($"Content for async message{idCounter}", message.Content.Message);
+                        Assert.That(message.Content.Message, Is.EqualTo($"Content for async message{idCounter}"));
                     }
                 }
             }
-            Assert.AreEqual(2, pages);
-            Assert.AreEqual(8, idCounter);
-            Assert.AreEqual(5, textMessagesCounter);
+            Assert.That(pages, Is.EqualTo(2));
+            Assert.That(idCounter, Is.EqualTo(8));
+            Assert.That(textMessagesCounter, Is.EqualTo(5));
         }
 
         [Test]
@@ -144,11 +144,11 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             await foreach (ChatMessageReadReceipt readReceipt in allReadReceipts)
             {
                 idCounter++;
-                Assert.AreEqual($"{idCounter}", readReceipt.ChatMessageId);
-                Assert.AreEqual($"{baseSenderId}{idCounter}", ((UnknownIdentifier)readReceipt.Sender).Id);
-                Assert.AreEqual(baseReadOnDate.AddSeconds(idCounter), readReceipt.ReadOn);
+                Assert.That(readReceipt.ChatMessageId, Is.EqualTo($"{idCounter}"));
+                Assert.That(((UnknownIdentifier)readReceipt.Sender).Id, Is.EqualTo($"{baseSenderId}{idCounter}"));
+                Assert.That(readReceipt.ReadOn, Is.EqualTo(baseReadOnDate.AddSeconds(idCounter)));
             }
-            Assert.AreEqual(5, idCounter);
+            Assert.That(idCounter, Is.EqualTo(5));
         }
 
         [Test]
@@ -167,11 +167,11 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             foreach (ChatMessageReadReceipt readReceipt in allReadReceipts)
             {
                 idCounter++;
-                Assert.AreEqual($"{idCounter}", readReceipt.ChatMessageId);
-                Assert.AreEqual($"{baseSenderId}{idCounter}", ((UnknownIdentifier)readReceipt.Sender).Id);
-                Assert.AreEqual(baseReadOnDate.AddSeconds(idCounter), readReceipt.ReadOn);
+                Assert.That(readReceipt.ChatMessageId, Is.EqualTo($"{idCounter}"));
+                Assert.That(((UnknownIdentifier)readReceipt.Sender).Id, Is.EqualTo($"{baseSenderId}{idCounter}"));
+                Assert.That(readReceipt.ReadOn, Is.EqualTo(baseReadOnDate.AddSeconds(idCounter)));
             }
-            Assert.AreEqual(5, idCounter);
+            Assert.That(idCounter, Is.EqualTo(5));
         }
         [Test]
         public async Task OrderInGetReadReceiptsIteratorIsNotAlteredByPaging()
@@ -209,14 +209,14 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 foreach (ChatMessageReadReceipt readReceipt in page.Values)
                 {
                     idCounter++;
-                    Assert.AreEqual($"{idCounter}", readReceipt.ChatMessageId);
-                    Assert.AreEqual($"{baseSenderId}{idCounter}", ((UnknownIdentifier)readReceipt.Sender).Id);
-                    Assert.AreEqual(baseReadOnDate.AddSeconds(idCounter), readReceipt.ReadOn);
+                    Assert.That(readReceipt.ChatMessageId, Is.EqualTo($"{idCounter}"));
+                    Assert.That(((UnknownIdentifier)readReceipt.Sender).Id, Is.EqualTo($"{baseSenderId}{idCounter}"));
+                    Assert.That(readReceipt.ReadOn, Is.EqualTo(baseReadOnDate.AddSeconds(idCounter)));
                 }
                 //continuationToken = page.ContinuationToken;
             }
-            Assert.AreEqual(2, pages);
-            Assert.AreEqual(5, idCounter);
+            Assert.That(pages, Is.EqualTo(2));
+            Assert.That(idCounter, Is.EqualTo(5));
         }
 
         [Test]
@@ -228,9 +228,9 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             CreateChatThreadResult createChatThreadResult = await chatClient.CreateChatThreadAsync("", new List<ChatParticipant>() { chatParticipant });
 
             //assert
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).CommunicationUser.Id);
-            Assert.AreEqual("Topic for testing success", createChatThreadResult.ChatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).CommunicationUser.Id, Is.EqualTo("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c"));
+            Assert.That(createChatThreadResult.ChatThread.Topic, Is.EqualTo("Topic for testing success"));
+            Assert.That(createChatThreadResult.ChatThread.Id, Is.EqualTo("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2"));
         }
 
         [Test]
@@ -242,9 +242,9 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             CreateChatThreadResult createChatThreadResult = chatClient.CreateChatThread("", new List<ChatParticipant>() { chatParticipant });
 
             //assert
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).CommunicationUser.Id);
-            Assert.AreEqual("Topic for testing success", createChatThreadResult.ChatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).CommunicationUser.Id, Is.EqualTo("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c"));
+            Assert.That(createChatThreadResult.ChatThread.Topic, Is.EqualTo("Topic for testing success"));
+            Assert.That(createChatThreadResult.ChatThread.Id, Is.EqualTo("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2"));
         }
 
         [Test]
@@ -257,7 +257,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             SendChatMessageResult sendChatMessageResult = await chatThreadClient.SendMessageAsync("Send Message Test");
 
             //assert
-            Assert.AreEqual("1", sendChatMessageResult.Id);
+            Assert.That(sendChatMessageResult.Id, Is.EqualTo("1"));
         }
 
         [Test]
@@ -275,7 +275,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -294,7 +294,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -309,7 +309,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             SendChatMessageResult sendChatMessageResult = await chatThreadClient.SendMessageAsync(sendChatMessageOptions);
 
             //assert
-            Assert.AreEqual("1", sendChatMessageResult.Id);
+            Assert.That(sendChatMessageResult.Id, Is.EqualTo("1"));
         }
 
         [Test]
@@ -322,7 +322,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response typingNotificationResponse = await chatThreadClient.SendTypingNotificationAsync();
 
             //assert
-            Assert.AreEqual(200, typingNotificationResponse.Status);
+            Assert.That(typingNotificationResponse.Status, Is.EqualTo(200));
         }
 
         [Test]
@@ -339,7 +339,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -357,7 +357,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -372,7 +372,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response typingNotificationResponse = await chatThreadClient.SendTypingNotificationAsync(options);
 
             //assert
-            Assert.AreEqual(200, typingNotificationResponse.Status);
+            Assert.That(typingNotificationResponse.Status, Is.EqualTo(200));
         }
 
         [Test]
@@ -386,7 +386,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response readReceiptResponse = await chatThreadClient.SendReadReceiptAsync(messageId);
 
             //assert
-            Assert.AreEqual(200, readReceiptResponse.Status);
+            Assert.That(readReceiptResponse.Status, Is.EqualTo(200));
         }
 
         [Test]
@@ -400,7 +400,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response readReceiptResponse = chatThreadClient.SendReadReceipt(messageId);
 
             //assert
-            Assert.AreEqual(200, readReceiptResponse.Status);
+            Assert.That(readReceiptResponse.Status, Is.EqualTo(200));
         }
 
         [Test]
@@ -418,7 +418,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -437,7 +437,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -452,7 +452,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             var response = await chatThreadClient.DeleteMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -466,7 +466,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             var response = chatThreadClient.DeleteMessage(messageId);
 
             //assert
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -484,7 +484,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -503,7 +503,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -519,7 +519,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response updateMessageResponse = await chatThreadClient.UpdateMessageAsync(messageId, content);
 
             //assert
-            Assert.AreEqual(204, updateMessageResponse.Status);
+            Assert.That(updateMessageResponse.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -538,7 +538,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -558,7 +558,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -574,7 +574,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response updateMessageResponse = chatThreadClient.UpdateMessage(messageId, content);
 
             //assert
-            Assert.AreEqual(204, updateMessageResponse.Status);
+            Assert.That(updateMessageResponse.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -588,12 +588,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = await chatThreadClient.GetMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.Text, message.Type);
-            Assert.AreEqual("1", message.Id);
-            Assert.AreEqual("Test Message", message.Content.Message);
-            Assert.AreEqual("DisplayName for Test Message", message.SenderDisplayName);
-            Assert.NotNull(message.Sender);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Sender!).CommunicationUser.Id);
+            Assert.That(message.Type, Is.EqualTo(ChatMessageType.Text));
+            Assert.That(message.Id, Is.EqualTo("1"));
+            Assert.That(message.Content.Message, Is.EqualTo("Test Message"));
+            Assert.That(message.SenderDisplayName, Is.EqualTo("DisplayName for Test Message"));
+            Assert.That(message.Sender, Is.Not.Null);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Sender!).CommunicationUser.Id, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
         }
 
         [Test]
@@ -611,7 +611,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -630,7 +630,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -645,12 +645,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = chatThreadClient.GetMessage(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.Text, message.Type);
-            Assert.AreEqual("1", message.Id);
-            Assert.AreEqual("Test Message", message.Content.Message);
-            Assert.AreEqual("DisplayName for Test Message", message.SenderDisplayName);
-            Assert.NotNull(message.Sender);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Sender!).CommunicationUser.Id);
+            Assert.That(message.Type, Is.EqualTo(ChatMessageType.Text));
+            Assert.That(message.Id, Is.EqualTo("1"));
+            Assert.That(message.Content.Message, Is.EqualTo("Test Message"));
+            Assert.That(message.SenderDisplayName, Is.EqualTo("DisplayName for Test Message"));
+            Assert.That(message.Sender, Is.Not.Null);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Sender!).CommunicationUser.Id, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
         }
         [Test]
         public async Task GetTopicUpdatedMessageAsyncShouldSucceed()
@@ -663,12 +663,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = await chatThreadClient.GetMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.TopicUpdated, message.Type);
-            Assert.AreEqual("2", message.Id);
-            Assert.AreEqual("TopicUpdateTest", message.Content.Topic);
-            Assert.AreEqual("2", message.Version);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
+            Assert.That(message.Type, Is.EqualTo(ChatMessageType.TopicUpdated));
+            Assert.That(message.Id, Is.EqualTo("2"));
+            Assert.That(message.Content.Topic, Is.EqualTo("TopicUpdateTest"));
+            Assert.That(message.Version, Is.EqualTo("2"));
+            Assert.That(message.Content.Initiator, Is.Not.Null);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
         }
 
         [Test]
@@ -682,12 +682,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = chatThreadClient.GetMessage(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.TopicUpdated, message.Type);
-            Assert.AreEqual("2", message.Id);
-            Assert.AreEqual("TopicUpdateTest", message.Content.Topic);
-            Assert.AreEqual("2", message.Version);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
+            Assert.That(message.Type, Is.EqualTo(ChatMessageType.TopicUpdated));
+            Assert.That(message.Id, Is.EqualTo("2"));
+            Assert.That(message.Content.Topic, Is.EqualTo("TopicUpdateTest"));
+            Assert.That(message.Version, Is.EqualTo("2"));
+            Assert.That(message.Content.Initiator, Is.Not.Null);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
         }
 
         [Test]
@@ -701,16 +701,16 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = await chatThreadClient.GetMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.ParticipantAdded, message.Type);
-            Assert.AreEqual("3", message.Id);
-            Assert.AreEqual("3", message.Version);
-            Assert.AreEqual(2, message.Content.Participants.Count);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.NotNull(message.Content.Participants[0].User);
-            Assert.NotNull(message.Content.Participants[1].User);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[1].User!).RawId);
+            Assert.That(message.Type, Is.EqualTo(ChatMessageType.ParticipantAdded));
+            Assert.That(message.Id, Is.EqualTo("3"));
+            Assert.That(message.Version, Is.EqualTo("3"));
+            Assert.That(message.Content.Participants.Count, Is.EqualTo(2));
+            Assert.That(message.Content.Initiator, Is.Not.Null);
+            Assert.That(message.Content.Participants[0].User, Is.Not.Null);
+            Assert.That(message.Content.Participants[1].User, Is.Not.Null);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9"));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Participants[1].User!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
         }
 
         [Test]
@@ -724,16 +724,16 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = chatThreadClient.GetMessage(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.ParticipantAdded, message.Type);
-            Assert.AreEqual("3", message.Id);
-            Assert.AreEqual("3", message.Version);
-            Assert.AreEqual(2, message.Content.Participants.Count);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.NotNull(message.Content.Participants[0].User);
-            Assert.NotNull(message.Content.Participants[1].User);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[1].User!).RawId);
+            Assert.That(message.Type, Is.EqualTo(ChatMessageType.ParticipantAdded));
+            Assert.That(message.Id, Is.EqualTo("3"));
+            Assert.That(message.Version, Is.EqualTo("3"));
+            Assert.That(message.Content.Participants.Count, Is.EqualTo(2));
+            Assert.That(message.Content.Initiator, Is.Not.Null);
+            Assert.That(message.Content.Participants[0].User, Is.Not.Null);
+            Assert.That(message.Content.Participants[1].User, Is.Not.Null);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9"));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Participants[1].User!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
         }
 
         [Test]
@@ -747,14 +747,14 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = await chatThreadClient.GetMessageAsync(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.ParticipantRemoved, message.Type);
-            Assert.AreEqual("4", message.Id);
-            Assert.AreEqual("4", message.Version);
-            Assert.AreEqual(1, message.Content.Participants.Count);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.NotNull(message.Content.Participants[0].User);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
+            Assert.That(message.Type, Is.EqualTo(ChatMessageType.ParticipantRemoved));
+            Assert.That(message.Id, Is.EqualTo("4"));
+            Assert.That(message.Version, Is.EqualTo("4"));
+            Assert.That(message.Content.Participants.Count, Is.EqualTo(1));
+            Assert.That(message.Content.Initiator, Is.Not.Null);
+            Assert.That(message.Content.Participants[0].User, Is.Not.Null);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9"));
         }
 
         public void GetParticipantRemovedMessageShouldSucceed()
@@ -767,14 +767,14 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatMessage message = chatThreadClient.GetMessage(messageId);
 
             //assert
-            Assert.AreEqual(ChatMessageType.ParticipantRemoved, message.Type);
-            Assert.AreEqual("4", message.Id);
-            Assert.AreEqual("4", message.Version);
-            Assert.AreEqual(1, message.Content.Participants.Count);
-            Assert.NotNull(message.Content.Initiator);
-            Assert.NotNull(message.Content.Participants[0].User);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9", CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId);
+            Assert.That(message.Type, Is.EqualTo(ChatMessageType.ParticipantRemoved));
+            Assert.That(message.Id, Is.EqualTo("4"));
+            Assert.That(message.Version, Is.EqualTo("4"));
+            Assert.That(message.Content.Participants.Count, Is.EqualTo(1));
+            Assert.That(message.Content.Initiator, Is.Not.Null);
+            Assert.That(message.Content.Participants[0].User, Is.Not.Null);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Initiator!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(message.Content.Participants[0].User!).RawId, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-0464-274b-b274-5a3a0d0002c9"));
         }
         [Test]
         public async Task GetThreadShouldSucceed()
@@ -787,9 +787,9 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             ChatThreadProperties chatThread = await chatThreadClient.GetPropertiesAsync();
 
             //assert
-            Assert.AreEqual(threadId, chatThread.Id);
-            Assert.AreEqual("Test Thread", chatThread.Topic);
-            Assert.AreEqual("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7", CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id);
+            Assert.That(chatThread.Id, Is.EqualTo(threadId));
+            Assert.That(chatThread.Topic, Is.EqualTo("Test Thread"));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id, Is.EqualTo("8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-8f5e-776d-ea7c-5a3a0d0027b7"));
         }
 
         [Test]
@@ -807,7 +807,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -826,7 +826,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -841,7 +841,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response UpdateTopiceResponse = await chatThreadClient.UpdateTopicAsync(topic);
 
             //assert
-            Assert.AreEqual(204, UpdateTopiceResponse.Status);
+            Assert.That(UpdateTopiceResponse.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -859,7 +859,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -878,7 +878,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (Exception ex)
             {
                 //assert
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -894,7 +894,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -908,7 +908,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(updateOptionsWithNewMetadata);
 
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -923,7 +923,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -936,7 +936,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -953,7 +953,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -972,7 +972,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             var response = await chatThreadClient.UpdatePropertiesAsync(options);
 
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -995,10 +995,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 {
                     continue;
                 }
-                Assert.AreEqual($"{idCounter}", chatThread.Id);
-                Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                Assert.That(chatThread.Id, Is.EqualTo($"{idCounter}"));
+                Assert.That(chatThread.Topic, Is.EqualTo($"Test Thread {idCounter}"));
             }
-            Assert.AreEqual(5, idCounter);
+            Assert.That(idCounter, Is.EqualTo(5));
         }
 
         [Test]
@@ -1028,12 +1028,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 foreach (ChatThreadItem chatThread in page.Values)
                 {
                     idCounter++;
-                    Assert.AreEqual($"{idCounter}", chatThread.Id);
-                    Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                    Assert.That(chatThread.Id, Is.EqualTo($"{idCounter}"));
+                    Assert.That(chatThread.Topic, Is.EqualTo($"Test Thread {idCounter}"));
                 }
             }
-            Assert.AreEqual(2, pages);
-            Assert.AreEqual(6, idCounter);
+            Assert.That(pages, Is.EqualTo(2));
+            Assert.That(idCounter, Is.EqualTo(6));
         }
 
         [Test]
@@ -1063,12 +1063,12 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 foreach (ChatThreadItem chatThread in page.Values)
                 {
                     idCounter++;
-                    Assert.AreEqual($"{idCounter}", chatThread.Id);
-                    Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                    Assert.That(chatThread.Id, Is.EqualTo($"{idCounter}"));
+                    Assert.That(chatThread.Topic, Is.EqualTo($"Test Thread {idCounter}"));
                 }
             }
-            Assert.AreEqual(2, pages);
-            Assert.AreEqual(6, idCounter);
+            Assert.That(pages, Is.EqualTo(2));
+            Assert.That(idCounter, Is.EqualTo(6));
         }
 
         [Test]
@@ -1090,10 +1090,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 {
                     continue;
                 }
-                Assert.AreEqual($"{idCounter}", chatThread.Id);
-                Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                Assert.That(chatThread.Id, Is.EqualTo($"{idCounter}"));
+                Assert.That(chatThread.Topic, Is.EqualTo($"Test Thread {idCounter}"));
             }
-            Assert.AreEqual(5, idCounter);
+            Assert.That(idCounter, Is.EqualTo(5));
         }
 
         [Test]
@@ -1115,10 +1115,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
                 {
                     continue;
                 }
-                Assert.AreEqual($"{idCounter}", chatThread.Id);
-                Assert.AreEqual($"Test Thread {idCounter}", chatThread.Topic);
+                Assert.That(chatThread.Id, Is.EqualTo($"{idCounter}"));
+                Assert.That(chatThread.Topic, Is.EqualTo($"Test Thread {idCounter}"));
             }
-            Assert.AreEqual(5, idCounter);
+            Assert.That(idCounter, Is.EqualTo(5));
         }
 
         [Test]
@@ -1140,7 +1140,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.IsTrue(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -1158,7 +1158,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.IsTrue(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -1176,7 +1176,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.IsTrue(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -1194,10 +1194,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             await foreach (ChatParticipant chatParticipant in chatParticipants)
             {
                 idCounter++;
-                Assert.AreEqual($"{idCounter}", CommunicationIdentifierSerializer.Serialize(chatParticipant.User).CommunicationUser.Id);
-                Assert.AreEqual($"Display Name {idCounter}", chatParticipant.DisplayName);
+                Assert.That(CommunicationIdentifierSerializer.Serialize(chatParticipant.User).CommunicationUser.Id, Is.EqualTo($"{idCounter}"));
+                Assert.That(chatParticipant.DisplayName, Is.EqualTo($"Display Name {idCounter}"));
             }
-            Assert.AreEqual(2, idCounter);
+            Assert.That(idCounter, Is.EqualTo(2));
         }
 
         [Test]
@@ -1212,7 +1212,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response RemoveParticipantResponse = chatThreadClient.RemoveParticipant(identifier);
 
             //assert
-            Assert.AreEqual(204, RemoveParticipantResponse.Status);
+            Assert.That(RemoveParticipantResponse.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -1227,7 +1227,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response RemoveParticipantResponse = await chatThreadClient.RemoveParticipantAsync(identifier);
 
             //assert
-            Assert.AreEqual(204, RemoveParticipantResponse.Status);
+            Assert.That(RemoveParticipantResponse.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -1242,7 +1242,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response AddParticipantResponse = chatThreadClient.AddParticipant(chatParticipant);
 
             //assert
-            Assert.AreEqual(201, AddParticipantResponse.Status);
+            Assert.That(AddParticipantResponse.Status, Is.EqualTo(201));
         }
 
         [Test]
@@ -1257,7 +1257,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response AddParticipantResponse = await chatThreadClient.AddParticipantAsync(chatParticipant);
 
             //assert
-            Assert.AreEqual(201, AddParticipantResponse.Status);
+            Assert.That(AddParticipantResponse.Status, Is.EqualTo(201));
         }
 
         [Test]
@@ -1270,7 +1270,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AddChatParticipantsResult AddParticipantsResponse = await chatThreadClient.AddParticipantsAsync(new List<ChatParticipant>());
 
             //assert
-            Assert.AreEqual(0, AddParticipantsResponse.InvalidParticipants.Count);
+            Assert.That(AddParticipantsResponse.InvalidParticipants.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -1283,7 +1283,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AddChatParticipantsResult AddParticipantsResponse = chatThreadClient.AddParticipants(new List<ChatParticipant>());
 
             //assert
-            Assert.AreEqual(0, AddParticipantsResponse.InvalidParticipants.Count);
+            Assert.That(AddParticipantsResponse.InvalidParticipants.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -1297,7 +1297,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response deleteChatThreadResponse = await chatClient.DeleteChatThreadAsync(threadId);
 
             //assert
-            Assert.AreEqual(204, deleteChatThreadResponse.Status);
+            Assert.That(deleteChatThreadResponse.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -1311,7 +1311,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             Response deleteChatThreadResponse = chatClient.DeleteChatThread(threadId);
 
             //assert
-            Assert.AreEqual(204, deleteChatThreadResponse.Status);
+            Assert.That(deleteChatThreadResponse.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -1329,7 +1329,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message.Contains("401"), Is.True);
             }
         }
 
@@ -1348,10 +1348,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AsssertParticipantError(createChatThreadResult.InvalidParticipants.First(x => x.Code == "403"), "Permissions check failed", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345679");
             AsssertParticipantError(createChatThreadResult.InvalidParticipants.First(x => x.Code == "404"), "Not found", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345677");
 
-            Assert.AreEqual(3, createChatThreadResult.InvalidParticipants.Count);
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).RawId);
-            Assert.AreEqual("Topic for testing errors", createChatThreadResult.ChatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
+            Assert.That(createChatThreadResult.InvalidParticipants.Count, Is.EqualTo(3));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).RawId, Is.EqualTo("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c"));
+            Assert.That(createChatThreadResult.ChatThread.Topic, Is.EqualTo("Topic for testing errors"));
+            Assert.That(createChatThreadResult.ChatThread.Id, Is.EqualTo("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2"));
         }
 
         [Test]
@@ -1364,14 +1364,14 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             //assert
             var chatThread = createChatThreadResult.ChatThread;
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id);
-            Assert.AreEqual("Topic for testing success", chatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", chatThread.Id);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id, Is.EqualTo("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c"));
+            Assert.That(chatThread.Topic, Is.EqualTo("Topic for testing success"));
+            Assert.That(chatThread.Id, Is.EqualTo("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2"));
 
             var threadCreationDateRetentionPolicy = chatThread.RetentionPolicy as ThreadCreationDateRetentionPolicy;
 
-            Assert.IsNotNull(threadCreationDateRetentionPolicy);
-            Assert.AreEqual(40, threadCreationDateRetentionPolicy?.DeleteThreadAfterDays);
+            Assert.That(threadCreationDateRetentionPolicy, Is.Not.Null);
+            Assert.That(threadCreationDateRetentionPolicy?.DeleteThreadAfterDays, Is.EqualTo(40));
         }
 
         [Test]
@@ -1384,13 +1384,13 @@ namespace Azure.Communication.Chat.Tests.ChatClients
 
             //assert
             var chatThread = createChatThreadResult.ChatThread;
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id);
-            Assert.AreEqual("Topic for testing success", chatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", chatThread.Id);
+            Assert.That(CommunicationIdentifierSerializer.Serialize(chatThread.CreatedBy).CommunicationUser.Id, Is.EqualTo("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c"));
+            Assert.That(chatThread.Topic, Is.EqualTo("Topic for testing success"));
+            Assert.That(chatThread.Id, Is.EqualTo("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2"));
 
             var noneRetentionPolicy = chatThread.RetentionPolicy as NoneRetentionPolicy;
 
-            Assert.IsNotNull(noneRetentionPolicy);
+            Assert.That(noneRetentionPolicy, Is.Not.Null);
         }
 
         [Test]
@@ -1408,10 +1408,10 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AsssertParticipantError(createChatThreadResult.InvalidParticipants.First(x => x.Code == "403"), "Permissions check failed", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345679");
             AsssertParticipantError(createChatThreadResult.InvalidParticipants.First(x => x.Code == "404"), "Not found", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345677");
 
-            Assert.AreEqual(3, createChatThreadResult.InvalidParticipants.Count);
-            Assert.AreEqual("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c", CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).RawId);
-            Assert.AreEqual("Topic for testing errors", createChatThreadResult.ChatThread.Topic);
-            Assert.AreEqual("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2", createChatThreadResult.ChatThread.Id);
+            Assert.That(createChatThreadResult.InvalidParticipants.Count, Is.EqualTo(3));
+            Assert.That(CommunicationIdentifierSerializer.Serialize(createChatThreadResult.ChatThread.CreatedBy).RawId, Is.EqualTo("8:acs:46849534-eb08-4ab7-bde7-c36928cd1547_00000007-165c-9b10-b0b7-3a3a0d00076c"));
+            Assert.That(createChatThreadResult.ChatThread.Topic, Is.EqualTo("Topic for testing errors"));
+            Assert.That(createChatThreadResult.ChatThread.Id, Is.EqualTo("19:e5e7a3fa5f314a01b2d12c6c7b37f433@thread.v2"));
         }
 
         [Test]
@@ -1427,7 +1427,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             AsssertParticipantError(addChatParticipantsResult.InvalidParticipants.First(x => x.Code == "401"), "Authentication failed", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345678");
             AsssertParticipantError(addChatParticipantsResult.InvalidParticipants.First(x => x.Code == "403"), "Permissions check failed", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345679");
             AsssertParticipantError(addChatParticipantsResult.InvalidParticipants.First(x => x.Code == "404"), "Not found", "8:acs:1b5cc06b-f352-4571-b1e6-d9b259b7c776_00000007-1234-1234-1234-223a12345677");
-            Assert.AreEqual(3, addChatParticipantsResult.InvalidParticipants.Count);
+            Assert.That(addChatParticipantsResult.InvalidParticipants.Count, Is.EqualTo(3));
         }
 
         [Test]
@@ -1445,7 +1445,7 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             catch (RequestFailedException requestFailedException)
             {
                 //assert
-                Assert.AreEqual(401, requestFailedException.Status);
+                Assert.That(requestFailedException.Status, Is.EqualTo(401));
             }
         }
 
@@ -1453,35 +1453,35 @@ namespace Azure.Communication.Chat.Tests.ChatClients
         public void TestMockingModels()
         {
             var chatThreadProperties = ChatModelFactory.ChatThreadProperties("id", "topic", It.IsAny<DateTimeOffset>(), It.IsAny<CommunicationIdentifier>(), It.IsAny<DateTimeOffset>());
-            Assert.IsNotNull(chatThreadProperties);
+            Assert.That(chatThreadProperties, Is.Not.Null);
 
             var createChatThreadResult = ChatModelFactory.CreateChatThreadResult(chatThreadProperties, It.IsAny<IEnumerable<ChatError>>());
-            Assert.IsNotNull(createChatThreadResult);
+            Assert.That(createChatThreadResult, Is.Not.Null);
 
             var sendChatMessageResult = ChatModelFactory.SendChatMessageResult("id");
-            Assert.IsNotNull(sendChatMessageResult);
+            Assert.That(sendChatMessageResult, Is.Not.Null);
 
             var innerChatError = new ChatError("innerErrorCode", "InnerCodeMessage");
             var chatErrorDetails = new List<ChatError>() { new ChatError("detailsErrorCode", "DetailsCodeMessage") };
             var chatError = ChatModelFactory.ChatError("code", "message", "target", chatErrorDetails, innerChatError);
-            Assert.IsNotNull(chatError);
-            Assert.AreEqual(chatError.Details, chatErrorDetails);
-            Assert.AreEqual(chatError.InnerError, innerChatError);
+            Assert.That(chatError, Is.Not.Null);
+            Assert.That(chatErrorDetails, Is.EqualTo(chatError.Details));
+            Assert.That(innerChatError, Is.EqualTo(chatError.InnerError));
 
             var chatParticipant = ChatModelFactory.ChatParticipant(It.IsAny<CommunicationIdentifier>(), It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<IDictionary<string, string>>());
-            Assert.IsNotNull(chatParticipant);
+            Assert.That(chatParticipant, Is.Not.Null);
 
             var addChatParticipantsResult = ChatModelFactory.AddChatParticipantsResult(It.IsAny<IEnumerable<ChatError>>());
-            Assert.IsNotNull(addChatParticipantsResult);
+            Assert.That(addChatParticipantsResult, Is.Not.Null);
 
             var addChatParticipantsResultEmpty = new AddChatParticipantsResult();
-            Assert.IsNotNull(addChatParticipantsResultEmpty);
+            Assert.That(addChatParticipantsResultEmpty, Is.Not.Null);
 
             var chatThreadItem = ChatModelFactory.ChatThreadItem("id", "topic", It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>());
-            Assert.IsNotNull(chatThreadItem);
+            Assert.That(chatThreadItem, Is.Not.Null);
 
             var chatMessageContent = ChatModelFactory.ChatMessageContent("id", "topic", It.IsAny<CommunicationUserIdentifier>(), It.IsAny<IEnumerable<ChatParticipant>>(), It.IsAny<IReadOnlyList<ChatAttachment>>());
-            Assert.IsNotNull(chatMessageContent);
+            Assert.That(chatMessageContent, Is.Not.Null);
 
             try
             {
@@ -1489,24 +1489,24 @@ namespace Azure.Communication.Chat.Tests.ChatClients
             }
             catch (Exception ex)
             {
-                Assert.IsNotNull(ex);
+                Assert.That(ex, Is.Not.Null);
             }
 
             var chatMessageReceipt = ChatModelFactory.ChatMessageReadReceipt(It.IsAny<CommunicationUserIdentifier>(), "messageId", It.IsAny<DateTimeOffset>());
-            Assert.IsNotNull(chatMessageReceipt);
+            Assert.That(chatMessageReceipt, Is.Not.Null);
         }
 
         [Test]
         public void TestChatClientOptions()
         {
             var options = new ChatClientOptions(ChatClientOptions.ServiceVersion.V2021_09_07);
-            Assert.IsNotNull(options);
+            Assert.That(options, Is.Not.Null);
         }
 
         private void AsssertParticipantError(ChatError chatParticipantError, string expectedMessage, string expectedTarget)
         {
-            Assert.AreEqual(expectedMessage, chatParticipantError.Message);
-            Assert.AreEqual(expectedTarget, chatParticipantError.Target);
+            Assert.That(chatParticipantError.Message, Is.EqualTo(expectedMessage));
+            Assert.That(chatParticipantError.Target, Is.EqualTo(expectedTarget));
         }
 
         private ChatClient CreateMockChatClient(int responseCode, string? responseContent = null)

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationIdentifierTest.cs
@@ -14,32 +14,32 @@ namespace Azure.Communication
         public void RawIdTakesPrecendenceInEqualityCheck()
         {
             // Teams users
-            Assert.AreEqual(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true), new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true));
-            Assert.AreNotEqual(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Raw Id"), new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Another Raw Id"));
+            Assert.That(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true), Is.EqualTo(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true)));
+            Assert.That(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Another Raw Id"), Is.Not.EqualTo(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Raw Id")));
 
-            Assert.AreEqual(new MicrosoftTeamsUserIdentifier("override", isAnonymous: true, rawId: "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true));
-            Assert.AreEqual(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true), new MicrosoftTeamsUserIdentifier("override", isAnonymous: true, rawId: "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+            Assert.That(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true), Is.EqualTo(new MicrosoftTeamsUserIdentifier("override", isAnonymous: true, rawId: "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(new MicrosoftTeamsUserIdentifier("override", isAnonymous: true, rawId: "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"), Is.EqualTo(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true)));
 
             // Phone numbers
-            Assert.AreEqual(new PhoneNumberIdentifier("+14255550123"), new PhoneNumberIdentifier("+14255550123"));
-            Assert.AreNotEqual(new PhoneNumberIdentifier("+14255550123", "Raw Id"), new PhoneNumberIdentifier("+14255550123", "Another Raw Id"));
+            Assert.That(new PhoneNumberIdentifier("+14255550123"), Is.EqualTo(new PhoneNumberIdentifier("+14255550123")));
+            Assert.That(new PhoneNumberIdentifier("+14255550123", "Another Raw Id"), Is.Not.EqualTo(new PhoneNumberIdentifier("+14255550123", "Raw Id")));
 
-            Assert.AreEqual(new PhoneNumberIdentifier("+override", "4:14255550123"), new PhoneNumberIdentifier("14255550123"));
-            Assert.AreEqual(new PhoneNumberIdentifier("14255550123"), new PhoneNumberIdentifier("+override", "4:14255550123"));
+            Assert.That(new PhoneNumberIdentifier("14255550123"), Is.EqualTo(new PhoneNumberIdentifier("+override", "4:14255550123")));
+            Assert.That(new PhoneNumberIdentifier("+override", "4:14255550123"), Is.EqualTo(new PhoneNumberIdentifier("14255550123")));
 
             // Teams app
-            Assert.AreEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"));
-            Assert.AreEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Public));
-            Assert.AreNotEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Dod));
-            Assert.AreNotEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Gcch));
+            Assert.That(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), Is.EqualTo(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Public), Is.EqualTo(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Dod), Is.Not.EqualTo(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", cloud: CommunicationCloudEnvironment.Gcch), Is.Not.EqualTo(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130")));
 
-            Assert.AreNotEqual(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), new MicrosoftTeamsAppIdentifier("override"));
+            Assert.That(new MicrosoftTeamsAppIdentifier("override"), Is.Not.EqualTo(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130")));
 
             // Teams extension user
-            Assert.AreEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"));
-            Assert.AreEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Public));
-            Assert.AreNotEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Gcch));
-            Assert.AreNotEqual(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Dod));
+            Assert.That(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd"), Is.EqualTo(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd")));
+            Assert.That(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Public), Is.EqualTo(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd")));
+            Assert.That(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Gcch), Is.Not.EqualTo(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd")));
+            Assert.That(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd", CommunicationCloudEnvironment.Dod), Is.Not.EqualTo(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd")));
         }
 
         [Test]
@@ -63,37 +63,37 @@ namespace Azure.Communication
         [Test]
         public void DefaultCloudIsPublic()
         {
-            Assert.AreEqual(CommunicationCloudEnvironment.Public, new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Raw Id").Cloud);
-            Assert.AreEqual(CommunicationCloudEnvironment.Public, new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130").Cloud);
-            Assert.AreEqual(CommunicationCloudEnvironment.Public, new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd").Cloud);
+            Assert.That(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", isAnonymous: true, rawId: "Raw Id").Cloud, Is.EqualTo(CommunicationCloudEnvironment.Public));
+            Assert.That(new MicrosoftTeamsAppIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130").Cloud, Is.EqualTo(CommunicationCloudEnvironment.Public));
+            Assert.That(new TeamsExtensionUserIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768", "45ab2481-1c1c-4005-be24-0ffb879b1130", "bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd").Cloud, Is.EqualTo(CommunicationCloudEnvironment.Public));
         }
 
         [Test]
         public void PhoneNumberIdentifier_ComputedProperties()
         {
-            Assert.AreEqual(false, new PhoneNumberIdentifier("14255550123").IsAnonymous);
-            Assert.AreEqual(true, new PhoneNumberIdentifier("anonymous").IsAnonymous);
-            Assert.AreEqual(true, new PhoneNumberIdentifier("override", "4:anonymous").IsAnonymous);
-            Assert.AreEqual(false, new PhoneNumberIdentifier("override", "4:anonymous123").IsAnonymous);
-            Assert.AreEqual(false, new PhoneNumberIdentifier("override", "4:_anonymous").IsAnonymous);
+            Assert.That(new PhoneNumberIdentifier("14255550123").IsAnonymous, Is.EqualTo(false));
+            Assert.That(new PhoneNumberIdentifier("anonymous").IsAnonymous, Is.EqualTo(true));
+            Assert.That(new PhoneNumberIdentifier("override", "4:anonymous").IsAnonymous, Is.EqualTo(true));
+            Assert.That(new PhoneNumberIdentifier("override", "4:anonymous123").IsAnonymous, Is.EqualTo(false));
+            Assert.That(new PhoneNumberIdentifier("override", "4:_anonymous").IsAnonymous, Is.EqualTo(false));
 
-            Assert.AreEqual(null, new PhoneNumberIdentifier("14255550121").AssertedId);
-            Assert.AreEqual(null, new PhoneNumberIdentifier("14255550121.123").AssertedId);
-            Assert.AreEqual(null, new PhoneNumberIdentifier("14255550121-123").AssertedId);
-            Assert.AreEqual("123", new PhoneNumberIdentifier("14255550121_123").AssertedId);
-            Assert.AreEqual("123", new PhoneNumberIdentifier("14255550121", "4:14255550121_123").AssertedId);
-            Assert.AreEqual("456", new PhoneNumberIdentifier("14255550121_123_456").AssertedId);
-            Assert.AreEqual("456", new PhoneNumberIdentifier("14255550121", "4:14255550121_123_456").AssertedId);
+            Assert.That(new PhoneNumberIdentifier("14255550121").AssertedId, Is.EqualTo(null));
+            Assert.That(new PhoneNumberIdentifier("14255550121.123").AssertedId, Is.EqualTo(null));
+            Assert.That(new PhoneNumberIdentifier("14255550121-123").AssertedId, Is.EqualTo(null));
+            Assert.That(new PhoneNumberIdentifier("14255550121_123").AssertedId, Is.EqualTo("123"));
+            Assert.That(new PhoneNumberIdentifier("14255550121", "4:14255550121_123").AssertedId, Is.EqualTo("123"));
+            Assert.That(new PhoneNumberIdentifier("14255550121_123_456").AssertedId, Is.EqualTo("456"));
+            Assert.That(new PhoneNumberIdentifier("14255550121", "4:14255550121_123_456").AssertedId, Is.EqualTo("456"));
 
             var staticPhoneNumberIdentifier = new PhoneNumberIdentifier("14255550121_123");
-            Assert.AreEqual("123", staticPhoneNumberIdentifier.AssertedId); // first use: compute assertedId
-            Assert.AreEqual("123", staticPhoneNumberIdentifier.AssertedId); // second use: reuse previously computed assertedId
+            Assert.That(staticPhoneNumberIdentifier.AssertedId, Is.EqualTo("123")); // first use: compute assertedId
+            Assert.That(staticPhoneNumberIdentifier.AssertedId, Is.EqualTo("123")); // second use: reuse previously computed assertedId
         }
 
         [Test]
         public void GetRawIdOfIdentifier()
         {
-            static void AssertRawId(CommunicationIdentifier identifier, string expectedRawId) => Assert.AreEqual(expectedRawId, identifier.RawId);
+            static void AssertRawId(CommunicationIdentifier identifier, string expectedRawId) => Assert.That(identifier.RawId, Is.EqualTo(expectedRawId));
 
             AssertRawId(new CommunicationUserIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"), "8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
             AssertRawId(new CommunicationUserIdentifier("8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"), "8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
@@ -127,10 +127,10 @@ namespace Azure.Communication
         {
             static void AssertIdentifier(string rawId, CommunicationIdentifier expectedIdentifier)
             {
-                Assert.AreEqual(expectedIdentifier, CommunicationIdentifier.FromRawId(rawId));
-                Assert.AreEqual(expectedIdentifier.GetHashCode(), CommunicationIdentifier.FromRawId(rawId).GetHashCode());
-                Assert.IsTrue(CommunicationIdentifier.FromRawId(rawId) == expectedIdentifier);
-                Assert.IsFalse(CommunicationIdentifier.FromRawId(rawId) != expectedIdentifier);
+                Assert.That(CommunicationIdentifier.FromRawId(rawId), Is.EqualTo(expectedIdentifier));
+                Assert.That(CommunicationIdentifier.FromRawId(rawId).GetHashCode(), Is.EqualTo(expectedIdentifier.GetHashCode()));
+                Assert.That(CommunicationIdentifier.FromRawId(rawId) == expectedIdentifier, Is.True);
+                Assert.That(CommunicationIdentifier.FromRawId(rawId) != expectedIdentifier, Is.False);
             }
 
             AssertIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130", new CommunicationUserIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
@@ -166,7 +166,7 @@ namespace Azure.Communication
         [Test]
         public void RawIdStaysTheSameAfterConversionToIdentifierAndBack()
         {
-            static void AssertRoundtrip(string rawId) => Assert.AreEqual(rawId, CommunicationIdentifier.FromRawId(rawId).RawId);
+            static void AssertRoundtrip(string rawId) => Assert.That(CommunicationIdentifier.FromRawId(rawId).RawId, Is.EqualTo(rawId));
 
             AssertRoundtrip("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
             AssertRoundtrip("8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
@@ -196,7 +196,7 @@ namespace Azure.Communication
             IEnumerable<Type>? implementations = baseType.Assembly.GetTypes().Where(type => type.IsSubclassOf(typeof(CommunicationIdentifier)));
             foreach (Type implementation in implementations)
             {
-                Assert.AreNotEqual(baseType, implementation.GetProperty(nameof(CommunicationIdentifier.RawId))?.DeclaringType);
+                Assert.That(implementation.GetProperty(nameof(CommunicationIdentifier.RawId))?.DeclaringType, Is.Not.EqualTo(baseType));
             }
         }
 
@@ -240,19 +240,19 @@ namespace Azure.Communication
             Assert.That(dictionary, Does.ContainKey(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130_207ffef6-9444-41fb-92ab-20eacaae2768")).WithValue(nameof(TeamsExtensionUserIdentifier)));
             Assert.That(dictionary, Does.ContainKey(CommunicationIdentifier.FromRawId("48:45ab2481-1c1c-4005-be24-0ffb879b1130")).WithValue(nameof(UnknownIdentifier)));
 
-            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
-            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"));
-            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("4:+14255550123"));
-            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"));
-            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130_207ffef6-9444-41fb-92ab-20eacaae2768"));
-            CollectionAssert.Contains(hashSet, CommunicationIdentifier.FromRawId("48:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+            Assert.That(hashSet, Has.Member(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(hashSet, Has.Member(CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(hashSet, Has.Member(CommunicationIdentifier.FromRawId("4:+14255550123")));
+            Assert.That(hashSet, Has.Member(CommunicationIdentifier.FromRawId("28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(hashSet, Has.Member(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130_207ffef6-9444-41fb-92ab-20eacaae2768")));
+            Assert.That(hashSet, Has.Member(CommunicationIdentifier.FromRawId("48:45ab2481-1c1c-4005-be24-0ffb879b1130")));
 
-            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
-            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"));
-            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("4:+14255550123"));
-            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"));
-            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130_207ffef6-9444-41fb-92ab-20eacaae2768"));
-            CollectionAssert.Contains(list, CommunicationIdentifier.FromRawId("48:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+            Assert.That(list, Has.Member(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(list, Has.Member(CommunicationIdentifier.FromRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(list, Has.Member(CommunicationIdentifier.FromRawId("4:+14255550123")));
+            Assert.That(list, Has.Member(CommunicationIdentifier.FromRawId("28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130")));
+            Assert.That(list, Has.Member(CommunicationIdentifier.FromRawId("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130_207ffef6-9444-41fb-92ab-20eacaae2768")));
+            Assert.That(list, Has.Member(CommunicationIdentifier.FromRawId("48:45ab2481-1c1c-4005-be24-0ffb879b1130")));
         }
 
         [Test]
@@ -264,31 +264,31 @@ namespace Azure.Communication
             var otherTypeIdentifier = new MicrosoftTeamsUserIdentifier("123");
             CommunicationIdentifier? nullIdentifier = null;
 
-            Assert.False(identifier == null);
-            Assert.False(null == identifier);
-            Assert.True(identifier != null);
-            Assert.True(null != identifier);
+            Assert.That(identifier, Is.Not.EqualTo(null));
+            Assert.That((CommunicationIdentifier?)null, Is.Not.EqualTo(identifier));
+            Assert.That(identifier, Is.Not.EqualTo(null));
+            Assert.That((CommunicationIdentifier?)null, Is.Not.EqualTo(identifier));
 
-            Assert.True(null as CommunicationIdentifier == null as CommunicationIdentifier);
-            Assert.False(identifier == null as CommunicationIdentifier);
-            Assert.False(null as CommunicationIdentifier == identifier);
-            Assert.True(identifier != null as CommunicationIdentifier);
-            Assert.True(null as CommunicationIdentifier != identifier);
+            Assert.That(null as CommunicationIdentifier == null as CommunicationIdentifier, Is.True);
+            Assert.That(identifier, Is.Not.EqualTo(null as CommunicationIdentifier));
+            Assert.That(null as CommunicationIdentifier, Is.Not.EqualTo(identifier));
+            Assert.That(identifier, Is.Not.EqualTo(null as CommunicationIdentifier));
+            Assert.That(null as CommunicationIdentifier, Is.Not.EqualTo(identifier));
 
-            Assert.True(null == nullIdentifier);
-            Assert.False(nullIdentifier == identifier);
+            Assert.That(null == nullIdentifier, Is.True);
+            Assert.That(nullIdentifier, Is.Not.EqualTo(identifier));
 
 #pragma warning disable CS1718 // Comparison made to same variable
-            Assert.True(identifier == identifier);
+            Assert.That(identifier == identifier, Is.True);
 #pragma warning restore CS1718 // Comparison made to same variable
-            Assert.True(identifier == sameIdentifier);
-            Assert.False(identifier != sameIdentifier);
-            Assert.True(sameIdentifier == identifier);
-            Assert.False(sameIdentifier != identifier);
-            Assert.False(identifier == otherIdentifier);
-            Assert.True(identifier != otherIdentifier);
-            Assert.False(identifier == otherTypeIdentifier);
-            Assert.True(identifier != otherTypeIdentifier);
+            Assert.That(identifier == sameIdentifier, Is.True);
+            Assert.That(identifier != sameIdentifier, Is.False);
+            Assert.That(sameIdentifier == identifier, Is.True);
+            Assert.That(sameIdentifier != identifier, Is.False);
+            Assert.That(identifier, Is.Not.EqualTo(otherIdentifier));
+            Assert.That(identifier, Is.Not.EqualTo(otherIdentifier));
+            Assert.That(identifier, Is.Not.EqualTo(otherTypeIdentifier));
+            Assert.That(identifier, Is.Not.EqualTo(otherTypeIdentifier));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/tests/CommunicationUserIdentifierTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/CommunicationUserIdentifierTests.cs
@@ -23,8 +23,8 @@ namespace Azure.Communication
             CommunicationUserIdentifier identifier1 = new(_id);
             CommunicationUserIdentifier identifier2 = new(_id);
 
-            Assert.True(identifier1.Equals(identifier1));
-            Assert.True(identifier1.Equals(identifier2));
+            Assert.That(identifier1.Equals(identifier1), Is.True);
+            Assert.That(identifier1.Equals(identifier2), Is.True);
         }
 
         [Test]
@@ -32,15 +32,15 @@ namespace Azure.Communication
         {
             CommunicationUserIdentifier identifier1 = new(_id);
             object identifier2 = new();
-            Assert.False(identifier1.Equals(identifier2));
+            Assert.That(identifier1, Is.Not.EqualTo(identifier2));
         }
 
         [Test]
         public void constructWithValidId()
         {
             CommunicationUserIdentifier result = new(_id);
-            Assert.NotNull(result.Id);
-            Assert.NotNull(result.GetHashCode());
+            Assert.That(result.Id, Is.Not.Null);
+            Assert.That(result.GetHashCode(), Is.Not.Null);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/CommunicationTokenCredentialTest.cs
@@ -71,7 +71,7 @@ namespace Azure.Communication.Identity
                     AsyncTokenRefresher = cancellationToken => FetchTokenForUserFromMyServerAsync("bob@contoso.com", cancellationToken)
                 });
             var accessToken = await tokenCredential.GetTokenAsync();
-            Assert.AreEqual(SampleToken, accessToken.Token);
+            Assert.That(accessToken.Token, Is.EqualTo(SampleToken));
         }
 
         [Test]
@@ -105,8 +105,8 @@ namespace Azure.Communication.Identity
             using var tokenCredential = new CommunicationTokenCredential(token);
             AccessToken accessToken = await tokenCredential.GetTokenAsync();
 
-            Assert.AreEqual(token, accessToken.Token);
-            Assert.AreEqual(expectedExpiryUnixTimeSeconds, accessToken.ExpiresOn.ToUnixTimeSeconds());
+            Assert.That(accessToken.Token, Is.EqualTo(token));
+            Assert.That(accessToken.ExpiresOn.ToUnixTimeSeconds(), Is.EqualTo(expectedExpiryUnixTimeSeconds));
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace Azure.Communication.Identity
             using var tokenCredential = new CommunicationTokenCredential(ExpiredToken);
 
             AccessToken token = async ? await tokenCredential.GetTokenAsync() : tokenCredential.GetToken();
-            Assert.AreEqual(ExpiredToken, token.Token);
+            Assert.That(token.Token, Is.EqualTo(ExpiredToken));
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace Azure.Communication.Identity
                 });
 
             AccessToken token = async ? await tokenCredential.GetTokenAsync(cancellationToken) : tokenCredential.GetToken(cancellationToken);
-            Assert.AreEqual(cancellationToken, actualCancellationToken);
+            Assert.That(actualCancellationToken, Is.EqualTo(cancellationToken));
 
             string RefreshToken(CancellationToken token)
             {
@@ -173,9 +173,9 @@ namespace Azure.Communication.Identity
                 _ => throw new NotImplementedException(),
                 expiredToken);
 
-            Assert.AreEqual(1, testClock.ScheduledActions.Count());
+            Assert.That(testClock.ScheduledActions.Count(), Is.EqualTo(1));
             testClock.Tick();
-            Assert.AreEqual(1, refreshCallCount);
+            Assert.That(refreshCallCount, Is.EqualTo(1));
 
             string RefreshToken(CancellationToken _)
             {
@@ -197,14 +197,14 @@ namespace Azure.Communication.Identity
                 _ => new ValueTask<string>(token),
                 initialToken: ExpiredToken);
 
-            Assert.AreEqual(0, testClock.ScheduledActions.Count());
+            Assert.That(testClock.ScheduledActions.Count(), Is.EqualTo(0));
 
             AccessToken accessToken = async
                 ? await tokenCredential.GetTokenAsync()
                 : tokenCredential.GetToken();
 
-            Assert.AreEqual(token, accessToken.Token);
-            Assert.AreEqual(expectedExpiryUnixTimeSeconds, accessToken.ExpiresOn.ToUnixTimeSeconds());
+            Assert.That(accessToken.Token, Is.EqualTo(token));
+            Assert.That(accessToken.ExpiresOn.ToUnixTimeSeconds(), Is.EqualTo(expectedExpiryUnixTimeSeconds));
         }
 
         [Test]
@@ -254,10 +254,10 @@ namespace Azure.Communication.Identity
                 _ => SampleToken,
                 _ => new ValueTask<string>(SampleToken));
 
-            Assert.AreEqual(1, testClock.ScheduledActions.Count());
+            Assert.That(testClock.ScheduledActions.Count(), Is.EqualTo(1));
             tokenCredential.Dispose();
 
-            Assert.AreEqual(0, testClock.ScheduledActions.Count());
+            Assert.That(testClock.ScheduledActions.Count(), Is.EqualTo(0));
         }
 
         [Test]
@@ -285,12 +285,12 @@ namespace Azure.Communication.Identity
 
             testClock.Tick(TimeSpan.FromMinutes(tokenValidForMinutes - ThreadSafeRefreshableAccessTokenCache.ProactiveRefreshIntervalInMinutes + 0.5));
 
-            Assert.AreEqual(1, refreshCallCount);
+            Assert.That(refreshCallCount, Is.EqualTo(1));
 
             AccessToken afterRefreshToken = tokenCredential.GetToken();
 
-            Assert.AreEqual(inCriticalExpiryWindow ? newToken : initialToken, token.Token);
-            Assert.AreEqual(newToken, afterRefreshToken.Token);
+            Assert.That(token.Token, Is.EqualTo(inCriticalExpiryWindow ? newToken : initialToken));
+            Assert.That(afterRefreshToken.Token, Is.EqualTo(newToken));
 
             string RefreshToken(CancellationToken _)
             {
@@ -330,14 +330,14 @@ namespace Azure.Communication.Identity
                 _ => throw new NotImplementedException(),
                 twentyMinToken);
 
-            Assert.AreEqual(1, testClock.ScheduledActions.Count());
+            Assert.That(testClock.ScheduledActions.Count(), Is.EqualTo(1));
             ThreadSafeRefreshableAccessTokenCache.IScheduledAction? firstTimer = testClock.ScheduledActions.First();
             // Go into the soon-to-expire window
             testClock.Tick(TimeSpan.FromMinutes(20 - ThreadSafeRefreshableAccessTokenCache.ProactiveRefreshIntervalInMinutes + 0.5));
 
-            Assert.AreEqual(1, testClock.ScheduledActions.Count());
+            Assert.That(testClock.ScheduledActions.Count(), Is.EqualTo(1));
             ThreadSafeRefreshableAccessTokenCache.IScheduledAction? secondTimer = testClock.ScheduledActions.First();
-            Assert.AreNotEqual(firstTimer, secondTimer);
+            Assert.That(secondTimer, Is.Not.EqualTo(firstTimer));
         }
 
         [Test]
@@ -367,7 +367,7 @@ namespace Azure.Communication.Identity
                     tokenCredential.GetToken();
             }
 
-            Assert.AreEqual(1, refreshCallCount);
+            Assert.That(refreshCallCount, Is.EqualTo(1));
 
             string RefreshToken(CancellationToken _)
             {
@@ -398,7 +398,7 @@ namespace Azure.Communication.Identity
             AccessToken refreshedToken = tokenCredential.GetToken();
 
             // Expect the token to be refreshed only once within the first 10 minutes
-            Assert.AreEqual(expectedTotalCallCounts, refreshCallCount);
+            Assert.That(refreshCallCount, Is.EqualTo(expectedTotalCallCounts));
 
             // iterate until the penultimate millisecond of the token expiration
             // to prevent an exception being thrown due to the token being expired
@@ -410,7 +410,7 @@ namespace Azure.Communication.Identity
                 testClock.Tick(TimeSpan.FromMilliseconds(soonToExpireMs));
                 expectedTotalCallCounts++;
             }
-            Assert.AreEqual(expectedTotalCallCounts, refreshCallCount);
+            Assert.That(refreshCallCount, Is.EqualTo(expectedTotalCallCounts));
 
             string RefreshToken(CancellationToken _)
             {

--- a/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Identity/EntraTokenCredentialTest.cs
@@ -115,7 +115,7 @@ namespace Azure.Communication.Identity
                 _resourceEndpoint,
                 _mockTokenCredential.Object);
             var scopes = new[] { "https://communication.azure.com/clients/.default" };
-            Assert.AreEqual(credential.Scopes, scopes);
+            Assert.That(scopes, Is.EqualTo(credential.Scopes));
         }
 
         [Test]
@@ -152,15 +152,15 @@ namespace Azure.Communication.Identity
             var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
 
             // Assert
-            Assert.AreEqual(SampleToken, token.Token);
-            Assert.AreEqual(token.ExpiresOn, expiryTime);
+            Assert.That(token.Token, Is.EqualTo(SampleToken));
+            Assert.That(expiryTime, Is.EqualTo(token.ExpiresOn));
             if (scopes.Contains(teamsExtensionScope))
             {
-                Assert.AreEqual(teamsExtensionEndpoint, mockTransport.SingleRequest.Uri.Path);
+                Assert.That(mockTransport.SingleRequest.Uri.Path, Is.EqualTo(teamsExtensionEndpoint));
             }
             else
             {
-                Assert.AreEqual(communicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
+                Assert.That(mockTransport.SingleRequest.Uri.Path, Is.EqualTo(communicationClientsEndpoint));
             }
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -178,9 +178,9 @@ namespace Azure.Communication.Identity
             var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
 
             // Assert
-            Assert.AreEqual(SampleToken, token.Token);
-            Assert.AreEqual(token.ExpiresOn, expiryTime);
-            Assert.AreEqual(communicationClientsEndpoint, mockTransport.SingleRequest.Uri.Path);
+            Assert.That(token.Token, Is.EqualTo(SampleToken));
+            Assert.That(expiryTime, Is.EqualTo(token.ExpiresOn));
+            Assert.That(mockTransport.SingleRequest.Uri.Path, Is.EqualTo(communicationClientsEndpoint));
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -206,7 +206,7 @@ namespace Azure.Communication.Identity
             var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
 
             // Assert for cached tokens are updated
-            Assert.AreEqual(newToken, token.Token);
+            Assert.That(token.Token, Is.EqualTo(newToken));
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
@@ -225,7 +225,7 @@ namespace Azure.Communication.Identity
                 token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
             }
             // Assert
-            Assert.AreEqual(SampleToken, token.Token);
+            Assert.That(token.Token, Is.EqualTo(SampleToken));
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -290,7 +290,7 @@ namespace Azure.Communication.Identity
 
             // Act & Assert
             var ex = Assert.ThrowsAsync<RequestFailedException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
-            StringAssert.Contains(lastRetryErrorMessage, ex?.Message);
+            Assert.That(ex?.Message, Does.Contain(lastRetryErrorMessage));
         }
 
         [Test, TestCaseSource(nameof(invalidScopes))]
@@ -313,7 +313,7 @@ namespace Azure.Communication.Identity
 
             // Act & Assert
             var ex = Assert.ThrowsAsync<ArgumentException>(async () => await entraTokenCredential.GetTokenAsync(CancellationToken.None));
-            StringAssert.Contains("Scopes validation failed. Ensure all scopes start with either", ex?.Message);
+            Assert.That(ex?.Message, Does.Contain("Scopes validation failed. Ensure all scopes start with either"));
         }
 
         [Test]
@@ -344,7 +344,7 @@ namespace Azure.Communication.Identity
             var token = await entraTokenCredential.GetTokenAsync(CancellationToken.None);
 
             // Assert for cached tokens are updated
-            Assert.AreEqual(newToken, token.Token);
+            Assert.That(token.Token, Is.EqualTo(newToken));
             _mockTokenCredential.Verify(tc => tc.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 

--- a/sdk/communication/Azure.Communication.Common/tests/Pipeline/CommunicationBearerTokenCredentialTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Pipeline/CommunicationBearerTokenCredentialTests.cs
@@ -76,8 +76,8 @@ namespace Azure.Communication.Pipeline
 
             var accessToken = await communicationBearerTokenCredential.GetTokenAsync(MockTokenRequestContext(), CancellationToken.None);
 
-            Assert.AreEqual(initialToken, accessToken.Token);
-            Assert.AreEqual(SampleTokenExpiry, accessToken.ExpiresOn.ToUnixTimeSeconds());
+            Assert.That(accessToken.Token, Is.EqualTo(initialToken));
+            Assert.That(accessToken.ExpiresOn.ToUnixTimeSeconds(), Is.EqualTo(SampleTokenExpiry));
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace Azure.Communication.Pipeline
             var communicationBearerTokenCredential = new CommunicationBearerTokenCredential(tokenCredential);
 
             var accessToken = communicationBearerTokenCredential.GetToken(MockTokenRequestContext(), CancellationToken.None);
-            Assert.AreEqual(ExpiredToken, accessToken.Token);
+            Assert.That(accessToken.Token, Is.EqualTo(ExpiredToken));
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace Azure.Communication.Pipeline
             var communicationBearerTokenCredential = new CommunicationBearerTokenCredential(tokenCredential);
 
             var accessToken = await communicationBearerTokenCredential.GetTokenAsync(MockTokenRequestContext(), CancellationToken.None);
-            Assert.AreEqual(ExpiredToken, accessToken.Token);
+            Assert.That(accessToken.Token, Is.EqualTo(ExpiredToken));
         }
 
         [Test]
@@ -118,7 +118,7 @@ namespace Azure.Communication.Pipeline
                 });
             var communicationBearerTokenCredential = new CommunicationBearerTokenCredential(tokenCredential);
             var accessToken = communicationBearerTokenCredential.GetToken(MockTokenRequestContext(), cancellationToken);
-            Assert.AreEqual(cancellationToken.GetHashCode(), actualCancellationToken.GetHashCode());
+            Assert.That(actualCancellationToken.GetHashCode(), Is.EqualTo(cancellationToken.GetHashCode()));
 
             string RefreshToken(CancellationToken token)
             {
@@ -146,7 +146,7 @@ namespace Azure.Communication.Pipeline
 
             var communicationBearerTokenCredential = new CommunicationBearerTokenCredential(tokenCredential);
             var accessToken = await communicationBearerTokenCredential.GetTokenAsync(MockTokenRequestContext(), cancellationToken);
-            Assert.AreEqual(cancellationToken.GetHashCode(), actualCancellationToken.GetHashCode());
+            Assert.That(actualCancellationToken.GetHashCode(), Is.EqualTo(cancellationToken.GetHashCode()));
 
             string RefreshToken(CancellationToken token)
             {

--- a/sdk/communication/Azure.Communication.Common/tests/Pipeline/EntraTokenGuardPolicyTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Pipeline/EntraTokenGuardPolicyTests.cs
@@ -179,7 +179,7 @@ namespace Azure.Communication.Pipeline
                 policy.Process(_httpMessage, pipelines);
                 _httpPipelinePolicyMock.Verify(p => p.Process(_httpMessage, It.IsAny<ReadOnlyMemory<HttpPipelinePolicy>>()), Times.Once);
             }
-            Assert.AreEqual(successfullResponse, _httpMessage.Response);
+            Assert.That(_httpMessage.Response, Is.EqualTo(successfullResponse));
         }
 
         private class CustomRequest : MockRequest

--- a/sdk/communication/Azure.Communication.Common/tests/Pipeline/HMACAuthenticationPolicyTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Pipeline/HMACAuthenticationPolicyTests.cs
@@ -22,16 +22,16 @@ namespace Azure.Communication.Pipeline
             await SendGetRequest(transport, authPolicy);
             var headers = transport.SingleRequest.Headers;
 
-            Assert.True(headers.Contains("x-ms-date"));
-            Assert.True(headers.Contains("Authorization"));
+            Assert.That(headers.Contains("x-ms-date"), Is.True);
+            Assert.That(headers.Contains("Authorization"), Is.True);
 
-            Assert.True(headers.TryGetValue("x-ms-content-sha256", out var shaValue));
-            Assert.AreEqual(expectedShaValue, shaValue);
+            Assert.That(headers.TryGetValue("x-ms-content-sha256", out var shaValue), Is.True);
+            Assert.That(shaValue, Is.EqualTo(expectedShaValue));
 
             var expectedAuthHeader = "HMAC-SHA256 SignedHeaders=x-ms-date;host;x-ms-content-sha256";
-            Assert.True(headers.TryGetValue("Authorization", out var authValue));
-            Assert.NotNull(authValue);
-            Assert.True(authValue!.Contains(expectedAuthHeader));
+            Assert.That(headers.TryGetValue("Authorization", out var authValue), Is.True);
+            Assert.That(authValue, Is.Not.Null);
+            Assert.That(authValue!.Contains(expectedAuthHeader), Is.True);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Common/tests/Pipeline/PolicyTestBase.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/Pipeline/PolicyTestBase.cs
@@ -13,7 +13,7 @@ namespace Azure.Communication.Pipeline
     {
         protected static async Task<Response> SendGetRequest(HttpPipelineTransport transport, HttpPipelinePolicy policy, ResponseClassifier? responseClassifier = null)
         {
-            Assert.IsInstanceOf<HttpPipelinePolicy>(policy, "Use HttpPipelinePolicy base type for policies");
+            Assert.That(policy, Is.InstanceOf<HttpPipelinePolicy>(), "Use HttpPipelinePolicy base type for policies");
 
             using (Request request = transport.CreateRequest())
             {

--- a/sdk/communication/Azure.Communication.Common/tests/UnknownIdentifierTests.cs
+++ b/sdk/communication/Azure.Communication.Common/tests/UnknownIdentifierTests.cs
@@ -22,8 +22,8 @@ namespace Azure.Communication
             UnknownIdentifier identifier1 = new(_id);
             UnknownIdentifier identifier2 = new(_id);
 
-            Assert.True(identifier1.Equals(identifier1));
-            Assert.True(identifier1.Equals(identifier2));
+            Assert.That(identifier1.Equals(identifier1), Is.True);
+            Assert.That(identifier1.Equals(identifier2), Is.True);
         }
 
         [Test]
@@ -31,15 +31,15 @@ namespace Azure.Communication
         {
             UnknownIdentifier identifier1 = new(_id);
             object identifier2 = new();
-            Assert.False(identifier1.Equals(identifier2));
+            Assert.That(identifier1, Is.Not.EqualTo(identifier2));
         }
 
         [Test]
         public void constructWithValidId()
         {
             UnknownIdentifier result = new(_id);
-            Assert.NotNull(result.Id);
-            Assert.NotNull(result.GetHashCode());
+            Assert.That(result.Id, Is.Not.Null);
+            Assert.That(result.GetHashCode(), Is.Not.Null);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Email/tests/EmailClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/EmailClientLiveTests.cs
@@ -29,7 +29,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = await SendEmailAndWaitForExistingOperationAsync(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            Assert.That(string.IsNullOrWhiteSpace(emailSendOperation.Id), Is.False);
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }
@@ -46,7 +46,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = SendEmailAndWaitForExistingOperation(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            Assert.That(string.IsNullOrWhiteSpace(emailSendOperation.Id), Is.False);
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }
@@ -61,7 +61,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = await SendEmailAndWaitForStatusWithManualPollingAsync(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            Assert.That(string.IsNullOrWhiteSpace(emailSendOperation.Id), Is.False);
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }
@@ -78,7 +78,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = await SendEmailAndWaitForStatusWithAutomaticPollingAsync(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            Assert.That(string.IsNullOrWhiteSpace(emailSendOperation.Id), Is.False);
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }
@@ -95,7 +95,7 @@ namespace Azure.Communication.Email.Tests
             EmailSendOperation emailSendOperation = SendEmailAndWaitForStatusWithAutomaticPolling(emailClient, emailRecipients);
             EmailSendResult statusMonitor = emailSendOperation.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(emailSendOperation.Id));
+            Assert.That(string.IsNullOrWhiteSpace(emailSendOperation.Id), Is.False);
             Console.WriteLine($"OperationId={emailSendOperation.Id}");
             Console.WriteLine($"Email send status = {statusMonitor.Status}");
         }

--- a/sdk/communication/Azure.Communication.Email/tests/EmailClientTests.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/EmailClientTests.cs
@@ -276,7 +276,7 @@ namespace Azure.Communication.Email.Tests
             {
                 exception = Assert.Throws<RequestFailedException>(() => emailClient.Send(WaitUntil.Started, emailMessage));
             }
-            Assert.AreEqual((int)HttpStatusCode.BadRequest, exception?.Status);
+            Assert.That(exception?.Status, Is.EqualTo((int)HttpStatusCode.BadRequest));
         }
 
         [Test]
@@ -294,7 +294,7 @@ namespace Azure.Communication.Email.Tests
             {
                 exception = Assert.Throws<ArgumentException>(() => emailClient.Send(WaitUntil.Started, emailMessage));
             }
-            Assert.IsTrue(exception?.Message.Contains(errorMessage));
+            Assert.That(exception?.Message.Contains(errorMessage), Is.True);
         }
 
         [Test]
@@ -312,7 +312,7 @@ namespace Azure.Communication.Email.Tests
             {
                 exception = Assert.Throws<RequestFailedException>(() => emailClient.Send(WaitUntil.Started, emailMessage));
             }
-            Assert.AreEqual((int)HttpStatusCode.BadRequest, exception?.Status);
+            Assert.That(exception?.Status, Is.EqualTo((int)HttpStatusCode.BadRequest));
         }
 
         [Test]
@@ -334,10 +334,10 @@ namespace Azure.Communication.Email.Tests
                 Thread.Sleep(1000);
             }
 
-            Assert.IsTrue(emailSendOperation.HasCompleted);
-            Assert.IsTrue(emailSendOperation.HasValue);
-            Assert.IsNotNull(emailSendOperation.Id);
-            Assert.AreEqual(EmailSendStatus.Succeeded, emailSendOperation.Value.Status);
+            Assert.That(emailSendOperation.HasCompleted, Is.True);
+            Assert.That(emailSendOperation.HasValue, Is.True);
+            Assert.That(emailSendOperation.Id, Is.Not.Null);
+            Assert.That(emailSendOperation.Value.Status, Is.EqualTo(EmailSendStatus.Succeeded));
         }
 
         [Test]
@@ -359,10 +359,10 @@ namespace Azure.Communication.Email.Tests
                 Thread.Sleep(1000);
             }
 
-            Assert.IsTrue(emailSendOperation.HasCompleted);
-            Assert.IsTrue(emailSendOperation.HasValue);
-            Assert.IsNotNull(emailSendOperation.Id);
-            Assert.AreEqual(EmailSendStatus.Succeeded, emailSendOperation.Value.Status);
+            Assert.That(emailSendOperation.HasCompleted, Is.True);
+            Assert.That(emailSendOperation.HasValue, Is.True);
+            Assert.That(emailSendOperation.Id, Is.Not.Null);
+            Assert.That(emailSendOperation.Value.Status, Is.EqualTo(EmailSendStatus.Succeeded));
         }
 
         [Test]
@@ -387,10 +387,10 @@ namespace Azure.Communication.Email.Tests
                 }
             });
 
-            Assert.AreEqual((int)HttpStatusCode.OK, exception?.Status);
-            Assert.IsTrue(emailSendOperation.HasCompleted);
-            Assert.IsFalse(emailSendOperation.HasValue);
-            Assert.IsNotNull(emailSendOperation.Id);
+            Assert.That(exception?.Status, Is.EqualTo((int)HttpStatusCode.OK));
+            Assert.That(emailSendOperation.HasCompleted, Is.True);
+            Assert.That(emailSendOperation.HasValue, Is.False);
+            Assert.That(emailSendOperation.Id, Is.Not.Null);
         }
 
         [Test]
@@ -415,10 +415,10 @@ namespace Azure.Communication.Email.Tests
                 }
             });
 
-            Assert.AreEqual((int)HttpStatusCode.OK, exception?.Status);
-            Assert.IsTrue(emailSendOperation.HasCompleted);
-            Assert.IsFalse(emailSendOperation.HasValue);
-            Assert.IsNotNull(emailSendOperation.Id);
+            Assert.That(exception?.Status, Is.EqualTo((int)HttpStatusCode.OK));
+            Assert.That(emailSendOperation.HasCompleted, Is.True);
+            Assert.That(emailSendOperation.HasValue, Is.False);
+            Assert.That(emailSendOperation.Id, Is.Not.Null);
         }
 
         private EmailClient CreateEmailClient(HttpStatusCode statusCode = HttpStatusCode.OK)

--- a/sdk/communication/Azure.Communication.Email/tests/EmailRecipientsTests.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/EmailRecipientsTests.cs
@@ -27,9 +27,9 @@ namespace Azure.Communication.Email.Tests
         {
             var recipients = new EmailRecipients(DefaultRecipients(toCount), DefaultRecipients(ccCount), DefaultRecipients(bccCount));
 
-            Assert.AreEqual(recipients.CC.Count, ccCount);
-            Assert.AreEqual(recipients.BCC.Count, bccCount);
-            Assert.AreEqual(recipients.To.Count, toCount);
+            Assert.That(ccCount, Is.EqualTo(recipients.CC.Count));
+            Assert.That(bccCount, Is.EqualTo(recipients.BCC.Count));
+            Assert.That(toCount, Is.EqualTo(recipients.To.Count));
         }
 
         private static List<EmailAddress> DefaultRecipients(int count = 1)

--- a/sdk/communication/Azure.Communication.Email/tests/Samples/Sample1_EmailClient.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/Samples/Sample1_EmailClient.cs
@@ -49,7 +49,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_Simple_AutoPolling
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            Assert.That(string.IsNullOrEmpty(operationId), Is.False);
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_With_MoreOptions
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            Assert.That(string.IsNullOrEmpty(operationId), Is.False);
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_Multiple_Recipients
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            Assert.That(string.IsNullOrEmpty(operationId), Is.False);
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.Email/tests/Samples/Sample1_EmailClientAsync.cs
+++ b/sdk/communication/Azure.Communication.Email/tests/Samples/Sample1_EmailClientAsync.cs
@@ -46,7 +46,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_Simple_AutoPolling_Async
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            Assert.That(string.IsNullOrEmpty(operationId), Is.False);
         }
 
         [RecordedTest]
@@ -136,7 +136,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_With_MoreOptions_Async
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            Assert.That(string.IsNullOrEmpty(operationId), Is.False);
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace Azure.Communication.Email.Tests.Samples
             //@@ }
             #endregion Snippet:Azure_Communication_Email_Send_Multiple_Recipients_Async
 
-            Assert.False(string.IsNullOrEmpty(operationId));
+            Assert.That(string.IsNullOrEmpty(operationId), Is.False);
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.Identity/tests/CommunicationIdentityClient/CommunicationIdentityClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Identity/tests/CommunicationIdentityClient/CommunicationIdentityClientLiveTests.cs
@@ -70,8 +70,8 @@ namespace Azure.Communication.Identity.Tests
 
             Response<CommunicationUserIdentifier> userResponse = await client.CreateUserAsync();
             Response<AccessToken> tokenResponse = await client.GetTokenAsync(userResponse.Value, scopes: scopes.Select(x => new CommunicationTokenScope(x)));
-            Assert.IsNotNull(tokenResponse.Value);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(tokenResponse.Value.Token));
+            Assert.That(tokenResponse.Value, Is.Not.Null);
+            Assert.That(string.IsNullOrWhiteSpace(tokenResponse.Value.Token), Is.False);
             ValidateScopesIfNotSanitized();
 
             void ValidateScopesIfNotSanitized()
@@ -79,7 +79,7 @@ namespace Azure.Communication.Identity.Tests
                 if (Mode != RecordedTestMode.Playback)
                 {
                     JwtTokenParser.JwtPayload payload = JwtTokenParser.DecodeJwtPayload(tokenResponse.Value.Token);
-                    CollectionAssert.AreEquivalent(scopes, payload.Scopes);
+                    Assert.That(payload.Scopes, Is.EquivalentTo(scopes));
                 }
             }
         }
@@ -99,8 +99,8 @@ namespace Azure.Communication.Identity.Tests
             Response<CommunicationUserIdentifier> userResponse = await client.CreateUserAsync();
             Response<AccessToken> tokenResponse = await client.GetTokenAsync(userResponse.Value, scopes: scopes.Select(x => new CommunicationTokenScope(x)));
 
-            Assert.IsNotNull(tokenResponse.Value);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(tokenResponse.Value.Token));
+            Assert.That(tokenResponse.Value, Is.Not.Null);
+            Assert.That(string.IsNullOrWhiteSpace(tokenResponse.Value.Token), Is.False);
             ValidateScopesIfNotSanitized();
 
             void ValidateScopesIfNotSanitized()
@@ -108,7 +108,7 @@ namespace Azure.Communication.Identity.Tests
                 if (Mode != RecordedTestMode.Playback)
                 {
                     JwtTokenParser.JwtPayload payload = JwtTokenParser.DecodeJwtPayload(tokenResponse.Value.Token);
-                    CollectionAssert.AreEquivalent(scopes, payload.Scopes);
+                    Assert.That(payload.Scopes, Is.EquivalentTo(scopes));
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (NullReferenceException ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -141,7 +141,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("scopes", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("scopes"));
                 return;
             }
             Assert.Fail("RevokeTokensAsync should have thrown an exception.");
@@ -162,8 +162,8 @@ namespace Azure.Communication.Identity.Tests
             CommunicationIdentityClient client = CreateClient();
             Response<CommunicationUserIdentifierAndToken> accessToken = await client.CreateUserAndTokenAsync(scopes: scopes.Select(x => new CommunicationTokenScope(x)));
 
-            Assert.IsNotNull(accessToken.Value.AccessToken);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(accessToken.Value.AccessToken.Token));
+            Assert.That(accessToken.Value.AccessToken, Is.Not.Null);
+            Assert.That(string.IsNullOrWhiteSpace(accessToken.Value.AccessToken.Token), Is.False);
             ValidateScopesIfNotSanitized();
 
             void ValidateScopesIfNotSanitized()
@@ -171,7 +171,7 @@ namespace Azure.Communication.Identity.Tests
                 if (Mode != RecordedTestMode.Playback)
                 {
                     JwtTokenParser.JwtPayload payload = JwtTokenParser.DecodeJwtPayload(accessToken.Value.AccessToken.Token);
-                    CollectionAssert.AreEquivalent(scopes, payload.Scopes);
+                    Assert.That(payload.Scopes, Is.EquivalentTo(scopes));
                 }
             }
         }
@@ -186,14 +186,15 @@ namespace Azure.Communication.Identity.Tests
             CommunicationIdentityClient client = CreateClient();
             Response<CommunicationUserIdentifierAndToken> accessToken = await client.CreateUserAndTokenAsync(scopes: new[] { CommunicationTokenScope.Chat }, tokenExpiresIn: tokenExpiresIn);
 
-            Assert.IsNotNull(accessToken.Value.AccessToken);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(accessToken.Value.AccessToken.Token));
+            Assert.That(accessToken.Value.AccessToken, Is.Not.Null);
+            Assert.That(string.IsNullOrWhiteSpace(accessToken.Value.AccessToken.Token), Is.False);
 
             if (Mode == RecordedTestMode.Live)
             {
                 TimeSpan tokenTimeSpan;
                 var tokenExpirationWithinAllowedDeviation = TokenExpirationWithinAllowedDeviation(tokenExpiresIn, accessToken.Value.AccessToken.ExpiresOn, TOKEN_EXPIRATION_ALLOWED_DEVIATION, out tokenTimeSpan);
-                Assert.True(tokenExpirationWithinAllowedDeviation,
+                Assert.That(tokenExpirationWithinAllowedDeviation,
+                    Is.True,
                     $"Token expiration is outside of allowed {TOKEN_EXPIRATION_ALLOWED_DEVIATION * 100}% deviation." +
                     $"Expected minutes: {tokenExpiresIn.TotalMinutes}, actual minutes: {tokenTimeSpan.TotalMinutes:0.##}.");
             }
@@ -212,7 +213,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -231,8 +232,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains(TOKEN_EXPIRATION_OVERFLOW_MESSAGE));
+                Assert.That(ex.Message, Is.Not.Null);
+                Assert.That(ex.Message.Contains(TOKEN_EXPIRATION_OVERFLOW_MESSAGE), Is.True);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -250,14 +251,15 @@ namespace Azure.Communication.Identity.Tests
             CommunicationUserIdentifier userIdentifier = await client.CreateUserAsync();
             Response<AccessToken> accessToken = await client.GetTokenAsync(communicationUser: userIdentifier, scopes: new[] { CommunicationTokenScope.VoIP }, tokenExpiresIn: tokenExpiresIn);
 
-            Assert.IsNotNull(accessToken.Value);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(accessToken.Value.Token));
+            Assert.That(accessToken.Value, Is.Not.Null);
+            Assert.That(string.IsNullOrWhiteSpace(accessToken.Value.Token), Is.False);
 
             if (Mode == RecordedTestMode.Live)
             {
                 TimeSpan tokenTimeSpan;
                 var tokenExpirationWithinAllowedDeviation = TokenExpirationWithinAllowedDeviation(tokenExpiresIn, accessToken.Value.ExpiresOn, TOKEN_EXPIRATION_ALLOWED_DEVIATION, out tokenTimeSpan);
-                Assert.True(tokenExpirationWithinAllowedDeviation,
+                Assert.That(tokenExpirationWithinAllowedDeviation,
+                    Is.True,
                     $"Token expiration is outside of allowed {TOKEN_EXPIRATION_ALLOWED_DEVIATION * 100}% deviation." +
                     $"Expected minutes: {tokenExpiresIn.TotalMinutes}, actual minutes: {tokenTimeSpan.TotalMinutes:0.##}.");
             }
@@ -277,7 +279,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -297,8 +299,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains(TOKEN_EXPIRATION_OVERFLOW_MESSAGE));
+                Assert.That(ex.Message, Is.Not.Null);
+                Assert.That(ex.Message.Contains(TOKEN_EXPIRATION_OVERFLOW_MESSAGE), Is.True);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -315,7 +317,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (NullReferenceException ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -332,7 +334,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (NullReferenceException ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -349,8 +351,8 @@ namespace Azure.Communication.Identity.Tests
 
             CommunicationIdentityClient client = CreateClient();
             Response<AccessToken> tokenResponse = await client.GetTokenForTeamsUserAsync(CTEOptions);
-            Assert.IsNotNull(tokenResponse.Value);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(tokenResponse.Value.Token));
+            Assert.That(tokenResponse.Value, Is.Not.Null);
+            Assert.That(string.IsNullOrWhiteSpace(tokenResponse.Value.Token), Is.False);
         }
 
         [Test]
@@ -370,7 +372,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(paramName, ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo(paramName));
                 return;
             }
             Assert.Fail("An exception should have been thrown.");
@@ -388,8 +390,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message, Is.Not.Null);
+                Assert.That(ex.Message.Contains("401"), Is.True);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -406,8 +408,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("401"));
+                Assert.That(ex.Message, Is.Not.Null);
+                Assert.That(ex.Message.Contains("401"), Is.True);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -431,8 +433,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("400"));
+                Assert.That(ex.Message, Is.Not.Null);
+                Assert.That(ex.Message.Contains("400"), Is.True);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -454,8 +456,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("400"));
+                Assert.That(ex.Message, Is.Not.Null);
+                Assert.That(ex.Message.Contains("400"), Is.True);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -479,8 +481,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("400"));
+                Assert.That(ex.Message, Is.Not.Null);
+                Assert.That(ex.Message.Contains("400"), Is.True);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -502,8 +504,8 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.NotNull(ex.Message);
-                Assert.True(ex.Message.Contains("400"));
+                Assert.That(ex.Message, Is.Not.Null);
+                Assert.That(ex.Message.Contains("400"), Is.True);
                 Console.WriteLine(ex.Message);
                 return;
             }
@@ -522,7 +524,7 @@ namespace Azure.Communication.Identity.Tests
             {
                 CommunicationIdentityClient client = CreateClient(default, version);
                 CommunicationUserIdentifier userResponse = await client.CreateUserAsync();
-                Assert.IsNotNull(userResponse);
+                Assert.That(userResponse, Is.Not.Null);
             }
             catch (Exception ex)
             {
@@ -537,12 +539,12 @@ namespace Azure.Communication.Identity.Tests
             CommunicationIdentityClient client = CreateClient();
             Response<CommunicationUserIdentifier> createResponse = await client.CreateUserAsync(customId);
 
-            Assert.IsTrue((int)HttpStatusCode.Created == createResponse.GetRawResponse().Status);
-            Assert.IsNotNull(createResponse.Value.Id);
+            Assert.That((int)HttpStatusCode.Created, Is.EqualTo(createResponse.GetRawResponse().Status));
+            Assert.That(createResponse.Value.Id, Is.Not.Null);
 
             Response<CommunicationUserIdentifier> createResponse2 = await client.CreateUserAsync(customId);
-            Assert.AreEqual((int)HttpStatusCode.Created, createResponse2.GetRawResponse().Status);
-            Assert.AreEqual(createResponse.Value.Id, createResponse2.Value.Id);
+            Assert.That(createResponse2.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.Created));
+            Assert.That(createResponse2.Value.Id, Is.EqualTo(createResponse.Value.Id));
         }
 
         [Test]
@@ -553,15 +555,15 @@ namespace Azure.Communication.Identity.Tests
             Response<CommunicationUserIdentifierAndToken> createResponse = await client.CreateUserAndTokenAsync(customId,
                 new List<CommunicationTokenScope> { CommunicationTokenScope.VoIP },
                 TimeSpan.FromHours(2));
-            Assert.IsTrue((int)HttpStatusCode.Created == createResponse.GetRawResponse().Status
-                || (int)HttpStatusCode.OK == createResponse.GetRawResponse().Status);
-            Assert.IsNotNull(createResponse.Value.User);
+            Assert.That((int)HttpStatusCode.Created == createResponse.GetRawResponse().Status
+                || (int)HttpStatusCode.OK == createResponse.GetRawResponse().Status, Is.True);
+            Assert.That(createResponse.Value.User, Is.Not.Null);
 
             Response<CommunicationUserDetail> getResponse = await client.GetUserDetailAsync(createResponse.Value.User);
-            Assert.AreEqual((int)HttpStatusCode.OK, getResponse.GetRawResponse().Status);
-            Assert.AreEqual(createResponse.Value.User.Id, getResponse.Value.User.Id);
-            Assert.AreEqual(customId, getResponse.Value.CustomId);
-            Assert.IsNotNull(getResponse.Value.LastTokenIssuedAt);
+            Assert.That(getResponse.GetRawResponse().Status, Is.EqualTo((int)HttpStatusCode.OK));
+            Assert.That(getResponse.Value.User.Id, Is.EqualTo(createResponse.Value.User.Id));
+            Assert.That(getResponse.Value.CustomId, Is.EqualTo(customId));
+            Assert.That(getResponse.Value.LastTokenIssuedAt, Is.Not.Null);
         }
 
         [Test]
@@ -574,7 +576,7 @@ namespace Azure.Communication.Identity.Tests
             }
             catch (ArgumentOutOfRangeException ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
                 return;
             }
             Assert.Fail("An exception should have been thrown.");

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Infrastructure/RouterLiveTestBase.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Infrastructure/RouterLiveTestBase.cs
@@ -161,10 +161,10 @@ namespace Azure.Communication.JobRouter.Tests.Infrastructure
                     Name = distributionPolicyName,
                 });
 
-            Assert.AreEqual(distributionId, createDistributionPolicyResponse.Value.Id);
-            Assert.AreEqual(distributionPolicyName, createDistributionPolicyResponse.Value.Name);
-            Assert.IsNotNull(createDistributionPolicyResponse.Value.Mode);
-            Assert.IsTrue(createDistributionPolicyResponse.Value.Mode.GetType() == typeof(LongestIdleMode));
+            Assert.That(createDistributionPolicyResponse.Value.Id, Is.EqualTo(distributionId));
+            Assert.That(createDistributionPolicyResponse.Value.Name, Is.EqualTo(distributionPolicyName));
+            Assert.That(createDistributionPolicyResponse.Value.Mode, Is.Not.Null);
+            Assert.That(createDistributionPolicyResponse.Value.Mode.GetType(), Is.EqualTo(typeof(LongestIdleMode)));
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(createDistributionPolicyResponse.Value.Id)));
             return createDistributionPolicyResponse;
         }
@@ -177,9 +177,9 @@ namespace Azure.Communication.JobRouter.Tests.Infrastructure
         {
             var response = upsertQueueResponse.Value;
 
-            Assert.AreEqual(queueId, response.Id);
-            Assert.AreEqual(queueName, response.Name);
-            Assert.AreEqual(distributionPolicyId, response.DistributionPolicyId);
+            Assert.That(response.Id, Is.EqualTo(queueId));
+            Assert.That(response.Name, Is.EqualTo(queueName));
+            Assert.That(response.DistributionPolicyId, Is.EqualTo(distributionPolicyId));
             if (queueLabels != default)
             {
                 var labelsWithID = queueLabels.ToDictionary(k => k.Key, k => k.Value);
@@ -189,12 +189,12 @@ namespace Azure.Communication.JobRouter.Tests.Infrastructure
                     labelsWithID.Add("Id", new RouterValue(queueId));
                 }
 
-                Assert.AreEqual(labelsWithID.ToDictionary(x => x.Key, x => x.Value?.Value), response.Labels.ToDictionary(x => x.Key, x => x.Value?.Value));
+                Assert.That(response.Labels.ToDictionary(x => x.Key, x => x.Value?.Value), Is.EqualTo(labelsWithID.ToDictionary(x => x.Key, x => x.Value?.Value)));
             }
 
             if (exceptionPolicyId != default)
             {
-                Assert.AreEqual(exceptionPolicyId, response.ExceptionPolicyId);
+                Assert.That(response.ExceptionPolicyId, Is.EqualTo(exceptionPolicyId));
             }
         }
 
@@ -206,26 +206,26 @@ namespace Azure.Communication.JobRouter.Tests.Infrastructure
         {
             var response = routerWorkerResponse.Value;
 
-            Assert.AreEqual(workerId, response.Id);
-            Assert.AreEqual(queues.Count(), response.Queues.Count);
-            Assert.AreEqual(capacity, response.Capacity);
+            Assert.That(response.Id, Is.EqualTo(workerId));
+            Assert.That(response.Queues.Count, Is.EqualTo(queues.Count()));
+            Assert.That(response.Capacity, Is.EqualTo(capacity));
 
             if (workerLabels != default)
             {
                 var labelsWithID = workerLabels.ToDictionary(k => k.Key, k => k.Value);
                 labelsWithID.Add("Id", new RouterValue(workerId));
-                Assert.AreEqual(labelsWithID, response.Labels);
+                Assert.That(response.Labels, Is.EqualTo(labelsWithID));
             }
 
             if (workerTags != default)
             {
                 var tags = workerTags.ToDictionary(k => k.Key, k => k.Value);
-                Assert.AreEqual(tags, response.Tags);
+                Assert.That(response.Tags, Is.EqualTo(tags));
             }
 
             if (channelsList != default)
             {
-                Assert.AreEqual(channelsList.Count, response.Channels.Count);
+                Assert.That(response.Channels.Count, Is.EqualTo(channelsList.Count));
             }
         }
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ClassificationPolicyLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ClassificationPolicyLiveTests.cs
@@ -34,35 +34,35 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteClassificationPolicyAsync(classificationPolicyId)));
-            Assert.NotNull(createClassificationPolicyResponse.Value);
+            Assert.That(createClassificationPolicyResponse.Value, Is.Not.Null);
 
             var createClassificationPolicy = createClassificationPolicyResponse.Value;
             Assert.DoesNotThrow(() =>
             {
                 var queueSelectors = createClassificationPolicy.QueueSelectorAttachments;
-                Assert.AreEqual(queueSelectors.Count, 1);
+                Assert.That(queueSelectors.Count, Is.EqualTo(1));
                 var qs = queueSelectors.First();
-                Assert.IsTrue(qs.GetType() == typeof(StaticQueueSelectorAttachment));
+                Assert.That(qs.GetType(), Is.EqualTo(typeof(StaticQueueSelectorAttachment)));
                 var staticQSelector = (StaticQueueSelectorAttachment)qs;
-                Assert.AreEqual(staticQSelector.QueueSelector.Key, "Id");
-                Assert.AreEqual(staticQSelector.QueueSelector.LabelOperator, LabelOperator.Equal);
-                Assert.AreEqual(staticQSelector.QueueSelector.Value.Value, createQueueResponse.Value.Id);
+                Assert.That(staticQSelector.QueueSelector.Key, Is.EqualTo("Id"));
+                Assert.That(LabelOperator.Equal, Is.EqualTo(staticQSelector.QueueSelector.LabelOperator));
+                Assert.That(createQueueResponse.Value.Id, Is.EqualTo(staticQSelector.QueueSelector.Value.Value));
             });
-            Assert.AreEqual(1, createClassificationPolicy.WorkerSelectorAttachments.Count);
+            Assert.That(createClassificationPolicy.WorkerSelectorAttachments.Count, Is.EqualTo(1));
             Assert.DoesNotThrow(() =>
             {
                 var workerSelectors = createClassificationPolicy.WorkerSelectorAttachments;
-                Assert.AreEqual(workerSelectors.Count, 1);
+                Assert.That(workerSelectors.Count, Is.EqualTo(1));
                 var ws = workerSelectors.First();
-                Assert.IsTrue(ws.GetType() == typeof(StaticWorkerSelectorAttachment));
+                Assert.That(ws.GetType(), Is.EqualTo(typeof(StaticWorkerSelectorAttachment)));
                 var staticWSelector = (StaticWorkerSelectorAttachment)ws;
-                Assert.AreEqual("key", staticWSelector.WorkerSelector.Key);
-                Assert.AreEqual(LabelOperator.Equal, staticWSelector.WorkerSelector.LabelOperator);
-                Assert.AreEqual("value", staticWSelector.WorkerSelector.Value.Value);
+                Assert.That(staticWSelector.WorkerSelector.Key, Is.EqualTo("key"));
+                Assert.That(staticWSelector.WorkerSelector.LabelOperator, Is.EqualTo(LabelOperator.Equal));
+                Assert.That(staticWSelector.WorkerSelector.Value.Value, Is.EqualTo("value"));
             });
-            Assert.IsTrue(createClassificationPolicy.PrioritizationRule.GetType() == typeof(StaticRouterRule));
-            Assert.IsTrue(string.IsNullOrWhiteSpace(createClassificationPolicy.FallbackQueueId));
-            Assert.IsTrue(string.IsNullOrWhiteSpace(createClassificationPolicy.Name));
+            Assert.That(createClassificationPolicy.PrioritizationRule.GetType(), Is.EqualTo(typeof(StaticRouterRule)));
+            Assert.That(string.IsNullOrWhiteSpace(createClassificationPolicy.FallbackQueueId), Is.True);
+            Assert.That(string.IsNullOrWhiteSpace(createClassificationPolicy.Name), Is.True);
 
             var classificationPolicyName = $"{classificationPolicyId}-Name";
 
@@ -76,35 +76,35 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = classificationPolicyName,
                 });
 
-            Assert.NotNull(updateClassificationPolicyResponse.Value);
+            Assert.That(updateClassificationPolicyResponse.Value, Is.Not.Null);
 
             createClassificationPolicy = updateClassificationPolicyResponse.Value;
             Assert.DoesNotThrow(() =>
             {
                 var queueSelectors = createClassificationPolicy.QueueSelectorAttachments;
-                Assert.AreEqual(queueSelectors.Count, 1);
+                Assert.That(queueSelectors.Count, Is.EqualTo(1));
                 var qs = queueSelectors.First();
-                Assert.IsTrue(qs.GetType() == typeof(StaticQueueSelectorAttachment));
+                Assert.That(qs.GetType(), Is.EqualTo(typeof(StaticQueueSelectorAttachment)));
                 var staticQSelector = (StaticQueueSelectorAttachment)qs;
-                Assert.AreEqual(staticQSelector.QueueSelector.Key, "Id");
-                Assert.AreEqual(staticQSelector.QueueSelector.LabelOperator, LabelOperator.Equal);
-                Assert.AreEqual(staticQSelector.QueueSelector.Value.Value, createQueueResponse.Value.Id);
+                Assert.That(staticQSelector.QueueSelector.Key, Is.EqualTo("Id"));
+                Assert.That(LabelOperator.Equal, Is.EqualTo(staticQSelector.QueueSelector.LabelOperator));
+                Assert.That(createQueueResponse.Value.Id, Is.EqualTo(staticQSelector.QueueSelector.Value.Value));
             });
-            Assert.AreEqual(1, createClassificationPolicy.WorkerSelectorAttachments.Count);
+            Assert.That(createClassificationPolicy.WorkerSelectorAttachments.Count, Is.EqualTo(1));
             Assert.DoesNotThrow(() =>
             {
                 var workerSelectors = createClassificationPolicy.WorkerSelectorAttachments;
-                Assert.AreEqual(workerSelectors.Count, 1);
+                Assert.That(workerSelectors.Count, Is.EqualTo(1));
                 var ws = workerSelectors.First();
-                Assert.IsTrue(ws.GetType() == typeof(StaticWorkerSelectorAttachment));
+                Assert.That(ws.GetType(), Is.EqualTo(typeof(StaticWorkerSelectorAttachment)));
                 var staticWSelector = (StaticWorkerSelectorAttachment)ws;
-                Assert.AreEqual("key", staticWSelector.WorkerSelector.Key);
-                Assert.AreEqual(LabelOperator.Equal, staticWSelector.WorkerSelector.LabelOperator);
-                Assert.AreEqual("value", staticWSelector.WorkerSelector.Value.Value);
+                Assert.That(staticWSelector.WorkerSelector.Key, Is.EqualTo("key"));
+                Assert.That(staticWSelector.WorkerSelector.LabelOperator, Is.EqualTo(LabelOperator.Equal));
+                Assert.That(staticWSelector.WorkerSelector.Value.Value, Is.EqualTo("value"));
             });
-            Assert.IsTrue(createClassificationPolicy.PrioritizationRule.GetType() == typeof(StaticRouterRule));
-            Assert.IsTrue(!string.IsNullOrWhiteSpace(createClassificationPolicy.FallbackQueueId) && createClassificationPolicy.FallbackQueueId == createQueueResponse.Value.Id);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(createClassificationPolicy.Name));
+            Assert.That(createClassificationPolicy.PrioritizationRule.GetType(), Is.EqualTo(typeof(StaticRouterRule)));
+            Assert.That(!string.IsNullOrWhiteSpace(createClassificationPolicy.FallbackQueueId) && createClassificationPolicy.FallbackQueueId == createQueueResponse.Value.Id, Is.True);
+            Assert.That(string.IsNullOrWhiteSpace(createClassificationPolicy.Name), Is.False);
 
             updateClassificationPolicyResponse.Value.FallbackQueueId = null;
             updateClassificationPolicyResponse.Value.PrioritizationRule = null;
@@ -116,9 +116,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 updateClassificationPolicyResponse.Value);
 
             var updateClassificationPolicy = updateClassificationPolicyResponse.Value;
-            Assert.IsFalse(updateClassificationPolicy.QueueSelectorAttachments.Any());
-            Assert.IsFalse(updateClassificationPolicy.WorkerSelectorAttachments.Any());
-            Assert.AreEqual(updateClassificationPolicy.Name, $"{classificationPolicyName}-updated");
+            Assert.That(updateClassificationPolicy.QueueSelectorAttachments.Any(), Is.False);
+            Assert.That(updateClassificationPolicy.WorkerSelectorAttachments.Any(), Is.False);
+            Assert.That($"{classificationPolicyName}-updated", Is.EqualTo(updateClassificationPolicy.Name));
         }
 
         [Test]
@@ -132,11 +132,11 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var getClassificationPolicyResponse =
                 await routerClient.GetClassificationPolicyAsync(classificationPolicyId);
 
-            Assert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
-            Assert.Null(getClassificationPolicyResponse.Value.Name);
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.QueueSelectorAttachments);
-            Assert.Null(getClassificationPolicyResponse.Value.PrioritizationRule);
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.WorkerSelectorAttachments);
+            Assert.That(getClassificationPolicyResponse.Value.FallbackQueueId, Is.Null);
+            Assert.That(getClassificationPolicyResponse.Value.Name, Is.Null);
+            Assert.That(getClassificationPolicyResponse.Value.QueueSelectorAttachments, Is.Empty);
+            Assert.That(getClassificationPolicyResponse.Value.PrioritizationRule, Is.Null);
+            Assert.That(getClassificationPolicyResponse.Value.WorkerSelectorAttachments, Is.Empty);
 
             AddForCleanup(new Task(async () => await routerClient.DeleteClassificationPolicyAsync(classificationPolicyId)));
         }
@@ -160,11 +160,11 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             var getClassificationPolicyResponse = await routerClient.GetClassificationPolicyAsync(classificationPolicyId);
 
-            Assert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
-            Assert.AreEqual(classificationPolicyName, getClassificationPolicyResponse.Value.Name);
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.QueueSelectorAttachments);
-            Assert.IsTrue(getClassificationPolicyResponse.Value.PrioritizationRule.GetType() == typeof(StaticRouterRule));
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.WorkerSelectorAttachments);
+            Assert.That(getClassificationPolicyResponse.Value.FallbackQueueId, Is.Null);
+            Assert.That(getClassificationPolicyResponse.Value.Name, Is.EqualTo(classificationPolicyName));
+            Assert.That(getClassificationPolicyResponse.Value.QueueSelectorAttachments, Is.Empty);
+            Assert.That(getClassificationPolicyResponse.Value.PrioritizationRule.GetType(), Is.EqualTo(typeof(StaticRouterRule)));
+            Assert.That(getClassificationPolicyResponse.Value.WorkerSelectorAttachments, Is.Empty);
         }
 
         [Test]
@@ -190,13 +190,13 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             AddForCleanup(new Task(async () => await routerClient.DeleteClassificationPolicyAsync(classificationPolicyId)));
 
             var getClassificationPolicyResponse = await routerClient.GetClassificationPolicyAsync(classificationPolicyId);
-            Assert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
-            Assert.AreEqual(classificationPolicyName, getClassificationPolicyResponse.Value.Name);
-            Assert.AreEqual(1, getClassificationPolicyResponse.Value.QueueSelectorAttachments.Count);
+            Assert.That(getClassificationPolicyResponse.Value.FallbackQueueId, Is.Null);
+            Assert.That(getClassificationPolicyResponse.Value.Name, Is.EqualTo(classificationPolicyName));
+            Assert.That(getClassificationPolicyResponse.Value.QueueSelectorAttachments.Count, Is.EqualTo(1));
             var staticQSelector = (StaticQueueSelectorAttachment)getClassificationPolicyResponse.Value.QueueSelectorAttachments.First();
-            Assert.NotNull(staticQSelector);
-            Assert.Null(getClassificationPolicyResponse.Value.PrioritizationRule);
-            Assert.AreEqual(0, getClassificationPolicyResponse.Value.WorkerSelectorAttachments.Count);
+            Assert.That(staticQSelector, Is.Not.Null);
+            Assert.That(getClassificationPolicyResponse.Value.PrioritizationRule, Is.Null);
+            Assert.That(getClassificationPolicyResponse.Value.WorkerSelectorAttachments.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -218,11 +218,11 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var getClassificationPolicyResponse =
                 await routerClient.GetClassificationPolicyAsync(classificationPolicyId);
 
-            Assert.Null(getClassificationPolicyResponse.Value.FallbackQueueId);
-            Assert.AreEqual(classificationPolicyName, getClassificationPolicyResponse.Value.Name);
-            Assert.Null(getClassificationPolicyResponse.Value.PrioritizationRule);
-            Assert.IsEmpty(getClassificationPolicyResponse.Value.QueueSelectorAttachments);
-            Assert.AreEqual(1, getClassificationPolicyResponse.Value.WorkerSelectorAttachments.Count);
+            Assert.That(getClassificationPolicyResponse.Value.FallbackQueueId, Is.Null);
+            Assert.That(getClassificationPolicyResponse.Value.Name, Is.EqualTo(classificationPolicyName));
+            Assert.That(getClassificationPolicyResponse.Value.PrioritizationRule, Is.Null);
+            Assert.That(getClassificationPolicyResponse.Value.QueueSelectorAttachments, Is.Empty);
+            Assert.That(getClassificationPolicyResponse.Value.WorkerSelectorAttachments.Count, Is.EqualTo(1));
         }
 
         #endregion Classification Policy Tests

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DateTimeOffsetParserTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DateTimeOffsetParserTests.cs
@@ -14,8 +14,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var input = "2022-05-13T16:59:04.531199+00:00";
             var sampleAsDateTimeOffset = DateTimeOffsetParser.ParseAndGetDateTimeOffset(input);
 
-            Assert.NotNull(sampleAsDateTimeOffset);
-            Assert.AreEqual(new TimeSpan(0, 0, 0), sampleAsDateTimeOffset.Offset);
+            Assert.That(sampleAsDateTimeOffset, Is.Not.Null);
+            Assert.That(sampleAsDateTimeOffset.Offset, Is.EqualTo(new TimeSpan(0, 0, 0)));
         }
 
         [Test]
@@ -24,8 +24,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var input = "2022-05-13T12:30:39.0516617-07:00";
             var sampleAsDateTimeOffset = DateTimeOffsetParser.ParseAndGetDateTimeOffset(input);
 
-            Assert.NotNull(sampleAsDateTimeOffset);
-            Assert.AreEqual(new TimeSpan(0, 0, 0), sampleAsDateTimeOffset.Offset);
+            Assert.That(sampleAsDateTimeOffset, Is.Not.Null);
+            Assert.That(sampleAsDateTimeOffset.Offset, Is.EqualTo(new TimeSpan(0, 0, 0)));
         }
 
         [Test]
@@ -34,8 +34,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var input = "2022-05-13T16:59:04.531199Z";
             var sampleAsDateTimeOffset = DateTimeOffsetParser.ParseAndGetDateTimeOffset(input);
 
-            Assert.NotNull(sampleAsDateTimeOffset);
-            Assert.AreEqual(new TimeSpan(0, 0, 0), sampleAsDateTimeOffset.Offset);
+            Assert.That(sampleAsDateTimeOffset, Is.Not.Null);
+            Assert.That(sampleAsDateTimeOffset.Offset, Is.EqualTo(new TimeSpan(0, 0, 0)));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DistributionPolicyLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/DistributionPolicyLiveTests.cs
@@ -37,12 +37,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(bestWorkerModeDistributionPolicyId)));
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            Assert.That(bestWorkerModeDistributionPolicyResponse.Value, Is.Not.Null);
 
             var bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers, Is.EqualTo(1));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers, Is.EqualTo(1));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.BypassSelectors, Is.False);
 
             bestWorkerModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
                 new DistributionPolicy(bestWorkerModeDistributionPolicyId)
@@ -56,12 +56,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = bestWorkerModeDistributionPolicyName
                 });
 
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            Assert.That(bestWorkerModeDistributionPolicyResponse.Value, Is.Not.Null);
 
             bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsTrue(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers, Is.EqualTo(1));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers, Is.EqualTo(1));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.BypassSelectors, Is.True);
 
             bestWorkerModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
                 new DistributionPolicy(bestWorkerModeDistributionPolicyId)
@@ -74,12 +74,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     }
                 });
 
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            Assert.That(bestWorkerModeDistributionPolicyResponse.Value, Is.Not.Null);
 
             bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsTrue(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers, Is.EqualTo(1));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers, Is.EqualTo(2));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.BypassSelectors, Is.True);
         }
 
         [Test]
@@ -110,32 +110,32 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 { Name = bestWorkerModeDistributionPolicyName });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(bestWorkerModeDistributionPolicyId)));
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            Assert.That(bestWorkerModeDistributionPolicyResponse.Value, Is.Not.Null);
 
             var bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers, Is.EqualTo(1));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers, Is.EqualTo(2));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.BypassSelectors, Is.False);
 
             var paramSelectors = ((BestWorkerMode)bestWorkerModeDistributionPolicy.Mode).ScoringRuleOptions
                 .ScoringParameters;
-            Assert.AreEqual(1, paramSelectors.Count);
-            Assert.AreEqual(ScoringRuleParameterSelector.WorkerSelectors, paramSelectors.First());
+            Assert.That(paramSelectors.Count, Is.EqualTo(1));
+            Assert.That(paramSelectors.First(), Is.EqualTo(ScoringRuleParameterSelector.WorkerSelectors));
 
             var scoringRule = ((BestWorkerMode)bestWorkerModeDistributionPolicy.Mode).ScoringRule;
-            Assert.NotNull(scoringRule);
+            Assert.That(scoringRule, Is.Not.Null);
             var azureFuncScoringRule = (FunctionRouterRule)scoringRule;
             // Assert.AreEqual("https://my.function.app/api/myfunction?code=Kg==", azureFuncScoringRule.FunctionAppUrl);
-            Assert.IsNotNull(azureFuncScoringRule.Credential);
+            Assert.That(azureFuncScoringRule.Credential, Is.Not.Null);
 
             if (Mode != RecordedTestMode.Playback)
             {
                 // any value will be sanitized when recordings are saved
-                Assert.AreEqual("MyAppKey", azureFuncScoringRule.Credential.AppKey);
-                Assert.IsTrue(string.IsNullOrWhiteSpace(azureFuncScoringRule.Credential.FunctionKey));
+                Assert.That(azureFuncScoringRule.Credential.AppKey, Is.EqualTo("MyAppKey"));
+                Assert.That(string.IsNullOrWhiteSpace(azureFuncScoringRule.Credential.FunctionKey), Is.True);
             }
 
-            Assert.AreEqual("MyClientId", azureFuncScoringRule.Credential.ClientId);
+            Assert.That(azureFuncScoringRule.Credential.ClientId, Is.EqualTo("MyClientId"));
 
             bestWorkerModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
                 new DistributionPolicy(bestWorkerModeDistributionPolicyId)
@@ -155,28 +155,28 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     }
                 });
 
-            Assert.NotNull(bestWorkerModeDistributionPolicyResponse.Value);
+            Assert.That(bestWorkerModeDistributionPolicyResponse.Value, Is.Not.Null);
 
             bestWorkerModeDistributionPolicy = bestWorkerModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(bestWorkerModeDistributionPolicy.Mode.BypassSelectors);
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MinConcurrentOffers, Is.EqualTo(1));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.MaxConcurrentOffers, Is.EqualTo(2));
+            Assert.That(bestWorkerModeDistributionPolicy.Mode.BypassSelectors, Is.False);
 
             paramSelectors = ((BestWorkerMode)bestWorkerModeDistributionPolicy.Mode).ScoringRuleOptions
                 .ScoringParameters;
-            Assert.AreEqual(1, paramSelectors.Count);
-            Assert.AreEqual(ScoringRuleParameterSelector.WorkerSelectors, paramSelectors.First());
+            Assert.That(paramSelectors.Count, Is.EqualTo(1));
+            Assert.That(paramSelectors.First(), Is.EqualTo(ScoringRuleParameterSelector.WorkerSelectors));
 
             scoringRule = ((BestWorkerMode)bestWorkerModeDistributionPolicy.Mode).ScoringRule;
-            Assert.NotNull(scoringRule);
+            Assert.That(scoringRule, Is.Not.Null);
             azureFuncScoringRule = (FunctionRouterRule)scoringRule;
-            Assert.AreEqual("https://my.function.app/api/myfunction?code=Kg==", azureFuncScoringRule.FunctionUri.ToString());
-            Assert.IsNotNull(azureFuncScoringRule.Credential);
+            Assert.That(azureFuncScoringRule.FunctionUri.ToString(), Is.EqualTo("https://my.function.app/api/myfunction?code=Kg=="));
+            Assert.That(azureFuncScoringRule.Credential, Is.Not.Null);
 
             if (Mode != RecordedTestMode.Playback)
             {
                 // any value will be sanitized when recordings are saved
-                Assert.AreEqual("MyKey", azureFuncScoringRule.Credential.FunctionKey);
+                Assert.That(azureFuncScoringRule.Credential.FunctionKey, Is.EqualTo("MyKey"));
             }
         }
 
@@ -198,12 +198,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(longestIdleModeDistributionPolicyId)));
-            Assert.NotNull(longestIdleModeDistributionPolicyResponse.Value);
+            Assert.That(longestIdleModeDistributionPolicyResponse.Value, Is.Not.Null);
 
             var longestIdleModeDistributionPolicy = longestIdleModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(longestIdleModeDistributionPolicy.Mode.BypassSelectors);
+            Assert.That(longestIdleModeDistributionPolicy.Mode.MinConcurrentOffers, Is.EqualTo(1));
+            Assert.That(longestIdleModeDistributionPolicy.Mode.MaxConcurrentOffers, Is.EqualTo(1));
+            Assert.That(longestIdleModeDistributionPolicy.Mode.BypassSelectors, Is.False);
 
             // specifying min and max concurrent offers
             longestIdleModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
@@ -217,12 +217,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     },
                 });
 
-            Assert.NotNull(longestIdleModeDistributionPolicyResponse.Value);
+            Assert.That(longestIdleModeDistributionPolicyResponse.Value, Is.Not.Null);
 
             longestIdleModeDistributionPolicy = longestIdleModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, longestIdleModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, longestIdleModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsTrue(longestIdleModeDistributionPolicy.Mode.BypassSelectors);
+            Assert.That(longestIdleModeDistributionPolicy.Mode.MinConcurrentOffers, Is.EqualTo(1));
+            Assert.That(longestIdleModeDistributionPolicy.Mode.MaxConcurrentOffers, Is.EqualTo(2));
+            Assert.That(longestIdleModeDistributionPolicy.Mode.BypassSelectors, Is.True);
         }
 
         #endregion longest idle mode constructors
@@ -245,12 +245,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
 
             AddForCleanup(new Task(async () => await routerClient.DeleteDistributionPolicyAsync(roundRobinModeDistributionPolicyId)));
-            Assert.NotNull(roundRobinModeDistributionPolicyResponse.Value);
+            Assert.That(roundRobinModeDistributionPolicyResponse.Value, Is.Not.Null);
 
             var roundRobinModeDistributionPolicy = roundRobinModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsFalse(roundRobinModeDistributionPolicy.Mode.BypassSelectors);
+            Assert.That(roundRobinModeDistributionPolicy.Mode.MinConcurrentOffers, Is.EqualTo(1));
+            Assert.That(roundRobinModeDistributionPolicy.Mode.MaxConcurrentOffers, Is.EqualTo(1));
+            Assert.That(roundRobinModeDistributionPolicy.Mode.BypassSelectors, Is.False);
 
             // specifying min and max concurrent offers
             roundRobinModeDistributionPolicyResponse = await routerClient.UpdateDistributionPolicyAsync(
@@ -264,12 +264,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     },
                 });
 
-            Assert.NotNull(roundRobinModeDistributionPolicyResponse.Value);
+            Assert.That(roundRobinModeDistributionPolicyResponse.Value, Is.Not.Null);
 
             roundRobinModeDistributionPolicy = roundRobinModeDistributionPolicyResponse.Value;
-            Assert.AreEqual(1, roundRobinModeDistributionPolicy.Mode.MinConcurrentOffers);
-            Assert.AreEqual(2, roundRobinModeDistributionPolicy.Mode.MaxConcurrentOffers);
-            Assert.IsTrue(roundRobinModeDistributionPolicy.Mode.BypassSelectors);
+            Assert.That(roundRobinModeDistributionPolicy.Mode.MinConcurrentOffers, Is.EqualTo(1));
+            Assert.That(roundRobinModeDistributionPolicy.Mode.MaxConcurrentOffers, Is.EqualTo(2));
+            Assert.That(roundRobinModeDistributionPolicy.Mode.BypassSelectors, Is.True);
         }
 
         #endregion round robin mode constructors

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExceptionPolicyLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExceptionPolicyLiveTests.cs
@@ -43,27 +43,27 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createExceptionPolicyResponse = await routerClient.CreateExceptionPolicyAsync(new CreateExceptionPolicyOptions(exceptionPolicyId, rules));
             AddForCleanup(new Task(async () => await routerClient.DeleteExceptionPolicyAsync(exceptionPolicyId)));
 
-            Assert.NotNull(createExceptionPolicyResponse.Value);
+            Assert.That(createExceptionPolicyResponse.Value, Is.Not.Null);
 
             var exceptionPolicy = createExceptionPolicyResponse.Value;
 
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
+            Assert.That(exceptionPolicy.Id, Is.EqualTo(exceptionPolicyId));
+            Assert.That(exceptionPolicy.Id, Is.EqualTo(exceptionPolicyId));
             Assert.DoesNotThrow(() =>
             {
                 var exceptionRule = exceptionPolicy.ExceptionRules.First();
 
-                Assert.AreEqual(exceptionRuleId, exceptionRule.Id);
-                Assert.IsTrue(exceptionRule.Trigger.GetType() == typeof(QueueLengthExceptionTrigger));
+                Assert.That(exceptionRule.Id, Is.EqualTo(exceptionRuleId));
+                Assert.That(exceptionRule.Trigger.GetType(), Is.EqualTo(typeof(QueueLengthExceptionTrigger)));
                 var trigger = exceptionRule.Trigger as QueueLengthExceptionTrigger;
-                Assert.NotNull(trigger);
-                Assert.AreEqual(1, trigger!.Threshold);
+                Assert.That(trigger, Is.Not.Null);
+                Assert.That(trigger!.Threshold, Is.EqualTo(1));
 
                 var actions = exceptionRule.Actions;
-                Assert.AreEqual(1, actions.Count);
+                Assert.That(actions.Count, Is.EqualTo(1));
                 var cancelAction = actions.FirstOrDefault() as CancelExceptionAction;
-                Assert.NotNull(cancelAction);
-                Assert.AreEqual($"CancelledDueToMaxQueueLengthReached", cancelAction!.DispositionCode);
+                Assert.That(cancelAction, Is.Not.Null);
+                Assert.That(cancelAction!.DispositionCode, Is.EqualTo($"CancelledDueToMaxQueueLengthReached"));
             });
 
             // with name
@@ -74,12 +74,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = exceptionPolicyName
                 });
 
-            Assert.NotNull(createExceptionPolicyResponse.Value);
+            Assert.That(createExceptionPolicyResponse.Value, Is.Not.Null);
 
             exceptionPolicy = createExceptionPolicyResponse.Value;
 
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
-            Assert.AreEqual(exceptionPolicyName, exceptionPolicy.Name);
+            Assert.That(exceptionPolicy.Id, Is.EqualTo(exceptionPolicyId));
+            Assert.That(exceptionPolicy.Name, Is.EqualTo(exceptionPolicyName));
         }
 
         [Test]
@@ -127,32 +127,32 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createExceptionPolicyResponse = await routerClient.CreateExceptionPolicyAsync(new CreateExceptionPolicyOptions(exceptionPolicyId, rules));
 
             AddForCleanup(new Task(async () => await routerClient.DeleteExceptionPolicyAsync(exceptionPolicyId)));
-            Assert.NotNull(createExceptionPolicyResponse.Value);
+            Assert.That(createExceptionPolicyResponse.Value, Is.Not.Null);
 
             var exceptionPolicy = createExceptionPolicyResponse.Value;
 
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
+            Assert.That(exceptionPolicy.Id, Is.EqualTo(exceptionPolicyId));
             Assert.DoesNotThrow(() =>
             {
                 var exceptionRule = exceptionPolicy.ExceptionRules.First();
 
-                Assert.AreEqual(exceptionRuleId, exceptionRule.Id);
-                Assert.IsTrue(exceptionRule.Trigger.GetType() == typeof(QueueLengthExceptionTrigger));
+                Assert.That(exceptionRule.Id, Is.EqualTo(exceptionRuleId));
+                Assert.That(exceptionRule.Trigger.GetType(), Is.EqualTo(typeof(QueueLengthExceptionTrigger)));
                 var trigger = exceptionRule.Trigger as QueueLengthExceptionTrigger;
-                Assert.NotNull(trigger);
-                Assert.AreEqual(1, trigger!.Threshold);
+                Assert.That(trigger, Is.Not.Null);
+                Assert.That(trigger!.Threshold, Is.EqualTo(1));
 
                 var actions = exceptionRule.Actions;
-                Assert.AreEqual(2, actions.Count);
+                Assert.That(actions.Count, Is.EqualTo(2));
                 var reclassifyExceptionAction = actions.FirstOrDefault() as ReclassifyExceptionAction;
-                Assert.NotNull(reclassifyExceptionAction);
-                Assert.AreEqual(classificationPolicyId, reclassifyExceptionAction?.ClassificationPolicyId);
-                Assert.AreEqual(labelsToUpsert.FirstOrDefault().Key, reclassifyExceptionAction?.LabelsToUpsert.FirstOrDefault().Key);
-                Assert.AreEqual(labelsToUpsert.FirstOrDefault().Value.Value as string, reclassifyExceptionAction?.LabelsToUpsert.FirstOrDefault().Value.Value as string);
+                Assert.That(reclassifyExceptionAction, Is.Not.Null);
+                Assert.That(reclassifyExceptionAction?.ClassificationPolicyId, Is.EqualTo(classificationPolicyId));
+                Assert.That(reclassifyExceptionAction?.LabelsToUpsert.FirstOrDefault().Key, Is.EqualTo(labelsToUpsert.FirstOrDefault().Key));
+                Assert.That(reclassifyExceptionAction?.LabelsToUpsert.FirstOrDefault().Value.Value as string, Is.EqualTo(labelsToUpsert.FirstOrDefault().Value.Value as string));
                 var manualReclassifyExceptionAction = actions.LastOrDefault() as ManualReclassifyExceptionAction;
-                Assert.NotNull(manualReclassifyExceptionAction);
-                Assert.AreEqual(queueId, manualReclassifyExceptionAction?.QueueId);
-                Assert.AreEqual(1, manualReclassifyExceptionAction?.Priority);
+                Assert.That(manualReclassifyExceptionAction, Is.Not.Null);
+                Assert.That(manualReclassifyExceptionAction?.QueueId, Is.EqualTo(queueId));
+                Assert.That(manualReclassifyExceptionAction?.Priority, Is.EqualTo(1));
             });
 
             // with name
@@ -163,12 +163,12 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                     Name = exceptionPolicyName
                 });
 
-            Assert.NotNull(createExceptionPolicyResponse.Value);
+            Assert.That(createExceptionPolicyResponse.Value, Is.Not.Null);
 
             exceptionPolicy = createExceptionPolicyResponse.Value;
 
-            Assert.AreEqual(exceptionPolicyId, exceptionPolicy.Id);
-            Assert.AreEqual(exceptionPolicyName, exceptionPolicy.Name);
+            Assert.That(exceptionPolicy.Id, Is.EqualTo(exceptionPolicyId));
+            Assert.That(exceptionPolicy.Name, Is.EqualTo(exceptionPolicyName));
         }
 
         #endregion Exception Policy Tests

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExpressionRuleTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/ExpressionRuleTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             if (languagePropertyInfo is not null)
             {
                 var getSetMethodForLanguage = languagePropertyInfo.GetSetMethod();
-                Assert.IsNull(getSetMethodForLanguage);
+                Assert.That(getSetMethodForLanguage, Is.Null);
             }
         }
     }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/FunctionRuleCredentialTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/FunctionRuleCredentialTests.cs
@@ -31,7 +31,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             Assert.DoesNotThrow(() =>
             {
                 var funcCredential = new FunctionRouterRuleCredential("functionKey");
-                Assert.AreEqual("functionKey", funcCredential.FunctionKey);
+                Assert.That(funcCredential.FunctionKey, Is.EqualTo("functionKey"));
             });
         }
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/LabelValueTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/LabelValueTests.cs
@@ -11,11 +11,11 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         public void LabelValueAcceptsNull()
         {
             var labelValue = new RouterValue(null);
-            Assert.IsNotNull(labelValue);
+            Assert.That(labelValue, Is.Not.Null);
             var testValue1 = new RouterValue(null);
-            Assert.AreEqual(labelValue, testValue1);
+            Assert.That(testValue1, Is.EqualTo(labelValue));
             var testValue2 = new RouterValue(null);
-            Assert.AreEqual(labelValue, testValue2);
+            Assert.That(testValue2, Is.EqualTo(labelValue));
         }
 
         [Test]
@@ -23,9 +23,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             short input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            Assert.That(labelValue, Is.Not.Null);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            Assert.That(testValue, Is.EqualTo(labelValue));
         }
 
         [Test]
@@ -33,9 +33,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             int input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            Assert.That(labelValue, Is.Not.Null);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            Assert.That(testValue, Is.EqualTo(labelValue));
         }
 
         [Test]
@@ -43,9 +43,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             long input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            Assert.That(labelValue, Is.Not.Null);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            Assert.That(testValue, Is.EqualTo(labelValue));
         }
 
         [Test]
@@ -53,9 +53,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             float input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            Assert.That(labelValue, Is.Not.Null);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            Assert.That(testValue, Is.EqualTo(labelValue));
         }
 
         [Test]
@@ -63,9 +63,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             double input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            Assert.That(labelValue, Is.Not.Null);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            Assert.That(testValue, Is.EqualTo(labelValue));
         }
 
         [Test]
@@ -73,9 +73,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             decimal input = 1;
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            Assert.That(labelValue, Is.Not.Null);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            Assert.That(testValue, Is.EqualTo(labelValue));
         }
 
         [Test]
@@ -83,9 +83,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             string input = "1";
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            Assert.That(labelValue, Is.Not.Null);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            Assert.That(testValue, Is.EqualTo(labelValue));
         }
 
         [Test]
@@ -94,9 +94,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         public void LabelValueAcceptsBoolean(bool input)
         {
             var labelValue = new RouterValue(input);
-            Assert.IsNotNull(labelValue);
+            Assert.That(labelValue, Is.Not.Null);
             var testValue = new RouterValue(input);
-            Assert.AreEqual(labelValue, testValue);
+            Assert.That(testValue, Is.EqualTo(labelValue));
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
         {
             string input = "1";
             var labelValue = new RouterValue(input);
-            Assert.AreEqual(labelValue.ToString(), labelValue.Value.ToString());
+            Assert.That(labelValue.Value.ToString(), Is.EqualTo(labelValue.ToString()));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterClientCrudTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterClientCrudTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -43,7 +43,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -59,7 +59,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -75,7 +75,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -91,7 +91,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -107,7 +107,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -128,7 +128,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -145,7 +145,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -161,7 +161,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -177,7 +177,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -193,7 +193,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -209,7 +209,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -230,7 +230,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -247,7 +247,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -263,7 +263,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -279,7 +279,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -295,7 +295,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -311,7 +311,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -340,7 +340,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -361,7 +361,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -377,7 +377,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -393,7 +393,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -409,7 +409,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -425,7 +425,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -446,7 +446,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -463,7 +463,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -479,7 +479,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 
@@ -495,7 +495,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             }
             catch (Exception e)
             {
-                Assert.AreEqual(exceptionType, e.GetType());
+                Assert.That(e.GetType(), Is.EqualTo(exceptionType));
             }
         }
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterJobLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterJobLiveTests.cs
@@ -65,8 +65,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
             }
 
-            Assert.IsNotEmpty(updatedJob1Response.Notes);
-            Assert.IsTrue(updatedJob1Response.Notes.Count == 1);
+            Assert.That(updatedJob1Response.Notes, Is.Not.Empty);
+            Assert.That(updatedJob1Response.Notes.Count, Is.EqualTo(1));
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -103,7 +103,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 job => job.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, job1Result.Value.Status);
+            Assert.That(job1Result.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
 
             // cancel job 1
             var cancelJob1Response = await routerClient.CancelJobAsync(new CancelJobOptions(createJob1.Id));
@@ -122,7 +122,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 job => job.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, job2Result.Value.Status);
+            Assert.That(job2Result.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
 
             // test get jobs
             var getJobsResponse = routerClient.GetJobsAsync(channelId: channelId, queueId: createQueue.Id, status: null, classificationPolicyId: null, scheduledBefore: null, scheduledAfter: null, cancellationToken: default);
@@ -136,8 +136,8 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 }
             }
 
-            Assert.IsTrue(allJobs.Contains(createJob1.Id));
-            Assert.IsTrue(allJobs.Contains(createJob2.Id));
+            Assert.That(allJobs.Contains(createJob1.Id), Is.True);
+            Assert.That(allJobs.Contains(createJob2.Id), Is.True);
 
             // in-test cleanup
             await routerClient.CancelJobAsync(new CancelJobOptions(jobId2)); // other wise queue deletion will throw error
@@ -178,7 +178,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 }
             }
 
-            Assert.IsTrue(allJobs.Contains(createJob1.Id));
+            Assert.That(allJobs.Contains(createJob1.Id), Is.True);
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -234,10 +234,10 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
-            Assert.AreEqual(createJob.Id, queuedJob.Value.Id);
-            Assert.AreEqual(10, queuedJob.Value.Priority); // from classification policy
-            Assert.AreEqual(createQueue.Id, queuedJob.Value.QueueId); // from direct queue assignment
+            Assert.That(queuedJob.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(queuedJob.Value.Id, Is.EqualTo(createJob.Id));
+            Assert.That(queuedJob.Value.Priority, Is.EqualTo(10)); // from classification policy
+            Assert.That(queuedJob.Value.QueueId, Is.EqualTo(createQueue.Id)); // from direct queue assignment
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -287,10 +287,10 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
-            Assert.AreEqual(createJob.Id, queuedJob.Value.Id);
+            Assert.That(queuedJob.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(queuedJob.Value.Id, Is.EqualTo(createJob.Id));
             // Assert.AreEqual(1, queuedJob.Value.Priority); // default value TODO: Should be 0 or 1?
-            Assert.AreEqual(createQueue2.Id, queuedJob.Value.QueueId); // from queue selector in classification policy
+            Assert.That(queuedJob.Value.QueueId, Is.EqualTo(createQueue2.Id)); // from queue selector in classification policy
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -341,9 +341,9 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
-            Assert.AreEqual(1, queuedJob.Value.Priority); // default priority value
-            Assert.AreEqual(createQueue2.Id, queuedJob.Value.QueueId); // from fallback queue of classification policy
+            Assert.That(queuedJob.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(queuedJob.Value.Priority, Is.EqualTo(1)); // default priority value
+            Assert.That(queuedJob.Value.QueueId, Is.EqualTo(createQueue2.Id)); // from fallback queue of classification policy
 
             // in-test cleanup
             await routerClient.CancelJobAsync(new CancelJobOptions(createJob.Id)); // other wise queue deletion will throw error
@@ -389,10 +389,10 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, queuedJob.Value.Status);
-            Assert.AreEqual(createJob.Id, queuedJob.Value.Id);
-            Assert.AreEqual(1, queuedJob.Value.Priority); // default value
-            Assert.AreEqual(createQueue1.Id, queuedJob.Value.QueueId); // from queue selector in classification policy
+            Assert.That(queuedJob.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(queuedJob.Value.Id, Is.EqualTo(createJob.Id));
+            Assert.That(queuedJob.Value.Priority, Is.EqualTo(1)); // default value
+            Assert.That(queuedJob.Value.QueueId, Is.EqualTo(createQueue1.Id)); // from queue selector in classification policy
 
             // in-test cleanup
             await routerClient.CancelJobAsync(new CancelJobOptions(createJob.Id)); // other wise queue deletion will throw error
@@ -421,7 +421,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createJob1 = createJob1Response.Value;
             AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(createJob1.Id)));
 
-            Assert.IsTrue(createJob1.MatchingMode.GetType() == typeof(QueueAndMatchMode));
+            Assert.That(createJob1.MatchingMode.GetType(), Is.EqualTo(typeof(QueueAndMatchMode)));
 
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob1.Id),
                 job => job.Value.Status == RouterJobStatus.Queued, TimeSpan.FromSeconds(10));
@@ -456,7 +456,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createJob1 = createJob1Response.Value;
             AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(createJob1.Id)));
 
-            Assert.IsTrue(createJob1.MatchingMode.GetType() == typeof(SuspendMode));
+            Assert.That(createJob1.MatchingMode.GetType(), Is.EqualTo(typeof(SuspendMode)));
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -489,7 +489,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var createJob1 = createJob1Response.Value;
             AddForCleanup(new Task(async () => await routerClient.DeleteJobAsync(createJob1.Id)));
 
-            Assert.IsTrue(createJob1.MatchingMode.GetType() == typeof(ScheduleAndSuspendMode));
+            Assert.That(createJob1.MatchingMode.GetType(), Is.EqualTo(typeof(ScheduleAndSuspendMode)));
 
             var queuedJob = await Poll(async () => await routerClient.GetJobAsync(createJob1.Id),
                 job => job.Value.Status == RouterJobStatus.Scheduled, TimeSpan.FromSeconds(10));
@@ -550,16 +550,16 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             var updateJobResponse = await routerClient.UpdateJobAsync(updateOptions);
 
-            Assert.AreEqual(updateJobResponse.Value.Labels, new Dictionary<string, RouterValue?>
+            Assert.That(new Dictionary<string, RouterValue?>
             {
                 ["Label_3"] = new RouterValue("Value_Updated_3"),
                 ["Label_4"] = new RouterValue("Value_4")
-            });
-            Assert.AreEqual(updateJobResponse.Value.Tags, new Dictionary<string, RouterValue?>
+            }, Is.EqualTo(updateJobResponse.Value.Labels));
+            Assert.That(new Dictionary<string, RouterValue?>
             {
                 ["Tag_3"] = new RouterValue("Value_Updated_3"),
                 ["Tag_4"] = new RouterValue("Value_4")
-            });
+            }, Is.EqualTo(updateJobResponse.Value.Tags));
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)
@@ -605,7 +605,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
 
             await routerClient.ReclassifyJobAsync(jobId1, CancellationToken.None);
 
-            Assert.AreEqual(createJob1.QueueId, createQueue.Id);
+            Assert.That(createQueue.Id, Is.EqualTo(createJob1.QueueId));
 
             // in-test cleanup
             if (Mode != RecordedTestMode.Playback)

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterWorkerLiveTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/RouterWorkerLiveTests.cs
@@ -55,7 +55,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
                 });
             AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(workerId)));
 
-            Assert.NotNull(routerWorkerResponse.Value);
+            Assert.That(routerWorkerResponse.Value, Is.Not.Null);
             AssertRegisteredWorkerIsValid(routerWorkerResponse, workerId, queues,
                 capacity, workerLabels, channels);
 
@@ -77,7 +77,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var routerWorkerResponse = await routerClient.CreateWorkerAsync(new CreateWorkerOptions(workerId, capacity) { AvailableForOffers = true });
             AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(workerId)));
 
-            Assert.NotNull(routerWorkerResponse.Value);
+            Assert.That(routerWorkerResponse.Value, Is.Not.Null);
 
             routerWorkerResponse.Value.AvailableForOffers = false;
             await routerClient.UpdateWorkerAsync(routerWorkerResponse);
@@ -293,7 +293,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             var routerWorkerResponse = await routerClient.CreateWorkerAsync(createWorkerOptions);
             AddForCleanup(new Task(async () => await routerClient.DeleteWorkerAsync(workerId)));
 
-            Assert.NotNull(routerWorkerResponse.Value);
+            Assert.That(routerWorkerResponse.Value, Is.Not.Null);
             AssertRegisteredWorkerIsValid(routerWorkerResponse, workerId, queues,
                 capacity, workerLabels, channels, workerTags);
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/StaticRuleTests.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/RouterClients/StaticRuleTests.cs
@@ -19,7 +19,7 @@ namespace Azure.Communication.JobRouter.Tests.RouterClients
             Assert.DoesNotThrow(() =>
             {
                 var rule = new StaticRouterRule(new RouterValue(input));
-                Assert.AreEqual(input, rule.Value.Value);
+                Assert.That(rule.Value.Value, Is.EqualTo(input));
             });
         }
     }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/AssignmentScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/AssignmentScenario.cs
@@ -62,16 +62,16 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
                 w => w.Value.Offers.Any(x => x.JobId == createJob.Value.Id),
                 TimeSpan.FromSeconds(10));
 
-            Assert.IsTrue(worker.Value.Offers.Any(x => x.JobId == createJob.Value.Id));
+            Assert.That(worker.Value.Offers.Any(x => x.JobId == createJob.Value.Id), Is.True);
 
             var offer = worker.Value.Offers.Single(x => x.JobId == createJob.Value.Id);
-            Assert.AreEqual(1, offer.CapacityCost);
-            Assert.IsNotNull(offer.OfferedAt);
-            Assert.IsNotNull(offer.ExpiresAt);
+            Assert.That(offer.CapacityCost, Is.EqualTo(1));
+            Assert.That(offer.OfferedAt, Is.Not.Null);
+            Assert.That(offer.ExpiresAt, Is.Not.Null);
 
             var accept = await client.AcceptJobOfferAsync(worker.Value.Id, offer.OfferId);
-            Assert.AreEqual(createJob.Value.Id, accept.Value.JobId);
-            Assert.AreEqual(worker.Value.Id, accept.Value.WorkerId);
+            Assert.That(accept.Value.JobId, Is.EqualTo(createJob.Value.Id));
+            Assert.That(accept.Value.WorkerId, Is.EqualTo(worker.Value.Id));
 
             Assert.ThrowsAsync<RequestFailedException>(async () =>
                 await client.DeclineJobOfferAsync(
@@ -84,21 +84,21 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             {
                 Note = $"Job completed by {workerId1}"
             });
-            Assert.AreEqual(200, complete.Status);
+            Assert.That(complete.Status, Is.EqualTo(200));
 
             var close = await client.CloseJobAsync(new CloseJobOptions(createJob.Value.Id, accept.Value.AssignmentId)
             {
                 Note = $"Job closed by {workerId1}"
             });
-            Assert.AreEqual(200, complete.Status);
+            Assert.That(complete.Status, Is.EqualTo(200));
 
             var finalJobState = await client.GetJobAsync(createJob.Value.Id);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].AssignedAt);
-            Assert.AreEqual(worker.Value.Id, finalJobState.Value.Assignments[accept.Value.AssignmentId].WorkerId);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].CompletedAt);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].ClosedAt);
-            Assert.IsNotEmpty(finalJobState.Value.Notes);
-            Assert.IsTrue(finalJobState.Value.Notes.Count == 2);
+            Assert.That(finalJobState.Value.Assignments[accept.Value.AssignmentId].AssignedAt, Is.Not.Null);
+            Assert.That(finalJobState.Value.Assignments[accept.Value.AssignmentId].WorkerId, Is.EqualTo(worker.Value.Id));
+            Assert.That(finalJobState.Value.Assignments[accept.Value.AssignmentId].CompletedAt, Is.Not.Null);
+            Assert.That(finalJobState.Value.Assignments[accept.Value.AssignmentId].ClosedAt, Is.Not.Null);
+            Assert.That(finalJobState.Value.Notes, Is.Not.Empty);
+            Assert.That(finalJobState.Value.Notes.Count, Is.EqualTo(2));
 
             // in-test cleanup
             worker.Value.AvailableForOffers = false;

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/CancellationScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/CancellationScenario.cs
@@ -53,7 +53,7 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
+            Assert.That(job.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
 
             await client.CancelJobAsync(new CancelJobOptions(job.Value.Id)
             {
@@ -61,8 +61,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             });
 
             var finalJobState = await client.GetJobAsync(createJob.Value.Id);
-            Assert.AreEqual(RouterJobStatus.Cancelled, finalJobState.Value.Status);
-            Assert.AreEqual(dispositionCode, finalJobState.Value.DispositionCode);
+            Assert.That(finalJobState.Value.Status, Is.EqualTo(RouterJobStatus.Cancelled));
+            Assert.That(finalJobState.Value.DispositionCode, Is.EqualTo(dispositionCode));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/LimitConcurrentOffersToWorkerScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/LimitConcurrentOffersToWorkerScenario.cs
@@ -72,7 +72,7 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var queriedWorker = await Poll(async () => await client.GetWorkerAsync(workerId1),
                 x => x.Value.Offers.Any(offer => offer.JobId == jobId1 || offer.JobId == jobId2),
                 TimeSpan.FromSeconds(30));
-            Assert.IsTrue(queriedWorker.Value.Offers.Count == 1);
+            Assert.That(queriedWorker.Value.Offers.Count, Is.EqualTo(1));
 
             var offer1 = queriedWorker.Value.Offers.First(offer => offer.JobId == jobId1 || offer.JobId == jobId2);
             var jobWithOffer = offer1.JobId;
@@ -83,7 +83,7 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             queriedWorker = await Poll(async () => await client.GetWorkerAsync(workerId1),
                 x => x.Value.Offers.Any(newOffer => newOffer.JobId == jobWithoutOffer),
                 TimeSpan.FromSeconds(30));
-            Assert.IsTrue(queriedWorker.Value.Offers.Count == 1);
+            Assert.That(queriedWorker.Value.Offers.Count, Is.EqualTo(1));
 
             var offer2 = queriedWorker.Value.Offers.First(newOffer => newOffer.JobId == jobWithoutOffer);
 

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/QueueScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/QueueScenario.cs
@@ -45,7 +45,7 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
+            Assert.That(job.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
         }
 
         [Test]
@@ -81,8 +81,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
-            Assert.AreEqual(job.Value.QueueId, queueResponse.Value.Id);
+            Assert.That(job.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(queueResponse.Value.Id, Is.EqualTo(job.Value.QueueId));
         }
 
         [Test]
@@ -118,8 +118,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
-            Assert.AreEqual(job.Value.QueueId, fallbackQueueResponse.Value.Id);
+            Assert.That(job.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(fallbackQueueResponse.Value.Id, Is.EqualTo(job.Value.QueueId));
         }
 
         [Test]
@@ -170,8 +170,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
-            Assert.AreEqual(job.Value.QueueId, queueResponse.Value.Id);
+            Assert.That(job.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(queueResponse.Value.Id, Is.EqualTo(job.Value.QueueId));
         }
 
         [Test]
@@ -234,8 +234,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
-            Assert.AreEqual(RouterJobStatus.Queued, job.Value.Status);
-            Assert.AreEqual(job.Value.QueueId, queueResponse.Value.Id);
+            Assert.That(job.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(queueResponse.Value.Id, Is.EqualTo(job.Value.QueueId));
         }
 
         [Test]
@@ -342,10 +342,10 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
                 x => x.Value.Status == RouterJobStatus.Queued,
                 TimeSpan.FromSeconds(10));
 
-            Assert.AreEqual(RouterJobStatus.Queued, job1.Value.Status);
-            Assert.AreEqual(RouterJobStatus.Queued, job2.Value.Status);
-            Assert.AreEqual(job1.Value.QueueId, queue1Response.Value.Id);
-            Assert.AreEqual(job2.Value.QueueId, queue2Response.Value.Id);
+            Assert.That(job1.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(job2.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(queue1Response.Value.Id, Is.EqualTo(job1.Value.QueueId));
+            Assert.That(queue2Response.Value.Id, Is.EqualTo(job2.Value.QueueId));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/SchedulingScenario.cs
+++ b/sdk/communication/Azure.Communication.JobRouter/tests/Scenarios/SchedulingScenario.cs
@@ -62,8 +62,8 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             var job = await Poll(async () => await client.GetJobAsync(createJob.Value.Id),
                 x => x.Value.Status == RouterJobStatus.WaitingForActivation,
                 TimeSpan.FromSeconds(30));
-            Assert.AreEqual(RouterJobStatus.WaitingForActivation, job.Value.Status);
-            Assert.NotNull(job.Value.ScheduledAt);
+            Assert.That(job.Value.Status, Is.EqualTo(RouterJobStatus.WaitingForActivation));
+            Assert.That(job.Value.ScheduledAt, Is.Not.Null);
             Assert.That(job.Value.ScheduledAt, Is.EqualTo(timeToEnqueueJob).Within(30).Seconds);
 
             var updateJobToStartMatching =
@@ -72,23 +72,23 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
                     MatchingMode = new QueueAndMatchMode()
                 });
 
-            Assert.AreEqual(RouterJobStatus.Queued, updateJobToStartMatching.Value.Status);
-            Assert.NotNull(updateJobToStartMatching.Value.ScheduledAt);
-            Assert.AreEqual(typeof(QueueAndMatchMode), updateJobToStartMatching.Value.MatchingMode.GetType());
+            Assert.That(updateJobToStartMatching.Value.Status, Is.EqualTo(RouterJobStatus.Queued));
+            Assert.That(updateJobToStartMatching.Value.ScheduledAt, Is.Not.Null);
+            Assert.That(updateJobToStartMatching.Value.MatchingMode.GetType(), Is.EqualTo(typeof(QueueAndMatchMode)));
 
             var worker = await Poll(async () => await client.GetWorkerAsync(registerWorker.Value.Id),
                 w => w.Value.Offers.Any(x => x.JobId == updateJobToStartMatching.Value.Id),
                 TimeSpan.FromSeconds(10));
-            Assert.IsTrue(worker.Value.Offers.Any(x => x.JobId == updateJobToStartMatching.Value.Id), "Offers should be sent to worker");
+            Assert.That(worker.Value.Offers.Any(x => x.JobId == updateJobToStartMatching.Value.Id), Is.True, "Offers should be sent to worker");
 
             var offer = worker.Value.Offers.Single(x => x.JobId == updateJobToStartMatching.Value.Id);
-            Assert.AreEqual(1, offer.CapacityCost);
-            Assert.IsNotNull(offer.OfferedAt);
-            Assert.IsNotNull(offer.ExpiresAt);
+            Assert.That(offer.CapacityCost, Is.EqualTo(1));
+            Assert.That(offer.OfferedAt, Is.Not.Null);
+            Assert.That(offer.ExpiresAt, Is.Not.Null);
 
             var accept = await client.AcceptJobOfferAsync(worker.Value.Id, offer.OfferId);
-            Assert.AreEqual(createJob.Value.Id, accept.Value.JobId);
-            Assert.AreEqual(worker.Value.Id, accept.Value.WorkerId);
+            Assert.That(accept.Value.JobId, Is.EqualTo(createJob.Value.Id));
+            Assert.That(accept.Value.WorkerId, Is.EqualTo(worker.Value.Id));
 
             Assert.ThrowsAsync<RequestFailedException>(async () =>
                 await client.DeclineJobOfferAsync(
@@ -101,22 +101,22 @@ namespace Azure.Communication.JobRouter.Tests.Scenarios
             {
                 Note = $"Job completed by {workerId1}"
             });
-            Assert.AreEqual(200, complete.Status);
+            Assert.That(complete.Status, Is.EqualTo(200));
 
             var close = await client.CloseJobAsync(new CloseJobOptions(createJob.Value.Id, accept.Value.AssignmentId)
             {
                 Note = $"Job closed by {workerId1}"
             });
-            Assert.AreEqual(200, complete.Status);
+            Assert.That(complete.Status, Is.EqualTo(200));
 
             var finalJobState = await client.GetJobAsync(createJob.Value.Id);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].AssignedAt);
-            Assert.AreEqual(worker.Value.Id, finalJobState.Value.Assignments[accept.Value.AssignmentId].WorkerId);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].CompletedAt);
-            Assert.IsNotNull(finalJobState.Value.Assignments[accept.Value.AssignmentId].ClosedAt);
-            Assert.IsNotEmpty(finalJobState.Value.Notes);
-            Assert.IsTrue(finalJobState.Value.Notes.Count == 2);
-            Assert.NotNull(finalJobState.Value.ScheduledAt);
+            Assert.That(finalJobState.Value.Assignments[accept.Value.AssignmentId].AssignedAt, Is.Not.Null);
+            Assert.That(finalJobState.Value.Assignments[accept.Value.AssignmentId].WorkerId, Is.EqualTo(worker.Value.Id));
+            Assert.That(finalJobState.Value.Assignments[accept.Value.AssignmentId].CompletedAt, Is.Not.Null);
+            Assert.That(finalJobState.Value.Assignments[accept.Value.AssignmentId].ClosedAt, Is.Not.Null);
+            Assert.That(finalJobState.Value.Notes, Is.Not.Empty);
+            Assert.That(finalJobState.Value.Notes.Count, Is.EqualTo(2));
+            Assert.That(finalJobState.Value.ScheduledAt, Is.Not.Null);
 
             // delete worker for straggling offers if any
             await client.UpdateWorkerAsync(new RouterWorker(workerId1) { AvailableForOffers = false });

--- a/sdk/communication/Azure.Communication.Messages/tests/NotificationMessagesClient/NotificationMessagesClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Messages/tests/NotificationMessagesClient/NotificationMessagesClientLiveTests.cs
@@ -563,8 +563,8 @@ namespace Azure.Communication.Messages.Tests
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
 
             // Assert the expected error code and message
-            Assert.AreEqual(400, ex.Status);
-            Assert.AreEqual("BadRequest", ex.ErrorCode);
+            Assert.That(ex.Status, Is.EqualTo(400));
+            Assert.That(ex.ErrorCode, Is.EqualTo("BadRequest"));
 
             return Task.CompletedTask;
         }
@@ -586,9 +586,9 @@ namespace Azure.Communication.Messages.Tests
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
 
             // Assert the expected error code and message
-            Assert.AreEqual(404, ex.Status);
-            Assert.AreEqual("TemplateNotFound", ex.ErrorCode);
-            Assert.IsTrue(ex.Message.Contains("Template does not exist"));
+            Assert.That(ex.Status, Is.EqualTo(404));
+            Assert.That(ex.ErrorCode, Is.EqualTo("TemplateNotFound"));
+            Assert.That(ex.Message.Contains("Template does not exist"), Is.True);
             return Task.CompletedTask;
         }
 
@@ -624,9 +624,9 @@ namespace Azure.Communication.Messages.Tests
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.SendAsync(content));
 
             // Assert the expected error code and message
-            Assert.AreEqual(400, ex.Status);
-            Assert.AreEqual("BadRequest", ex.ErrorCode);
-            Assert.IsTrue(ex.Message.Contains("InvalidParameter: (#100) Param text['body'] must be at most 4096 characters long."));
+            Assert.That(ex.Status, Is.EqualTo(400));
+            Assert.That(ex.ErrorCode, Is.EqualTo("BadRequest"));
+            Assert.That(ex.Message.Contains("InvalidParameter: (#100) Param text['body'] must be at most 4096 characters long."), Is.True);
 
             return Task.CompletedTask;
         }
@@ -643,7 +643,7 @@ namespace Azure.Communication.Messages.Tests
 
             // Assert
             mediaStream.Position = 0; // Reset stream position for reading
-            Assert.IsTrue(mediaStream.Length > 0);
+            Assert.That(mediaStream.Length > 0, Is.True);
         }
 
         [Test]
@@ -657,8 +657,8 @@ namespace Azure.Communication.Messages.Tests
             Assert.ThrowsAsync<ArgumentException>(async () => await notificationMessagesClient.DownloadMediaAsync(string.Empty));
             Assert.ThrowsAsync<ArgumentException>(async () => await notificationMessagesClient.DownloadMediaAsync(""));
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.DownloadMediaAsync("  "));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 400);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -669,9 +669,9 @@ namespace Azure.Communication.Messages.Tests
 
             // Act & Assert
             RequestFailedException ex = Assert.ThrowsAsync<RequestFailedException>(async () => await notificationMessagesClient.DownloadMediaAsync("test"));
-            Assert.NotNull(ex);
-            Assert.AreEqual(ex?.Status, 404);
-            Assert.AreEqual(ex?.ErrorCode, "MediaNotFound");
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
+            Assert.That(ex?.ErrorCode, Is.EqualTo("MediaNotFound"));
         }
 
         [Test]
@@ -686,9 +686,9 @@ namespace Azure.Communication.Messages.Tests
             Response downloadResponse = await notificationMessagesClient.DownloadMediaToAsync(mediaContentId, destinationStream);
 
             // Assert
-            Assert.AreEqual(200, downloadResponse.Status);
+            Assert.That(downloadResponse.Status, Is.EqualTo(200));
             destinationStream.Position = 0; // Reset stream position for reading
-            Assert.IsTrue(destinationStream.Length > 0);
+            Assert.That(destinationStream.Length > 0, Is.True);
         }
 
         [Test]
@@ -703,16 +703,16 @@ namespace Azure.Communication.Messages.Tests
             Response downloadResponse = await notificationMessagesClient.DownloadMediaToAsync(mediaContentId, destinationPath);
 
             // Assert
-            Assert.AreEqual(200, downloadResponse.Status);
-            Assert.IsTrue(File.Exists(destinationPath));
+            Assert.That(downloadResponse.Status, Is.EqualTo(200));
+            Assert.That(File.Exists(destinationPath), Is.True);
         }
 
         private void validateResponse(Response<SendMessageResult> response)
         {
-            Assert.AreEqual(202, response.GetRawResponse().Status);
-            Assert.IsNotNull(response.Value.Receipts[0].MessageId);
-            Assert.IsNotNull(response.Value.Receipts[0].To);
-            Assert.AreEqual(TestEnvironment.RecipientIdentifier, response.Value.Receipts[0].To);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(202));
+            Assert.That(response.Value.Receipts[0].MessageId, Is.Not.Null);
+            Assert.That(response.Value.Receipts[0].To, Is.Not.Null);
+            Assert.That(response.Value.Receipts[0].To, Is.EqualTo(TestEnvironment.RecipientIdentifier));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Messages/tests/NotificationMessagesClient/NotificationMessagesClientTests.cs
+++ b/sdk/communication/Azure.Communication.Messages/tests/NotificationMessagesClient/NotificationMessagesClientTests.cs
@@ -63,10 +63,10 @@ namespace Azure.Communication.Messages.Tests
             SendMessageResult sendMessageResult = await notificationMessagesClient.SendAsync(content);
 
             //assert
-            Assert.IsNotNull(sendMessageResult.Receipts[0].MessageId);
-            Assert.IsNotNull(sendMessageResult.Receipts[0].To);
-            Assert.AreEqual("d53605de-2f6e-437d-9e40-8d83b2111cb8", sendMessageResult.Receipts[0].MessageId);
-            Assert.AreEqual("+1(123)456-7890", sendMessageResult.Receipts[0].To);
+            Assert.That(sendMessageResult.Receipts[0].MessageId, Is.Not.Null);
+            Assert.That(sendMessageResult.Receipts[0].To, Is.Not.Null);
+            Assert.That(sendMessageResult.Receipts[0].MessageId, Is.EqualTo("d53605de-2f6e-437d-9e40-8d83b2111cb8"));
+            Assert.That(sendMessageResult.Receipts[0].To, Is.EqualTo("+1(123)456-7890"));
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace Azure.Communication.Messages.Tests
             catch (RequestFailedException requestFailedException)
             {
                 //assert
-                Assert.AreEqual(400, requestFailedException.Status);
+                Assert.That(requestFailedException.Status, Is.EqualTo(400));
             }
         }
 

--- a/sdk/communication/Azure.Communication.Messages/tests/TemplateClient/MessageTemplateClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Messages/tests/TemplateClient/MessageTemplateClientLiveTests.cs
@@ -28,14 +28,14 @@ namespace Azure.Communication.Messages.Tests
             AsyncPageable<MessageTemplateItem> templates = messageTemplateClient.GetTemplatesAsync(channelRegistrationId);
 
             // Assert
-            Assert.IsNotNull(templates);
+            Assert.That(templates, Is.Not.Null);
             List<MessageTemplateItem> templatesEnumerable = templates.ToEnumerableAsync().Result;
-            Assert.IsNotEmpty(templatesEnumerable);
+            Assert.That(templatesEnumerable, Is.Not.Empty);
             foreach (WhatsAppMessageTemplateItem template in templatesEnumerable.Cast<WhatsAppMessageTemplateItem>())
             {
-                Assert.IsNotNull(template.Name);
-                Assert.IsNotNull(template.Language);
-                Assert.IsNotNull(template.Content);
+                Assert.That(template.Name, Is.Not.Null);
+                Assert.That(template.Language, Is.Not.Null);
+                Assert.That(template.Content, Is.Not.Null);
             }
 
             return Task.CompletedTask;
@@ -52,14 +52,14 @@ namespace Azure.Communication.Messages.Tests
             AsyncPageable<MessageTemplateItem> templates = messageTemplateClient.GetTemplatesAsync(channelRegistrationId);
 
             // Assert
-            Assert.IsNotNull(templates);
+            Assert.That(templates, Is.Not.Null);
             List<MessageTemplateItem> templatesEnumerable = templates.ToEnumerableAsync().Result;
-            Assert.IsNotEmpty(templatesEnumerable);
+            Assert.That(templatesEnumerable, Is.Not.Empty);
             foreach (WhatsAppMessageTemplateItem template in templatesEnumerable.Cast<WhatsAppMessageTemplateItem>())
             {
-                Assert.IsNotNull(template.Name);
-                Assert.IsNotNull(template.Language);
-                Assert.IsNotNull(template.Content);
+                Assert.That(template.Name, Is.Not.Null);
+                Assert.That(template.Language, Is.Not.Null);
+                Assert.That(template.Content, Is.Not.Null);
             }
 
             return Task.CompletedTask;

--- a/sdk/communication/Azure.Communication.Messages/tests/TemplateClient/MessageTemplateClientTests.cs
+++ b/sdk/communication/Azure.Communication.Messages/tests/TemplateClient/MessageTemplateClientTests.cs
@@ -55,7 +55,7 @@ namespace Azure.Communication.Messages.Tests
             catch (RequestFailedException requestFailedException)
             {
                 //assert
-                Assert.AreEqual(400, requestFailedException.Status);
+                Assert.That(requestFailedException.Status, Is.EqualTo(400));
             }
 
             return Task.CompletedTask;
@@ -74,10 +74,10 @@ namespace Azure.Communication.Messages.Tests
             //assert
             await foreach (MessageTemplateItem template in templates)
             {
-                Assert.IsNotNull(template.Name);
-                Assert.IsNotNull(template.Language);
-                Assert.IsNotNull(template.Status);
-                Assert.IsTrue(template is WhatsAppMessageTemplateItem);
+                Assert.That(template.Name, Is.Not.Null);
+                Assert.That(template.Language, Is.Not.Null);
+                Assert.That(template.Status, Is.Not.Null);
+                Assert.That(template is WhatsAppMessageTemplateItem, Is.True);
             }
         }
 

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersClientLiveTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var numbersPagable = client.GetPurchasedPhoneNumbersAsync();
             var numbers = await numbersPagable.ToEnumerableAsync();
 
-            Assert.IsNotNull(numbers);
+            Assert.That(numbers, Is.Not.Null);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPurchasedPhoneNumbersUsingConnectionString")]
@@ -53,7 +53,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var numbersPagable = client.GetPurchasedPhoneNumbers();
             var numbers = numbersPagable.AsPages().ToList();
 
-            Assert.IsNotNull(numbers);
+            Assert.That(numbers, Is.Not.Null);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPhoneNumberUsingConnectionString")]
@@ -67,9 +67,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var client = CreateClient(authMethod);
             var phoneNumber = await client.GetPurchasedPhoneNumberAsync(number);
 
-            Assert.IsNotNull(phoneNumber);
-            Assert.IsNotNull(phoneNumber.Value);
-            Assert.AreEqual(number, phoneNumber.Value.PhoneNumber);
+            Assert.That(phoneNumber, Is.Not.Null);
+            Assert.That(phoneNumber.Value, Is.Not.Null);
+            Assert.That(phoneNumber.Value.PhoneNumber, Is.EqualTo(number));
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPhoneNumberUsingConnectionString")]
@@ -83,9 +83,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var client = CreateClient(authMethod);
             var phoneNumber = client.GetPurchasedPhoneNumber(number);
 
-            Assert.IsNotNull(phoneNumber);
-            Assert.IsNotNull(phoneNumber.Value);
-            Assert.AreEqual(number, phoneNumber.Value.PhoneNumber);
+            Assert.That(phoneNumber, Is.Not.Null);
+            Assert.That(phoneNumber.Value, Is.Not.Null);
+            Assert.That(phoneNumber.Value.PhoneNumber, Is.EqualTo(number));
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("phoneNumber", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("phoneNumber"));
                 return;
             }
 
@@ -119,7 +119,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("phoneNumber", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("phoneNumber"));
                 return;
             }
 
@@ -138,7 +138,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("phoneNumber", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("phoneNumber"));
                 return;
             }
 
@@ -157,7 +157,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("phoneNumber", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("phoneNumber"));
                 return;
             }
 
@@ -178,7 +178,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
                 return;
             }
 
@@ -199,7 +199,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
                 return;
             }
 
@@ -218,7 +218,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("twoLetterIsoCountryName", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("twoLetterIsoCountryName"));
                 return;
             }
 
@@ -237,7 +237,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("twoLetterIsoCountryName", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("twoLetterIsoCountryName"));
                 return;
             }
 
@@ -258,22 +258,22 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             await searchOperation.WaitForCompletionAsync();
 
-            Assert.IsTrue(searchOperation.HasCompleted);
-            Assert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
+            Assert.That(searchOperation.HasCompleted, Is.True);
+            Assert.That(searchOperation.Value.PhoneNumbers.Count, Is.EqualTo(1));
+            Assert.That(searchOperation.Value.AssignmentType, Is.EqualTo(PhoneNumberAssignmentType.Application));
+            Assert.That(searchOperation.Value.Capabilities.Calling, Is.EqualTo(PhoneNumberCapabilityType.Outbound));
+            Assert.That(searchOperation.Value.Capabilities.Sms, Is.EqualTo(PhoneNumberCapabilityType.None));
+            Assert.That(searchOperation.Value.PhoneNumberType, Is.EqualTo(PhoneNumberType.TollFree));
 
             var searchId = searchOperation.Value.SearchId;
 
             var response = await client.GetPhoneNumberSearchResultAsync(searchId);
 
-            Assert.AreEqual(1, response.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, response.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, response.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, response.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, response.Value.PhoneNumberType);
+            Assert.That(response.Value.PhoneNumbers.Count, Is.EqualTo(1));
+            Assert.That(response.Value.AssignmentType, Is.EqualTo(PhoneNumberAssignmentType.Application));
+            Assert.That(response.Value.Capabilities.Calling, Is.EqualTo(PhoneNumberCapabilityType.Outbound));
+            Assert.That(response.Value.Capabilities.Sms, Is.EqualTo(PhoneNumberCapabilityType.None));
+            Assert.That(response.Value.PhoneNumberType, Is.EqualTo(PhoneNumberType.TollFree));
         }
 
         [Test]
@@ -294,22 +294,22 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 searchOperation.UpdateStatus();
             }
 
-            Assert.IsTrue(searchOperation.HasCompleted);
-            Assert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
+            Assert.That(searchOperation.HasCompleted, Is.True);
+            Assert.That(searchOperation.Value.PhoneNumbers.Count, Is.EqualTo(1));
+            Assert.That(searchOperation.Value.AssignmentType, Is.EqualTo(PhoneNumberAssignmentType.Application));
+            Assert.That(searchOperation.Value.Capabilities.Calling, Is.EqualTo(PhoneNumberCapabilityType.Outbound));
+            Assert.That(searchOperation.Value.Capabilities.Sms, Is.EqualTo(PhoneNumberCapabilityType.None));
+            Assert.That(searchOperation.Value.PhoneNumberType, Is.EqualTo(PhoneNumberType.TollFree));
 
             var searchId = searchOperation.Value.SearchId;
 
             var response = client.GetPhoneNumberSearchResult(searchId);
 
-            Assert.AreEqual(1, response.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, response.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, response.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, response.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, response.Value.PhoneNumberType);
+            Assert.That(response.Value.PhoneNumbers.Count, Is.EqualTo(1));
+            Assert.That(response.Value.AssignmentType, Is.EqualTo(PhoneNumberAssignmentType.Application));
+            Assert.That(response.Value.Capabilities.Calling, Is.EqualTo(PhoneNumberCapabilityType.Outbound));
+            Assert.That(response.Value.Capabilities.Sms, Is.EqualTo(PhoneNumberCapabilityType.None));
+            Assert.That(response.Value.PhoneNumberType, Is.EqualTo(PhoneNumberType.TollFree));
         }
 
         [Test]
@@ -323,7 +323,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -338,7 +338,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -353,8 +353,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -369,8 +369,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -385,8 +385,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -401,8 +401,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -417,7 +417,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -432,7 +432,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -447,7 +447,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -462,7 +462,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (Exception ex)
             {
-                Assert.NotNull(ex.Message);
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -477,8 +477,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -493,8 +493,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -515,12 +515,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             await searchOperation.WaitForCompletionAsync();
 
-            Assert.IsTrue(searchOperation.HasCompleted);
-            Assert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
+            Assert.That(searchOperation.HasCompleted, Is.True);
+            Assert.That(searchOperation.Value.PhoneNumbers.Count, Is.EqualTo(1));
+            Assert.That(searchOperation.Value.AssignmentType, Is.EqualTo(PhoneNumberAssignmentType.Application));
+            Assert.That(searchOperation.Value.Capabilities.Calling, Is.EqualTo(PhoneNumberCapabilityType.Outbound));
+            Assert.That(searchOperation.Value.Capabilities.Sms, Is.EqualTo(PhoneNumberCapabilityType.None));
+            Assert.That(searchOperation.Value.PhoneNumberType, Is.EqualTo(PhoneNumberType.TollFree));
 
             var searchId = searchOperation.Value.SearchId;
 
@@ -530,8 +530,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -556,12 +556,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 searchOperation.UpdateStatus();
             }
 
-            Assert.IsTrue(searchOperation.HasCompleted);
-            Assert.AreEqual(1, searchOperation.Value.PhoneNumbers.Count);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, searchOperation.Value.AssignmentType);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, searchOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.None, searchOperation.Value.Capabilities.Sms);
-            Assert.AreEqual(PhoneNumberType.TollFree, searchOperation.Value.PhoneNumberType);
+            Assert.That(searchOperation.HasCompleted, Is.True);
+            Assert.That(searchOperation.Value.PhoneNumbers.Count, Is.EqualTo(1));
+            Assert.That(searchOperation.Value.AssignmentType, Is.EqualTo(PhoneNumberAssignmentType.Application));
+            Assert.That(searchOperation.Value.Capabilities.Calling, Is.EqualTo(PhoneNumberCapabilityType.Outbound));
+            Assert.That(searchOperation.Value.Capabilities.Sms, Is.EqualTo(PhoneNumberCapabilityType.None));
+            Assert.That(searchOperation.Value.PhoneNumberType, Is.EqualTo(PhoneNumberType.TollFree));
 
             var searchId = searchOperation.Value.SearchId;
 
@@ -571,8 +571,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -588,7 +588,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 Console.WriteLine("phone " + purchasedPhone.PhoneNumber);
             }
 
-            Assert.NotNull(purchasedPhoneNumbers);
+            Assert.That(purchasedPhoneNumbers, Is.Not.Null);
         }
 
         [Test]
@@ -603,7 +603,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 Console.WriteLine("phone " + purchasedPhone.PhoneNumber);
             }
 
-            Assert.NotNull(purchasedPhoneNumbers);
+            Assert.That(purchasedPhoneNumbers, Is.Not.Null);
         }
 
         [Test]
@@ -632,7 +632,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -640,7 +640,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(phoneNumbersCount, actual);
+            Assert.That(actual, Is.EqualTo(phoneNumbersCount));
         }
 
         [Test]
@@ -669,7 +669,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -677,7 +677,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(phoneNumbersCount, actual);
+            Assert.That(actual, Is.EqualTo(phoneNumbersCount));
         }
 
         [Test]
@@ -698,10 +698,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var updateOperation = await client.StartUpdateCapabilitiesAsync(number, callingCapabilityType, smsCapabilityType);
             await updateOperation.WaitForCompletionAsync();
 
-            Assert.IsTrue(updateOperation.HasCompleted);
-            Assert.IsNotNull(updateOperation.Value);
-            Assert.AreEqual(number, updateOperation.Value.PhoneNumber);
-            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status), $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
+            Assert.That(updateOperation.HasCompleted, Is.True);
+            Assert.That(updateOperation.Value, Is.Not.Null);
+            Assert.That(updateOperation.Value.PhoneNumber, Is.EqualTo(number));
+            Assert.That(IsSuccess(updateOperation.GetRawResponse().Status), Is.True, $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
         }
 
         [Test]
@@ -727,10 +727,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 updateOperation.UpdateStatus();
             }
 
-            Assert.IsTrue(updateOperation.HasCompleted);
-            Assert.IsNotNull(updateOperation.Value);
-            Assert.AreEqual(number, updateOperation.Value.PhoneNumber);
-            Assert.IsTrue(IsSuccess(updateOperation.GetRawResponse().Status), $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
+            Assert.That(updateOperation.HasCompleted, Is.True);
+            Assert.That(updateOperation.Value, Is.Not.Null);
+            Assert.That(updateOperation.Value.PhoneNumber, Is.EqualTo(number));
+            Assert.That(IsSuccess(updateOperation.GetRawResponse().Status), Is.True, $"Status code {updateOperation.GetRawResponse().Status} does not indicate success");
         }
 
         [Test]
@@ -744,8 +744,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -760,8 +760,8 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
-                Assert.NotNull(ex.Message);
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(ex.Message, Is.Not.Null);
             }
         }
 
@@ -775,9 +775,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var areaCodes = client.GetAvailableAreaCodesTollFreeAsync("US");
             await foreach (PhoneNumberAreaCode areaCode in areaCodes)
             {
-                Assert.Contains(areaCode.AreaCode, expectedAreaCodes);
+                Assert.That(expectedAreaCodes, Does.Contain(areaCode.AreaCode));
             }
-            Assert.IsNotNull(areaCodes);
+            Assert.That(areaCodes, Is.Not.Null);
         }
 
         [Test]
@@ -790,9 +790,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var areaCodes = client.GetAvailableAreaCodesTollFree("US");
             foreach (PhoneNumberAreaCode areaCode in areaCodes)
             {
-                Assert.Contains(areaCode.AreaCode, expectedAreaCodes);
+                Assert.That(expectedAreaCodes, Does.Contain(areaCode.AreaCode));
             }
-            Assert.IsNotNull(areaCodes);
+            Assert.That(areaCodes, Is.Not.Null);
         }
 
         [Test]
@@ -820,7 +820,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -828,7 +828,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(areaCodesCount, actual);
+            Assert.That(actual, Is.EqualTo(areaCodesCount));
         }
 
         [Test]
@@ -857,7 +857,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -865,7 +865,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(areaCodesCount, actual);
+            Assert.That(actual, Is.EqualTo(areaCodesCount));
         }
 
         [Test]
@@ -881,7 +881,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 {
                     Console.WriteLine("Area Code " + areaCode.AreaCode);
                 }
-                Assert.IsNotNull(areaCodes);
+                Assert.That(areaCodes, Is.Not.Null);
                 break;
             }
         }
@@ -899,7 +899,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 {
                     Console.WriteLine("Area Code " + areaCode.AreaCode);
                 }
-                Assert.IsNotNull(areaCodes);
+                Assert.That(areaCodes, Is.Not.Null);
                 break;
             }
         }
@@ -930,7 +930,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -938,7 +938,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(areaCodesCount, actual);
+            Assert.That(actual, Is.EqualTo(areaCodesCount));
         }
 
         [Test]
@@ -968,7 +968,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -976,7 +976,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(areaCodesCount, actual);
+            Assert.That(actual, Is.EqualTo(areaCodesCount));
         }
 
         [Test]
@@ -992,7 +992,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 {
                     Console.WriteLine("Mobile Area Code " + areaCode.AreaCode);
                 }
-                Assert.IsNotNull(areaCodes);
+                Assert.That(areaCodes, Is.Not.Null);
                 break;
             }
         }
@@ -1010,7 +1010,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 {
                     Console.WriteLine("Mobile Area Code " + areaCode.AreaCode);
                 }
-                Assert.IsNotNull(areaCodes);
+                Assert.That(areaCodes, Is.Not.Null);
                 break;
             }
         }
@@ -1031,9 +1031,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             foreach (string country in expectedCountries)
             {
-                Assert.Contains(country, countriesResponse);
+                Assert.That(countriesResponse, Does.Contain(country));
             }
-            Assert.IsNotNull(countries);
+            Assert.That(countries, Is.Not.Null);
         }
 
         [Test]
@@ -1052,9 +1052,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             foreach (string country in expectedCountries)
             {
-                Assert.Contains(country, countriesResponse);
+                Assert.That(countriesResponse, Does.Contain(country));
             }
-            Assert.IsNotNull(countries);
+            Assert.That(countries, Is.Not.Null);
         }
 
         [Test]
@@ -1083,7 +1083,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1091,7 +1091,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(countriesCount, actual);
+            Assert.That(actual, Is.EqualTo(countriesCount));
         }
 
         [Test]
@@ -1120,7 +1120,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1128,7 +1128,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(countriesCount, actual);
+            Assert.That(actual, Is.EqualTo(countriesCount));
         }
 
         [Test]
@@ -1142,7 +1142,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Locality " + locality.LocalizedName);
             }
-            Assert.IsNotNull(localities);
+            Assert.That(localities, Is.Not.Null);
         }
 
         [Test]
@@ -1156,7 +1156,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Locality " + locality.LocalizedName);
             }
-            Assert.IsNotNull(localities);
+            Assert.That(localities, Is.Not.Null);
         }
 
         [Test]
@@ -1170,7 +1170,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Locality " + locality.LocalizedName);
             }
-            Assert.IsNotNull(localities);
+            Assert.That(localities, Is.Not.Null);
         }
 
         [Test]
@@ -1184,7 +1184,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Locality " + locality.LocalizedName);
             }
-            Assert.IsNotNull(localities);
+            Assert.That(localities, Is.Not.Null);
         }
 
         [Test]
@@ -1210,7 +1210,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1218,7 +1218,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(localitiesCount, actual);
+            Assert.That(actual, Is.EqualTo(localitiesCount));
         }
 
         [Test]
@@ -1244,7 +1244,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1252,7 +1252,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(localitiesCount, actual);
+            Assert.That(actual, Is.EqualTo(localitiesCount));
         }
 
         [Test]
@@ -1280,7 +1280,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1288,7 +1288,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(localitiesCount, actual);
+            Assert.That(actual, Is.EqualTo(localitiesCount));
         }
 
         [Test]
@@ -1316,7 +1316,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1324,7 +1324,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(localitiesCount, actual);
+            Assert.That(actual, Is.EqualTo(localitiesCount));
         }
 
         [Test]
@@ -1339,9 +1339,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 await foreach (PhoneNumberLocality locality in localities)
                 {
                     Console.WriteLine("Locality " + locality.LocalizedName);
-                    Assert.AreEqual(locality.AdministrativeDivision.AbbreviatedName, firstLocality.AdministrativeDivision.AbbreviatedName);
+                    Assert.That(firstLocality.AdministrativeDivision.AbbreviatedName, Is.EqualTo(locality.AdministrativeDivision.AbbreviatedName));
                 }
-                Assert.IsNotNull(localities);
+                Assert.That(localities, Is.Not.Null);
                 break;
             }
         }
@@ -1358,9 +1358,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 foreach (PhoneNumberLocality locality in localities)
                 {
                     Console.WriteLine("Locality " + locality.LocalizedName);
-                    Assert.AreEqual(locality.AdministrativeDivision.AbbreviatedName, firstLocality.AdministrativeDivision.AbbreviatedName);
+                    Assert.That(firstLocality.AdministrativeDivision.AbbreviatedName, Is.EqualTo(locality.AdministrativeDivision.AbbreviatedName));
                 }
-                Assert.IsNotNull(localities);
+                Assert.That(localities, Is.Not.Null);
                 break;
             }
         }
@@ -1376,7 +1376,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Offering " + offering.ToString());
             }
-            Assert.IsNotNull(offerings);
+            Assert.That(offerings, Is.Not.Null);
         }
 
         [Test]
@@ -1390,7 +1390,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Offering " + offering.ToString());
             }
-            Assert.IsNotNull(offerings);
+            Assert.That(offerings, Is.Not.Null);
         }
 
         [Test]
@@ -1418,7 +1418,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1426,7 +1426,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(offeringsCount, actual);
+            Assert.That(actual, Is.EqualTo(offeringsCount));
         }
 
         [Test]
@@ -1454,7 +1454,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 // guaranteed to be of expectedPageSize
                 if (actual == 0)
                 {
-                    Assert.AreEqual(expectedPageSize, page.Values.Count);
+                    Assert.That(page.Values.Count, Is.EqualTo(expectedPageSize));
                 }
                 foreach (var phoneNumber in page.Values)
                 {
@@ -1462,7 +1462,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
                 }
             }
 
-            Assert.AreEqual(offeringsCount, actual);
+            Assert.That(actual, Is.EqualTo(offeringsCount));
         }
 
         [Test]
@@ -1476,7 +1476,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Offering " + offering.ToString());
             }
-            Assert.IsNotNull(offerings);
+            Assert.That(offerings, Is.Not.Null);
         }
 
         [Test]
@@ -1490,7 +1490,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             {
                 Console.WriteLine("Offering " + offering.ToString());
             }
-            Assert.IsNotNull(offerings);
+            Assert.That(offerings, Is.Not.Null);
         }
 
         [Test]
@@ -1503,7 +1503,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var client = CreateClient();
 
             var results = await client.SearchOperatorInformationAsync(phoneNumbers);
-            Assert.AreEqual(phoneNumber, results.Value.Values[0].PhoneNumber);
+            Assert.That(results.Value.Values[0].PhoneNumber, Is.EqualTo(phoneNumber));
         }
 
         [Test]
@@ -1516,7 +1516,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var client = CreateClient();
 
             var results = client.SearchOperatorInformation(phoneNumbers);
-            Assert.AreEqual(phoneNumber, results.Value.Values[0].PhoneNumber);
+            Assert.That(results.Value.Values[0].PhoneNumber, Is.EqualTo(phoneNumber));
         }
 
         [Test]
@@ -1534,7 +1534,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
                 return;
             }
 
@@ -1556,7 +1556,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsTrue(IsClientError(ex.Status), $"Status code {ex.Status} does not indicate a client error.");
+                Assert.That(IsClientError(ex.Status), Is.True, $"Status code {ex.Status} does not indicate a client error.");
                 return;
             }
 
@@ -1574,19 +1574,19 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var results = await client.SearchOperatorInformationAsync(phoneNumbers, new OperatorInformationOptions() { IncludeAdditionalOperatorDetails = false });
             var operatorInformation = results.Value.Values[0];
-            Assert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
-            Assert.IsNotNull(operatorInformation.InternationalFormat);
-            Assert.IsNotNull(operatorInformation.NationalFormat);
-            Assert.IsNull(operatorInformation.IsoCountryCode);
-            Assert.IsNull(operatorInformation.OperatorDetails);
+            Assert.That(operatorInformation.PhoneNumber, Is.EqualTo(phoneNumber));
+            Assert.That(operatorInformation.InternationalFormat, Is.Not.Null);
+            Assert.That(operatorInformation.NationalFormat, Is.Not.Null);
+            Assert.That(operatorInformation.IsoCountryCode, Is.Null);
+            Assert.That(operatorInformation.OperatorDetails, Is.Null);
 
             results = await client.SearchOperatorInformationAsync(phoneNumbers, new OperatorInformationOptions() { IncludeAdditionalOperatorDetails = true });
             operatorInformation = results.Value.Values[0];
-            Assert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
-            Assert.IsNotNull(operatorInformation.InternationalFormat);
-            Assert.IsNotNull(operatorInformation.NationalFormat);
-            Assert.IsNotNull(operatorInformation.IsoCountryCode);
-            Assert.IsNotNull(operatorInformation.OperatorDetails);
+            Assert.That(operatorInformation.PhoneNumber, Is.EqualTo(phoneNumber));
+            Assert.That(operatorInformation.InternationalFormat, Is.Not.Null);
+            Assert.That(operatorInformation.NationalFormat, Is.Not.Null);
+            Assert.That(operatorInformation.IsoCountryCode, Is.Not.Null);
+            Assert.That(operatorInformation.OperatorDetails, Is.Not.Null);
         }
 
         [Test]
@@ -1600,19 +1600,19 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var results = client.SearchOperatorInformation(phoneNumbers, new OperatorInformationOptions() { IncludeAdditionalOperatorDetails = false });
             var operatorInformation = results.Value.Values[0];
-            Assert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
-            Assert.IsNotNull(operatorInformation.InternationalFormat);
-            Assert.IsNotNull(operatorInformation.NationalFormat);
-            Assert.IsNull(operatorInformation.IsoCountryCode);
-            Assert.IsNull(operatorInformation.OperatorDetails);
+            Assert.That(operatorInformation.PhoneNumber, Is.EqualTo(phoneNumber));
+            Assert.That(operatorInformation.InternationalFormat, Is.Not.Null);
+            Assert.That(operatorInformation.NationalFormat, Is.Not.Null);
+            Assert.That(operatorInformation.IsoCountryCode, Is.Null);
+            Assert.That(operatorInformation.OperatorDetails, Is.Null);
 
             results = client.SearchOperatorInformation(phoneNumbers, new OperatorInformationOptions() { IncludeAdditionalOperatorDetails = true });
             operatorInformation = results.Value.Values[0];
-            Assert.AreEqual(phoneNumber, operatorInformation.PhoneNumber);
-            Assert.IsNotNull(operatorInformation.InternationalFormat);
-            Assert.IsNotNull(operatorInformation.NationalFormat);
-            Assert.IsNotNull(operatorInformation.IsoCountryCode);
-            Assert.IsNotNull(operatorInformation.OperatorDetails);
+            Assert.That(operatorInformation.PhoneNumber, Is.EqualTo(phoneNumber));
+            Assert.That(operatorInformation.InternationalFormat, Is.Not.Null);
+            Assert.That(operatorInformation.NationalFormat, Is.Not.Null);
+            Assert.That(operatorInformation.IsoCountryCode, Is.Not.Null);
+            Assert.That(operatorInformation.OperatorDetails, Is.Not.Null);
         }
 
         private static bool IsSuccess(int statusCode)

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersReservationsTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersClient/PhoneNumbersReservationsTests.cs
@@ -66,14 +66,14 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = await client.CreateOrUpdateReservationAsync(request).ConfigureAwait(false);
 
             // The response should be a 201 Created.
-            Assert.AreEqual(201, reservationResponse.GetRawResponse().Status);
-            Assert.IsNotNull(reservationResponse.Value);
-            Assert.AreEqual(reservationId, reservationResponse.Value.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationResponse.Value.Status);
-            Assert.IsEmpty(reservationResponse.Value.PhoneNumbers);
+            Assert.That(reservationResponse.GetRawResponse().Status, Is.EqualTo(201));
+            Assert.That(reservationResponse.Value, Is.Not.Null);
+            Assert.That(reservationResponse.Value.Id, Is.EqualTo(reservationId));
+            Assert.That(reservationResponse.Value.Status, Is.EqualTo(ReservationStatus.Active));
+            Assert.That(reservationResponse.Value.PhoneNumbers, Is.Empty);
             if (Mode != RecordedTestMode.Playback)
             {
-                Assert.Greater(reservationResponse.Value.ExpiresAt, DateTimeOffset.UtcNow);
+                Assert.That(reservationResponse.Value.ExpiresAt, Is.GreaterThan(DateTimeOffset.UtcNow));
             }
 
             _initialReservationState = reservationResponse.Value;
@@ -91,14 +91,14 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = client.CreateOrUpdateReservation(request);
 
             // The response should be a 201 Created.
-            Assert.AreEqual(201, reservationResponse.GetRawResponse().Status);
-            Assert.IsNotNull(reservationResponse.Value);
-            Assert.AreEqual(reservationId, reservationResponse.Value.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationResponse.Value.Status);
-            Assert.IsEmpty(reservationResponse.Value.PhoneNumbers);
+            Assert.That(reservationResponse.GetRawResponse().Status, Is.EqualTo(201));
+            Assert.That(reservationResponse.Value, Is.Not.Null);
+            Assert.That(reservationResponse.Value.Id, Is.EqualTo(reservationId));
+            Assert.That(reservationResponse.Value.Status, Is.EqualTo(ReservationStatus.Active));
+            Assert.That(reservationResponse.Value.PhoneNumbers, Is.Empty);
             if (Mode != RecordedTestMode.Playback)
             {
-                Assert.Greater(reservationResponse.Value.ExpiresAt, DateTimeOffset.UtcNow);
+                Assert.That(reservationResponse.Value.ExpiresAt, Is.GreaterThan(DateTimeOffset.UtcNow));
             }
 
             _initialReservationState = reservationResponse.Value;
@@ -115,16 +115,16 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var response = await client.BrowseAvailableNumbersAsync(browseRequest);
 
-            Assert.IsNotNull(response.Value);
-            Assert.Greater(response.Value.PhoneNumbers.Count, 0);
+            Assert.That(response.Value, Is.Not.Null);
+            Assert.That(response.Value.PhoneNumbers.Count, Is.GreaterThan(0));
 
             browseRequest = new PhoneNumbersBrowseOptions("IE", PhoneNumberType.Mobile);
 
             response = await client.BrowseAvailableNumbersAsync(browseRequest);
 
-            Assert.IsNotNull(response.Value);
-            Assert.Greater(response.Value.PhoneNumbers.Count, 0);
-            Assert.IsTrue(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.Mobile);
+            Assert.That(response.Value, Is.Not.Null);
+            Assert.That(response.Value.PhoneNumbers.Count, Is.GreaterThan(0));
+            Assert.That(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.Mobile, Is.True);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "BrowseAvailableNumbersUsingConnectionString")]
@@ -138,17 +138,17 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var response = client.BrowseAvailableNumbers(browseRequest);
 
-            Assert.IsNotNull(response.Value);
-            Assert.Greater(response.Value.PhoneNumbers.Count, 0);
-            Assert.IsTrue(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.TollFree);
+            Assert.That(response.Value, Is.Not.Null);
+            Assert.That(response.Value.PhoneNumbers.Count, Is.GreaterThan(0));
+            Assert.That(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.TollFree, Is.True);
 
             browseRequest = new PhoneNumbersBrowseOptions("IE", PhoneNumberType.Mobile);
 
             response = client.BrowseAvailableNumbers(browseRequest);
 
-            Assert.IsNotNull(response.Value);
-            Assert.Greater(response.Value.PhoneNumbers.Count, 0);
-            Assert.IsTrue(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.Mobile);
+            Assert.That(response.Value, Is.Not.Null);
+            Assert.That(response.Value.PhoneNumbers.Count, Is.GreaterThan(0));
+            Assert.That(response.Value.PhoneNumbers[0].PhoneNumberType == PhoneNumberType.Mobile, Is.True);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPhoneNumbersReservationsAsyncWithConnectionString")]
@@ -163,9 +163,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationsPageable = client.GetReservationsAsync();
             var reservations = await reservationsPageable.ToEnumerableAsync();
 
-            Assert.IsNotNull(reservations);
-            Assert.Greater(reservations.Count, 0);
-            Assert.True(reservations.Any(reservations => reservations.Id == _initialReservationState?.Id));
+            Assert.That(reservations, Is.Not.Null);
+            Assert.That(reservations.Count, Is.GreaterThan(0));
+            Assert.That(reservations.Any(reservations => reservations.Id == _initialReservationState?.Id), Is.True);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetPhoneNumbersReservationsWithConnectionString")]
@@ -179,9 +179,9 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             var reservations = client.GetReservations();
 
-            Assert.IsNotNull(reservations);
-            Assert.Greater(reservations.Count(), 0);
-            Assert.True(reservations.Any(reservations => reservations.Id == _initialReservationState?.Id));
+            Assert.That(reservations, Is.Not.Null);
+            Assert.That(reservations.Count(), Is.GreaterThan(0));
+            Assert.That(reservations.Any(reservations => reservations.Id == _initialReservationState?.Id), Is.True);
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetReservationAsyncUsingConnectionString")]
@@ -196,10 +196,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = await client.GetReservationAsync((Guid)(_initialReservationState!.Id)!);
             var reservation = reservationResponse.Value;
 
-            Assert.IsNotNull(reservation);
-            Assert.AreEqual(_initialReservationState!.Id, reservation.Id);
-            Assert.AreEqual(_initialReservationState!.ExpiresAt, reservation.ExpiresAt);
-            Assert.AreEqual(_initialReservationState!.Status, reservation.Status);
+            Assert.That(reservation, Is.Not.Null);
+            Assert.That(reservation.Id, Is.EqualTo(_initialReservationState!.Id));
+            Assert.That(reservation.ExpiresAt, Is.EqualTo(_initialReservationState!.ExpiresAt));
+            Assert.That(reservation.Status, Is.EqualTo(_initialReservationState!.Status));
         }
 
         [TestCase(AuthMethod.ConnectionString, TestName = "GetReservationUsingConnectionString")]
@@ -214,10 +214,10 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = client.GetReservation((Guid)(_initialReservationState!.Id)!);
             var reservation = reservationResponse.Value;
 
-            Assert.IsNotNull(reservation);
-            Assert.AreEqual(_initialReservationState!.Id, reservation.Id);
-            Assert.AreEqual(_initialReservationState!.ExpiresAt, reservation.ExpiresAt);
-            Assert.AreEqual(_initialReservationState!.Status, reservation.Status);
+            Assert.That(reservation, Is.Not.Null);
+            Assert.That(reservation.Id, Is.EqualTo(_initialReservationState!.Id));
+            Assert.That(reservation.ExpiresAt, Is.EqualTo(_initialReservationState!.ExpiresAt));
+            Assert.That(reservation.Status, Is.EqualTo(_initialReservationState!.Status));
         }
 
         [TestCase(AuthMethod.ConnectionString, "US", "tollFree", TestName = "CreateOrUpdateReservationAsyncTollFreeUsingConnectionString")]
@@ -249,12 +249,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = await client.CreateOrUpdateReservationAsync(updateRequest).ConfigureAwait(false);
             var reservationAfterAdd = reservationResponse.Value;
 
-            Assert.IsNotNull(reservationAfterAdd);
-            Assert.AreEqual(_initialReservationState!.Id, reservationAfterAdd.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationAfterAdd.Status);
-            Assert.Greater(reservationAfterAdd.ExpiresAt, _initialReservationState.ExpiresAt);
-            Assert.IsTrue(reservationAfterAdd.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
-            Assert.IsTrue(reservationAfterAdd.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
+            Assert.That(reservationAfterAdd, Is.Not.Null);
+            Assert.That(reservationAfterAdd.Id, Is.EqualTo(_initialReservationState!.Id));
+            Assert.That(reservationAfterAdd.Status, Is.EqualTo(ReservationStatus.Active));
+            Assert.That(reservationAfterAdd.ExpiresAt, Is.GreaterThan(_initialReservationState.ExpiresAt));
+            Assert.That(reservationAfterAdd.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error), Is.True);
+            Assert.That(reservationAfterAdd.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id), Is.True);
 
             // Now remove the reserved number
             var phoneNumberIdToRemove = phoneNumberToReserve.Id;
@@ -266,12 +266,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
 
             reservationResponse = await client.CreateOrUpdateReservationAsync(removeRequest).ConfigureAwait(false);
             var reservationAfterRemove = reservationResponse.Value;
-            Assert.IsNotNull(reservationAfterRemove);
-            Assert.AreEqual(_initialReservationState!.Id, reservationAfterRemove.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationAfterRemove.Status);
-            Assert.Greater(reservationAfterRemove.ExpiresAt, reservationAfterAdd.ExpiresAt);
-            Assert.IsTrue(reservationAfterRemove.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
-            Assert.IsFalse(reservationAfterRemove.PhoneNumbers.ContainsKey(phoneNumberIdToRemove));
+            Assert.That(reservationAfterRemove, Is.Not.Null);
+            Assert.That(reservationAfterRemove.Id, Is.EqualTo(_initialReservationState!.Id));
+            Assert.That(reservationAfterRemove.Status, Is.EqualTo(ReservationStatus.Active));
+            Assert.That(reservationAfterRemove.ExpiresAt, Is.GreaterThan(reservationAfterAdd.ExpiresAt));
+            Assert.That(reservationAfterRemove.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error), Is.True);
+            Assert.That(reservationAfterRemove.PhoneNumbers.ContainsKey(phoneNumberIdToRemove), Is.False);
         }
 
         [TestCase(AuthMethod.ConnectionString, "US", "tollFree", TestName = "CreateOrUpdateReservationTollFreeUsingConnectionString")]
@@ -303,12 +303,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = client.CreateOrUpdateReservation(updateRequest);
             var reservationAfterAdd = reservationResponse.Value;
 
-            Assert.IsNotNull(reservationAfterAdd);
-            Assert.AreEqual(reservationBeforeAdd.Id, reservationAfterAdd.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationAfterAdd.Status);
-            Assert.Greater(reservationAfterAdd.ExpiresAt, reservationBeforeAdd.ExpiresAt);
-            Assert.IsTrue(reservationAfterAdd.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
-            Assert.IsTrue(reservationAfterAdd.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
+            Assert.That(reservationAfterAdd, Is.Not.Null);
+            Assert.That(reservationAfterAdd.Id, Is.EqualTo(reservationBeforeAdd.Id));
+            Assert.That(reservationAfterAdd.Status, Is.EqualTo(ReservationStatus.Active));
+            Assert.That(reservationAfterAdd.ExpiresAt, Is.GreaterThan(reservationBeforeAdd.ExpiresAt));
+            Assert.That(reservationAfterAdd.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error), Is.True);
+            Assert.That(reservationAfterAdd.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id), Is.True);
 
             // Now remove the reserved number
             var phoneNumberIdToRemove = phoneNumberToReserve.Id;
@@ -321,12 +321,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             reservationResponse = client.CreateOrUpdateReservation(removeRequest);
             var reservationAfterRemove = reservationResponse.Value;
 
-            Assert.IsNotNull(reservationAfterRemove);
-            Assert.AreEqual(reservationBeforeRemove.Id, reservationAfterRemove.Id);
-            Assert.AreEqual(ReservationStatus.Active, reservationAfterRemove.Status);
-            Assert.Greater(reservationAfterRemove.ExpiresAt, reservationBeforeRemove.ExpiresAt);
-            Assert.IsTrue(reservationAfterRemove.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error));
-            Assert.IsFalse(reservationAfterRemove.PhoneNumbers.ContainsKey(phoneNumberIdToRemove));
+            Assert.That(reservationAfterRemove, Is.Not.Null);
+            Assert.That(reservationAfterRemove.Id, Is.EqualTo(reservationBeforeRemove.Id));
+            Assert.That(reservationAfterRemove.Status, Is.EqualTo(ReservationStatus.Active));
+            Assert.That(reservationAfterRemove.ExpiresAt, Is.GreaterThan(reservationBeforeRemove.ExpiresAt));
+            Assert.That(reservationAfterRemove.PhoneNumbers.Values.All(number => number.Status != PhoneNumberAvailabilityStatus.Error), Is.True);
+            Assert.That(reservationAfterRemove.PhoneNumbers.ContainsKey(phoneNumberIdToRemove), Is.False);
         }
 
         [TestCase]
@@ -339,7 +339,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             await client.DeleteReservationAsync(_initialReservationState!.Id);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () => await client.GetReservationAsync(_initialReservationState!.Id));
-            Assert.AreEqual(404, exception!.Status);
+            Assert.That(exception!.Status, Is.EqualTo(404));
         }
 
         [TestCase]
@@ -352,7 +352,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             client.DeleteReservation(_initialReservationState!.Id);
 
             var exception = Assert.Throws<RequestFailedException>(() => client.GetReservation(_initialReservationState!.Id));
-            Assert.AreEqual(404, exception!.Status);
+            Assert.That(exception!.Status, Is.EqualTo(404));
         }
 
         [TestCase]
@@ -376,7 +376,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var phoneNumberToReserve = availablePhoneNumbers.First();
 
             // The phone number should require an agreement to not resell.
-            Assert.IsTrue(phoneNumberToReserve.IsAgreementToNotResellRequired);
+            Assert.That(phoneNumberToReserve.IsAgreementToNotResellRequired, Is.True);
 
             var reservationId = GetReservationId();
             var request = new CreateOrUpdateReservationOptions(reservationId)
@@ -387,12 +387,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = await client.CreateOrUpdateReservationAsync(request).ConfigureAwait(false);
 
             // The phone number was successfully reserved.
-            Assert.IsTrue(reservationResponse.Value.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservationResponse.Value.PhoneNumbers[phoneNumberToReserve.Id]);
+            Assert.That(reservationResponse.Value.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id), Is.True);
+            Assert.That(reservationResponse.Value.PhoneNumbers[phoneNumberToReserve.Id], Is.Not.EqualTo(PhoneNumberAvailabilityStatus.Error));
 
             // The phone number should not be purchasable without agreeing to not resell.
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () => await client.StartPurchaseReservationAsync(reservationId, agreeToNotResell: false));
-            Assert.AreEqual(400, exception!.Status);
+            Assert.That(exception!.Status, Is.EqualTo(400));
 
             // Clean up the reservation.
             await client.DeleteReservationAsync(reservationId);
@@ -419,7 +419,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var phoneNumberToReserve = availablePhoneNumbers.First();
 
             // The phone number should require an agreement to not resell.
-            Assert.IsTrue(phoneNumberToReserve.IsAgreementToNotResellRequired);
+            Assert.That(phoneNumberToReserve.IsAgreementToNotResellRequired, Is.True);
 
             var reservationId = GetReservationId();
             var request = new CreateOrUpdateReservationOptions(reservationId)
@@ -430,12 +430,12 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var reservationResponse = client.CreateOrUpdateReservation(request);
 
             // The phone number was successfully reserved.
-            Assert.IsTrue(reservationResponse.Value.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id));
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservationResponse.Value.PhoneNumbers[phoneNumberToReserve.Id]);
+            Assert.That(reservationResponse.Value.PhoneNumbers.ContainsKey(phoneNumberToReserve.Id), Is.True);
+            Assert.That(reservationResponse.Value.PhoneNumbers[phoneNumberToReserve.Id], Is.Not.EqualTo(PhoneNumberAvailabilityStatus.Error));
 
             // The phone number should not be purchasable without agreeing to not resell.
             var exception = Assert.Throws<RequestFailedException>(() => client.StartPurchaseReservation(reservationId, agreeToNotResell: false));
-            Assert.AreEqual(400, exception!.Status);
+            Assert.That(exception!.Status, Is.EqualTo(400));
 
             // Clean up the reservation.
             client.DeleteReservation(reservationId);

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumberSearchResultErrorTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumberSearchResultErrorTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
         public void Constructor_SetsValue_WhenValueIsNotNull(string value)
         {
             var error = new PhoneNumberSearchResultError(value);
-            Assert.AreEqual(value, error.ToString());
+            Assert.That(error.ToString(), Is.EqualTo(value));
         }
 
         [Test]
@@ -43,7 +43,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("NoError");
 
-            Assert.IsTrue(error1 == error2);
+            Assert.That(error1 == error2, Is.True);
         }
 
         [Test]
@@ -52,14 +52,14 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("UnknownErrorCode");
 
-            Assert.IsTrue(error1 != error2);
+            Assert.That(error1, Is.Not.EqualTo(error2));
         }
 
         [Test]
         public void ImplicitConversion_ReturnsCorrectError()
         {
             PhoneNumberSearchResultError error = "NoError";
-            Assert.AreEqual("NoError", error.ToString());
+            Assert.That(error.ToString(), Is.EqualTo("NoError"));
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("NoError");
 
-            Assert.IsTrue(error1.Equals(error2));
+            Assert.That(error1.Equals(error2), Is.True);
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("UnknownErrorCode");
 
-            Assert.IsFalse(error1.Equals(error2));
+            Assert.That(error1, Is.Not.EqualTo(error2));
         }
 
         [Test]
@@ -86,14 +86,14 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("NoError");
 
-            Assert.AreEqual(error1.GetHashCode(), error2.GetHashCode());
+            Assert.That(error2.GetHashCode(), Is.EqualTo(error1.GetHashCode()));
         }
 
         [Test]
         public void ToString_ReturnsCorrectValue()
         {
             var error = new PhoneNumberSearchResultError("NoError");
-            Assert.AreEqual("NoError", error.ToString());
+            Assert.That(error.ToString(), Is.EqualTo("NoError"));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumberSearchResultErrorTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumberSearchResultErrorTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("UnknownErrorCode");
 
-            Assert.That(error1, Is.Not.EqualTo(error2));
+            Assert.That(error1 != error2, Is.True);
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error1 = new PhoneNumberSearchResultError("NoError");
             var error2 = new PhoneNumberSearchResultError("UnknownErrorCode");
 
-            Assert.That(error1, Is.Not.EqualTo(error2));
+            Assert.That(error1.Equals(error2), Is.False);
         }
 
         [Test]

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumbersModelFactoryTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/PhoneNumbersModels/PhoneNumbersModelFactoryTests.cs
@@ -13,17 +13,17 @@ namespace Azure.Communication.PhoneNumbers.Tests
         public void PhoneNumberAreaCode_ShouldReturnInstanceOfPhoneNumberAreaCode()
         {
             var result = PhoneNumbersModelFactory.PhoneNumberAreaCode("123");
-            Assert.IsNotNull(result);
-            Assert.AreEqual("123", result.AreaCode);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.AreaCode, Is.EqualTo("123"));
         }
 
         [Test]
         public void PhoneNumberCountry_WhenLocalizedAndCountryCodeNotNull_ShouldReturnInstanceOfPhoneNumberCountry()
         {
             var result = PhoneNumbersModelFactory.PhoneNumberCountry("USA", "US");
-            Assert.IsNotNull(result);
-            Assert.AreEqual("USA", result.LocalizedName);
-            Assert.AreEqual("US", result.CountryCode);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.LocalizedName, Is.EqualTo("USA"));
+            Assert.That(result.CountryCode, Is.EqualTo("US"));
         }
 
         [Test]
@@ -31,18 +31,18 @@ namespace Azure.Communication.PhoneNumbers.Tests
         {
             var administrativeDivision = PhoneNumbersModelFactory.PhoneNumberAdministrativeDivision("Washington", "WA");
             var result = PhoneNumbersModelFactory.PhoneNumberLocality("Seattle", administrativeDivision);
-            Assert.IsNotNull(result);
-            Assert.AreEqual("Seattle", result.LocalizedName);
-            Assert.AreEqual(administrativeDivision, result.AdministrativeDivision);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.LocalizedName, Is.EqualTo("Seattle"));
+            Assert.That(result.AdministrativeDivision, Is.EqualTo(administrativeDivision));
         }
 
         [Test]
         public void PhoneNumberAdministrativeDivision_WhenLocalizedAndAbbreviatedNameNotNull_ShouldReturnInstanceOfPhoneNumberAdministrativeDivision()
         {
             var result = PhoneNumbersModelFactory.PhoneNumberAdministrativeDivision("Washington", "WA");
-            Assert.IsNotNull(result);
-            Assert.AreEqual("Washington", result.LocalizedName);
-            Assert.AreEqual("WA", result.AbbreviatedName);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.LocalizedName, Is.EqualTo("Washington"));
+            Assert.That(result.AbbreviatedName, Is.EqualTo("WA"));
         }
 
         [Test]
@@ -51,21 +51,21 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var capabilities = new PhoneNumberCapabilities(PhoneNumberCapabilityType.Inbound, PhoneNumberCapabilityType.Inbound);
             var cost = PhoneNumbersModelFactory.PhoneNumberCost(10, "USD", BillingFrequency.Monthly);
             var result = PhoneNumbersModelFactory.PhoneNumberOffering(PhoneNumberType.Geographic, PhoneNumberAssignmentType.Application, capabilities, cost);
-            Assert.IsNotNull(result);
-            Assert.AreEqual(PhoneNumberType.Geographic, result.PhoneNumberType);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, result.AssignmentType);
-            Assert.AreEqual(capabilities, result.AvailableCapabilities);
-            Assert.AreEqual(cost, result.Cost);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.PhoneNumberType, Is.EqualTo(PhoneNumberType.Geographic));
+            Assert.That(result.AssignmentType, Is.EqualTo(PhoneNumberAssignmentType.Application));
+            Assert.That(result.AvailableCapabilities, Is.EqualTo(capabilities));
+            Assert.That(result.Cost, Is.EqualTo(cost));
         }
 
         [Test]
         public void PhoneNumberCost_WhenIsoCurrencySymbolNotNull_ShouldReturnInstanceOfPhoneNumberCost()
         {
             var result = PhoneNumbersModelFactory.PhoneNumberCost(10, "USD", BillingFrequency.Monthly);
-            Assert.IsNotNull(result);
-            Assert.AreEqual(10, result.Amount);
-            Assert.AreEqual("USD", result.IsoCurrencySymbol);
-            Assert.AreEqual(BillingFrequency.Monthly, result.BillingFrequency);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Amount, Is.EqualTo(10));
+            Assert.That(result.IsoCurrencySymbol, Is.EqualTo("USD"));
+            Assert.That(result.BillingFrequency, Is.EqualTo(BillingFrequency.Monthly));
         }
 
         [Test]
@@ -77,15 +77,15 @@ namespace Azure.Communication.PhoneNumbers.Tests
             var error = PhoneNumberSearchResultError.NoError;
 
             var result = PhoneNumbersModelFactory.PhoneNumberSearchResult("search1", phoneNumbers, PhoneNumberType.Geographic, PhoneNumberAssignmentType.Application, capabilities, cost, DateTimeOffset.Now, 0, error);
-            Assert.IsNotNull(result);
-            Assert.AreEqual("search1", result.SearchId);
-            Assert.AreEqual(phoneNumbers, result.PhoneNumbers);
-            Assert.AreEqual(PhoneNumberType.Geographic, result.PhoneNumberType);
-            Assert.AreEqual(PhoneNumberAssignmentType.Application, result.AssignmentType);
-            Assert.AreEqual(capabilities, result.Capabilities);
-            Assert.AreEqual(cost, result.Cost);
-            Assert.AreEqual(0, result.ErrorCode);
-            Assert.AreEqual(error, result.Error);
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.SearchId, Is.EqualTo("search1"));
+            Assert.That(result.PhoneNumbers, Is.EqualTo(phoneNumbers));
+            Assert.That(result.PhoneNumberType, Is.EqualTo(PhoneNumberType.Geographic));
+            Assert.That(result.AssignmentType, Is.EqualTo(PhoneNumberAssignmentType.Application));
+            Assert.That(result.Capabilities, Is.EqualTo(capabilities));
+            Assert.That(result.Cost, Is.EqualTo(cost));
+            Assert.That(result.ErrorCode, Is.EqualTo(0));
+            Assert.That(result.Error, Is.EqualTo(error));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/SipRouting/SipRoutingClientLiveTests.cs
@@ -37,8 +37,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
         public async Task ClearConfiguration()
         {
             var client = CreateClient();
-            Assert.AreEqual(200, (await client.SetRoutesAsync(new List<SipTrunkRoute>())).Status);
-            Assert.AreEqual(200, (await client.SetTrunksAsync(new List<SipTrunk>())).Status);
+            Assert.That((await client.SetRoutesAsync(new List<SipTrunkRoute>())).Status, Is.EqualTo(200));
+            Assert.That((await client.SetTrunksAsync(new List<SipTrunk>())).Status, Is.EqualTo(200));
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var client = CreateClientWithTokenCredential();
 
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
-            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var client = CreateClientWithTokenCredential();
 
             var response = await client.SetTrunkAsync(new SipTrunk(TestData!.TrunkList[0].Fqdn, 5555)).ConfigureAwait(false);
-            Assert.AreEqual(200, response.Status);
+            Assert.That(response.Status, Is.EqualTo(200));
         }
 
         [Test]
@@ -81,10 +81,10 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
             var trunks = response.Value;
 
-            Assert.IsNotNull(trunks);
-            Assert.AreEqual(TestData!.TrunkList.Count, trunks.Count());
-            Assert.IsTrue(TrunkAreEqual(TestData!.TrunkList[0], trunks[0]));
-            Assert.IsTrue(TrunkAreEqual(TestData!.TrunkList[1], trunks[1]));
+            Assert.That(trunks, Is.Not.Null);
+            Assert.That(trunks.Count(), Is.EqualTo(TestData!.TrunkList.Count));
+            Assert.That(TrunkAreEqual(TestData!.TrunkList[0], trunks[0]), Is.True);
+            Assert.That(TrunkAreEqual(TestData!.TrunkList[1], trunks[1]), Is.True);
         }
 
         [Test]
@@ -100,9 +100,9 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetRoutesAsync().ConfigureAwait(false);
             var routes = response.Value;
 
-            Assert.IsNotNull(routes);
-            Assert.AreEqual(1, routes.Count());
-            Assert.IsTrue(RouteAreEqual(TestData!.RuleWithoutTrunks, routes[0]));
+            Assert.That(routes, Is.Not.Null);
+            Assert.That(routes.Count(), Is.EqualTo(1));
+            Assert.That(RouteAreEqual(TestData!.RuleWithoutTrunks, routes[0]), Is.True);
         }
 
         [Test]
@@ -117,8 +117,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.SetTrunkAsync(TestData!.NewTrunk).ConfigureAwait(false);
             var actualTrunks = await client.GetTrunksAsync().ConfigureAwait(false);
 
-            Assert.AreEqual(3, actualTrunks.Value.Count());
-            Assert.IsNotNull(actualTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.NewTrunk.Fqdn));
+            Assert.That(actualTrunks.Value.Count(), Is.EqualTo(3));
+            Assert.That(actualTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.NewTrunk.Fqdn), Is.Not.Null);
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             await client.SetTrunkAsync(modifiedTrunk).ConfigureAwait(false);
 
             var actualTrunk = await client.GetTrunkAsync(TestData!.TrunkList[0].Fqdn).ConfigureAwait(false);
-            Assert.AreEqual(modifiedTrunk.SipSignalingPort, actualTrunk.Value.SipSignalingPort);
+            Assert.That(actualTrunk.Value.SipSignalingPort, Is.EqualTo(modifiedTrunk.SipSignalingPort));
         }
 
         [Test]
@@ -147,13 +147,13 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var client = InitializeTest();
             var initialTrunks = await client.GetTrunksAsync().ConfigureAwait(false);
-            Assert.AreEqual(TestData!.TrunkList.Count, initialTrunks.Value.Count());
+            Assert.That(initialTrunks.Value.Count(), Is.EqualTo(TestData!.TrunkList.Count));
 
             await client.DeleteTrunkAsync(TestData!.TrunkList[1].Fqdn).ConfigureAwait(false);
 
             var finalTrunks = await client.GetTrunksAsync().ConfigureAwait(false);
-            Assert.AreEqual(TestData!.TrunkList.Count - 1, finalTrunks.Value.Count());
-            Assert.IsNull(finalTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.TrunkList[1].Fqdn));
+            Assert.That(finalTrunks.Value.Count(), Is.EqualTo(TestData!.TrunkList.Count - 1));
+            Assert.That(finalTrunks.Value.FirstOrDefault(x => x.Fqdn == TestData!.TrunkList[1].Fqdn), Is.Null);
         }
 
         [Test]
@@ -169,8 +169,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetTrunkAsync(TestData!.TrunkList[1].Fqdn).ConfigureAwait(false);
 
             var trunk = response.Value;
-            Assert.IsNotNull(trunk);
-            Assert.IsTrue(TrunkAreEqual(TestData!.TrunkList[1], trunk));
+            Assert.That(trunk, Is.Not.Null);
+            Assert.That(TrunkAreEqual(TestData!.TrunkList[1], trunk), Is.True);
         }
 
         [Test]
@@ -188,9 +188,9 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetRoutesAsync().ConfigureAwait(false);
 
             var newRoutes = response.Value;
-            Assert.IsNotNull(newRoutes);
-            Assert.AreEqual(1, newRoutes.Count);
-            Assert.IsTrue(RouteAreEqual(TestData!.RuleWithoutTrunks2, newRoutes[0]));
+            Assert.That(newRoutes, Is.Not.Null);
+            Assert.That(newRoutes.Count, Is.EqualTo(1));
+            Assert.That(RouteAreEqual(TestData!.RuleWithoutTrunks2, newRoutes[0]), Is.True);
         }
 
         [Test]
@@ -207,9 +207,9 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
 
             var newTrunks = response.Value;
-            Assert.IsNotNull(newTrunks);
-            Assert.AreEqual(1, newTrunks.Count);
-            Assert.IsTrue(TrunkAreEqual(TestData!.NewTrunk, newTrunks[0]));
+            Assert.That(newTrunks, Is.Not.Null);
+            Assert.That(newTrunks.Count, Is.EqualTo(1));
+            Assert.That(TrunkAreEqual(TestData!.NewTrunk, newTrunks[0]), Is.True);
         }
 
         [Test]
@@ -227,8 +227,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
             var newTrunks = response.Value;
-            Assert.IsNotNull(newTrunks);
-            Assert.IsEmpty(newTrunks);
+            Assert.That(newTrunks, Is.Not.Null);
+            Assert.That(newTrunks, Is.Empty);
         }
 
         [Test]
@@ -246,8 +246,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var response = await client.GetTrunksAsync().ConfigureAwait(false);
             var newTrunks = response.Value;
-            Assert.IsNotNull(newTrunks);
-            Assert.IsEmpty(newTrunks);
+            Assert.That(newTrunks, Is.Not.Null);
+            Assert.That(newTrunks, Is.Empty);
         }
 
         [Test]
@@ -265,8 +265,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var response = await client.GetRoutesAsync().ConfigureAwait(false);
             var newRoutes = response.Value;
-            Assert.IsNotNull(newRoutes);
-            Assert.IsEmpty(newRoutes);
+            Assert.That(newRoutes, Is.Not.Null);
+            Assert.That(newRoutes, Is.Empty);
         }
 
         [Test]
@@ -284,8 +284,8 @@ namespace Azure.Communication.PhoneNumbers.SipRouting.Tests
 
             var response = await client.GetRoutesAsync().ConfigureAwait(false);
             var newRoutes = response.Value;
-            Assert.IsNotNull(newRoutes);
-            Assert.IsEmpty(newRoutes);
+            Assert.That(newRoutes, Is.Not.Null);
+            Assert.That(newRoutes, Is.Empty);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_PhoneNumbersClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_PhoneNumbersClient.cs
@@ -77,7 +77,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             #endregion Snippet:StartPurchaseSearchAsync
 
             await WaitForCompletionResponseAsync(purchaseOperation!);
-            Assert.AreEqual(purchaseOperation.GetRawResponse().Status, 200);
+            Assert.That(purchaseOperation.GetRawResponse().Status, Is.EqualTo(200));
 
             #region Snippet:GetPurchasedPhoneNumbersAsync
             var purchasedPhoneNumbers = client.GetPurchasedPhoneNumbersAsync();
@@ -99,8 +99,8 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             #endregion Snippet:UpdateCapabilitiesNumbersAsync
 
             await WaitForCompletionAsync(updateCapabilitiesOperation);
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, updateCapabilitiesOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.InboundOutbound, updateCapabilitiesOperation.Value.Capabilities.Sms);
+            Assert.That(updateCapabilitiesOperation.Value.Capabilities.Calling, Is.EqualTo(PhoneNumberCapabilityType.Outbound));
+            Assert.That(updateCapabilitiesOperation.Value.Capabilities.Sms, Is.EqualTo(PhoneNumberCapabilityType.InboundOutbound));
 
             #region Snippet:ReleasePhoneNumbersAsync
 
@@ -122,7 +122,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             {
                 purchasedPhoneNumbersAfterReleaseStatus = e.ErrorCode;
             }
-            Assert.AreEqual("NotFound", purchasedPhoneNumbersAfterReleaseStatus);
+            Assert.That(purchasedPhoneNumbersAfterReleaseStatus, Is.EqualTo("NotFound"));
         }
 
         private ValueTask<Response<T>> WaitForCompletionAsync<T>(Operation<T> operation) where T : notnull
@@ -186,7 +186,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:StartPurchaseSearch
 
-            Assert.AreEqual(purchaseOperation.GetRawResponse().Status, 200);
+            Assert.That(purchaseOperation.GetRawResponse().Status, Is.EqualTo(200));
 
             #region Snippet:GetPurchasedPhoneNumbers
             var purchasedPhoneNumbers = client.GetPurchasedPhoneNumbers();
@@ -212,8 +212,8 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:UpdateCapabilitiesNumbers
 
-            Assert.AreEqual(PhoneNumberCapabilityType.Outbound, updateCapabilitiesOperation.Value.Capabilities.Calling);
-            Assert.AreEqual(PhoneNumberCapabilityType.InboundOutbound, updateCapabilitiesOperation.Value.Capabilities.Sms);
+            Assert.That(updateCapabilitiesOperation.Value.Capabilities.Calling, Is.EqualTo(PhoneNumberCapabilityType.Outbound));
+            Assert.That(updateCapabilitiesOperation.Value.Capabilities.Sms, Is.EqualTo(PhoneNumberCapabilityType.InboundOutbound));
 
             #region Snippet:ReleasePhoneNumbers
             //@@var purchasedPhoneNumber = "<purchased_phone_number>";
@@ -239,7 +239,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             {
                 purchasedPhoneNumbersAfterReleaseStatus = e.ErrorCode;
             }
-            Assert.AreEqual("NotFound", purchasedPhoneNumbersAfterReleaseStatus);
+            Assert.That(purchasedPhoneNumbersAfterReleaseStatus, Is.EqualTo("NotFound"));
         }
 
         [TestCase]
@@ -280,9 +280,9 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:CreateReservationAsync
 
-            Assert.IsTrue(phoneNumbersToReserve.All(n => reservation.PhoneNumbers.ContainsKey(n.Id)));
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.First().Id]);
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.Last().Id]);
+            Assert.That(phoneNumbersToReserve.All(n => reservation.PhoneNumbers.ContainsKey(n.Id)), Is.True);
+            Assert.That(reservation.PhoneNumbers[phoneNumbersToReserve.First().Id], Is.Not.EqualTo(PhoneNumberAvailabilityStatus.Error));
+            Assert.That(reservation.PhoneNumbers[phoneNumbersToReserve.Last().Id], Is.Not.EqualTo(PhoneNumberAvailabilityStatus.Error));
 
             #region Snippet:CheckForPartialFailure
             var phoneNumbersWithError = reservation.PhoneNumbers.Values
@@ -330,7 +330,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:ValidateReservationPurchaseAsync
 
-            Assert.IsTrue(purchasedReservation.PhoneNumbers.All(n => n.Value.Status == PhoneNumberAvailabilityStatus.Purchased));
+            Assert.That(purchasedReservation.PhoneNumbers.All(n => n.Value.Status == PhoneNumberAvailabilityStatus.Purchased), Is.True);
 
             // Release the number to prevent additional costs.
             foreach (var phoneNumberToReserve in phoneNumbersToReserve)
@@ -382,9 +382,9 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:CreateReservation
 
-            Assert.IsTrue(phoneNumbersToReserve.All(n => reservation.PhoneNumbers.ContainsKey(n.Id)));
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.First().Id]);
-            Assert.AreNotEqual(PhoneNumberAvailabilityStatus.Error, reservation.PhoneNumbers[phoneNumbersToReserve.Last().Id]);
+            Assert.That(phoneNumbersToReserve.All(n => reservation.PhoneNumbers.ContainsKey(n.Id)), Is.True);
+            Assert.That(reservation.PhoneNumbers[phoneNumbersToReserve.First().Id], Is.Not.EqualTo(PhoneNumberAvailabilityStatus.Error));
+            Assert.That(reservation.PhoneNumbers[phoneNumbersToReserve.Last().Id], Is.Not.EqualTo(PhoneNumberAvailabilityStatus.Error));
 
             var phoneNumbersWithError = reservation
                 .PhoneNumbers
@@ -431,7 +431,7 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
 
             #endregion Snippet:ValidateReservationPurchase
 
-            Assert.IsTrue(purchasedReservation.PhoneNumbers.All(n => n.Value.Status == PhoneNumberAvailabilityStatus.Purchased));
+            Assert.That(purchasedReservation.PhoneNumbers.All(n => n.Value.Status == PhoneNumberAvailabilityStatus.Purchased), Is.True);
 
             // Release the number to prevent additional costs.
             foreach (var phoneNumberToReserve in phoneNumbersToReserve)

--- a/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_SipRoutingClient.cs
+++ b/sdk/communication/Azure.Communication.PhoneNumbers/tests/samples/Sample_SipRoutingClient.cs
@@ -60,10 +60,10 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             var routesResponse = client.GetRoutes();
             #endregion Snippet:RetrieveList
 
-            Assert.AreEqual(1, trunksResponse.Value.Count);
-            Assert.IsTrue(TrunkAreEqual(TestData.NewTrunk, trunksResponse.Value[0]));
-            Assert.AreEqual(1, routesResponse.Value.Count);
-            Assert.IsTrue(RouteAreEqual(TestData.RuleNavigateToNewTrunk, routesResponse.Value[0]));
+            Assert.That(trunksResponse.Value.Count, Is.EqualTo(1));
+            Assert.That(TrunkAreEqual(TestData.NewTrunk, trunksResponse.Value[0]), Is.True);
+            Assert.That(routesResponse.Value.Count, Is.EqualTo(1));
+            Assert.That(RouteAreEqual(TestData.RuleNavigateToNewTrunk, routesResponse.Value[0]), Is.True);
 
             var fqdnToRetrieve = TestData.NewTrunk.Fqdn;
 
@@ -94,9 +94,9 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             var trunksFinalResponse = client.GetTrunks();
             var routesFinalResponse = client.GetRoutes();
 
-            Assert.AreEqual(1, trunksFinalResponse.Value.Count);
-            Assert.IsTrue(TrunkAreEqual(trunkToSet, trunksFinalResponse.Value[0]));
-            Assert.AreEqual(1, routesFinalResponse.Value.Count);
+            Assert.That(trunksFinalResponse.Value.Count, Is.EqualTo(1));
+            Assert.That(TrunkAreEqual(trunkToSet, trunksFinalResponse.Value[0]), Is.True);
+            Assert.That(routesFinalResponse.Value.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -124,10 +124,10 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             var routesResponse = await client.GetRoutesAsync();
             #endregion Snippet:RetrieveListAsync
 
-            Assert.AreEqual(1, trunksResponse.Value.Count);
-            Assert.IsTrue(TrunkAreEqual(TestData.NewTrunk, trunksResponse.Value[0]));
-            Assert.AreEqual(1, routesResponse.Value.Count);
-            Assert.IsTrue(RouteAreEqual(TestData.RuleNavigateToNewTrunk, routesResponse.Value[0]));
+            Assert.That(trunksResponse.Value.Count, Is.EqualTo(1));
+            Assert.That(TrunkAreEqual(TestData.NewTrunk, trunksResponse.Value[0]), Is.True);
+            Assert.That(routesResponse.Value.Count, Is.EqualTo(1));
+            Assert.That(RouteAreEqual(TestData.RuleNavigateToNewTrunk, routesResponse.Value[0]), Is.True);
 
             var fqdnToRetrieve = TestData.NewTrunk.Fqdn;
 
@@ -158,9 +158,9 @@ namespace Azure.Communication.PhoneNumbers.Tests.Samples
             var trunksFinalResponse = client.GetTrunksAsync();
             var routesFinalResponse = client.GetRoutesAsync();
 
-            Assert.AreEqual(1, trunksFinalResponse.Result.Value.Count);
-            Assert.IsTrue(TrunkAreEqual(trunkToSet, trunksFinalResponse.Result.Value[0]));
-            Assert.AreEqual(1, routesFinalResponse.Result.Value.Count);
+            Assert.That(trunksFinalResponse.Result.Value.Count, Is.EqualTo(1));
+            Assert.That(TrunkAreEqual(trunkToSet, trunksFinalResponse.Result.Value[0]), Is.True);
+            Assert.That(routesFinalResponse.Result.Value.Count, Is.EqualTo(1));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomClientPstnDialOutLiveTest.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomClientPstnDialOutLiveTest.cs
@@ -69,8 +69,8 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
+                Assert.That(createRoomResponse.GetRawResponse().Status, Is.EqualTo(201));
                 ValidateRoom(createCommunicationRoom);
                 var createdRoomId = createCommunicationRoom.Id;
 
@@ -79,8 +79,8 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, getCommunicationRoom.Id);
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(getCommunicationRoom.Id, Is.EqualTo(createdRoomId));
+                Assert.That(getRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(getCommunicationRoom);
 
                 // Act: Update Room
@@ -96,15 +96,15 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, updateCommunicationRoom.Id);
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(updateCommunicationRoom.Id, Is.EqualTo(createdRoomId));
+                Assert.That(updateRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(updateCommunicationRoom);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert:
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             }
             catch (RequestFailedException ex)
             {
@@ -141,8 +141,8 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
+                Assert.That(createRoomResponse.GetRawResponse().Status, Is.EqualTo(201));
                 ValidateRoom(createCommunicationRoom, roomCreateOptions);
 
                 // Act: Get Room
@@ -151,8 +151,8 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, getCommunicationRoom.Id);
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(getCommunicationRoom.Id, Is.EqualTo(createdRoomId));
+                Assert.That(getRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(getCommunicationRoom, roomCreateOptions);
 
                 // Act: Update Room
@@ -169,15 +169,15 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, updateCommunicationRoom.Id);
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(updateCommunicationRoom.Id, Is.EqualTo(createdRoomId));
+                Assert.That(updateRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert:
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             }
             catch (RequestFailedException ex)
             {
@@ -226,7 +226,7 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                Assert.That(createRoomResponse.GetRawResponse().Status, Is.EqualTo(201));
                 ValidateRoom(createCommunicationRoom);
 
                 var createdRoomId = createCommunicationRoom.Id;
@@ -236,7 +236,7 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(getRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(getCommunicationRoom);
 
                 // Act Update Room
@@ -252,19 +252,19 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(updateRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(updateCommunicationRoom);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
 
                 // Get Deleted Room
                 RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-                Assert.NotNull(ex);
-                Assert.AreEqual(404, ex?.Status);
+                Assert.That(ex, Is.Not.Null);
+                Assert.That(ex?.Status, Is.EqualTo(404));
             }
             catch (RequestFailedException ex)
             {
@@ -316,7 +316,7 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                Assert.That(createRoomResponse.GetRawResponse().Status, Is.EqualTo(201));
                 ValidateRoom(createCommunicationRoom, roomCreateOptions);
 
                 // Act: Get Room
@@ -325,7 +325,7 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(getRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(getCommunicationRoom, roomCreateOptions);
 
                 // Act Update Room
@@ -343,19 +343,19 @@ namespace Azure.Communication.Rooms.Test
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(updateRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
 
                 // Get Deleted Room
                 RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-                Assert.NotNull(ex);
-                Assert.AreEqual(404, ex?.Status);
+                Assert.That(ex, Is.Not.Null);
+                Assert.That(ex?.Status, Is.EqualTo(404));
             }
             catch (RequestFailedException ex)
             {
@@ -378,7 +378,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(options: null);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value);
         }
 
@@ -392,7 +392,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(new CreateRoomOptions());
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value);
         }
 
@@ -417,7 +417,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value, roomCreateOptions);
         }
 
@@ -442,7 +442,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value);
         }
 
@@ -468,7 +468,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value, roomCreateOptions);
         }
 
@@ -497,7 +497,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value);
         }
 
@@ -527,7 +527,7 @@ namespace Azure.Communication.Rooms.Test
             var createdRoom = await roomsClient.CreateRoomAsync(roomCreateOptions);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value, roomCreateOptions);
         }
 
@@ -547,8 +547,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -568,8 +568,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -587,8 +587,8 @@ namespace Azure.Communication.Rooms.Test
             };
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -608,8 +608,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -628,8 +628,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -650,8 +650,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(roomCreateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -669,8 +669,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync("invalid_id"));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -697,8 +697,8 @@ namespace Azure.Communication.Rooms.Test
             CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
             // Assert:
-            Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
-            Assert.AreEqual(createRoomResponse.Value.Id, updateCommunicationRoom.Id);
+            Assert.That(updateRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
+            Assert.That(updateCommunicationRoom.Id, Is.EqualTo(createRoomResponse.Value.Id));
             ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
         }
 
@@ -728,9 +728,9 @@ namespace Azure.Communication.Rooms.Test
             CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
             // Assert:
-            Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
-            Assert.AreEqual(createRoomResponse.Value.Id, updateCommunicationRoom.Id);
-            Assert.AreEqual(updateCommunicationRoom.PstnDialOutEnabled, roomCreateOptions.PstnDialOutEnabled); // PSTN Enabled Dial-Out remains unchanged as in the room create operation
+            Assert.That(updateRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
+            Assert.That(updateCommunicationRoom.Id, Is.EqualTo(createRoomResponse.Value.Id));
+            Assert.That(roomCreateOptions.PstnDialOutEnabled, Is.EqualTo(updateCommunicationRoom.PstnDialOutEnabled)); // PSTN Enabled Dial-Out remains unchanged as in the room create operation
             ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
         }
 
@@ -756,9 +756,9 @@ namespace Azure.Communication.Rooms.Test
             CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
             // Assert:
-            Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
-            Assert.AreEqual(createRoomResponse.Value.Id, updateCommunicationRoom.Id);
-            Assert.AreEqual(updateCommunicationRoom.PstnDialOutEnabled, roomCreateOptions.PstnDialOutEnabled); // PSTN Enabled Dial-Out remains unchanged as in the room create operation
+            Assert.That(updateRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
+            Assert.That(updateCommunicationRoom.Id, Is.EqualTo(createRoomResponse.Value.Id));
+            Assert.That(roomCreateOptions.PstnDialOutEnabled, Is.EqualTo(updateCommunicationRoom.PstnDialOutEnabled)); // PSTN Enabled Dial-Out remains unchanged as in the room create operation
             ValidateRoom(updateCommunicationRoom, roomUpdateOptions);
         }
 
@@ -785,8 +785,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -814,8 +814,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -842,8 +842,8 @@ namespace Azure.Communication.Rooms.Test
             };
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -871,8 +871,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -898,8 +898,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync("invalid_id", roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -926,8 +926,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync("invalid_id", roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -953,8 +953,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionPstnEnabledSource))]
@@ -984,8 +984,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, roomUpdateOptions));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -1000,8 +1000,8 @@ namespace Azure.Communication.Rooms.Test
             };
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.AddOrUpdateParticipantsAsync(createRoomResponse.Value.Id, participants: roomParticipants));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -1077,7 +1077,7 @@ namespace Azure.Communication.Rooms.Test
                 Response<CommunicationRoom> createRoomResponse = await roomsClient.CreateRoomAsync(roomCreateOptions);
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
 
                 var createdRoomId = createCommunicationRoom.Id;
                 participant2 = new RoomParticipant(communicationUser2) { Role = ParticipantRole.Consumer };
@@ -1092,19 +1092,19 @@ namespace Azure.Communication.Rooms.Test
                 };
 
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                Assert.That(addOrUpdateParticipantsResponse.Status, Is.EqualTo(200));
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Presenter), "Expected participants to contain Presenter");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Consumer), "Expected participants to contain Consumer");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Attendee), "Expected participants to contain Attendee");
+                Assert.That(addOrUpdateRoomParticipantsResult.Count, Is.EqualTo(3), "Expected Room participants count to be 3");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.True, "Expected participants to contain user1 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.True, "Expected participants to contain user2 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Presenter), Is.True, "Expected participants to contain Presenter");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Consumer), Is.True, "Expected participants to contain Consumer");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Attendee), Is.True, "Expected participants to contain Attendee");
 
                 // Arrange: Remove participants
                 List<CommunicationIdentifier> toRemoveCommunicationUsers = new List<CommunicationIdentifier>
@@ -1118,13 +1118,13 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(1, removeRoomParticipantsResult.Count, "Expected Room participants count to be 1 after removal");
-                Assert.IsTrue(removeRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                Assert.That(removeParticipantsResponse.Status, Is.EqualTo(200));
+                Assert.That(removeRoomParticipantsResult.Count, Is.EqualTo(1), "Expected Room participants count to be 1 after removal");
+                Assert.That(removeRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             }
             catch (RequestFailedException ex)
             {
@@ -1187,20 +1187,23 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> roomParticipantsResult = await roomParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, roomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                Assert.That(roomParticipantsResult.Count, Is.EqualTo(3), "Expected Room participants count to be 3");
+                Assert.That(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.True, "Expected participants to contain user1 after add or update.");
+                Assert.That(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.True, "Expected participants to contain user2 after add or update.");
+                Assert.That(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
+                Assert.That(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
+                    Is.True,
                     "Expected participant1 to have Presenter role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                Assert.That(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                    Is.True,
                     "Expected participant2 to have Attendee role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                Assert.That(roomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
+                   Is.True,
                    "Expected participant3 to have Presenter role.");
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
 
                 // Arrange
                 // participant1 should be updated to Attendee which is default
@@ -1219,29 +1222,33 @@ namespace Azure.Communication.Rooms.Test
 
                 // Act
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                Assert.That(addOrUpdateParticipantsResponse.Status, Is.EqualTo(200));
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(4, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 4");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Count, Is.EqualTo(4), "Expected Room participants count to be 4");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.True, "Expected participants to contain user1 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.True, "Expected participants to contain user2 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), Is.True, "Expected participants to contain user4 after add or update.");
 
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                   Is.True,
                    "Expected participant1 to have Attendee role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Consumer)),
+                    Is.True,
                     "Expected participant2 to have Consumer role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
+                  Is.True,
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                   Is.True,
                    "Expected participant4 to have Attendee role.");
 
                 // Act Remove participants
@@ -1255,22 +1262,24 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> allParticipantsAfterDeleteResult = await allParticipantsAfterDelete.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(2, allParticipantsAfterDeleteResult.Count, "Expected Room participants count to be 2");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add and update.");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                Assert.That(removeParticipantsResponse.Status, Is.EqualTo(200));
+                Assert.That(allParticipantsAfterDeleteResult.Count, Is.EqualTo(2), "Expected Room participants count to be 2");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.False, "Expected participants to contain user1 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.False, "Expected participants to contain user2 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), Is.True, "Expected participants to contain user4 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
+                  Is.True,
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                Assert.That(allParticipantsAfterDeleteResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                   Is.True,
                    "Expected participant4 to have Attendee role.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             }
             catch (RequestFailedException ex)
             {
@@ -1309,8 +1318,8 @@ namespace Azure.Communication.Rooms.Test
             List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
             // Assert
-            Assert.AreEqual(removeParticipantResponse.Status, 200);
-            Assert.AreEqual(removeRoomParticipantsResult.Count, 0);
+            Assert.That(removeParticipantResponse.Status, Is.EqualTo(200));
+            Assert.That(removeRoomParticipantsResult.Count, Is.EqualTo(0));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -1333,8 +1342,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -1349,10 +1358,10 @@ namespace Azure.Communication.Rooms.Test
             Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
             // Assert:
-            Assert.AreEqual(204, deleteRoomResponse.Status);
+            Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [TestCaseSource(nameof(AuthenticationVersionSource))]
@@ -1371,8 +1380,8 @@ namespace Azure.Communication.Rooms.Test
 
             // Act and Assert:
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(invalidRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [TestCase(ServiceVersion.V2025_03_13)]
@@ -1419,20 +1428,23 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> roomParticipantsResult = await roomParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, roomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                Assert.That(roomParticipantsResult.Count, Is.EqualTo(3), "Expected Room participants count to be 3");
+                Assert.That(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.True, "Expected participants to contain user1 after add or update.");
+                Assert.That(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.True, "Expected participants to contain user2 after add or update.");
+                Assert.That(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
+                Assert.That(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
+                    Is.True,
                     "Expected participant1 to have Presenter role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                Assert.That(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                    Is.True,
                     "Expected participant2 to have Attendee role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                Assert.That(roomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Collaborator)),
+                   Is.True,
                    "Expected participant3 to have Presenter role.");
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
 
                 // Arrange
                 // participant1 should be updated to Attendee which is default
@@ -1451,29 +1463,33 @@ namespace Azure.Communication.Rooms.Test
 
                 // Act
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                Assert.That(addOrUpdateParticipantsResponse.Status, Is.EqualTo(200));
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(4, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 4");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Count, Is.EqualTo(4), "Expected Room participants count to be 4");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.True, "Expected participants to contain user1 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.True, "Expected participants to contain user2 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), Is.True, "Expected participants to contain user4 after add or update.");
 
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                   Is.True,
                    "Expected participant1 to have Attendee role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Collaborator)),
+                    Is.True,
                     "Expected participant2 to have Consumer role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Collaborator)),
+                  Is.True,
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                   Is.True,
                    "Expected participant4 to have Attendee role.");
 
                 // Act Remove participants
@@ -1487,22 +1503,24 @@ namespace Azure.Communication.Rooms.Test
                 List<RoomParticipant> allParticipantsAfterDeleteResult = await allParticipantsAfterDelete.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(2, allParticipantsAfterDeleteResult.Count, "Expected Room participants count to be 2");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add and update.");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                Assert.That(removeParticipantsResponse.Status, Is.EqualTo(200));
+                Assert.That(allParticipantsAfterDeleteResult.Count, Is.EqualTo(2), "Expected Room participants count to be 2");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.False, "Expected participants to contain user1 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.False, "Expected participants to contain user2 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), Is.True, "Expected participants to contain user4 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Collaborator)),
+                  Is.True,
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                Assert.That(allParticipantsAfterDeleteResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                   Is.True,
                    "Expected participant4 to have Attendee role.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             }
             catch (RequestFailedException ex)
             {
@@ -1517,22 +1535,22 @@ namespace Azure.Communication.Rooms.Test
 
         private void ValidateRoom(CommunicationRoom? room)
         {
-            Assert.NotNull(room);
-            Assert.NotNull(room?.Id);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.ValidFrom);
-            Assert.NotNull(room?.ValidUntil);
-            Assert.NotNull(room?.PstnDialOutEnabled);
+            Assert.That(room, Is.Not.Null);
+            Assert.That(room?.Id, Is.Not.Null);
+            Assert.That(room?.CreatedAt, Is.Not.Null);
+            Assert.That(room?.ValidFrom, Is.Not.Null);
+            Assert.That(room?.ValidUntil, Is.Not.Null);
+            Assert.That(room?.PstnDialOutEnabled, Is.Not.Null);
         }
 
         private void ValidateRoom(CommunicationRoom? room, CreateRoomOptions roomCreateOptions)
         {
-            Assert.NotNull(room);
-            Assert.NotNull(room?.Id);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.ValidFrom);
-            Assert.NotNull(room?.ValidUntil);
-            Assert.AreEqual(room?.PstnDialOutEnabled, roomCreateOptions.PstnDialOutEnabled.HasValue ? roomCreateOptions?.PstnDialOutEnabled : false);
+            Assert.That(room, Is.Not.Null);
+            Assert.That(room?.Id, Is.Not.Null);
+            Assert.That(room?.CreatedAt, Is.Not.Null);
+            Assert.That(room?.ValidFrom, Is.Not.Null);
+            Assert.That(room?.ValidUntil, Is.Not.Null);
+            Assert.That(roomCreateOptions.PstnDialOutEnabled.HasValue ? roomCreateOptions?.PstnDialOutEnabled : false, Is.EqualTo(room?.PstnDialOutEnabled));
             Console.Write("Room Id: " + room?.Id);
             Console.Write("CreatedAt: " + room?.CreatedAt);
             Console.Write("ValidFrom: " + room?.ValidFrom);
@@ -1542,12 +1560,12 @@ namespace Azure.Communication.Rooms.Test
 
         private void ValidateRoom(CommunicationRoom? room, UpdateRoomOptions roomUpdateOptions)
         {
-            Assert.NotNull(room);
-            Assert.NotNull(room?.Id);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.ValidFrom);
-            Assert.AreEqual(room?.PstnDialOutEnabled, roomUpdateOptions.PstnDialOutEnabled.HasValue ? roomUpdateOptions.PstnDialOutEnabled : room?.PstnDialOutEnabled);
+            Assert.That(room, Is.Not.Null);
+            Assert.That(room?.Id, Is.Not.Null);
+            Assert.That(room?.CreatedAt, Is.Not.Null);
+            Assert.That(room?.CreatedAt, Is.Not.Null);
+            Assert.That(room?.ValidFrom, Is.Not.Null);
+            Assert.That(roomUpdateOptions.PstnDialOutEnabled.HasValue ? roomUpdateOptions.PstnDialOutEnabled : room?.PstnDialOutEnabled, Is.EqualTo(room?.PstnDialOutEnabled));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientLiveTests.cs
@@ -36,8 +36,8 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
+                Assert.That(createRoomResponse.GetRawResponse().Status, Is.EqualTo(201));
                 ValidateRoom(createCommunicationRoom);
                 var createdRoomId = createCommunicationRoom.Id;
 
@@ -46,8 +46,8 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, getCommunicationRoom.Id);
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(getCommunicationRoom.Id, Is.EqualTo(createdRoomId));
+                Assert.That(getRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(getCommunicationRoom);
 
                 // Act: Update Room
@@ -57,15 +57,15 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert:
-                Assert.AreEqual(createdRoomId, updateCommunicationRoom.Id);
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(updateCommunicationRoom.Id, Is.EqualTo(createdRoomId));
+                Assert.That(updateRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(updateCommunicationRoom);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert:
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             }
             catch (RequestFailedException ex)
             {
@@ -109,7 +109,7 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(createRoomResponse.GetRawResponse().Status, 201);
+                Assert.That(createRoomResponse.GetRawResponse().Status, Is.EqualTo(201));
                 ValidateRoom(createCommunicationRoom);
 
                 var createdRoomId = createCommunicationRoom.Id;
@@ -119,7 +119,7 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(getRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(getRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(getCommunicationRoom);
 
                 // Act Update Room
@@ -130,19 +130,19 @@ namespace Azure.Communication.Rooms.Tests
                 CommunicationRoom updateCommunicationRoom = updateRoomResponse.Value;
 
                 // Assert
-                Assert.AreEqual(updateRoomResponse.GetRawResponse().Status, 200);
+                Assert.That(updateRoomResponse.GetRawResponse().Status, Is.EqualTo(200));
                 ValidateRoom(updateCommunicationRoom);
 
                 // Act: Delete Room
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
                 // Assert
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
 
                 // Get Deleted Room
                 RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-                Assert.NotNull(ex);
-                Assert.AreEqual(404, ex?.Status);
+                Assert.That(ex, Is.Not.Null);
+                Assert.That(ex?.Status, Is.EqualTo(404));
             }
             catch (RequestFailedException ex)
             {
@@ -165,7 +165,7 @@ namespace Azure.Communication.Rooms.Tests
             var createdRoom = await roomsClient.CreateRoomAsync();
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value);
         }
 
@@ -185,7 +185,7 @@ namespace Azure.Communication.Rooms.Tests
             var createdRoom = await roomsClient.CreateRoomAsync(participants: roomParticipants);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value);
         }
 
@@ -207,7 +207,7 @@ namespace Azure.Communication.Rooms.Tests
             var createdRoom = await roomsClient.CreateRoomAsync(participants: roomParticipants, validFrom: validFrom, validUntil: validUntil);
 
             // Assert
-            Assert.AreEqual(createdRoom.GetRawResponse().Status, 201);
+            Assert.That(createdRoom.GetRawResponse().Status, Is.EqualTo(201));
             ValidateRoom(createdRoom.Value);
         }
 
@@ -221,8 +221,8 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -235,8 +235,8 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -251,8 +251,8 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.CreateRoomAsync(participants: roomParticipants));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -263,8 +263,8 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync("invalid_id"));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -279,8 +279,8 @@ namespace Azure.Communication.Rooms.Tests
             // Act and Assert
             validUntil = validFrom.AddDays(200);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -295,8 +295,8 @@ namespace Azure.Communication.Rooms.Tests
             // Act and Assert
             validUntil = validFrom.AddDays(-20);
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -309,8 +309,8 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and Assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync("invalid_id", validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -325,8 +325,8 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.UpdateRoomAsync(createRoomResponse.Value.Id, validFrom: validFrom, validUntil: validUntil));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -341,8 +341,8 @@ namespace Azure.Communication.Rooms.Tests
             };
 
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.AddOrUpdateParticipantsAsync(createRoomResponse.Value.Id, participants: roomParticipants));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -404,7 +404,7 @@ namespace Azure.Communication.Rooms.Tests
                 Response<CommunicationRoom> createRoomResponse = await roomsClient.CreateRoomAsync(validFrom, validUntil, createRoomParticipants);
                 CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
 
                 var createdRoomId = createCommunicationRoom.Id;
                 participant2 = new RoomParticipant(communicationUser2) { Role = ParticipantRole.Consumer };
@@ -419,19 +419,19 @@ namespace Azure.Communication.Rooms.Tests
                 };
 
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                Assert.That(addOrUpdateParticipantsResponse.Status, Is.EqualTo(200));
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Presenter), "Expected participants to contain Presenter");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Consumer), "Expected participants to contain Consumer");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Attendee), "Expected participants to contain Attendee");
+                Assert.That(addOrUpdateRoomParticipantsResult.Count, Is.EqualTo(3), "Expected Room participants count to be 3");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.True, "Expected participants to contain user1 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.True, "Expected participants to contain user2 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Presenter), Is.True, "Expected participants to contain Presenter");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Consumer), Is.True, "Expected participants to contain Consumer");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.Role == ParticipantRole.Attendee), Is.True, "Expected participants to contain Attendee");
 
                 // Arrange: Remove participants
                 List<CommunicationIdentifier> toRemoveCommunicationUsers = new List<CommunicationIdentifier>
@@ -445,13 +445,13 @@ namespace Azure.Communication.Rooms.Tests
                 List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(1, removeRoomParticipantsResult.Count, "Expected Room participants count to be 1 after removal");
-                Assert.IsTrue(removeRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
+                Assert.That(removeParticipantsResponse.Status, Is.EqualTo(200));
+                Assert.That(removeRoomParticipantsResult.Count, Is.EqualTo(1), "Expected Room participants count to be 1 after removal");
+                Assert.That(removeRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             }
             catch (RequestFailedException ex)
             {
@@ -501,20 +501,23 @@ namespace Azure.Communication.Rooms.Tests
                 List<RoomParticipant> roomParticipantsResult = await roomParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(3, roomParticipantsResult.Count, "Expected Room participants count to be 3");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                Assert.That(roomParticipantsResult.Count, Is.EqualTo(3), "Expected Room participants count to be 3");
+                Assert.That(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.True, "Expected participants to contain user1 after add or update.");
+                Assert.That(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.True, "Expected participants to contain user2 after add or update.");
+                Assert.That(roomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
+                Assert.That(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
+                    Is.True,
                     "Expected participant1 to have Presenter role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                Assert.That(roomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                    Is.True,
                     "Expected participant2 to have Attendee role.");
-                Assert.IsTrue(roomParticipantsResult.Any(
+                Assert.That(roomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
+                   Is.True,
                    "Expected participant3 to have Presenter role.");
-                Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+                Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
 
                 // Arrange
                 // participant1 should be updated to Attendee which is default
@@ -533,29 +536,33 @@ namespace Azure.Communication.Rooms.Tests
 
                 // Act
                 Response addOrUpdateParticipantsResponse = await roomsClient.AddOrUpdateParticipantsAsync(createdRoomId, toAddOrUpdateCommunicationUsers);
-                Assert.AreEqual(200, addOrUpdateParticipantsResponse.Status);
+                Assert.That(addOrUpdateParticipantsResponse.Status, Is.EqualTo(200));
 
                 AsyncPageable<RoomParticipant> allParticipants = roomsClient.GetParticipantsAsync(createdRoomId);
                 List<RoomParticipant> addOrUpdateRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(4, addOrUpdateRoomParticipantsResult.Count, "Expected Room participants count to be 4");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add or update.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Count, Is.EqualTo(4), "Expected Room participants count to be 4");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.True, "Expected participants to contain user1 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.True, "Expected participants to contain user2 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add or update.");
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), Is.True, "Expected participants to contain user4 after add or update.");
 
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                   Is.True,
                    "Expected participant1 to have Attendee role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                     x => (x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier) && x.Role == ParticipantRole.Consumer)),
+                    Is.True,
                     "Expected participant2 to have Consumer role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
+                  Is.True,
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(addOrUpdateRoomParticipantsResult.Any(
+                Assert.That(addOrUpdateRoomParticipantsResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                   Is.True,
                    "Expected participant4 to have Attendee role.");
 
                 // Act Remove participants
@@ -569,22 +576,24 @@ namespace Azure.Communication.Rooms.Tests
                 List<RoomParticipant> allParticipantsAfterDeleteResult = await allParticipantsAfterDelete.ToEnumerableAsync();
 
                 // Assert
-                Assert.AreEqual(200, removeParticipantsResponse.Status);
-                Assert.AreEqual(2, allParticipantsAfterDeleteResult.Count, "Expected Room participants count to be 2");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), "Expected participants to contain user1 after add and update.");
-                Assert.IsFalse(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), "Expected participants to contain user2 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), "Expected participants to contain user3 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), "Expected participants to contain user4 after add and update.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                Assert.That(removeParticipantsResponse.Status, Is.EqualTo(200));
+                Assert.That(allParticipantsAfterDeleteResult.Count, Is.EqualTo(2), "Expected Room participants count to be 2");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant1.CommunicationIdentifier)), Is.False, "Expected participants to contain user1 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant2.CommunicationIdentifier)), Is.False, "Expected participants to contain user2 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier)), Is.True, "Expected participants to contain user3 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(x => x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier)), Is.True, "Expected participants to contain user4 after add and update.");
+                Assert.That(allParticipantsAfterDeleteResult.Any(
                   x => (x.CommunicationIdentifier.Equals(participant3.CommunicationIdentifier) && x.Role == ParticipantRole.Presenter)),
+                  Is.True,
                   "Expected participant3 to have Presenter role.");
-                Assert.IsTrue(allParticipantsAfterDeleteResult.Any(
+                Assert.That(allParticipantsAfterDeleteResult.Any(
                    x => (x.CommunicationIdentifier.Equals(participant4.CommunicationIdentifier) && x.Role == ParticipantRole.Attendee)),
+                   Is.True,
                    "Expected participant4 to have Attendee role.");
 
                 // Clean up
                 Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
-                Assert.AreEqual(204, deleteRoomResponse.Status);
+                Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             }
             catch (RequestFailedException ex)
             {
@@ -616,8 +625,8 @@ namespace Azure.Communication.Rooms.Tests
             List<RoomParticipant> removeRoomParticipantsResult = await allParticipants.ToEnumerableAsync();
 
             // Assert
-            Assert.AreEqual(removeParticipantResponse.Status, 200);
-            Assert.AreEqual(removeRoomParticipantsResult.Count, 0);
+            Assert.That(removeParticipantResponse.Status, Is.EqualTo(200));
+            Assert.That(removeRoomParticipantsResult.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -633,8 +642,8 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and assert
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.RemoveParticipantsAsync(createRoomResponse.Value.Id, participantIdentifiers: communicationUsers));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         [Test]
@@ -649,10 +658,10 @@ namespace Azure.Communication.Rooms.Tests
             Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
 
             // Assert:
-            Assert.AreEqual(204, deleteRoomResponse.Status);
+            Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.GetRoomAsync(createdRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(404, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(404));
         }
 
         [Test]
@@ -664,17 +673,17 @@ namespace Azure.Communication.Rooms.Tests
 
             // Act and Assert:
             RequestFailedException? ex = Assert.ThrowsAsync<RequestFailedException>(async () => await roomsClient.DeleteRoomAsync(ivnalidRoomId));
-            Assert.NotNull(ex);
-            Assert.AreEqual(400, ex?.Status);
+            Assert.That(ex, Is.Not.Null);
+            Assert.That(ex?.Status, Is.EqualTo(400));
         }
 
         private void ValidateRoom(CommunicationRoom? room)
         {
-            Assert.NotNull(room);
-            Assert.NotNull(room?.Id);
-            Assert.NotNull(room?.CreatedAt);
-            Assert.NotNull(room?.ValidFrom);
-            Assert.NotNull(room?.ValidUntil);
+            Assert.That(room, Is.Not.Null);
+            Assert.That(room?.Id, Is.Not.Null);
+            Assert.That(room?.CreatedAt, Is.Not.Null);
+            Assert.That(room?.ValidFrom, Is.Not.Null);
+            Assert.That(room?.ValidUntil, Is.Not.Null);
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientTest.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/RoomsClient/RoomsClientTest.cs
@@ -44,7 +44,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.CreateRoomAsync(validFrom, validUntil, createRoomParticipants, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.CreateRoomAsync(validFrom, validUntil, createRoomParticipants, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Theory]
@@ -89,7 +89,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.CreateRoomAsync(createRoomOptions, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.CreateRoomAsync(createRoomOptions, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.CreateRoom(validFrom, validUntil, createRoomParticipants, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.CreateRoom(validFrom, validUntil, createRoomParticipants, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Theory]
@@ -150,7 +150,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.CreateRoom(createRoomOptions, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.CreateRoom(createRoomOptions, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -170,7 +170,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.UpdateRoomAsync(roomId, validFrom, validUntil, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.UpdateRoomAsync(roomId, validFrom, validUntil, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Theory]
@@ -199,7 +199,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.UpdateRoomAsync(roomId, roomUpdateOptions, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.UpdateRoomAsync(roomId, roomUpdateOptions, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -220,7 +220,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.UpdateRoom(roomId, validFrom, validUntil, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.UpdateRoom(roomId, validFrom, validUntil, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Theory]
@@ -248,7 +248,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.UpdateRoom(roomId, roomUpdateOptions, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.UpdateRoom(roomId, roomUpdateOptions, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -266,7 +266,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = await mockRoomsClient.Object.GetRoomAsync(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetRoomAsync(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -284,7 +284,7 @@ namespace Azure.Communication.Rooms.Tests
             Response<CommunicationRoom> actualResponse = mockRoomsClient.Object.GetRoom(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetRoom(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -301,7 +301,7 @@ namespace Azure.Communication.Rooms.Tests
             AsyncPageable<CommunicationRoom> actualResponse = mockRoomsClient.Object.GetRoomsAsync(cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetRoomsAsync(cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -318,7 +318,7 @@ namespace Azure.Communication.Rooms.Tests
             Pageable<CommunicationRoom> actualResponse = mockRoomsClient.Object.GetRooms(cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetRooms(cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -336,7 +336,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = await mockRoomsClient.Object.DeleteRoomAsync(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.DeleteRoomAsync(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -354,7 +354,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = mockRoomsClient.Object.DeleteRoom(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.DeleteRoom(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -389,7 +389,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = await mockRoomsClient.Object.AddOrUpdateParticipantsAsync(roomId, participants, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.AddOrUpdateParticipantsAsync(roomId, participants, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResult));
         }
 
         [Test]
@@ -425,7 +425,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = mockRoomsClient.Object.AddOrUpdateParticipants(roomId, communicationUsers, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.AddOrUpdateParticipants(roomId, communicationUsers, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
         [Test]
         public async Task RemoveParticipantsAsyncShouldSucceed()
@@ -450,7 +450,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = await mockRoomsClient.Object.RemoveParticipantsAsync(roomId, communicationUsers, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.RemoveParticipantsAsync(roomId, communicationUsers, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResult));
         }
 
         [Test]
@@ -474,7 +474,7 @@ namespace Azure.Communication.Rooms.Tests
             Response actualResponse = mockRoomsClient.Object.RemoveParticipants(roomId, communicationUsers, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.RemoveParticipants(roomId, communicationUsers, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResult));
         }
 
         [Test]
@@ -492,7 +492,7 @@ namespace Azure.Communication.Rooms.Tests
             AsyncPageable<RoomParticipant> actualResponse = mockRoomsClient.Object.GetParticipantsAsync(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetParticipantsAsync(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
 
         [Test]
@@ -511,7 +511,7 @@ namespace Azure.Communication.Rooms.Tests
             Pageable<RoomParticipant> actualResponse = mockRoomsClient.Object.GetParticipants(roomId, cancellationToken);
 
             mockRoomsClient.Verify(roomsClient => roomsClient.GetParticipants(roomId, cancellationToken), Times.Once());
-            Assert.AreEqual(expectedRoomResult, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedRoomResult));
         }
     }
 }

--- a/sdk/communication/Azure.Communication.Rooms/tests/Samples/Sample1_RoomsClient.cs
+++ b/sdk/communication/Azure.Communication.Rooms/tests/Samples/Sample1_RoomsClient.cs
@@ -64,7 +64,7 @@ namespace Azure.Communication.Rooms.Tests.samples
 
             #endregion Snippet:Azure_Communication_Rooms_Tests_Samples_CreateRoomAsync
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+            Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
 
             string createdRoomId = createCommunicationRoom.Id;
 
@@ -86,14 +86,14 @@ namespace Azure.Communication.Rooms.Tests.samples
 
             #endregion Snippet:Azure_Communication_Rooms_Tests_Samples_UpdateRoomAsync
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(updateCommunicationRoom.Id));
+            Assert.That(string.IsNullOrWhiteSpace(updateCommunicationRoom.Id), Is.False);
 
             #region Snippet:Azure_Communication_Rooms_Tests_Samples_GetRoomAsync
             Response<CommunicationRoom> getRoomResponse = await roomsClient.GetRoomAsync(createdRoomId);
             CommunicationRoom getCommunicationRoom = getRoomResponse.Value;
             #endregion Snippet:Azure_Communication_Rooms_Tests_Samples_GetRoomAsync
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(getCommunicationRoom.Id));
+            Assert.That(string.IsNullOrWhiteSpace(getCommunicationRoom.Id), Is.False);
 
             #region Snippet:Azure_Communication_Rooms_Tests_Samples_GetRoomsAsync
 
@@ -120,7 +120,7 @@ namespace Azure.Communication.Rooms.Tests.samples
             Response deleteRoomResponse = await roomsClient.DeleteRoomAsync(createdRoomId);
             #endregion Snippet:Azure_Communication_Rooms_Tests_Samples_DeleteRoomAsync
 
-            Assert.AreEqual(204, deleteRoomResponse.Status);
+            Assert.That(deleteRoomResponse.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -142,7 +142,7 @@ namespace Azure.Communication.Rooms.Tests.samples
             Response<CommunicationRoom> createRoomResponse = await roomsClient.CreateRoomAsync(validFrom, validUntil, createRoomParticipants);
             CommunicationRoom createCommunicationRoom = createRoomResponse.Value;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(createCommunicationRoom.Id));
+            Assert.That(string.IsNullOrWhiteSpace(createCommunicationRoom.Id), Is.False);
 
             string createdRoomId = createCommunicationRoom.Id;
 

--- a/sdk/communication/Azure.Communication.ShortCodes/tests/ShortCodesClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.ShortCodes/tests/ShortCodesClientLiveTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Communication.ShortCodes.Tests
             }
             #endregion Snippet:GetShortCodes
 
-            Assert.NotNull(shortCodes);
+            Assert.That(shortCodes, Is.Not.Null);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace Azure.Communication.ShortCodes.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("body", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("body"));
                 return;
             }
 
@@ -66,7 +66,7 @@ namespace Azure.Communication.ShortCodes.Tests
             var client = CreateClient();
             var response = await client.DeleteUSProgramBriefAsync(programBriefId);
 
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace Azure.Communication.ShortCodes.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.That(ex.Status, Is.EqualTo(404));
                 return;
             }
 
@@ -95,7 +95,7 @@ namespace Azure.Communication.ShortCodes.Tests
             var pageable = client.GetUSProgramBriefsAsync();
             var programBriefs = await pageable.ToEnumerableAsync();
 
-            Assert.NotNull(programBriefs);
+            Assert.That(programBriefs, Is.Not.Null);
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace Azure.Communication.ShortCodes.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status);
+                Assert.That(ex.Status, Is.EqualTo(404));
                 return;
             }
 

--- a/sdk/communication/Azure.Communication.Sms/tests/OptOutsClientTest.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/OptOutsClientTest.cs
@@ -54,16 +54,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .ReturnsAsync((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    Assert.That(from, Is.EqualTo(expectedFrom));
+                    Assert.That(to, Is.EqualTo(expectedTo));
+                    Assert.That(token, Is.EqualTo(cancellationToken));
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutResponseItem>> actualResponse = await mockClient.Object.CheckAsync(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResponse));
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -78,16 +78,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .Returns((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    Assert.That(from, Is.EqualTo(expectedFrom));
+                    Assert.That(to, Is.EqualTo(expectedTo));
+                    Assert.That(token, Is.EqualTo(cancellationToken));
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutResponseItem>> actualResponse = mockClient.Object.Check(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResponse));
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -102,16 +102,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .ReturnsAsync((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    Assert.That(from, Is.EqualTo(expectedFrom));
+                    Assert.That(to, Is.EqualTo(expectedTo));
+                    Assert.That(token, Is.EqualTo(cancellationToken));
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutAddResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutAddResponseItem>> actualResponse = await mockClient.Object.AddAsync(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResponse));
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -126,16 +126,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .Returns((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    Assert.That(from, Is.EqualTo(expectedFrom));
+                    Assert.That(to, Is.EqualTo(expectedTo));
+                    Assert.That(token, Is.EqualTo(cancellationToken));
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutAddResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutAddResponseItem>> actualResponse = mockClient.Object.Add(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResponse));
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -150,16 +150,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .ReturnsAsync((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    Assert.That(from, Is.EqualTo(expectedFrom));
+                    Assert.That(to, Is.EqualTo(expectedTo));
+                    Assert.That(token, Is.EqualTo(cancellationToken));
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutRemoveResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutRemoveResponseItem>> actualResponse = await mockClient.Object.RemoveAsync(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResponse));
         }
 
         [TestCaseSource(nameof(TestData))]
@@ -174,16 +174,16 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .Returns((string from, IEnumerable<string> to, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(cancellationToken, token);
+                    Assert.That(from, Is.EqualTo(expectedFrom));
+                    Assert.That(to, Is.EqualTo(expectedTo));
+                    Assert.That(token, Is.EqualTo(cancellationToken));
                     return expectedResponse = new Mock<Response<IReadOnlyList<OptOutRemoveResponseItem>>>().Object;
                 });
 
             Response<IReadOnlyList<OptOutRemoveResponseItem>> actualResponse = mockClient.Object.Remove(expectedFrom, expectedTo, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResponse));
         }
 
         private static IEnumerable<object> TestData()

--- a/sdk/communication/Azure.Communication.Sms/tests/OptOutsRestClientTests.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/OptOutsRestClientTests.cs
@@ -63,7 +63,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
         }
@@ -81,7 +81,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("recipients"));
                 return;
             }
         }
@@ -99,7 +99,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
         }
@@ -117,7 +117,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("recipients"));
                 return;
             }
         }
@@ -135,7 +135,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
         }
@@ -153,7 +153,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("recipients"));
                 return;
             }
         }
@@ -171,7 +171,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
         }
@@ -189,7 +189,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("recipients"));
                 return;
             }
         }
@@ -207,7 +207,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
         }
@@ -225,7 +225,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("recipients"));
                 return;
             }
         }
@@ -243,7 +243,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
         }
@@ -261,7 +261,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("recipients", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("recipients"));
                 return;
             }
         }

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTests.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsClientLiveTests.cs
@@ -86,8 +86,8 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.IsNotEmpty(ex.Message);
-                Assert.True(ex.Message.Contains("401")); // Unauthorized
+                Assert.That(ex.Message, Is.Not.Empty);
+                Assert.That(ex.Message.Contains("401"), Is.True); // Unauthorized
                 Console.WriteLine(ex.Message);
             }
             catch (Exception ex)
@@ -150,7 +150,7 @@ namespace Azure.Communication.Sms.Tests
                 SmsSendResult firstMessageResult = firstMessageResponse.Value;
                 SmsSendResult secondMessageResult = secondMessageResponse.Value;
 
-                Assert.AreNotEqual(firstMessageResult.MessageId, secondMessageResult.MessageId);
+                Assert.That(secondMessageResult.MessageId, Is.Not.EqualTo(firstMessageResult.MessageId));
                 AssertSmsSendingHappyPath(firstMessageResult);
                 AssertSmsSendingHappyPath(secondMessageResult);
             }
@@ -178,7 +178,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
             Assert.Fail("SendAsync should have thrown an exception.");
@@ -201,7 +201,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.ApiKey).ToLower(), ex.ParamName?.ToLower());
+                Assert.That(ex.ParamName?.ToLower(), Is.EqualTo(nameof(MessagingConnectOptions.ApiKey).ToLower()));
                 return;
             }
             Assert.Fail("SendAsync should have thrown an exception.");
@@ -224,7 +224,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.Partner).ToLower(), ex.ParamName?.ToLower());
+                Assert.That(ex.ParamName?.ToLower(), Is.EqualTo(nameof(MessagingConnectOptions.Partner).ToLower()));
                 return;
             }
             Assert.Fail("SendAsync should have thrown an exception.");
@@ -244,7 +244,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("to"));
                 return;
             }
             Assert.Fail("SendAsync should have thrown an exception.");
@@ -263,7 +263,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
             Assert.Fail("CheckAsync should have thrown an exception.");
@@ -282,7 +282,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("to"));
                 return;
             }
             Assert.Fail("CheckAsync should have thrown an exception.");
@@ -308,7 +308,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("to"));
                 return;
             }
             Assert.Fail("CheckAsync should have thrown an exception.");
@@ -348,7 +348,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
             Assert.Fail("AddAsync should have thrown an exception.");
@@ -367,7 +367,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("to"));
                 return;
             }
             Assert.Fail("AddAsync should have thrown an exception.");
@@ -393,7 +393,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("to"));
                 return;
             }
             Assert.Fail("AddAsync should have thrown an exception.");
@@ -433,7 +433,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
             Assert.Fail("RemoveAsync should have thrown an exception.");
@@ -452,7 +452,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("to"));
                 return;
             }
             Assert.Fail("RemoveAsync should have thrown an exception.");
@@ -478,7 +478,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("to", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("to"));
                 return;
             }
             Assert.Fail("RemoveAsync should have thrown an exception.");
@@ -521,7 +521,7 @@ namespace Azure.Communication.Sms.Tests
                   from: TestEnvironment.FromPhoneNumber,
                   to: to);
 
-                Assert.IsTrue(checkResult.Value[0].IsOptedOut);
+                Assert.That(checkResult.Value[0].IsOptedOut, Is.True);
             }
             catch (Exception ex)
             {
@@ -551,7 +551,7 @@ namespace Azure.Communication.Sms.Tests
                     from: TestEnvironment.FromPhoneNumber,
                     to: to);
 
-                Assert.IsFalse(checkResult.Value[0].IsOptedOut);
+                Assert.That(checkResult.Value[0].IsOptedOut, Is.False);
             }
             catch (Exception ex)
             {
@@ -577,8 +577,8 @@ namespace Azure.Communication.Sms.Tests
                   from: TestEnvironment.FromPhoneNumber,
                   to: to);
 
-                Assert.IsTrue(checkResult.Value[0].IsOptedOut);
-                Assert.IsTrue(checkResult.Value[1].IsOptedOut);
+                Assert.That(checkResult.Value[0].IsOptedOut, Is.True);
+                Assert.That(checkResult.Value[1].IsOptedOut, Is.True);
             }
             catch (Exception ex)
             {
@@ -608,7 +608,7 @@ namespace Azure.Communication.Sms.Tests
                     from: TestEnvironment.FromPhoneNumber,
                     to: to);
 
-                Assert.IsFalse(checkResult.Value[0].IsOptedOut);
+                Assert.That(checkResult.Value[0].IsOptedOut, Is.False);
             }
             catch (Exception ex)
             {
@@ -620,9 +620,9 @@ namespace Azure.Communication.Sms.Tests
 
         private void AssertSmsSendingHappyPath(SmsSendResult sendResult)
         {
-            Assert.True(sendResult.Successful);
-            Assert.AreEqual(202, sendResult.HttpStatusCode);
-            Assert.IsFalse(string.IsNullOrWhiteSpace(sendResult.MessageId));
+            Assert.That(sendResult.Successful, Is.True);
+            Assert.That(sendResult.HttpStatusCode, Is.EqualTo(202));
+            Assert.That(string.IsNullOrWhiteSpace(sendResult.MessageId), Is.False);
         }
 
         private void AssertSmsSendingRawResponseHappyPath(Stream contentStream)
@@ -632,7 +632,7 @@ namespace Azure.Communication.Sms.Tests
                 StreamReader streamReader = new StreamReader(contentStream);
                 streamReader.BaseStream.Seek(0, SeekOrigin.Begin);
                 string rawResponse = streamReader.ReadToEnd();
-                Assert.True(rawResponse.Contains("\"repeatabilityResult\":\"accepted\""));
+                Assert.That(rawResponse.Contains("\"repeatabilityResult\":\"accepted\""), Is.True);
                 return;
             }
             Assert.Fail("Response content stream is empty.");

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsClientTest.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsClientTest.cs
@@ -73,7 +73,7 @@ namespace Azure.Communication.Sms.Tests
         {
             var smsClient = new SmsClient(TestConnectionString);
 
-            Assert.NotNull(smsClient.OptOuts);
+            Assert.That(smsClient.OptOuts, Is.Not.Null);
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace Azure.Communication.Sms.Tests
         {
             var smsClient = new SmsClient(TestConnectionString, new SmsClientOptions(SmsClientOptions.ServiceVersion.V2021_03_07));
 
-            Assert.NotNull(smsClient.OptOuts);
+            Assert.That(smsClient.OptOuts, Is.Not.Null);
         }
 
         [Test]
@@ -91,7 +91,7 @@ namespace Azure.Communication.Sms.Tests
             Uri endpoint = new Uri("http://localhost");
             var smsClient = new SmsClient(endpoint, mockCredential, new SmsClientOptions(SmsClientOptions.ServiceVersion.V2021_03_07));
 
-            Assert.NotNull(smsClient.OptOuts);
+            Assert.That(smsClient.OptOuts, Is.Not.Null);
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace Azure.Communication.Sms.Tests
             Uri endpoint = new Uri("http://localhost");
             var smsClient = new SmsClient(endpoint, mockCredential, new SmsClientOptions(SmsClientOptions.ServiceVersion.V2021_03_07));
 
-            Assert.NotNull(smsClient.OptOuts);
+            Assert.That(smsClient.OptOuts, Is.Not.Null);
         }
 
         [TestCaseSource(nameof(TestDataForSingleSms))]
@@ -116,18 +116,18 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .ReturnsAsync((string from, string to, string message, SmsSendOptions options, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(expectedMessage, message);
-                    Assert.AreEqual(cancellationToken, token);
-                    Assert.AreEqual(expectedOptions, options);
+                    Assert.That(from, Is.EqualTo(expectedFrom));
+                    Assert.That(to, Is.EqualTo(expectedTo));
+                    Assert.That(message, Is.EqualTo(expectedMessage));
+                    Assert.That(token, Is.EqualTo(cancellationToken));
+                    Assert.That(options, Is.EqualTo(expectedOptions));
                     return expectedResponse = new Mock<Response<SmsSendResult>>().Object;
                 });
 
             Response<SmsSendResult> actualResponse = await mockClient.Object.SendAsync(expectedFrom, expectedTo, expectedMessage, expectedOptions, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResponse));
         }
 
         [TestCaseSource(nameof(TestDataForSingleSms))]
@@ -142,18 +142,18 @@ namespace Azure.Communication.Sms.Tests
                 .Setup(callExpression)
                 .Returns((string from, string to, string message, SmsSendOptions options, CancellationToken token) =>
                 {
-                    Assert.AreEqual(expectedFrom, from);
-                    Assert.AreEqual(expectedTo, to);
-                    Assert.AreEqual(expectedMessage, message);
-                    Assert.AreEqual(cancellationToken, token);
-                    Assert.AreEqual(expectedOptions, options);
+                    Assert.That(from, Is.EqualTo(expectedFrom));
+                    Assert.That(to, Is.EqualTo(expectedTo));
+                    Assert.That(message, Is.EqualTo(expectedMessage));
+                    Assert.That(token, Is.EqualTo(cancellationToken));
+                    Assert.That(options, Is.EqualTo(expectedOptions));
                     return expectedResponse = new Mock<Response<SmsSendResult>>().Object;
                 });
 
             Response<SmsSendResult> actualResponse = mockClient.Object.Send(expectedFrom, expectedTo, expectedMessage, expectedOptions, cancellationToken);
 
             mockClient.Verify(callExpression, Times.Once());
-            Assert.AreEqual(expectedResponse, actualResponse);
+            Assert.That(actualResponse, Is.EqualTo(expectedResponse));
         }
 
         private static IEnumerable<object?[]> TestDataForSingleSms()

--- a/sdk/communication/Azure.Communication.Sms/tests/SmsRestClientTest.cs
+++ b/sdk/communication/Azure.Communication.Sms/tests/SmsRestClientTest.cs
@@ -64,7 +64,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
         }
@@ -83,7 +83,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("smsRecipients", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("smsRecipients"));
                 return;
             }
         }
@@ -102,7 +102,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("message", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("message"));
                 return;
             }
         }
@@ -125,7 +125,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.Partner).ToLower(), ex.ParamName?.ToLower());
+                Assert.That(ex.ParamName?.ToLower(), Is.EqualTo(nameof(MessagingConnectOptions.Partner).ToLower()));
                 return;
             }
         }
@@ -148,7 +148,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.ApiKey).ToLower(), ex.ParamName?.ToLower());
+                Assert.That(ex.ParamName?.ToLower(), Is.EqualTo(nameof(MessagingConnectOptions.ApiKey).ToLower()));
                 return;
             }
         }
@@ -167,7 +167,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("from", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("from"));
                 return;
             }
         }
@@ -186,7 +186,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("smsRecipients", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("smsRecipients"));
                 return;
             }
         }
@@ -205,7 +205,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual("message", ex.ParamName);
+                Assert.That(ex.ParamName, Is.EqualTo("message"));
                 return;
             }
         }
@@ -228,7 +228,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.ApiKey).ToLower(), ex.ParamName?.ToLower());
+                Assert.That(ex.ParamName?.ToLower(), Is.EqualTo(nameof(MessagingConnectOptions.ApiKey).ToLower()));
                 return;
             }
         }
@@ -251,7 +251,7 @@ namespace Azure.Communication.Sms.Tests
             }
             catch (ArgumentNullException ex)
             {
-                Assert.AreEqual(nameof(MessagingConnectOptions.Partner).ToLower(), ex.ParamName?.ToLower());
+                Assert.That(ex.ParamName?.ToLower(), Is.EqualTo(nameof(MessagingConnectOptions.Partner).ToLower()));
                 return;
             }
         }

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/CommunicationServiceTests.cs
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/CommunicationServiceTests.cs
@@ -74,8 +74,8 @@ namespace Azure.ResourceManager.Communication.Tests
             await communication.AddTagAsync("testkey", "testvalue");
             communication = await collection.GetAsync(communicationServiceName);
             var tagValue = communication.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            Assert.That("testkey", Is.EqualTo(tagValue.Key));
+            Assert.That("testvalue", Is.EqualTo(tagValue.Value));
         }
 
         [TestCase(null)]
@@ -90,12 +90,12 @@ namespace Azure.ResourceManager.Communication.Tests
             await communication.AddTagAsync("testkey", "testvalue");
             communication = await collection.GetAsync(communicationServiceName);
             var tagValue = communication.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            Assert.That("testkey", Is.EqualTo(tagValue.Key));
+            Assert.That("testvalue", Is.EqualTo(tagValue.Value));
             await communication.RemoveTagAsync("testkey");
             communication = await collection.GetAsync(communicationServiceName);
             var tag = communication.Data.Tags;
-            Assert.IsTrue(tag.Count == 0);
+            Assert.That(tag.Count == 0, Is.True);
         }
 
         [TestCase(null)]
@@ -110,15 +110,15 @@ namespace Azure.ResourceManager.Communication.Tests
             await communication.AddTagAsync("testkey", "testvalue");
             communication = await collection.GetAsync(communicationServiceName);
             var tagValue = communication.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            Assert.That("testkey", Is.EqualTo(tagValue.Key));
+            Assert.That("testvalue", Is.EqualTo(tagValue.Value));
             var tag = new Dictionary<string, string>() { { "newtestkey", "newtestvalue" } };
             await communication.SetTagsAsync(tag);
             communication = await collection.GetAsync(communicationServiceName);
             tagValue = communication.Data.Tags.FirstOrDefault();
-            Assert.IsTrue(communication.Data.Tags.Count == 1);
-            Assert.AreEqual(tagValue.Key, "newtestkey");
-            Assert.AreEqual(tagValue.Value, "newtestvalue");
+            Assert.That(communication.Data.Tags.Count == 1, Is.True);
+            Assert.That("newtestkey", Is.EqualTo(tagValue.Key));
+            Assert.That("newtestvalue", Is.EqualTo(tagValue.Value));
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace Azure.ResourceManager.Communication.Tests
             string communicationServiceName = Recording.GenerateAssetName("communication-service-");
             var communicationServiceLro = await _resourceGroup.GetCommunicationServiceResources().CreateOrUpdateAsync(WaitUntil.Completed, communicationServiceName, data);
             var resource = communicationServiceLro.Value;
-            Assert.AreEqual(resource.Data.Identity.ManagedServiceIdentityType, ManagedServiceIdentityType.SystemAssignedUserAssigned);
+            Assert.That(ManagedServiceIdentityType.SystemAssignedUserAssigned, Is.EqualTo(resource.Data.Identity.ManagedServiceIdentityType));
         }
 
         [Test]
@@ -145,10 +145,10 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetCommunicationServiceResources();
             var communication = await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             var keys = await communication.GetKeysAsync();
-            Assert.NotNull(keys.Value.PrimaryKey);
-            Assert.NotNull(keys.Value.SecondaryKey);
-            Assert.NotNull(keys.Value.PrimaryConnectionString);
-            Assert.NotNull(keys.Value.SecondaryConnectionString);
+            Assert.That(keys.Value.PrimaryKey, Is.Not.Null);
+            Assert.That(keys.Value.SecondaryKey, Is.Not.Null);
+            Assert.That(keys.Value.PrimaryConnectionString, Is.Not.Null);
+            Assert.That(keys.Value.SecondaryConnectionString, Is.Not.Null);
         }
 
         // [Test]
@@ -164,12 +164,12 @@ namespace Azure.ResourceManager.Communication.Tests
             string secondaryConnectionString = keys.Value.SecondaryConnectionString;
             var parameter = new RegenerateCommunicationServiceKeyContent() { KeyType = CommunicationServiceKeyType.Primary };
             var newkeys = await communication.RegenerateKeyAsync(parameter);
-            Assert.AreEqual(primaryKey, newkeys.Value.PrimaryKey);
-            Assert.NotNull(primaryConnectionString, keys.Value.PrimaryConnectionString);
+            Assert.That(newkeys.Value.PrimaryKey, Is.EqualTo(primaryKey));
+            Assert.That(primaryConnectionString, Is.Not.Null);
             parameter = new RegenerateCommunicationServiceKeyContent() { KeyType = CommunicationServiceKeyType.Secondary };
             newkeys = await communication.RegenerateKeyAsync(parameter);
-            Assert.NotNull(secondaryKey, keys.Value.SecondaryKey);
-            Assert.NotNull(secondaryConnectionString, keys.Value.SecondaryConnectionString);
+            Assert.That(secondaryKey, Is.Not.Null);
+            Assert.That(secondaryConnectionString, Is.Not.Null);
         }
 
         [Test]
@@ -182,7 +182,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var parameter = new LinkNotificationHubContent(new ResourceIdentifier(((CommunicationManagementTestEnvironment)TestEnvironment).NotificationHubsResourceId),
                 ((CommunicationManagementTestEnvironment)TestEnvironment).NotificationHubsConnectionString);
             var hub = await communication.LinkNotificationHubAsync(parameter);
-            Assert.NotNull(hub.Value.ResourceId);
+            Assert.That(hub.Value.ResourceId, Is.Not.Null);
         }
 
         [Test]
@@ -192,7 +192,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetCommunicationServiceResources();
             await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             bool exists = await collection.ExistsAsync(communicationServiceName);
-            Assert.IsTrue(exists);
+            Assert.That(exists, Is.True);
         }
 
         [Test]
@@ -200,10 +200,10 @@ namespace Azure.ResourceManager.Communication.Tests
         {
             string communicationServiceName = Recording.GenerateAssetName("communication-service-");
             var communicationService = await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
-            Assert.IsNotNull(communicationService);
-            Assert.AreEqual(communicationServiceName, communicationService.Data.Name);
-            Assert.AreEqual(_location.ToString(), communicationService.Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), communicationService.Data.DataLocation.ToString());
+            Assert.That(communicationService, Is.Not.Null);
+            Assert.That(communicationService.Data.Name, Is.EqualTo(communicationServiceName));
+            Assert.That(communicationService.Data.Location.ToString(), Is.EqualTo(_location.ToString()));
+            Assert.That(communicationService.Data.DataLocation.ToString(), Is.EqualTo(_dataLocation.ToString()));
         }
 
         [Test]
@@ -216,9 +216,9 @@ namespace Azure.ResourceManager.Communication.Tests
                 Tags = { { "newtag", "newvalue" } }
             };
             var communication2 = (await communication1.UpdateAsync(patch)).Value;
-            Assert.IsNotNull(communication2);
-            Assert.AreEqual("newtag", communication2.Data.Tags.FirstOrDefault().Key);
-            Assert.AreEqual(communication1.Data.Name, communication2.Data.Name);
+            Assert.That(communication2, Is.Not.Null);
+            Assert.That(communication2.Data.Tags.FirstOrDefault().Key, Is.EqualTo("newtag"));
+            Assert.That(communication2.Data.Name, Is.EqualTo(communication1.Data.Name));
         }
 
         [Test]
@@ -229,7 +229,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var communicationService = await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             await communicationService.DeleteAsync(WaitUntil.Completed);
             bool exists = await collection.ExistsAsync(communicationServiceName);
-            Assert.IsFalse(exists);
+            Assert.That(exists, Is.False);
         }
 
         [Test]
@@ -239,10 +239,10 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetCommunicationServiceResources();
             await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             var communicationService = await collection.GetAsync(communicationServiceName);
-            Assert.IsNotNull(communicationService);
-            Assert.AreEqual(communicationServiceName, communicationService.Value.Data.Name);
-            Assert.AreEqual(_location.ToString(), communicationService.Value.Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), communicationService.Value.Data.DataLocation.ToString());
+            Assert.That(communicationService, Is.Not.Null);
+            Assert.That(communicationService.Value.Data.Name, Is.EqualTo(communicationServiceName));
+            Assert.That(communicationService.Value.Data.Location.ToString(), Is.EqualTo(_location.ToString()));
+            Assert.That(communicationService.Value.Data.DataLocation.ToString(), Is.EqualTo(_dataLocation.ToString()));
         }
 
         [Test]
@@ -251,10 +251,10 @@ namespace Azure.ResourceManager.Communication.Tests
             string communicationServiceName = Recording.GenerateAssetName("communication-service-");
             await CreateDefaultCommunicationServices(communicationServiceName, _resourceGroup);
             var list = await _resourceGroup.GetCommunicationServiceResources().GetAllAsync().ToEnumerableAsync();
-            Assert.IsNotEmpty(list);
-            Assert.AreEqual(communicationServiceName, list.FirstOrDefault().Data.Name);
-            Assert.AreEqual(_location.ToString(), list.FirstOrDefault().Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), list.FirstOrDefault().Data.DataLocation.ToString());
+            Assert.That(list, Is.Not.Empty);
+            Assert.That(list.FirstOrDefault().Data.Name, Is.EqualTo(communicationServiceName));
+            Assert.That(list.FirstOrDefault().Data.Location.ToString(), Is.EqualTo(_location.ToString()));
+            Assert.That(list.FirstOrDefault().Data.DataLocation.ToString(), Is.EqualTo(_dataLocation.ToString()));
         }
     }
 }

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/DomainTests.cs
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/DomainTests.cs
@@ -68,8 +68,8 @@ namespace Azure.ResourceManager.Communication.Tests
             await domain.AddTagAsync("testkey", "testvalue");
             domain = await collection.GetAsync(domainName);
             var tagValue = domain.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            Assert.That("testkey", Is.EqualTo(tagValue.Key));
+            Assert.That("testvalue", Is.EqualTo(tagValue.Value));
         }
 
         [TestCase(null)]
@@ -84,12 +84,12 @@ namespace Azure.ResourceManager.Communication.Tests
             await domain.AddTagAsync("testkey", "testvalue");
             domain = await collection.GetAsync(domainName);
             var tagValue = domain.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            Assert.That("testkey", Is.EqualTo(tagValue.Key));
+            Assert.That("testvalue", Is.EqualTo(tagValue.Value));
             await domain.RemoveTagAsync("testkey");
             domain = await collection.GetAsync(domainName);
             var tag = domain.Data.Tags;
-            Assert.IsTrue(tag.Count == 0);
+            Assert.That(tag.Count == 0, Is.True);
         }
 
         [TestCase(null)]
@@ -104,15 +104,15 @@ namespace Azure.ResourceManager.Communication.Tests
             await domain.AddTagAsync("testkey", "testvalue");
             domain = await collection.GetAsync(domainName);
             var tagValue = domain.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            Assert.That("testkey", Is.EqualTo(tagValue.Key));
+            Assert.That("testvalue", Is.EqualTo(tagValue.Value));
             var tag = new Dictionary<string, string>() { { "newtestkey", "newtestvalue" } };
             await domain.SetTagsAsync(tag);
             domain = await collection.GetAsync(domainName);
             tagValue = domain.Data.Tags.FirstOrDefault();
-            Assert.IsTrue(domain.Data.Tags.Count == 1);
-            Assert.AreEqual(tagValue.Key, "newtestkey");
-            Assert.AreEqual(tagValue.Value, "newtestvalue");
+            Assert.That(domain.Data.Tags.Count == 1, Is.True);
+            Assert.That("newtestkey", Is.EqualTo(tagValue.Key));
+            Assert.That("newtestvalue", Is.EqualTo(tagValue.Value));
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _emailService.GetCommunicationDomainResources();
             await CreateDefaultDomain(domainName, _emailService);
             bool exists = await collection.ExistsAsync(domainName);
-            Assert.IsTrue(exists);
+            Assert.That(exists, Is.True);
         }
 
         [Test]
@@ -130,10 +130,10 @@ namespace Azure.ResourceManager.Communication.Tests
         {
             string domainName = Recording.GenerateAssetName("domain-") + ".com";
             var domain = await CreateDefaultDomain(domainName, _emailService);
-            Assert.IsNotNull(domain);
-            Assert.AreEqual(domainName, domain.Data.Name);
-            Assert.AreEqual(_location.ToString().ToLower(), domain.Data.Location.ToString().ToLower());
-            Assert.AreEqual(_dataLocation.ToString().ToLower(), domain.Data.DataLocation.ToString().ToLower());
+            Assert.That(domain, Is.Not.Null);
+            Assert.That(domain.Data.Name, Is.EqualTo(domainName));
+            Assert.That(domain.Data.Location.ToString().ToLower(), Is.EqualTo(_location.ToString().ToLower()));
+            Assert.That(domain.Data.DataLocation.ToString().ToLower(), Is.EqualTo(_dataLocation.ToString().ToLower()));
         }
 
         [Test]
@@ -146,8 +146,8 @@ namespace Azure.ResourceManager.Communication.Tests
                 UserEngagementTracking = UserEngagementTracking.Enabled
             };
             var domain2 = (await domain1.UpdateAsync(WaitUntil.Completed, patch)).Value;
-            Assert.IsNotNull(domain2);
-            Assert.AreEqual(domain1.Data.Name, domain2.Data.Name);
+            Assert.That(domain2, Is.Not.Null);
+            Assert.That(domain2.Data.Name, Is.EqualTo(domain1.Data.Name));
         }
 
         [Test]
@@ -158,7 +158,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var domain = await CreateDefaultDomain(domainName, _emailService);
             await domain.DeleteAsync(WaitUntil.Completed);
             bool exists = await collection.ExistsAsync(domainName);
-            Assert.IsFalse(exists);
+            Assert.That(exists, Is.False);
         }
 
         [Test]
@@ -168,10 +168,10 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _emailService.GetCommunicationDomainResources();
             await CreateDefaultDomain(domainName, _emailService);
             var domain = await collection.GetAsync(domainName);
-            Assert.IsNotNull(domain);
-            Assert.AreEqual(domainName, domain.Value.Data.Name);
-            Assert.AreEqual(_location.ToString().ToLower(), domain.Value.Data.Location.ToString().ToLower());
-            Assert.AreEqual(_dataLocation.ToString().ToLower(), domain.Value.Data.DataLocation.ToString().ToLower());
+            Assert.That(domain, Is.Not.Null);
+            Assert.That(domain.Value.Data.Name, Is.EqualTo(domainName));
+            Assert.That(domain.Value.Data.Location.ToString().ToLower(), Is.EqualTo(_location.ToString().ToLower()));
+            Assert.That(domain.Value.Data.DataLocation.ToString().ToLower(), Is.EqualTo(_dataLocation.ToString().ToLower()));
         }
 
         [Test]
@@ -180,10 +180,10 @@ namespace Azure.ResourceManager.Communication.Tests
             string domainName = Recording.GenerateAssetName("domain-") + ".com";
             await CreateDefaultDomain(domainName, _emailService);
             var list = await _emailService.GetCommunicationDomainResources().GetAllAsync().ToEnumerableAsync();
-            Assert.IsNotEmpty(list);
-            Assert.AreEqual(domainName, list.FirstOrDefault().Data.Name);
-            Assert.AreEqual(_location.ToString().ToLower(), list.FirstOrDefault().Data.Location.ToString().ToLower());
-            Assert.AreEqual(_dataLocation.ToString().ToLower(), list.FirstOrDefault().Data.DataLocation.ToString().ToLower());
+            Assert.That(list, Is.Not.Empty);
+            Assert.That(list.FirstOrDefault().Data.Name, Is.EqualTo(domainName));
+            Assert.That(list.FirstOrDefault().Data.Location.ToString().ToLower(), Is.EqualTo(_location.ToString().ToLower()));
+            Assert.That(list.FirstOrDefault().Data.DataLocation.ToString().ToLower(), Is.EqualTo(_dataLocation.ToString().ToLower()));
         }
 
         [Test]

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/EmailServiceTests.cs
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/EmailServiceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -68,8 +68,8 @@ namespace Azure.ResourceManager.Communication.Tests
             await email.AddTagAsync("testkey", "testvalue");
             email = await collection.GetAsync(emailServiceName);
             var tagValue = email.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            Assert.That("testkey", Is.EqualTo(tagValue.Key));
+            Assert.That("testvalue", Is.EqualTo(tagValue.Value));
         }
 
         [TestCase(null)]
@@ -84,12 +84,12 @@ namespace Azure.ResourceManager.Communication.Tests
             await email.AddTagAsync("testkey", "testvalue");
             email = await collection.GetAsync(emailServiceName);
             var tagValue = email.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            Assert.That("testkey", Is.EqualTo(tagValue.Key));
+            Assert.That("testvalue", Is.EqualTo(tagValue.Value));
             await email.RemoveTagAsync("testkey");
             email = await collection.GetAsync(emailServiceName);
             var tag = email.Data.Tags;
-            Assert.IsTrue(tag.Count == 0);
+            Assert.That(tag.Count == 0, Is.True);
         }
 
         [TestCase(null)]
@@ -104,15 +104,15 @@ namespace Azure.ResourceManager.Communication.Tests
             await email.AddTagAsync("testkey", "testvalue");
             email = await collection.GetAsync(emailServiceName);
             var tagValue = email.Data.Tags.FirstOrDefault();
-            Assert.AreEqual(tagValue.Key, "testkey");
-            Assert.AreEqual(tagValue.Value, "testvalue");
+            Assert.That("testkey", Is.EqualTo(tagValue.Key));
+            Assert.That("testvalue", Is.EqualTo(tagValue.Value));
             var tag = new Dictionary<string, string>() { { "newtestkey", "newtestvalue" } };
             await email.SetTagsAsync(tag);
             email = await collection.GetAsync(emailServiceName);
             tagValue = email.Data.Tags.FirstOrDefault();
-            Assert.IsTrue(email.Data.Tags.Count == 1);
-            Assert.AreEqual(tagValue.Key, "newtestkey");
-            Assert.AreEqual(tagValue.Value, "newtestvalue");
+            Assert.That(email.Data.Tags.Count == 1, Is.True);
+            Assert.That("newtestkey", Is.EqualTo(tagValue.Key));
+            Assert.That("newtestvalue", Is.EqualTo(tagValue.Value));
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetEmailServiceResources();
             await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             bool exists = await collection.ExistsAsync(emailServiceName);
-            Assert.IsTrue(exists);
+            Assert.That(exists, Is.True);
         }
 
         [Test]
@@ -130,10 +130,10 @@ namespace Azure.ResourceManager.Communication.Tests
         {
             string emailServiceName = Recording.GenerateAssetName("email-service-");
             var emailService = await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
-            Assert.IsNotNull(emailService);
-            Assert.AreEqual(emailServiceName, emailService.Data.Name);
-            Assert.AreEqual(_location.ToString(), emailService.Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), emailService.Data.DataLocation.ToString());
+            Assert.That(emailService, Is.Not.Null);
+            Assert.That(emailService.Data.Name, Is.EqualTo(emailServiceName));
+            Assert.That(emailService.Data.Location.ToString(), Is.EqualTo(_location.ToString()));
+            Assert.That(emailService.Data.DataLocation.ToString(), Is.EqualTo(_dataLocation.ToString()));
         }
 
         [Test]
@@ -143,8 +143,8 @@ namespace Azure.ResourceManager.Communication.Tests
             var emailService1 = await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             var patch = new EmailServiceResourcePatch();
             var emailService2 = (await emailService1.UpdateAsync(WaitUntil.Completed, patch)).Value;
-            Assert.IsNotNull(emailService2);
-            Assert.AreEqual(emailService1.Data.Name, emailService2.Data.Name);
+            Assert.That(emailService2, Is.Not.Null);
+            Assert.That(emailService2.Data.Name, Is.EqualTo(emailService1.Data.Name));
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var emailService = await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             await emailService.DeleteAsync(WaitUntil.Completed);
             bool exists = await collection.ExistsAsync(emailServiceName);
-            Assert.IsFalse(exists);
+            Assert.That(exists, Is.False);
         }
 
         [Test]
@@ -165,10 +165,10 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _resourceGroup.GetEmailServiceResources();
             await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             var emailService = await collection.GetAsync(emailServiceName);
-            Assert.IsNotNull(emailService);
-            Assert.AreEqual(emailServiceName, emailService.Value.Data.Name);
-            Assert.AreEqual(_location.ToString(), emailService.Value.Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), emailService.Value.Data.DataLocation.ToString());
+            Assert.That(emailService, Is.Not.Null);
+            Assert.That(emailService.Value.Data.Name, Is.EqualTo(emailServiceName));
+            Assert.That(emailService.Value.Data.Location.ToString(), Is.EqualTo(_location.ToString()));
+            Assert.That(emailService.Value.Data.DataLocation.ToString(), Is.EqualTo(_dataLocation.ToString()));
         }
 
         [Test]
@@ -177,10 +177,10 @@ namespace Azure.ResourceManager.Communication.Tests
             string emailServiceName = Recording.GenerateAssetName("email-service-");
             await CreateDefaultEmailServices(emailServiceName, _resourceGroup);
             var list = await _resourceGroup.GetEmailServiceResources().GetAllAsync().ToEnumerableAsync();
-            Assert.IsNotEmpty(list);
-            Assert.AreEqual(emailServiceName, list.FirstOrDefault().Data.Name);
-            Assert.AreEqual(_location.ToString(), list.FirstOrDefault().Data.Location.ToString());
-            Assert.AreEqual(_dataLocation.ToString(), list.FirstOrDefault().Data.DataLocation.ToString());
+            Assert.That(list, Is.Not.Empty);
+            Assert.That(list.FirstOrDefault().Data.Name, Is.EqualTo(emailServiceName));
+            Assert.That(list.FirstOrDefault().Data.Location.ToString(), Is.EqualTo(_location.ToString()));
+            Assert.That(list.FirstOrDefault().Data.DataLocation.ToString(), Is.EqualTo(_dataLocation.ToString()));
         }
     }
 }

--- a/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/SenderUsernameTests.cs
+++ b/sdk/communication/Azure.ResourceManager.Communication/tests/ScenarioTests/SenderUsernameTests.cs
@@ -77,7 +77,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var collection = _domainResource.GetSenderUsernameResources();
             await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
             bool exists = await collection.ExistsAsync(username);
-            Assert.IsTrue(exists);
+            Assert.That(exists, Is.True);
         }
 
         [Test]
@@ -88,9 +88,9 @@ namespace Azure.ResourceManager.Communication.Tests
 
             var senderUsername = await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
 
-            Assert.IsNotNull(senderUsername);
-            Assert.AreEqual(username, senderUsername.Data.Username);
-            Assert.AreEqual(displayName, senderUsername.Data.DisplayName);
+            Assert.That(senderUsername, Is.Not.Null);
+            Assert.That(senderUsername.Data.Username, Is.EqualTo(username));
+            Assert.That(senderUsername.Data.DisplayName, Is.EqualTo(displayName));
         }
 
         // todo: follow up on update bug. Updating a record with the same name results in 400 error a username already exists.
@@ -111,10 +111,10 @@ namespace Azure.ResourceManager.Communication.Tests
         //    };
         //    var senderUsername2 = (await senderUsername1.UpdateAsync(WaitUntil.Completed, patch)).Value;
 
-        //    Assert.IsNotNull(senderUsername2);
-        //    Assert.AreEqual(senderUsername1.Data.Name, senderUsername2.Data.Name);
-        //    Assert.AreNotEqual(senderUsername1.Data.Username, senderUsername2.Data.Username);
-        //    Assert.AreNotEqual(senderUsername1.Data.DisplayName, senderUsername2.Data.DisplayName);
+        //    Assert.That(senderUsername2, Is.Not.Null);
+        //    Assert.That(senderUsername2.Data.Name, Is.EqualTo(senderUsername1.Data.Name));
+        //    Assert.That(senderUsername2.Data.Username, Is.Not.EqualTo(senderUsername1.Data.Username));
+        //    Assert.That(senderUsername2.Data.DisplayName, Is.Not.EqualTo(senderUsername1.Data.DisplayName));
         //}
 
         [Test]
@@ -127,7 +127,7 @@ namespace Azure.ResourceManager.Communication.Tests
             var senderUsername = await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
             await senderUsername.DeleteAsync(WaitUntil.Completed);
             bool exists = await collection.ExistsAsync(username);
-            Assert.IsFalse(exists);
+            Assert.That(exists, Is.False);
         }
 
         [Test]
@@ -140,9 +140,9 @@ namespace Azure.ResourceManager.Communication.Tests
             await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
 
             var actualSenderUsername = await collection.GetAsync(username);
-            Assert.IsNotNull(actualSenderUsername);
-            Assert.AreEqual(actualSenderUsername.Value.Data.Username, username);
-            Assert.AreEqual(actualSenderUsername.Value.Data.DisplayName, displayName);
+            Assert.That(actualSenderUsername, Is.Not.Null);
+            Assert.That(username, Is.EqualTo(actualSenderUsername.Value.Data.Username));
+            Assert.That(displayName, Is.EqualTo(actualSenderUsername.Value.Data.DisplayName));
         }
 
         [Test]
@@ -154,9 +154,9 @@ namespace Azure.ResourceManager.Communication.Tests
             await CreateDefaultSenderUsernameResource(username, displayName, _domainResource);
 
             var list = await _domainResource.GetSenderUsernameResources().GetAllAsync().ToEnumerableAsync();
-            Assert.IsNotEmpty(list);
-            Assert.IsTrue(list.Any(s => s.HasData && s.Data.Username == username));
-            Assert.IsTrue(list.Any(s => s.HasData && s.Data.DisplayName == displayName));
+            Assert.That(list, Is.Not.Empty);
+            Assert.That(list.Any(s => s.HasData && s.Data.Username == username), Is.True);
+            Assert.That(list.Any(s => s.HasData && s.Data.DisplayName == displayName), Is.True);
         }
     }
 }

--- a/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
+++ b/sdk/communication/Shared/src/CommunicationIdentifierSerializerTest.cs
@@ -83,7 +83,7 @@ namespace Azure.Communication
         {
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(new CommunicationUserIdentifier(TestUserId));
 
-            Assert.AreEqual(TestUserId, model.CommunicationUser.Id);
+            Assert.That(model.CommunicationUser.Id, Is.EqualTo(TestUserId));
         }
 
         [Test]
@@ -98,8 +98,8 @@ namespace Azure.Communication
 
             CommunicationUserIdentifier expectedIdentifier = new(TestUserId);
 
-            Assert.AreEqual(expectedIdentifier.Id, identifier.Id);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.Id, Is.EqualTo(expectedIdentifier.Id));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -115,8 +115,8 @@ namespace Azure.Communication
 
             CommunicationUserIdentifier expectedIdentifier = new(TestUserId);
 
-            Assert.AreEqual(expectedIdentifier.Id, identifier.Id);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.Id, Is.EqualTo(expectedIdentifier.Id));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -131,8 +131,8 @@ namespace Azure.Communication
 
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -140,7 +140,7 @@ namespace Azure.Communication
         {
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(new UnknownIdentifier(TestRawId));
 
-            Assert.AreEqual(TestRawId, model.RawId);
+            Assert.That(model.RawId, Is.EqualTo(TestRawId));
         }
 
         [Test]
@@ -153,8 +153,8 @@ namespace Azure.Communication
                 });
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.Id, identifier.Id);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.Id, Is.EqualTo(expectedIdentifier.Id));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -164,8 +164,8 @@ namespace Azure.Communication
         {
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(new PhoneNumberIdentifier(TestPhoneNumber, rawId));
 
-            Assert.AreEqual(TestPhoneNumber, model.PhoneNumber.Value);
-            Assert.AreEqual(TestPhoneNumberRawId, model.RawId);
+            Assert.That(model.PhoneNumber.Value, Is.EqualTo(TestPhoneNumber));
+            Assert.That(model.RawId, Is.EqualTo(TestPhoneNumberRawId));
         }
 
         [Test]
@@ -180,9 +180,9 @@ namespace Azure.Communication
 
             PhoneNumberIdentifier expectedIdentifier = new(TestPhoneNumber, TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.PhoneNumber, identifier.PhoneNumber);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.PhoneNumber, Is.EqualTo(expectedIdentifier.PhoneNumber));
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -198,9 +198,9 @@ namespace Azure.Communication
 
             PhoneNumberIdentifier expectedIdentifier = new(TestPhoneNumber, TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.PhoneNumber, identifier.PhoneNumber);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.PhoneNumber, Is.EqualTo(expectedIdentifier.PhoneNumber));
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -215,8 +215,8 @@ namespace Azure.Communication
 
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -229,10 +229,10 @@ namespace Azure.Communication
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(
                 new MicrosoftTeamsUserIdentifier(TestTeamsUserId, isAnonymous, CommunicationCloudEnvironment.Dod, rawId));
 
-            Assert.AreEqual(TestTeamsUserId, model.MicrosoftTeamsUser.UserId);
-            Assert.AreEqual(CommunicationCloudEnvironmentModel.Dod, model.MicrosoftTeamsUser.Cloud);
-            Assert.AreEqual(isAnonymous, model.MicrosoftTeamsUser.IsAnonymous);
-            Assert.AreEqual(rawId ?? $"8:{(isAnonymous ? "teamsvisitor" : "dod")}:{TestTeamsUserId}", model.RawId);
+            Assert.That(model.MicrosoftTeamsUser.UserId, Is.EqualTo(TestTeamsUserId));
+            Assert.That(model.MicrosoftTeamsUser.Cloud, Is.EqualTo(CommunicationCloudEnvironmentModel.Dod));
+            Assert.That(model.MicrosoftTeamsUser.IsAnonymous, Is.EqualTo(isAnonymous));
+            Assert.That(model.RawId, Is.EqualTo(rawId ?? $"8:{(isAnonymous ? "teamsvisitor" : "dod")}:{TestTeamsUserId}"));
         }
 
         [Test]
@@ -253,11 +253,11 @@ namespace Azure.Communication
 
             MicrosoftTeamsUserIdentifier expectedIdentifier = new(TestTeamsUserId, isAnonymous, CommunicationCloudEnvironment.Gcch, TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.UserId, identifier.UserId);
-            Assert.AreEqual(expectedIdentifier.IsAnonymous, identifier.IsAnonymous);
-            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.UserId, Is.EqualTo(expectedIdentifier.UserId));
+            Assert.That(identifier.IsAnonymous, Is.EqualTo(expectedIdentifier.IsAnonymous));
+            Assert.That(identifier.Cloud, Is.EqualTo(expectedIdentifier.Cloud));
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -277,11 +277,11 @@ namespace Azure.Communication
 
             MicrosoftTeamsUserIdentifier expectedIdentifier = new(TestTeamsUserId, false, CommunicationCloudEnvironment.Gcch, TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.UserId, identifier.UserId);
-            Assert.AreEqual(expectedIdentifier.IsAnonymous, identifier.IsAnonymous);
-            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.UserId, Is.EqualTo(expectedIdentifier.UserId));
+            Assert.That(identifier.IsAnonymous, Is.EqualTo(expectedIdentifier.IsAnonymous));
+            Assert.That(identifier.Cloud, Is.EqualTo(expectedIdentifier.Cloud));
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -296,8 +296,8 @@ namespace Azure.Communication
 
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -306,9 +306,9 @@ namespace Azure.Communication
             CommunicationIdentifierModel model = CommunicationIdentifierSerializer.Serialize(
                 new MicrosoftTeamsAppIdentifier(TestTeamsAppId, CommunicationCloudEnvironment.Dod));
 
-            Assert.AreEqual(TestTeamsAppId, model.MicrosoftTeamsApp.AppId);
-            Assert.AreEqual(CommunicationCloudEnvironmentModel.Dod, model.MicrosoftTeamsApp.Cloud);
-            Assert.AreEqual($"28:dod:{TestTeamsAppId}", model.RawId);
+            Assert.That(model.MicrosoftTeamsApp.AppId, Is.EqualTo(TestTeamsAppId));
+            Assert.That(model.MicrosoftTeamsApp.Cloud, Is.EqualTo(CommunicationCloudEnvironmentModel.Dod));
+            Assert.That(model.RawId, Is.EqualTo($"28:dod:{TestTeamsAppId}"));
         }
 
         [Test]
@@ -326,10 +326,10 @@ namespace Azure.Communication
 
             MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, CommunicationCloudEnvironment.Gcch);
 
-            Assert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
-            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.AppId, Is.EqualTo(expectedIdentifier.AppId));
+            Assert.That(identifier.Cloud, Is.EqualTo(expectedIdentifier.Cloud));
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -348,10 +348,10 @@ namespace Azure.Communication
 
             MicrosoftTeamsAppIdentifier expectedIdentifier = new(TestTeamsAppId, CommunicationCloudEnvironment.Gcch);
 
-            Assert.AreEqual(expectedIdentifier.AppId, identifier.AppId);
-            Assert.AreEqual(expectedIdentifier.Cloud, identifier.Cloud);
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.AppId, Is.EqualTo(expectedIdentifier.AppId));
+            Assert.That(identifier.Cloud, Is.EqualTo(expectedIdentifier.Cloud));
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
 
         [Test]
@@ -366,8 +366,8 @@ namespace Azure.Communication
 
             UnknownIdentifier expectedIdentifier = new(TestRawId);
 
-            Assert.AreEqual(expectedIdentifier.RawId, identifier.RawId);
-            Assert.AreEqual(expectedIdentifier, identifier);
+            Assert.That(identifier.RawId, Is.EqualTo(expectedIdentifier.RawId));
+            Assert.That(identifier, Is.EqualTo(expectedIdentifier));
         }
     }
 }


### PR DESCRIPTION
This PR contributes to https://github.com/Azure/azure-sdk-for-net/issues/53413 by migrating all packages within the communication service directory to NUnit 4, following the NUnit migration guide: https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html
