### PR TITLE
Refresh Azure.ResourceManager SDK releases - Batch 9 (31 packages: RecoveryServicesDataReplication to WorkloadsSapVirtualInstance)

### DIFF
--- a/sdk/arc-scvmm/Azure.ResourceManager.ScVmm/CHANGELOG.md
+++ b/sdk/arc-scvmm/Azure.ResourceManager.ScVmm/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Release History
 
-## 1.0.0-beta.7 (Unreleased)
+## 1.0.0 (2026-04-29)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+This is the first stable release of this library.
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0-beta.6 (2025-03-11)
 

--- a/sdk/arc-scvmm/Azure.ResourceManager.ScVmm/README.md
+++ b/sdk/arc-scvmm/Azure.ResourceManager.ScVmm/README.md
@@ -19,7 +19,7 @@ This library follows the [new Azure SDK guidelines](https://azure.github.io/azur
 Install the Microsoft Azure Arc ScVmm management library for .NET with [NuGet](https://www.nuget.org/):
 
 ```dotnetcli
-dotnet add package Azure.ResourceManager.ScVmm --prerelease
+dotnet add package Azure.ResourceManager.ScVmm
 ```
 
 ### Prerequisites

--- a/sdk/arc-scvmm/Azure.ResourceManager.ScVmm/src/Azure.ResourceManager.ScVmm.csproj
+++ b/sdk/arc-scvmm/Azure.ResourceManager.ScVmm/src/Azure.ResourceManager.ScVmm.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta.7</Version>
+    <Version>1.0.0</Version>
     <PackageId>Azure.ResourceManager.ScVmm</PackageId>
     <Description>Microsoft Azure Resource Manager client SDK for Azure resource provider Microsoft.Arc.ScVmm.</Description>
     <PackageTags>azure;management;arm;resource manager;scvmm</PackageTags>

--- a/sdk/recoveryservices-datareplication/Azure.ResourceManager.RecoveryServicesDataReplication/CHANGELOG.md
+++ b/sdk/recoveryservices-datareplication/Azure.ResourceManager.RecoveryServicesDataReplication/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.1 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0 (2025-04-09)
 

--- a/sdk/recoveryservices-datareplication/Azure.ResourceManager.RecoveryServicesDataReplication/src/Azure.ResourceManager.RecoveryServicesDataReplication.csproj
+++ b/sdk/recoveryservices-datareplication/Azure.ResourceManager.RecoveryServicesDataReplication/src/Azure.ResourceManager.RecoveryServicesDataReplication.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.RecoveryServicesDataReplication</PackageId>

--- a/sdk/recoveryservices-siterecovery/Azure.ResourceManager.RecoveryServicesSiteRecovery/CHANGELOG.md
+++ b/sdk/recoveryservices-siterecovery/Azure.ResourceManager.RecoveryServicesSiteRecovery/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.4.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.1 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.3.0 (2025-05-09)
 

--- a/sdk/recoveryservices-siterecovery/Azure.ResourceManager.RecoveryServicesSiteRecovery/src/Azure.ResourceManager.RecoveryServicesSiteRecovery.csproj
+++ b/sdk/recoveryservices-siterecovery/Azure.ResourceManager.RecoveryServicesSiteRecovery/src/Azure.ResourceManager.RecoveryServicesSiteRecovery.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0-beta.1</Version>
+    <Version>1.3.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.3.0</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.RecoveryServicesSiteRecovery</PackageId>

--- a/sdk/relay/Azure.ResourceManager.Relay/CHANGELOG.md
+++ b/sdk/relay/Azure.ResourceManager.Relay/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.2.1 (2025-03-11)
 

--- a/sdk/relay/Azure.ResourceManager.Relay/src/Azure.ResourceManager.Relay.csproj
+++ b/sdk/relay/Azure.ResourceManager.Relay/src/Azure.ResourceManager.Relay.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta.1</Version>
+    <Version>1.2.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.Relay</PackageId>

--- a/sdk/reservations/Azure.ResourceManager.Reservations/CHANGELOG.md
+++ b/sdk/reservations/Azure.ResourceManager.Reservations/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.5.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.4.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.4.1 (2025-03-11)
 

--- a/sdk/reservations/Azure.ResourceManager.Reservations/src/Azure.ResourceManager.Reservations.csproj
+++ b/sdk/reservations/Azure.ResourceManager.Reservations/src/Azure.ResourceManager.Reservations.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0-beta.1</Version>
+    <Version>1.4.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.4.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.Reservations</PackageId>

--- a/sdk/resourcemover/Azure.ResourceManager.ResourceMover/CHANGELOG.md
+++ b/sdk/resourcemover/Azure.ResourceManager.ResourceMover/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.1.2-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.1.2-beta.2 (2025-03-11)
 

--- a/sdk/resourcemover/Azure.ResourceManager.ResourceMover/CHANGELOG.md
+++ b/sdk/resourcemover/Azure.ResourceManager.ResourceMover/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.2 (2026-04-29)
+## 1.1.2-beta.3 (2026-04-29)
 
 ### Other Changes
 

--- a/sdk/resourcemover/Azure.ResourceManager.ResourceMover/src/Azure.ResourceManager.ResourceMover.csproj
+++ b/sdk/resourcemover/Azure.ResourceManager.ResourceMover/src/Azure.ResourceManager.ResourceMover.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.2-beta.3</Version>
+    <Version>1.1.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.ResourceMover</PackageId>

--- a/sdk/resourcemover/Azure.ResourceManager.ResourceMover/src/Azure.ResourceManager.ResourceMover.csproj
+++ b/sdk/resourcemover/Azure.ResourceManager.ResourceMover/src/Azure.ResourceManager.ResourceMover.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.2</Version>
+    <Version>1.1.2-beta.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.ResourceMover</PackageId>

--- a/sdk/secretsstoreextension/Azure.ResourceManager.SecretsStoreExtension/CHANGELOG.md
+++ b/sdk/secretsstoreextension/Azure.ResourceManager.SecretsStoreExtension/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0-beta.1 (2025-05-22)
 

--- a/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/CHANGELOG.md
+++ b/sdk/securitycenter/Azure.ResourceManager.SecurityCenter/CHANGELOG.md
@@ -1,16 +1,12 @@
 # Release History
 
-## 1.2.0-beta.7 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.0-beta.7 (2026-04-29)
 
 ### Other Changes
 
 - Remove VersionOverrides for IotHub and Logic in SecurityCenter tests
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.2.0-beta.6 (2025-03-11)
 

--- a/sdk/securitydevops/Azure.ResourceManager.SecurityDevOps/CHANGELOG.md
+++ b/sdk/securitydevops/Azure.ResourceManager.SecurityDevOps/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.0-beta.6 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.6 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0-beta.5 (2025-03-11)
 

--- a/sdk/securityinsights/Azure.ResourceManager.SecurityInsights/CHANGELOG.md
+++ b/sdk/securityinsights/Azure.ResourceManager.SecurityInsights/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.0-beta.3 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.2.0-beta.2 (2025-03-11)
 

--- a/sdk/selfhelp/Azure.ResourceManager.SelfHelp/CHANGELOG.md
+++ b/sdk/selfhelp/Azure.ResourceManager.SelfHelp/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.1.0-beta.6 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.0-beta.6 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.1.0-beta.5 (2025-03-11)
 

--- a/sdk/servicefabric/Azure.ResourceManager.ServiceFabric/CHANGELOG.md
+++ b/sdk/servicefabric/Azure.ResourceManager.ServiceFabric/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.0-beta.3 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.2.0-beta.2 (2025-03-11)
 

--- a/sdk/servicelinker/Azure.ResourceManager.ServiceLinker/CHANGELOG.md
+++ b/sdk/servicelinker/Azure.ResourceManager.ServiceLinker/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.1.1 (2025-03-11)
 

--- a/sdk/servicelinker/Azure.ResourceManager.ServiceLinker/src/Azure.ResourceManager.ServiceLinker.csproj
+++ b/sdk/servicelinker/Azure.ResourceManager.ServiceLinker/src/Azure.ResourceManager.ServiceLinker.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.1.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.ServiceLinker</PackageId>

--- a/sdk/servicenetworking/Azure.ResourceManager.ServiceNetworking/CHANGELOG.md
+++ b/sdk/servicenetworking/Azure.ResourceManager.ServiceNetworking/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.0-beta.1 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.1.0 (2025-03-04)
 

--- a/sdk/sphere/Azure.ResourceManager.Sphere/CHANGELOG.md
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.1 (2025-03-11)
 

--- a/sdk/sphere/Azure.ResourceManager.Sphere/src/Azure.ResourceManager.Sphere.csproj
+++ b/sdk/sphere/Azure.ResourceManager.Sphere/src/Azure.ResourceManager.Sphere.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.Sphere</PackageId>

--- a/sdk/springappdiscovery/Azure.ResourceManager.SpringAppDiscovery/CHANGELOG.md
+++ b/sdk/springappdiscovery/Azure.ResourceManager.SpringAppDiscovery/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.3 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0-beta.2 (2025-03-11)
 

--- a/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/CHANGELOG.md
+++ b/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.1.1 (2025-03-11)
 

--- a/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/src/Azure.ResourceManager.SqlVirtualMachine.csproj
+++ b/sdk/sqlvirtualmachine/Azure.ResourceManager.SqlVirtualMachine/src/Azure.ResourceManager.SqlVirtualMachine.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.1.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.SqlVirtualMachine</PackageId>

--- a/sdk/storageactions/Azure.ResourceManager.StorageActions/CHANGELOG.md
+++ b/sdk/storageactions/Azure.ResourceManager.StorageActions/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.1 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0 (2025-06-27)
 

--- a/sdk/storageactions/Azure.ResourceManager.StorageActions/src/Azure.ResourceManager.StorageActions.csproj
+++ b/sdk/storageactions/Azure.ResourceManager.StorageActions/src/Azure.ResourceManager.StorageActions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.1</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.0</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.StorageActions</PackageId>

--- a/sdk/storagepool/Azure.ResourceManager.StoragePool/CHANGELOG.md
+++ b/sdk/storagepool/Azure.ResourceManager.StoragePool/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.1.1 (2025-03-11)
 

--- a/sdk/storagepool/Azure.ResourceManager.StoragePool/src/Azure.ResourceManager.StoragePool.csproj
+++ b/sdk/storagepool/Azure.ResourceManager.StoragePool/src/Azure.ResourceManager.StoragePool.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.1.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.StoragePool</PackageId>

--- a/sdk/streamanalytics/Azure.ResourceManager.StreamAnalytics/CHANGELOG.md
+++ b/sdk/streamanalytics/Azure.ResourceManager.StreamAnalytics/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.3.0-beta.1 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.2.1 (2025-03-11)
 

--- a/sdk/subscription/Azure.ResourceManager.Subscription/CHANGELOG.md
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.1.1 (2025-03-11)
 

--- a/sdk/subscription/Azure.ResourceManager.Subscription/src/Azure.ResourceManager.Subscription.csproj
+++ b/sdk/subscription/Azure.ResourceManager.Subscription/src/Azure.ResourceManager.Subscription.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.1.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.Subscription</PackageId>

--- a/sdk/support/Azure.ResourceManager.Support/CHANGELOG.md
+++ b/sdk/support/Azure.ResourceManager.Support/CHANGELOG.md
@@ -1,19 +1,17 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
+## 1.2.0-beta.1 (2026-04-29)
 
 ### Features Added
 
 - Upgraded API version to `2025-06-01-preview`
 - Migrated from Swagger to TypeSpec-based generation
 
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
 
 - Upgraded Azure.ResourceManager dependency
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.1.1 (2025-03-11)
 

--- a/sdk/support/Azure.ResourceManager.Support/CHANGELOG.md
+++ b/sdk/support/Azure.ResourceManager.Support/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### Other Changes
 
-- Upgraded Azure.ResourceManager dependency
 - Upgraded dependent `Azure.Core` to `1.54.0`.
 - Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 

--- a/sdk/synapse/Azure.ResourceManager.Synapse/CHANGELOG.md
+++ b/sdk/synapse/Azure.ResourceManager.Synapse/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.2.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.2.1 (2025-03-11)
 

--- a/sdk/synapse/Azure.ResourceManager.Synapse/src/Azure.ResourceManager.Synapse.csproj
+++ b/sdk/synapse/Azure.ResourceManager.Synapse/src/Azure.ResourceManager.Synapse.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.3.0-beta.1</Version>
+    <Version>1.2.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.2.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.Synapse</PackageId>

--- a/sdk/terraform/Azure.ResourceManager.Terraform/CHANGELOG.md
+++ b/sdk/terraform/Azure.ResourceManager.Terraform/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.0-beta.3 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.3 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0-beta.2 (2025-06-19)
 

--- a/sdk/trustedsigning/Azure.ResourceManager.TrustedSigning/CHANGELOG.md
+++ b/sdk/trustedsigning/Azure.ResourceManager.TrustedSigning/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Release History
 
-## 1.0.0 (Unreleased)
+## 1.0.0 (2026-04-29)
 
-This release is the first stable release of the Trusted Signing Management client library.
+This is the first stable release of this library.
 
 ### Features Added
 
 - Upgraded api-version to 2025-10-13.
 - Make `Azure.ResourceManager.TrustedSigning` AOT-compatible.
+
+### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0-beta.2 (2025-03-11)
 

--- a/sdk/trustedsigning/Azure.ResourceManager.TrustedSigning/README.md
+++ b/sdk/trustedsigning/Azure.ResourceManager.TrustedSigning/README.md
@@ -24,7 +24,7 @@ This library follows the [new Azure SDK guidelines](https://azure.github.io/azur
 Install the Microsoft Azure TrustedSigning management library for .NET with [NuGet](https://www.nuget.org/):
 
 ```dotnetcli
-dotnet add package Azure.ResourceManager.TrustedSigning --prerelease
+dotnet add package Azure.ResourceManager.TrustedSigning
 ```
 
 ### Prerequisites

--- a/sdk/voiceservices/Azure.ResourceManager.VoiceServices/CHANGELOG.md
+++ b/sdk/voiceservices/Azure.ResourceManager.VoiceServices/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.1.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.3 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.2 (2025-03-11)
 

--- a/sdk/voiceservices/Azure.ResourceManager.VoiceServices/src/Azure.ResourceManager.VoiceServices.csproj
+++ b/sdk/voiceservices/Azure.ResourceManager.VoiceServices/src/Azure.ResourceManager.VoiceServices.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.0.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.0.2</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.VoiceServices</PackageId>

--- a/sdk/webpubsub/Azure.ResourceManager.WebPubSub/CHANGELOG.md
+++ b/sdk/webpubsub/Azure.ResourceManager.WebPubSub/CHANGELOG.md
@@ -1,16 +1,15 @@
 # Release History
 
-## 1.3.0-beta.1 (Unreleased)
+## 1.3.0-beta.1 (2026-04-29)
 
 ### Features Added
 
 - Upgraded API version to `2025-08-01-preview`.
 
-### Breaking Changes
-
-### Bugs Fixed
-
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.2.0 (2025-06-13)
 
@@ -30,7 +29,6 @@
 
 - Enable the new model serialization by using the System.ClientModel, refer this [document](https://aka.ms/azsdk/net/mrw) for more details.
 - Enable Bicep serialization.
-
 
 ## 1.1.0 (2023-11-30)
 

--- a/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases/CHANGELOG.md
+++ b/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0 (2026-04-29)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+This is the first stable release of this library.
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0-beta.1 (2025-04-24)
 

--- a/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases/README.md
+++ b/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases/README.md
@@ -19,7 +19,7 @@ This library follows the [new Azure SDK guidelines](https://azure.github.io/azur
 Install the Microsoft Azure Weights & Biases management library for .NET with [NuGet](https://www.nuget.org/):
 
 ```dotnetcli
-dotnet add package Azure.ResourceManager.WeightsAndBiases --prerelease
+dotnet add package Azure.ResourceManager.WeightsAndBiases
 ```
 
 ### Prerequisites

--- a/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases/src/Azure.ResourceManager.WeightsAndBiases.csproj
+++ b/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases/src/Azure.ResourceManager.WeightsAndBiases.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta.2</Version>
+    <Version>1.0.0</Version>
     <PackageId>Azure.ResourceManager.WeightsAndBiases</PackageId>
     <Description>Azure Resource Manager client SDK for Azure resource provider liftrweightsandbiases.</Description>
     <PackageTags>azure;management;arm;resource manager;liftrweightsandbiases</PackageTags>

--- a/sdk/workloadmonitor/Azure.ResourceManager.WorkloadMonitor/CHANGELOG.md
+++ b/sdk/workloadmonitor/Azure.ResourceManager.WorkloadMonitor/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.0.0-beta.6 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.0.0-beta.6 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0-beta.5 (2025-03-11)
 

--- a/sdk/workloads/Azure.ResourceManager.Workloads/CHANGELOG.md
+++ b/sdk/workloads/Azure.ResourceManager.Workloads/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+## 1.1.2 (2026-04-29)
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.1.1 (2025-03-11)
 
@@ -66,7 +63,6 @@ AMS
   - Added operation for SapLandscapeMonitor for Storing SPOG Config.
   - Added sapSid property in os, hana providers
   - Added support for secure communication
-
 
 ### Breaking Changes
 

--- a/sdk/workloads/Azure.ResourceManager.Workloads/src/Azure.ResourceManager.Workloads.csproj
+++ b/sdk/workloads/Azure.ResourceManager.Workloads/src/Azure.ResourceManager.Workloads.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.2.0-beta.1</Version>
+    <Version>1.1.2</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.1.1</ApiCompatVersion>
     <PackageId>Azure.ResourceManager.Workloads</PackageId>

--- a/sdk/workloadssapvirtualinstance/Azure.ResourceManager.WorkloadsSapVirtualInstance/CHANGELOG.md
+++ b/sdk/workloadssapvirtualinstance/Azure.ResourceManager.WorkloadsSapVirtualInstance/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Release History
 
-## 1.0.0-beta.2 (Unreleased)
+## 1.0.0 (2026-04-29)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
+This is the first stable release of this library.
 
 ### Other Changes
+
+- Upgraded dependent `Azure.Core` to `1.54.0`.
+- Upgraded dependent `Azure.ResourceManager` to `1.14.0`.
 
 ## 1.0.0-beta.1 (2025-04-29)
 

--- a/sdk/workloadssapvirtualinstance/Azure.ResourceManager.WorkloadsSapVirtualInstance/README.md
+++ b/sdk/workloadssapvirtualinstance/Azure.ResourceManager.WorkloadsSapVirtualInstance/README.md
@@ -17,7 +17,7 @@ This library follows the [new Azure SDK guidelines](https://azure.github.io/azur
 Install the Microsoft Azure Workloads SapVirtualInstance management library for .NET with [NuGet](https://www.nuget.org/):
 
 ```dotnetcli
-dotnet add package Azure.ResourceManager.WorkloadsSapVirtualInstance --prerelease
+dotnet add package Azure.ResourceManager.WorkloadsSapVirtualInstance
 ```
 
 ### Prerequisites

--- a/sdk/workloadssapvirtualinstance/Azure.ResourceManager.WorkloadsSapVirtualInstance/src/Azure.ResourceManager.WorkloadsSapVirtualInstance.csproj
+++ b/sdk/workloadssapvirtualinstance/Azure.ResourceManager.WorkloadsSapVirtualInstance/src/Azure.ResourceManager.WorkloadsSapVirtualInstance.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta.2</Version>
+    <Version>1.0.0</Version>
     <PackageId>Azure.ResourceManager.WorkloadsSapVirtualInstance</PackageId>
     <Description>Azure Resource Manager client SDK for Azure resource provider Workloads SapVirtualInstance.</Description>
     <PackageTags>azure;management;arm;resource manager;workloads;acss;sap;workloadssapvirtualinstance</PackageTags>


### PR DESCRIPTION
## Summary

This PR refreshes the Azure.ResourceManager SDK packages for batch 9 (items 81-111 of the dependency upgrade list). All packages upgrade **Azure.Core** to **1.54.0** and **Azure.ResourceManager** to **1.14.0**.

## Changes

### Stable releases (17 packages)
| Package | New Version | Notes |
|---------|------------|-------|
| Azure.ResourceManager.RecoveryServicesDataReplication | 1.0.1 | |
| Azure.ResourceManager.RecoveryServicesSiteRecovery | 1.3.1 | |
| Azure.ResourceManager.Relay | 1.2.2 | |
| Azure.ResourceManager.Reservations | 1.4.2 | |
| Azure.ResourceManager.ScVmm | 1.0.0 | First stable release |
| Azure.ResourceManager.ServiceLinker | 1.1.2 | |
| Azure.ResourceManager.Sphere | 1.0.2 | |
| Azure.ResourceManager.SqlVirtualMachine | 1.1.2 | |
| Azure.ResourceManager.StorageActions | 1.0.1 | |
| Azure.ResourceManager.StoragePool | 1.1.2 | |
| Azure.ResourceManager.Subscription | 1.1.2 | |
| Azure.ResourceManager.Synapse | 1.2.2 | |
| Azure.ResourceManager.TrustedSigning | 1.0.0 | First stable release |
| Azure.ResourceManager.VoiceServices | 1.0.3 | |
| Azure.ResourceManager.WeightsAndBiases | 1.0.0 | First stable release |
| Azure.ResourceManager.Workloads | 1.1.2 | |
| Azure.ResourceManager.WorkloadsSapVirtualInstance | 1.0.0 | First stable release |

### Beta releases (14 packages)
Azure.ResourceManager.ResourceMover 1.1.2-beta.3, SecretsStoreExtension 1.0.0-beta.2, SecurityCenter 1.2.0-beta.7, SecurityDevOps 1.0.0-beta.6, SecurityInsights 1.2.0-beta.3, SelfHelp 1.1.0-beta.6, ServiceFabric 1.2.0-beta.3, ServiceNetworking 1.2.0-beta.1, SpringAppDiscovery 1.0.0-beta.3, StreamAnalytics 1.3.0-beta.1, Support 1.2.0-beta.1, Terraform 1.0.0-beta.3, WebPubSub 1.3.0-beta.1, WorkloadMonitor 1.0.0-beta.6

## First Stable Releases
4 packages promoted to first stable (ScVmm, TrustedSigning, WeightsAndBiases, WorkloadsSapVirtualInstance):
- CHANGELOG updated with first-stable note
- README updated to remove --prerelease flag
- Version promoted from beta to 1.0.0

## API Version Source
All stable packages confirmed pointing to stable API versions via metadata.json or autorest.md tag resolution.