### PR TITLE
Add missing Spector tests for SpecialWords scenarios

### DIFF
--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.ExtensibleStrings.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.ExtensibleStrings.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SpecialWords;
+using SpecialWords._ExtensibleStrings;
+
+namespace TestProjects.Spector.Tests.Http.SpecialWords
+{
+    public partial class SpecialWordsTests : SpectorTestBase
+    {
+        [SpectorTest]
+        public Task ExtensibleStringsPutExtensibleStringValueAsync() => Test(async (host) =>
+        {
+            var client = new SpecialWordsClient(host, null).GetExtensibleStringsClient();
+            var response = await client.PutExtensibleStringValueAsync(ExtensibleString.Class);
+            Assert.AreEqual(200, response.GetRawResponse().Status);
+            Assert.AreEqual(ExtensibleString.Class, response.Value);
+        });
+    }
+}

--- a/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.Models.cs
+++ b/eng/packages/http-client-csharp/generator/TestProjects/Spector.Tests/Http/SpecialWords/SpecialWordsTests.Models.cs
@@ -285,5 +285,23 @@ namespace TestProjects.Spector.Tests.Http.SpecialWords
             var response = await client.SameAsModelAsync(body);
             NUnit.Framework.Assert.AreEqual(204, response.Status);
         });
+
+        [SpectorTest]
+        public Task ModelProperties_DictMethodsAsync() => Test(async (host) =>
+        {
+            DictMethods body = new DictMethods("ok", "ok", "ok", "ok", "ok", "ok", "ok", "ok", "ok", "ok");
+            var client = new SpecialWordsClient(host, null).GetModelPropertiesClient();
+            var response = await client.DictMethodsAsync(body);
+            NUnit.Framework.Assert.AreEqual(204, response.Status);
+        });
+
+        [SpectorTest]
+        public Task ModelProperties_WithListAsync() => Test(async (host) =>
+        {
+            ModelWithList body = new ModelWithList("ok");
+            var client = new SpecialWordsClient(host, null).GetModelPropertiesClient();
+            var response = await client.WithListAsync(body);
+            NUnit.Framework.Assert.AreEqual(204, response.Status);
+        });
     }
 }


### PR DESCRIPTION
Adds C# Spector test coverage for three previously-uncovered scenarios in [`http/special-words`](https://github.com/microsoft/typespec/blob/main/packages/http-specs/specs/special-words/main.tsp).

## Scenarios covered

| Scenario | Description |
|---|---|
| `ModelProperties.dictMethods` | Model with properties named after Python dict methods (`keys`, `items`, `values`, `popitem`, `clear`, `update`, `setdefault`, `pop`, `get`, `copy`) |
| `ModelProperties.withList` | Model with a property named `list` (reserved in many languages) |
| `ExtensibleStrings.putExtensibleStringValue` | Round-trip an extensible enum (union) whose members are reserved words |

The other `SpecialWords` scenarios (`Operations`, `Parameters`, `Models`, `ModelProperties.sameAsModel`) were already covered.

## Validation

```
pwsh eng/scripts/Test-Spector.ps1 -filter "http/special-words"

Passed!  - Failed:     0, Passed:   104, Skipped:     0, Total:   104
```