### PR TITLE
[Azure.Core] Identity Adding Github actions token credential

### DIFF
--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1517,6 +1517,21 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
+    public partial class GitHubActionsTokenCredential : Azure.Core.TokenCredential
+    {
+        public GitHubActionsTokenCredential() { }
+        public GitHubActionsTokenCredential(Azure.Identity.GitHubActionsTokenCredentialOptions options) { }
+        public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public partial class GitHubActionsTokenCredentialOptions : Azure.Identity.TokenCredentialOptions
+    {
+        public const string DefaultIdTokenAudience = "api://AzureADTokenExchange";
+        public GitHubActionsTokenCredentialOptions() { }
+        public string IdTokenAudience { get { throw null; } set { } }
+        public string IdTokenUserAgent { get { throw null; } set { } }
+    }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class IdentityModelFactory
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -1483,6 +1483,20 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
     }
+    public partial class GitHubActionsTokenCredential : Azure.Core.TokenCredential
+    {
+        public GitHubActionsTokenCredential() { }
+        public GitHubActionsTokenCredential(Azure.Identity.GitHubActionsTokenCredentialOptions options) { }
+        public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public partial class GitHubActionsTokenCredentialOptions : Azure.Identity.TokenCredentialOptions
+    {
+        public const string DefaultIdTokenAudience = "api://AzureADTokenExchange";
+        public GitHubActionsTokenCredentialOptions() { }
+        public string IdTokenAudience { get { throw null; } set { } }
+        public string IdTokenUserAgent { get { throw null; } set { } }
+    }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class IdentityModelFactory
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -1483,6 +1483,20 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
     }
+    public partial class GitHubActionsTokenCredential : Azure.Core.TokenCredential
+    {
+        public GitHubActionsTokenCredential() { }
+        public GitHubActionsTokenCredential(Azure.Identity.GitHubActionsTokenCredentialOptions options) { }
+        public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public partial class GitHubActionsTokenCredentialOptions : Azure.Identity.TokenCredentialOptions
+    {
+        public const string DefaultIdTokenAudience = "api://AzureADTokenExchange";
+        public GitHubActionsTokenCredentialOptions() { }
+        public string IdTokenAudience { get { throw null; } set { } }
+        public string IdTokenUserAgent { get { throw null; } set { } }
+    }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class IdentityModelFactory
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -1517,6 +1517,21 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
     }
+    [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
+    public partial class GitHubActionsTokenCredential : Azure.Core.TokenCredential
+    {
+        public GitHubActionsTokenCredential() { }
+        public GitHubActionsTokenCredential(Azure.Identity.GitHubActionsTokenCredentialOptions options) { }
+        public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public partial class GitHubActionsTokenCredentialOptions : Azure.Identity.TokenCredentialOptions
+    {
+        public const string DefaultIdTokenAudience = "api://AzureADTokenExchange";
+        public GitHubActionsTokenCredentialOptions() { }
+        public string IdTokenAudience { get { throw null; } set { } }
+        public string IdTokenUserAgent { get { throw null; } set { } }
+    }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class IdentityModelFactory
     {

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -1483,6 +1483,20 @@ namespace Azure.Identity
         public System.Collections.Generic.IList<string> AdditionallyAllowedTenants { get { throw null; } }
         public bool DisableInstanceDiscovery { get { throw null; } set { } }
     }
+    public partial class GitHubActionsTokenCredential : Azure.Core.TokenCredential
+    {
+        public GitHubActionsTokenCredential() { }
+        public GitHubActionsTokenCredential(Azure.Identity.GitHubActionsTokenCredentialOptions options) { }
+        public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public override System.Threading.Tasks.ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
+    public partial class GitHubActionsTokenCredentialOptions : Azure.Identity.TokenCredentialOptions
+    {
+        public const string DefaultIdTokenAudience = "api://AzureADTokenExchange";
+        public GitHubActionsTokenCredentialOptions() { }
+        public string IdTokenAudience { get { throw null; } set { } }
+        public string IdTokenUserAgent { get { throw null; } set { } }
+    }
     [System.Runtime.CompilerServices.TypeForwardedFromAttribute("Azure.Identity, Version=1.0.0.0, Culture=neutral, PublicKeyToken=92742159e12e44c8")]
     public static partial class IdentityModelFactory
     {

--- a/sdk/core/Azure.Core/src/Identity/Credentials/GitHubActionsTokenCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/GitHubActionsTokenCredential.cs
@@ -11,7 +11,7 @@ using Azure.Core;
 namespace Azure.Identity
 {
     /// <summary>
-    /// Enabled authentication in GitHub Actions using the GitHub OIDC provider.
+    /// Enables authentication in GitHub Actions using the GitHub OIDC provider.
     /// </summary>
 #pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]

--- a/sdk/core/Azure.Core/src/Identity/Credentials/GitHubActionsTokenCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/GitHubActionsTokenCredential.cs
@@ -50,11 +50,11 @@ namespace Azure.Identity
 
         private ClientAssertionCredential GetOrCreateClientAssertionCredential()
         {
-            if (_clientAssertionCredential == null)
+            LazyInitializer.EnsureInitialized(ref _clientAssertionCredential, () =>
             {
                 ClientAssertionCredentialOptions assertionOptions = _options.Clone<ClientAssertionCredentialOptions>();
-                _clientAssertionCredential = new ClientAssertionCredential(_options.TenantId, _options.ClientId, GetIdToken, assertionOptions);
-            }
+                return new ClientAssertionCredential(_options.TenantId, _options.ClientId, GetIdToken, assertionOptions);
+            });
             return _clientAssertionCredential;
         }
 

--- a/sdk/core/Azure.Core/src/Identity/Credentials/GitHubActionsTokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/GitHubActionsTokenCredentialOptions.cs
@@ -25,13 +25,13 @@ namespace Azure.Identity
         /// <summary>
         /// The token used to request an ID token from the GitHub Actions OIDC provider. This value defaults to the value of the environment variable ACTIONS_ID_TOKEN_REQUEST_TOKEN.
         /// </summary>
-        internal string RequestToken { get; set; } = EnvironmentVariables.GithubActionsRequestToken;
+        internal string RequestToken { get; set; } = EnvironmentVariables.GitHubActionsRequestToken;
 
         internal const string ActionsRequestUrlKey = "ACTIONS_ID_TOKEN_REQUEST_URL";
         /// <summary>
         /// The URL used to request an ID token from the GitHub Actions OIDC provider. This value defaults to the value of the environment variable ACTIONS_ID_TOKEN_REQUEST_URL.
         /// </summary>
-        internal string RequestUrl { get; set; } = EnvironmentVariables.GithubActionsRequestUrl;
+        internal string RequestUrl { get; set; } = EnvironmentVariables.GitHubActionsRequestUrl;
 
         /// <summary>
         /// The default audience to use when requesting an ID token from the GitHub Actions OIDC provider.

--- a/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredential.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Enabled authentication in GitHub Actions using the GitHub OIDC provider.
+    /// </summary>
+    [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+    public class GithubActionsTokenCredential : TokenCredential
+    {
+        private readonly CredentialPipeline _pipeline;
+        private readonly GithubActionsTokenCredentialOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GithubActionsTokenCredential"/> class with default options.
+        /// For the credential to work, the environment variables 'ACTIONS_ID_TOKEN_REQUEST_TOKEN' and 'ACTIONS_ID_TOKEN_REQUEST_URL' must be set by the GitHub Actions runtime.
+        /// You need to set the 'AZURE_TENANT_ID' and 'AZURE_CLIENT_ID' environment variables to specify the tenant and client ID to use when authenticating with Entra ID.
+        /// The credential will request an ID token from the GitHub OIDC provider using the request token and request URL provided in the environment variables, and then exchange that ID token for an access token from Entra ID using the client assertion flow.
+        /// </summary>
+        public GithubActionsTokenCredential() : this(null, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GithubActionsTokenCredential"/>.
+        /// For the credential to work, the environment variables 'ACTIONS_ID_TOKEN_REQUEST_TOKEN' and 'ACTIONS_ID_TOKEN_REQUEST_URL' must be set by the GitHub Actions runtime.
+        /// You need to set the 'AZURE_TENANT_ID' and 'AZURE_CLIENT_ID' environment variables to specify the tenant and client ID to use when authenticating with Entra ID.
+        /// The credential will request an ID token from the GitHub OIDC provider using the request token and request URL provided in the environment variables, and then exchange that ID token for an access token from Entra ID using the client assertion flow.
+        /// </summary>
+        /// <param name="options">The options for configuring the credential.</param>
+        public GithubActionsTokenCredential(GithubActionsTokenCredentialOptions options) : this(null, options)
+        {
+        }
+
+        internal GithubActionsTokenCredential(CredentialPipeline pipeline, TokenCredentialOptions options = null)
+        {
+            _options = options as GithubActionsTokenCredentialOptions ?? new GithubActionsTokenCredentialOptions();
+            _pipeline = pipeline ?? CredentialPipeline.GetInstance(_options);
+        }
+
+        /// <inheritdoc/>
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            ValidateSettings();
+
+            var clientAssertionCredential = new ClientAssertionCredential(_options.TenantId, _options.ClientId, (cancallationToken) => GetIdToken(cancellationToken));
+
+            return clientAssertionCredential.GetToken(requestContext, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            ValidateSettings();
+            var clientAssertionCredential = new ClientAssertionCredential(_options.TenantId, _options.ClientId, (cancallationToken) => GetIdToken(cancellationToken));
+            return clientAssertionCredential.GetTokenAsync(requestContext, cancellationToken);
+        }
+
+        private void ValidateSettings()
+        {
+            if (string.IsNullOrWhiteSpace(_options.RequestToken) || string.IsNullOrWhiteSpace(_options.RequestUrl) || !Uri.TryCreate(_options.RequestUrl, UriKind.Absolute, out _))
+            {
+                throw new CredentialUnavailableException($"Environment variables '{GithubActionsTokenCredentialOptions.ActionsRequestTokenKey}' and/or '{GithubActionsTokenCredentialOptions.ActionsRequestUrlKey}' are not set.");
+            }
+
+            if (string.IsNullOrWhiteSpace(_options.IdTokenAudience))
+            {
+                throw new ArgumentException("Audience must be set.", nameof(_options.IdTokenAudience));
+            }
+
+            if (string.IsNullOrWhiteSpace(_options.TenantId))
+            {
+                throw new ArgumentException("Tenant ID must be set", nameof(_options.TenantId));
+            }
+
+            if (string.IsNullOrWhiteSpace(_options.ClientId))
+            {
+                throw new ArgumentException("Client ID must be set", nameof(_options.ClientId));
+            }
+        }
+
+        private async Task<string> GetIdToken(CancellationToken cancellationToken)
+        {
+            var request = _pipeline.HttpPipeline.CreateRequest();
+            request.Method = RequestMethod.Get;
+            request.Uri.Reset(new Uri($"{_options.RequestUrl!}&audience={System.Web.HttpUtility.UrlEncode(_options.IdTokenAudience!)}"));
+            request.Headers.Add("Authorization", $"Bearer {_options.RequestToken!}");
+            var response = await _pipeline.HttpPipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            if (response.Status != 200)
+            {
+                throw new CredentialUnavailableException($"Request to '{request.Uri}' failed with status code '{response.Status}'.");
+            }
+            return GetOidcTokenResponse(response);
+        }
+
+        private string GetOidcTokenResponse(Response response)
+        {
+            string oidcToken = null;
+            try
+            {
+                Utf8JsonReader reader = new Utf8JsonReader(response.Content);
+                while (oidcToken is null && reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.PropertyName)
+                    {
+                        switch (reader.GetString())
+                        {
+                            case "value":
+                                reader.Read();
+                                oidcToken = reader.GetString();
+                                break;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                //Just don't want to throw here, we will throw in the next if block
+            }
+            if (oidcToken is null)
+            {
+                string error = $"OIDC token not found in response.";
+                throw new AuthenticationFailedException(error);
+            }
+            return oidcToken;
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredential.cs
@@ -91,7 +91,7 @@ namespace Azure.Identity
         {
             var request = _pipeline.HttpPipeline.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.Uri.Reset(new Uri($"{_options.RequestUrl!}&audience={System.Web.HttpUtility.UrlEncode(_options.IdTokenAudience!)}"));
+            request.Uri.Reset(new Uri($"{_options.RequestUrl!}&audience={Uri.EscapeDataString(_options.IdTokenAudience!)}"));
             request.Headers.Add("Authorization", $"Bearer {_options.RequestToken!}");
             var response = await _pipeline.HttpPipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
             if (response.Status != 200)

--- a/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredential.cs
@@ -19,6 +19,7 @@ namespace Azure.Identity
     {
         private readonly CredentialPipeline _pipeline;
         private readonly GitHubActionsTokenCredentialOptions _options;
+        private ClientAssertionCredential _clientAssertionCredential;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GitHubActionsTokenCredential"/> class with default options.
@@ -47,22 +48,28 @@ namespace Azure.Identity
             _pipeline = pipeline ?? CredentialPipeline.GetInstance(_options);
         }
 
+        private ClientAssertionCredential GetOrCreateClientAssertionCredential()
+        {
+            if (_clientAssertionCredential == null)
+            {
+                ClientAssertionCredentialOptions assertionOptions = _options.Clone<ClientAssertionCredentialOptions>();
+                _clientAssertionCredential = new ClientAssertionCredential(_options.TenantId, _options.ClientId, GetIdToken, assertionOptions);
+            }
+            return _clientAssertionCredential;
+        }
+
         /// <inheritdoc/>
         public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
             ValidateSettings();
-
-            var clientAssertionCredential = new ClientAssertionCredential(_options.TenantId, _options.ClientId, (cancellationToken) => GetIdToken(cancellationToken));
-
-            return clientAssertionCredential.GetToken(requestContext, cancellationToken);
+            return GetOrCreateClientAssertionCredential().GetToken(requestContext, cancellationToken);
         }
 
         /// <inheritdoc/>
         public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
             ValidateSettings();
-            var clientAssertionCredential = new ClientAssertionCredential(_options.TenantId, _options.ClientId, (cancallationToken) => GetIdToken(cancellationToken));
-            return clientAssertionCredential.GetTokenAsync(requestContext, cancellationToken);
+            return GetOrCreateClientAssertionCredential().GetTokenAsync(requestContext, cancellationToken);
         }
 
         private void ValidateSettings()

--- a/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredential.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredential.cs
@@ -13,36 +13,37 @@ namespace Azure.Identity
     /// <summary>
     /// Enabled authentication in GitHub Actions using the GitHub OIDC provider.
     /// </summary>
+#pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
     [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
-    public class GithubActionsTokenCredential : TokenCredential
+    public class GitHubActionsTokenCredential : TokenCredential
     {
         private readonly CredentialPipeline _pipeline;
-        private readonly GithubActionsTokenCredentialOptions _options;
+        private readonly GitHubActionsTokenCredentialOptions _options;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="GithubActionsTokenCredential"/> class with default options.
+        /// Initializes a new instance of the <see cref="GitHubActionsTokenCredential"/> class with default options.
         /// For the credential to work, the environment variables 'ACTIONS_ID_TOKEN_REQUEST_TOKEN' and 'ACTIONS_ID_TOKEN_REQUEST_URL' must be set by the GitHub Actions runtime.
         /// You need to set the 'AZURE_TENANT_ID' and 'AZURE_CLIENT_ID' environment variables to specify the tenant and client ID to use when authenticating with Entra ID.
         /// The credential will request an ID token from the GitHub OIDC provider using the request token and request URL provided in the environment variables, and then exchange that ID token for an access token from Entra ID using the client assertion flow.
         /// </summary>
-        public GithubActionsTokenCredential() : this(null, null)
+        public GitHubActionsTokenCredential() : this(null, null)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="GithubActionsTokenCredential"/>.
+        /// Initializes a new instance of the <see cref="GitHubActionsTokenCredential"/>.
         /// For the credential to work, the environment variables 'ACTIONS_ID_TOKEN_REQUEST_TOKEN' and 'ACTIONS_ID_TOKEN_REQUEST_URL' must be set by the GitHub Actions runtime.
         /// You need to set the 'AZURE_TENANT_ID' and 'AZURE_CLIENT_ID' environment variables to specify the tenant and client ID to use when authenticating with Entra ID.
         /// The credential will request an ID token from the GitHub OIDC provider using the request token and request URL provided in the environment variables, and then exchange that ID token for an access token from Entra ID using the client assertion flow.
         /// </summary>
         /// <param name="options">The options for configuring the credential.</param>
-        public GithubActionsTokenCredential(GithubActionsTokenCredentialOptions options) : this(null, options)
+        public GitHubActionsTokenCredential(GitHubActionsTokenCredentialOptions options) : this(null, options)
         {
         }
 
-        internal GithubActionsTokenCredential(CredentialPipeline pipeline, TokenCredentialOptions options = null)
+        internal GitHubActionsTokenCredential(CredentialPipeline pipeline, TokenCredentialOptions options = null)
         {
-            _options = options as GithubActionsTokenCredentialOptions ?? new GithubActionsTokenCredentialOptions();
+            _options = options as GitHubActionsTokenCredentialOptions ?? new GitHubActionsTokenCredentialOptions();
             _pipeline = pipeline ?? CredentialPipeline.GetInstance(_options);
         }
 
@@ -51,7 +52,7 @@ namespace Azure.Identity
         {
             ValidateSettings();
 
-            var clientAssertionCredential = new ClientAssertionCredential(_options.TenantId, _options.ClientId, (cancallationToken) => GetIdToken(cancellationToken));
+            var clientAssertionCredential = new ClientAssertionCredential(_options.TenantId, _options.ClientId, (cancellationToken) => GetIdToken(cancellationToken));
 
             return clientAssertionCredential.GetToken(requestContext, cancellationToken);
         }
@@ -66,11 +67,20 @@ namespace Azure.Identity
 
         private void ValidateSettings()
         {
-            if (string.IsNullOrWhiteSpace(_options.RequestToken) || string.IsNullOrWhiteSpace(_options.RequestUrl) || !Uri.TryCreate(_options.RequestUrl, UriKind.Absolute, out _))
+            if (string.IsNullOrWhiteSpace(_options.RequestToken))
             {
-                throw new CredentialUnavailableException($"Environment variables '{GithubActionsTokenCredentialOptions.ActionsRequestTokenKey}' and/or '{GithubActionsTokenCredentialOptions.ActionsRequestUrlKey}' are not set.");
+                throw new CredentialUnavailableException($"Environment variable '{GitHubActionsTokenCredentialOptions.ActionsRequestTokenKey}' is not set.");
             }
 
+            if (string.IsNullOrWhiteSpace(_options.RequestUrl))
+            {
+                throw new CredentialUnavailableException($"Environment variable '{GitHubActionsTokenCredentialOptions.ActionsRequestUrlKey}' is not set.");
+            }
+
+            if (!Uri.TryCreate(_options.RequestUrl, UriKind.Absolute, out _))
+            {
+                throw new CredentialUnavailableException($"Environment variable '{GitHubActionsTokenCredentialOptions.ActionsRequestUrlKey}' is invalid.");
+            }
             if (string.IsNullOrWhiteSpace(_options.IdTokenAudience))
             {
                 throw new ArgumentException("Audience must be set.", nameof(_options.IdTokenAudience));
@@ -91,14 +101,29 @@ namespace Azure.Identity
         {
             var request = _pipeline.HttpPipeline.CreateRequest();
             request.Method = RequestMethod.Get;
-            request.Uri.Reset(new Uri($"{_options.RequestUrl!}&audience={Uri.EscapeDataString(_options.IdTokenAudience!)}"));
+            request.Uri.Reset(BuildRequestUri(_options.RequestUrl!, _options.IdTokenAudience!));
             request.Headers.Add("Authorization", $"Bearer {_options.RequestToken!}");
-            var response = await _pipeline.HttpPipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(_options.IdTokenUserAgent))
+            {
+                request.Headers.SetValue("User-Agent", _options.IdTokenUserAgent);
+            }
+            using var response = await _pipeline.HttpPipeline.SendRequestAsync(request, cancellationToken).ConfigureAwait(false);
             if (response.Status != 200)
             {
                 throw new CredentialUnavailableException($"Request to '{request.Uri}' failed with status code '{response.Status}'.");
             }
             return GetOidcTokenResponse(response);
+        }
+
+        private static Uri BuildRequestUri(string requestUrl, string audience)
+        {
+            var builder = new UriBuilder(requestUrl);
+            string audienceQuery = $"audience={Uri.EscapeDataString(audience)}";
+            string query = builder.Query;
+            builder.Query = string.IsNullOrEmpty(query) || query == "?"
+                ? audienceQuery
+                : $"{query.TrimStart('?')}&{audienceQuery}";
+            return builder.Uri;
         }
 
         private string GetOidcTokenResponse(Response response)
@@ -133,4 +158,5 @@ namespace Azure.Identity
             return oidcToken;
         }
     }
+#pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredentialOptions.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+namespace Azure.Identity
+{
+    /// <summary>
+    /// Options used to configure the <see cref="GithubActionsTokenCredential"/>.
+    /// </summary>
+
+    public class GithubActionsTokenCredentialOptions : TokenCredentialOptions
+    {
+        /// <summary>
+        /// The client ID (app ID) of the service pricipal the credential will authenticate. This value defaults to the value of the environment variable AZURE_CLIENT_ID.
+        /// </summary>
+        internal string ClientId { get; set; } = EnvironmentVariables.ClientId;
+
+        /// <summary>
+        /// The ID of the tenant to which the credential will authenticate by default. This value defaults to the value of the environment variable AZURE_TENANT_ID.
+        /// </summary>
+        internal string TenantId { get; set; } = EnvironmentVariables.TenantId;
+
+        internal const string ActionsRequestTokenKey = "ACTIONS_ID_TOKEN_REQUEST_TOKEN";
+        /// <summary>
+        /// The token used to request an ID token from the GitHub Actions OIDC provider. This value defaults to the value of the environment variable ACTIONS_ID_TOKEN_REQUEST_TOKEN.
+        /// </summary>
+        internal string RequestToken { get; set; } = EnvironmentVariables.GithubActionsRequestToken;
+
+        internal const string ActionsRequestUrlKey = "ACTIONS_ID_TOKEN_REQUEST_URL";
+        /// <summary>
+        /// The URL used to request an ID token from the GitHub Actions OIDC provider. This value defaults to the value of the environment variable ACTIONS_ID_TOKEN_REQUEST_URL.
+        /// </summary>
+        internal string RequestUrl { get; set; } = EnvironmentVariables.GithubActionsRequestUrl;
+
+        /// <summary>
+        /// The default audience to use when requesting an ID token from the GitHub Actions OIDC provider.
+        /// </summary>
+        public const string DefaultIdTokenAudience = "api://AzureADTokenExchange";
+
+        /// <summary>
+        /// The audience to use when requesting an ID token from the GitHub Actions OIDC provider. This value defaults to "api://AzureADTokenExchange".
+        /// </summary>
+        public string IdTokenAudience {get;set;} = DefaultIdTokenAudience;
+
+        /// <summary>
+        /// The User-Agent to use when requesting an ID token from the GitHub Actions OIDC provider. This value defaults to "actions/oidc-client;1.0".
+        /// </summary>
+        public string IdTokenUserAgent { get; set; } = "actions/oidc-client;1.0";
+    }
+}

--- a/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/GithubActionsTokenCredentialOptions.cs
@@ -6,13 +6,13 @@
 namespace Azure.Identity
 {
     /// <summary>
-    /// Options used to configure the <see cref="GithubActionsTokenCredential"/>.
+    /// Options used to configure the <see cref="GitHubActionsTokenCredential"/>.
     /// </summary>
-
-    public class GithubActionsTokenCredentialOptions : TokenCredentialOptions
+#pragma warning disable AZC0034 // Type moved from Azure.Identity to Azure.Core; name conflict with NuGet Azure.Identity is expected
+    public class GitHubActionsTokenCredentialOptions : TokenCredentialOptions
     {
         /// <summary>
-        /// The client ID (app ID) of the service pricipal the credential will authenticate. This value defaults to the value of the environment variable AZURE_CLIENT_ID.
+        /// The client ID (app ID) of the service principal the credential will authenticate. This value defaults to the value of the environment variable AZURE_CLIENT_ID.
         /// </summary>
         internal string ClientId { get; set; } = EnvironmentVariables.ClientId;
 
@@ -41,11 +41,12 @@ namespace Azure.Identity
         /// <summary>
         /// The audience to use when requesting an ID token from the GitHub Actions OIDC provider. This value defaults to "api://AzureADTokenExchange".
         /// </summary>
-        public string IdTokenAudience {get;set;} = DefaultIdTokenAudience;
+        public string IdTokenAudience { get; set; } = DefaultIdTokenAudience;
 
         /// <summary>
-        /// The User-Agent to use when requesting an ID token from the GitHub Actions OIDC provider. This value defaults to "actions/oidc-client;1.0".
+        /// The User-Agent to use when requesting an ID token from the GitHub Actions OIDC provider. This value defaults to "actions/oidc-client (1.0)".
         /// </summary>
-        public string IdTokenUserAgent { get; set; } = "actions/oidc-client;1.0";
+        public string IdTokenUserAgent { get; set; } = "actions/oidc-client (1.0)";
     }
+#pragma warning restore AZC0034
 }

--- a/sdk/core/Azure.Core/src/Identity/EnvironmentVariables.cs
+++ b/sdk/core/Azure.Core/src/Identity/EnvironmentVariables.cs
@@ -23,8 +23,8 @@ namespace Azure.Identity
 
         public static string IdentityEndpoint => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("IDENTITY_ENDPOINT"));
         public static string IdentityHeader => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("IDENTITY_HEADER"));
-        public static string GithubActionsRequestToken => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GitHubActionsTokenCredentialOptions.ActionsRequestTokenKey));
-        public static string GithubActionsRequestUrl => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GitHubActionsTokenCredentialOptions.ActionsRequestUrlKey));
+        public static string GitHubActionsRequestToken => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GitHubActionsTokenCredentialOptions.ActionsRequestTokenKey));
+        public static string GitHubActionsRequestUrl => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GitHubActionsTokenCredentialOptions.ActionsRequestUrlKey));
         public static string PodIdentityEndpoint => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("AZURE_POD_IDENTITY_AUTHORITY_HOST"));
 
         public static string Path => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("PATH"));

--- a/sdk/core/Azure.Core/src/Identity/EnvironmentVariables.cs
+++ b/sdk/core/Azure.Core/src/Identity/EnvironmentVariables.cs
@@ -23,8 +23,8 @@ namespace Azure.Identity
 
         public static string IdentityEndpoint => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("IDENTITY_ENDPOINT"));
         public static string IdentityHeader => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("IDENTITY_HEADER"));
-        public static string GithubActionsRequestToken => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GithubActionsTokenCredentialOptions.ActionsRequestTokenKey));
-        public static string GithubActionsRequestUrl => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GithubActionsTokenCredentialOptions.ActionsRequestUrlKey));
+        public static string GithubActionsRequestToken => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GitHubActionsTokenCredentialOptions.ActionsRequestTokenKey));
+        public static string GithubActionsRequestUrl => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GitHubActionsTokenCredentialOptions.ActionsRequestUrlKey));
         public static string PodIdentityEndpoint => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("AZURE_POD_IDENTITY_AUTHORITY_HOST"));
 
         public static string Path => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("PATH"));

--- a/sdk/core/Azure.Core/src/Identity/EnvironmentVariables.cs
+++ b/sdk/core/Azure.Core/src/Identity/EnvironmentVariables.cs
@@ -23,6 +23,8 @@ namespace Azure.Identity
 
         public static string IdentityEndpoint => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("IDENTITY_ENDPOINT"));
         public static string IdentityHeader => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("IDENTITY_HEADER"));
+        public static string GithubActionsRequestToken => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GithubActionsTokenCredentialOptions.ActionsRequestTokenKey));
+        public static string GithubActionsRequestUrl => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable(GithubActionsTokenCredentialOptions.ActionsRequestUrlKey));
         public static string PodIdentityEndpoint => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("AZURE_POD_IDENTITY_AUTHORITY_HOST"));
 
         public static string Path => GetNonEmptyStringOrNull(Environment.GetEnvironmentVariable("PATH"));

--- a/sdk/core/Azure.Core/tests/GithubActionsTokenCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/GithubActionsTokenCredentialTests.cs
@@ -13,7 +13,7 @@ using NUnit.Framework;
 namespace Azure.Core.Tests
 {
     [TestFixture]
-    public class GithubActionsTokenCredentialTests
+    public class GitHubActionsTokenCredentialTests
     {
         [TestCase(null)]
         [TestCase("")]
@@ -21,8 +21,8 @@ namespace Azure.Core.Tests
         [TestCase("not-a-url")]
         public void GetTokenValidatesRequestUrl(string requestUrl)
         {
-            var credential = new GithubActionsTokenCredential(
-                options: new GithubActionsTokenCredentialOptions
+            var credential = new GitHubActionsTokenCredential(
+                options: new GitHubActionsTokenCredentialOptions
                 {
                     RequestToken = "request-token",
                     RequestUrl = requestUrl,
@@ -33,7 +33,7 @@ namespace Azure.Core.Tests
 
             var exception = Assert.Throws<CredentialUnavailableException>(() => credential.GetToken(new TokenRequestContext(["scope"]), CancellationToken.None));
 
-            Assert.That(exception.Message, Does.Contain(GithubActionsTokenCredentialOptions.ActionsRequestUrlKey));
+            Assert.That(exception.Message, Does.Contain(GitHubActionsTokenCredentialOptions.ActionsRequestUrlKey));
         }
 
         [TestCase(null)]
@@ -41,8 +41,8 @@ namespace Azure.Core.Tests
         [TestCase(" ")]
         public void GetTokenValidatesRequestToken(string requestToken)
         {
-            var credential = new GithubActionsTokenCredential(
-                options: new GithubActionsTokenCredentialOptions
+            var credential = new GitHubActionsTokenCredential(
+                options: new GitHubActionsTokenCredentialOptions
                 {
                     RequestToken = requestToken,
                     RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
@@ -53,7 +53,7 @@ namespace Azure.Core.Tests
 
             var exception = Assert.Throws<CredentialUnavailableException>(() => credential.GetToken(new TokenRequestContext(["scope"]), CancellationToken.None));
 
-            Assert.That(exception.Message, Does.Contain(GithubActionsTokenCredentialOptions.ActionsRequestTokenKey));
+            Assert.That(exception.Message, Does.Contain(GitHubActionsTokenCredentialOptions.ActionsRequestTokenKey));
         }
 
         [TestCase(null)]
@@ -61,8 +61,8 @@ namespace Azure.Core.Tests
         [TestCase(" ")]
         public void GetTokenValidatesAudience(string audience)
         {
-            var credential = new GithubActionsTokenCredential(
-                options: new GithubActionsTokenCredentialOptions
+            var credential = new GitHubActionsTokenCredential(
+                options: new GitHubActionsTokenCredentialOptions
                 {
                     RequestToken = "request-token",
                     RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
@@ -81,8 +81,8 @@ namespace Azure.Core.Tests
         [TestCase(" ")]
         public void GetTokenValidatesTenantId(string tenantId)
         {
-            var credential = new GithubActionsTokenCredential(
-                options: new GithubActionsTokenCredentialOptions
+            var credential = new GitHubActionsTokenCredential(
+                options: new GitHubActionsTokenCredentialOptions
                 {
                     RequestToken = "request-token",
                     RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
@@ -101,8 +101,8 @@ namespace Azure.Core.Tests
         [TestCase(" ")]
         public async Task GetTokenAsyncValidatesClientId(string clientId)
         {
-            var credential = new GithubActionsTokenCredential(
-                options: new GithubActionsTokenCredentialOptions
+            var credential = new GitHubActionsTokenCredential(
+                options: new GitHubActionsTokenCredentialOptions
                 {
                     RequestToken = "request-token",
                     RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
@@ -123,7 +123,7 @@ namespace Azure.Core.Tests
             var transport = new MockTransport(response);
             var credential = CreateCredential(
                 transport,
-                new GithubActionsTokenCredentialOptions
+                new GitHubActionsTokenCredentialOptions
                 {
                     RequestToken = "request-token",
                     RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
@@ -147,7 +147,7 @@ namespace Azure.Core.Tests
             var transport = new MockTransport(_ => new MockResponse(500));
             var credential = CreateCredential(
                 transport,
-                new GithubActionsTokenCredentialOptions
+                new GitHubActionsTokenCredentialOptions
                 {
                     RequestToken = "request-token",
                     RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
@@ -167,7 +167,7 @@ namespace Azure.Core.Tests
             var transport = new MockTransport(new MockResponse(200).WithJson("{\"unexpected\":\"payload\"}"));
             var credential = CreateCredential(
                 transport,
-                new GithubActionsTokenCredentialOptions
+                new GitHubActionsTokenCredentialOptions
                 {
                     RequestToken = "request-token",
                     RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
@@ -181,16 +181,16 @@ namespace Azure.Core.Tests
             Assert.That(exception.Message, Does.Contain("OIDC token not found in response."));
         }
 
-        private static GithubActionsTokenCredential CreateCredential(MockTransport transport, GithubActionsTokenCredentialOptions options)
+        private static GitHubActionsTokenCredential CreateCredential(MockTransport transport, GitHubActionsTokenCredentialOptions options)
         {
             options.Transport = transport;
             var pipeline = CredentialPipeline.GetInstance(options);
-            return new GithubActionsTokenCredential(pipeline, options);
+            return new GitHubActionsTokenCredential(pipeline, options);
         }
 
-        private static async Task<string> InvokeGetIdTokenAsync(GithubActionsTokenCredential credential, CancellationToken cancellationToken)
+        private static async Task<string> InvokeGetIdTokenAsync(GitHubActionsTokenCredential credential, CancellationToken cancellationToken)
         {
-            var method = typeof(GithubActionsTokenCredential).GetMethod("GetIdToken", BindingFlags.Instance | BindingFlags.NonPublic);
+            var method = typeof(GitHubActionsTokenCredential).GetMethod("GetIdToken", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.That(method, Is.Not.Null);
 
             var task = (Task<string>)method.Invoke(credential, [cancellationToken]);

--- a/sdk/core/Azure.Core/tests/GithubActionsTokenCredentialTests.cs
+++ b/sdk/core/Azure.Core/tests/GithubActionsTokenCredentialTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+using Azure.Core.TestFramework;
+using Azure.Identity;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    [TestFixture]
+    public class GithubActionsTokenCredentialTests
+    {
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("not-a-url")]
+        public void GetTokenValidatesRequestUrl(string requestUrl)
+        {
+            var credential = new GithubActionsTokenCredential(
+                options: new GithubActionsTokenCredentialOptions
+                {
+                    RequestToken = "request-token",
+                    RequestUrl = requestUrl,
+                    IdTokenAudience = "api://AzureADTokenExchange",
+                    TenantId = "tenant-id",
+                    ClientId = "client-id"
+                });
+
+            var exception = Assert.Throws<CredentialUnavailableException>(() => credential.GetToken(new TokenRequestContext(["scope"]), CancellationToken.None));
+
+            Assert.That(exception.Message, Does.Contain(GithubActionsTokenCredentialOptions.ActionsRequestUrlKey));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void GetTokenValidatesRequestToken(string requestToken)
+        {
+            var credential = new GithubActionsTokenCredential(
+                options: new GithubActionsTokenCredentialOptions
+                {
+                    RequestToken = requestToken,
+                    RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
+                    IdTokenAudience = "api://AzureADTokenExchange",
+                    TenantId = "tenant-id",
+                    ClientId = "client-id"
+                });
+
+            var exception = Assert.Throws<CredentialUnavailableException>(() => credential.GetToken(new TokenRequestContext(["scope"]), CancellationToken.None));
+
+            Assert.That(exception.Message, Does.Contain(GithubActionsTokenCredentialOptions.ActionsRequestTokenKey));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void GetTokenValidatesAudience(string audience)
+        {
+            var credential = new GithubActionsTokenCredential(
+                options: new GithubActionsTokenCredentialOptions
+                {
+                    RequestToken = "request-token",
+                    RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
+                    IdTokenAudience = audience,
+                    TenantId = "tenant-id",
+                    ClientId = "client-id"
+                });
+
+            var exception = Assert.Throws<ArgumentException>(() => credential.GetToken(new TokenRequestContext(["scope"]), CancellationToken.None));
+
+            Assert.That(exception.ParamName, Is.EqualTo("IdTokenAudience"));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void GetTokenValidatesTenantId(string tenantId)
+        {
+            var credential = new GithubActionsTokenCredential(
+                options: new GithubActionsTokenCredentialOptions
+                {
+                    RequestToken = "request-token",
+                    RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
+                    IdTokenAudience = "api://AzureADTokenExchange",
+                    TenantId = tenantId,
+                    ClientId = "client-id"
+                });
+
+            var exception = Assert.Throws<ArgumentException>(() => credential.GetToken(new TokenRequestContext(["scope"]), CancellationToken.None));
+
+            Assert.That(exception.ParamName, Is.EqualTo("TenantId"));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public async Task GetTokenAsyncValidatesClientId(string clientId)
+        {
+            var credential = new GithubActionsTokenCredential(
+                options: new GithubActionsTokenCredentialOptions
+                {
+                    RequestToken = "request-token",
+                    RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
+                    IdTokenAudience = "api://AzureADTokenExchange",
+                    TenantId = "tenant-id",
+                    ClientId = clientId
+                });
+
+            var exception = Assert.ThrowsAsync<ArgumentException>(async () => await credential.GetTokenAsync(new TokenRequestContext(["scope"]), CancellationToken.None));
+
+            Assert.That(exception.ParamName, Is.EqualTo("ClientId"));
+        }
+
+        [Test]
+        public async Task GetIdTokenEncodesAudienceAndSetsAuthorizationHeader()
+        {
+            var response = new MockResponse(200).WithJson("{\"value\":\"oidc-token\"}");
+            var transport = new MockTransport(response);
+            var credential = CreateCredential(
+                transport,
+                new GithubActionsTokenCredentialOptions
+                {
+                    RequestToken = "request-token",
+                    RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
+                    IdTokenAudience = "api://Azure Token/Exchange+value",
+                    TenantId = "tenant-id",
+                    ClientId = "client-id"
+                });
+
+            var token = await InvokeGetIdTokenAsync(credential, CancellationToken.None);
+
+            Assert.That(token, Is.EqualTo("oidc-token"));
+            Assert.That(transport.SingleRequest.Method, Is.EqualTo(RequestMethod.Get));
+            Assert.That(transport.SingleRequest.Uri.ToUri().AbsoluteUri, Is.EqualTo("https://token.actions.githubusercontent.com/?existing=1&audience=api%3A%2F%2FAzure%20Token%2FExchange%2Bvalue"));
+            Assert.That(transport.SingleRequest.Headers.TryGetValue("Authorization", out string authorization), Is.True);
+            Assert.That(authorization, Is.EqualTo("Bearer request-token"));
+        }
+
+        [Test]
+        public void GetIdTokenThrowsWhenOidcEndpointReturnsNonSuccess()
+        {
+            var transport = new MockTransport(_ => new MockResponse(500));
+            var credential = CreateCredential(
+                transport,
+                new GithubActionsTokenCredentialOptions
+                {
+                    RequestToken = "request-token",
+                    RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
+                    IdTokenAudience = "api://AzureADTokenExchange",
+                    TenantId = "tenant-id",
+                    ClientId = "client-id"
+                });
+
+            var exception = Assert.ThrowsAsync<CredentialUnavailableException>(async () => await InvokeGetIdTokenAsync(credential, CancellationToken.None));
+
+            Assert.That(exception.Message, Does.Contain("status code '500'"));
+        }
+
+        [Test]
+        public void GetIdTokenThrowsWhenValueIsMissingFromResponse()
+        {
+            var transport = new MockTransport(new MockResponse(200).WithJson("{\"unexpected\":\"payload\"}"));
+            var credential = CreateCredential(
+                transport,
+                new GithubActionsTokenCredentialOptions
+                {
+                    RequestToken = "request-token",
+                    RequestUrl = "https://token.actions.githubusercontent.com?existing=1",
+                    IdTokenAudience = "api://AzureADTokenExchange",
+                    TenantId = "tenant-id",
+                    ClientId = "client-id"
+                });
+
+            var exception = Assert.ThrowsAsync<AuthenticationFailedException>(async () => await InvokeGetIdTokenAsync(credential, CancellationToken.None));
+
+            Assert.That(exception.Message, Does.Contain("OIDC token not found in response."));
+        }
+
+        private static GithubActionsTokenCredential CreateCredential(MockTransport transport, GithubActionsTokenCredentialOptions options)
+        {
+            options.Transport = transport;
+            var pipeline = CredentialPipeline.GetInstance(options);
+            return new GithubActionsTokenCredential(pipeline, options);
+        }
+
+        private static async Task<string> InvokeGetIdTokenAsync(GithubActionsTokenCredential credential, CancellationToken cancellationToken)
+        {
+            var method = typeof(GithubActionsTokenCredential).GetMethod("GetIdToken", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null);
+
+            var task = (Task<string>)method.Invoke(credential, [cancellationToken]);
+            return await task.ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
The current flow that is used in **a lot** of GitHub actions is: `azure/login` and then use `DefaultAzureCredential` in a step underneath it. If you're not using the Azure cli for anything else this adds like 3 to 10 seconds to each run of that workflow.

This PR adds direct support for the `GithubActionsTokenCredential` and would allow skipping the azure cli all together by directly interacting with the GitHub OIDC endpoints, which hopefully gets added to the DefaultAzureCredential chain in the future.

For now you would use it as:

```csharp
// Replace this line
var credentials = new DefaultAzureCredential();

// with this line
var credentials = new ChainedTokenCredential(new GithubActionsTokenCredential(), new DefaultAzureCredential());

// And then use those credentials to get a token for the Graph API (or any other resource)
var tokenResult = await credentials.GetTokenAsync(new Azure.Core.TokenRequestContext(new[] { "https://graph.microsoft.com/.default" }));
```

## Overwhelmed

I must say this is my first PR to this massive repo, and I'm not sure how the flow actually goes, but I did added some test to validate the inner workings of this new credential.
I guess I forgot to run the `eng\scripts\Export-API.ps1` script

## Related things:

- blog [How do Federated credentials in GitHub Actions actually work](https://svrooij.io/2023/11/07/github-actions-federated-credentials-explained/)

## Test run:

```csharp
dotnet test "c:\Users\stephan\source\repos\azure-sdk-for-net\sdk\core\Azure.Core\tests\Azure.Core.Tests.csproj" --filter FullyQualifiedName~GithubActionsTokenCredentialTests
Restore complete (2,0s)
  Azure.SdkAnalyzers netstandard2.0 succeeded (2,4s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.SdkAnalyzers\Debug\netstandard2.0\Azure.SdkAnalyzers.dll
  System.ClientModel.SourceGeneration netstandard2.0 succeeded (2,3s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\System.ClientModel.SourceGeneration\Debug\netstandard2.0\System.ClientModel.SourceGeneration.dll
  Microsoft.Azure.Core.NewtonsoftJson netstandard2.0 succeeded (3,7s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Microsoft.Azure.Core.NewtonsoftJson\Debug\netstandard2.0\Microsoft.Azure.Core.NewtonsoftJson.dll
  Microsoft.Azure.Core.NewtonsoftJson net8.0 succeeded (4,7s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Microsoft.Azure.Core.NewtonsoftJson\Debug\net8.0\Microsoft.Azure.Core.NewtonsoftJson.dll
  Microsoft.Azure.Core.NewtonsoftJson net10.0 succeeded (5,4s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Microsoft.Azure.Core.NewtonsoftJson\Debug\net10.0\Microsoft.Azure.Core.NewtonsoftJson.dll
  Azure.Core.TestFramework net8.0 succeeded (6,2s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.TestFramework\Debug\net8.0\Azure.Core.TestFramework.dll
  Azure.Core.TestFramework net10.0 succeeded (6,2s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.TestFramework\Debug\net10.0\Azure.Core.TestFramework.dll
  Azure.Core.Experimental net10.0 succeeded (4,3s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Experimental\Debug\net10.0\Azure.Core.Experimental.dll
  Azure.Security.KeyVault.Secrets net8.0 succeeded (4,5s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Security.KeyVault.Secrets\Debug\net8.0\Azure.Security.KeyVault.Secrets.dll
  Azure.Security.KeyVault.Secrets netstandard2.0 succeeded (4,8s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Security.KeyVault.Secrets\Debug\netstandard2.0\Azure.Security.KeyVault.Secrets.dll
  Azure.Core.Experimental net8.0 succeeded (3,2s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Experimental\Debug\net8.0\Azure.Core.Experimental.dll
  Azure.Security.KeyVault.Secrets net10.0 succeeded (5,9s) → c:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Security.KeyVault.Secrets\Debug\net10.0\Azure.Security.KeyVault.Secrets.dll
  Azure.Core net10.0 succeeded (6,7s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core\Debug\net10.0\Azure.Core.dll
  Azure.Core net8.0 succeeded (4,3s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core\Debug\net8.0\Azure.Core.dll
  System.ClientModel netstandard2.0 succeeded (3,0s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\System.ClientModel\Debug\netstandard2.0\System.ClientModel.dll
  System.ClientModel net8.0 succeeded (3,5s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\System.ClientModel\Debug\net8.0\System.ClientModel.dll
  System.ClientModel net10.0 succeeded (3,6s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\System.ClientModel\Debug\net10.0\System.ClientModel.dll
  Azure.Core.TestFramework net9.0 succeeded (2,5s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.TestFramework\Debug\net9.0\Azure.Core.TestFramework.dll
  Azure.Core.Tests.Common net8.0 succeeded (1,3s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests.Common\Debug\net8.0\Azure.Core.Tests.Common.dll
  Azure.Core.Tests.Common net10.0 succeeded (1,3s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests.Common\Debug\net10.0\Azure.Core.Tests.Common.dll
  System.ClientModel net9.0 succeeded (4,2s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\System.ClientModel\Debug\net9.0\System.ClientModel.dll
  Azure.Core.TestFramework net462 succeeded (1,7s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.TestFramework\Debug\net462\Azure.Core.TestFramework.dll
  Azure.Core.Experimental net462 succeeded (1,6s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Experimental\Debug\net462\Azure.Core.Experimental.dll
  Azure.Core.Tests.Common net9.0 succeeded (2,6s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests.Common\Debug\net9.0\Azure.Core.Tests.Common.dll
  Azure.Core.Tests net10.0 succeeded (4,3s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests\Debug\net10.0\Azure.Core.Tests.dll
  Azure.Core.Tests net8.0 succeeded (4,4s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests\Debug\net8.0\Azure.Core.Tests.dll
  Azure.Core net462 succeeded (4,6s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core\Debug\net462\Azure.Core.dll
  Azure.Core.Tests.Common net462 succeeded (1,5s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests.Common\Debug\net462\Azure.Core.Tests.Common.dll
  Azure.Core.Tests net9.0 succeeded (2,4s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests\Debug\net9.0\Azure.Core.Tests.dll                                                                                                                       
  Azure.Core.Tests net462 succeeded (2,1s) → C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests\Debug\net462\Azure.Core.Tests.dll
NUnit Adapter 4.6.0.0: Test execution started
Running selected tests in C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests\Debug\net8.0\Azure.Core.Tests.dll
NUnit Adapter 4.6.0.0: Test execution started
NUnit Adapter 4.6.0.0: Test execution started                                                                                             
Running selected tests in C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests\Debug\net9.0\Azure.Core.Tests.dll
Running selected tests in C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests\Debug\net10.0\Azure.Core.Tests.dll                                                                                                                                         
   NUnit3TestExecutor discovered 19 of 19 NUnit test cases using Current Discovery mode, Non-Explicit run
   NUnit3TestExecutor discovered 19 of 19 NUnit test cases using Current Discovery mode, Non-Explicit run
   NUnit3TestExecutor discovered 19 of 19 NUnit test cases using Current Discovery mode, Non-Explicit run                                 
NUnit Adapter 4.6.0.0: Test execution started
Running selected tests in C:\Users\stephan\source\repos\azure-sdk-for-net\artifacts\bin\Azure.Core.Tests\Debug\net462\Azure.Core.Tests.dll
   NUnit3TestExecutor discovered 19 of 19 NUnit test cases using Current Discovery mode, Non-Explicit run
NUnit Adapter 4.6.0.0: Test execution complete
  Azure.Core.Tests test net9.0 succeeded (6,3s)
NUnit Adapter 4.6.0.0: Test execution complete
NUnit Adapter 4.6.0.0: Test execution complete
  Azure.Core.Tests test net10.0 succeeded (7,3s)
  Azure.Core.Tests test net8.0 succeeded (7,4s)
NUnit Adapter 4.6.0.0: Test execution complete
  Azure.Core.Tests test net462 succeeded (8,4s)

Test summary: total: 76, failed: 0, succeeded: 76, skipped: 0, duration: 8,4s
Build succeeded in 35,2s
```

<!--
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
-->