### PR TITLE
Add AZC0012.md docs and link rules table in README

### DIFF
--- a/sdk/tools/Azure.SdkAnalyzers/README.md
+++ b/sdk/tools/Azure.SdkAnalyzers/README.md
@@ -12,9 +12,9 @@ This package is automatically included in all Azure SDK libraries in this reposi
 
 | Rule | Description | Fix |
 |------|-------------|-----|
-| **AZC0012** | Avoid single word type names | — |
-| **AZC0020** | Propagate CancellationToken to RequestContext | — |
-| **AZC0101** | Do not use `ConfigureAwait(true)` | ✅ |
+| [**AZC0012**](docs/AZC0012.md) | Avoid single word type names | — |
+| [**AZC0020**](docs/AZC0020.md) | Propagate CancellationToken to RequestContext | — |
+| [**AZC0101**](docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
 
 ## For Library Authors
 

--- a/sdk/tools/Azure.SdkAnalyzers/README.md
+++ b/sdk/tools/Azure.SdkAnalyzers/README.md
@@ -12,9 +12,9 @@ This package is automatically included in all Azure SDK libraries in this reposi
 
 | Rule | Description | Fix |
 |------|-------------|-----|
-| [**AZC0012**](docs/AZC0012.md) | Avoid single word type names | ✅ |
-| [**AZC0020**](docs/AZC0020.md) | Propagate CancellationToken to RequestContext | — |
-| [**AZC0101**](docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
+| [**AZC0012**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md) | Avoid single word type names | ✅ |
+| [**AZC0020**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0020.md) | Propagate CancellationToken to RequestContext | — |
+| [**AZC0101**](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/tools/Azure.SdkAnalyzers/docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
 
 ## For Library Authors
 

--- a/sdk/tools/Azure.SdkAnalyzers/README.md
+++ b/sdk/tools/Azure.SdkAnalyzers/README.md
@@ -12,7 +12,7 @@ This package is automatically included in all Azure SDK libraries in this reposi
 
 | Rule | Description | Fix |
 |------|-------------|-----|
-| [**AZC0012**](docs/AZC0012.md) | Avoid single word type names | — |
+| [**AZC0012**](docs/AZC0012.md) | Avoid single word type names | ✅ |
 | [**AZC0020**](docs/AZC0020.md) | Propagate CancellationToken to RequestContext | — |
 | [**AZC0101**](docs/AZC0101.md) | Do not use `ConfigureAwait(true)` | ✅ |
 

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md
@@ -17,12 +17,12 @@ Single-word type names such as `Format`, `Manager`, or `Options` are highly like
 
 Use descriptive multi-word names. Add a prefix or suffix that describes the purpose or domain of the type:
 
-```csharp
-namespace Azure.Data.Tables
-{
+```diff
+ namespace Azure.Data.Tables
+ {
 -   public class Format { }
 +   public class TableDataFormat { }
-}
+ }
 ```
 
 

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md
@@ -3,7 +3,7 @@
 | Property | Value |
 |----------|-------|
 | **Severity** | Warning |
-| **Code fix** | No |
+| **Code fix** | Yes (rename suggestions available) |
 
 ## Cause
 

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md
@@ -1,0 +1,60 @@
+# AZC0012: Avoid single word type names
+
+| Property | Value |
+|----------|-------|
+| **Severity** | Warning |
+| **Code fix** | No |
+
+## Cause
+
+Public types (classes, interfaces, or structs) in Azure SDK namespaces (`Azure.*`, excluding `Azure.Core.*`) use single-word names, which are too generic and risk colliding with BCL types or types from other libraries.
+
+## Why this matters
+
+Single-word type names such as `Format`, `Manager`, or `Options` are highly likely to conflict with types already defined in the .NET BCL or other libraries, leading to ambiguous references and confusing API surfaces.
+
+## How to fix
+
+Use descriptive multi-word names. Add a prefix or suffix that describes the purpose or domain of the type:
+
+```csharp
+namespace Azure.Data.Tables
+{
+-   public class Format { }
++   public class TableDataFormat { }
+}
+```
+
+## When to suppress warnings
+
+Suppress only if the type name is genuinely well-known and intentionally mirrors a BCL type for compatibility reasons. Document the justification:
+
+```csharp
+#pragma warning disable AZC0012 // Justified: intentional alias for well-known BCL type
+public class Stream { }
+#pragma warning restore AZC0012
+```
+
+## Example of a violation
+
+```csharp
+namespace Azure.Data.Tables
+{
+    public class Format { } // ❌ single-word name
+}
+```
+
+## Example of how to fix
+
+```csharp
+namespace Azure.Data.Tables
+{
+    public class TableDataFormat { } // ✅ descriptive multi-word name
+}
+```
+
+## Notes
+
+- Only public types in Azure SDK namespaces (starting with `Azure.` except `Azure.Core.*`) are analyzed.
+- Interface names starting with `I` have the prefix ignored (e.g., `IClient` is treated as single-word).
+- Nested types are not analyzed.

--- a/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md
+++ b/sdk/tools/Azure.SdkAnalyzers/docs/AZC0012.md
@@ -25,15 +25,6 @@ namespace Azure.Data.Tables
 }
 ```
 
-## When to suppress warnings
-
-Suppress only if the type name is genuinely well-known and intentionally mirrors a BCL type for compatibility reasons. Document the justification:
-
-```csharp
-#pragma warning disable AZC0012 // Justified: intentional alias for well-known BCL type
-public class Stream { }
-#pragma warning restore AZC0012
-```
 
 ## Example of a violation
 


### PR DESCRIPTION
Create missing documentation file for AZC0012 (Avoid single word type names) and hyperlink all rules in the README table to their individual doc pages.

Fixes Azure/azure-sdk-for-net#58450

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
