### PR TITLE
[Storage] [DataMovement] Fix to DataMovement Samples and Stress Tests build

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/stress/src/Azure.Storage.DataMovement.Blobs.Stress.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/stress/src/Azure.Storage.DataMovement.Blobs.Stress.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="NUnit" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\..\core\Azure.Core.TestFramework\src\Azure.Core.TestFramework.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\Azure.Storage.DataMovement\src\Azure.Storage.DataMovement.csproj" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\..\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" >
       <Aliases>BaseBlobs</Aliases>

--- a/sdk/storage/Azure.Storage.DataMovement/samples/Azure.Storage.DataMovement.Samples.Tests.csproj
+++ b/sdk/storage/Azure.Storage.DataMovement/samples/Azure.Storage.DataMovement.Samples.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Remove="$(AzureStorageSharedTestSources)\StorageTestBase.SasVersion.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\ClientSideEncryptionTestExtensions.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\RepeatingStream.cs" />
+    <Compile Remove="$(AzureStorageSharedTestSources)\ObserveStructuredMessagePolicy.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\TransferValidationTestBase.cs" />
     <Compile Remove="$(AzureStorageSharedTestSources)\Sas\*.cs" />
     <None Include="$(AzureStorageSharedTestSources)\*.xml">


### PR DESCRIPTION
Builds for our DataMovement Stress and Sample Tests have been broken for a bit, just fixing them.

- Added reference to Azure.Core.TestFramework to Stress Tests
- Removed reference of ObserveStructuredMessagePolicy from our samples since it's not needed for them