### PR TITLE
[Core] Fix StackOverflowException in AwaitWithCancellation by scheduling cancellation continuations asynchronously

### DIFF
--- a/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs
+++ b/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs
@@ -286,20 +286,34 @@ namespace Azure.Core.Pipeline
 
         private class WithCancellationContinuationWrapper
         {
+            private static readonly WaitCallback s_invokeContinuation = static state => ((Action)state)();
+
             private Action _originalContinuation;
-            private readonly CancellationTokenRegistration _registration;
+            private CancellationTokenRegistration _registration;
 
             public WithCancellationContinuationWrapper(Action originalContinuation, CancellationToken cancellationToken)
             {
-                Action continuation = ContinuationImplementation;
                 _originalContinuation = originalContinuation;
-                _registration = cancellationToken.Register(continuation);
-                Continuation = continuation;
+                // Schedule the cancellation continuation on the thread pool to avoid StackOverflowException
+                // when CancellationTokenSource.Cancel() synchronously invokes callbacks.
+                _registration = cancellationToken.Register(static s => OnCancellation(s), this);
+                Continuation = TaskCompletionCallback;
             }
 
             public Action Continuation { get; }
 
-            private void ContinuationImplementation()
+            private static void OnCancellation(object state)
+            {
+                var wrapper = (WithCancellationContinuationWrapper)state;
+                Action originalContinuation = Interlocked.Exchange(ref wrapper._originalContinuation, null);
+                if (originalContinuation != null)
+                {
+                    wrapper._registration.Dispose();
+                    ThreadPool.UnsafeQueueUserWorkItem(s_invokeContinuation, originalContinuation);
+                }
+            }
+
+            private void TaskCompletionCallback()
             {
                 Action originalContinuation = Interlocked.Exchange(ref _originalContinuation, null);
                 if (originalContinuation != null)

--- a/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs
+++ b/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs
@@ -286,34 +286,22 @@ namespace Azure.Core.Pipeline
 
         private class WithCancellationContinuationWrapper
         {
-            private static readonly WaitCallback s_invokeContinuation = static state => ((Action)state)();
-
             private Action _originalContinuation;
-            private CancellationTokenRegistration _registration;
+            private readonly CancellationTokenRegistration _registration;
 
             public WithCancellationContinuationWrapper(Action originalContinuation, CancellationToken cancellationToken)
             {
+                Action continuation = ContinuationImplementation;
                 _originalContinuation = originalContinuation;
                 // Schedule the cancellation continuation on the thread pool to avoid StackOverflowException
                 // when CancellationTokenSource.Cancel() synchronously invokes callbacks.
-                _registration = cancellationToken.Register(static s => OnCancellation(s), this);
-                Continuation = TaskCompletionCallback;
+                _registration = cancellationToken.Register(() => Task.Run(continuation));
+                Continuation = continuation;
             }
 
             public Action Continuation { get; }
 
-            private static void OnCancellation(object state)
-            {
-                var wrapper = (WithCancellationContinuationWrapper)state;
-                Action originalContinuation = Interlocked.Exchange(ref wrapper._originalContinuation, null);
-                if (originalContinuation != null)
-                {
-                    wrapper._registration.Dispose();
-                    ThreadPool.UnsafeQueueUserWorkItem(s_invokeContinuation, originalContinuation);
-                }
-            }
-
-            private void TaskCompletionCallback()
+            private void ContinuationImplementation()
             {
                 Action originalContinuation = Interlocked.Exchange(ref _originalContinuation, null);
                 if (originalContinuation != null)

--- a/sdk/core/Azure.Core/tests/TaskExtensionsTest.cs
+++ b/sdk/core/Azure.Core/tests/TaskExtensionsTest.cs
@@ -65,21 +65,29 @@ namespace Azure.Core.Tests
             var tcs = new TaskCompletionSource<int>();
             var cts = new CancellationTokenSource();
             var awaiter = tcs.Task.AwaitWithCancellation(cts.Token).GetAwaiter();
+            using var continuationCalledEvent = new ManualResetEventSlim(false);
             var continuationCalled = 0;
 
             Assert.AreEqual(false, awaiter.IsCompleted);
-            awaiter.UnsafeOnCompleted(() => continuationCalled++);
+            awaiter.UnsafeOnCompleted(() =>
+            {
+                Interlocked.Increment(ref continuationCalled);
+                continuationCalledEvent.Set();
+            });
 
             Assert.AreEqual(false, awaiter.IsCompleted);
             Assert.AreEqual(0, continuationCalled);
             cts.Cancel();
 
-            Assert.AreEqual(1, continuationCalled);
+            // The continuation is now scheduled asynchronously on the thread pool
+            // to prevent StackOverflowException from deep synchronous call stacks.
+            Assert.IsTrue(continuationCalledEvent.Wait(TimeSpan.FromSeconds(5)), "Continuation was not called within timeout");
+            Assert.AreEqual(1, Volatile.Read(ref continuationCalled));
             Assert.AreEqual(true, awaiter.IsCompleted);
             Assert.Catch<OperationCanceledException>(() => awaiter.GetResult());
 
             tcs.SetResult(0);
-            Assert.AreEqual(1, continuationCalled);
+            Assert.AreEqual(1, Volatile.Read(ref continuationCalled));
         }
 
         [Test]
@@ -156,21 +164,29 @@ namespace Azure.Core.Tests
             var tcs = new TaskCompletionSource<int>();
             var cts = new CancellationTokenSource();
             var awaiter = new ValueTask<int>(tcs.Task).AwaitWithCancellation(cts.Token).GetAwaiter();
+            using var continuationCalledEvent = new ManualResetEventSlim(false);
             var continuationCalled = 0;
 
             Assert.AreEqual(false, awaiter.IsCompleted);
-            awaiter.UnsafeOnCompleted(() => continuationCalled++);
+            awaiter.UnsafeOnCompleted(() =>
+            {
+                Interlocked.Increment(ref continuationCalled);
+                continuationCalledEvent.Set();
+            });
 
             Assert.AreEqual(false, awaiter.IsCompleted);
             Assert.AreEqual(0, continuationCalled);
             cts.Cancel();
 
-            Assert.AreEqual(1, continuationCalled);
+            // The continuation is now scheduled asynchronously on the thread pool
+            // to prevent StackOverflowException from deep synchronous call stacks.
+            Assert.IsTrue(continuationCalledEvent.Wait(TimeSpan.FromSeconds(5)), "Continuation was not called within timeout");
+            Assert.AreEqual(1, Volatile.Read(ref continuationCalled));
             Assert.AreEqual(true, awaiter.IsCompleted);
             Assert.Catch<OperationCanceledException>(() => awaiter.GetResult());
 
             tcs.SetResult(0);
-            Assert.AreEqual(1, continuationCalled);
+            Assert.AreEqual(1, Volatile.Read(ref continuationCalled));
         }
 
         [Test]
@@ -191,6 +207,104 @@ namespace Azure.Core.Tests
             Assert.AreEqual(true, continuationCalled);
             Assert.AreEqual(true, awaiter.IsCompleted);
             Assert.Catch<OperationCanceledException>(() => awaiter.GetResult(), "Error");
+        }
+
+        [Test]
+        public void TaskExtensions_CancellationDoesNotRunContinuationSynchronouslyOnCallerStack()
+        {
+            // Regression test for https://github.com/Azure/azure-sdk-for-net/issues/57412
+            // Verifies that cancelling a token does not run AwaitWithCancellation continuations
+            // synchronously on the CancellationTokenSource.Cancel() caller's stack, which would
+            // cause StackOverflowException on constrained-stack environments.
+            var tcs = new TaskCompletionSource<int>();
+            var cts = new CancellationTokenSource();
+            var awaiter = tcs.Task.AwaitWithCancellation(cts.Token).GetAwaiter();
+
+            int cancelThreadId = -1;
+            int continuationThreadId = -1;
+            using var continuationRanEvent = new ManualResetEventSlim(false);
+            using var cancelCompletedEvent = new ManualResetEventSlim(false);
+
+            awaiter.UnsafeOnCompleted(() =>
+            {
+                continuationThreadId = Environment.CurrentManagedThreadId;
+                continuationRanEvent.Set();
+            });
+
+            var cancelThread = new Thread(() =>
+            {
+                cancelThreadId = Environment.CurrentManagedThreadId;
+                cts.Cancel();
+                cancelCompletedEvent.Set();
+            });
+
+            // Cancel on a dedicated thread; continuation should not run synchronously on that stack.
+            cancelThread.Start();
+            Assert.IsTrue(cancelCompletedEvent.Wait(TimeSpan.FromSeconds(5)), "Cancellation did not complete within timeout");
+            cancelThread.Join();
+
+            Assert.IsTrue(continuationRanEvent.Wait(TimeSpan.FromSeconds(5)), "Continuation was not called within timeout");
+
+            // The continuation must have run on a different thread than the Cancel() caller's thread.
+            Assert.AreNotEqual(cancelThreadId, continuationThreadId,
+                "Continuation ran synchronously on the Cancel() caller's thread; this can cause StackOverflowException on constrained stacks");
+        }
+
+        [Test]
+        public void TaskExtensions_CancellationContinuationProducesOperationCanceledException()
+        {
+            // End-to-end test: an async method awaiting AwaitWithCancellation should throw
+            // OperationCanceledException when the token is cancelled, even with async scheduling.
+            var tcs = new TaskCompletionSource<int>();
+            var cts = new CancellationTokenSource();
+
+            async Task<int> AwaitWithCancellationAsync()
+            {
+                return await tcs.Task.AwaitWithCancellation(cts.Token);
+            }
+
+            var task = AwaitWithCancellationAsync();
+            Assert.IsFalse(task.IsCompleted);
+
+            cts.Cancel();
+
+            Assert.CatchAsync<OperationCanceledException>(async () => await task);
+        }
+
+        [Test]
+        public void TaskExtensions_NonGenericTask_CancellationDoesNotRunContinuationSynchronously()
+        {
+            // Same test as above but for the non-generic Task overload.
+            var tcs = new TaskCompletionSource<bool>();
+            var cts = new CancellationTokenSource();
+            Task nonGenericTask = tcs.Task;
+            var awaiter = nonGenericTask.AwaitWithCancellation(cts.Token).GetAwaiter();
+
+            int cancelThreadId = -1;
+            int continuationThreadId = -1;
+            using var continuationRanEvent = new ManualResetEventSlim(false);
+            using var cancelCompletedEvent = new ManualResetEventSlim(false);
+
+            awaiter.UnsafeOnCompleted(() =>
+            {
+                continuationThreadId = Environment.CurrentManagedThreadId;
+                continuationRanEvent.Set();
+            });
+
+            var cancelThread = new Thread(() =>
+            {
+                cancelThreadId = Environment.CurrentManagedThreadId;
+                cts.Cancel();
+                cancelCompletedEvent.Set();
+            });
+
+            cancelThread.Start();
+            Assert.IsTrue(cancelCompletedEvent.Wait(TimeSpan.FromSeconds(5)), "Cancellation did not complete within timeout");
+            cancelThread.Join();
+
+            Assert.IsTrue(continuationRanEvent.Wait(TimeSpan.FromSeconds(5)), "Continuation was not called within timeout");
+            Assert.AreNotEqual(cancelThreadId, continuationThreadId,
+                "Continuation ran synchronously on the Cancel() caller's thread");
         }
     }
 }

--- a/sdk/core/Azure.Core/tests/TaskExtensionsTest.cs
+++ b/sdk/core/Azure.Core/tests/TaskExtensionsTest.cs
@@ -236,18 +236,27 @@ namespace Azure.Core.Tests
                 cancelThreadId = Environment.CurrentManagedThreadId;
                 cts.Cancel();
                 cancelCompletedEvent.Set();
-            });
+            })
+            {
+                IsBackground = true
+            };
 
-            // Cancel on a dedicated thread; continuation should not run synchronously on that stack.
-            cancelThread.Start();
-            Assert.IsTrue(cancelCompletedEvent.Wait(TimeSpan.FromSeconds(5)), "Cancellation did not complete within timeout");
-            cancelThread.Join();
+            try
+            {
+                // Cancel on a dedicated thread; continuation should not run synchronously on that stack.
+                cancelThread.Start();
+                Assert.IsTrue(cancelCompletedEvent.Wait(TimeSpan.FromSeconds(5)), "Cancellation did not complete within timeout");
 
-            Assert.IsTrue(continuationRanEvent.Wait(TimeSpan.FromSeconds(5)), "Continuation was not called within timeout");
+                Assert.IsTrue(continuationRanEvent.Wait(TimeSpan.FromSeconds(5)), "Continuation was not called within timeout");
 
-            // The continuation must have run on a different thread than the Cancel() caller's thread.
-            Assert.AreNotEqual(cancelThreadId, continuationThreadId,
-                "Continuation ran synchronously on the Cancel() caller's thread; this can cause StackOverflowException on constrained stacks");
+                // The continuation must have run on a different thread than the Cancel() caller's thread.
+                Assert.AreNotEqual(cancelThreadId, continuationThreadId,
+                    "Continuation ran synchronously on the Cancel() caller's thread; this can cause StackOverflowException on constrained stacks");
+            }
+            finally
+            {
+                cancelThread.Join(TimeSpan.FromSeconds(5));
+            }
         }
 
         [Test]
@@ -296,15 +305,24 @@ namespace Azure.Core.Tests
                 cancelThreadId = Environment.CurrentManagedThreadId;
                 cts.Cancel();
                 cancelCompletedEvent.Set();
-            });
+            })
+            {
+                IsBackground = true
+            };
 
-            cancelThread.Start();
-            Assert.IsTrue(cancelCompletedEvent.Wait(TimeSpan.FromSeconds(5)), "Cancellation did not complete within timeout");
-            cancelThread.Join();
+            try
+            {
+                cancelThread.Start();
+                Assert.IsTrue(cancelCompletedEvent.Wait(TimeSpan.FromSeconds(5)), "Cancellation did not complete within timeout");
 
-            Assert.IsTrue(continuationRanEvent.Wait(TimeSpan.FromSeconds(5)), "Continuation was not called within timeout");
-            Assert.AreNotEqual(cancelThreadId, continuationThreadId,
-                "Continuation ran synchronously on the Cancel() caller's thread");
+                Assert.IsTrue(continuationRanEvent.Wait(TimeSpan.FromSeconds(5)), "Continuation was not called within timeout");
+                Assert.AreNotEqual(cancelThreadId, continuationThreadId,
+                    "Continuation ran synchronously on the Cancel() caller's thread");
+            }
+            finally
+            {
+                cancelThread.Join(TimeSpan.FromSeconds(5));
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/57412

This bug was found with Azure Identity, but the root cause is in Azure.Core's shared `TaskExtensions`. The cancellation callback registered via `CancellationToken.Register` invokes the async continuation synchronously on the `Cancel()` caller's stack, which can exhaust constrained stacks.

---

✨ AI summary:

This pull request updates the `AwaitWithCancellation` implementation to ensure that cancellation continuations are always scheduled asynchronously on the thread pool, preventing potential `StackOverflowException` issues when cancellation tokens are triggered synchronously. It also expands and improves the test coverage to verify this behavior for both `Task` and `ValueTask` scenarios, including regression and end-to-end tests.

**Improvements to cancellation continuation scheduling:**

* Refactored `WithCancellationContinuationWrapper` in `TaskExtensions.cs` to ensure that cancellation continuations are always queued to the thread pool instead of running synchronously, addressing the risk of `StackOverflowException` when `CancellationTokenSource.Cancel()` is called in deep call stacks.

**Enhancements to test coverage:**

* Updated existing tests in `TaskExtensionsTest.cs` to account for the new asynchronous scheduling of continuations, using `ManualResetEventSlim` to wait for continuations and verifying correct execution. [[1]](diffhunk://#diff-7de2f2dda735ddf01a6bf18ea58a43ba0bf738b9be107b18090a48db6aeb9080R68-R90) [[2]](diffhunk://#diff-7de2f2dda735ddf01a6bf18ea58a43ba0bf738b9be107b18090a48db6aeb9080R167-R189)
* Added regression tests to ensure continuations do not run synchronously on the caller's stack during cancellation, verifying thread separation and robustness against stack overflows.
* Added end-to-end tests to confirm that `OperationCanceledException` is thrown as expected when cancellation occurs, and that non-generic `Task` overloads also behave correctly with asynchronous continuation scheduling.