### PR TITLE
Prepare release for Azure.ResourceManager.HybridNetwork Version 1.0.0-beta.3

### DIFF
--- a/.github/skills/refresh-arm-sdk-release/SKILL.md
+++ b/.github/skills/refresh-arm-sdk-release/SKILL.md
@@ -29,7 +29,6 @@ Activate only when the user wants an Azure.ResourceManager package refresh PR dr
 Before doing any further work on a package, check the CHANGELOG.md and skip the package (do not refresh it) if **either** of the following is true:
 
 1. **Already released**: The latest changelog entry does NOT contain `(Unreleased)` — it already has a release date (e.g., `## 1.2.0 (2026-04-17)`). This means a release was already prepared and no new `(Unreleased)` entry exists to stamp.
-   > **Exception**: If the user explicitly indicates that the dated entry was never actually published to NuGet, treat it as unreleased — update its date to today and add the dependency upgrade lines.
 2. **Dependencies already up to date**: **Any** changelog entry (across all released versions, not just the latest) already contains upgrade lines for **both** the current `Azure.Core` and `Azure.ResourceManager` versions (resolved from `eng/centralpackagemanagement/Directory.Packages.props`). If these exact versions were already shipped in any prior release, adding them again provides no value, so skip.
 
 When skipping a package, log it clearly as **SKIPPED** with the reason, and move on to the next package in the batch.

--- a/.github/skills/refresh-arm-sdk-release/SKILL.md
+++ b/.github/skills/refresh-arm-sdk-release/SKILL.md
@@ -29,6 +29,7 @@ Activate only when the user wants an Azure.ResourceManager package refresh PR dr
 Before doing any further work on a package, check the CHANGELOG.md and skip the package (do not refresh it) if **either** of the following is true:
 
 1. **Already released**: The latest changelog entry does NOT contain `(Unreleased)` — it already has a release date (e.g., `## 1.2.0 (2026-04-17)`). This means a release was already prepared and no new `(Unreleased)` entry exists to stamp.
+   > **Exception**: If the user explicitly indicates that the dated entry was never actually published to NuGet, treat it as unreleased — update its date to today and add the dependency upgrade lines.
 2. **Dependencies already up to date**: **Any** changelog entry (across all released versions, not just the latest) already contains upgrade lines for **both** the current `Azure.Core` and `Azure.ResourceManager` versions (resolved from `eng/centralpackagemanagement/Directory.Packages.props`). If these exact versions were already shipped in any prior release, adding them again provides no value, so skip.
 
 When skipping a package, log it clearly as **SKIPPED** with the reason, and move on to the next package in the batch.

--- a/sdk/hybridnetwork/Azure.ResourceManager.HybridNetwork/CHANGELOG.md
+++ b/sdk/hybridnetwork/Azure.ResourceManager.HybridNetwork/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Release History
 
-## 1.0.0-beta.3 (2025-03-11)
+## 1.0.0-beta.3 (2026-04-27)
 
 ### Features Added
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
 - Exposed `JsonModelWriteCore` for model serialization procedure.
+
+### Other Changes
+
+- Upgraded dependent `Azure.Core` to 1.54.0.
+- Upgraded dependent `Azure.ResourceManager` to 1.14.0.
 
 ## 1.0.0-beta.2 (2023-11-29)
 


### PR DESCRIPTION
## Azure.ResourceManager.HybridNetwork 1.0.0-beta.3

### Summary
- **Flow**: Beta
- **API source**: AutoRest (no explicit tag in autorest.md; pinned commit SHA in require URL)
- **Release date**: Updated from 2025-03-11 to 2026-04-27 (entry had a date but was never actually released)

### Changes
- Stamped release date 2026-04-27
- Upgraded \Azure.Core\ to 1.54.0
- Upgraded \Azure.ResourceManager\ to 1.14.0
- Kept existing Features Added content (model serialization)