### PR TITLE
Add Spector tests for Encode_Array_Property

### DIFF
--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Encode/_Array/EncodeArrayTests.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/Encode/_Array/EncodeArrayTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Encode._Array;
+using Encode._Array._Property;
+using NUnit.Framework;
+
+namespace TestProjects.Spector.Tests.Http.Encode._Array
+{
+    public class EncodeArrayTests : SpectorTestBase
+    {
+        [SpectorTest]
+        public Task EncodeArrayPropertyCommaDelimited() => Test(async (host) =>
+        {
+            var value = new[] { "blue", "red", "green" };
+            var response = await new ArrayClient(host, null).GetPropertyClient().CommaDelimitedAsync(new CommaDelimitedArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertySpaceDelimited() => Test(async (host) =>
+        {
+            var value = new[] { "blue", "red", "green" };
+            var response = await new ArrayClient(host, null).GetPropertyClient().SpaceDelimitedAsync(new SpaceDelimitedArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyPipeDelimited() => Test(async (host) =>
+        {
+            var value = new[] { "blue", "red", "green" };
+            var response = await new ArrayClient(host, null).GetPropertyClient().PipeDelimitedAsync(new PipeDelimitedArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyNewlineDelimited() => Test(async (host) =>
+        {
+            var value = new[] { "blue", "red", "green" };
+            var response = await new ArrayClient(host, null).GetPropertyClient().NewlineDelimitedAsync(new NewlineDelimitedArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyEnumCommaDelimited() => Test(async (host) =>
+        {
+            var value = new[] { Colors.Blue, Colors.Red, Colors.Green };
+            var response = await new ArrayClient(host, null).GetPropertyClient().EnumCommaDelimitedAsync(new CommaDelimitedEnumArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyEnumSpaceDelimited() => Test(async (host) =>
+        {
+            var value = new[] { Colors.Blue, Colors.Red, Colors.Green };
+            var response = await new ArrayClient(host, null).GetPropertyClient().EnumSpaceDelimitedAsync(new SpaceDelimitedEnumArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyEnumPipeDelimited() => Test(async (host) =>
+        {
+            var value = new[] { Colors.Blue, Colors.Red, Colors.Green };
+            var response = await new ArrayClient(host, null).GetPropertyClient().EnumPipeDelimitedAsync(new PipeDelimitedEnumArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyEnumNewlineDelimited() => Test(async (host) =>
+        {
+            var value = new[] { Colors.Blue, Colors.Red, Colors.Green };
+            var response = await new ArrayClient(host, null).GetPropertyClient().EnumNewlineDelimitedAsync(new NewlineDelimitedEnumArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyExtensibleEnumCommaDelimited() => Test(async (host) =>
+        {
+            var value = new[] { ColorsExtensibleEnum.Blue, ColorsExtensibleEnum.Red, ColorsExtensibleEnum.Green };
+            var response = await new ArrayClient(host, null).GetPropertyClient().ExtensibleEnumCommaDelimitedAsync(new CommaDelimitedExtensibleEnumArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyExtensibleEnumSpaceDelimited() => Test(async (host) =>
+        {
+            var value = new[] { ColorsExtensibleEnum.Blue, ColorsExtensibleEnum.Red, ColorsExtensibleEnum.Green };
+            var response = await new ArrayClient(host, null).GetPropertyClient().ExtensibleEnumSpaceDelimitedAsync(new SpaceDelimitedExtensibleEnumArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyExtensibleEnumPipeDelimited() => Test(async (host) =>
+        {
+            var value = new[] { ColorsExtensibleEnum.Blue, ColorsExtensibleEnum.Red, ColorsExtensibleEnum.Green };
+            var response = await new ArrayClient(host, null).GetPropertyClient().ExtensibleEnumPipeDelimitedAsync(new PipeDelimitedExtensibleEnumArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+
+        [SpectorTest]
+        public Task EncodeArrayPropertyExtensibleEnumNewlineDelimited() => Test(async (host) =>
+        {
+            var value = new[] { ColorsExtensibleEnum.Blue, ColorsExtensibleEnum.Red, ColorsExtensibleEnum.Green };
+            var response = await new ArrayClient(host, null).GetPropertyClient().ExtensibleEnumNewlineDelimitedAsync(new NewlineDelimitedExtensibleEnumArrayProperty(value));
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            CollectionAssert.AreEqual(value, response.Value.Value);
+        });
+    }
+}


### PR DESCRIPTION
Adds C# Spector test coverage for the http/encode/array spec (`Encode_Array_Property`), which was previously missing on the Azure dashboard.

## Scenarios covered

All 12 `Property.*` scenarios in [`packages/http-specs/specs/encode/array/main.tsp`](https://github.com/microsoft/typespec/blob/main/packages/http-specs/specs/encode/array/main.tsp):

- **`string[]`** — `commaDelimited`, `spaceDelimited`, `pipeDelimited`, `newlineDelimited`
- **`Colors[]`** (closed enum) — `enumCommaDelimited`, `enumSpaceDelimited`, `enumPipeDelimited`, `enumNewlineDelimited`
- **`ColorsExtensibleEnum[]`** (extensible enum / union) — `extensibleEnumCommaDelimited`, `extensibleEnumSpaceDelimited`, `extensibleEnumPipeDelimited`, `extensibleEnumNewlineDelimited`

## Validation

Verified locally by regenerating the project unstubbed and running the tests via `Test-Spector.ps1`:

```
pwsh eng/scripts/Test-Spector.ps1 -filter "http/encode/array"

Test summary: total: 12, failed: 0, succeeded: 12, skipped: 0, duration: 19.8s
```