### PR TITLE
Add CLI mode to Azure.GeneratorAgent for CI

### DIFF
--- a/sdk/tools/Azure.GeneratorAgent/CHANGELOG.md
+++ b/sdk/tools/Azure.GeneratorAgent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Initial release of Azure.GeneratorAgent, an MCP (Model Context Protocol) server that exposes deterministic fix tools for automating Azure SDK code generation and migration workflows
 - MCP server mode (`McpServerHost.RunAsync`) serving tools over stdio transport with auto-discovery from the assembly at startup
+- CLI mode for non-interactive (CI) use: `generate-and-fix` subcommand runs code generation, then iteratively fixes deterministic build errors in customization code only (never in `Generated/`), with a snapshot/verify safety net. Distinct exit codes (0/1/2/3/4) make CI failure modes unambiguous.
 - `DeterministicFixRegistry` with 27 error-pattern-to-tool rules covering field renames, type pattern replacements, missing using directives, obsolete using removal, nullable annotations, and method call replacements
 - 19 individual MCP tool classes including regex replacements, nullable annotation fixes, code generation, build output parsing, error classification, test execution, commit iteration, project discovery, generated code snapshots, `[CodeGenSuppress]` attribute insertion, and finalization
 - `TestResult` structured return type for the `run_tests` tool with properties for `Success`, `ExitCode`, `Passed`, `Failed`, `Skipped`, `Total`, `Failures`, `Error`, and `RawOutput`

--- a/sdk/tools/Azure.GeneratorAgent/README.md
+++ b/sdk/tools/Azure.GeneratorAgent/README.md
@@ -26,6 +26,54 @@ Start the MCP server over stdio transport:
 dotnet run --project src/Azure.GeneratorAgent.csproj
 ```
 
+### Run as a CLI (for CI)
+
+For non-interactive use (e.g., CI pipelines that can't host an LLM), the binary
+also exposes a CLI subcommand that wraps the same deterministic fix tools.
+
+```bash
+dotnet run --project src/Azure.GeneratorAgent.csproj -- generate-and-fix \
+  --project <abs-path-to-sdk-project> \
+  [--specs-path <abs-path-to-local-specs>] \
+  [--max-iterations 10] \
+  [--skip-generation]
+```
+
+Workflow:
+
+1. Run `dotnet build /t:generateCode`.
+2. Snapshot the contents of `Generated/`.
+3. Loop (capped by `--max-iterations`, default 10):
+   build → classify errors → apply deterministic fixes (in customization code only) → rebuild,
+   exiting as soon as the build is clean.
+4. Verify `Generated/` is unchanged; auto-revert any modifications via `git checkout`.
+
+Output contract:
+
+- Progress lines go to **stderr**.
+- A JSON summary (iterations, fixes per tool, remaining errors, generated violations) goes to **stdout** at the end.
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | Build is clean and `Generated/` is unchanged. |
+| `1` | Build still has errors after the fix loop, or non-deterministic errors remain. |
+| `2` | Code generation failed. |
+| `3` | Files in `Generated/` were modified during the fix loop and could not be reverted. |
+| `4` | Invalid arguments / usage error. |
+
+Example pipeline step:
+
+```yaml
+- pwsh: |
+    dotnet run --project sdk/tools/Azure.GeneratorAgent/src/Azure.GeneratorAgent.csproj -- `
+      generate-and-fix --project $(Build.SourcesDirectory)/sdk/<service>/<library>
+  displayName: Regenerate and auto-fix SDK
+```
+
+Run `dotnet run --project src/Azure.GeneratorAgent.csproj -- --help` for the full option list.
+
 #### Register in VS Code (GitHub Copilot)
 
 Add the server to your VS Code `settings.json` under `mcp.servers`:

--- a/sdk/tools/Azure.GeneratorAgent/src/Cli/CliRunner.cs
+++ b/sdk/tools/Azure.GeneratorAgent/src/Cli/CliRunner.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace Azure.GeneratorAgent.Cli;
+
+/// <summary>
+/// Front-end for the <c>generate-and-fix</c> CLI subcommand.
+/// Parses arguments, runs <see cref="GenerateAndFixOrchestrator"/>, prints a JSON
+/// summary to <paramref name="stdout"/>, progress to <paramref name="stderr"/>, and
+/// returns an exit code mapped from <see cref="GenerateAndFixExitReason"/>.
+/// </summary>
+public static class CliRunner
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+    };
+
+    /// <summary>
+    /// Entry point for CLI mode. <paramref name="args"/> is the full argv (i.e., the
+    /// subcommand is at index 0).
+    /// </summary>
+    public static async Task<int> RunAsync(
+        string[] args,
+        TextWriter stdout,
+        TextWriter stderr,
+        IOrchestratorSteps? steps = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (args.Length == 0)
+        {
+            PrintUsage(stderr);
+            return (int)GenerateAndFixExitReason.UsageError;
+        }
+
+        switch (args[0])
+        {
+            case "-h":
+            case "--help":
+            case "help":
+                PrintUsage(stdout);
+                return 0;
+
+            case "generate-and-fix":
+                return await RunGenerateAndFixAsync(args, stdout, stderr, steps, cancellationToken).ConfigureAwait(false);
+
+            default:
+                stderr.WriteLine($"Unknown command: {args[0]}");
+                PrintUsage(stderr);
+                return (int)GenerateAndFixExitReason.UsageError;
+        }
+    }
+
+    private static async Task<int> RunGenerateAndFixAsync(
+        string[] args,
+        TextWriter stdout,
+        TextWriter stderr,
+        IOrchestratorSteps? steps,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseGenerateAndFixOptions(args, stderr, out var options))
+        {
+            return (int)GenerateAndFixExitReason.UsageError;
+        }
+
+        var orchestrator = new GenerateAndFixOrchestrator(steps, msg => stderr.WriteLine(msg));
+
+        GenerateAndFixResult result;
+        try
+        {
+            result = await orchestrator.RunAsync(options, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            stderr.WriteLine("Cancelled.");
+            return (int)GenerateAndFixExitReason.BuildFailed;
+        }
+        catch (Exception ex)
+        {
+            stderr.WriteLine($"Unhandled error: {ex}");
+            return (int)GenerateAndFixExitReason.BuildFailed;
+        }
+
+        stdout.WriteLine(JsonSerializer.Serialize(result, s_jsonOptions));
+        return (int)result.Reason;
+    }
+
+    /// <summary>
+    /// Parses <c>--project</c>, <c>--specs-path</c>, <c>--max-iterations</c>, <c>--skip-generation</c>
+    /// from <paramref name="args"/> (skipping <c>args[0]</c>, the subcommand name).
+    /// </summary>
+    internal static bool TryParseGenerateAndFixOptions(string[] args, TextWriter stderr, out GenerateAndFixOptions options)
+    {
+        string? project = null;
+        string? specs = null;
+        var maxIterations = 10;
+        var skipGeneration = false;
+
+        for (var i = 1; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--project":
+                case "-p":
+                    if (++i >= args.Length)
+                    {
+                        stderr.WriteLine("--project requires a value.");
+                        options = new GenerateAndFixOptions();
+                        return false;
+                    }
+                    project = args[i];
+                    break;
+
+                case "--specs-path":
+                case "-s":
+                    if (++i >= args.Length)
+                    {
+                        stderr.WriteLine("--specs-path requires a value.");
+                        options = new GenerateAndFixOptions();
+                        return false;
+                    }
+                    specs = args[i];
+                    break;
+
+                case "--max-iterations":
+                    if (++i >= args.Length || !int.TryParse(args[i], out maxIterations) || maxIterations <= 0)
+                    {
+                        stderr.WriteLine("--max-iterations requires a positive integer.");
+                        options = new GenerateAndFixOptions();
+                        return false;
+                    }
+                    break;
+
+                case "--skip-generation":
+                    skipGeneration = true;
+                    break;
+
+                case "-h":
+                case "--help":
+                    PrintUsage(stderr);
+                    options = new GenerateAndFixOptions();
+                    return false;
+
+                default:
+                    stderr.WriteLine($"Unknown argument: {args[i]}");
+                    options = new GenerateAndFixOptions();
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(project))
+        {
+            stderr.WriteLine("--project is required.");
+            options = new GenerateAndFixOptions();
+            return false;
+        }
+
+        options = new GenerateAndFixOptions
+        {
+            ProjectPath = Path.GetFullPath(project),
+            LocalSpecsPath = string.IsNullOrWhiteSpace(specs) ? null : Path.GetFullPath(specs),
+            MaxIterations = maxIterations,
+            SkipGeneration = skipGeneration,
+        };
+        return true;
+    }
+
+    private static void PrintUsage(TextWriter writer)
+    {
+        writer.WriteLine("Azure.GeneratorAgent CLI");
+        writer.WriteLine();
+        writer.WriteLine("Usage:");
+        writer.WriteLine("  Azure.GeneratorAgent                       Run as MCP server over stdio (default).");
+        writer.WriteLine("  Azure.GeneratorAgent mcp                   Same as default.");
+        writer.WriteLine("  Azure.GeneratorAgent --mcp-server          Same as default.");
+        writer.WriteLine("  Azure.GeneratorAgent generate-and-fix      Regenerate the project, then deterministically");
+        writer.WriteLine("                                             fix build errors in custom (non-Generated/) code.");
+        writer.WriteLine();
+        writer.WriteLine("generate-and-fix options:");
+        writer.WriteLine("  --project, -p <path>     Absolute path to the SDK project directory. Required.");
+        writer.WriteLine("  --specs-path, -s <path>  Optional path to a local azure-rest-api-specs clone or spec dir.");
+        writer.WriteLine("  --max-iterations <N>     Max build → fix iterations. Default: 10.");
+        writer.WriteLine("  --skip-generation        Skip code generation; only run the build–fix loop.");
+        writer.WriteLine("  --help, -h               Show this help.");
+        writer.WriteLine();
+        writer.WriteLine("Output:");
+        writer.WriteLine("  Progress lines are written to stderr.");
+        writer.WriteLine("  A JSON summary is written to stdout when generate-and-fix completes.");
+        writer.WriteLine();
+        writer.WriteLine("Exit codes:");
+        writer.WriteLine("  0  Build is clean and Generated/ is unchanged.");
+        writer.WriteLine("  1  Build still has errors after the fix loop, or non-deterministic errors remain.");
+        writer.WriteLine("  2  Code generation failed.");
+        writer.WriteLine("  3  Files in Generated/ were modified during the fix loop and could not be reverted.");
+        writer.WriteLine("  4  Invalid arguments / usage error.");
+    }
+}

--- a/sdk/tools/Azure.GeneratorAgent/src/Cli/GenerateAndFixOptions.cs
+++ b/sdk/tools/Azure.GeneratorAgent/src/Cli/GenerateAndFixOptions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.GeneratorAgent.Cli;
+
+/// <summary>
+/// Inputs to the <see cref="GenerateAndFixOrchestrator"/>.
+/// </summary>
+public sealed class GenerateAndFixOptions
+{
+    /// <summary>
+    /// Absolute path to the SDK project directory (contains src/ and tsp-location.yaml).
+    /// </summary>
+    public string ProjectPath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional absolute path to a local azure-rest-api-specs clone or a specific spec directory.
+    /// When null, generation uses the configured tsp-location.yaml commit.
+    /// </summary>
+    public string? LocalSpecsPath { get; init; }
+
+    /// <summary>
+    /// Maximum number of build → fix iterations. Defaults to 10.
+    /// </summary>
+    public int MaxIterations { get; init; } = 10;
+
+    /// <summary>
+    /// When true, skip the code generation step and run only the build–fix loop.
+    /// Useful when CI wants to validate fixes against an already-generated tree.
+    /// </summary>
+    public bool SkipGeneration { get; init; }
+}

--- a/sdk/tools/Azure.GeneratorAgent/src/Cli/GenerateAndFixOrchestrator.cs
+++ b/sdk/tools/Azure.GeneratorAgent/src/Cli/GenerateAndFixOrchestrator.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.GeneratorAgent.Mcp;
+using Azure.GeneratorAgent.Mcp.Tools;
+
+namespace Azure.GeneratorAgent.Cli;
+
+/// <summary>
+/// End-to-end orchestrator for the <c>generate-and-fix</c> CI workflow.
+///
+/// Mirrors the dpg/mpg migration skill but without an LLM:
+///   1. Run code generation.
+///   2. Snapshot Generated/.
+///   3. Loop: build → classify → batch_fix (deterministic only, customization code only).
+///   4. Verify Generated/ is unchanged.
+///
+/// All "fixes only in custom code" enforcement happens here and in the underlying
+/// fix tools (which already call <c>GeneratedPathGuard.ValidateNotGenerated</c>).
+/// </summary>
+public sealed class GenerateAndFixOrchestrator
+{
+    private readonly IOrchestratorSteps _steps;
+    private readonly Action<string> _logProgress;
+
+    /// <summary>
+    /// Creates a new orchestrator.
+    /// </summary>
+    /// <param name="steps">Workflow step implementation. Defaults to <see cref="DefaultOrchestratorSteps"/>.</param>
+    /// <param name="logProgress">
+    /// Callback that receives human-readable progress lines. Tests can capture them; the
+    /// CLI front-end writes them to stderr.
+    /// </param>
+    public GenerateAndFixOrchestrator(IOrchestratorSteps? steps = null, Action<string>? logProgress = null)
+    {
+        _steps = steps ?? new DefaultOrchestratorSteps();
+        _logProgress = logProgress ?? (_ => { });
+    }
+
+    /// <summary>
+    /// Runs the workflow described in the class summary.
+    /// </summary>
+    public async Task<GenerateAndFixResult> RunAsync(GenerateAndFixOptions options, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(options.ProjectPath))
+        {
+            return Fail(GenerateAndFixExitReason.UsageError, "ProjectPath is required.");
+        }
+
+        if (options.MaxIterations <= 0)
+        {
+            return Fail(GenerateAndFixExitReason.UsageError, "MaxIterations must be a positive integer.");
+        }
+
+        var result = new GenerateAndFixResult();
+
+        // ── 1. Generate ────────────────────────────────────────────────
+        if (!options.SkipGeneration)
+        {
+            _logProgress($"[1/4] Running code generation for {options.ProjectPath}");
+            var (genSuccess, genOutput, genError) = await _steps
+                .RunCodeGenerationAsync(options.ProjectPath, options.LocalSpecsPath, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!genSuccess)
+            {
+                result.Success = false;
+                result.Reason = GenerateAndFixExitReason.GenerationFailed;
+                result.ExitReason = result.Reason.ToString();
+                result.Message = genError ?? "Code generation failed.";
+                _logProgress($"  ✗ Code generation failed: {result.Message}");
+                _logProgress(genOutput);
+                return result;
+            }
+            _logProgress("  ✓ Code generation succeeded");
+        }
+        else
+        {
+            _logProgress("[1/4] Skipping code generation (--skip-generation)");
+        }
+
+        // ── 2. Snapshot ────────────────────────────────────────────────
+        _logProgress("[2/4] Snapshotting Generated/ for tamper detection");
+        var snapshotCount = _steps.TakeGeneratedSnapshot(options.ProjectPath);
+        _logProgress($"  ✓ Snapshotted {snapshotCount} file(s)");
+
+        // ── 3. Build–fix loop ──────────────────────────────────────────
+        _logProgress($"[3/4] Build–fix loop (max {options.MaxIterations} iteration(s))");
+        for (var iteration = 1; iteration <= options.MaxIterations; iteration++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            result.Iterations = iteration;
+            _logProgress($"  Iteration {iteration}: building…");
+
+            var (buildResult, classified) = await _steps
+                .BuildAndClassifyAsync(options.ProjectPath, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (buildResult.Success)
+            {
+                _logProgress("  ✓ Build is clean — exiting fix loop");
+                break;
+            }
+
+            _logProgress($"    {buildResult.Errors.Count} error(s) reported");
+
+            // Filter to deterministic fixes that target customization code only.
+            var fixOps = new List<FixOperation>();
+            var skippedGenerated = 0;
+            foreach (var ce in classified)
+            {
+                if (!ce.IsDeterministic || ce.ToolName is null || ce.ToolArgs is null)
+                {
+                    continue;
+                }
+
+                if (TargetsGenerated(ce.ToolArgs))
+                {
+                    skippedGenerated++;
+                    continue;
+                }
+
+                fixOps.Add(new FixOperation
+                {
+                    ToolName = ce.ToolName,
+                    ToolArgs = new Dictionary<string, string>(ce.ToolArgs)
+                });
+            }
+
+            if (skippedGenerated > 0)
+            {
+                _logProgress($"    Skipped {skippedGenerated} fix(es) targeting Generated/ (must be fixed in custom code)");
+            }
+
+            if (fixOps.Count == 0)
+            {
+                result.RemainingErrors = classified;
+                return Fail(
+                    result,
+                    GenerateAndFixExitReason.BuildFailed,
+                    $"No deterministic fixes available for {classified.Count} error(s) after iteration {iteration}. " +
+                    "These errors require human intervention.");
+            }
+
+            _logProgress($"    Applying {fixOps.Count} deterministic fix(es)");
+            var fixResults = _steps.ApplyFixes(fixOps);
+
+            var appliedThisIteration = 0;
+            foreach (var fr in fixResults)
+            {
+                if (fr.Success)
+                {
+                    appliedThisIteration++;
+                    result.TotalFixesApplied++;
+                    result.FixesByTool[fr.Tool] = result.FixesByTool.GetValueOrDefault(fr.Tool) + 1;
+                }
+                else
+                {
+                    _logProgress($"      ✗ {fr.Tool}: {fr.Message}");
+                }
+            }
+
+            _logProgress($"    {appliedThisIteration}/{fixOps.Count} fix(es) succeeded this iteration");
+
+            if (appliedThisIteration == 0)
+            {
+                // No-progress guard: if every fix failed, the next iteration would
+                // produce the same errors. Bail out instead of looping uselessly.
+                result.RemainingErrors = classified;
+                return Fail(
+                    result,
+                    GenerateAndFixExitReason.BuildFailed,
+                    $"No fixes succeeded in iteration {iteration}; aborting to avoid an infinite loop.");
+            }
+        }
+
+        // If the loop fell through without a clean build, we hit the iteration cap.
+        if (result.Iterations == options.MaxIterations)
+        {
+            var (finalBuild, finalClassified) = await _steps
+                .BuildAndClassifyAsync(options.ProjectPath, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!finalBuild.Success)
+            {
+                result.RemainingErrors = finalClassified;
+                return Fail(
+                    result,
+                    GenerateAndFixExitReason.BuildFailed,
+                    $"Reached --max-iterations={options.MaxIterations} without a clean build.");
+            }
+        }
+
+        // ── 4. Verify Generated/ ───────────────────────────────────────
+        _logProgress("[4/4] Verifying Generated/ is unchanged");
+        var violations = _steps.VerifyGeneratedUnchanged(options.ProjectPath);
+        if (violations.Count > 0)
+        {
+            result.GeneratedViolations = violations;
+            return Fail(
+                result,
+                GenerateAndFixExitReason.GeneratedViolation,
+                $"{violations.Count} file(s) in Generated/ were modified during the fix loop and could not be reverted.");
+        }
+        _logProgress("  ✓ Generated/ is unchanged");
+
+        result.Success = true;
+        result.Reason = GenerateAndFixExitReason.Success;
+        result.ExitReason = result.Reason.ToString();
+        result.Message = $"Build clean after {result.Iterations} iteration(s); applied {result.TotalFixesApplied} fix(es).";
+        _logProgress("✓ " + result.Message);
+        return result;
+    }
+
+    /// <summary>
+    /// Returns true if any of the well-known "filePath" arguments would point inside Generated/.
+    /// </summary>
+    private static bool TargetsGenerated(IReadOnlyDictionary<string, string> toolArgs)
+    {
+        foreach (var key in s_pathArgKeys)
+        {
+            if (toolArgs.TryGetValue(key, out var path)
+                && !string.IsNullOrWhiteSpace(path)
+                && GeneratedPathGuard.IsInGeneratedDirectory(path))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Tool-args keys that may carry a file path the fixer will write to.
+    /// (Kept in sync with <see cref="BatchFixTool"/>'s switch.)
+    /// </summary>
+    private static readonly string[] s_pathArgKeys = { "filePath" };
+
+    private GenerateAndFixResult Fail(GenerateAndFixExitReason reason, string message)
+        => Fail(new GenerateAndFixResult(), reason, message);
+
+    private GenerateAndFixResult Fail(GenerateAndFixResult result, GenerateAndFixExitReason reason, string message)
+    {
+        result.Success = false;
+        result.Reason = reason;
+        result.ExitReason = reason.ToString();
+        result.Message = message;
+        _logProgress("✗ " + message);
+        return result;
+    }
+}

--- a/sdk/tools/Azure.GeneratorAgent/src/Cli/GenerateAndFixResult.cs
+++ b/sdk/tools/Azure.GeneratorAgent/src/Cli/GenerateAndFixResult.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+using Azure.GeneratorAgent.Mcp;
+
+namespace Azure.GeneratorAgent.Cli;
+
+/// <summary>
+/// Reason the orchestrator stopped. Drives the process exit code.
+/// </summary>
+public enum GenerateAndFixExitReason
+{
+    /// <summary>Build is clean and Generated/ is unchanged.</summary>
+    Success = 0,
+
+    /// <summary>Build still has errors after the fix loop, or non-deterministic errors remain.</summary>
+    BuildFailed = 1,
+
+    /// <summary>Code generation itself failed.</summary>
+    GenerationFailed = 2,
+
+    /// <summary>One or more files in Generated/ were modified during the fix loop.</summary>
+    GeneratedViolation = 3,
+
+    /// <summary>Invalid arguments / usage error. Set by the CLI front-end.</summary>
+    UsageError = 4,
+}
+
+/// <summary>
+/// Structured result of a <see cref="GenerateAndFixOrchestrator"/> run.
+/// Serialized to stdout as the final CI artifact.
+/// </summary>
+public sealed class GenerateAndFixResult
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("exitReason")]
+    public string ExitReason { get; set; } = nameof(GenerateAndFixExitReason.Success);
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonIgnore]
+    public GenerateAndFixExitReason Reason { get; set; }
+
+    [JsonPropertyName("iterations")]
+    public int Iterations { get; set; }
+
+    [JsonPropertyName("totalFixesApplied")]
+    public int TotalFixesApplied { get; set; }
+
+    [JsonPropertyName("fixesByTool")]
+    public Dictionary<string, int> FixesByTool { get; set; } = new();
+
+    /// <summary>
+    /// Errors that remain after the loop ended. Empty when <see cref="Success"/> is true.
+    /// </summary>
+    [JsonPropertyName("remainingErrors")]
+    public List<ClassifiedError> RemainingErrors { get; set; } = new();
+
+    /// <summary>
+    /// Files in <c>Generated/</c> that were modified during the loop.
+    /// Populated only when <see cref="Reason"/> is <see cref="GenerateAndFixExitReason.GeneratedViolation"/>.
+    /// </summary>
+    [JsonPropertyName("generatedViolations")]
+    public List<string> GeneratedViolations { get; set; } = new();
+
+    /// <summary>
+    /// Free-form human-readable summary message.
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+}

--- a/sdk/tools/Azure.GeneratorAgent/src/Cli/IOrchestratorSteps.cs
+++ b/sdk/tools/Azure.GeneratorAgent/src/Cli/IOrchestratorSteps.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.GeneratorAgent.Mcp;
+using Azure.GeneratorAgent.Mcp.Tools;
+
+namespace Azure.GeneratorAgent.Cli;
+
+/// <summary>
+/// Abstraction over the workflow steps the orchestrator depends on. Production code uses
+/// <see cref="DefaultOrchestratorSteps"/>, which delegates to the in-process MCP tools.
+/// Tests provide mocks to drive the orchestrator through specific scenarios without
+/// invoking dotnet build, git, or the file system.
+/// </summary>
+public interface IOrchestratorSteps
+{
+    /// <summary>
+    /// Runs <c>dotnet build /t:generateCode</c>.
+    /// </summary>
+    Task<(bool Success, string Output, string? Error)> RunCodeGenerationAsync(
+        string projectPath, string? localSpecsPath, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Snapshots the contents of the project's <c>Generated/</c> directory.
+    /// </summary>
+    int TakeGeneratedSnapshot(string projectPath);
+
+    /// <summary>
+    /// Runs <c>dotnet build</c> and classifies the resulting errors.
+    /// </summary>
+    Task<(BuildResult BuildResult, List<ClassifiedError> Classified)> BuildAndClassifyAsync(
+        string projectPath, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Applies a batch of deterministic fixes.
+    /// </summary>
+    List<FixResult> ApplyFixes(List<FixOperation> fixes);
+
+    /// <summary>
+    /// Verifies that no files in <c>Generated/</c> were modified since the snapshot.
+    /// Returns the list of relative paths that violate the contract (after auto-revert).
+    /// </summary>
+    List<string> VerifyGeneratedUnchanged(string projectPath);
+}
+
+/// <summary>
+/// Production implementation: delegates each step to the real MCP tool's in-process method.
+/// </summary>
+public sealed class DefaultOrchestratorSteps : IOrchestratorSteps
+{
+    public Task<(bool Success, string Output, string? Error)> RunCodeGenerationAsync(
+        string projectPath, string? localSpecsPath, CancellationToken cancellationToken)
+        => CodeGenerationTool.ExecuteInProcessAsync(projectPath, localSpecsPath, cancellationToken);
+
+    public int TakeGeneratedSnapshot(string projectPath)
+    {
+        var result = GeneratedSnapshotTool.TakeSnapshotInProcess(projectPath);
+        return result.FileCount;
+    }
+
+    public Task<(BuildResult BuildResult, List<ClassifiedError> Classified)> BuildAndClassifyAsync(
+        string projectPath, CancellationToken cancellationToken)
+        => BuildAndClassifyTool.ExecuteInProcessAsync(projectPath);
+
+    public List<FixResult> ApplyFixes(List<FixOperation> fixes)
+        => BatchFixTool.ExecuteInProcess(fixes);
+
+    public List<string> VerifyGeneratedUnchanged(string projectPath)
+    {
+        var result = GeneratedSnapshotTool.VerifyInProcess(projectPath, autoRevert: true);
+
+        // After auto-revert, anything still present (e.g., revert failed, or "Added" file
+        // that couldn't be deleted) is a real violation.
+        if (!result.HasViolations)
+        {
+            return new List<string>();
+        }
+
+        // Re-verify to filter out anything the auto-revert successfully cleaned up.
+        var post = GeneratedSnapshotTool.VerifyInProcess(projectPath, autoRevert: false);
+        return post.Violations.Select(v => v.RelativePath).ToList();
+    }
+}

--- a/sdk/tools/Azure.GeneratorAgent/src/Program.cs
+++ b/sdk/tools/Azure.GeneratorAgent/src/Program.cs
@@ -1,22 +1,48 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.GeneratorAgent.Cli;
 using Azure.GeneratorAgent.Mcp;
 
 namespace Azure.GeneratorAgent;
 
 /// <summary>
-/// Main program class for the Azure Generator Agent MCP server.
+/// Main program class for the Azure Generator Agent.
+///
+/// Default behavior (no args, <c>mcp</c>, or <c>--mcp-server</c>) runs the MCP server
+/// over stdio for use by VS Code / Claude Desktop. Any other first argument enters
+/// CLI mode (see <see cref="CliRunner"/>) for non-interactive use, e.g., from CI.
 /// </summary>
 public static class GeneratorAgentProgram
 {
     /// <summary>
-    /// Application entry point. Starts the MCP server over stdio transport.
+    /// Application entry point.
     /// </summary>
     /// <param name="args">Command line arguments.</param>
     /// <returns>Exit code.</returns>
     public static async Task<int> Main(string[] args)
     {
-        return await McpServerHost.RunAsync(args).ConfigureAwait(false);
+        if (IsMcpServerInvocation(args))
+        {
+            // Strip our own "mcp" selector so it doesn't reach the MCP host's argument
+            // parser. "--mcp-server" is left in place for backward compatibility with
+            // existing IDE configurations that pass it explicitly.
+            var hostArgs = args.Length > 0 && args[0] == "mcp" ? args[1..] : args;
+            return await McpServerHost.RunAsync(hostArgs).ConfigureAwait(false);
+        }
+
+        return await CliRunner.RunAsync(args, Console.Out, Console.Error).ConfigureAwait(false);
+    }
+
+    private static bool IsMcpServerInvocation(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            return true;
+        }
+
+        var first = args[0];
+        return string.Equals(first, "mcp", StringComparison.Ordinal)
+            || string.Equals(first, "--mcp-server", StringComparison.Ordinal);
     }
 }

--- a/sdk/tools/Azure.GeneratorAgent/tests/Cli/CliRunnerTests.cs
+++ b/sdk/tools/Azure.GeneratorAgent/tests/Cli/CliRunnerTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.Json;
+using Azure.GeneratorAgent.Cli;
+using Azure.GeneratorAgent.Mcp;
+using NUnit.Framework;
+
+namespace Azure.GeneratorAgent.Tests.Cli;
+
+[TestFixture]
+public class CliRunnerTests
+{
+    private StringWriter _stdout = null!;
+    private StringWriter _stderr = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _stdout = new StringWriter();
+        _stderr = new StringWriter();
+    }
+
+    [Test]
+    public async Task NoArgs_PrintsUsage_ReturnsExit4()
+    {
+        var exit = await CliRunner.RunAsync(Array.Empty<string>(), _stdout, _stderr);
+
+        Assert.That(exit, Is.EqualTo((int)GenerateAndFixExitReason.UsageError));
+        Assert.That(_stderr.ToString(), Does.Contain("Usage:"));
+    }
+
+    [Test]
+    public async Task Help_PrintsUsageToStdout_ReturnsZero()
+    {
+        var exit = await CliRunner.RunAsync(new[] { "--help" }, _stdout, _stderr);
+
+        Assert.That(exit, Is.EqualTo(0));
+        Assert.That(_stdout.ToString(), Does.Contain("Usage:"));
+    }
+
+    [Test]
+    public async Task UnknownCommand_ReturnsUsageError()
+    {
+        var exit = await CliRunner.RunAsync(new[] { "do-the-thing" }, _stdout, _stderr);
+
+        Assert.That(exit, Is.EqualTo((int)GenerateAndFixExitReason.UsageError));
+        Assert.That(_stderr.ToString(), Does.Contain("Unknown command"));
+    }
+
+    [Test]
+    public async Task GenerateAndFix_MissingProject_ReturnsUsageError()
+    {
+        var exit = await CliRunner.RunAsync(new[] { "generate-and-fix" }, _stdout, _stderr);
+
+        Assert.That(exit, Is.EqualTo((int)GenerateAndFixExitReason.UsageError));
+        Assert.That(_stderr.ToString(), Does.Contain("--project"));
+    }
+
+    [Test]
+    public async Task GenerateAndFix_BadMaxIterations_ReturnsUsageError()
+    {
+        var exit = await CliRunner.RunAsync(
+            new[] { "generate-and-fix", "--project", "x", "--max-iterations", "-1" },
+            _stdout, _stderr);
+
+        Assert.That(exit, Is.EqualTo((int)GenerateAndFixExitReason.UsageError));
+    }
+
+    [Test]
+    public async Task GenerateAndFix_HappyPath_WritesJsonSummaryToStdout()
+    {
+        var steps = new FakeOrchestratorSteps();
+        steps.BuildResponses.Enqueue((TestFixtures.Clean(), new List<Mcp.ClassifiedError>()));
+
+        var exit = await CliRunner.RunAsync(
+            new[] { "generate-and-fix", "--project", Path.GetTempPath(), "--skip-generation" },
+            _stdout, _stderr, steps);
+
+        Assert.That(exit, Is.EqualTo(0));
+        var stdoutText = _stdout.ToString();
+        using var doc = JsonDocument.Parse(stdoutText);
+        Assert.That(doc.RootElement.GetProperty("success").GetBoolean(), Is.True);
+        Assert.That(doc.RootElement.GetProperty("exitReason").GetString(), Is.EqualTo("Success"));
+    }
+
+    [Test]
+    public async Task GenerateAndFix_BuildFails_PropagatesExitCode1()
+    {
+        var steps = new FakeOrchestratorSteps();
+        steps.BuildResponses.Enqueue((
+            TestFixtures.Failed(1),
+            new List<Mcp.ClassifiedError> { TestFixtures.NonDeterministic("src/Foo.cs") }));
+
+        var exit = await CliRunner.RunAsync(
+            new[] { "generate-and-fix", "-p", Path.GetTempPath(), "--skip-generation" },
+            _stdout, _stderr, steps);
+
+        Assert.That(exit, Is.EqualTo((int)GenerateAndFixExitReason.BuildFailed));
+        Assert.That(_stdout.ToString(), Does.Contain("\"success\": false"));
+    }
+
+    [Test]
+    public void TryParseGenerateAndFixOptions_AcceptsAllFlags()
+    {
+        var ok = CliRunner.TryParseGenerateAndFixOptions(
+            new[]
+            {
+                "generate-and-fix",
+                "--project", "C:\\foo",
+                "--specs-path", "C:\\bar",
+                "--max-iterations", "3",
+                "--skip-generation",
+            },
+            _stderr,
+            out var options);
+
+        Assert.That(ok, Is.True);
+        Assert.That(options.ProjectPath, Is.EqualTo(Path.GetFullPath("C:\\foo")));
+        Assert.That(options.LocalSpecsPath, Is.EqualTo(Path.GetFullPath("C:\\bar")));
+        Assert.That(options.MaxIterations, Is.EqualTo(3));
+        Assert.That(options.SkipGeneration, Is.True);
+    }
+}

--- a/sdk/tools/Azure.GeneratorAgent/tests/Cli/FakeOrchestratorSteps.cs
+++ b/sdk/tools/Azure.GeneratorAgent/tests/Cli/FakeOrchestratorSteps.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.GeneratorAgent.Cli;
+using Azure.GeneratorAgent.Mcp;
+using Azure.GeneratorAgent.Mcp.Tools;
+
+namespace Azure.GeneratorAgent.Tests.Cli;
+
+/// <summary>
+/// In-memory test double for <see cref="IOrchestratorSteps"/>. Each method records its
+/// invocations and returns a queued response so tests can drive the orchestrator
+/// through specific scenarios without invoking dotnet, git, or the file system.
+/// </summary>
+internal sealed class FakeOrchestratorSteps : IOrchestratorSteps
+{
+    public Func<string, string?, CancellationToken, (bool, string, string?)>? OnRunCodeGeneration { get; set; }
+    public Func<string, int>? OnTakeSnapshot { get; set; }
+    public Queue<(BuildResult BuildResult, List<ClassifiedError> Classified)> BuildResponses { get; } = new();
+    public Queue<List<FixResult>> FixResponses { get; } = new();
+    public Func<string, List<string>>? OnVerify { get; set; }
+
+    public int CodeGenerationCalls { get; private set; }
+    public int SnapshotCalls { get; private set; }
+    public int BuildCalls { get; private set; }
+    public int FixCalls { get; private set; }
+    public int VerifyCalls { get; private set; }
+    public List<List<FixOperation>> FixCallArgs { get; } = new();
+
+    public Task<(bool Success, string Output, string? Error)> RunCodeGenerationAsync(
+        string projectPath, string? localSpecsPath, CancellationToken cancellationToken)
+    {
+        CodeGenerationCalls++;
+        var (s, o, e) = OnRunCodeGeneration?.Invoke(projectPath, localSpecsPath, cancellationToken)
+            ?? (true, string.Empty, null);
+        return Task.FromResult((s, o, e));
+    }
+
+    public int TakeGeneratedSnapshot(string projectPath)
+    {
+        SnapshotCalls++;
+        return OnTakeSnapshot?.Invoke(projectPath) ?? 0;
+    }
+
+    public Task<(BuildResult BuildResult, List<ClassifiedError> Classified)> BuildAndClassifyAsync(
+        string projectPath, CancellationToken cancellationToken)
+    {
+        BuildCalls++;
+        if (BuildResponses.Count == 0)
+        {
+            throw new InvalidOperationException("No queued build response.");
+        }
+        return Task.FromResult(BuildResponses.Dequeue());
+    }
+
+    public List<FixResult> ApplyFixes(List<FixOperation> fixes)
+    {
+        FixCalls++;
+        FixCallArgs.Add(fixes);
+        if (FixResponses.Count == 0)
+        {
+            // Default: every fix succeeds.
+            return fixes.Select(f => new FixResult(true, f.ToolName, "ok")).ToList();
+        }
+        return FixResponses.Dequeue();
+    }
+
+    public List<string> VerifyGeneratedUnchanged(string projectPath)
+    {
+        VerifyCalls++;
+        return OnVerify?.Invoke(projectPath) ?? new List<string>();
+    }
+}
+
+/// <summary>
+/// Helpers for building <see cref="BuildResult"/> / <see cref="ClassifiedError"/>
+/// fixtures used by the orchestrator tests.
+/// </summary>
+internal static class TestFixtures
+{
+    public static BuildResult Clean() => new() { Success = true, ExitCode = 0 };
+
+    public static BuildResult Failed(int errorCount = 1) => new()
+    {
+        Success = false,
+        ExitCode = 1,
+        Errors = Enumerable.Range(0, errorCount).Select(i => new BuildError
+        {
+            Code = "CS0246",
+            FilePath = $"src/Foo{i}.cs",
+            Message = $"placeholder error {i}"
+        }).ToList()
+    };
+
+    public static ClassifiedError Deterministic(string tool, string filePath, string code = "CS0246") => new()
+    {
+        Error = new BuildError { Code = code, FilePath = filePath, Message = "x" },
+        IsDeterministic = true,
+        ToolName = tool,
+        ToolArgs = new Dictionary<string, string> { ["filePath"] = filePath },
+        Reason = "test"
+    };
+
+    public static ClassifiedError NonDeterministic(string filePath, string code = "CS0103") => new()
+    {
+        Error = new BuildError { Code = code, FilePath = filePath, Message = "x" },
+        IsDeterministic = false,
+        Reason = "requires reasoning"
+    };
+}

--- a/sdk/tools/Azure.GeneratorAgent/tests/Cli/GenerateAndFixOrchestratorTests.cs
+++ b/sdk/tools/Azure.GeneratorAgent/tests/Cli/GenerateAndFixOrchestratorTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.GeneratorAgent.Cli;
+using Azure.GeneratorAgent.Mcp;
+using Azure.GeneratorAgent.Mcp.Tools;
+using NUnit.Framework;
+
+namespace Azure.GeneratorAgent.Tests.Cli;
+
+[TestFixture]
+public class GenerateAndFixOrchestratorTests
+{
+    private FakeOrchestratorSteps _steps = null!;
+    private GenerateAndFixOptions _options = null!;
+    private List<string> _progress = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _steps = new FakeOrchestratorSteps();
+        _options = new GenerateAndFixOptions
+        {
+            ProjectPath = Path.Combine(Path.GetTempPath(), "FakeProject"),
+            MaxIterations = 5,
+        };
+        _progress = new List<string>();
+    }
+
+    private GenerateAndFixOrchestrator CreateOrchestrator()
+        => new(_steps, msg => _progress.Add(msg));
+
+    [Test]
+    public async Task UsageError_WhenProjectPathMissing()
+    {
+        var result = await CreateOrchestrator().RunAsync(new GenerateAndFixOptions { ProjectPath = "" });
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Reason, Is.EqualTo(GenerateAndFixExitReason.UsageError));
+    }
+
+    [Test]
+    public async Task UsageError_WhenMaxIterationsNonPositive()
+    {
+        _options = new GenerateAndFixOptions { ProjectPath = "x", MaxIterations = 0 };
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        Assert.That(result.Reason, Is.EqualTo(GenerateAndFixExitReason.UsageError));
+    }
+
+    [Test]
+    public async Task GenerationFailure_ExitsWithGenerationFailedReason()
+    {
+        _steps.OnRunCodeGeneration = (_, _, _) => (false, "gen output", "boom");
+
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Reason, Is.EqualTo(GenerateAndFixExitReason.GenerationFailed));
+        Assert.That(result.Message, Does.Contain("boom"));
+        // We must not snapshot, build, fix, or verify after a failed generation.
+        Assert.That(_steps.SnapshotCalls, Is.EqualTo(0));
+        Assert.That(_steps.BuildCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task CleanBuildOnFirstIteration_ReturnsSuccessImmediately()
+    {
+        _steps.BuildResponses.Enqueue((TestFixtures.Clean(), new List<ClassifiedError>()));
+
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Reason, Is.EqualTo(GenerateAndFixExitReason.Success));
+        Assert.That(result.Iterations, Is.EqualTo(1));
+        Assert.That(result.TotalFixesApplied, Is.EqualTo(0));
+        Assert.That(_steps.FixCalls, Is.EqualTo(0));
+        Assert.That(_steps.VerifyCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeterministicErrorsAreFixed_ThenBuildClean_ReturnsSuccess()
+    {
+        // First build: one deterministic error. Second build: clean.
+        var customFile = Path.Combine(Path.GetTempPath(), "FakeProject", "src", "Custom", "Foo.cs");
+        _steps.BuildResponses.Enqueue((
+            TestFixtures.Failed(1),
+            new List<ClassifiedError> { TestFixtures.Deterministic("add_using_directive", customFile) }));
+        _steps.BuildResponses.Enqueue((TestFixtures.Clean(), new List<ClassifiedError>()));
+
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(result.Iterations, Is.EqualTo(2));
+        Assert.That(result.TotalFixesApplied, Is.EqualTo(1));
+        Assert.That(result.FixesByTool["add_using_directive"], Is.EqualTo(1));
+        Assert.That(_steps.FixCalls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task NonDeterministicErrors_ExitsWithBuildFailed()
+    {
+        _steps.BuildResponses.Enqueue((
+            TestFixtures.Failed(1),
+            new List<ClassifiedError> { TestFixtures.NonDeterministic("src/Foo.cs") }));
+
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        Assert.That(result.Success, Is.False);
+        Assert.That(result.Reason, Is.EqualTo(GenerateAndFixExitReason.BuildFailed));
+        Assert.That(result.RemainingErrors, Has.Count.EqualTo(1));
+        Assert.That(_steps.FixCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task DeterministicFixTargetingGenerated_IsSkipped()
+    {
+        var generatedFile = Path.Combine(Path.GetTempPath(), "FakeProject", "src", "Generated", "Bad.cs");
+        _steps.BuildResponses.Enqueue((
+            TestFixtures.Failed(1),
+            new List<ClassifiedError> { TestFixtures.Deterministic("regex_replacement", generatedFile) }));
+
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        // No fixable errors after filtering -> BuildFailed, no fix call.
+        Assert.That(result.Reason, Is.EqualTo(GenerateAndFixExitReason.BuildFailed));
+        Assert.That(_steps.FixCalls, Is.EqualTo(0));
+        Assert.That(string.Join('\n', _progress), Does.Contain("Skipped 1 fix"));
+    }
+
+    [Test]
+    public async Task NoProgressGuard_StopsLoopWhenAllFixesFail()
+    {
+        var customFile = Path.Combine(Path.GetTempPath(), "FakeProject", "src", "Custom", "Foo.cs");
+        _steps.BuildResponses.Enqueue((
+            TestFixtures.Failed(1),
+            new List<ClassifiedError> { TestFixtures.Deterministic("regex_replacement", customFile) }));
+        _steps.FixResponses.Enqueue(new List<FixResult>
+        {
+            new FixResult(false, "regex_replacement", "could not match")
+        });
+
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        Assert.That(result.Reason, Is.EqualTo(GenerateAndFixExitReason.BuildFailed));
+        Assert.That(_steps.BuildCalls, Is.EqualTo(1), "no second build attempt after zero progress");
+        Assert.That(result.Message, Does.Contain("No fixes succeeded"));
+    }
+
+    [Test]
+    public async Task MaxIterationsCap_StopsLoopWithBuildFailed()
+    {
+        _options = new GenerateAndFixOptions { ProjectPath = _options.ProjectPath, MaxIterations = 2 };
+        var customFile = Path.Combine(Path.GetTempPath(), "FakeProject", "src", "Custom", "Foo.cs");
+
+        // Three failing builds (every iteration succeeds at fixing but the next build still fails).
+        for (var i = 0; i < 3; i++)
+        {
+            _steps.BuildResponses.Enqueue((
+                TestFixtures.Failed(1),
+                new List<ClassifiedError> { TestFixtures.Deterministic("add_using_directive", customFile) }));
+        }
+
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        Assert.That(result.Reason, Is.EqualTo(GenerateAndFixExitReason.BuildFailed));
+        Assert.That(result.Iterations, Is.EqualTo(2));
+        Assert.That(result.Message, Does.Contain("max-iterations"));
+    }
+
+    [Test]
+    public async Task GeneratedViolation_ReturnsExit3()
+    {
+        _steps.BuildResponses.Enqueue((TestFixtures.Clean(), new List<ClassifiedError>()));
+        _steps.OnVerify = _ => new List<string> { "src/Generated/Leaked.cs" };
+
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        Assert.That(result.Reason, Is.EqualTo(GenerateAndFixExitReason.GeneratedViolation));
+        Assert.That(result.GeneratedViolations, Contains.Item("src/Generated/Leaked.cs"));
+    }
+
+    [Test]
+    public async Task SkipGeneration_BypassesGenerationStep()
+    {
+        _options = new GenerateAndFixOptions
+        {
+            ProjectPath = _options.ProjectPath,
+            MaxIterations = 5,
+            SkipGeneration = true,
+        };
+        _steps.BuildResponses.Enqueue((TestFixtures.Clean(), new List<ClassifiedError>()));
+
+        var result = await CreateOrchestrator().RunAsync(_options);
+
+        Assert.That(result.Success, Is.True);
+        Assert.That(_steps.CodeGenerationCalls, Is.EqualTo(0));
+        Assert.That(_steps.SnapshotCalls, Is.EqualTo(1));
+    }
+}


### PR DESCRIPTION
Adds a generate-and-fix subcommand that orchestrates code generation and the deterministic build-fix loop in-process, with a hard rule that fixes only land in customization code (never in Generated/). MCP server mode is preserved for zero-arg, mcp, and --mcp-server invocations - no breaking change for existing VS Code / Claude Desktop configurations.

Workflow: run_code_generation -> snapshot_generated -> loop(build_and_classify -> filter to deterministic + non-Generated -> batch_fix) -> verify_generated_unchanged with auto-revert. Bounded by --max-iterations (default 10) and a no-progress guard.

Output: progress to stderr, JSON summary to stdout. Exit codes: 0 clean, 1 build still failing, 2 generation failed, 3 Generated/ violation, 4 usage.

All 406 tests pass (+18 new).

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
