### PR TITLE
Map Microsoft.OpenTelemetry distro name to 'mot' label in sdkVersion

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -86,6 +86,7 @@ internal static class ResourceExtensions
                         "Microsoft.ApplicationInsights.WorkerService" => SdkVersionType.ShimWorkerService,
                         "Microsoft.ApplicationInsights.Web" => SdkVersionType.ShimWeb,
                         "Microsoft.ApplicationInsights.NLogTarget" => SdkVersionType.ShimNLog,
+                        "Microsoft.OpenTelemetry" => SdkVersionType.MicrosoftOpenTelemetry,
                         _ => null,
                     };
                     break;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/SdkVersionUtils.cs
@@ -138,6 +138,9 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
                     case SdkVersionType.ShimNLog:
                         ExtensionLabel = "shn";
                         break;
+                    case SdkVersionType.MicrosoftOpenTelemetry:
+                        ExtensionLabel = "mot";
+                        break;
                     case SdkVersionType.Exporter:
                     default:
                         ExtensionLabel = "ext";
@@ -188,5 +191,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
         ShimWeb,
         /// <summary>Application Insights NLog shim (Microsoft.ApplicationInsights.NLogTarget).</summary>
         ShimNLog,
+        /// <summary>Microsoft OpenTelemetry distro (Microsoft.OpenTelemetry).</summary>
+        MicrosoftOpenTelemetry,
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/ResourceExtensionsTests.cs
@@ -179,6 +179,7 @@ public class ResourceExtensionsTests
     [InlineData("Microsoft.ApplicationInsights.AspNetCore", "shc", SdkVersionType.ShimAspNetCore)]
     [InlineData("Microsoft.ApplicationInsights.WorkerService", "shw", SdkVersionType.ShimWorkerService)]
     [InlineData("Microsoft.ApplicationInsights.Web", "shf", SdkVersionType.ShimWeb)]
+    [InlineData("Microsoft.OpenTelemetry", "mot", SdkVersionType.MicrosoftOpenTelemetry)]
     internal void SetsSdkShimLabelForAllShimPackages(string distroName, string expectedLabel, SdkVersionType expectedType)
     {
         // SDK version is static, preserve to clean up later.


### PR DESCRIPTION
Add MicrosoftOpenTelemetry to SdkVersionType enum and map 'Microsoft.OpenTelemetry' telemetry.distro.name to the 'mot' extension label so ai.internal.sdkVersion emits e.g. dotnet8.0:otel1.15:mot1.0.0-beta.2
