### PR TITLE
skill(mgmt-pr-review): add VM->Vm casing rule to ACRONYM001 scanner

### DIFF
--- a/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
+++ b/.github/skills/azure-sdk-mgmt-pr-review/Check-MgmtNamingRules.ps1
@@ -157,8 +157,8 @@ for ($i = 0; $i -lt $totalLines; $i++) {
         continue
     }
 
-    # Match type declarations: public partial class Foo : Bar, IBaz
-    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?<kind>class|struct|enum|interface)\s+(?<name>\w+)(?:<[^>]+>)?\s*(?::\s*(?<bases>.+?))?\s*$') {
+    # Match type declarations: public [readonly] [partial|abstract|static|sealed]* class/struct/enum Foo : Bar
+    if ($line -match '^\s*public\s+(?:readonly\s+)?(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?<kind>class|struct|enum|interface)\s+(?<name>\w+)(?:<[^>]+>)?\s*(?::\s*(?<bases>.+?))?\s*$') {
         $shortName = $Matches['name']
         $kind = $Matches['kind']
         $bases = if ($Matches['bases']) { $Matches['bases'].Trim() } else { '' }
@@ -447,10 +447,10 @@ $acronymPatterns = @(
     @{ AllCaps = 'SSH';   PascalCase = 'Ssh';   Id = 'ACRONYM001' }
     @{ AllCaps = 'SQL';   PascalCase = 'Sql';   Id = 'ACRONYM001' }
     @{ AllCaps = 'AAD';   PascalCase = 'Aad';   Id = 'ACRONYM001' }
+    # VM is a 2-letter acronym with a mandatory exception: always use Vm (never VM) in type/member names.
+    # This differs from IO/OS which stay uppercase when standalone; Vm follows the Id pattern.
+    @{ AllCaps = 'VM';    PascalCase = 'Vm';    Id = 'ACRONYM001' }
 )
-
-# NOTE: Potential future enhancement: consider enforcing "ID" -> "Id" and "VM" -> "Vm"
-#       with appropriate exceptions (e.g., when standalone or after a lowercase letter).
 
 foreach ($typeName in $typeInfos.Keys) {
     $info = $typeInfos[$typeName]
@@ -482,7 +482,7 @@ $currentTypeName = ''
 for ($i = 0; $i -lt $totalLines; $i++) {
     $line = $lines[$i]
 
-    if ($line -match '^\s*public\s+(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?:class|struct|enum)\s+(\w+)') {
+    if ($line -match '^\s*public\s+(?:readonly\s+)?(?:partial\s+|abstract\s+|static\s+|sealed\s+)*(?:class|struct|enum)\s+(\w+)') {
         $currentTypeName = $Matches[1]
         continue
     }

--- a/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
+++ b/.github/skills/azure-sdk-mgmt-pr-review/SKILL.md
@@ -66,7 +66,7 @@ To determine the review scope:
    The scanner currently emits these rule families (see "API Review Checklist" for details):
    - `SUFFIX001`–`SUFFIX010` – forbidden type-name suffixes (Parameters, Request, Options, Response, Data, Definition, Operation, Collection, **Update**, …)
    - `RESINFIX001` – `Resource` infix in `*Data`/`*Collection` model names (with PrivateLinkResource exception)
-   - `ACRONYM001` – curated acronyms in wrong casing (HTTP/TCP/SSL/TLS/…)
+   - `ACRONYM001` – curated acronyms in wrong casing (HTTP/TCP/SSL/TLS/VM/…); includes `VM` → `Vm` which must always use mixed case in type and member names
    - `ACRONYM002` – generic 3+ letter all-caps run inside a name (NNI, IPV, BFD, …)
    - `ARMCOMMON001` – type duplicates an Azure.ResourceManager/Azure.Core common type (`OperationStatusResult`, `ManagedServiceIdentity*`, `TagsUpdate`, `ErrorResponse`, …)
    - `BOOL001` / `DATETIME001` / `TTL001` – property naming


### PR DESCRIPTION
## Summary

Updates the `azure-sdk-mgmt-pr-review` skill scanner to enforce the `VM`  `Vm` naming rule, and fixes a pre-existing bug where `readonly partial struct` types were silently skipped.

### Changes

**`Check-MgmtNamingRules.ps1`**
- Added `VM`  `Vm` to the `$acronymPatterns` list (ACRONYM001). `Vm` is the established .NET Azure SDK exception for this two-letter acronym  it must always use mixed case in type and member names, unlike standalone acronyms like `IO`.
- Fixed the type-declaration regex in **both** the first-pass type-info collector and the member-scan loop: added `readonly\s+` to the modifiers alternation so that `readonly partial struct` declarations are parsed correctly. Without this fix, all `readonly struct` types (common for SDK value-types like enums and lightweight structs) were silently excluded from ACRONYM001 checks.
- Removed the `# NOTE: Potential future enhancement` comment for `VM`  `Vm` since it is now implemented.

**`SKILL.md`**
- Updated the ACRONYM001 rule description to explicitly mention `VM` → `Vm`.

### Motivation

Discovered while reviewing PR #58666 (`Azure.ResourceManager.ComputeSchedule`), where 9 new types violated the `Vm` casing rule and were not caught by the automated scanner:

| Incorrect name | Correct name |
|---|---|
| `BulkVMConfiguration` | `BulkVmConfiguration` |
| `VMDiskSecurityProfile` | `VmDiskSecurityProfile` |
| `VMGalleryApplication` | `VmGalleryApplication` |
| `LinuxVMGuestPatchAutomaticByPlatformRebootSetting` | `LinuxVmGuestPatch...` |
| `LinuxVMGuestPatchAutomaticByPlatformSettings` | `LinuxVmGuestPatch...` |
| `LinuxVMGuestPatchMode` | `LinuxVmGuestPatchMode` |
| `WindowsVMGuestPatchAutomaticByPlatformRebootSetting` | `WindowsVmGuestPatch...` |
| `WindowsVMGuestPatchAutomaticByPlatformSettings` | `WindowsVmGuestPatch...` |
| `WindowsVMGuestPatchMode` | `WindowsVmGuestPatchMode` |

The `readonly struct` bug also meant 4 additional member-level violations (`DiskWithVMGuestState`, `VMGuestStateOnly`, `ConfidentialVM`, `InVMAccessControlProfileReferenceId`) were missed.