### PR TITLE
Migrate another batch of packages from NUnit 3 to NUnit 4

### DIFF
--- a/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
+++ b/eng/centralpackagemanagement/Directory.NUnit3Baseline.Packages.props
@@ -41,13 +41,6 @@
         $(MSBuildProjectName) == 'Azure.AI.Vision.Face.Tests' or
         $(MSBuildProjectName) == 'Azure.AI.Vision.ImageAnalysis.Tests' or
         $(MSBuildProjectName) == 'Azure.AI.VoiceLive.Tests' or
-        $(MSBuildProjectName) == 'Azure.Analytics.Defender.Easm.Tests' or
-        $(MSBuildProjectName) == 'Azure.Analytics.OnlineExperimentation.Tests' or
-        $(MSBuildProjectName) == 'Azure.Analytics.PlanetaryComputer.Tests' or
-        $(MSBuildProjectName) == 'Azure.Analytics.Purview.DataMap.Tests' or
-        $(MSBuildProjectName) == 'Azure.Analytics.Purview.Sharing.Tests' or
-        $(MSBuildProjectName) == 'Azure.Analytics.Purview.Workflows.Tests' or
-        $(MSBuildProjectName) == 'Azure.Analytics.Synapse.Artifacts.Tests' or
         $(MSBuildProjectName) == 'Azure.Compute.Batch.Tests' or
         $(MSBuildProjectName) == 'Azure.Containers.ContainerRegistry.Tests' or
         $(MSBuildProjectName) == 'Azure.Core.Amqp.Tests' or
@@ -257,14 +250,12 @@
         $(MSBuildProjectName) == 'Azure.ResourceManager.NewRelicObservability.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Nginx.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.NotificationHubs.Tests' or
-        $(MSBuildProjectName) == 'Azure.ResourceManager.OnlineExperimentation.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.OperationalInsights.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.OracleDatabase.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Orbital.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.PaloAltoNetworks.Ngfw.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Peering.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.PineconeVectorDB.Tests' or
-        $(MSBuildProjectName) == 'Azure.ResourceManager.PlanetaryComputer.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Playwright.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.PolicyInsights.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.PortalServicesCopilot.Tests' or
@@ -273,7 +264,6 @@
         $(MSBuildProjectName) == 'Azure.ResourceManager.PrivateDns.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.ProviderHub.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.PureStorageBlock.Tests' or
-        $(MSBuildProjectName) == 'Azure.ResourceManager.Purview.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Quantum.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Qumulo.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Quota.Tests' or
@@ -325,8 +315,6 @@
         $(MSBuildProjectName) == 'Azure.ResourceManager.StreamAnalytics.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Subscription.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Support.Tests' or
-        $(MSBuildProjectName) == 'Azure.ResourceManager.Synapse.Samples' or
-        $(MSBuildProjectName) == 'Azure.ResourceManager.Synapse.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Terraform.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.Tests' or
         $(MSBuildProjectName) == 'Azure.ResourceManager.TrafficManager.Tests' or

--- a/sdk/easm/Azure.Analytics.Defender.Easm/tests/AssetsTest.cs
+++ b/sdk/easm/Azure.Analytics.Defender.Easm/tests/AssetsTest.cs
@@ -27,10 +27,10 @@ namespace Azure.Analytics.Defender.Easm.Tests
         public async System.Threading.Tasks.Task AssetsListTest()
         {
             var results = client.GetAssetResourcesAsync();
-            Assert.IsNotNull(results);
+            Assert.That(results, Is.Not.Null);
             await foreach (var result in results)
             {
-                Assert.IsNotNull((result.Name));
+                Assert.That((result.Name), Is.Not.Null);
                 break;
             }
         }
@@ -40,7 +40,7 @@ namespace Azure.Analytics.Defender.Easm.Tests
         {
             var result = await client.GetAssetResourceAsync(assetId);
             AssetResource resource = result.Value;
-            Assert.AreEqual(assetName, resource.Name);
+            Assert.That(resource.Name, Is.EqualTo(assetName));
         }
 
         [Test]
@@ -51,9 +51,9 @@ namespace Azure.Analytics.Defender.Easm.Tests
 
             Response<TaskResource> result = await client.UpdateAssetsAsync(filter, assetUpdateData);
             TaskResource task = result.Value;
-            Assert.AreEqual(TaskResourceState.Complete, task.State);
-            Assert.AreEqual(TaskResourcePhase.Complete, task.Phase);
-            Assert.IsNotEmpty(UUID_REGEX.Matches(task.Id));
+            Assert.That(task.State, Is.EqualTo(TaskResourceState.Complete));
+            Assert.That(task.Phase, Is.EqualTo(TaskResourcePhase.Complete));
+            Assert.That(UUID_REGEX.Matches(task.Id), Is.Not.Empty);
         }
     }
 }

--- a/sdk/easm/Azure.Analytics.Defender.Easm/tests/DataConnectionsTest.cs
+++ b/sdk/easm/Azure.Analytics.Defender.Easm/tests/DataConnectionsTest.cs
@@ -29,13 +29,13 @@ namespace Azure.Analytics.Defender.Easm.Tests
         {
             var results = client.GetDataConnectionsAsync();
             var asyncNumerator = results.GetAsyncEnumerator();
-            Assert.IsNotNull(results);
+            Assert.That(results, Is.Not.Null);
             await foreach (DataConnection result in results)
             {
-                Assert.IsNotNull(result.Name);
-                Assert.IsNotNull(result.DisplayName);
-                Assert.IsNotNull(result.Active);
-                Assert.IsNotNull(result.Content);
+                Assert.That(result.Name, Is.Not.Null);
+                Assert.That(result.DisplayName, Is.Not.Null);
+                Assert.That(result.Active, Is.Not.Null);
+                Assert.That(result.Content, Is.Not.Null);
             }
         }
 
@@ -44,10 +44,10 @@ namespace Azure.Analytics.Defender.Easm.Tests
         {
             var result = await client.GetDataConnectionAsync(DataConnectionName);
             DataConnection dataConnection = result.Value;
-            Assert.AreEqual(DataConnectionName, dataConnection.Name);
-            Assert.AreEqual(DataConnectionName, dataConnection.DisplayName);
-            Assert.IsNotNull(dataConnection.Active);
-            Assert.IsNotNull(dataConnection.Content);
+            Assert.That(dataConnection.Name, Is.EqualTo(DataConnectionName));
+            Assert.That(dataConnection.DisplayName, Is.EqualTo(DataConnectionName));
+            Assert.That(dataConnection.Active, Is.Not.Null);
+            Assert.That(dataConnection.Content, Is.Not.Null);
         }
 
         [RecordedTest]
@@ -62,8 +62,8 @@ namespace Azure.Analytics.Defender.Easm.Tests
             request.Content = DataConnectionContent.Assets;
             request.Frequency = DataConnectionFrequency.Daily;
             var response = await client.ValidateDataConnectionAsync(request).ConfigureAwait(false);
-            Assert.IsNotNull(response);
-            Assert.IsNull(response.Value.Error);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Value.Error, Is.Null);
         }
 
         [RecordedTest]
@@ -78,10 +78,10 @@ namespace Azure.Analytics.Defender.Easm.Tests
             request.Content = DataConnectionContent.Assets;
             request.Frequency = DataConnectionFrequency.Daily;
             var response = await client.CreateOrReplaceDataConnectionAsync(NewDataConnectionName, request).ConfigureAwait(false);
-            Assert.AreEqual(NewDataConnectionName, response.Value.Name);
-            Assert.AreEqual(NewDataConnectionName, response.Value.DisplayName);
-            Assert.True(response.Value.GetType() == typeof(AzureDataExplorerDataConnection));
-            Assert.AreEqual(DataConnectionFrequency.Daily, response.Value.Frequency);
+            Assert.That(response.Value.Name, Is.EqualTo(NewDataConnectionName));
+            Assert.That(response.Value.DisplayName, Is.EqualTo(NewDataConnectionName));
+            Assert.That(response.Value.GetType(), Is.EqualTo(typeof(AzureDataExplorerDataConnection)));
+            Assert.That(response.Value.Frequency, Is.EqualTo(DataConnectionFrequency.Daily));
         }
     }
 }

--- a/sdk/easm/Azure.Analytics.Defender.Easm/tests/DataConnectionsTest.cs
+++ b/sdk/easm/Azure.Analytics.Defender.Easm/tests/DataConnectionsTest.cs
@@ -80,7 +80,7 @@ namespace Azure.Analytics.Defender.Easm.Tests
             var response = await client.CreateOrReplaceDataConnectionAsync(NewDataConnectionName, request).ConfigureAwait(false);
             Assert.That(response.Value.Name, Is.EqualTo(NewDataConnectionName));
             Assert.That(response.Value.DisplayName, Is.EqualTo(NewDataConnectionName));
-            Assert.That(response.Value.GetType(), Is.EqualTo(typeof(AzureDataExplorerDataConnection)));
+            Assert.That(response.Value, Is.InstanceOf<AzureDataExplorerDataConnection>());
             Assert.That(response.Value.Frequency, Is.EqualTo(DataConnectionFrequency.Daily));
         }
     }

--- a/sdk/easm/Azure.Analytics.Defender.Easm/tests/DiscoveryGroupsTest.cs
+++ b/sdk/easm/Azure.Analytics.Defender.Easm/tests/DiscoveryGroupsTest.cs
@@ -30,15 +30,15 @@ namespace Azure.Analytics.Defender.Easm.Tests
         public async System.Threading.Tasks.Task DiscoveryGroupsListTest()
         {
             var results = client.GetDiscoveryGroupsAsync();
-            Assert.IsNotNull(results);
+            Assert.That(results, Is.Not.Null);
             await foreach (DiscoveryGroup result in results)
             {
-                Assert.IsNotNull(result.Name);
-                Assert.IsNotNull(result.DisplayName);
-                Assert.IsNotNull(result.Description);
-                Assert.IsNotNull(result.Seeds);
-                Assert.IsNotNull(result.Seeds[0].Kind);
-                Assert.IsNotNull(result.Seeds[0].Name);
+                Assert.That(result.Name, Is.Not.Null);
+                Assert.That(result.DisplayName, Is.Not.Null);
+                Assert.That(result.Description, Is.Not.Null);
+                Assert.That(result.Seeds, Is.Not.Null);
+                Assert.That(result.Seeds[0].Kind, Is.Not.Null);
+                Assert.That(result.Seeds[0].Name, Is.Not.Null);
                 break;
             }
         }
@@ -55,19 +55,19 @@ namespace Azure.Analytics.Defender.Easm.Tests
             request.FrequencyMilliseconds = 604800000L;
             request.Tier = "advanced";
             var result = await client.ValidateDiscoveryGroupAsync(request).ConfigureAwait(false);
-            Assert.IsNull(result.Value.Error);
+            Assert.That(result.Value.Error, Is.Null);
         }
         [RecordedTest]
         public async System.Threading.Tasks.Task DiscoveryGroupsGetTest()
         {
             var result = await client.GetDiscoveryGroupAsync(knownGroupName);
             DiscoveryGroup discoGroup = result.Value;
-            Assert.AreEqual(knownGroupName, discoGroup.Name);
-            Assert.AreEqual(knownGroupName, discoGroup.DisplayName);
-            Assert.IsNotNull(discoGroup.Description);
-            Assert.IsNotNull(discoGroup.Seeds);
-            Assert.IsNotNull(discoGroup.Seeds[0].Kind);
-            Assert.IsNotNull(discoGroup.Seeds[0].Name);
+            Assert.That(discoGroup.Name, Is.EqualTo(knownGroupName));
+            Assert.That(discoGroup.DisplayName, Is.EqualTo(knownGroupName));
+            Assert.That(discoGroup.Description, Is.Not.Null);
+            Assert.That(discoGroup.Seeds, Is.Not.Null);
+            Assert.That(discoGroup.Seeds[0].Kind, Is.Not.Null);
+            Assert.That(discoGroup.Seeds[0].Name, Is.Not.Null);
         }
         [RecordedTest]
         public async System.Threading.Tasks.Task DiscoveryGroupsCreateOrReplaceTest()
@@ -83,13 +83,13 @@ namespace Azure.Analytics.Defender.Easm.Tests
             request.Tier = "advanced";
             var response = await client.CreateOrReplaceDiscoveryGroupAsync(newGroupName, request).ConfigureAwait(false);
             DiscoveryGroup discoGroup = response.Value;
-            Assert.IsTrue(doSeedsMatch(seed, discoGroup.Seeds[0]));
+            Assert.That(doSeedsMatch(seed, discoGroup.Seeds[0]), Is.True);
         }
         [RecordedTest]
         public async System.Threading.Tasks.Task DiscoGroupsRunTest()
         {
             Response response = await client.RunDiscoveryGroupAsync(knownGroupName).ConfigureAwait(false);
-            Assert.AreEqual(204, response.Status);
+            Assert.That(response.Status, Is.EqualTo(204));
         }
         [RecordedTest]
         public async System.Threading.Tasks.Task DiscoRunListTest()
@@ -97,8 +97,8 @@ namespace Azure.Analytics.Defender.Easm.Tests
             var response = client.GetDiscoveryGroupRunsAsync(knownGroupName).ConfigureAwait(false);
             await foreach (var run in response)
             {
-                Assert.IsNotNull(run.State);
-                Assert.IsNotNull(run.TotalAssetsFoundCount);
+                Assert.That(run.State, Is.Not.Null);
+                Assert.That(run.TotalAssetsFoundCount, Is.Not.Null);
             }
         }
         private bool? doSeedsMatch(DiscoverySource seed, DiscoverySource discoSource)

--- a/sdk/easm/Azure.Analytics.Defender.Easm/tests/DiscoveryTemplatesTest.cs
+++ b/sdk/easm/Azure.Analytics.Defender.Easm/tests/DiscoveryTemplatesTest.cs
@@ -26,7 +26,7 @@ namespace Azure.Analytics.Defender.Easm.Tests
             var response = client.GetDiscoveryTemplatesAsync(PartialName);
             await foreach (var template in response)
             {
-                Assert.IsTrue(template.Name.ToLower().Contains(PartialName));
+                Assert.That(template.Name.ToLower().Contains(PartialName), Is.True);
             }
         }
         [RecordedTest]
@@ -34,8 +34,8 @@ namespace Azure.Analytics.Defender.Easm.Tests
         {
             var response = await client.GetDiscoveryTemplateAsync(TemplateId);
             DiscoveryTemplate discoTemplate = response.Value;
-            Assert.IsNotNull(discoTemplate.Name);
-            Assert.IsNotNull(discoTemplate.Id);
+            Assert.That(discoTemplate.Name, Is.Not.Null);
+            Assert.That(discoTemplate.Id, Is.Not.Null);
         }
     }
 }

--- a/sdk/easm/Azure.Analytics.Defender.Easm/tests/EasmClientTest.cs
+++ b/sdk/easm/Azure.Analytics.Defender.Easm/tests/EasmClientTest.cs
@@ -33,7 +33,7 @@ namespace Azure.Analytics.Defender.Easm.Tests
         [RecordedTest]
         public void TestOperation()
         {
-            Assert.IsTrue(true);
+            Assert.That(true, Is.True);
         }
 
         #region Helpers

--- a/sdk/easm/Azure.Analytics.Defender.Easm/tests/ReportsTest.cs
+++ b/sdk/easm/Azure.Analytics.Defender.Easm/tests/ReportsTest.cs
@@ -24,9 +24,9 @@ namespace Azure.Analytics.Defender.Easm.Tests
             ReportAssetSnapshotPayload.Metric = metric;
             var response = await client.GetSnapshotAsync(ReportAssetSnapshotPayload);
             ReportAssetSnapshotResult reportAssetSnapshotResult = response.Value;
-            Assert.IsNotNull(reportAssetSnapshotResult);
-            Assert.AreEqual(metric, reportAssetSnapshotResult.Metric);
-            Assert.IsNotNull(reportAssetSnapshotResult.Description);
+            Assert.That(reportAssetSnapshotResult, Is.Not.Null);
+            Assert.That(reportAssetSnapshotResult.Metric, Is.EqualTo(metric));
+            Assert.That(reportAssetSnapshotResult.Description, Is.Not.Null);
         }
         [RecordedTest]
         public async System.Threading.Tasks.Task ReportsSnapshotTest()
@@ -35,10 +35,10 @@ namespace Azure.Analytics.Defender.Easm.Tests
             ReportAssetSnapshotPayload.Metric = metric;
             var response = await client.GetSnapshotAsync(ReportAssetSnapshotPayload);
             ReportAssetSnapshotResult reportAssetSnapshotResult = response.Value;
-            Assert.IsNotNull(reportAssetSnapshotResult.DisplayName);
-            Assert.AreEqual(metric, reportAssetSnapshotResult.Metric);
-            Assert.IsNotNull(reportAssetSnapshotResult.Description);
-            Assert.IsNotNull(reportAssetSnapshotResult.Assets);
+            Assert.That(reportAssetSnapshotResult.DisplayName, Is.Not.Null);
+            Assert.That(reportAssetSnapshotResult.Metric, Is.EqualTo(metric));
+            Assert.That(reportAssetSnapshotResult.Description, Is.Not.Null);
+            Assert.That(reportAssetSnapshotResult.Assets, Is.Not.Null);
         }
         [RecordedTest]
         public async System.Threading.Tasks.Task ReportsSummaryTest()
@@ -46,7 +46,7 @@ namespace Azure.Analytics.Defender.Easm.Tests
             ReportAssetSummaryPayload reportAssetSummaryRequest = new ReportAssetSummaryPayload();
             reportAssetSummaryRequest.Metrics.Add(metric);
             var response = await client.GetSummaryAsync(reportAssetSummaryRequest);
-            Assert.IsTrue(response.Value.AssetSummaries.Count > 0);
+            Assert.That(response.Value.AssetSummaries.Count > 0, Is.True);
         }
     }
 }

--- a/sdk/onlineexperimentation/Azure.Analytics.OnlineExperimentation/tests/ExperimentMetricUpdateSerializationTests.cs
+++ b/sdk/onlineexperimentation/Azure.Analytics.OnlineExperimentation/tests/ExperimentMetricUpdateSerializationTests.cs
@@ -150,16 +150,16 @@ namespace Azure.Analytics.OnlineExperimentation.Tests
             var categoriesEmitted = document.RootElement.TryGetProperty("categories", out var categoriesElement);
             if (originalCategories.IsUndefined)
             {
-                Assert.IsFalse(categoriesEmitted);
+                Assert.That(categoriesEmitted, Is.False);
             }
             else
             {
-                Assert.IsTrue(categoriesEmitted);
-                Assert.AreEqual(JsonValueKind.Array, categoriesElement.ValueKind);
-                Assert.AreEqual(originalCategories.Count, categoriesElement.GetArrayLength());
+                Assert.That(categoriesEmitted, Is.True);
+                Assert.That(categoriesElement.ValueKind, Is.EqualTo(JsonValueKind.Array));
+                Assert.That(categoriesElement.GetArrayLength(), Is.EqualTo(originalCategories.Count));
                 for (int i = 0; i < originalCategories.Count; i++)
                 {
-                    Assert.AreEqual(originalCategories[i], categoriesElement[i].GetString());
+                    Assert.That(categoriesElement[i].GetString(), Is.EqualTo(originalCategories[i]));
                 }
             }
         }

--- a/sdk/onlineexperimentation/Azure.ResourceManager.OnlineExperimentation/tests/CustomerManagedKeyTests.cs
+++ b/sdk/onlineexperimentation/Azure.ResourceManager.OnlineExperimentation/tests/CustomerManagedKeyTests.cs
@@ -25,12 +25,12 @@ namespace Azure.ResourceManager.OnlineExperimentation.Tests
         {
             var experimentWorkspaceRead = await TestWorkspaceResource.GetAsync();
 
-            Assert.IsTrue(experimentWorkspaceRead.Value.HasData);
+            Assert.That(experimentWorkspaceRead.Value.HasData, Is.True);
 
             var workspaceResourceData = experimentWorkspaceRead.Value.Data;
 
-            Assert.IsNotNull(workspaceResourceData.Properties.Endpoint);
-            Assert.AreEqual(Uri.UriSchemeHttps, workspaceResourceData.Properties.Endpoint.Scheme);
+            Assert.That(workspaceResourceData.Properties.Endpoint, Is.Not.Null);
+            Assert.That(workspaceResourceData.Properties.Endpoint.Scheme, Is.EqualTo(Uri.UriSchemeHttps));
         }
 
         [TestCase]

--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/PlanetaryComputerTestBase.cs
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/PlanetaryComputerTestBase.cs
@@ -64,8 +64,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
         /// <param name="propertyName">The name of the property being validated, used in error messages.</param>
         protected static void ValidateNotNullOrEmpty(string value, string propertyName)
         {
-            Assert.IsNotNull(value, $"{propertyName} should not be null");
-            Assert.IsNotEmpty(value, $"{propertyName} should not be empty");
+            Assert.That(value, Is.Not.Null, $"{propertyName} should not be null");
+            Assert.That(value, Is.Not.Empty, $"{propertyName} should not be empty");
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
         /// <param name="responseName">Optional name of the response, used in error messages. If null, the type name is used.</param>
         protected static void ValidateResponse<T>(T response, string responseName = null) where T : class
         {
-            Assert.IsNotNull(response, $"{responseName ?? typeof(T).Name} response should not be null");
+            Assert.That(response, Is.Not.Null, $"{responseName ?? typeof(T).Name} response should not be null");
         }
     }
 }

--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/StacClientTests.cs
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/StacClientTests.cs
@@ -33,8 +33,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Validate response using base class helper methods
             ValidateResponse(response, "GetCollections");
-            Assert.AreEqual(200, response.Status, "Expected successful response");
-            Assert.IsNotNull(response.Content, "Response content should not be null");
+            Assert.That(response.Status, Is.EqualTo(200), "Expected successful response");
+            Assert.That(response.Content, Is.Not.Null, "Response content should not be null");
 
             TestContext.WriteLine($"Successfully retrieved collections. Status: {response.Status}");
         }

--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer01StacCollectionTests.cs
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer01StacCollectionTests.cs
@@ -45,34 +45,34 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetCollections");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacCatalogCollections collections = response.Value;
-            Assert.IsNotNull(collections, "Collections should not be null");
-            Assert.IsNotNull(collections.Collections, "Collections array should not be null");
+            Assert.That(collections, Is.Not.Null, "Collections should not be null");
+            Assert.That(collections.Collections, Is.Not.Null, "Collections array should not be null");
 
             // Verify collections array exists
             int collectionCount = collections.Collections.Count;
             TestContext.WriteLine($"Number of collections: {collectionCount}");
 
             // Verify we have at least one collection
-            Assert.Greater(collectionCount, 0, "Should have at least one collection");
+            Assert.That(collectionCount, Is.GreaterThan(0), "Should have at least one collection");
 
             // Verify first collection has required STAC properties
             if (collectionCount > 0)
             {
                 StacCollectionResource firstCollection = collections.Collections[0];
 
-                Assert.IsNotNull(firstCollection.Id, "Collection should have 'id' property");
+                Assert.That(firstCollection.Id, Is.Not.Null, "Collection should have 'id' property");
                 string collectionId = firstCollection.Id;
                 ValidateNotNullOrEmpty(collectionId, "collection.id");
 
                 TestContext.WriteLine($"First collection ID: {collectionId}");
 
                 // Verify other STAC collection properties
-                Assert.IsNotNull(firstCollection.Type, "Collection should have 'type' property");
-                Assert.IsNotNull(firstCollection.Links, "Collection should have 'links' property");
-                Assert.IsNotNull(firstCollection.StacVersion, "Collection should have 'stac_version' property");
+                Assert.That(firstCollection.Type, Is.Not.Null, "Collection should have 'type' property");
+                Assert.That(firstCollection.Links, Is.Not.Null, "Collection should have 'links' property");
+                Assert.That(firstCollection.StacVersion, Is.Not.Null, "Collection should have 'stac_version' property");
 
                 if (firstCollection.Title != null)
                 {
@@ -106,29 +106,29 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetCollection");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacCollectionResource collection = response.Value;
-            Assert.IsNotNull(collection, "Collection should not be null");
+            Assert.That(collection, Is.Not.Null, "Collection should not be null");
 
             // Verify collection ID matches
-            Assert.IsNotNull(collection.Id, "Response should contain 'id' property");
+            Assert.That(collection.Id, Is.Not.Null, "Response should contain 'id' property");
             string returnedId = collection.Id;
-            Assert.AreEqual(collectionId, returnedId, "Returned collection ID should match requested ID");
+            Assert.That(returnedId, Is.EqualTo(collectionId), "Returned collection ID should match requested ID");
 
             // Verify STAC collection required properties
-            Assert.IsNotNull(collection.Type, "Collection should have 'type' property");
-            Assert.AreEqual("Collection", collection.Type, "Type should be 'Collection'");
+            Assert.That(collection.Type, Is.Not.Null, "Collection should have 'type' property");
+            Assert.That(collection.Type, Is.EqualTo("Collection"), "Type should be 'Collection'");
 
-            Assert.IsNotNull(collection.StacVersion, "Collection should have 'stac_version' property");
+            Assert.That(collection.StacVersion, Is.Not.Null, "Collection should have 'stac_version' property");
             ValidateNotNullOrEmpty(collection.StacVersion, "stac_version");
             TestContext.WriteLine($"STAC version: {collection.StacVersion}");
 
-            Assert.IsNotNull(collection.Links, "Collection should have 'links' property");
-            Assert.Greater(collection.Links.Count, 0, "Links should have at least one item");
+            Assert.That(collection.Links, Is.Not.Null, "Collection should have 'links' property");
+            Assert.That(collection.Links.Count, Is.GreaterThan(0), "Links should have at least one item");
 
-            Assert.IsNotNull(collection.Extent, "Collection should have 'extent' property");
-            Assert.IsNotNull(collection.License, "Collection should have 'license' property");
+            Assert.That(collection.Extent, Is.Not.Null, "Collection should have 'extent' property");
+            Assert.That(collection.License, Is.Not.Null, "Collection should have 'license' property");
 
             // Log additional properties
             if (collection.Title != null)
@@ -170,15 +170,15 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetConformanceClass");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacConformanceClasses conformance = response.Value;
-            Assert.IsNotNull(conformance, "Conformance should not be null");
-            Assert.IsNotNull(conformance.ConformsTo, "ConformsTo should not be null");
+            Assert.That(conformance, Is.Not.Null, "Conformance should not be null");
+            Assert.That(conformance.ConformsTo, Is.Not.Null, "ConformsTo should not be null");
 
             int conformanceCount = conformance.ConformsTo.Count;
             TestContext.WriteLine($"Number of conformance classes: {conformanceCount}");
-            Assert.Greater(conformanceCount, 0, "Should have at least one conformance class");
+            Assert.That(conformanceCount, Is.GreaterThan(0), "Should have at least one conformance class");
 
             // Log first few conformance URIs
             for (int i = 0; i < System.Math.Min(5, conformanceCount); i++)
@@ -211,17 +211,17 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetPartitionType");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             PartitionType partitionType = response.Value;
-            Assert.IsNotNull(partitionType, "PartitionType should not be null");
-            Assert.IsNotNull(partitionType.Scheme, "Partition scheme should not be null");
+            Assert.That(partitionType, Is.Not.Null, "PartitionType should not be null");
+            Assert.That(partitionType.Scheme, Is.Not.Null, "Partition scheme should not be null");
 
             TestContext.WriteLine($"Partition scheme: {partitionType.Scheme}");
 
             // Verify scheme is a valid value
             string scheme = partitionType.Scheme.ToString();
-            Assert.IsNotNull(scheme, "Scheme should have a value");
+            Assert.That(scheme, Is.Not.Null, "Scheme should have a value");
 
             TestContext.WriteLine($"Successfully retrieved partition type: {scheme}");
         }
@@ -248,10 +248,10 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetRenderOptions");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             IReadOnlyList<RenderConfiguration> renderOptions = response.Value;
-            Assert.IsNotNull(renderOptions, "RenderOptions should not be null");
+            Assert.That(renderOptions, Is.Not.Null, "RenderOptions should not be null");
 
             int optionCount = renderOptions.Count;
             TestContext.WriteLine($"Number of render options: {optionCount}");
@@ -259,7 +259,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             if (optionCount > 0)
             {
                 RenderConfiguration firstOption = renderOptions[0];
-                Assert.IsNotNull(firstOption.Id, "Render option should have ID");
+                Assert.That(firstOption.Id, Is.Not.Null, "Render option should have ID");
                 TestContext.WriteLine($"First render option ID: {firstOption.Id}");
 
                 if (firstOption.Name != null)
@@ -293,10 +293,10 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetTileSettings");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             TileSettings tileSettings = response.Value;
-            Assert.IsNotNull(tileSettings, "TileSettings should not be null");
+            Assert.That(tileSettings, Is.Not.Null, "TileSettings should not be null");
 
             // Log available properties
             TestContext.WriteLine($"Max items per tile: {tileSettings.MaxItemsPerTile}");
@@ -332,10 +332,10 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetMosaics");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             IReadOnlyList<StacMosaic> mosaics = response.Value;
-            Assert.IsNotNull(mosaics, "Mosaics should not be null");
+            Assert.That(mosaics, Is.Not.Null, "Mosaics should not be null");
 
             int mosaicCount = mosaics.Count;
             TestContext.WriteLine($"Number of mosaics: {mosaicCount}");
@@ -343,7 +343,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             if (mosaicCount > 0)
             {
                 StacMosaic firstMosaic = mosaics[0];
-                Assert.IsNotNull(firstMosaic.Id, "Mosaic should have ID");
+                Assert.That(firstMosaic.Id, Is.Not.Null, "Mosaic should have ID");
                 TestContext.WriteLine($"First mosaic ID: {firstMosaic.Id}");
 
                 if (firstMosaic.Name != null)
@@ -378,13 +378,13 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response, "GetCollectionQueryables");
-            Assert.AreEqual(200, response.Status, "Expected successful response");
+            Assert.That(response.Status, Is.EqualTo(200), "Expected successful response");
 
             // Parse JSON response
             using JsonDocument doc = JsonDocument.Parse(response.Content);
             JsonElement root = doc.RootElement;
 
-            Assert.IsTrue(root.TryGetProperty("properties", out JsonElement properties), "Response should have 'properties' key");
+            Assert.That(root.TryGetProperty("properties", out JsonElement properties), Is.True, "Response should have 'properties' key");
 
             int propertyCount = 0;
             foreach (JsonProperty prop in properties.EnumerateObject())
@@ -424,13 +424,13 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response, "GetQueryables");
-            Assert.AreEqual(200, response.Status, "Expected successful response");
+            Assert.That(response.Status, Is.EqualTo(200), "Expected successful response");
 
             // Parse JSON response
             using JsonDocument doc = JsonDocument.Parse(response.Content);
             JsonElement root = doc.RootElement;
 
-            Assert.IsTrue(root.TryGetProperty("properties", out JsonElement properties), "Response should have 'properties' key");
+            Assert.That(root.TryGetProperty("properties", out JsonElement properties), Is.True, "Response should have 'properties' key");
 
             int propertyCount = 0;
             foreach (JsonProperty prop in properties.EnumerateObject())
@@ -465,10 +465,10 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetCollectionConfiguration");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             UserCollectionSettings config = response.Value;
-            Assert.IsNotNull(config, "Configuration should not be null");
+            Assert.That(config, Is.Not.Null, "Configuration should not be null");
 
             TestContext.WriteLine("Successfully retrieved collection configuration");
         }
@@ -507,11 +507,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response, "GetCollectionThumbnail");
-            Assert.AreEqual(200, response.Status, "Expected successful response");
+            Assert.That(response.Status, Is.EqualTo(200), "Expected successful response");
 
             // Read the streaming content
             System.IO.Stream contentStream = response.ContentStream;
-            Assert.IsNotNull(contentStream, "Content stream should not be null");
+            Assert.That(contentStream, Is.Not.Null, "Content stream should not be null");
 
             // Read into byte array
             using var memoryStream = new System.IO.MemoryStream();
@@ -519,8 +519,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             byte[] thumbnailBytes = memoryStream.ToArray();
 
             TestContext.WriteLine($"Thumbnail size: {thumbnailBytes.Length} bytes");
-            Assert.Greater(thumbnailBytes.Length, 0, "Thumbnail bytes should not be empty");
-            Assert.Greater(thumbnailBytes.Length, 100, "Thumbnail should be substantial");
+            Assert.That(thumbnailBytes.Length, Is.GreaterThan(0), "Thumbnail bytes should not be empty");
+            Assert.That(thumbnailBytes.Length, Is.GreaterThan(100), "Thumbnail should be substantial");
 
             // Check for common image format magic bytes
             bool isPng = thumbnailBytes.Length >= 8 &&
@@ -531,7 +531,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
                          thumbnailBytes[0] == 0xFF && thumbnailBytes[1] == 0xD8 &&
                          thumbnailBytes[2] == 0xFF;
 
-            Assert.IsTrue(isPng || isJpeg, "Thumbnail should be either PNG or JPEG format");
+            Assert.That(isPng || isJpeg, Is.True, "Thumbnail should be either PNG or JPEG format");
 
             if (isPng)
             {
@@ -587,12 +587,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "CreateRenderOption");
-            Assert.AreEqual(201, response.GetRawResponse().Status, "Expected 201 Created response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(201), "Expected 201 Created response");
 
             RenderConfiguration createdOption = response.Value;
-            Assert.IsNotNull(createdOption, "Created render option should not be null");
-            Assert.AreEqual("test-natural-color", createdOption.Id, "ID should match");
-            Assert.AreEqual("Test Natural color", createdOption.Name, "Name should match");
+            Assert.That(createdOption, Is.Not.Null, "Created render option should not be null");
+            Assert.That(createdOption.Id, Is.EqualTo("test-natural-color"), "ID should match");
+            Assert.That(createdOption.Name, Is.EqualTo("Test Natural color"), "Name should match");
 
             TestContext.WriteLine($"Successfully created render option: {createdOption.Id}");
         }
@@ -619,12 +619,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetRenderOption");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             RenderConfiguration renderOption = response.Value;
-            Assert.IsNotNull(renderOption, "Render option should not be null");
-            Assert.AreEqual("test-natural-color", renderOption.Id, "ID should match");
-            Assert.IsNotNull(renderOption.Name, "Name should not be null");
+            Assert.That(renderOption, Is.Not.Null, "Render option should not be null");
+            Assert.That(renderOption.Id, Is.EqualTo("test-natural-color"), "ID should match");
+            Assert.That(renderOption.Name, Is.Not.Null, "Name should not be null");
 
             TestContext.WriteLine($"Successfully retrieved render option: {renderOption.Id}");
         }
@@ -661,12 +661,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "ReplaceRenderOption");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             RenderConfiguration updatedOption = response.Value;
-            Assert.IsNotNull(updatedOption, "Updated render option should not be null");
-            Assert.AreEqual("test-natural-color", updatedOption.Id, "ID should match");
-            Assert.AreEqual("RGB from visual assets - updated", updatedOption.Description, "Description should be updated");
+            Assert.That(updatedOption, Is.Not.Null, "Updated render option should not be null");
+            Assert.That(updatedOption.Id, Is.EqualTo("test-natural-color"), "ID should match");
+            Assert.That(updatedOption.Description, Is.EqualTo("RGB from visual assets - updated"), "Description should be updated");
 
             TestContext.WriteLine($"Successfully replaced render option: {updatedOption.Id}");
         }
@@ -702,7 +702,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify it exists
             Response<RenderConfiguration> getResponse = await stacClient.GetRenderOptionAsync(collectionId, "test-render-opt-delete");
-            Assert.IsNotNull(getResponse.Value, "Render option should exist before deletion");
+            Assert.That(getResponse.Value, Is.Not.Null, "Render option should exist before deletion");
 
             // Act - Delete it
             Response deleteResponse = await stacClient.DeleteRenderOptionAsync(collectionId, "test-render-opt-delete");
@@ -721,7 +721,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status, "Should return 404 for deleted resource");
+                Assert.That(ex.Status, Is.EqualTo(404), "Should return 404 for deleted resource");
                 TestContext.WriteLine("Verified render option was deleted");
             }
         }
@@ -767,12 +767,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "AddMosaic");
-            Assert.IsTrue(response.GetRawResponse().Status == 201 || response.GetRawResponse().Status == 200,
-                "Expected 201 Created or 200 OK response");
+            Assert.That(response.GetRawResponse().Status == 201 || response.GetRawResponse().Status == 200, Is.True, "Expected 201 Created or 200 OK response");
 
             StacMosaic createdMosaic = response.Value;
-            Assert.IsNotNull(createdMosaic, "Created mosaic should not be null");
-            Assert.AreEqual("test-mosaic-1", createdMosaic.Id, "ID should match");
+            Assert.That(createdMosaic, Is.Not.Null, "Created mosaic should not be null");
+            Assert.That(createdMosaic.Id, Is.EqualTo("test-mosaic-1"), "ID should match");
 
             TestContext.WriteLine($"Successfully added mosaic: {createdMosaic.Id}");
         }
@@ -799,11 +798,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetMosaic");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacMosaic mosaic = response.Value;
-            Assert.IsNotNull(mosaic, "Mosaic should not be null");
-            Assert.AreEqual("test-mosaic-1", mosaic.Id, "ID should match");
+            Assert.That(mosaic, Is.Not.Null, "Mosaic should not be null");
+            Assert.That(mosaic.Id, Is.EqualTo("test-mosaic-1"), "ID should match");
 
             TestContext.WriteLine($"Successfully retrieved mosaic: {mosaic.Id}");
         }
@@ -838,12 +837,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "ReplaceMosaic");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacMosaic updatedMosaic = response.Value;
-            Assert.IsNotNull(updatedMosaic, "Updated mosaic should not be null");
-            Assert.AreEqual("test-mosaic-1", updatedMosaic.Id, "ID should match");
-            Assert.AreEqual("Test Mosaic Updated", updatedMosaic.Name, "Name should be updated");
+            Assert.That(updatedMosaic, Is.Not.Null, "Updated mosaic should not be null");
+            Assert.That(updatedMosaic.Id, Is.EqualTo("test-mosaic-1"), "ID should match");
+            Assert.That(updatedMosaic.Name, Is.EqualTo("Test Mosaic Updated"), "Name should be updated");
 
             TestContext.WriteLine($"Successfully replaced mosaic: {updatedMosaic.Id}");
         }
@@ -878,7 +877,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify it exists
             Response<StacMosaic> getResponse = await stacClient.GetMosaicAsync(collectionId, "test-mosaic-delete");
-            Assert.IsNotNull(getResponse.Value, "Mosaic should exist before deletion");
+            Assert.That(getResponse.Value, Is.Not.Null, "Mosaic should exist before deletion");
 
             // Act - Delete it
             Response deleteResponse = await stacClient.DeleteMosaicAsync(collectionId, "test-mosaic-delete");
@@ -897,7 +896,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             }
             catch (RequestFailedException ex)
             {
-                Assert.AreEqual(404, ex.Status, "Should return 404 for deleted resource");
+                Assert.That(ex.Status, Is.EqualTo(404), "Should return 404 for deleted resource");
                 TestContext.WriteLine("Verified mosaic was deleted");
             }
         }

--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer02IngestionManagementTests.cs
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer02IngestionManagementTests.cs
@@ -57,7 +57,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             }
 
             // Assert
-            Assert.IsNotNull(managedIdentities, "Managed identities list should not be null");
+            Assert.That(managedIdentities, Is.Not.Null, "Managed identities list should not be null");
             TestContext.WriteLine($"\n=== Total Identities Found: {managedIdentities.Count} ===");
 
             // Verify each identity has required properties
@@ -69,8 +69,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
                 TestContext.WriteLine($"    - Resource ID: {identity.ResourceId}");
 
                 // Verify properties
-                Assert.AreNotEqual(Guid.Empty, identity.ObjectId, "Object ID should not be empty");
-                Assert.IsNotNull(identity.ResourceId, "Resource ID should not be null");
+                Assert.That(identity.ObjectId, Is.Not.EqualTo(Guid.Empty), "Object ID should not be empty");
+                Assert.That(identity.ResourceId, Is.Not.Null, "Resource ID should not be null");
             }
 
             TestContext.WriteLine($"Successfully listed {managedIdentities.Count} managed identities");
@@ -101,13 +101,13 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             }
 
             // Assert
-            Assert.IsNotNull(sources, "Sources list should not be null");
+            Assert.That(sources, Is.Not.Null, "Sources list should not be null");
             TestContext.WriteLine($"Found {sources.Count} ingestion sources");
 
             // Verify each source has required properties
             foreach (IngestionSourceSummary source in sources)
             {
-                Assert.IsNotNull(source.Id, "Source should have ID");
+                Assert.That(source.Id, Is.Not.Null, "Source should have ID");
                 TestContext.WriteLine($"  Source ID: {source.Id}");
 
                 TestContext.WriteLine($"    Kind: {source.Kind}");
@@ -141,7 +141,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             }
 
             // Assert
-            Assert.IsNotNull(sources, "Sources list should not be null");
+            Assert.That(sources, Is.Not.Null, "Sources list should not be null");
             TestContext.WriteLine($"Found {sources.Count} ingestion sources");
 
             // Verify each source has required properties
@@ -180,7 +180,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
                 firstIdentity = identity;
                 break;
             }
-            Assert.IsNotNull(firstIdentity, "No managed identities found");
+            Assert.That(firstIdentity, Is.Not.Null, "No managed identities found");
 
             Guid objectId = firstIdentity.ObjectId;
             TestContext.WriteLine($"Using Managed Identity Object ID: {objectId}");
@@ -210,8 +210,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             Response<IngestionSource> createResponse = await ingestionClient.CreateSourceAsync(ingestionSource);
 
             // Assert
-            Assert.IsNotNull(createResponse, "Create response should not be null");
-            Assert.IsNotNull(createResponse.Value, "Created source should not be null");
+            Assert.That(createResponse, Is.Not.Null, "Create response should not be null");
+            Assert.That(createResponse.Value, Is.Not.Null, "Created source should not be null");
 
             TestContext.WriteLine($"Created ingestion source:");
             TestContext.WriteLine($"  - ID: {createResponse.Value.Id}");
@@ -262,8 +262,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             Response<IngestionSource> createResponse = await ingestionClient.CreateSourceAsync(sasIngestionSource);
 
             // Assert
-            Assert.IsNotNull(createResponse, "Create response should not be null");
-            Assert.IsNotNull(createResponse.Value, "Created source should not be null");
+            Assert.That(createResponse, Is.Not.Null, "Create response should not be null");
+            Assert.That(createResponse.Value, Is.Not.Null, "Created source should not be null");
 
             TestContext.WriteLine($"Created SAS token ingestion source:");
             TestContext.WriteLine($"  - ID: {createResponse.Value.Id}");
@@ -329,9 +329,9 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             Response<IngestionInformation> response = await ingestionClient.CreateAsync(collectionId, ingestionDefinition);
 
             // Assert
-            Assert.IsNotNull(response, "Ingestion response should not be null");
-            Assert.IsNotNull(response.Value, "Ingestion value should not be null");
-            Assert.IsNotNull(response.Value.Id, "Ingestion ID should not be null");
+            Assert.That(response, Is.Not.Null, "Ingestion response should not be null");
+            Assert.That(response.Value, Is.Not.Null, "Ingestion value should not be null");
+            Assert.That(response.Value.Id, Is.Not.Null, "Ingestion ID should not be null");
 
             TestContext.WriteLine($"Created ingestion: {response.Value.Id}");
         }
@@ -389,8 +389,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             TestContext.WriteLine($"  - Display Name: {updatedIngestion.DisplayName}");
             TestContext.WriteLine($"  - Import Type: {updatedIngestion.ImportType}");
 
-            Assert.AreEqual(ingestionId, updatedIngestion.Id, "Ingestion ID should remain the same");
-            Assert.AreEqual("Updated Ingestion Name", updatedIngestion.DisplayName, "Display name should be updated");
+            Assert.That(updatedIngestion.Id, Is.EqualTo(ingestionId), "Ingestion ID should remain the same");
+            Assert.That(updatedIngestion.DisplayName, Is.EqualTo("Updated Ingestion Name"), "Display name should be updated");
         }
 
         /// <summary>
@@ -428,10 +428,10 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             Response<IngestionRun> runResponse = await ingestionClient.CreateRunAsync(collectionId, ingestionId);
 
             // Assert
-            Assert.IsNotNull(runResponse, "Run response should not be null");
-            Assert.IsNotNull(runResponse.Value, "Run value should not be null");
-            Assert.IsNotNull(runResponse.Value.Id, "Run ID should not be null");
-            Assert.IsNotNull(runResponse.Value.Operation, "Operation should not be null");
+            Assert.That(runResponse, Is.Not.Null, "Run response should not be null");
+            Assert.That(runResponse.Value, Is.Not.Null, "Run value should not be null");
+            Assert.That(runResponse.Value.Id, Is.Not.Null, "Run ID should not be null");
+            Assert.That(runResponse.Value.Operation, Is.Not.Null, "Operation should not be null");
 
             TestContext.WriteLine($"Created ingestion run:");
             TestContext.WriteLine($"  - Run ID: {runResponse.Value.Id}");
@@ -477,8 +477,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             Response<IngestionRun> getRunResponse = await ingestionClient.GetRunAsync(collectionId, ingestionId, runId);
 
             // Assert
-            Assert.IsNotNull(getRunResponse, "Get run response should not be null");
-            Assert.IsNotNull(getRunResponse.Value, "Run should not be null");
+            Assert.That(getRunResponse, Is.Not.Null, "Get run response should not be null");
+            Assert.That(getRunResponse.Value, Is.Not.Null, "Run should not be null");
             IngestionRun run = getRunResponse.Value;
 
             TestContext.WriteLine("Run status:");
@@ -489,9 +489,9 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             TestContext.WriteLine($"  - Failed Items: {run.Operation.TotalFailedItems}");
             TestContext.WriteLine($"  - Pending Items: {run.Operation.TotalPendingItems}");
 
-            Assert.AreEqual(runId, run.Id, "Run ID should match");
-            Assert.IsNotNull(run.Operation, "Operation should not be null");
-            Assert.IsNotNull(run.Operation.Status, "Status should not be null");
+            Assert.That(run.Id, Is.EqualTo(runId), "Run ID should match");
+            Assert.That(run.Operation, Is.Not.Null, "Operation should not be null");
+            Assert.That(run.Operation.Status, Is.Not.Null, "Status should not be null");
         }
 
         /// <summary>
@@ -533,8 +533,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             Response<LongRunningOperation> operationResponse = await ingestionClient.GetOperationAsync(operationId);
 
             // Assert
-            Assert.IsNotNull(operationResponse, "Operation response should not be null");
-            Assert.IsNotNull(operationResponse.Value, "Operation should not be null");
+            Assert.That(operationResponse, Is.Not.Null, "Operation response should not be null");
+            Assert.That(operationResponse.Value, Is.Not.Null, "Operation should not be null");
             LongRunningOperation operation = operationResponse.Value;
 
             TestContext.WriteLine("Retrieved operation:");
@@ -542,8 +542,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             TestContext.WriteLine($"  - Status: {operation.Status}");
             TestContext.WriteLine($"  - Type: {operation.Type}");
 
-            Assert.AreEqual(operationId, operation.Id, "Operation ID should match");
-            Assert.IsNotNull(operation.Status, "Status should not be null");
+            Assert.That(operation.Id, Is.EqualTo(operationId), "Operation ID should match");
+            Assert.That(operation.Status, Is.Not.Null, "Status should not be null");
         }
 
         /// <summary>
@@ -751,8 +751,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             Response<IngestionSource> getResponse = await ingestionClient.GetSourceAsync(createdSourceId);
 
             // Assert
-            Assert.IsNotNull(getResponse, "Get source response should not be null");
-            Assert.IsNotNull(getResponse.Value, "Retrieved source should not be null");
+            Assert.That(getResponse, Is.Not.Null, "Get source response should not be null");
+            Assert.That(getResponse.Value, Is.Not.Null, "Retrieved source should not be null");
 
             TestContext.WriteLine("Retrieved source:");
             TestContext.WriteLine($"  - ID: {getResponse.Value.Id}");
@@ -912,8 +912,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             Response<IngestionInformation> getResponse = await ingestionClient.GetAsync(collectionId, ingestionId);
 
             // Assert
-            Assert.IsNotNull(getResponse, "Get response should not be null");
-            Assert.IsNotNull(getResponse.Value, "Retrieved ingestion should not be null");
+            Assert.That(getResponse, Is.Not.Null, "Get response should not be null");
+            Assert.That(getResponse.Value, Is.Not.Null, "Retrieved ingestion should not be null");
             IngestionInformation retrievedIngestion = getResponse.Value;
 
             TestContext.WriteLine("Retrieved ingestion:");
@@ -922,7 +922,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             TestContext.WriteLine($"  - Import Type: {retrievedIngestion.ImportType}");
             TestContext.WriteLine($"  - Source Catalog URL: {retrievedIngestion.SourceCatalogUrl}");
 
-            Assert.AreEqual(ingestionId, retrievedIngestion.Id, "Ingestion ID should match");
+            Assert.That(retrievedIngestion.Id, Is.EqualTo(ingestionId), "Ingestion ID should match");
         }
 
         /// <summary>

--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer03SharedAccessSignatureClientTests.cs
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer03SharedAccessSignatureClientTests.cs
@@ -53,7 +53,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetToken");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             SharedAccessSignatureToken token = response.Value;
 
@@ -69,7 +69,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             if (Mode == RecordedTestMode.Live)
             {
                 var sasPattern = new Regex(@"st=[^&]+&se=[^&]+&sp=[^&]+&sv=[^&]+&sr=[^&]+&.*sig=[^&]+");
-                Assert.IsTrue(sasPattern.IsMatch(token.Token), "Token should match SAS token format (st, se, sp, sv, sr, sig)");
+                Assert.That(sasPattern.IsMatch(token.Token), Is.True, "Token should match SAS token format (st, se, sp, sv, sr, sig)");
             }
 
             // Verify expires_on field exists
@@ -78,7 +78,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             // Verify expiry is in the future (only in live mode)
             if (Mode == RecordedTestMode.Live)
             {
-                Assert.Greater(expiresOn, DateTimeOffset.UtcNow, "Token expiry should be in the future");
+                Assert.That(expiresOn, Is.GreaterThan(DateTimeOffset.UtcNow), "Token expiry should be in the future");
 
                 // Verify default duration is approximately 24 hours (allow 5 minute tolerance)
                 TimeSpan expectedDuration = TimeSpan.FromHours(24);
@@ -116,7 +116,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetToken");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             SharedAccessSignatureToken token = response.Value;
 
@@ -129,7 +129,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             // Verify custom duration (only in live mode)
             if (Mode == RecordedTestMode.Live)
             {
-                Assert.Greater(expiresOn, DateTimeOffset.UtcNow, "Token expiry should be in the future");
+                Assert.That(expiresOn, Is.GreaterThan(DateTimeOffset.UtcNow), "Token expiry should be in the future");
 
                 // Verify duration is approximately 60 minutes (allow 2 minute tolerance)
                 TimeSpan expectedDuration = TimeSpan.FromMinutes(customDuration);
@@ -167,15 +167,15 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             Response<StacCollectionResource> collectionResponse = await stacClient.GetCollectionAsync(collectionId);
             StacCollectionResource collection = collectionResponse.Value;
 
-            Assert.IsNotNull(collection, "Collection should not be null");
-            Assert.IsNotNull(collection.Assets, "Collection should have assets");
-            Assert.IsTrue(collection.Assets.ContainsKey("thumbnail"), "Collection should have thumbnail asset");
+            Assert.That(collection, Is.Not.Null, "Collection should not be null");
+            Assert.That(collection.Assets, Is.Not.Null, "Collection should have assets");
+            Assert.That(collection.Assets.ContainsKey("thumbnail"), Is.True, "Collection should have thumbnail asset");
 
             StacAsset thumbnailAsset = collection.Assets["thumbnail"];
             string originalHrefString = thumbnailAsset.Href;
             Uri originalHref = new Uri(originalHrefString);
             TestContext.WriteLine($"Original HREF: {originalHref}");
-            Assert.IsNotNull(originalHref, "Thumbnail HREF should not be null");
+            Assert.That(originalHref, Is.Not.Null, "Thumbnail HREF should not be null");
 
             // Act - Sign the HREF
             TestContext.WriteLine($"Calling GetSign(href={originalHref})");
@@ -183,7 +183,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(signResponse.GetRawResponse(), "GetSign");
-            Assert.AreEqual(200, signResponse.GetRawResponse().Status, "Expected successful response");
+            Assert.That(signResponse.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             SharedAccessSignatureSignedLink signedLink = signResponse.Value;
             Uri signedHref = signedLink.Href;
@@ -194,20 +194,20 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             TestContext.WriteLine($"Has sig param: {signedHref.Query.Contains("sig=")}");
 
             // Verify signed HREF is different from original
-            Assert.AreNotEqual(originalHref, signedHref, "Signed HREF should differ from original HREF");
+            Assert.That(signedHref, Is.Not.EqualTo(originalHref), "Signed HREF should differ from original HREF");
 
             // Verify SAS parameters in HREF (only in live mode)
             if (Mode == RecordedTestMode.Live)
             {
                 var sasHrefPattern = new Regex(@"\?.*st=[^&]+&se=[^&]+&sp=[^&]+&sv=[^&]+&sr=[^&]+&.*sig=[^&]+");
-                Assert.IsTrue(sasHrefPattern.IsMatch(signedHref.ToString()),
+                Assert.That(sasHrefPattern.IsMatch(signedHref.ToString()), Is.True,
                     "Signed HREF should contain SAS parameters (st, se, sp, sv, sr, sig)");
             }
             else
             {
                 // In playback mode, just verify basic SAS structure exists
-                Assert.IsTrue(signedHref.Query.Length > 0, "Signed HREF should have query parameters");
-                Assert.IsTrue(signedHref.Query.ToLower().Contains("sig="), "Signed HREF should contain signature parameter");
+                Assert.That(signedHref.Query.Length > 0, Is.True, "Signed HREF should have query parameters");
+                Assert.That(signedHref.Query.ToLower().Contains("sig="), Is.True, "Signed HREF should contain signature parameter");
             }
 
             // Verify expires_on is present and valid
@@ -217,7 +217,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
                 if (Mode == RecordedTestMode.Live)
                 {
-                    Assert.Greater(signedLink.ExpiresOn.Value, DateTimeOffset.UtcNow,
+                    Assert.That(signedLink.ExpiresOn.Value, Is.GreaterThan(DateTimeOffset.UtcNow),
                         "Token expiry should be in the future");
                 }
             }
@@ -225,7 +225,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             // Verify the signed HREF has the same base URL as original
             string originalBase = originalHref.GetLeftPart(UriPartial.Path);
             string signedBase = signedHref.GetLeftPart(UriPartial.Path);
-            Assert.AreEqual(originalBase, signedBase, "Signed HREF should have the same base URL as original");
+            Assert.That(signedBase, Is.EqualTo(originalBase), "Signed HREF should have the same base URL as original");
 
             TestContext.WriteLine("Successfully signed HREF");
         }
@@ -275,20 +275,20 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
                     TestContext.WriteLine($"Content-Type: {downloadResponse.Content.Headers.ContentType}");
 
                     // Verify successful download
-                    Assert.AreEqual(System.Net.HttpStatusCode.OK, downloadResponse.StatusCode,
+                    Assert.That(downloadResponse.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.OK),
                         $"Expected 200 OK, got {(int)downloadResponse.StatusCode}");
 
                     byte[] content = await downloadResponse.Content.ReadAsByteArrayAsync();
                     TestContext.WriteLine($"Content length: {content.Length} bytes");
 
-                    Assert.Greater(content.Length, 0, "Downloaded content should not be empty");
-                    Assert.Greater(content.Length, 1000, "Downloaded file should be larger than 1KB");
+                    Assert.That(content.Length, Is.GreaterThan(0), "Downloaded content should not be empty");
+                    Assert.That(content.Length, Is.GreaterThan(1000), "Downloaded file should be larger than 1KB");
 
                     // Verify it's actually binary image data by checking PNG magic bytes
-                    Assert.AreEqual(0x89, content[0], "First byte should be 0x89 (PNG magic)");
-                    Assert.AreEqual((byte)'P', content[1], "Second byte should be 'P'");
-                    Assert.AreEqual((byte)'N', content[2], "Third byte should be 'N'");
-                    Assert.AreEqual((byte)'G', content[3], "Fourth byte should be 'G'");
+                    Assert.That(content[0], Is.EqualTo((byte)0x89), "First byte should be 0x89 (PNG magic)");
+                    Assert.That(content[1], Is.EqualTo((byte)'P'), "Second byte should be 'P'");
+                    Assert.That(content[2], Is.EqualTo((byte)'N'), "Third byte should be 'N'");
+                    Assert.That(content[3], Is.EqualTo((byte)'G'), "Fourth byte should be 'G'");
 
                     TestContext.WriteLine("Successfully downloaded and verified PNG image");
                 }
@@ -326,8 +326,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
                 collectionId,
                 durationInMinutes: 60);
 
-            Assert.IsNotNull(tokenResponse, "Token response should not be null");
-            Assert.IsNotNull(tokenResponse.Value, "Token value should not be null");
+            Assert.That(tokenResponse, Is.Not.Null, "Token response should not be null");
+            Assert.That(tokenResponse.Value, Is.Not.Null, "Token value should not be null");
 
             string tokenPreview = tokenResponse.Value.Token.Length > 50
                 ? tokenResponse.Value.Token.Substring(0, 50) + "..."

--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer04StacSpecificationTests.cs
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer04StacSpecificationTests.cs
@@ -46,14 +46,14 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetConformanceClass");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacConformanceClasses conformance = response.Value;
-            Assert.IsNotNull(conformance, "Conformance should not be null");
-            Assert.IsNotNull(conformance.ConformsTo, "ConformsTo should not be null");
+            Assert.That(conformance, Is.Not.Null, "Conformance should not be null");
+            Assert.That(conformance.ConformsTo, Is.Not.Null, "ConformsTo should not be null");
 
             int conformanceCount = conformance.ConformsTo.Count;
-            Assert.Greater(conformanceCount, 0, "Should have at least one conformance class");
+            Assert.That(conformanceCount, Is.GreaterThan(0), "Should have at least one conformance class");
 
             TestContext.WriteLine($"Number of conformance classes: {conformanceCount}");
 
@@ -83,8 +83,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
                 }
             }
 
-            Assert.AreEqual(expectedUris.Length, foundUris.Count,
-                $"Expected all {expectedUris.Length} core STAC URIs, found {foundUris.Count}: {string.Join(", ", foundUris)}");
+            Assert.That(foundUris.Count, Is.EqualTo(expectedUris.Length), $"Expected all {expectedUris.Length} core STAC URIs, found {foundUris.Count}: {string.Join(", ", foundUris)}");
 
             TestContext.WriteLine($"Successfully retrieved {conformanceCount} conformance classes");
         }
@@ -111,26 +110,26 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetCollection");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacCollectionResource collection = response.Value;
 
             // Verify STAC Collection spec compliance
-            Assert.IsNotNull(collection.Id, "Collection must have 'id'");
-            Assert.AreEqual("Collection", collection.Type, "Type must be 'Collection'");
-            Assert.IsNotNull(collection.StacVersion, "Collection must have 'stac_version'");
+            Assert.That(collection.Id, Is.Not.Null, "Collection must have 'id'");
+            Assert.That(collection.Type, Is.EqualTo("Collection"), "Type must be 'Collection'");
+            Assert.That(collection.StacVersion, Is.Not.Null, "Collection must have 'stac_version'");
             Assert.That(collection.StacVersion, Does.Match(@"^\d+\.\d+\.\d+"), "STAC version should be in format X.Y.Z");
 
-            Assert.IsNotNull(collection.Description, "Collection must have 'description'");
-            Assert.IsNotNull(collection.License, "Collection must have 'license'");
-            Assert.IsNotNull(collection.Extent, "Collection must have 'extent'");
+            Assert.That(collection.Description, Is.Not.Null, "Collection must have 'description'");
+            Assert.That(collection.License, Is.Not.Null, "Collection must have 'license'");
+            Assert.That(collection.Extent, Is.Not.Null, "Collection must have 'extent'");
 
             // Verify extent structure
-            Assert.IsNotNull(collection.Extent.Spatial, "Extent must have 'spatial' property");
-            Assert.IsNotNull(collection.Extent.Temporal, "Extent must have 'temporal' property");
+            Assert.That(collection.Extent.Spatial, Is.Not.Null, "Extent must have 'spatial' property");
+            Assert.That(collection.Extent.Temporal, Is.Not.Null, "Extent must have 'temporal' property");
 
-            Assert.IsNotNull(collection.Links, "Collection must have 'links'");
-            Assert.Greater(collection.Links.Count, 0, "Collection should have at least one link");
+            Assert.That(collection.Links, Is.Not.Null, "Collection must have 'links'");
+            Assert.That(collection.Links.Count, Is.GreaterThan(0), "Collection should have at least one link");
 
             TestContext.WriteLine($"Collection '{collectionId}' is STAC {collection.StacVersion} compliant");
         }
@@ -157,13 +156,13 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetCollections");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacCatalogCollections collectionsResponse = response.Value;
-            Assert.IsNotNull(collectionsResponse, "Collections response should not be null");
-            Assert.IsNotNull(collectionsResponse.Collections, "Collections should not be null");
-            Assert.Greater(collectionsResponse.Collections.Count, 0, "Should have at least one collection");
-            Assert.GreaterOrEqual(collectionsResponse.Collections.Count, 5, $"Expected at least 5 collections, got {collectionsResponse.Collections.Count}");
+            Assert.That(collectionsResponse, Is.Not.Null, "Collections response should not be null");
+            Assert.That(collectionsResponse.Collections, Is.Not.Null, "Collections should not be null");
+            Assert.That(collectionsResponse.Collections.Count, Is.GreaterThan(0), "Should have at least one collection");
+            Assert.That(collectionsResponse.Collections.Count, Is.GreaterThanOrEqualTo(5), $"Expected at least 5 collections, got {collectionsResponse.Collections.Count}");
 
             TestContext.WriteLine($"Retrieved {collectionsResponse.Collections.Count} collections");
 
@@ -192,13 +191,13 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Validate collection structure
             StacCollectionResource firstCollection = collectionsResponse.Collections[0];
-            Assert.IsNotNull(firstCollection.Id, "Collection should have id");
-            Assert.IsNotEmpty(firstCollection.Id, "Collection ID should not be empty");
-            Assert.IsNotNull(firstCollection.Extent, "Collection should have extent");
+            Assert.That(firstCollection.Id, Is.Not.Null, "Collection should have id");
+            Assert.That(firstCollection.Id, Is.Not.Empty, "Collection ID should not be empty");
+            Assert.That(firstCollection.Extent, Is.Not.Null, "Collection should have extent");
 
             // Validate that the test collection is in the list
             bool foundTestCollection = collectionsResponse.Collections.Any(c => c.Id == collectionId);
-            Assert.IsTrue(foundTestCollection, $"{collectionId} collection should be present");
+            Assert.That(foundTestCollection, Is.True, $"{collectionId} collection should be present");
         }
 
         /// <summary>
@@ -290,12 +289,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "Search");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacItemCollectionResource searchResponse = response.Value;
-            Assert.IsNotNull(searchResponse, "Search response should not be null");
-            Assert.IsNotNull(searchResponse.Features, "Response should have features");
-            Assert.GreaterOrEqual(searchResponse.Features.Count, 2, $"Expected at least 2 items in spatial search, got {searchResponse.Features.Count}");
+            Assert.That(searchResponse, Is.Not.Null, "Search response should not be null");
+            Assert.That(searchResponse.Features, Is.Not.Null, "Response should have features");
+            Assert.That(searchResponse.Features.Count, Is.GreaterThanOrEqualTo(2), $"Expected at least 2 items in spatial search, got {searchResponse.Features.Count}");
 
             TestContext.WriteLine($"Search returned {searchResponse.Features.Count} items");
 
@@ -316,9 +315,9 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             if (searchResponse.Features.Count > 0)
             {
                 StacItemResource firstItem = searchResponse.Features[0];
-                Assert.IsNotNull(firstItem.Id, "Item should have id");
-                Assert.IsNotNull(firstItem.Collection, "Item should have collection");
-                Assert.AreEqual(collectionId, firstItem.Collection, "Item collection should match search collection");
+                Assert.That(firstItem.Id, Is.Not.Null, "Item should have id");
+                Assert.That(firstItem.Collection, Is.Not.Null, "Item should have collection");
+                Assert.That(firstItem.Collection, Is.EqualTo(collectionId), "Item collection should match search collection");
             }
         }
 
@@ -344,12 +343,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetItemCollection");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacItemCollectionResource itemsResponse = response.Value;
-            Assert.IsNotNull(itemsResponse, "Items response should not be null");
-            Assert.IsNotNull(itemsResponse.Features, "Response should have features");
-            Assert.GreaterOrEqual(itemsResponse.Features.Count, 5, $"Expected at least 5 items, got {itemsResponse.Features.Count}");
+            Assert.That(itemsResponse, Is.Not.Null, "Items response should not be null");
+            Assert.That(itemsResponse.Features, Is.Not.Null, "Response should have features");
+            Assert.That(itemsResponse.Features.Count, Is.GreaterThanOrEqualTo(5), $"Expected at least 5 items, got {itemsResponse.Features.Count}");
 
             TestContext.WriteLine($"Retrieved {itemsResponse.Features.Count} items from collection {collectionId}");
 
@@ -371,13 +370,13 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             if (itemsResponse.Features.Count > 0)
             {
                 StacItemResource firstItem = itemsResponse.Features[0];
-                Assert.IsNotNull(firstItem.Assets, "Item should have assets");
-                Assert.GreaterOrEqual(firstItem.Assets.Count, 2, $"Expected at least 2 assets, got {firstItem.Assets.Count}");
+                Assert.That(firstItem.Assets, Is.Not.Null, "Item should have assets");
+                Assert.That(firstItem.Assets.Count, Is.GreaterThanOrEqualTo(2), $"Expected at least 2 assets, got {firstItem.Assets.Count}");
 
                 // Check for common assets
                 string[] commonAssets = new[] { "image", "tilejson", "thumbnail", "rendered_preview" };
                 var foundAssets = commonAssets.Where(asset => firstItem.Assets.ContainsKey(asset)).ToList();
-                Assert.GreaterOrEqual(foundAssets.Count, 1, $"Expected at least one common asset type, found: {string.Join(", ", foundAssets)}");
+                Assert.That(foundAssets.Count, Is.GreaterThanOrEqualTo(1), $"Expected at least one common asset type, found: {string.Join(", ", foundAssets)}");
             }
         }
 
@@ -403,22 +402,22 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetCollectionQueryables");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             IReadOnlyDictionary<string, BinaryData> queryables = response.Value.AdditionalProperties;
-            Assert.IsNotNull(queryables, "Queryables should not be null");
+            Assert.That(queryables, Is.Not.Null, "Queryables should not be null");
 
             TestContext.WriteLine($"Retrieved queryables for collection: {collectionId}");
 
             // The queryables is a JSON Schema object - check the schema structure
-            Assert.IsTrue(queryables.ContainsKey("$schema"), "Queryables should have '$schema' key");
-            Assert.IsTrue(queryables.ContainsKey("properties"), "Queryables should have 'properties' key");
+            Assert.That(queryables.ContainsKey("$schema"), Is.True, "Queryables should have '$schema' key");
+            Assert.That(queryables.ContainsKey("properties"), Is.True, "Queryables should have 'properties' key");
 
             // Parse the properties to count the actual queryable fields
             var propertiesJson = JsonDocument.Parse(queryables["properties"]).RootElement;
             int propertyCount = propertiesJson.EnumerateObject().Count();
 
-            Assert.GreaterOrEqual(propertyCount, 3, $"Expected at least 3 queryable properties, got {propertyCount}");
+            Assert.That(propertyCount, Is.GreaterThanOrEqualTo(3), $"Expected at least 3 queryable properties, got {propertyCount}");
             TestContext.WriteLine($"Found {propertyCount} queryable properties in schema");
 
             // Log the queryable property names
@@ -484,12 +483,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "Search");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacItemCollectionResource searchResponse = response.Value;
-            Assert.IsNotNull(searchResponse, "Search response should not be null");
-            Assert.IsNotNull(searchResponse.Features, "Response should have features");
-            Assert.GreaterOrEqual(searchResponse.Features.Count, 5, $"Expected at least 5 items in temporal search, got {searchResponse.Features.Count}");
+            Assert.That(searchResponse, Is.Not.Null, "Search response should not be null");
+            Assert.That(searchResponse.Features, Is.Not.Null, "Response should have features");
+            Assert.That(searchResponse.Features.Count, Is.GreaterThanOrEqualTo(5), $"Expected at least 5 items in temporal search, got {searchResponse.Features.Count}");
 
             TestContext.WriteLine($"Temporal search returned {searchResponse.Features.Count} items");
 
@@ -498,7 +497,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             {
                 StacItemResource item = searchResponse.Features[i];
                 TestContext.WriteLine($"\nItem {i + 1}: {item.Id}");
-                Assert.IsNotNull(item.Properties, "Item should have properties");
+                Assert.That(item.Properties, Is.Not.Null, "Item should have properties");
 
                 // Access datetime from AdditionalProperties if not a direct property
                 if (item.Properties.Datetime != null)
@@ -540,12 +539,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert - DESC sort
             ValidateResponse(responseDesc.GetRawResponse(), "Search DESC");
-            Assert.AreEqual(200, responseDesc.GetRawResponse().Status, "Expected successful response");
+            Assert.That(responseDesc.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacItemCollectionResource searchResponseDesc = responseDesc.Value;
-            Assert.IsNotNull(searchResponseDesc, "Search response should not be null");
-            Assert.IsNotNull(searchResponseDesc.Features, "Response should have features");
-            Assert.GreaterOrEqual(searchResponseDesc.Features.Count, 3, $"Expected at least 3 items in DESC sort, got {searchResponseDesc.Features.Count}");
+            Assert.That(searchResponseDesc, Is.Not.Null, "Search response should not be null");
+            Assert.That(searchResponseDesc.Features, Is.Not.Null, "Response should have features");
+            Assert.That(searchResponseDesc.Features.Count, Is.GreaterThanOrEqualTo(3), $"Expected at least 3 items in DESC sort, got {searchResponseDesc.Features.Count}");
 
             TestContext.WriteLine($"Search with DESC sorting returned {searchResponseDesc.Features.Count} items");
             foreach (var item in searchResponseDesc.Features)
@@ -568,12 +567,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert - ASC sort
             ValidateResponse(responseAsc.GetRawResponse(), "Search ASC");
-            Assert.AreEqual(200, responseAsc.GetRawResponse().Status, "Expected successful response");
+            Assert.That(responseAsc.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacItemCollectionResource searchResponseAsc = responseAsc.Value;
-            Assert.IsNotNull(searchResponseAsc, "ASC search response should not be null");
-            Assert.IsNotNull(searchResponseAsc.Features, "ASC response should have features");
-            Assert.GreaterOrEqual(searchResponseAsc.Features.Count, 3, $"Expected at least 3 items in ASC sort, got {searchResponseAsc.Features.Count}");
+            Assert.That(searchResponseAsc, Is.Not.Null, "ASC search response should not be null");
+            Assert.That(searchResponseAsc.Features, Is.Not.Null, "ASC response should have features");
+            Assert.That(searchResponseAsc.Features.Count, Is.GreaterThanOrEqualTo(3), $"Expected at least 3 items in ASC sort, got {searchResponseAsc.Features.Count}");
 
             TestContext.WriteLine($"\nSearch with ASC sorting returned {searchResponseAsc.Features.Count} items");
             foreach (var item in searchResponseAsc.Features)
@@ -606,7 +605,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             // First, get an item ID from the collection
             Response<StacItemCollectionResource> itemsResponse = await stacClient.GetItemCollectionAsync(collectionId, limit: 1);
 
-            Assert.Greater(itemsResponse.Value.Features.Count, 0, "Should have at least one item to test");
+            Assert.That(itemsResponse.Value.Features.Count, Is.GreaterThan(0), "Should have at least one item to test");
 
             string itemId = itemsResponse.Value.Features[0].Id;
             TestContext.WriteLine($"Getting item: {itemId}");
@@ -616,18 +615,18 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Assert
             ValidateResponse(response.GetRawResponse(), "GetItem");
-            Assert.AreEqual(200, response.GetRawResponse().Status, "Expected successful response");
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200), "Expected successful response");
 
             StacItemResource item = response.Value;
-            Assert.IsNotNull(item, "Item should not be null");
-            Assert.AreEqual(itemId, item.Id, "Item ID should match requested ID");
-            Assert.AreEqual(collectionId, item.Collection, "Item collection should match");
+            Assert.That(item, Is.Not.Null, "Item should not be null");
+            Assert.That(item.Id, Is.EqualTo(itemId), "Item ID should match requested ID");
+            Assert.That(item.Collection, Is.EqualTo(collectionId), "Item collection should match");
 
             // Validate item structure
-            Assert.IsNotNull(item.Geometry, "Item should have geometry");
-            Assert.IsNotNull(item.Properties, "Item should have properties");
-            Assert.IsNotNull(item.Assets, "Item should have assets");
-            Assert.GreaterOrEqual(item.Assets.Count, 2, $"Expected at least 2 assets, got {item.Assets.Count}");
+            Assert.That(item.Geometry, Is.Not.Null, "Item should have geometry");
+            Assert.That(item.Properties, Is.Not.Null, "Item should have properties");
+            Assert.That(item.Assets, Is.Not.Null, "Item should have assets");
+            Assert.That(item.Assets.Count, Is.GreaterThanOrEqualTo(2), $"Expected at least 2 assets, got {item.Assets.Count}");
 
             TestContext.WriteLine($"Retrieved item: {item.Id}");
             TestContext.WriteLine($"  Collection: {item.Collection}");

--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer05MosaicsTilerTests.cs
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer05MosaicsTilerTests.cs
@@ -100,8 +100,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             );
 
             // Assert
-            Assert.IsNotNull(response);
-            Assert.IsNotNull(response.Value);
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response.Value, Is.Not.Null);
 
             TilerMosaicSearchRegistrationResult result = response.Value;
             ValidateNotNullOrEmpty(result.SearchId, "Search ID");
@@ -152,7 +152,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetMosaicsSearchInfo");
 
             TilerStacSearchRegistration searchInfo = response.Value;
-            Assert.IsNotNull(searchInfo, "Search info should not be null");
+            Assert.That(searchInfo, Is.Not.Null, "Search info should not be null");
 
             TestContext.WriteLine($"Search registration retrieved successfully");
             TestContext.WriteLine($"Search info retrieved for search ID: {searchId}");
@@ -198,10 +198,10 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetMosaicsTileJson");
 
             TileJsonMetadata tileJson = response.Value;
-            Assert.IsNotNull(tileJson, "TileJSON should not be null");
-            Assert.IsNotNull(tileJson.TileJson, "TileJSON version should not be null");
-            Assert.IsNotNull(tileJson.Tiles, "Tiles array should not be null");
-            Assert.Greater(tileJson.Tiles.Count, 0, "Should have at least one tile URL pattern");
+            Assert.That(tileJson, Is.Not.Null, "TileJSON should not be null");
+            Assert.That(tileJson.TileJson, Is.Not.Null, "TileJSON version should not be null");
+            Assert.That(tileJson.Tiles, Is.Not.Null, "Tiles array should not be null");
+            Assert.That(tileJson.Tiles.Count, Is.GreaterThan(0), "Should have at least one tile URL pattern");
 
             TestContext.WriteLine($"TileJSON version: {tileJson.TileJson}");
             TestContext.WriteLine($"Number of tile URL patterns: {tileJson.Tiles.Count}");
@@ -262,12 +262,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify PNG magic bytes
             byte[] pngMagic = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-            Assert.Greater(imageBytes.Length, 0, "Image bytes should not be empty");
-            Assert.Greater(imageBytes.Length, 100, $"Image should be substantial, got only {imageBytes.Length} bytes");
+            Assert.That(imageBytes.Length, Is.GreaterThan(0), "Image bytes should not be empty");
+            Assert.That(imageBytes.Length, Is.GreaterThan(100), $"Image should be substantial, got only {imageBytes.Length} bytes");
 
             for (int i = 0; i < pngMagic.Length; i++)
             {
-                Assert.AreEqual(pngMagic[i], imageBytes[i], $"PNG magic byte {i} mismatch");
+                Assert.That(imageBytes[i], Is.EqualTo(pngMagic[i]), $"PNG magic byte {i} mismatch");
             }
 
             TestContext.WriteLine("PNG magic bytes verified successfully");
@@ -320,7 +320,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             TestContext.WriteLine($"XML first 200 chars: {xmlString.Substring(0, Math.Min(200, xmlString.Length))}");
 
             // Validate XML structure
-            Assert.Greater(xmlBytes.Length, 0, "XML bytes should not be empty");
+            Assert.That(xmlBytes.Length, Is.GreaterThan(0), "XML bytes should not be empty");
             Assert.That(xmlString, Does.Contain("Capabilities"), "Response should contain Capabilities element");
             Assert.That(xmlString.ToLower(), Does.Contain("wmts"), "Response should reference WMTS");
             Assert.That(xmlString, Does.Contain("TileMatrix"), "Response should contain TileMatrix information");
@@ -374,7 +374,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetMosaicsAssetsForPoint");
 
             IReadOnlyList<StacItemPointAsset> assets = response.Value;
-            Assert.IsNotNull(assets, "Assets list should not be null");
+            Assert.That(assets, Is.Not.Null, "Assets list should not be null");
 
             TestContext.WriteLine($"Number of assets: {assets.Count}");
 
@@ -382,9 +382,9 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             if (assets.Count > 0)
             {
                 StacItemPointAsset firstAsset = assets[0];
-                Assert.IsNotNull(firstAsset, "First asset should not be null");
-                Assert.IsNotNull(firstAsset.Id, "Asset ID should not be null");
-                Assert.IsNotEmpty(firstAsset.Id, "Asset ID should not be empty");
+                Assert.That(firstAsset, Is.Not.Null, "First asset should not be null");
+                Assert.That(firstAsset.Id, Is.Not.Null, "Asset ID should not be null");
+                Assert.That(firstAsset.Id, Is.Not.Empty, "Asset ID should not be empty");
 
                 TestContext.WriteLine($"First asset ID: {firstAsset.Id}");
             }
@@ -434,7 +434,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetMosaicsAssetsForTile");
 
             IReadOnlyList<TilerAssetGeoJson> assets = response.Value;
-            Assert.IsNotNull(assets, "Assets list should not be null");
+            Assert.That(assets, Is.Not.Null, "Assets list should not be null");
 
             TestContext.WriteLine($"Number of assets: {assets.Count}");
             TestContext.WriteLine("Assets for tile retrieved successfully");
@@ -528,8 +528,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "CreateStaticImage");
 
             ImageResponse imageResponse = response.Value;
-            Assert.IsNotNull(imageResponse, "Image response should not be null");
-            Assert.IsNotNull(imageResponse.Url, "Image URL should not be null");
+            Assert.That(imageResponse, Is.Not.Null, "Image response should not be null");
+            Assert.That(imageResponse.Url, Is.Not.Null, "Image URL should not be null");
 
             TestContext.WriteLine($"Static image created successfully");
             TestContext.WriteLine($"Image URL: {imageResponse.Url}");
@@ -620,8 +620,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             TestContext.WriteLine($"Created image with ID: {imageId}");
             TestContext.WriteLine($"Image URL: {url}");
 
-            Assert.IsNotNull(imageId, "Image ID should not be null");
-            Assert.IsNotEmpty(imageId, "Image ID should not be empty");
+            Assert.That(imageId, Is.Not.Null, "Image ID should not be null");
+            Assert.That(imageId, Is.Not.Empty, "Image ID should not be empty");
 
             // Act - Get the static image
             Response<BinaryData> response = await dataClient.GetStaticImageAsync(
@@ -640,11 +640,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify PNG magic bytes
             byte[] pngMagic = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-            Assert.Greater(imageBytes.Length, 0, "Image bytes should not be empty");
+            Assert.That(imageBytes.Length, Is.GreaterThan(0), "Image bytes should not be empty");
 
             for (int i = 0; i < Math.Min(pngMagic.Length, imageBytes.Length); i++)
             {
-                Assert.AreEqual(pngMagic[i], imageBytes[i], $"PNG magic byte {i} mismatch");
+                Assert.That(imageBytes[i], Is.EqualTo(pngMagic[i]), $"PNG magic byte {i} mismatch");
             }
 
             TestContext.WriteLine("PNG magic bytes verified successfully");

--- a/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer06StacItemTilerTests.cs
+++ b/sdk/planetarycomputer/Azure.Analytics.PlanetaryComputer/tests/TestPlanetaryComputer06StacItemTilerTests.cs
@@ -47,9 +47,9 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response.GetRawResponse(), "GetTileMatrixDefinitions");
 
             TileMatrixSet tileMatrixSet = response.Value;
-            Assert.IsNotNull(tileMatrixSet, "TileMatrixSet should not be null");
-            Assert.IsNotNull(tileMatrixSet.Id, "TileMatrixSet ID should not be null");
-            Assert.IsNotNull(tileMatrixSet.TileMatrices, "TileMatrices should not be null");
+            Assert.That(tileMatrixSet, Is.Not.Null, "TileMatrixSet should not be null");
+            Assert.That(tileMatrixSet.Id, Is.Not.Null, "TileMatrixSet ID should not be null");
+            Assert.That(tileMatrixSet.TileMatrices, Is.Not.Null, "TileMatrices should not be null");
 
             TestContext.WriteLine($"TileMatrixSet ID: {tileMatrixSet.Id}");
 
@@ -66,13 +66,13 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Validate first tile matrix structure
             var firstMatrix = tileMatrixSet.TileMatrices[0];
-            Assert.IsNotNull(firstMatrix, "First tile matrix should not be null");
+            Assert.That(firstMatrix, Is.Not.Null, "First tile matrix should not be null");
 
             // Verify required tile matrix properties
-            Assert.IsNotNull(firstMatrix.Id, "Tile matrix should have 'id'");
+            Assert.That(firstMatrix.Id, Is.Not.Null, "Tile matrix should have 'id'");
             ValidateNotNullOrEmpty(firstMatrix.Id, "Tile matrix id");
 
-            Assert.IsNotNull(firstMatrix.ScaleDenominator, "Tile matrix should have 'scaleDenominator'");
+            Assert.That(firstMatrix.ScaleDenominator, Is.Not.Null, "Tile matrix should have 'scaleDenominator'");
 
             int tileWidth = firstMatrix.TileWidth;
             int tileHeight = firstMatrix.TileHeight;
@@ -144,8 +144,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetAvailableAssets");
 
             IReadOnlyList<string> assets = response.Value;
-            Assert.IsNotNull(assets, "Assets list should not be null");
-            Assert.Greater(assets.Count, 0, "Should have at least one asset");
+            Assert.That(assets, Is.Not.Null, "Assets list should not be null");
+            Assert.That(assets.Count, Is.GreaterThan(0), "Should have at least one asset");
 
             TestContext.WriteLine($"Number of assets: {assets.Count}");
             TestContext.WriteLine($"Available assets: {string.Join(", ", assets.Take(10))}");
@@ -153,8 +153,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             // All items should be asset names (strings)
             foreach (var asset in assets)
             {
-                Assert.IsNotNull(asset, "Asset name should not be null");
-                Assert.IsNotEmpty(asset, "Asset name should not be empty");
+                Assert.That(asset, Is.Not.Null, "Asset name should not be null");
+                Assert.That(asset, Is.Not.Empty, "Asset name should not be empty");
             }
         }
 
@@ -185,9 +185,9 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetBounds");
 
             StacItemBounds boundsResult = response.Value;
-            Assert.IsNotNull(boundsResult, "Bounds result should not be null");
-            Assert.IsNotNull(boundsResult.Bounds, "Bounds array should not be null");
-            Assert.AreEqual(4, boundsResult.Bounds.Count, "Bounds should have 4 coordinates [minx, miny, maxx, maxy]");
+            Assert.That(boundsResult, Is.Not.Null, "Bounds result should not be null");
+            Assert.That(boundsResult.Bounds, Is.Not.Null, "Bounds array should not be null");
+            Assert.That(boundsResult.Bounds.Count, Is.EqualTo(4), "Bounds should have 4 coordinates [minx, miny, maxx, maxy]");
 
             var bounds = boundsResult.Bounds;
             float minx = bounds[0];
@@ -198,8 +198,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             TestContext.WriteLine($"Bounds: [{minx}, {miny}, {maxx}, {maxy}]");
 
             // Validate bounds logic
-            Assert.Less(minx, maxx, "minx should be less than maxx");
-            Assert.Less(miny, maxy, "miny should be less than maxy");
+            Assert.That(minx, Is.LessThan(maxx), "minx should be less than maxx");
+            Assert.That(miny, Is.LessThan(maxy), "miny should be less than maxy");
         }
 
         /// <summary>
@@ -242,12 +242,12 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify PNG magic bytes
             byte[] pngMagic = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-            Assert.Greater(imageBytes.Length, 0, "Image bytes should not be empty");
-            Assert.Greater(imageBytes.Length, 100, $"Image should be substantial, got only {imageBytes.Length} bytes");
+            Assert.That(imageBytes.Length, Is.GreaterThan(0), "Image bytes should not be empty");
+            Assert.That(imageBytes.Length, Is.GreaterThan(100), $"Image should be substantial, got only {imageBytes.Length} bytes");
 
             for (int i = 0; i < pngMagic.Length; i++)
             {
-                Assert.AreEqual(pngMagic[i], imageBytes[i], $"PNG magic byte {i} mismatch");
+                Assert.That(imageBytes[i], Is.EqualTo(pngMagic[i]), $"PNG magic byte {i} mismatch");
             }
 
             TestContext.WriteLine("PNG magic bytes verified successfully");
@@ -281,7 +281,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetInfoGeoJson");
 
             TilerInfoGeoJsonFeature data = response.Value;
-            Assert.IsNotNull(data, "Response data should not be null");
+            Assert.That(data, Is.Not.Null, "Response data should not be null");
 
             TestContext.WriteLine("Info GeoJSON retrieved successfully");
         }
@@ -314,7 +314,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetStatistics");
 
             TilerStacItemStatistics statistics = response.Value;
-            Assert.IsNotNull(statistics, "Statistics should not be null");
+            Assert.That(statistics, Is.Not.Null, "Statistics should not be null");
 
             TestContext.WriteLine("Statistics retrieved successfully");
         }
@@ -360,7 +360,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             TestContext.WriteLine($"XML first 200 chars: {xmlString.Substring(0, System.Math.Min(200, xmlString.Length))}");
 
             // Validate XML structure
-            Assert.Greater(xmlBytes.Length, 0, "XML bytes should not be empty");
+            Assert.That(xmlBytes.Length, Is.GreaterThan(0), "XML bytes should not be empty");
             Assert.That(xmlString, Does.Contain("Capabilities"), "Response should contain Capabilities element");
             Assert.That(xmlString.ToLower(), Does.Contain("wmts"), "Response should reference WMTS");
             Assert.That(xmlString, Does.Contain("TileMatrix"), "Response should contain TileMatrix information");
@@ -396,8 +396,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetAssetStatistics");
 
             IReadOnlyDictionary<string, BinaryData> assetStatistics = response.Value.AdditionalProperties;
-            Assert.IsNotNull(assetStatistics, "Asset statistics should not be null");
-            Assert.Greater(assetStatistics.Count, 0, "Should have statistics for at least one asset");
+            Assert.That(assetStatistics, Is.Not.Null, "Asset statistics should not be null");
+            Assert.That(assetStatistics.Count, Is.GreaterThan(0), "Should have statistics for at least one asset");
 
             TestContext.WriteLine($"Number of assets with statistics: {assetStatistics.Count}");
 
@@ -408,7 +408,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
                 BinaryData statisticsData = assetEntry.Value;
 
                 TestContext.WriteLine($"\nAsset: {assetName}");
-                Assert.IsNotNull(statisticsData, $"Statistics data for asset '{assetName}' should not be null");
+                Assert.That(statisticsData, Is.Not.Null, $"Statistics data for asset '{assetName}' should not be null");
 
                 // Parse the statistics to verify structure
                 using JsonDocument doc = JsonDocument.Parse(statisticsData);
@@ -443,7 +443,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
                         }
                     }
 
-                    Assert.Greater(bandCount, 0, $"Asset '{assetName}' should have at least one band with statistics");
+                    Assert.That(bandCount, Is.GreaterThan(0), $"Asset '{assetName}' should have at least one band with statistics");
                 }
             }
 
@@ -507,11 +507,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify PNG magic bytes
             byte[] pngMagic = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-            Assert.Greater(imageBytes.Length, 0, "Image bytes should not be empty");
+            Assert.That(imageBytes.Length, Is.GreaterThan(0), "Image bytes should not be empty");
 
             for (int i = 0; i < pngMagic.Length; i++)
             {
-                Assert.AreEqual(pngMagic[i], imageBytes[i], $"PNG magic byte {i} mismatch");
+                Assert.That(imageBytes[i], Is.EqualTo(pngMagic[i]), $"PNG magic byte {i} mismatch");
             }
 
             TestContext.WriteLine("PNG format verified successfully");
@@ -576,11 +576,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify PNG magic bytes
             byte[] pngMagic = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-            Assert.Greater(imageBytes.Length, 0, "Image bytes should not be empty");
+            Assert.That(imageBytes.Length, Is.GreaterThan(0), "Image bytes should not be empty");
 
             for (int i = 0; i < pngMagic.Length; i++)
             {
-                Assert.AreEqual(pngMagic[i], imageBytes[i], $"PNG magic byte {i} mismatch");
+                Assert.That(imageBytes[i], Is.EqualTo(pngMagic[i]), $"PNG magic byte {i} mismatch");
             }
 
             TestContext.WriteLine("PNG format verified successfully");
@@ -635,7 +635,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetGeoJsonStatistics");
 
             StacItemStatisticsGeoJson data = response.Value;
-            Assert.IsNotNull(data, "Response data should not be null");
+            Assert.That(data, Is.Not.Null, "Response data should not be null");
 
             TestContext.WriteLine("GeoJSON statistics retrieved successfully");
         }
@@ -684,11 +684,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify PNG magic bytes
             byte[] pngMagic = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-            Assert.Greater(imageBytes.Length, 0, "Image bytes should not be empty");
+            Assert.That(imageBytes.Length, Is.GreaterThan(0), "Image bytes should not be empty");
 
             for (int i = 0; i < pngMagic.Length; i++)
             {
-                Assert.AreEqual(pngMagic[i], imageBytes[i], $"PNG magic byte {i} mismatch");
+                Assert.That(imageBytes[i], Is.EqualTo(pngMagic[i]), $"PNG magic byte {i} mismatch");
             }
 
             TestContext.WriteLine("PNG format verified successfully");
@@ -741,11 +741,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify PNG magic bytes
             byte[] pngMagic = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-            Assert.Greater(imageBytes.Length, 0, "Image bytes should not be empty");
+            Assert.That(imageBytes.Length, Is.GreaterThan(0), "Image bytes should not be empty");
 
             for (int i = 0; i < pngMagic.Length; i++)
             {
-                Assert.AreEqual(pngMagic[i], imageBytes[i], $"PNG magic byte {i} mismatch");
+                Assert.That(imageBytes[i], Is.EqualTo(pngMagic[i]), $"PNG magic byte {i} mismatch");
             }
 
             TestContext.WriteLine("PNG format verified successfully");
@@ -783,7 +783,7 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetPoint");
 
             TilerCoreModelsResponsesPoint data = response.Value;
-            Assert.IsNotNull(data, "Response data should not be null");
+            Assert.That(data, Is.Not.Null, "Response data should not be null");
 
             TestContext.WriteLine("Point data retrieved successfully");
         }
@@ -826,11 +826,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify JPEG magic bytes
             byte[] jpegMagic = new byte[] { 0xFF, 0xD8, 0xFF };
-            Assert.Greater(imageBytes.Length, 0, "Image bytes should not be empty");
+            Assert.That(imageBytes.Length, Is.GreaterThan(0), "Image bytes should not be empty");
 
             for (int i = 0; i < jpegMagic.Length; i++)
             {
-                Assert.AreEqual(jpegMagic[i], imageBytes[i], $"JPEG magic byte {i} mismatch");
+                Assert.That(imageBytes[i], Is.EqualTo(jpegMagic[i]), $"JPEG magic byte {i} mismatch");
             }
 
             TestContext.WriteLine("JPEG magic bytes verified successfully");
@@ -870,10 +870,10 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             ValidateResponse(response, "GetTileJson");
 
             TileJsonMetadata tileJson = response.Value;
-            Assert.IsNotNull(tileJson, "TileJSON should not be null");
-            Assert.IsNotNull(tileJson.TileJson, "TileJSON version should not be null");
-            Assert.IsNotNull(tileJson.Tiles, "Tiles array should not be null");
-            Assert.Greater(tileJson.Tiles.Count, 0, "Should have at least one tile URL pattern");
+            Assert.That(tileJson, Is.Not.Null, "TileJSON should not be null");
+            Assert.That(tileJson.TileJson, Is.Not.Null, "TileJSON version should not be null");
+            Assert.That(tileJson.Tiles, Is.Not.Null, "Tiles array should not be null");
+            Assert.That(tileJson.Tiles.Count, Is.GreaterThan(0), "Should have at least one tile URL pattern");
 
             TestContext.WriteLine($"TileJSON version: {tileJson.TileJson}");
             TestContext.WriteLine($"Number of tile URL patterns: {tileJson.Tiles.Count}");
@@ -921,11 +921,11 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
 
             // Verify PNG magic bytes
             byte[] pngMagic = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-            Assert.Greater(imageBytes.Length, 0, "Image bytes should not be empty");
+            Assert.That(imageBytes.Length, Is.GreaterThan(0), "Image bytes should not be empty");
 
             for (int i = 0; i < pngMagic.Length; i++)
             {
-                Assert.AreEqual(pngMagic[i], imageBytes[i], $"PNG magic byte {i} mismatch");
+                Assert.That(imageBytes[i], Is.EqualTo(pngMagic[i]), $"PNG magic byte {i} mismatch");
             }
 
             TestContext.WriteLine("PNG format verified successfully");
@@ -982,8 +982,8 @@ namespace Azure.Analytics.PlanetaryComputer.Tests
             // Validate asset names
             foreach (var asset in assets)
             {
-                Assert.IsNotNull(asset, "Asset name should not be null");
-                Assert.IsNotEmpty(asset, "Asset name should not be empty");
+                Assert.That(asset, Is.Not.Null, "Asset name should not be null");
+                Assert.That(asset, Is.Not.Empty, "Asset name should not be empty");
             }
         }
     }

--- a/sdk/planetarycomputer/Azure.ResourceManager.PlanetaryComputer/tests/Scenario/GeoCatalogCollectionTests.cs
+++ b/sdk/planetarycomputer/Azure.ResourceManager.PlanetaryComputer/tests/Scenario/GeoCatalogCollectionTests.cs
@@ -45,7 +45,7 @@ namespace Azure.ResourceManager.PlanetaryComputer.Tests
                 count++;
             }
 
-            Assert.GreaterOrEqual(count, 0);
+            Assert.That(count, Is.GreaterThanOrEqualTo(0));
         }
 
         [Test]
@@ -61,8 +61,8 @@ namespace Azure.ResourceManager.PlanetaryComputer.Tests
             PlanetaryComputerGeoCatalogCollection collection = await GetGeoCatalogCollectionAsync();
             PlanetaryComputerGeoCatalogResource catalog = await collection.GetAsync(ExistingGeoCatalogName);
 
-            Assert.AreEqual(ExistingGeoCatalogName, catalog.Data.Name);
-            Assert.AreEqual(Region.ToLowerInvariant(), catalog.Data.Location.ToString().ToLowerInvariant());
+            Assert.That(catalog.Data.Name, Is.EqualTo(ExistingGeoCatalogName));
+            Assert.That(catalog.Data.Location.ToString().ToLowerInvariant(), Is.EqualTo(Region.ToLowerInvariant()));
             TestContext.WriteLine($"Catalog URI: {catalog.Data.Properties.CatalogUri}");
         }
 
@@ -92,8 +92,8 @@ namespace Azure.ResourceManager.PlanetaryComputer.Tests
             ArmOperation<PlanetaryComputerGeoCatalogResource> operation = await collection.CreateOrUpdateAsync(WaitUntil.Completed, catalogName, data);
             PlanetaryComputerGeoCatalogResource result = operation.Value;
 
-            Assert.AreEqual(catalogName, result.Data.Name);
-            Assert.AreEqual(PlanetaryComputerGeoCatalogTier.Basic, result.Data.Properties.Tier);
+            Assert.That(result.Data.Name, Is.EqualTo(catalogName));
+            Assert.That(result.Data.Properties.Tier, Is.EqualTo(PlanetaryComputerGeoCatalogTier.Basic));
             TestContext.WriteLine($"Created GeoCatalog: {result.Id}");
         }
 
@@ -121,7 +121,7 @@ namespace Azure.ResourceManager.PlanetaryComputer.Tests
             ArmOperation<PlanetaryComputerGeoCatalogResource> updateOp = await collection.CreateOrUpdateAsync(WaitUntil.Completed, catalogName, resource.Data);
             PlanetaryComputerGeoCatalogResource updated = updateOp.Value;
 
-            Assert.AreEqual("updated", updated.Data.Tags["env"]);
+            Assert.That(updated.Data.Tags["env"], Is.EqualTo("updated"));
             TestContext.WriteLine($"Updated GeoCatalog: {updated.Id}");
         }
 
@@ -146,10 +146,10 @@ namespace Azure.ResourceManager.PlanetaryComputer.Tests
             PlanetaryComputerGeoCatalogResource resource = createOp.Value;
 
             ArmOperation deleteOp = await resource.DeleteAsync(WaitUntil.Completed);
-            Assert.IsTrue(deleteOp.HasCompleted);
+            Assert.That(deleteOp.HasCompleted, Is.True);
 
             bool exists = await collection.ExistsAsync(catalogName);
-            Assert.IsFalse(exists);
+            Assert.That(exists, Is.False);
             TestContext.WriteLine($"Deleted GeoCatalog: {catalogName}");
         }
 
@@ -166,7 +166,7 @@ namespace Azure.ResourceManager.PlanetaryComputer.Tests
                 TestContext.WriteLine($"[Subscription List] GeoCatalog: {item.Data.Name}");
                 count++;
             }
-            Assert.GreaterOrEqual(count, 0);
+            Assert.That(count, Is.GreaterThanOrEqualTo(0));
         }
         [Test]
         [RecordedTest]
@@ -191,7 +191,7 @@ namespace Azure.ResourceManager.PlanetaryComputer.Tests
             ArmOperation<PlanetaryComputerGeoCatalogResource> createOp = await collection.CreateOrUpdateAsync(WaitUntil.Completed, catalogName, data);
             PlanetaryComputerGeoCatalogResource resource = createOp.Value;
 
-            Assert.AreEqual("initial", resource.Data.Tags["env"]);
+            Assert.That(resource.Data.Tags["env"], Is.EqualTo("initial"));
             TestContext.WriteLine($"✅ Created GeoCatalog: {resource.Id}");
 
             // Step 2: Update
@@ -199,15 +199,15 @@ namespace Azure.ResourceManager.PlanetaryComputer.Tests
             ArmOperation<PlanetaryComputerGeoCatalogResource> updateOp = await collection.CreateOrUpdateAsync(WaitUntil.Completed, catalogName, resource.Data);
             PlanetaryComputerGeoCatalogResource updated = updateOp.Value;
 
-            Assert.AreEqual("updated", updated.Data.Tags["env"]);
+            Assert.That(updated.Data.Tags["env"], Is.EqualTo("updated"));
             TestContext.WriteLine($"🔄 Updated GeoCatalog: {updated.Id}");
 
             // Step 3: Delete
             ArmOperation deleteOp = await updated.DeleteAsync(WaitUntil.Completed);
-            Assert.IsTrue(deleteOp.HasCompleted);
+            Assert.That(deleteOp.HasCompleted, Is.True);
 
             bool exists = await collection.ExistsAsync(catalogName);
-            Assert.IsFalse(exists);
+            Assert.That(exists, Is.False);
             TestContext.WriteLine($"❌ Deleted GeoCatalog: {catalogName}");
         }
 

--- a/sdk/purview/Azure.Analytics.Purview.DataMap/tests/DataMapClientTest.cs
+++ b/sdk/purview/Azure.Analytics.Purview.DataMap/tests/DataMapClientTest.cs
@@ -26,7 +26,7 @@ namespace Azure.Analytics.Purview.DataMap.Tests
             sg.Keywords = "Glossary";
             sg.Limit = 1;
             Response<QueryResult> result = await client.GetDiscoveryClient().QueryAsync(sg);
-            Assert.AreEqual(200, result.GetRawResponse().Status);
+            Assert.That(result.GetRawResponse().Status, Is.EqualTo(200));
         }
 
         [RecordedTest]
@@ -35,7 +35,7 @@ namespace Azure.Analytics.Purview.DataMap.Tests
             var client = GetDataMapClient().GetGlossaryClient();
             Response fetchResponse = await client.BatchGetAsync(1, null, null, true, new RequestContext());
             // Console.WriteLine(fetchResponse.Content);
-            Assert.AreEqual(200, fetchResponse.Status);
+            Assert.That(fetchResponse.Status, Is.EqualTo(200));
         }
 
         [RecordedTest]
@@ -44,7 +44,7 @@ namespace Azure.Analytics.Purview.DataMap.Tests
             var client = GetDataMapClient().GetTypeDefinitionClient();
             Response<AtlasTypeDef> response = await client.GetByNameAsync("AtlasGlossary");
             // Console.WriteLine(response);
-            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(200));
         }
     }
 }

--- a/sdk/purview/Azure.Analytics.Purview.Sharing/tests/ReceivedSharesClientTest.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Sharing/tests/ReceivedSharesClientTest.cs
@@ -52,18 +52,18 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             Operation<BinaryData> createResponse = await client.CreateOrReplaceReceivedShareAsync(WaitUntil.Completed, receivedShareId, RequestContent.Create(data));
 
-            Assert.IsTrue(createResponse.HasCompleted);
+            Assert.That(createResponse.HasCompleted, Is.True);
 
             var jsonDocument = JsonDocument.Parse(createResponse.Value);
             var actualId = jsonDocument.RootElement.GetProperty("id").ToString();
 
-            Assert.AreEqual(receivedShareId, actualId);
+            Assert.That(actualId, Is.EqualTo(receivedShareId));
 
             JsonElement properties = jsonDocument.RootElement.GetProperty("properties");
 
             var actualShareStatus = properties.GetProperty("shareStatus").ToString();
 
-            Assert.AreEqual("Attached", actualShareStatus);
+            Assert.That(actualShareStatus, Is.EqualTo("Attached"));
         }
 
         [RecordedTest]
@@ -76,7 +76,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
             var jsonDocument = JsonDocument.Parse(GetContentFromResponse(response));
             JsonElement getBodyJson = jsonDocument.RootElement;
 
-            Assert.AreEqual(receivedShareId, getBodyJson.GetProperty("id").GetString());
+            Assert.That(getBodyJson.GetProperty("id").GetString(), Is.EqualTo(receivedShareId));
         }
 
         [RecordedTest]
@@ -86,7 +86,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             Operation response = await client.DeleteReceivedShareAsync(WaitUntil.Completed, receivedShareId, new());
 
-            Assert.IsTrue(response.HasCompleted);
+            Assert.That(response.HasCompleted, Is.True);
         }
 
         [RecordedTest]
@@ -96,7 +96,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             List<BinaryData> detachedReceivedShares = await client.GetAllDetachedReceivedSharesAsync(null, null, new()).ToEnumerableAsync();
 
-            Assert.Greater(detachedReceivedShares.Count, 0);
+            Assert.That(detachedReceivedShares.Count, Is.GreaterThan(0));
 
             var detachedReceivedShare = detachedReceivedShares[0];
 
@@ -104,7 +104,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             var actualShareStatus = jsonDocument.RootElement.GetProperty("properties").GetProperty("shareStatus").ToString();
 
-            Assert.AreEqual("Detached", actualShareStatus);
+            Assert.That(actualShareStatus, Is.EqualTo("Detached"));
         }
 
         [RecordedTest]
@@ -114,7 +114,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             List<BinaryData> attachedReceivedShares = await client.GetAllAttachedReceivedSharesAsync("/subscriptions/d941aad1-e4af-44a5-a70e-0381a9f702f1/resourcegroups/dev-rg/providers/Microsoft.Storage/storageAccounts/consumeraccount", null, null, new()).ToEnumerableAsync();
 
-            Assert.Greater(attachedReceivedShares.Count, 0);
+            Assert.That(attachedReceivedShares.Count, Is.GreaterThan(0));
 
             var attachedReceivedShare = attachedReceivedShares[0];
 
@@ -122,7 +122,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             var actualShareStatus = jsonDocument.RootElement.GetProperty("properties").GetProperty("shareStatus").ToString();
 
-            Assert.AreEqual("Attached", actualShareStatus);
+            Assert.That(actualShareStatus, Is.EqualTo("Attached"));
         }
 
         #region Helpers

--- a/sdk/purview/Azure.Analytics.Purview.Sharing/tests/SentSharesClientTest.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Sharing/tests/SentSharesClientTest.cs
@@ -56,19 +56,19 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             Operation<BinaryData> createResponse = await client.CreateOrReplaceSentShareAsync(WaitUntil.Completed, sentShareId, RequestContent.Create(data));
 
-            Assert.IsTrue(createResponse.HasCompleted);
+            Assert.That(createResponse.HasCompleted, Is.True);
 
             var jsonDocument = JsonDocument.Parse(createResponse.Value);
 
             var actualId = jsonDocument.RootElement.GetProperty("id").ToString();
             var expectedId = sentShareId;
-            Assert.AreEqual(expectedId, actualId);
+            Assert.That(actualId, Is.EqualTo(expectedId));
 
             JsonElement properties = jsonDocument.RootElement.GetProperty("properties");
 
             var actualDisplayName = properties.GetProperty("displayName").ToString();
             var expectedDisplayName = "testDisplayName1";
-            Assert.AreEqual(expectedDisplayName, actualDisplayName);
+            Assert.That(actualDisplayName, Is.EqualTo(expectedDisplayName));
         }
 
         [RecordedTest]
@@ -81,17 +81,17 @@ namespace Azure.Analytics.Purview.Sharing.Tests
             using var jsonDocumentGet = JsonDocument.Parse(GetContentFromResponse(response));
             JsonElement getBodyJson = jsonDocumentGet.RootElement;
 
-            Assert.AreEqual(sentShareId, getBodyJson.GetProperty("id").GetString());
+            Assert.That(getBodyJson.GetProperty("id").GetString(), Is.EqualTo(sentShareId));
 
             JsonElement properties = getBodyJson.GetProperty("properties");
 
             var actualDisplayName = properties.GetProperty("displayName").ToString();
             var expectedDisplayName = "testDisplayName1";
-            Assert.AreEqual(expectedDisplayName, actualDisplayName);
+            Assert.That(actualDisplayName, Is.EqualTo(expectedDisplayName));
 
             List<BinaryData> listResponse = await client.GetAllSentSharesAsync("/subscriptions/d941aad1-e4af-44a5-a70e-0381a9f702f1/resourcegroups/dev-rg/providers/Microsoft.Storage/storageAccounts/provideraccount", null, null, new()).ToEnumerableAsync();
 
-            Assert.Greater(listResponse.Count, 0);
+            Assert.That(listResponse.Count, Is.GreaterThan(0));
         }
 
         [RecordedTest]
@@ -101,7 +101,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             Operation response = await client.DeleteSentShareAsync(WaitUntil.Completed, sentShareId, new());
 
-            Assert.IsTrue(response.HasCompleted);
+            Assert.That(response.HasCompleted, Is.True);
         }
 
         [RecordedTest]
@@ -121,7 +121,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             Response response = await client.CreateSentShareInvitationAsync(sentShareId, sentShareInvitationId, RequestContent.Create(data));
 
-            Assert.AreEqual(201, response.Status);
+            Assert.That(response.Status, Is.EqualTo(201));
         }
         [RecordedTest]
         public async Task CreateSentShareUserInvitationTest()
@@ -140,7 +140,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             Response response = await client.CreateSentShareInvitationAsync(sentShareId, sentShareInvitationId, RequestContent.Create(data));
 
-            Assert.AreEqual(201, response.Status);
+            Assert.That(response.Status, Is.EqualTo(201));
         }
 
         [RecordedTest]
@@ -150,11 +150,11 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             Response testing = await client.GetSentShareInvitationAsync(sentShareId, sentShareInvitationId, new());
 
-            Assert.AreEqual(200, testing.Status);
+            Assert.That(testing.Status, Is.EqualTo(200));
 
             List<BinaryData> invitations = await client.GetAllSentShareInvitationsAsync(sentShareId, null, null, new()).ToEnumerableAsync();
 
-            Assert.GreaterOrEqual(invitations.Count, 0);
+            Assert.That(invitations.Count, Is.GreaterThanOrEqualTo(0));
         }
 
         [RecordedTest]
@@ -164,7 +164,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             Operation response = await client.DeleteSentShareInvitationAsync(WaitUntil.Completed, sentShareId, sentShareInvitationId, new());
 
-            Assert.IsTrue(response.HasCompleted);
+            Assert.That(response.HasCompleted, Is.True);
         }
 
         #region Helpers

--- a/sdk/purview/Azure.Analytics.Purview.Sharing/tests/ShareResourcesClientTest.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Sharing/tests/ShareResourcesClientTest.cs
@@ -26,7 +26,7 @@ namespace Azure.Analytics.Purview.Sharing.Tests
 
             List<BinaryData> listResponse = await client.GetAllShareResourcesAsync(null, null, null).ToEnumerableAsync();
 
-            Assert.Greater(listResponse.Count, 0);
+            Assert.That(listResponse.Count, Is.GreaterThan(0));
         }
     }
 }

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample1_HelloWorld.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample1_HelloWorld.cs
@@ -40,7 +40,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
                 Console.WriteLine(bodyJson.GetProperty("name").ToString());
             }
 
-            Assert.IsNotNull(workflowList);
+            Assert.That(workflowList, Is.Not.Null);
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
             using var createJsonDocument = JsonDocument.Parse(GetContentFromResponse(createResult));
             JsonElement createBodyJson = createJsonDocument.RootElement;
 
-            Assert.AreEqual(workflowId.ToString(), createBodyJson.GetProperty("id").ToString());
+            Assert.That(createBodyJson.GetProperty("id").ToString(), Is.EqualTo(workflowId.ToString()));
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
 
             using var jsonDocument = JsonDocument.Parse(GetContentFromResponse(getResult));
             JsonElement getBodyJson = jsonDocument.RootElement;
-            Assert.AreEqual(workflowId.ToString(), getBodyJson.GetProperty("id").GetString());
+            Assert.That(getBodyJson.GetProperty("id").GetString(), Is.EqualTo(workflowId.ToString()));
         }
 
         private static BinaryData GetContentFromResponse(Response r)

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample2_SubmitUserRequests.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample2_SubmitUserRequests.cs
@@ -26,7 +26,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
 
             #endregion
 
-            Assert.AreEqual(200, submitResult.Status);
+            Assert.That(submitResult.Status, Is.EqualTo(200));
         }
     }
 }

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample3_WorkflowTasks.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample3_WorkflowTasks.cs
@@ -29,7 +29,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
 
             #endregion
 
-            Assert.AreEqual(200, approveResult.Status);
+            Assert.That(approveResult.Status, Is.EqualTo(200));
         }
     }
 }

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample4_WorkflowRuns.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/Samples/Sample4_WorkflowRuns.cs
@@ -28,7 +28,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests.Samples
 
             #endregion
 
-            Assert.AreEqual(200, cancelResult.Status);
+            Assert.That(cancelResult.Status, Is.EqualTo(200));
         }
     }
 }

--- a/sdk/purview/Azure.Analytics.Purview.Workflows/tests/WorkflowsClientTest.cs
+++ b/sdk/purview/Azure.Analytics.Purview.Workflows/tests/WorkflowsClientTest.cs
@@ -32,7 +32,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests
             using var createJsonDocument = JsonDocument.Parse(GetContentFromResponse(createResult));
             JsonElement createBodyJson = createJsonDocument.RootElement;
 
-            Assert.AreEqual(workflowId.ToString(), createBodyJson.GetProperty("id").ToString());
+            Assert.That(createBodyJson.GetProperty("id").ToString(), Is.EqualTo(workflowId.ToString()));
         }
 
         [RecordedTest]
@@ -44,7 +44,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests
             using var workflowsListJsonDocument = JsonDocument.Parse(workflowsList.Current);
             JsonElement listBodyJson = workflowsListJsonDocument.RootElement;
             await workflowsList.DisposeAsync();
-            Assert.NotNull(listBodyJson);
+            Assert.That(listBodyJson, Is.Not.Null);
         }
 
         [RecordedTest]
@@ -55,7 +55,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests
             Response getResult = await client.GetWorkflowAsync(workflowId, new());
             using var jsonDocument = JsonDocument.Parse(GetContentFromResponse(getResult));
             JsonElement getBodyJson = jsonDocument.RootElement;
-            Assert.AreEqual(workflowId.ToString(), getBodyJson.GetProperty("id").GetString());
+            Assert.That(getBodyJson.GetProperty("id").GetString(), Is.EqualTo(workflowId.ToString()));
         }
 
         [RecordedTest]
@@ -66,7 +66,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests
             Guid workflowId = new Guid("3f7a14f2-c9cd-4fe4-96df-ed3447256118");
 
             Response deleteResult = await client.DeleteAsync(workflowId);
-            Assert.AreEqual(204, deleteResult.Status);
+            Assert.That(deleteResult.Status, Is.EqualTo(204));
         }
 
         [RecordedTest]
@@ -77,7 +77,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests
             string request = "{\"operations\":[{\"type\":\"CreateTerm\",\"payload\":{\"glossaryTerm\":{\"name\":\"term\",\"anchor\":{\"glossaryGuid\":\"5dae5e5b-5aa6-48f1-9e46-26fe7328de71\"},\"status\":\"Approved\",\"nickName\":\"term\"}}}],\"comment\":\"Thanks!\"}";
 
             Response submitResult = await client.SubmitAsync(RequestContent.Create(request));
-            Assert.AreEqual(200, submitResult.Status);
+            Assert.That(submitResult.Status, Is.EqualTo(200));
         }
 
         [RecordedTest]
@@ -91,7 +91,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests
 
             Response cancelResult = await client.CancelAsync(workflowRunId, RequestContent.Create(request));
 
-            Assert.AreEqual(200, cancelResult.Status);
+            Assert.That(cancelResult.Status, Is.EqualTo(200));
         }
 
         [RecordedTest]
@@ -105,7 +105,7 @@ namespace Azure.Analytics.Purview.Workflows.Tests
 
             Response approveResult = await client.ApproveAsync(taskId, RequestContent.Create(request));
 
-            Assert.AreEqual(200, approveResult.Status);
+            Assert.That(approveResult.Status, Is.EqualTo(200));
         }
         #region Helpers
 

--- a/sdk/purview/Azure.ResourceManager.Purview/tests/Scenario/PurviewAccountTests.cs
+++ b/sdk/purview/Azure.ResourceManager.Purview/tests/Scenario/PurviewAccountTests.cs
@@ -59,7 +59,7 @@ namespace Azure.ResourceManager.Purview.Samples.Scenario
 
             // Exist
             var flag = await _purviewAccountCollection.ExistsAsync(purviewAccountName);
-            Assert.That(flag, Is.True);
+            Assert.That(flag.Value, Is.True);
 
             // Get
             var getPurviewAccount = await _purviewAccountCollection.GetAsync(purviewAccountName);
@@ -73,7 +73,7 @@ namespace Azure.ResourceManager.Purview.Samples.Scenario
             // Delete
             await purviewAccount.DeleteAsync(WaitUntil.Completed);
             flag = await _purviewAccountCollection.ExistsAsync(purviewAccountName);
-            Assert.That(flag, Is.False);
+            Assert.That(flag.Value, Is.False);
         }
 
         // The current api-version 2022-09 does donot support use GetTagResource().CreateOrUpdate()

--- a/sdk/purview/Azure.ResourceManager.Purview/tests/Scenario/PurviewAccountTests.cs
+++ b/sdk/purview/Azure.ResourceManager.Purview/tests/Scenario/PurviewAccountTests.cs
@@ -59,7 +59,7 @@ namespace Azure.ResourceManager.Purview.Samples.Scenario
 
             // Exist
             var flag = await _purviewAccountCollection.ExistsAsync(purviewAccountName);
-            Assert.IsTrue(flag);
+            Assert.That(flag, Is.True);
 
             // Get
             var getPurviewAccount = await _purviewAccountCollection.GetAsync(purviewAccountName);
@@ -67,13 +67,13 @@ namespace Azure.ResourceManager.Purview.Samples.Scenario
 
             // GetAll
             var list = await _purviewAccountCollection.GetAllAsync().ToEnumerableAsync();
-            Assert.IsNotEmpty(list);
+            Assert.That(list, Is.Not.Empty);
             ValidatePurviewAccount(list.FirstOrDefault().Data, purviewAccountName);
 
             // Delete
             await purviewAccount.DeleteAsync(WaitUntil.Completed);
             flag = await _purviewAccountCollection.ExistsAsync(purviewAccountName);
-            Assert.IsFalse(flag);
+            Assert.That(flag, Is.False);
         }
 
         // The current api-version 2022-09 does donot support use GetTagResource().CreateOrUpdate()
@@ -90,25 +90,25 @@ namespace Azure.ResourceManager.Purview.Samples.Scenario
             // AddTag
             await purviewAccount.AddTagAsync("addtagkey", "addtagvalue");
             purviewAccount = await _purviewAccountCollection.GetAsync(purviewAccountName);
-            Assert.AreEqual(1, purviewAccount.Data.Tags.Count);
+            Assert.That(purviewAccount.Data.Tags.Count, Is.EqualTo(1));
             KeyValuePair<string, string> tag = purviewAccount.Data.Tags.Where(tag => tag.Key == "addtagkey").FirstOrDefault();
-            Assert.AreEqual("addtagkey", tag.Key);
-            Assert.AreEqual("addtagvalue", tag.Value);
+            Assert.That(tag.Key, Is.EqualTo("addtagkey"));
+            Assert.That(tag.Value, Is.EqualTo("addtagvalue"));
 
             // RemoveTag
             await purviewAccount.RemoveTagAsync("addtagkey");
             purviewAccount = await _purviewAccountCollection.GetAsync(purviewAccountName);
-            Assert.AreEqual(0, purviewAccount.Data.Tags.Count);
+            Assert.That(purviewAccount.Data.Tags.Count, Is.EqualTo(0));
         }
 
         private void ValidatePurviewAccount(PurviewAccountData purviewAccount, string purviewAccountName)
         {
-            Assert.IsNotNull(purviewAccount);
-            Assert.IsNotEmpty(purviewAccount.Id);
-            Assert.AreEqual(purviewAccountName, purviewAccount.Name);
-            Assert.AreEqual(DefaultLocation, purviewAccount.Location);
-            Assert.AreEqual("Standard", purviewAccount.Sku.Name.ToString());
-            Assert.AreEqual("SystemAssigned", purviewAccount.Identity.ManagedServiceIdentityType.ToString());
+            Assert.That(purviewAccount, Is.Not.Null);
+            Assert.That(purviewAccount.Id.ToString(), Is.Not.Empty);
+            Assert.That(purviewAccount.Name, Is.EqualTo(purviewAccountName));
+            Assert.That(purviewAccount.Location, Is.EqualTo(DefaultLocation));
+            Assert.That(purviewAccount.Sku.Name.ToString(), Is.EqualTo("Standard"));
+            Assert.That(purviewAccount.Identity.ManagedServiceIdentityType.ToString(), Is.EqualTo("SystemAssigned"));
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/BigDataPoolsClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/BigDataPoolsClientLiveTests.cs
@@ -40,7 +40,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
         {
             BigDataPoolsClient client = CreateClient();
             BigDataPoolResourceInfoListResult pools = await client.ListAsync();
-            Assert.GreaterOrEqual(1, pools.Value.Count);
+            Assert.That(1, Is.GreaterThanOrEqualTo(pools.Value.Count));
         }
 
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/18080 - This test case cannot be automated due to the inability to configure infrastructure to test against.")]
@@ -50,7 +50,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             const string PoolName = "sparkchhamosyna";
             BigDataPoolsClient client = CreateClient();
             BigDataPoolResourceInfo pool = await client.GetAsync(PoolName);
-            Assert.AreEqual(PoolName, pool.Name);
+            Assert.That(pool.Name, Is.EqualTo(PoolName));
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/BigDataPoolsClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/BigDataPoolsClientLiveTests.cs
@@ -40,7 +40,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
         {
             BigDataPoolsClient client = CreateClient();
             BigDataPoolResourceInfoListResult pools = await client.ListAsync();
-            Assert.That(1, Is.GreaterThanOrEqualTo(pools.Value.Count));
+            Assert.That(pools.Value.Count, Is.GreaterThanOrEqualTo(1));
         }
 
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/18080 - This test case cannot be automated due to the inability to configure infrastructure to test against.")]

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/DataFlowClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/DataFlowClientLiveTests.cs
@@ -40,7 +40,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposableDataFlow flow = await DisposableDataFlow.Create(client, this.Recording);
 
             AsyncPageable<DataFlowResource> dataFlows = client.GetDataFlowsByWorkspaceAsync();
-            Assert.GreaterOrEqual((await dataFlows.ToListAsync()).Count, 1);
+            Assert.That((await dataFlows.ToListAsync()).Count, Is.GreaterThanOrEqualTo(1));
         }
 
         [RecordedTest]
@@ -50,7 +50,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposableDataFlow flow = await DisposableDataFlow.Create(client, this.Recording);
 
             DataFlowResource dataFlow = await client.GetDataFlowAsync(flow.Name);
-            Assert.AreEqual(flow.Name, dataFlow.Name);
+            Assert.That(dataFlow.Name, Is.EqualTo(flow.Name));
         }
 
         [RecordedTest]
@@ -66,7 +66,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await renameOperation.WaitForCompletionResponseAsync();
 
             DataFlowResource dataFlow = await client.GetDataFlowAsync(newFlowName);
-            Assert.AreEqual(newFlowName, dataFlow.Name);
+            Assert.That(dataFlow.Name, Is.EqualTo(newFlowName));
 
             DataFlowDeleteDataFlowOperation operation = await client.StartDeleteDataFlowAsync(newFlowName);
             await operation.WaitForCompletionResponseAsync();

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/DataFlowDebugSessionClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/DataFlowDebugSessionClientLiveTests.cs
@@ -87,7 +87,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             // SYNAPSE_API_ISSUE - Why do we need to pass in SessionId here?
             DataFlowDebugPackage debugPackage = new DataFlowDebugPackage() { DataFlow = new DataFlowDebugResource(flow.Resource.Properties), SessionId = debugSession.SessionId };
             AddDataFlowToDebugSessionResponse response = await debugClient.AddDataFlowAsync(debugPackage);
-            Assert.NotNull(response.JobVersion);
+            Assert.That(response.JobVersion, Is.Not.Null);
         }
 
         [RecordedTest]
@@ -100,7 +100,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposableDataFlowDebugSession debugSession = await DisposableDataFlowDebugSession.Create(debugClient, this.Recording);
 
             AsyncPageable<DataFlowDebugSessionInfo> sessions = debugClient.QueryDataFlowDebugSessionsByWorkspaceAsync();
-            Assert.GreaterOrEqual((await sessions.ToListAsync()).Count, 1);
+            Assert.That((await sessions.ToListAsync()).Count, Is.GreaterThanOrEqualTo(1));
         }
 
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/18079 prevents test from working")]
@@ -116,7 +116,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             // SYNAPSE_API_ISSUE - What payload do we need here?
             DataFlowDebugSessionExecuteCommandOperation executeOperation = await debugClient.StartExecuteCommandAsync(new DataFlowDebugCommandRequest { SessionId = debugSession.SessionId });
             DataFlowDebugCommandResponse response = await executeOperation.WaitForCompletionAsync();
-            Assert.AreEqual(200, response.Status);
+            Assert.That(response.Status, Is.EqualTo(200));
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/DatasetClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/DatasetClientLiveTests.cs
@@ -43,8 +43,8 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await foreach (var expectedDataset in client.GetDatasetsByWorkspaceAsync())
             {
                 DatasetResource actualDataset = await client.GetDatasetAsync(expectedDataset.Name);
-                Assert.AreEqual(expectedDataset.Name, actualDataset.Name);
-                Assert.AreEqual(expectedDataset.Id, actualDataset.Id);
+                Assert.That(actualDataset.Name, Is.EqualTo(expectedDataset.Name));
+                Assert.That(actualDataset.Id, Is.EqualTo(expectedDataset.Id));
             }
         }
 
@@ -56,7 +56,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             string datasetName = Recording.GenerateId("Dataset", 16);
             DatasetCreateOrUpdateDatasetOperation operation = await client.StartCreateOrUpdateDatasetAsync(datasetName, new DatasetResource(new Dataset(new LinkedServiceReference(LinkedServiceReferenceType.LinkedServiceReference, TestEnvironment.WorkspaceName + "-WorkspaceDefaultStorage"))));
             DatasetResource dataset = await operation.WaitForCompletionAsync();
-            Assert.AreEqual(datasetName, dataset.Name);
+            Assert.That(dataset.Name, Is.EqualTo(datasetName));
         }
 
         [RecordedTest]
@@ -70,7 +70,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
 
             DatasetDeleteDatasetOperation deleteOperation = await client.StartDeleteDatasetAsync(datasetName);
             Response response = await deleteOperation.WaitForCompletionResponseAsync();
-            Assert.AreEqual(200, response.Status);
+            Assert.That(response.Status, Is.EqualTo(200));
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/IntegrationRuntimesClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/IntegrationRuntimesClientLiveTests.cs
@@ -42,9 +42,9 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             foreach (IntegrationRuntimeResource integration in integrations.Value)
             {
                 IntegrationRuntimeResource fetchedIntegration = await client.GetAsync(integration.Name);
-                Assert.AreEqual(integration.Name, fetchedIntegration.Name);
-                Assert.AreEqual(integration.Id, fetchedIntegration.Id);
-                Assert.AreEqual(integration.Type, fetchedIntegration.Type);
+                Assert.That(fetchedIntegration.Name, Is.EqualTo(integration.Name));
+                Assert.That(fetchedIntegration.Id, Is.EqualTo(integration.Id));
+                Assert.That(fetchedIntegration.Type, Is.EqualTo(integration.Type));
             }
         }
 
@@ -55,8 +55,8 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             IntegrationRuntimeListResponse integrations = await client.ListAsync();
             foreach (IntegrationRuntimeResource integration in integrations.Value)
             {
-                Assert.NotNull(integration.Id);
-                Assert.NotNull(integration.Name);
+                Assert.That(integration.Id, Is.Not.Null);
+                Assert.That(integration.Name, Is.Not.Null);
             }
         }
     }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/LinkedServiceClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/LinkedServiceClientLiveTests.cs
@@ -73,13 +73,13 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposableLinkedService service = await DisposableLinkedService.Create(client, this.Recording);
 
             IList<LinkedServiceResource> services = await client.GetLinkedServicesByWorkspaceAsync().ToListAsync();
-            Assert.GreaterOrEqual(services.Count, 1);
+            Assert.That(services.Count, Is.GreaterThanOrEqualTo(1));
 
             foreach (var expectedLinkedService in services)
             {
                 LinkedServiceResource actualLinkedService = await client.GetLinkedServiceAsync(expectedLinkedService.Name);
-                Assert.AreEqual(expectedLinkedService.Name, actualLinkedService.Name);
-                Assert.AreEqual(expectedLinkedService.Id, actualLinkedService.Id);
+                Assert.That(actualLinkedService.Name, Is.EqualTo(expectedLinkedService.Name));
+                Assert.That(actualLinkedService.Id, Is.EqualTo(expectedLinkedService.Id));
             }
         }
 
@@ -107,7 +107,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await renameOperation.WaitForCompletionResponseAsync();
 
             LinkedServiceResource service = await client.GetLinkedServiceAsync(newLinkedServiceName);
-            Assert.AreEqual(newLinkedServiceName, service.Name);
+            Assert.That(service.Name, Is.EqualTo(newLinkedServiceName));
 
             LinkedServiceDeleteLinkedServiceOperation operation = await client.StartDeleteLinkedServiceAsync(newLinkedServiceName);
             await operation.WaitForCompletionResponseAsync();

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/NotebookClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/NotebookClientLiveTests.cs
@@ -78,14 +78,14 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposableNotebook notebook = await DisposableNotebook.Create(client, this.Recording);
 
             IList<NotebookResource> notebooks = await client.GetNotebooksByWorkspaceAsync().ToListAsync();
-            Assert.GreaterOrEqual(notebooks.Count, 1);
+            Assert.That(notebooks.Count, Is.GreaterThanOrEqualTo(1));
 
             foreach (var expectedNotebook in notebooks)
             {
                 NotebookResource actualNotebook = await client.GetNotebookAsync(expectedNotebook.Name);
-                Assert.AreEqual(expectedNotebook.Name, actualNotebook.Name);
-                Assert.AreEqual(expectedNotebook.Id, actualNotebook.Id);
-                Assert.AreEqual(expectedNotebook.Properties.BigDataPool?.ReferenceName, actualNotebook.Properties.BigDataPool?.ReferenceName);
+                Assert.That(actualNotebook.Name, Is.EqualTo(expectedNotebook.Name));
+                Assert.That(actualNotebook.Id, Is.EqualTo(expectedNotebook.Id));
+                Assert.That(actualNotebook.Properties.BigDataPool?.ReferenceName, Is.EqualTo(expectedNotebook.Properties.BigDataPool?.ReferenceName));
             }
         }
 
@@ -113,7 +113,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await renameOperation.WaitForCompletionResponseAsync();
 
             NotebookResource notebook = await client.GetNotebookAsync(newNotebookName);
-            Assert.AreEqual(newNotebookName, notebook.Name);
+            Assert.That(notebook.Name, Is.EqualTo(newNotebookName));
 
             NotebookDeleteNotebookOperation operation = await client.StartDeleteNotebookAsync(newNotebookName);
             await operation.WaitForCompletionResponseAsync();
@@ -127,7 +127,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
 
             await using DisposableNotebook notebook = await DisposableNotebook.Create(client, this.Recording);
             AsyncPageable<NotebookResource> summary = client.GetNotebookSummaryByWorkSpaceAsync();
-            Assert.GreaterOrEqual((await summary.ToListAsync()).Count, 1);
+            Assert.That((await summary.ToListAsync()).Count, Is.GreaterThanOrEqualTo(1));
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/PipelineClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/PipelineClientLiveTests.cs
@@ -41,13 +41,13 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposablePipeline pipeline = await DisposablePipeline.Create(client, this.Recording);
 
             IList<PipelineResource> pipelines = await client.GetPipelinesByWorkspaceAsync().ToListAsync();
-            Assert.GreaterOrEqual(pipelines.Count, 1);
+            Assert.That(pipelines.Count, Is.GreaterThanOrEqualTo(1));
 
             foreach (var expectedPipeline in pipelines)
             {
                 PipelineResource actualPipeline = await client.GetPipelineAsync(expectedPipeline.Name);
-                Assert.AreEqual(expectedPipeline.Name, actualPipeline.Name);
-                Assert.AreEqual(expectedPipeline.Id, actualPipeline.Id);
+                Assert.That(actualPipeline.Name, Is.EqualTo(expectedPipeline.Name));
+                Assert.That(actualPipeline.Id, Is.EqualTo(expectedPipeline.Id));
             }
         }
 
@@ -75,7 +75,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await renameOperation.WaitForCompletionResponseAsync();
 
             PipelineResource pipeline = await client.GetPipelineAsync(newPipelineName);
-            Assert.AreEqual(newPipelineName, pipeline.Name);
+            Assert.That(pipeline.Name, Is.EqualTo(newPipelineName));
 
             PipelineDeletePipelineOperation operation = await client.StartDeletePipelineAsync(newPipelineName);
             await operation.WaitForCompletionResponseAsync();
@@ -89,7 +89,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposablePipeline pipeline = await DisposablePipeline.Create(client, this.Recording);
 
             CreateRunResponse runResponse = await client.CreatePipelineRunAsync(pipeline.Name);
-            Assert.NotNull(runResponse.RunId);
+            Assert.That(runResponse.RunId, Is.Not.Null);
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/PipelineRunClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/PipelineRunClientLiveTests.cs
@@ -53,7 +53,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposablePipeline pipeline = await DisposablePipeline.Create(pipelineClient, this.Recording);
 
             CreateRunResponse runResponse = await pipelineClient.CreatePipelineRunAsync(pipeline.Name);
-            Assert.NotNull(runResponse.RunId);
+            Assert.That(runResponse.RunId, Is.Not.Null);
 
             Response response = await runClient.CancelPipelineRunAsync(runResponse.RunId);
             response.AssertSuccess();
@@ -68,11 +68,11 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposablePipeline pipeline = await DisposablePipeline.Create(pipelineClient, this.Recording);
 
             CreateRunResponse runResponse = await pipelineClient.CreatePipelineRunAsync(pipeline.Name);
-            Assert.NotNull(runResponse.RunId);
+            Assert.That(runResponse.RunId, Is.Not.Null);
 
             PipelineRun run = await runClient.GetPipelineRunAsync(runResponse.RunId);
-            Assert.AreEqual(run.RunId, runResponse.RunId);
-            Assert.NotNull(run.Status);
+            Assert.That(runResponse.RunId, Is.EqualTo(run.RunId));
+            Assert.That(run.Status, Is.Not.Null);
         }
 
         [RecordedTest]
@@ -84,10 +84,10 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposablePipeline pipeline = await DisposablePipeline.Create(pipelineClient, this.Recording);
 
             CreateRunResponse runResponse = await pipelineClient.CreatePipelineRunAsync(pipeline.Name);
-            Assert.NotNull(runResponse.RunId);
+            Assert.That(runResponse.RunId, Is.Not.Null);
 
             PipelineRunsQueryResponse queryResponse = await runClient.QueryPipelineRunsByWorkspaceAsync(new RunFilterParameters(DateTimeOffset.MinValue, DateTimeOffset.MaxValue));
-            Assert.GreaterOrEqual(queryResponse.Value.Count, 1);
+            Assert.That(queryResponse.Value.Count, Is.GreaterThanOrEqualTo(1));
         }
 
         [RecordedTest]
@@ -99,10 +99,10 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposablePipeline pipeline = await DisposablePipeline.Create(pipelineClient, this.Recording);
 
             CreateRunResponse runResponse = await pipelineClient.CreatePipelineRunAsync(pipeline.Name);
-            Assert.NotNull(runResponse.RunId);
+            Assert.That(runResponse.RunId, Is.Not.Null);
 
             PipelineRunsQueryResponse queryResponse = await runClient.QueryPipelineRunsByWorkspaceAsync(new RunFilterParameters(DateTimeOffset.MinValue, DateTimeOffset.MaxValue));
-            Assert.GreaterOrEqual(queryResponse.Value.Count, 1);
+            Assert.That(queryResponse.Value.Count, Is.GreaterThanOrEqualTo(1));
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/SparkJobDefinitionClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/SparkJobDefinitionClientLiveTests.cs
@@ -77,13 +77,13 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposableSparkJobDefinition sparkJobDefinition = await DisposableSparkJobDefinition.Create(client, Recording, TestEnvironment.StorageFileSystemName, TestEnvironment.StorageAccountName);
 
             IList<SparkJobDefinitionResource> jobs = await client.GetSparkJobDefinitionsByWorkspaceAsync().ToListAsync();
-            Assert.GreaterOrEqual(jobs.Count, 1);
+            Assert.That(jobs.Count, Is.GreaterThanOrEqualTo(1));
 
             foreach (var expectedJob in jobs)
             {
                 SparkJobDefinitionResource actualJob = await client.GetSparkJobDefinitionAsync(expectedJob.Name);
-                Assert.AreEqual(expectedJob.Name, actualJob.Name);
-                Assert.AreEqual(expectedJob.Id, actualJob.Id);
+                Assert.That(actualJob.Name, Is.EqualTo(expectedJob.Name));
+                Assert.That(actualJob.Id, Is.EqualTo(expectedJob.Id));
             }
         }
 
@@ -111,7 +111,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await renameOperation.WaitForCompletionResponseAsync();
 
             SparkJobDefinitionResource sparkJob = await client.GetSparkJobDefinitionAsync(newSparkJobName);
-            Assert.AreEqual(newSparkJobName, sparkJob.Name);
+            Assert.That(sparkJob.Name, Is.EqualTo(newSparkJobName));
 
             SparkJobDefinitionDeleteSparkJobDefinitionOperation deleteOperation = await client.StartDeleteSparkJobDefinitionAsync(newSparkJobName);
             await deleteOperation.WaitForCompletionResponseAsync();

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/SqlPoolsClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/SqlPoolsClientLiveTests.cs
@@ -42,9 +42,9 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             foreach (SqlPool pool in pools.Value)
             {
                 SqlPool actualPool = await client.GetAsync(pool.Name);
-                Assert.AreEqual(pool.Id, actualPool.Id);
-                Assert.AreEqual(pool.Name, actualPool.Name);
-                Assert.AreEqual(pool.Status, actualPool.Status);
+                Assert.That(actualPool.Id, Is.EqualTo(pool.Id));
+                Assert.That(actualPool.Name, Is.EqualTo(pool.Name));
+                Assert.That(actualPool.Status, Is.EqualTo(pool.Status));
             }
         }
     }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/SqlScriptClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/SqlScriptClientLiveTests.cs
@@ -78,14 +78,14 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposableSqlScript singleScript = await DisposableSqlScript.Create(client, Recording);
 
             IList<SqlScriptResource> scripts = await client.GetSqlScriptsByWorkspaceAsync().ToListAsync();
-            Assert.GreaterOrEqual(scripts.Count, 1);
+            Assert.That(scripts.Count, Is.GreaterThanOrEqualTo(1));
 
             foreach (SqlScriptResource script in scripts)
             {
                 SqlScriptResource actualScript = await client.GetSqlScriptAsync(script.Name);
-                Assert.AreEqual(actualScript.Name, script.Name);
-                Assert.AreEqual(actualScript.Id, script.Id);
-                Assert.AreEqual(actualScript.Type, script.Type);
+                Assert.That(script.Name, Is.EqualTo(actualScript.Name));
+                Assert.That(script.Id, Is.EqualTo(actualScript.Id));
+                Assert.That(script.Type, Is.EqualTo(actualScript.Type));
             }
         }
 
@@ -113,7 +113,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await renameOperation.WaitForCompletionResponseAsync();
 
             SqlScriptResource sparkJob = await client.GetSqlScriptAsync(newScriptName);
-            Assert.AreEqual(newScriptName, sparkJob.Name);
+            Assert.That(sparkJob.Name, Is.EqualTo(newScriptName));
 
             SqlScriptDeleteSqlScriptOperation deleteOperation = await client.StartDeleteSqlScriptAsync(newScriptName);
             await deleteOperation.WaitForCompletionResponseAsync();

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/TriggerClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/TriggerClientLiveTests.cs
@@ -52,8 +52,8 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await foreach (var trigger in client.GetTriggersByWorkspaceAsync())
             {
                 TriggerResource actualTrigger = await client.GetTriggerAsync(trigger.Name);
-                Assert.AreEqual(trigger.Name, actualTrigger.Name);
-                Assert.AreEqual(trigger.Id, actualTrigger.Id);
+                Assert.That(actualTrigger.Name, Is.EqualTo(trigger.Name));
+                Assert.That(actualTrigger.Id, Is.EqualTo(trigger.Id));
             }
         }
 
@@ -96,11 +96,11 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await using DisposableTrigger trigger = await DisposableTrigger.Create(client, Recording);
             TriggerSubscribeTriggerToEventsOperation subOperation = await client.StartSubscribeTriggerToEventsAsync(trigger.Name);
             TriggerSubscriptionOperationStatus subResponse = await subOperation.WaitForCompletionAsync();
-            Assert.AreEqual(EventSubscriptionStatus.Enabled, subResponse.Status);
+            Assert.That(subResponse.Status, Is.EqualTo(EventSubscriptionStatus.Enabled));
 
             TriggerUnsubscribeTriggerFromEventsOperation unsubOperation = await client.StartUnsubscribeTriggerFromEventsAsync(trigger.Name);
             TriggerSubscriptionOperationStatus unsubResponse = await unsubOperation.WaitForCompletionAsync();
-            Assert.AreEqual(EventSubscriptionStatus.Disabled, unsubResponse.Status);
+            Assert.That(unsubResponse.Status, Is.EqualTo(EventSubscriptionStatus.Disabled));
         }
 
         [RecordedTest]
@@ -110,7 +110,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
 
             await using DisposableTrigger trigger = await DisposableTrigger.Create(client, Recording);
             TriggerSubscriptionOperationStatus statusOperation = await client.GetEventSubscriptionStatusAsync(trigger.Name);
-            Assert.AreEqual(statusOperation.TriggerName, trigger.Name);
+            Assert.That(trigger.Name, Is.EqualTo(statusOperation.TriggerName));
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/TriggerRunClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/TriggerRunClientLiveTests.cs
@@ -56,7 +56,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             await startOperation.WaitAndAssertSuccessfulCompletion();
 
             TriggerRunsQueryResponse response = await runClient.QueryTriggerRunsByWorkspaceAsync(new RunFilterParameters(DateTimeOffset.MinValue, DateTimeOffset.MaxValue));
-            Assert.GreaterOrEqual(response.Value.Count, 1);
+            Assert.That(response.Value.Count, Is.GreaterThanOrEqualTo(1));
         }
 
         [Ignore("https://github.com/Azure/azure-sdk-for-net/issues/18079 - Missing or invalid pipeline references for trigger but no obvious place to put pipeline?")]

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/WorkspaceClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/WorkspaceClientLiveTests.cs
@@ -39,8 +39,8 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
         {
             WorkspaceClient client = CreateClient();
             Workspace space = await client.GetAsync();
-            Assert.NotNull(space.Name);
-            Assert.NotNull(space.WorkspaceUID);
+            Assert.That(space.Name, Is.Not.Null);
+            Assert.That(space.WorkspaceUID, Is.Not.Null);
         }
     }
 }

--- a/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/WorkspaceGitRepoManagementClientLiveTests.cs
+++ b/sdk/synapse/Azure.Analytics.Synapse.Artifacts/tests/WorkspaceGitRepoManagementClientLiveTests.cs
@@ -43,7 +43,7 @@ namespace Azure.Analytics.Synapse.Artifacts.Tests
             string accessToken = "";
             GitHubAccessTokenRequest request = new GitHubAccessTokenRequest(clientID, accessToken, "https://github.com/login/oauth/access_token");
             GitHubAccessTokenResponse response = await client.GetGitHubAccessTokenAsync(request);
-            Assert.NotNull(response.GitHubAccessToken);
+            Assert.That(response.GitHubAccessToken, Is.Not.Null);
         }
     }
 }

--- a/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/BigDatapoolOperationTests.cs
+++ b/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/BigDatapoolOperationTests.cs
@@ -40,9 +40,9 @@ namespace Azure.ResourceManager.Synapse.Tests
             var createBigDatapoolParams = CommonData.PrepareBigDatapoolCreateParams(enableAutoScale: false, enableAutoPause: false);
             SynapseBigDataPoolInfoCollection bigdatapoolCollection = WorkspaceResource.GetSynapseBigDataPoolInfos();
             var bigDatapoolUnableAutoScale = (await bigdatapoolCollection.CreateOrUpdateAsync(WaitUntil.Completed, bigDatapoolName, createBigDatapoolParams)).Value;
-            Assert.AreEqual(CommonTestFixture.SparkpoolType, bigDatapoolUnableAutoScale.Data.ResourceType);
-            Assert.AreEqual(bigDatapoolName, bigDatapoolUnableAutoScale.Data.Name);
-            Assert.AreEqual(CommonData.Location, bigDatapoolUnableAutoScale.Data.Location);
+            Assert.That(bigDatapoolUnableAutoScale.Data.ResourceType, Is.EqualTo(CommonTestFixture.SparkpoolType));
+            Assert.That(bigDatapoolUnableAutoScale.Data.Name, Is.EqualTo(bigDatapoolName));
+            Assert.That(bigDatapoolUnableAutoScale.Data.Location, Is.EqualTo(CommonData.Location));
 
             // update BigDatapool
             var bigDatapoolCreated = (await bigdatapoolCollection.GetAsync(bigDatapoolName)).Value;
@@ -52,20 +52,20 @@ namespace Azure.ResourceManager.Synapse.Tests
             await bigDatapoolCreated.UpdateAsync(bigdataPoolPatchInfo);
 
             var bigDatapoolUpdate = (await bigdatapoolCollection.GetAsync(bigDatapoolName)).Value;
-            Assert.NotNull(bigDatapoolUpdate.Data.Tags);
-            Assert.AreEqual("TestUpdate", bigDatapoolUpdate.Data.Tags["TestTag"]);
+            Assert.That(bigDatapoolUpdate.Data.Tags, Is.Not.Null);
+            Assert.That(bigDatapoolUpdate.Data.Tags["TestTag"], Is.EqualTo("TestUpdate"));
 
             // Enable Auto-scale and Auto-pause
             createBigDatapoolParams = CommonData.PrepareBigDatapoolCreateParams(enableAutoScale: true, enableAutoPause: true);
             var bigDatapoolEnableAutoScale = (await bigdatapoolCollection.CreateOrUpdateAsync(WaitUntil.Completed, bigDatapoolName, createBigDatapoolParams)).Value;
-            Assert.AreEqual(CommonTestFixture.SparkpoolType, bigDatapoolUnableAutoScale.Data.ResourceType);
-            Assert.AreEqual(bigDatapoolName, bigDatapoolUnableAutoScale.Data.Name);
-            Assert.AreEqual(CommonData.Location, bigDatapoolUnableAutoScale.Data.Location);
-            Assert.True(bigDatapoolEnableAutoScale.Data.AutoScale.IsEnabled);
-            Assert.AreEqual(CommonData.AutoScaleMaxNodeCount, bigDatapoolEnableAutoScale.Data.AutoScale.MaxNodeCount);
-            Assert.AreEqual(CommonData.AutoScaleMinNodeCount, bigDatapoolEnableAutoScale.Data.AutoScale.MinNodeCount);
-            Assert.True(bigDatapoolEnableAutoScale.Data.AutoPause.IsEnabled);
-            Assert.AreEqual(CommonData.AutoPauseDelayInMinute, bigDatapoolEnableAutoScale.Data.AutoPause.DelayInMinutes);
+            Assert.That(bigDatapoolUnableAutoScale.Data.ResourceType, Is.EqualTo(CommonTestFixture.SparkpoolType));
+            Assert.That(bigDatapoolUnableAutoScale.Data.Name, Is.EqualTo(bigDatapoolName));
+            Assert.That(bigDatapoolUnableAutoScale.Data.Location, Is.EqualTo(CommonData.Location));
+            Assert.That(bigDatapoolEnableAutoScale.Data.AutoScale.IsEnabled, Is.True);
+            Assert.That(bigDatapoolEnableAutoScale.Data.AutoScale.MaxNodeCount, Is.EqualTo(CommonData.AutoScaleMaxNodeCount));
+            Assert.That(bigDatapoolEnableAutoScale.Data.AutoScale.MinNodeCount, Is.EqualTo(CommonData.AutoScaleMinNodeCount));
+            Assert.That(bigDatapoolEnableAutoScale.Data.AutoPause.IsEnabled, Is.True);
+            Assert.That(bigDatapoolEnableAutoScale.Data.AutoPause.DelayInMinutes, Is.EqualTo(CommonData.AutoPauseDelayInMinute));
 
             // list BigDatapool from workspace
             var bigDataPoolFromWorkspace = bigdatapoolCollection.GetAllAsync();
@@ -73,12 +73,12 @@ namespace Azure.ResourceManager.Synapse.Tests
             var bigDatapoolCount = bigDataPoolList.Count;
             var bigDataPool = bigDataPoolList.Single(bigdatapool => bigdatapool.Data.Name == bigDatapoolName);
 
-            Assert.True(bigDataPool != null, string.Format("BigDatapool created earlier is not found when listing all in workspace {0}", workspaceName));
+            Assert.That(bigDataPool != null, Is.True, string.Format("BigDatapool created earlier is not found when listing all in workspace {0}", workspaceName));
 
             // delete spark pool
             await bigDataPool.DeleteAsync(WaitUntil.Completed);
             var bigDatapoolAfterDelete = await bigdatapoolCollection.GetAllAsync().ToEnumerableAsync();
-            Assert.AreEqual(bigDatapoolCount - 1, bigDatapoolAfterDelete.Count);
+            Assert.That(bigDatapoolAfterDelete.Count, Is.EqualTo(bigDatapoolCount - 1));
         }
     }
 }

--- a/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/FirewallRuleOperationTests.cs
+++ b/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/FirewallRuleOperationTests.cs
@@ -38,20 +38,20 @@ namespace Azure.ResourceManager.Synapse.Tests
             var firewallRuleCreateParams = CommonData.PrepareFirewallRuleParams(CommonData.StartIpAddress, CommonData.EndIpAddress);
             SynapseIPFirewallRuleInfoCollection firewallRuleCollection = WorkspaceResource.GetSynapseIPFirewallRuleInfos();
             var firewallRuleCreate = (await firewallRuleCollection.CreateOrUpdateAsync(WaitUntil.Completed, firewallRuleName, firewallRuleCreateParams)).Value;
-            Assert.AreEqual(CommonData.StartIpAddress, firewallRuleCreate.Data.StartIPAddress);
-            Assert.AreEqual(CommonData.EndIpAddress, firewallRuleCreate.Data.EndIPAddress);
+            Assert.That(firewallRuleCreate.Data.StartIPAddress, Is.EqualTo(CommonData.StartIpAddress));
+            Assert.That(firewallRuleCreate.Data.EndIPAddress, Is.EqualTo(CommonData.EndIpAddress));
 
             // get firewall rule
             var firewallRuleGet = (await firewallRuleCollection.GetAsync(firewallRuleName)).Value;
-            Assert.AreEqual(SynapseProvisioningState.Succeeded, firewallRuleGet.Data.ProvisioningState);
-            Assert.AreEqual(CommonData.StartIpAddress, firewallRuleCreate.Data.StartIPAddress);
-            Assert.AreEqual(CommonData.EndIpAddress, firewallRuleCreate.Data.EndIPAddress);
+            Assert.That(firewallRuleGet.Data.ProvisioningState, Is.EqualTo(SynapseProvisioningState.Succeeded));
+            Assert.That(firewallRuleCreate.Data.StartIPAddress, Is.EqualTo(CommonData.StartIpAddress));
+            Assert.That(firewallRuleCreate.Data.EndIPAddress, Is.EqualTo(CommonData.EndIpAddress));
 
             // update firewall rule
             var firewallRuleUpdateParams = CommonData.PrepareFirewallRuleParams(CommonData.UpdatedStartIpAddress, CommonData.UpdatedEndIpAddress);
             var firewallRuleUpdate = (await firewallRuleCollection.CreateOrUpdateAsync(WaitUntil.Completed, firewallRuleName, firewallRuleUpdateParams)).Value;
-            Assert.AreEqual(CommonData.UpdatedStartIpAddress, firewallRuleUpdate.Data.StartIPAddress);
-            Assert.AreEqual(CommonData.UpdatedEndIpAddress, firewallRuleUpdate.Data.EndIPAddress);
+            Assert.That(firewallRuleUpdate.Data.StartIPAddress, Is.EqualTo(CommonData.UpdatedStartIpAddress));
+            Assert.That(firewallRuleUpdate.Data.EndIPAddress, Is.EqualTo(CommonData.UpdatedEndIpAddress));
 
             // list firewall rules from workspace
             var firewallRuleFromWorkspace = firewallRuleCollection.GetAllAsync();
@@ -59,12 +59,12 @@ namespace Azure.ResourceManager.Synapse.Tests
             var firewallRuleCount = firewallRuleList.Count;
             var firewallRule = firewallRuleList.Single(rule => rule.Id.Name == firewallRuleName);
 
-            Assert.True(firewallRule != null, string.Format("firewall Rule created earlier is not found when listing all in workspace {0}", workspaceName));
+            Assert.That(firewallRule != null, Is.True, string.Format("firewall Rule created earlier is not found when listing all in workspace {0}", workspaceName));
 
             // delete firewall rule
             await firewallRule.DeleteAsync(WaitUntil.Completed);
             firewallRuleList = await firewallRuleCollection.GetAllAsync().ToEnumerableAsync();
-            Assert.AreEqual(firewallRuleCount - 1, firewallRuleList.Count);
+            Assert.That(firewallRuleList.Count, Is.EqualTo(firewallRuleCount - 1));
         }
     }
 }

--- a/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/KustopoolOperationTests.cs
+++ b/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/KustopoolOperationTests.cs
@@ -63,12 +63,12 @@ namespace Azure.ResourceManager.Synapse.Tests
             var expectedKustoPoolName = GetFullKustoPoolName(workspaceName, kustoPoolName);
             var kustoPool = kustoPoolList.Single(pool => pool.Data.Name == expectedKustoPoolName);
 
-            Assert.True(kustoPool != null, string.Format("kusto pool created earlier is not found when listing all in workspace {0}", workspaceName));
+            Assert.That(kustoPool != null, Is.True, string.Format("kusto pool created earlier is not found when listing all in workspace {0}", workspaceName));
 
             // delete kusto pool
             await kustoPool.DeleteAsync(WaitUntil.Completed);
             kustoPoolList = await kustoPoolCollection.GetAllAsync().ToEnumerableAsync();
-            Assert.AreEqual(kustoPoolCount - 1, kustoPoolList.Count);
+            Assert.That(kustoPoolList.Count, Is.EqualTo(kustoPoolCount - 1));
         }
 
         [Test]
@@ -108,20 +108,20 @@ namespace Azure.ResourceManager.Synapse.Tests
             var expectedKustoDatabaseName = GetFullKustoDatabaseName(workspaceName, kustoPoolName, kustoDatabaseName);
             var kustoDatabase = kustoDatabaseList.Single(database => database.Data.Name == expectedKustoDatabaseName);
 
-            Assert.True(kustoDatabase != null, string.Format("kusto Database created earlier is not found when listing all in kusto pool {0}", kustoPoolName));
+            Assert.That(kustoDatabase != null, Is.True, string.Format("kusto Database created earlier is not found when listing all in kusto pool {0}", kustoPoolName));
 
             // delete database
             await kustoDatabase.DeleteAsync(WaitUntil.Completed);
             kustoDatabaseList = await kustoPoolDatabaseCollection.GetAllAsync().ToEnumerableAsync();
-            Assert.AreEqual(kustoDatabaseCount - 1, kustoDatabaseList.Count);
+            Assert.That(kustoDatabaseList.Count, Is.EqualTo(kustoDatabaseCount - 1));
         }
 
         private void VerifyKustoPool(SynapseKustoPoolResource kustoPool, string name, SynapseDataSourceSku sku, KustoPoolState state, string workspaceName)
         {
             var poolFullName = GetFullKustoPoolName(workspaceName, name);
-            Assert.AreEqual(kustoPool.Data.Name, poolFullName);
+            Assert.That(kustoPool.Data.Name, Is.EqualTo(poolFullName));
             AssetEqualtsSku(kustoPool.Data.Sku, sku);
-            Assert.AreEqual(state, kustoPool.Data.State);
+            Assert.That(kustoPool.Data.State, Is.EqualTo(state));
         }
 
         private string GetFullKustoPoolName(string workspaceName, string kustoPoolName)
@@ -131,17 +131,17 @@ namespace Azure.ResourceManager.Synapse.Tests
 
         private void AssetEqualtsSku(SynapseDataSourceSku sku1, SynapseDataSourceSku sku2)
         {
-            Assert.AreEqual(sku1.Size, sku2.Size);
-            Assert.AreEqual(sku1.Name, sku2.Name);
+            Assert.That(sku1.Size, Is.EqualTo(sku2.Size));
+            Assert.That(sku1.Name, Is.EqualTo(sku2.Name));
         }
 
         private void VerifyReadWriteDatabase(SynapseReadWriteDatabase database, string databaseName, TimeSpan? softDeletePeriod, TimeSpan? hotCachePeriod, string workspaceName, string kustoPoolName)
         {
             var databaseFullName = GetFullKustoDatabaseName(workspaceName, kustoPoolName, databaseName);
-            Assert.NotNull(database);
-            Assert.AreEqual(database.Name, databaseFullName);
-            Assert.AreEqual(database.SoftDeletePeriod, softDeletePeriod);
-            Assert.AreEqual(database.HotCachePeriod, hotCachePeriod);
+            Assert.That(database, Is.Not.Null);
+            Assert.That(database.Name, Is.EqualTo(databaseFullName));
+            Assert.That(database.SoftDeletePeriod, Is.EqualTo(softDeletePeriod));
+            Assert.That(database.HotCachePeriod, Is.EqualTo(hotCachePeriod));
         }
 
         private string GetFullKustoDatabaseName(string workspaceName, string kustoPoolName, string kustoDatabaseName)

--- a/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/SqlpoolOperationTests.cs
+++ b/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/SqlpoolOperationTests.cs
@@ -40,9 +40,9 @@ namespace Azure.ResourceManager.Synapse.Tests
             var createSqlpoolParams = CommonData.PrepareSqlpoolCreateParams();
             SynapseSqlPoolCollection sqlPoolCollection = WorkspaceResource.GetSynapseSqlPools();
             var sqlpoolCreate = (await sqlPoolCollection.CreateOrUpdateAsync(WaitUntil.Completed, sqlpoolName, createSqlpoolParams)).Value;
-            Assert.AreEqual(CommonTestFixture.SqlpoolType, sqlpoolCreate.Data.ResourceType);
-            Assert.AreEqual(sqlpoolName, sqlpoolCreate.Data.Name);
-            Assert.AreEqual(CommonData.Location, sqlpoolCreate.Data.Location);
+            Assert.That(sqlpoolCreate.Data.ResourceType, Is.EqualTo(CommonTestFixture.SqlpoolType));
+            Assert.That(sqlpoolCreate.Data.Name, Is.EqualTo(sqlpoolName));
+            Assert.That(sqlpoolCreate.Data.Location, Is.EqualTo(CommonData.Location));
 
             // get sqlpool
             for (int i = 0; i < 60; i++)
@@ -50,14 +50,14 @@ namespace Azure.ResourceManager.Synapse.Tests
                 var sqlpoolGet = (await sqlPoolCollection.GetAsync(sqlpoolName)).Value;
                 if (sqlpoolGet.Data.ProvisioningState.Equals("Succeeded"))
                 {
-                    Assert.AreEqual(CommonTestFixture.SqlpoolType, sqlpoolCreate.Data.ResourceType);
-                    Assert.AreEqual(sqlpoolName, sqlpoolCreate.Data.Name);
-                    Assert.AreEqual(CommonData.Location, sqlpoolCreate.Data.Location);
+                    Assert.That(sqlpoolCreate.Data.ResourceType, Is.EqualTo(CommonTestFixture.SqlpoolType));
+                    Assert.That(sqlpoolCreate.Data.Name, Is.EqualTo(sqlpoolName));
+                    Assert.That(sqlpoolCreate.Data.Location, Is.EqualTo(CommonData.Location));
                     break;
                 }
 
                 Thread.Sleep(30000);
-                Assert.True(i < 60, "Synapse SqlPool is not in succeeded state even after 30 min.");
+                Assert.That(i < 60, Is.True, "Synapse SqlPool is not in succeeded state even after 30 min.");
             }
 
             // update sqlpool
@@ -71,8 +71,8 @@ namespace Azure.ResourceManager.Synapse.Tests
             await sqlpoolCreate.UpdateAsync(WaitUntil.Completed, sqlPoolPatchInfo);
 
             var sqlpoolUpdate = (await sqlPoolCollection.GetAsync(sqlpoolName)).Value;
-            Assert.NotNull(sqlpoolUpdate.Data.Tags);
-            Assert.AreEqual("TestUpdate", sqlpoolUpdate.Data.Tags["TestTag"]);
+            Assert.That(sqlpoolUpdate.Data.Tags, Is.Not.Null);
+            Assert.That(sqlpoolUpdate.Data.Tags["TestTag"], Is.EqualTo("TestUpdate"));
 
             // list sqlpool from workspace
             var sqlpoolFromWorkspace = sqlPoolCollection.GetAllAsync();
@@ -80,12 +80,12 @@ namespace Azure.ResourceManager.Synapse.Tests
             var sqlpoolCount = sqlpoolList.Count;
             var sqlpool = sqlpoolList.Single(pool => pool.Data.Name == sqlpoolName);
 
-            Assert.True(sqlpool != null, string.Format("sql pool created earlier is not found when listing all in workspace {0}", workspaceName));
+            Assert.That(sqlpool != null, Is.True, string.Format("sql pool created earlier is not found when listing all in workspace {0}", workspaceName));
 
             // delete sqlpool
             await sqlpool.DeleteAsync(WaitUntil.Completed);
             var sqlPoolList = await sqlPoolCollection.GetAllAsync().ToEnumerableAsync();
-            Assert.AreEqual(sqlpoolCount - 1, sqlPoolList.Count);
+            Assert.That(sqlPoolList.Count, Is.EqualTo(sqlpoolCount - 1));
         }
     }
 }

--- a/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/WorkspaceOperationTests.cs
+++ b/sdk/synapse/Azure.ResourceManager.Synapse/tests/ScenarioTests/WorkspaceOperationTests.cs
@@ -34,14 +34,14 @@ namespace Azure.ResourceManager.Synapse.Tests
             var createParams = CommonData.PrepareWorkspaceCreateParams();
             SynapseWorkspaceCollection workspaceCollection = ResourceGroup.GetSynapseWorkspaces();
             var workspaceCreate = (await workspaceCollection.CreateOrUpdateAsync(WaitUntil.Completed, workspaceName, createParams)).Value;
-            Assert.AreEqual(CommonTestFixture.WorkspaceType, workspaceCreate.Id.ResourceType);
-            Assert.AreEqual(workspaceName, workspaceCreate.Id.Name);
+            Assert.That(workspaceCreate.Id.ResourceType, Is.EqualTo(CommonTestFixture.WorkspaceType));
+            Assert.That(workspaceCreate.Id.Name, Is.EqualTo(workspaceName));
 
             // update workspace
             createParams.Tags.Add("TestTag", "TestUpdate");
             var workspaceUpdate = (await workspaceCollection.CreateOrUpdateAsync(WaitUntil.Completed, workspaceName, createParams)).Value;
-            Assert.NotNull(workspaceUpdate.Data.Tags);
-            Assert.AreEqual("TestUpdate", workspaceUpdate.Data.Tags["TestTag"]);
+            Assert.That(workspaceUpdate.Data.Tags, Is.Not.Null);
+            Assert.That(workspaceUpdate.Data.Tags["TestTag"], Is.EqualTo("TestUpdate"));
 
             // list workspace from resource group
             var workspaceFromResourceGroup = workspaceCollection.GetAllAsync();
@@ -49,7 +49,7 @@ namespace Azure.ResourceManager.Synapse.Tests
             var workspaceCount = workspaceList.Count;
             var workspace = workspaceList.Single(workspace => workspace.Data.Name == workspaceName);
 
-            Assert.True(workspace != null, string.Format("Workspace created earlier is not found when listing all in resource group {0}", CommonData.ResourceGroupName));
+            Assert.That(workspace != null, Is.True, string.Format("Workspace created earlier is not found when listing all in resource group {0}", CommonData.ResourceGroupName));
 
             try
             {
@@ -62,7 +62,7 @@ namespace Azure.ResourceManager.Synapse.Tests
             }
 
             workspaceList = await workspaceCollection.GetAllAsync().ToEnumerableAsync();
-            Assert.AreEqual(workspaceCount - 1, workspaceList.Count);
+            Assert.That(workspaceList.Count, Is.EqualTo(workspaceCount - 1));
         }
     }
 }


### PR DESCRIPTION
Migrates 12 test projects from NUnit 3 to NUnit 4 constraint model:
- Azure.Analytics.Defender.Easm.Tests
- Azure.Analytics.OnlineExperimentation.Tests
- Azure.ResourceManager.OnlineExperimentation.Tests
- Azure.Analytics.PlanetaryComputer.Tests
- Azure.ResourceManager.PlanetaryComputer.Tests
- Azure.Analytics.Purview.DataMap.Tests
- Azure.Analytics.Purview.Sharing.Tests
- Azure.Analytics.Purview.Workflows.Tests
- Azure.ResourceManager.Purview.Tests
- Azure.Analytics.Synapse.Artifacts.Tests
- Azure.ResourceManager.Synapse.Tests
- Azure.ResourceManager.Synapse.Samples

Part of https://github.com/Azure/azure-sdk-for-net/issues/53413

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
