### PR TITLE
Fix checkpoint store sovereign-cloud endpoint resolution (#57543)

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where the checkpoint store's `BlobServiceClient` was constructed using the hard-coded `core.windows.net` suffix when `AzureWebJobsStorage__accountName` was set, even if an explicit `AzureWebJobsStorage__blobServiceUri` was also present. The explicit `__blobServiceUri` is now preferred over `__accountName`, and an optional `__endpointSuffix` setting is honored when constructing the URI from `__accountName`. This unblocks Event Hub triggers that use managed-identity storage in sovereign clouds (e.g. Azure US Government, Azure China). ([#57543](https://github.com/Azure/azure-sdk-for-net/issues/57543))
+
 ### Other Changes
 
 - Replaced scaling warning/error log calls with standardized `LogFunctionScaleWarning` extension method to enable Scale Controller App Insights diagnostics.

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/StorageClientProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/StorageClientProviderTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Storage.Blobs;
+using Microsoft.Azure.WebJobs.Extensions.Clients.Shared;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
+{
+    public class StorageClientProviderTests
+    {
+        [Test]
+        public void TryGetServiceUri_AccountNameOnly_UsesDefaultSuffix()
+        {
+            var provider = CreateProvider(new Dictionary<string, string>
+            {
+                ["accountName"] = "myacct",
+            });
+
+            Assert.IsTrue(provider.TryGetServiceUri(out Uri uri));
+            Assert.AreEqual("https://myacct.blob.core.windows.net/", uri.AbsoluteUri);
+        }
+
+        [Test]
+        public void TryGetServiceUri_AccountNameWithEndpointSuffix_UsesSovereignSuffix()
+        {
+            var provider = CreateProvider(new Dictionary<string, string>
+            {
+                ["accountName"] = "myacct",
+                ["endpointSuffix"] = "core.usgovcloudapi.net",
+            });
+
+            Assert.IsTrue(provider.TryGetServiceUri(out Uri uri));
+            Assert.AreEqual("https://myacct.blob.core.usgovcloudapi.net/", uri.AbsoluteUri);
+        }
+
+        [Test]
+        public void TryGetServiceUri_BlobServiceUriOnly_UsesExplicitUri()
+        {
+            var provider = CreateProvider(new Dictionary<string, string>
+            {
+                ["blobServiceUri"] = "https://myacct.blob.core.usgovcloudapi.net/",
+            });
+
+            Assert.IsTrue(provider.TryGetServiceUri(out Uri uri));
+            Assert.AreEqual("https://myacct.blob.core.usgovcloudapi.net/", uri.AbsoluteUri);
+        }
+
+        // Regression test for https://github.com/Azure/azure-sdk-for-net/issues/57543:
+        // when both `accountName` and the explicit `{subdomain}ServiceUri` are configured,
+        // the explicit URI must win so sovereign-cloud endpoints are not silently overridden
+        // by the default `core.windows.net` suffix.
+        [Test]
+        public void TryGetServiceUri_AccountNameAndBlobServiceUri_PrefersExplicitUri()
+        {
+            var provider = CreateProvider(new Dictionary<string, string>
+            {
+                ["accountName"] = "myacct",
+                ["blobServiceUri"] = "https://myacct.blob.core.usgovcloudapi.net/",
+            });
+
+            Assert.IsTrue(provider.TryGetServiceUri(out Uri uri));
+            Assert.AreEqual("https://myacct.blob.core.usgovcloudapi.net/", uri.AbsoluteUri);
+        }
+
+        [Test]
+        public void TryGetServiceUri_NoConfiguration_ReturnsFalse()
+        {
+            var provider = CreateProvider(new Dictionary<string, string>());
+
+            Assert.IsFalse(provider.TryGetServiceUri(out Uri uri));
+            Assert.IsNull(uri);
+        }
+
+        private static TestStorageClientProvider CreateProvider(IDictionary<string, string> settings)
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(settings)
+                .Build();
+            return new TestStorageClientProvider(configuration);
+        }
+
+        private class TestStorageClientProvider : StorageClientProvider<BlobServiceClient, BlobClientOptions>
+        {
+            private readonly IConfiguration _configuration;
+
+            public TestStorageClientProvider(IConfiguration configuration)
+                : base(configuration: null, componentFactory: null, logForwarder: null, logger: NullLogger<BlobServiceClient>.Instance)
+            {
+                _configuration = configuration;
+            }
+
+            protected override string ServiceUriSubDomain => "blob";
+
+            public bool TryGetServiceUri(out Uri serviceUri) => TryGetServiceUri(_configuration, out serviceUri);
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/StorageClientProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.WebJobs.Extensions.EventHubs/tests/StorageClientProviderTests.cs
@@ -76,6 +76,47 @@ namespace Microsoft.Azure.WebJobs.EventHubs.UnitTests
             Assert.IsNull(uri);
         }
 
+        // Regression test: an empty `{subdomain}ServiceUri` should be ignored so the
+        // `accountName` fallback can still produce a valid service URI. This matters in
+        // sovereign clouds where tooling may inject empty placeholders.
+        [Test]
+        public void TryGetServiceUri_EmptyBlobServiceUri_FallsBackToAccountName()
+        {
+            var provider = CreateProvider(new Dictionary<string, string>
+            {
+                ["accountName"] = "myacct",
+                ["blobServiceUri"] = string.Empty,
+            });
+
+            Assert.IsTrue(provider.TryGetServiceUri(out Uri uri));
+            Assert.AreEqual("https://myacct.blob.core.windows.net/", uri.AbsoluteUri);
+        }
+
+        [Test]
+        public void TryGetServiceUri_NullBlobServiceUri_FallsBackToAccountName()
+        {
+            var provider = CreateProvider(new Dictionary<string, string>
+            {
+                ["accountName"] = "myacct",
+                ["blobServiceUri"] = null,
+            });
+
+            Assert.IsTrue(provider.TryGetServiceUri(out Uri uri));
+            Assert.AreEqual("https://myacct.blob.core.windows.net/", uri.AbsoluteUri);
+        }
+
+        [Test]
+        public void TryGetServiceUri_EmptyBlobServiceUriWithoutAccountName_ReturnsFalse()
+        {
+            var provider = CreateProvider(new Dictionary<string, string>
+            {
+                ["blobServiceUri"] = string.Empty,
+            });
+
+            Assert.IsFalse(provider.TryGetServiceUri(out Uri uri));
+            Assert.IsNull(uri);
+        }
+
         private static TestStorageClientProvider CreateProvider(IDictionary<string, string> settings)
         {
             IConfiguration configuration = new ConfigurationBuilder()

--- a/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/CHANGELOG.md
+++ b/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 1.0.0-beta.1 (Unreleased)
 
 - Initial release of the package.
+- `StorageClientProvider` now prefers an explicit `{subdomain}ServiceUri` configuration value over `accountName` when both are present, and honors an optional `endpointSuffix` setting when constructing the service URI from `accountName`. This enables sovereign-cloud (e.g. Azure US Government, Azure China) deployments where the Azure Functions host injects `accountName` automatically. ([#57543](https://github.com/Azure/azure-sdk-for-net/issues/57543))

--- a/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared/StorageClientProvider.cs
+++ b/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared/StorageClientProvider.cs
@@ -145,16 +145,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Clients.Shared
             {
                 var serviceUriConfig = string.Format(CultureInfo.InvariantCulture, "{0}ServiceUri", ServiceUriSubDomain);
 
-                string accountName;
+                // Prefer an explicit {subdomain}ServiceUri when present. This allows callers in
+                // sovereign clouds (e.g. Azure US Government, Azure China) to provide the correct
+                // endpoint even when `accountName` is also configured (which the Azure Functions
+                // host injects automatically when managed-identity storage is used).
                 string uriStr;
-                if ((accountName = configuration.GetValue<string>("accountName")) != null)
-                {
-                    serviceUri = FormatServiceUri(accountName);
-                    return true;
-                }
-                else if ((uriStr = configuration.GetValue<string>(serviceUriConfig)) != null)
+                if ((uriStr = configuration.GetValue<string>(serviceUriConfig)) != null)
                 {
                     serviceUri = new Uri(uriStr);
+                    return true;
+                }
+
+                string accountName;
+                if ((accountName = configuration.GetValue<string>("accountName")) != null)
+                {
+                    var endpointSuffix = configuration.GetValue<string>("endpointSuffix");
+                    serviceUri = string.IsNullOrEmpty(endpointSuffix)
+                        ? FormatServiceUri(accountName)
+                        : FormatServiceUri(accountName, endpointSuffix: endpointSuffix);
                     return true;
                 }
             }

--- a/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared/StorageClientProvider.cs
+++ b/sdk/extensions/Microsoft.Azure.WebJobs.Extensions.Clients/src/Shared/StorageClientProvider.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Clients.Shared
                 // endpoint even when `accountName` is also configured (which the Azure Functions
                 // host injects automatically when managed-identity storage is used).
                 string uriStr;
-                if ((uriStr = configuration.GetValue<string>(serviceUriConfig)) != null)
+                if ((uriStr = configuration.GetValue<string>(serviceUriConfig)) is { Length: > 0 })
                 {
                     serviceUri = new Uri(uriStr);
                     return true;

--- a/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/CHANGELOG.md
+++ b/sdk/tables/Microsoft.Azure.WebJobs.Extensions.Tables/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed an issue where the `TableServiceClient` was constructed using the hard-coded `core.windows.net` suffix when `AzureWebJobsStorage__accountName` was set, even if an explicit `AzureWebJobsStorage__tableServiceUri` was also present. The explicit `__tableServiceUri` is now preferred over `__accountName`, and an optional `__endpointSuffix` setting is honored when constructing the URI from `__accountName`. This unblocks bindings that use managed-identity storage in sovereign clouds (e.g. Azure US Government, Azure China). ([#57543](https://github.com/Azure/azure-sdk-for-net/issues/57543))
+
 ### Other Changes
 
 ## 1.4.0 (2025-06-20)


### PR DESCRIPTION
StorageClientProvider.TryGetServiceUri now prefers an explicit {subdomain}ServiceUri over accountName when both are configured, and honors an optional endpointSuffix value when constructing the URI from accountName. This unblocks Event Hubs and Tables WebJobs extensions in sovereign clouds (Azure US Government, Azure China) where the Functions host injects __accountName automatically alongside user-supplied __blobServiceUri.