### PR TITLE
Fix git restore error in Spector scripts when running against new specs

### DIFF
--- a/eng/packages/http-client-csharp/eng/scripts/Get-Spector-Coverage.ps1
+++ b/eng/packages/http-client-csharp/eng/scripts/Get-Spector-Coverage.ps1
@@ -68,10 +68,14 @@ foreach ($specFile in $specs) {
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }
-    $command = "git restore $outputDir"
-    Invoke $command
-    # exit if the restore failed
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
+    # Only restore if git tracks files in this directory (new specs won't have tracked files)
+    $trackedFiles = & git ls-files $outputDir
+    if ($trackedFiles) {
+        $command = "git restore $outputDir"
+        Invoke $command
+        # exit if the restore failed
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
     }
 }

--- a/eng/packages/http-client-csharp/eng/scripts/Test-Spector.ps1
+++ b/eng/packages/http-client-csharp/eng/scripts/Test-Spector.ps1
@@ -82,10 +82,14 @@ foreach ($specFile in Get-Sorted-Specs) {
     if ($LASTEXITCODE -ne 0) {
         exit $LASTEXITCODE
     }
-    $command = "git restore $outputDir"
-    Invoke $command
-    # exit if the restore failed
-    if ($LASTEXITCODE -ne 0) {
-        exit $LASTEXITCODE
+    # Only restore if git tracks files in this directory (new specs won't have tracked files)
+    $trackedFiles = & git ls-files $outputDir
+    if ($trackedFiles) {
+        $command = "git restore $outputDir"
+        Invoke $command
+        # exit if the restore failed
+        if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+        }
     }
 }


### PR DESCRIPTION
Ports [microsoft/typespec#10426](https://github.com/microsoft/typespec/pull/10426) to the azure generator (`@azure-typespec/http-client-csharp`).

In TypeSpecNext runs, new specs produce test directories not yet tracked by git. After `git clean -xfd` removes these directories, `git restore` fails with `pathspec did not match any file(s) known to git`.

- **Guard `git restore` with `git ls-files` check** in both `Test-Spector.ps1` and `Get-Spector-Coverage.ps1` — skip restore when the directory has no tracked files (i.e., it's a new spec).

```powershell
# Before: unconditional restore fails on new specs
$command = "git restore $outputDir"
Invoke $command

# After: only restore if git tracks files in this directory
$trackedFiles = & git ls-files $outputDir
if ($trackedFiles) {
    $command = "git restore $outputDir"
    Invoke $command
}
```
