### PR TITLE
[ContentUnderstanding] Add preview disclaimer for ToLlmInput

### DIFF
--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
@@ -198,10 +198,11 @@ See the [samples directory][samples_directory] for complete examples.
 
 ### Convert results to LLM-ready text
 
+> [!NOTE]
 > **Preview feature**: `.ToLlmInput()` is currently in preview and may change in
 > future releases. We welcome feedback — please file suggestions or issues on
 > [GitHub Issues](https://github.com/Azure/azure-sdk-for-net/issues) with the
-> **"Cognitive - Content Understanding"** label.
+> `Cognitive - Content Understanding` label.
 
 Use `.ToLlmInput()` to convert any analysis result into a text format that LLMs can consume directly — YAML front matter with extracted fields followed by the markdown body. This works with all content types (documents, images, audio, video) and handles multi-segment results and classification hierarchies automatically.
 

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
@@ -200,10 +200,8 @@ See the [samples directory][samples_directory] for complete examples.
 
 ### Convert results to LLM-ready text
 
-> [!NOTE]
-> **Preview feature**: `.ToLlmInput()` is currently in preview and may change in
-> future releases. We welcome feedback — please
-> [file an issue][file_issue].
+> **Note:** `.ToLlmInput()` is currently in preview and may change in future releases.
+> We welcome feedback — please [file an issue][file_issue].
 
 Use `.ToLlmInput()` to convert any analysis result into a text format that LLMs can consume directly — YAML front matter with extracted fields followed by the markdown body. This works with all content types (documents, images, audio, video) and handles multi-segment results and classification hierarchies automatically.
 

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
@@ -11,6 +11,8 @@ Use the client library for Azure AI Content Understanding to:
 * **Create custom analyzers** - Build domain-specific analyzers for specialized content extraction needs across all four modalities (documents, video, audio, and images)
 * **Classify documents and video** - Automatically categorize and extract information from documents and video by type
 
+If you have encountered issues or want to suggest features, please [file an issue][file_issue].
+
 [Source code][source_code] | [Package (NuGet)][nuget_package] | [API reference documentation][api_reference] | [Product documentation][product_docs]
 
 ## Getting started
@@ -200,9 +202,8 @@ See the [samples directory][samples_directory] for complete examples.
 
 > [!NOTE]
 > **Preview feature**: `.ToLlmInput()` is currently in preview and may change in
-> future releases. We welcome feedback — please file suggestions or issues on
-> [GitHub Issues](https://github.com/Azure/azure-sdk-for-net/issues) with the
-> `Cognitive - Content Understanding` label.
+> future releases. We welcome feedback — please
+> [file an issue][file_issue].
 
 Use `.ToLlmInput()` to convert any analysis result into a text format that LLMs can consume directly — YAML front matter with extracted fields followed by the markdown body. This works with all content types (documents, images, audio, video) and handles multi-segment results and classification hierarchies automatically.
 
@@ -326,3 +327,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct][code_of_con
 [opencode_email]: mailto:opencode@microsoft.com
 [style-guide-msft]: https://learn.microsoft.com/style-guide/capitalization
 [style-guide-cloud]: https://aka.ms/azsdk/cloud-style-guide
+[file_issue]: https://github.com/Azure/azure-sdk-for-net/issues/new?labels=Cognitive%20-%20Content%20Understanding&title=[ContentUnderstanding]%20&body=%23%23%20Library%20Version%0A%0A%23%23%20Repro%20Steps%0A%0A%23%23%20Expected%20Result%0A%0A%23%23%20Actual%20Result

--- a/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
+++ b/sdk/contentunderstanding/Azure.AI.ContentUnderstanding/README.md
@@ -198,6 +198,11 @@ See the [samples directory][samples_directory] for complete examples.
 
 ### Convert results to LLM-ready text
 
+> **Preview feature**: `.ToLlmInput()` is currently in preview and may change in
+> future releases. We welcome feedback — please file suggestions or issues on
+> [GitHub Issues](https://github.com/Azure/azure-sdk-for-net/issues) with the
+> **"Cognitive - Content Understanding"** label.
+
 Use `.ToLlmInput()` to convert any analysis result into a text format that LLMs can consume directly — YAML front matter with extracted fields followed by the markdown body. This works with all content types (documents, images, audio, video) and handles multi-segment results and classification hierarchies automatically.
 
 ```csharp


### PR DESCRIPTION
Adds a preview feature disclaimer to the `ToLlmInput()` section in the README, directing users to file feedback on GitHub Issues with the **Cognitive - Content Understanding** label.

This is a cross-language change requested in https://github.com/Azure/azure-sdk-for-java/pull/49000.