### PR TITLE
[WebPubSub] Fix live test for continuation token pagination

### DIFF
--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/assets.json
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/webpubsub/Azure.Messaging.WebPubSub",
-  "Tag": "net/webpubsub/Azure.Messaging.WebPubSub_61ea04e0f7"
+  "Tag": "net/webpubsub/Azure.Messaging.WebPubSub_9127424be2"
 }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
@@ -48,44 +48,54 @@ namespace Azure.Rest.WebPubSub.Tests
         public async Task ServiceClientCanListConnectionsInGroup(int totalConnectionCount, int? maxCountToList, int? maxPageSize, int expectedTotalCount, int expectedPageCount)
         {
             WebPubSubServiceClientOptions serviceClientOptions = InstrumentClientOptions(new WebPubSubServiceClientOptions());
-            var serviceClient = new WebPubSubServiceClient(TestEnvironment.ConnectionString, nameof(ServiceClientCanListConnectionsInGroup).ToLower(), serviceClientOptions);
+            var hubName = Recording.GenerateAlphaNumericId("list", useOnlyLowercase: true);
+            var serviceClient = new WebPubSubServiceClient(TestEnvironment.ConnectionString, hubName, serviceClientOptions);
 
             // Connect a few websocket connections to a group
-            var groupName = "group1";
+            var groupName = Recording.GenerateAlphaNumericId("group", useOnlyLowercase: true);
             Uri clientAccessUri = serviceClient.GetClientAccessUri(groups: [groupName]);
 
             var clients = new ClientWebSocket[totalConnectionCount];
-            // Client WebSocket connections cannot be recorded, so disable them in playback mode.
-            if (TestEnvironment.Mode != RecordedTestMode.Playback)
+            try
             {
-                for (int i = 0; i < totalConnectionCount; i++)
+                // Client WebSocket connections cannot be recorded, so disable them in playback mode.
+                if (TestEnvironment.Mode != RecordedTestMode.Playback)
                 {
-                    var client = new ClientWebSocket();
-                    await client.ConnectAsync(clientAccessUri, CancellationToken.None);
-                    clients[i] = client;
+                    for (int i = 0; i < totalConnectionCount; i++)
+                    {
+                        var client = new ClientWebSocket();
+                        await client.ConnectAsync(clientAccessUri, CancellationToken.None);
+                        clients[i] = client;
+                    }
                 }
-            }
 
-            // List connections in the group
-            var actualPageCount = 0;
-            var actualConnectionCount = 0;
+                // List connections in the group
+                var actualPageCount = 0;
+                var actualConnectionCount = 0;
 
-            await foreach (Page<WebPubSubGroupMember> page in serviceClient.ListConnectionsInGroupAsync(groupName, maxPageSize, maxCountToList).AsPages())
-            {
-                //actualPageCount++;
-                actualConnectionCount += page.Values.Count;
-                actualPageCount++;
-            }
-
-            Assert.AreEqual(expectedPageCount, actualPageCount);
-            Assert.AreEqual(expectedTotalCount, actualConnectionCount);
-
-            if (TestEnvironment.Mode != RecordedTestMode.Playback)
-            {
-                foreach (ClientWebSocket client in clients)
+                await foreach (Page<WebPubSubGroupMember> page in serviceClient.ListConnectionsInGroupAsync(groupName, maxPageSize, maxCountToList).AsPages())
                 {
-                    await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
-                    client.Dispose();
+                    actualConnectionCount += page.Values.Count;
+                    actualPageCount++;
+                }
+
+                Assert.AreEqual(expectedPageCount, actualPageCount);
+                Assert.AreEqual(expectedTotalCount, actualConnectionCount);
+            }
+            finally
+            {
+                if (TestEnvironment.Mode != RecordedTestMode.Playback)
+                {
+                    foreach (ClientWebSocket client in clients)
+                    {
+                        if (client == null)
+                        {
+                            continue;
+                        }
+
+                        await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                        client.Dispose();
+                    }
                 }
             }
         }
@@ -94,49 +104,60 @@ namespace Azure.Rest.WebPubSub.Tests
         public async Task ServiceClientCanListConnectionsInGroupWithContinuationToken()
         {
             WebPubSubServiceClientOptions options = InstrumentClientOptions(new WebPubSubServiceClientOptions());
-            var serviceClient = new WebPubSubServiceClient(TestEnvironment.ConnectionString, nameof(ServiceClientCanListConnectionsInGroupWithContinuationToken).ToLower(), options);
+            var hubName = Recording.GenerateAlphaNumericId("list", useOnlyLowercase: true);
+            var serviceClient = new WebPubSubServiceClient(TestEnvironment.ConnectionString, hubName, options);
 
             // Connect a few websocket connections to a group
-            var groupName = nameof(ServiceClientCanListConnectionsInGroupWithContinuationToken).ToLower();
+            var groupName = Recording.GenerateAlphaNumericId("group", useOnlyLowercase: true);
             var totalCount = 2;
             Uri clientAccessUri = serviceClient.GetClientAccessUri(groups: [groupName]);
 
             var clients = new ClientWebSocket[totalCount];
-            // Client WebSocket connections cannot be recorded, so disable them in playback mode.
-            if (TestEnvironment.Mode != RecordedTestMode.Playback)
+            try
             {
-                for (int i = 0; i < totalCount; i++)
+                // Client WebSocket connections cannot be recorded, so disable them in playback mode.
+                if (TestEnvironment.Mode != RecordedTestMode.Playback)
                 {
-                    var client = new ClientWebSocket();
-                    await client.ConnectAsync(clientAccessUri, CancellationToken.None);
-                    clients[i] = client;
+                    for (int i = 0; i < totalCount; i++)
+                    {
+                        var client = new ClientWebSocket();
+                        await client.ConnectAsync(clientAccessUri, CancellationToken.None);
+                        clients[i] = client;
+                    }
                 }
-            }
 
-            // List connections in the group
-            var firstContinuationToken = "";
-            var firstPageSize = 0;
+                // List connections in the group
+                var firstContinuationToken = "";
+                var firstPageSize = 0;
 
-            await foreach (var page in serviceClient.ListConnectionsInGroupAsync(groupName, maxpagesize: 1).AsPages())
-            {
-                firstContinuationToken = page.ContinuationToken;
-                firstPageSize = page.Values.Count;
-                break;
-            }
-
-            var remainingConnectionsAfterFirstPage = new List<WebPubSubGroupMember>();
-            await foreach (var page in serviceClient.ListConnectionsInGroupAsync(groupName).AsPages(continuationToken: firstContinuationToken))
-            {
-                remainingConnectionsAfterFirstPage.AddRange(page.Values);
-            }
-            Assert.AreEqual(totalCount - firstPageSize, remainingConnectionsAfterFirstPage.Count);
-
-            if (TestEnvironment.Mode != RecordedTestMode.Playback)
-            {
-                foreach (ClientWebSocket client in clients)
+                await foreach (var page in serviceClient.ListConnectionsInGroupAsync(groupName, maxpagesize: 1).AsPages())
                 {
-                    await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
-                    client.Dispose();
+                    firstContinuationToken = page.ContinuationToken;
+                    firstPageSize = page.Values.Count;
+                    break;
+                }
+
+                var remainingConnectionsAfterFirstPage = new List<WebPubSubGroupMember>();
+                await foreach (var page in serviceClient.ListConnectionsInGroupAsync(groupName).AsPages(continuationToken: firstContinuationToken))
+                {
+                    remainingConnectionsAfterFirstPage.AddRange(page.Values);
+                }
+                Assert.AreEqual(totalCount - firstPageSize, remainingConnectionsAfterFirstPage.Count);
+            }
+            finally
+            {
+                if (TestEnvironment.Mode != RecordedTestMode.Playback)
+                {
+                    foreach (ClientWebSocket client in clients)
+                    {
+                        if (client == null)
+                        {
+                            continue;
+                        }
+
+                        await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                        client.Dispose();
+                    }
                 }
             }
         }

--- a/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
+++ b/sdk/webpubsub/Azure.Messaging.WebPubSub/tests/WebPubSubGeneralTests.cs
@@ -124,7 +124,11 @@ namespace Azure.Rest.WebPubSub.Tests
                 break;
             }
 
-            List<WebPubSubGroupMember> remainingConnectionsAfterFirstPage = await serviceClient.ListConnectionsInGroupAsync(groupName, continuationToken: firstContinuationToken).ToEnumerableAsync();
+            var remainingConnectionsAfterFirstPage = new List<WebPubSubGroupMember>();
+            await foreach (var page in serviceClient.ListConnectionsInGroupAsync(groupName).AsPages(continuationToken: firstContinuationToken))
+            {
+                remainingConnectionsAfterFirstPage.AddRange(page.Values);
+            }
             Assert.AreEqual(totalCount - firstPageSize, remainingConnectionsAfterFirstPage.Count);
 
             if (TestEnvironment.Mode != RecordedTestMode.Playback)


### PR DESCRIPTION
The `ServiceClientCanListConnectionsInGroupWithContinuationToken` test was failing with assertion errors (e.g., Expected: 1 But was: 0/2/3...).

The root cause was a misuse of the continuation token. `page.ContinuationToken` returns a nextLink URL (e.g., https://endpoint/api/.../connections?continuationToken=abc&api-version=...) not a raw token, but the original code passed it to the `ListConnectionsInGroupAsync` method's parameter, which appends it as a raw query parameter value. This produced a malformed request with a URL-inside-a-URL, causing the service to return unpredictable results.

The `.AsPages()` method correctly treats the value as a nextLink URL, which is how the Azure SDK pagination model is designed to work.

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
