### PR TITLE
Use 10-page PDF in CU .NET sample-run for multi-page ContentRange snippets

### DIFF
--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/.github/skills/cu-sdk-sample-run/scripts/run_sample.ps1
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/.github/skills/cu-sdk-sample-run/scripts/run_sample.ps1
@@ -667,7 +667,7 @@ $fullProgram = $programHeader + $codeBody
 # Replace placeholders
 $fullProgram = $fullProgram -replace '"<endpoint>"', '_endpoint'
 $fullProgram = $fullProgram -replace '"<apiKey>"', '_apiKey'
-$fullProgram = $fullProgram -replace '"<document_url>"', '"https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/invoice.pdf"'
+$fullProgram = $fullProgram -replace '"<document_url>"', '"https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/mixed_financial_invoices.pdf"'
 
 # Sample00: Replace model deployment name placeholders
 $fullProgram = $fullProgram -replace '<your-gpt-4.1-deployment-name>', $gpt41Deployment
@@ -718,10 +718,11 @@ if (-not [string]::IsNullOrEmpty($FilePath)) {
 # If sample needs a local file but none provided, download test file
 if ($fullProgram -match '<localDocumentFilePath>|<filePath>|<file_path>') {
     if ([string]::IsNullOrEmpty($FilePath)) {
-        Write-ColorOutput "Warning: Sample requires a local file. Downloading a test PDF..." "Yellow"
+        # Use a 10-page PDF so multi-page ContentRange snippets (e.g. PagesFrom(9)) work.
+        Write-ColorOutput "Warning: Sample requires a local file. Downloading a 10-page test PDF..." "Yellow"
         $testFile = Join-Path $runnerDir "test_document.pdf"
         try {
-            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/invoice.pdf" -OutFile $testFile -UseBasicParsing
+            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/mixed_financial_invoices.pdf" -OutFile $testFile -UseBasicParsing
         } catch {
             Write-ColorOutput "Warning: Could not download test file: $_" "Yellow"
         }

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/.github/skills/cu-sdk-sample-run/scripts/run_sample.sh
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/.github/skills/cu-sdk-sample-run/scripts/run_sample.sh
@@ -649,7 +649,7 @@ fi
 # These are already handled by the config loading, but some snippets have them inline
 sed -i 's|"<endpoint>"|_endpoint|g' "$RUNNER_DIR/Program.cs"
 sed -i 's|"<apiKey>"|_apiKey|g' "$RUNNER_DIR/Program.cs"
-sed -i 's|"<document_url>"|"https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/invoice.pdf"|g' "$RUNNER_DIR/Program.cs"
+sed -i 's|"<document_url>"|"https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/mixed_financial_invoices.pdf"|g' "$RUNNER_DIR/Program.cs"
 
 # Sample00: Replace model deployment name placeholders
 sed -i "s|<your-gpt-4.1-deployment-name>|$GPT41_DEPLOYMENT|g" "$RUNNER_DIR/Program.cs"
@@ -688,9 +688,10 @@ fi
 # For samples that need a local file but none provided, download a test file
 if grep -q '<localDocumentFilePath>\|<filePath>\|<file_path>' "$RUNNER_DIR/Program.cs" 2>/dev/null; then
     if [ -z "$LOCAL_FILE" ]; then
-        print_warning "⚠ Sample requires a local file. Downloading a test PDF..."
+        # Use a 10-page PDF so multi-page ContentRange snippets (e.g. PagesFrom(9)) work.
+        print_warning "⚠ Sample requires a local file. Downloading a 10-page test PDF..."
         TEST_FILE="$RUNNER_DIR/test_document.pdf"
-        curl -sL "https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/invoice.pdf" -o "$TEST_FILE"
+        curl -sL "https://raw.githubusercontent.com/Azure-Samples/azure-ai-content-understanding-assets/main/document/mixed_financial_invoices.pdf" -o "$TEST_FILE"
         ESCAPED_TEST=$(echo "$TEST_FILE" | sed 's/\\/\\\\/g')
         sed -i "s|<localDocumentFilePath>|$ESCAPED_TEST|g" "$RUNNER_DIR/Program.cs"
         sed -i "s|<filePath>|$ESCAPED_TEST|g" "$RUNNER_DIR/Program.cs"


### PR DESCRIPTION
## What

Updates the .NET `cu-sdk-sample-run` skill helpers (`run_sample.ps1` and `run_sample.sh`) to download/use the 10-page `mixed_financial_invoices.pdf` instead of the 1-2 page `invoice.pdf`.

## Why

`Sample01_AnalyzeBinary` exercises `ContentRange.PagesFrom(9)` (and similar multi-page snippets). The previously downloaded `invoice.pdf` only had 1-2 pages, causing `InvalidRequest` errors when the snippet asked for page 9+. Other languages (Java/Python/JS) already use `mixed_financial_invoices.pdf` for multi-page scenarios; this aligns .NET with them.

## Files changed

- `sdk/contentunderstanding/Azure.AI.ContentUnderstanding/.github/skills/cu-sdk-sample-run/scripts/run_sample.ps1`
- `sdk/contentunderstanding/Azure.AI.ContentUnderstanding/.github/skills/cu-sdk-sample-run/scripts/run_sample.sh`

## Verified

- `Sample01_AnalyzeBinary` now runs end-to-end without `-FilePath` override.
- `Sample02_AnalyzeUrl` still passes.