### PR TITLE
[Extensions] Fix/dataprotection crypto xml vulnerability by updating dependencies

### DIFF
--- a/eng/centralpackagemanagement/Directory.Extensions.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Extensions.Packages.props
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsExtensionClientLibrary)' == 'true'">
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Connections" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Update="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)" />

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.6.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.5.2 (2026-04-28)
 
 ### Other Changes
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated `Microsoft.AspNetCore.DataProtection` dependency to 10.0.7 to mitigate [GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx) and [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf).
+
 ## 1.5.1 (2025-06-23)
 
 ### Acknowledgments

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Microsoft Azure Blob storage support as key store (https://docs.microsoft.com/aspnet/core/security/data-protection/implementation/key-storage-providers).</Description>
     <PackageTags>aspnetcore;dataprotection;azure;blob;key store</PackageTags>
-    <Version>1.6.0-beta.1</Version>
+    <Version>1.5.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.5.1</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Other Changes
 
+- Updated `Microsoft.AspNetCore.DataProtection` dependency to 10.0.7 to mitigate [GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx) and [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf).
+
 ## 1.6.1 (2025-06-23)
 
 ### Acknowledgments

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Release History
 
-## 1.7.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.6.2 (2026-04-28)
 
 ### Other Changes
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Microsoft Azure Key Vault key encryption support.</Description>
     <PackageTags>aspnetcore;dataprotection;azure;keyvault</PackageTags>
-    <Version>1.7.0-beta.1</Version>
+    <Version>1.6.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.6.1</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>


### PR DESCRIPTION
### Fixes

- https://github.com/Azure/azure-sdk-for-net/issues/58235
- https://github.com/Azure/azure-sdk-for-net/issues/58359

### Description

Bumps `Microsoft.AspNetCore.DataProtection` from 10.0.1 to 10.0.7 in the central package management for extension libraries. Version 10.0.1 transitively depends on `System.Security.Cryptography.Xml` <= 10.0.5, which has two high-severity DoS vulnerabilities in the `EncryptedXml` class:

- [GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx) — Infinite loop (CWE-835)
- [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf) — Uncontrolled resource consumption / XXE (CWE-400, CWE-611)

Version 10.0.7 resolves this by pulling `System.Security.Cryptography.Xml` >= 10.0.7 (patched).

### Affected packages

- `Azure.Extensions.AspNetCore.DataProtection.Keys`
- `Azure.Extensions.AspNetCore.DataProtection.Blobs`