### PR TITLE
Fix incorrect comment for Delete case in CategorizeMethods

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ArmResourceMetadataExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/ArmResourceMetadataExtensions.cs
@@ -82,7 +82,7 @@ namespace Azure.Generator.Management.Utilities
                             methodsInResource.Add(method);
                             break;
                         case ResourceOperationKind.Delete:
-                            // only resource has get
+                            // only resource has delete
                             methodsInResource.Add(method);
                             break;
                         case ResourceOperationKind.Action:


### PR DESCRIPTION
Corrects the inline comment under case ResourceOperationKind.Delete: in ArmResourceMetadataExtensions.CategorizeMethods() from 'only resource has get' to 'only resource has delete'.