### PR TITLE
Generate serialization ctor for flattened models

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -708,6 +708,7 @@ namespace Azure.Generator.Management.Visitors
                 model.Update(properties: [.. model.Properties, .. flattenedProperties]);
                 _flattenedModelTypes.Add(model.Type, propertyNameMap);
                 UpdatePublicConstructor(model, propertyNameMap);
+                EnsureParameterlessSerializationConstructor(model);
             }
             else if (model.BaseModelProvider is ModelProvider flattenedBase && _flattenedModelTypes.TryGetValue(flattenedBase.Type, out var basePropertyNameMap))
             {
@@ -716,6 +717,25 @@ namespace Azure.Generator.Management.Visitors
                 // ExportDeliveryInfo param became ExportDeliveryDestination), so update this
                 // model's public constructor params and base initializer call to match.
                 UpdatePublicConstructor(model, basePropertyNameMap);
+            }
+        }
+
+        private static void EnsureParameterlessSerializationConstructor(ModelProvider model)
+        {
+            var hasParameterlessConstructor = model.Constructors.Any(c => !c.Signature.Parameters.Any())
+                || model.SerializationProviders.SelectMany(p => p.Constructors).Any(c => !c.Signature.Parameters.Any());
+            if (hasParameterlessConstructor)
+            {
+                return;
+            }
+
+            foreach (var serializationType in model.SerializationProviders)
+            {
+                var constructor = new ConstructorProvider(
+                    new ConstructorSignature(model.Type, $"Initializes a new instance of {model.Name} for deserialization.", MethodSignatureModifiers.Internal, []),
+                    new MethodBodyStatement[] { MethodBodyStatement.Empty },
+                    serializationType);
+                serializationType.Update(constructors: [.. serializationType.Constructors, constructor]);
             }
         }
 

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -700,6 +700,50 @@ namespace Azure.Generator.Mgmt.Tests
                 $"Base initializer should pass the flattened 'wrapperValue'. Args: [{string.Join(", ", initializerArgNames)}]");
         }
 
+        [Test]
+        public void TestSafeFlattenAddsSerializationConstructorWhenNoParameterlessCtorExists()
+        {
+            // Mirrors PostgreSQL BackupRequestBase: the base model has a required single-property
+            // wrapper that is safe-flattened, and derived serialization constructors need base().
+            var settingsName = InputFactory.Property("name", InputPrimitiveType.String, isRequired: true, serializedName: "name");
+            var settingsModel = InputFactory.Model(
+                "SettingsModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties: [settingsName]);
+
+            var settingsProperty = InputFactory.Property("settings", settingsModel, isRequired: true, serializedName: "settings");
+            var baseModel = InputFactory.Model(
+                "BaseContent",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                properties: [settingsProperty]);
+
+            var derivedModel = InputFactory.Model(
+                "DerivedContent",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Json,
+                baseModel: baseModel,
+                properties: []);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [settingsModel, baseModel, derivedModel]);
+
+            var baseModelProvider = plugin.Object.TypeFactory.CreateModel(baseModel)!;
+            Assert.That(baseModelProvider.Constructors.Any(c => !c.Signature.Parameters.Any()), Is.False);
+
+            var visitor = new FlattenPropertyVisitor();
+            var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                "VisitTypeCore",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(visitTypeCore, Is.Not.Null);
+
+            visitTypeCore!.Invoke(visitor, [baseModelProvider]);
+
+            var parameterlessSerializationCtor = baseModelProvider.SerializationProviders
+                .SelectMany(p => p.Constructors)
+                .SingleOrDefault(c => !c.Signature.Parameters.Any());
+            Assert.That(parameterlessSerializationCtor, Is.Not.Null);
+            Assert.That(parameterlessSerializationCtor!.Signature.Modifiers.HasFlag(MethodSignatureModifiers.Internal), Is.True);
+        }
+
         /// <summary>
         /// Verifies that <see cref="FlattenPropertyVisitor.FilterAttributesForFlatten"/> drops any
         /// WirePath attribute attached to the inner property while preserving other attributes.


### PR DESCRIPTION
## Summary
- generate an internal parameterless serialization constructor for flattened models that otherwise have no parameterless constructor
- add a regression test covering a PostgreSQL-style inherited model whose base safe-flattens a required wrapper property

## Validation
- `dotnet test eng\\packages\\http-client-csharp-mgmt\\generator\\Azure.Generator.Management\\test\\Azure.Generator.Mgmt.Tests.csproj --filter TestSafeFlattenAddsSerializationConstructorWhenNoParameterlessCtorExists --verbosity:minimal`
- `pwsh eng\\packages\\http-client-csharp-mgmt\\eng\\scripts\\Generate.ps1`