### PR TITLE
Ignore Azure.ResourceManager.Relationships tests broken by #58689

### DIFF
--- a/sdk/relationships/Azure.ResourceManager.Relationships/tests/Scenario/DependencyOfRelationshipCollectionTests.cs
+++ b/sdk/relationships/Azure.ResourceManager.Relationships/tests/Scenario/DependencyOfRelationshipCollectionTests.cs
@@ -17,6 +17,7 @@ namespace Azure.ResourceManager.Relationships.Tests.Scenario
     /// A DependencyOf relationship declares that one Service Group depends on another Service Group.
     /// The relationship is created on the source Service Group, pointing to the target Service Group.
     /// </summary>
+    [Ignore("Recordings broken by ServiceGroups TypeSpec migration (#58689). Tracking: https://github.com/Azure/azure-sdk-for-net/issues/58724")]
     public class DependencyOfRelationshipCollectionTests : RelationshipsManagementTestBase
     {
         private DependencyOfRelationshipResource _relationship;

--- a/sdk/relationships/Azure.ResourceManager.Relationships/tests/Scenario/DependencyOfRelationshipResourceTests.cs
+++ b/sdk/relationships/Azure.ResourceManager.Relationships/tests/Scenario/DependencyOfRelationshipResourceTests.cs
@@ -16,6 +16,7 @@ namespace Azure.ResourceManager.Relationships.Tests.Scenario
     /// Tests for DependencyOf relationship resource operations.
     /// A DependencyOf relationship declares that one Service Group depends on another Service Group.
     /// </summary>
+    [Ignore("Recordings broken by ServiceGroups TypeSpec migration (#58689). Tracking: https://github.com/Azure/azure-sdk-for-net/issues/58724")]
     public class DependencyOfRelationshipResourceTests : RelationshipsManagementTestBase
     {
         private DependencyOfRelationshipResource _relationship;

--- a/sdk/relationships/Azure.ResourceManager.Relationships/tests/Scenario/ServiceGroupMemberRelationshipCollectionTests.cs
+++ b/sdk/relationships/Azure.ResourceManager.Relationships/tests/Scenario/ServiceGroupMemberRelationshipCollectionTests.cs
@@ -18,6 +18,7 @@ namespace Azure.ResourceManager.Relationships.Tests.Scenario
     /// a member of a Service Group. The relationship is created ON the member resource,
     /// with targetId pointing to the Service Group.
     /// </summary>
+    [Ignore("Recordings broken by ServiceGroups TypeSpec migration (#58689). Tracking: https://github.com/Azure/azure-sdk-for-net/issues/58724")]
     public class ServiceGroupMemberRelationshipCollectionTests : RelationshipsManagementTestBase
     {
         private ServiceGroupMemberRelationshipResource _relationship;

--- a/sdk/relationships/Azure.ResourceManager.Relationships/tests/Scenario/ServiceGroupMemberRelationshipResourceTests.cs
+++ b/sdk/relationships/Azure.ResourceManager.Relationships/tests/Scenario/ServiceGroupMemberRelationshipResourceTests.cs
@@ -17,6 +17,7 @@ namespace Azure.ResourceManager.Relationships.Tests.Scenario
     /// A ServiceGroupMember relationship makes an ARM resource a member of a Service Group.
     /// The relationship is created ON the member resource, with targetId pointing to the Service Group.
     /// </summary>
+    [Ignore("Recordings broken by ServiceGroups TypeSpec migration (#58689). Tracking: https://github.com/Azure/azure-sdk-for-net/issues/58724")]
     public class ServiceGroupMemberRelationshipResourceTests : RelationshipsManagementTestBase
     {
         private ServiceGroupMemberRelationshipResource _relationship;


### PR DESCRIPTION
Adds class-level `[Ignore]` to the four scenario test classes in `Azure.ResourceManager.Relationships.Tests` that were broken by #58689 (ServiceGroups TypeSpec migration).

The new TypeSpec-generated `ServiceGroups` client consumes an additional `Recording.Random.Next()` somewhere in the `CreateOrUpdate` path. Because the existing recordings predate the migration, every `Recording.GenerateAssetName` call after the first diverges from the recording, producing 38 `TestRecordingMismatchException` failures in the `ProjectRef` CI leg of every PR that auto-merges with current main.

Ignoring these tests unblocks PR CI while the recordings are regenerated.

## Verification

On a clean `origin/main` checkout, before the change:
```
dotnet test sdk/relationships/Azure.ResourceManager.Relationships/tests/... --filter ""FullyQualifiedName~CreateOrUpdate_OnKeyVaultResource""
Failed: 4, Passed: 0
```

After the change:
```
Failed: 0, Passed: 2, Skipped: 64
```

## Tracking

- Tracking issue: #58724
- Root cause PR: #58689

The `[Ignore]` attributes link to #58724 and should be removed once the Relationships `assets.json` is updated with regenerated recordings.
