### PR TITLE
[Identity] [Core] Add support for MSAL's additional query params

### DIFF
--- a/sdk/core/Azure.Core/CHANGELOG.md
+++ b/sdk/core/Azure.Core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added `AzureLocation.DenmarkEast` for the Denmark East Azure region.
+- Added experimental `AdditionalQueryParameters` property to `TokenCredentialOptions` to enable forwarding extra query string parameters to MSAL during authentication.
 
 ### Breaking Changes
 

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1671,6 +1671,8 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID5001")]
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1671,7 +1671,7 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID5001")]
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0001")]
         public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1671,8 +1671,8 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0001")]
-        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID5001")]
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net10.0.cs
@@ -1671,7 +1671,7 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID5001")]
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0001")]
         public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -1633,6 +1633,7 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net462.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net462.cs
@@ -1633,7 +1633,7 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
-        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -1633,6 +1633,7 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net472.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net472.cs
@@ -1633,7 +1633,7 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
-        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -1671,6 +1671,8 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID5001")]
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -1672,7 +1672,7 @@ namespace Azure.Identity
     {
         public TokenCredentialOptions() { }
         [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID5001")]
-        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.net8.0.cs
@@ -1671,7 +1671,7 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
-        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID5001")]
+        [System.Diagnostics.CodeAnalysis.ExperimentalAttribute("AZID0001")]
         public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -1633,6 +1633,7 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
+++ b/sdk/core/Azure.Core/api/Azure.Core.netstandard2.0.cs
@@ -1633,7 +1633,7 @@ namespace Azure.Identity
     public partial class TokenCredentialOptions : Azure.Core.ClientOptions
     {
         public TokenCredentialOptions() { }
-        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } set { } }
+        public System.Collections.Generic.IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get { throw null; } }
         public System.Uri AuthorityHost { get { throw null; } set { } }
         public new Azure.Identity.TokenCredentialDiagnosticsOptions Diagnostics { get { throw null; } }
         public bool IsUnsafeSupportLoggingEnabled { get { throw null; } set { } }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
@@ -67,6 +67,14 @@ namespace Azure.Identity
         public bool IsUnsafeSupportLoggingEnabled { get; set; }
 
         /// <summary>
+        /// Gets or sets extra query parameters that will be appended to the authentication request sent to Microsoft Entra.
+        /// Each entry maps a parameter name to its value and a flag that controls whether the parameter is part of the token-cache key.
+        /// This property is only honored by MSAL-backed credentials.
+        /// </summary>
+        [Experimental("AZID5001")]
+        public IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; set; }
+
+        /// <summary>
         /// Gets or sets whether this credential is part of a chained credential.
         /// </summary>
         internal bool IsChainedCredential { get; set; }
@@ -82,6 +90,14 @@ namespace Azure.Identity
             clone.AuthorityHost = AuthorityHost;
 
             clone.IsUnsafeSupportLoggingEnabled = IsUnsafeSupportLoggingEnabled;
+
+            // copy AdditionalQueryParameters (deep copy to avoid shared mutable state)
+#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+            if (AdditionalQueryParameters != null)
+            {
+                clone.AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>(AdditionalQueryParameters);
+            }
+#pragma warning restore AZID5001
 
             // copy TokenCredentialDiagnosticsOptions specific options
             clone.Diagnostics.IsAccountIdentifierLoggingEnabled = Diagnostics.IsAccountIdentifierLoggingEnabled;

--- a/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
@@ -67,12 +67,12 @@ namespace Azure.Identity
         public bool IsUnsafeSupportLoggingEnabled { get; set; }
 
         /// <summary>
-        /// Gets or sets extra query parameters that will be appended to the authentication request sent to Microsoft Entra.
-        /// Each entry maps a parameter name to its value and a flag that controls whether the parameter is part of the token-cache key.
+        /// Gets or sets extra query parameters that will be appended to the authentication request sent to Microsoft Entra ID.
+        /// Each entry maps a parameter name to its value and a flag that controls whether the parameter is part of the token cache key.
         /// This property is only honored by MSAL-backed credentials.
         /// </summary>
         [Experimental("AZID5001")]
-        public IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; set; }
+        public IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; } = new();
 
         /// <summary>
         /// Gets or sets whether this credential is part of a chained credential.
@@ -93,7 +93,7 @@ namespace Azure.Identity
 
             // copy AdditionalQueryParameters (deep copy to avoid shared mutable state)
 #pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
-            if (AdditionalQueryParameters != null)
+            if (AdditionalQueryParameters.Count > 0)
             {
                 clone.AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>(AdditionalQueryParameters);
             }

--- a/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
@@ -71,7 +71,7 @@ namespace Azure.Identity
         /// Each entry maps a parameter name to its value and a flag that controls whether the parameter is part of the token cache key.
         /// This property is only honored by MSAL-backed credentials.
         /// </summary>
-        [Experimental("AZID5001")]
+        [Experimental("AZID0001")]
         public IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; } = new Dictionary<string, (string Value, bool IncludeInCacheKey)>();
 
         /// <summary>
@@ -92,9 +92,9 @@ namespace Azure.Identity
             clone.IsUnsafeSupportLoggingEnabled = IsUnsafeSupportLoggingEnabled;
 
             // copy AdditionalQueryParameters (deep copy to avoid shared mutable state)
-#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+#pragma warning disable AZID0001 // AdditionalQueryParameters is experimental
             CloneListItems(AdditionalQueryParameters, clone.AdditionalQueryParameters);
-#pragma warning restore AZID5001
+#pragma warning restore AZID0001
 
             // copy TokenCredentialDiagnosticsOptions specific options
             clone.Diagnostics.IsAccountIdentifierLoggingEnabled = Diagnostics.IsAccountIdentifierLoggingEnabled;

--- a/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
+++ b/sdk/core/Azure.Core/src/Identity/Credentials/TokenCredentialOptions.cs
@@ -72,7 +72,7 @@ namespace Azure.Identity
         /// This property is only honored by MSAL-backed credentials.
         /// </summary>
         [Experimental("AZID5001")]
-        public IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; } = new();
+        public IDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; } = new Dictionary<string, (string Value, bool IncludeInCacheKey)>();
 
         /// <summary>
         /// Gets or sets whether this credential is part of a chained credential.
@@ -93,10 +93,7 @@ namespace Azure.Identity
 
             // copy AdditionalQueryParameters (deep copy to avoid shared mutable state)
 #pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
-            if (AdditionalQueryParameters.Count > 0)
-            {
-                clone.AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>(AdditionalQueryParameters);
-            }
+            CloneListItems(AdditionalQueryParameters, clone.AdditionalQueryParameters);
 #pragma warning restore AZID5001
 
             // copy TokenCredentialDiagnosticsOptions specific options
@@ -148,7 +145,7 @@ namespace Azure.Identity
             return clone;
         }
 
-        private static void CloneListItems<T>(IList<T> original, IList<T> clone)
+        private static void CloneListItems<T>(ICollection<T> original, ICollection<T> clone)
         {
             clone.Clear();
 

--- a/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
@@ -52,11 +52,11 @@ namespace Azure.Identity
             ISupportsTokenCachePersistenceOptions cacheOptions = options as ISupportsTokenCachePersistenceOptions;
             _tokenCachePersistenceOptions = cacheOptions?.TokenCachePersistenceOptions;
             IsSupportLoggingEnabled = options?.IsUnsafeSupportLoggingEnabled ?? false;
-#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+#pragma warning disable AZID0001 // AdditionalQueryParameters is experimental
             AdditionalQueryParameters = options?.AdditionalQueryParameters is { Count: > 0 }
                 ? new ReadOnlyDictionary<string, (string Value, bool IncludeInCacheKey)>(new Dictionary<string, (string Value, bool IncludeInCacheKey)>(options.AdditionalQueryParameters))
                 : null;
-#pragma warning restore AZID5001
+#pragma warning restore AZID0001
             Pipeline = pipeline;
             TenantId = tenantId;
             ClientId = clientId;

--- a/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalClientBase.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,6 +24,7 @@ namespace Azure.Identity
         private readonly TokenCachePersistenceOptions _tokenCachePersistenceOptions;
         protected internal bool IsSupportLoggingEnabled { get; }
         protected internal bool DisableInstanceDiscovery { get; }
+        protected internal IReadOnlyDictionary<string, (string Value, bool IncludeInCacheKey)> AdditionalQueryParameters { get; }
         protected string[] cp1Capabilities = new[] { "CP1" };
         protected internal CredentialPipeline Pipeline { get; }
         internal string TenantId { get; }
@@ -49,6 +52,11 @@ namespace Azure.Identity
             ISupportsTokenCachePersistenceOptions cacheOptions = options as ISupportsTokenCachePersistenceOptions;
             _tokenCachePersistenceOptions = cacheOptions?.TokenCachePersistenceOptions;
             IsSupportLoggingEnabled = options?.IsUnsafeSupportLoggingEnabled ?? false;
+#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+            AdditionalQueryParameters = options?.AdditionalQueryParameters is { Count: > 0 }
+                ? new ReadOnlyDictionary<string, (string Value, bool IncludeInCacheKey)>(new Dictionary<string, (string Value, bool IncludeInCacheKey)>(options.AdditionalQueryParameters))
+                : null;
+#pragma warning restore AZID5001
             Pipeline = pipeline;
             TenantId = tenantId;
             ClientId = clientId;

--- a/sdk/core/Azure.Core/src/Identity/MsalConfidentialClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalConfidentialClient.cs
@@ -143,7 +143,7 @@ namespace Azure.Identity
                 confClientBuilder.WithRedirectUri(RedirectUrl);
             }
 
-            if (AdditionalQueryParameters != null)
+            if (AdditionalQueryParameters.Count > 0)
             {
                 confClientBuilder.WithExtraQueryParameters(AdditionalQueryParameters.ToDictionary(kvp => kvp.Key, kvp => (kvp.Value.Value, kvp.Value.IncludeInCacheKey)));
             }

--- a/sdk/core/Azure.Core/src/Identity/MsalConfidentialClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalConfidentialClient.cs
@@ -143,7 +143,7 @@ namespace Azure.Identity
                 confClientBuilder.WithRedirectUri(RedirectUrl);
             }
 
-            if (AdditionalQueryParameters.Count > 0)
+            if (AdditionalQueryParameters != null)
             {
                 confClientBuilder.WithExtraQueryParameters(AdditionalQueryParameters.ToDictionary(kvp => kvp.Key, kvp => (kvp.Value.Value, kvp.Value.IncludeInCacheKey)));
             }

--- a/sdk/core/Azure.Core/src/Identity/MsalConfidentialClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalConfidentialClient.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -139,6 +141,11 @@ namespace Azure.Identity
             if (!string.IsNullOrEmpty(RedirectUrl))
             {
                 confClientBuilder.WithRedirectUri(RedirectUrl);
+            }
+
+            if (AdditionalQueryParameters != null)
+            {
+                confClientBuilder.WithExtraQueryParameters(AdditionalQueryParameters.ToDictionary(kvp => kvp.Key, kvp => (kvp.Value.Value, kvp.Value.IncludeInCacheKey)));
             }
 
             return confClientBuilder.Build();

--- a/sdk/core/Azure.Core/src/Identity/MsalPublicClient.cs
+++ b/sdk/core/Azure.Core/src/Identity/MsalPublicClient.cs
@@ -74,6 +74,11 @@ namespace Azure.Identity
                 pubAppBuilder.WithInstanceDiscovery(false);
             }
 
+            if (AdditionalQueryParameters != null)
+            {
+                pubAppBuilder.WithExtraQueryParameters(AdditionalQueryParameters.ToDictionary(kvp => kvp.Key, kvp => (kvp.Value.Value, kvp.Value.IncludeInCacheKey)));
+            }
+
             return new ValueTask<IPublicClientApplication>(pubAppBuilder.Build());
         }
 

--- a/sdk/core/Azure.Core/tests/Identity/DefaultAzureCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/DefaultAzureCredentialOptionsTests.cs
@@ -140,6 +140,12 @@ namespace Azure.Core.Tests.Identity
                     list.Add(Guid.NewGuid().ToString());
                     list.Add(Guid.NewGuid().ToString());
                 }
+                else if (propInfo.PropertyType == typeof(IDictionary<string, (string Value, bool IncludeInCacheKey)>))
+                {
+                    var dict = propInfo.GetValue(orig) as IDictionary<string, (string Value, bool IncludeInCacheKey)>;
+                    dict[Guid.NewGuid().ToString()] = (Guid.NewGuid().ToString(), true);
+                    dict[Guid.NewGuid().ToString()] = (Guid.NewGuid().ToString(), false);
+                }
                 else
                 {
                     Assert.Fail($"test doesn't support property type {propInfo.PropertyType} for property {propInfo.Name}");
@@ -153,6 +159,13 @@ namespace Azure.Core.Tests.Identity
                 if (propInfo.PropertyType == typeof(IList<string>))
                 {
                     CollectionAssert.AreEqual((IList<string>)propInfo.GetValue(orig), (IList<string>)propInfo.GetValue(clone), $"Cloned {propInfo.Name} does not match original");
+                }
+                else if (propInfo.PropertyType == typeof(IDictionary<string, (string Value, bool IncludeInCacheKey)>))
+                {
+                    CollectionAssert.AreEqual(
+                        (IDictionary<string, (string Value, bool IncludeInCacheKey)>)propInfo.GetValue(orig),
+                        (IDictionary<string, (string Value, bool IncludeInCacheKey)>)propInfo.GetValue(clone),
+                        $"Cloned {propInfo.Name} does not match original");
                 }
                 else
                 {

--- a/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalConfidentialClient.cs
+++ b/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalConfidentialClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
@@ -122,6 +123,11 @@ namespace Azure.Core.Tests.Identity.Mock
         internal ValueTask<IConfidentialClientApplication> CallBaseGetClientAsync(bool enableCae, bool async, CancellationToken cancellationToken)
         {
             return GetClientAsync(enableCae, async, cancellationToken);
+        }
+
+        internal IReadOnlyDictionary<string, (string Value, bool IncludeInCacheKey)> GetAdditionalQueryParameters()
+        {
+            return AdditionalQueryParameters;
         }
 
         protected override ValueTask<IConfidentialClientApplication> CreateClientCoreAsync(bool enableCae, bool async, CancellationToken cancellationToken)

--- a/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalPublicClient.cs
+++ b/sdk/core/Azure.Core/tests/Identity/Mock/MockMsalPublicClient.cs
@@ -156,6 +156,11 @@ namespace Azure.Core.Tests.Identity.Mock
             return CreateClientAsync(enableCae, async, cancellationToken);
         }
 
+        internal IReadOnlyDictionary<string, (string Value, bool IncludeInCacheKey)> GetAdditionalQueryParameters()
+        {
+            return AdditionalQueryParameters;
+        }
+
         protected override ValueTask<IPublicClientApplication> CreateClientCoreAsync(bool enableCae, bool async, CancellationToken cancellationToken)
         {
             if (ClientAppFactory == null)

--- a/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
@@ -87,6 +88,76 @@ namespace Azure.Core.Tests.Identity
             // If MSAL retry was active, we'd see one or more extra requests.
             Assert.AreEqual(expectedCalls, requestCount, $"Expected exactly {expectedCalls} requests (1 initial + {maxRetries} Azure SDK retries). MSAL retry is not disabled.");
         }
+
+#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+        [Test]
+        public void AdditionalQueryParametersAreForwardedToBuilder()
+        {
+            var extraParams = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
+            {
+                ["feature"] = ("agenticSession", false),
+                ["session_id"] = ("abc-123", true)
+            };
+
+            var options = new ClientSecretCredentialOptions
+            {
+                Transport = new MockTransport(),
+                DisableInstanceDiscovery = true,
+                AdditionalQueryParameters = extraParams
+            };
+
+            var pipeline = CredentialPipeline.GetInstance(options);
+            var client = new MockMsalConfidentialClient(pipeline, "tenant", "client", "secret", "https://redirect", options);
+
+            // Verify the parameters were snapshotted into the MSAL client
+            var stored = client.GetAdditionalQueryParameters();
+            Assert.IsNotNull(stored);
+            Assert.AreEqual(2, stored.Count);
+            Assert.AreEqual(("agenticSession", false), stored["feature"]);
+            Assert.AreEqual(("abc-123", true), stored["session_id"]);
+
+            // Verify it's a snapshot (mutation of the original doesn't affect the client)
+            extraParams["new_param"] = ("new_value", false);
+            Assert.IsFalse(stored.ContainsKey("new_param"));
+
+            // Verify the builder still works
+            Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
+        }
+
+        [Test]
+        public void NullAdditionalQueryParametersDoesNotThrow()
+        {
+            var options = new ClientSecretCredentialOptions
+            {
+                Transport = new MockTransport(),
+                DisableInstanceDiscovery = true,
+                AdditionalQueryParameters = null
+            };
+
+            var pipeline = CredentialPipeline.GetInstance(options);
+            var client = new MockMsalConfidentialClient(pipeline, "tenant", "client", "secret", "https://redirect", options);
+
+            Assert.IsNull(client.GetAdditionalQueryParameters());
+            Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
+        }
+
+        [Test]
+        public void EmptyAdditionalQueryParametersDoesNotThrow()
+        {
+            var options = new ClientSecretCredentialOptions
+            {
+                Transport = new MockTransport(),
+                DisableInstanceDiscovery = true,
+                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>()
+            };
+
+            var pipeline = CredentialPipeline.GetInstance(options);
+            var client = new MockMsalConfidentialClient(pipeline, "tenant", "client", "secret", "https://redirect", options);
+
+            Assert.IsNull(client.GetAdditionalQueryParameters());
+            Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
+        }
+#pragma warning restore AZID5001
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions
         {

--- a/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
@@ -93,18 +93,13 @@ namespace Azure.Core.Tests.Identity
         [Test]
         public void AdditionalQueryParametersAreForwardedToBuilder()
         {
-            var extraParams = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
-            {
-                ["feature"] = ("agenticSession", false),
-                ["session_id"] = ("abc-123", true)
-            };
-
             var options = new ClientSecretCredentialOptions
             {
                 Transport = new MockTransport(),
                 DisableInstanceDiscovery = true,
-                AdditionalQueryParameters = extraParams
             };
+            options.AdditionalQueryParameters["feature"] = ("agenticSession", false);
+            options.AdditionalQueryParameters["session_id"] = ("abc-123", true);
 
             var pipeline = CredentialPipeline.GetInstance(options);
             var client = new MockMsalConfidentialClient(pipeline, "tenant", "client", "secret", "https://redirect", options);
@@ -117,7 +112,7 @@ namespace Azure.Core.Tests.Identity
             Assert.AreEqual(("abc-123", true), stored["session_id"]);
 
             // Verify it's a snapshot (mutation of the original doesn't affect the client)
-            extraParams["new_param"] = ("new_value", false);
+            options.AdditionalQueryParameters["new_param"] = ("new_value", false);
             Assert.IsFalse(stored.ContainsKey("new_param"));
 
             // Verify the builder still works
@@ -125,30 +120,50 @@ namespace Azure.Core.Tests.Identity
         }
 
         [Test]
-        public void NullAdditionalQueryParametersDoesNotThrow()
+        public async Task AdditionalQueryParametersAreIncludedInRequests()
         {
+            var capturedRequests = new List<MockRequest>();
+            var mockTransport = new MockTransport(req =>
+            {
+                capturedRequests.Add(req);
+                var response = new MockResponse(400);
+                response.SetContent("{\"error\":\"invalid_grant\",\"error_description\":\"bad request\"}");
+                return response;
+            });
+
             var options = new ClientSecretCredentialOptions
             {
-                Transport = new MockTransport(),
+                Transport = mockTransport,
+                Retry = { MaxRetries = 0 },
                 DisableInstanceDiscovery = true,
-                AdditionalQueryParameters = null
             };
+#pragma warning disable AZID5001
+            options.AdditionalQueryParameters["feature"] = ("agenticSession", false);
+            options.AdditionalQueryParameters["session_id"] = ("abc-123", true);
+#pragma warning restore AZID5001
 
-            var pipeline = CredentialPipeline.GetInstance(options);
-            var client = new MockMsalConfidentialClient(pipeline, "tenant", "client", "secret", "https://redirect", options);
+            var credential = new ClientSecretCredential("tenant", "client", "secret", options);
 
-            Assert.IsNull(client.GetAdditionalQueryParameters());
-            Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
+            Assert.ThrowsAsync<AuthenticationFailedException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })));
+
+            Assert.IsNotEmpty(capturedRequests);
+            // Find the token request (POST to /oauth2/v2.0/token)
+            var tokenRequest = capturedRequests.Find(r => r.Uri.Path.Contains("/oauth2/v2.0/token"));
+            Assert.IsNotNull(tokenRequest, "Expected a token request to /oauth2/v2.0/token");
+
+            var query = tokenRequest.Uri.Query;
+            Assert.IsTrue(query.Contains("feature=agenticSession"), $"Expected 'feature=agenticSession' in query: {query}");
+            Assert.IsTrue(query.Contains("session_id=abc-123"), $"Expected 'session_id=abc-123' in query: {query}");
         }
 
         [Test]
-        public void EmptyAdditionalQueryParametersDoesNotThrow()
+        public void DefaultEmptyAdditionalQueryParametersDoesNotThrow()
         {
             var options = new ClientSecretCredentialOptions
             {
                 Transport = new MockTransport(),
                 DisableInstanceDiscovery = true,
-                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>()
             };
 
             var pipeline = CredentialPipeline.GetInstance(options);

--- a/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
@@ -89,7 +89,7 @@ namespace Azure.Core.Tests.Identity
             Assert.AreEqual(expectedCalls, requestCount, $"Expected exactly {expectedCalls} requests (1 initial + {maxRetries} Azure SDK retries). MSAL retry is not disabled.");
         }
 
-#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+#pragma warning disable AZID0001 // AdditionalQueryParameters is experimental
         [Test]
         public void AdditionalQueryParametersAreForwardedToBuilder()
         {
@@ -137,10 +137,10 @@ namespace Azure.Core.Tests.Identity
                 Retry = { MaxRetries = 0 },
                 DisableInstanceDiscovery = true,
             };
-#pragma warning disable AZID5001
+#pragma warning disable AZID0001
             options.AdditionalQueryParameters["feature"] = ("agenticSession", false);
             options.AdditionalQueryParameters["session_id"] = ("abc-123", true);
-#pragma warning restore AZID5001
+#pragma warning restore AZID0001
 
             var credential = new ClientSecretCredential("tenant", "client", "secret", options);
 
@@ -172,7 +172,7 @@ namespace Azure.Core.Tests.Identity
             Assert.IsNull(client.GetAdditionalQueryParameters());
             Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
         }
-#pragma warning restore AZID5001
+#pragma warning restore AZID0001
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions
         {

--- a/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalConfidentialClientTests.cs
@@ -122,10 +122,8 @@ namespace Azure.Core.Tests.Identity
         [Test]
         public async Task AdditionalQueryParametersAreIncludedInRequests()
         {
-            var capturedRequests = new List<MockRequest>();
             var mockTransport = new MockTransport(req =>
             {
-                capturedRequests.Add(req);
                 var response = new MockResponse(400);
                 response.SetContent("{\"error\":\"invalid_grant\",\"error_description\":\"bad request\"}");
                 return response;
@@ -147,9 +145,8 @@ namespace Azure.Core.Tests.Identity
             Assert.ThrowsAsync<AuthenticationFailedException>(
                 async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })));
 
-            Assert.IsNotEmpty(capturedRequests);
-            // Find the token request (POST to /oauth2/v2.0/token)
-            var tokenRequest = capturedRequests.Find(r => r.Uri.Path.Contains("/oauth2/v2.0/token"));
+            Assert.IsNotEmpty(mockTransport.Requests);
+            var tokenRequest = mockTransport.Requests.Find(r => r.Uri.Path.Contains("/oauth2/v2.0/token"));
             Assert.IsNotNull(tokenRequest, "Expected a token request to /oauth2/v2.0/token");
 
             var query = tokenRequest.Uri.Query;

--- a/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
@@ -93,18 +93,13 @@ namespace Azure.Core.Tests.Identity
         [Test]
         public void AdditionalQueryParametersAreForwardedToBuilder()
         {
-            var extraParams = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
-            {
-                ["feature"] = ("agenticSession", false),
-                ["session_id"] = ("abc-123", true)
-            };
-
             var options = new InteractiveBrowserCredentialOptions
             {
                 Transport = new MockTransport(),
                 DisableInstanceDiscovery = true,
-                AdditionalQueryParameters = extraParams
             };
+            options.AdditionalQueryParameters["feature"] = ("agenticSession", false);
+            options.AdditionalQueryParameters["session_id"] = ("abc-123", true);
 
             var pipeline = CredentialPipeline.GetInstance(options);
             var client = new MockMsalPublicClient(pipeline, "tenant", Guid.NewGuid().ToString(), "https://redirect", options);
@@ -117,7 +112,7 @@ namespace Azure.Core.Tests.Identity
             Assert.AreEqual(("abc-123", true), stored["session_id"]);
 
             // Verify it's a snapshot (mutation of the original doesn't affect the client)
-            extraParams["new_param"] = ("new_value", false);
+            options.AdditionalQueryParameters["new_param"] = ("new_value", false);
             Assert.IsFalse(stored.ContainsKey("new_param"));
 
             // Verify the builder still works
@@ -125,30 +120,50 @@ namespace Azure.Core.Tests.Identity
         }
 
         [Test]
-        public void NullAdditionalQueryParametersDoesNotThrow()
+        public async Task AdditionalQueryParametersAreIncludedInRequests()
         {
-            var options = new InteractiveBrowserCredentialOptions
+            var capturedRequests = new List<MockRequest>();
+            var mockTransport = new MockTransport(req =>
             {
-                Transport = new MockTransport(),
+                capturedRequests.Add(req);
+                var response = new MockResponse(400);
+                response.SetContent("{\"error\":\"invalid_grant\",\"error_description\":\"bad request\"}");
+                return response;
+            });
+
+            var options = new ClientSecretCredentialOptions
+            {
+                Transport = mockTransport,
+                Retry = { MaxRetries = 0 },
                 DisableInstanceDiscovery = true,
-                AdditionalQueryParameters = null
             };
+#pragma warning disable AZID5001
+            options.AdditionalQueryParameters["feature"] = ("agenticSession", false);
+            options.AdditionalQueryParameters["session_id"] = ("abc-123", true);
+#pragma warning restore AZID5001
 
-            var pipeline = CredentialPipeline.GetInstance(options);
-            var client = new MockMsalPublicClient(pipeline, "tenant", Guid.NewGuid().ToString(), "https://redirect", options);
+            var credential = new ClientSecretCredential("tenant", "client", "secret", options);
 
-            Assert.IsNull(client.GetAdditionalQueryParameters());
-            Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
+            Assert.ThrowsAsync<AuthenticationFailedException>(
+                async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })));
+
+            Assert.IsNotEmpty(capturedRequests);
+            // Find the token request (POST to /oauth2/v2.0/token)
+            var tokenRequest = capturedRequests.Find(r => r.Uri.Path.Contains("/oauth2/v2.0/token"));
+            Assert.IsNotNull(tokenRequest, "Expected a token request to /oauth2/v2.0/token");
+
+            var query = tokenRequest.Uri.Query;
+            Assert.IsTrue(query.Contains("feature=agenticSession"), $"Expected 'feature=agenticSession' in query: {query}");
+            Assert.IsTrue(query.Contains("session_id=abc-123"), $"Expected 'session_id=abc-123' in query: {query}");
         }
 
         [Test]
-        public void EmptyAdditionalQueryParametersDoesNotThrow()
+        public void DefaultEmptyAdditionalQueryParametersDoesNotThrow()
         {
             var options = new InteractiveBrowserCredentialOptions
             {
                 Transport = new MockTransport(),
                 DisableInstanceDiscovery = true,
-                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>()
             };
 
             var pipeline = CredentialPipeline.GetInstance(options);

--- a/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Core.TestFramework;
@@ -87,6 +88,76 @@ namespace Azure.Core.Tests.Identity
             // If MSAL retry was active, we'd see one or more extra requests.
             Assert.AreEqual(expectedCalls, requestCount, $"Expected exactly {expectedCalls} requests (1 initial + {maxRetries} Azure SDK retries). If this is {expectedCalls + 1}, MSAL retry is not disabled.");
         }
+
+#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+        [Test]
+        public void AdditionalQueryParametersAreForwardedToBuilder()
+        {
+            var extraParams = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
+            {
+                ["feature"] = ("agenticSession", false),
+                ["session_id"] = ("abc-123", true)
+            };
+
+            var options = new InteractiveBrowserCredentialOptions
+            {
+                Transport = new MockTransport(),
+                DisableInstanceDiscovery = true,
+                AdditionalQueryParameters = extraParams
+            };
+
+            var pipeline = CredentialPipeline.GetInstance(options);
+            var client = new MockMsalPublicClient(pipeline, "tenant", Guid.NewGuid().ToString(), "https://redirect", options);
+
+            // Verify the parameters were snapshotted into the MSAL client
+            var stored = client.GetAdditionalQueryParameters();
+            Assert.IsNotNull(stored);
+            Assert.AreEqual(2, stored.Count);
+            Assert.AreEqual(("agenticSession", false), stored["feature"]);
+            Assert.AreEqual(("abc-123", true), stored["session_id"]);
+
+            // Verify it's a snapshot (mutation of the original doesn't affect the client)
+            extraParams["new_param"] = ("new_value", false);
+            Assert.IsFalse(stored.ContainsKey("new_param"));
+
+            // Verify the builder still works
+            Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
+        }
+
+        [Test]
+        public void NullAdditionalQueryParametersDoesNotThrow()
+        {
+            var options = new InteractiveBrowserCredentialOptions
+            {
+                Transport = new MockTransport(),
+                DisableInstanceDiscovery = true,
+                AdditionalQueryParameters = null
+            };
+
+            var pipeline = CredentialPipeline.GetInstance(options);
+            var client = new MockMsalPublicClient(pipeline, "tenant", Guid.NewGuid().ToString(), "https://redirect", options);
+
+            Assert.IsNull(client.GetAdditionalQueryParameters());
+            Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
+        }
+
+        [Test]
+        public void EmptyAdditionalQueryParametersDoesNotThrow()
+        {
+            var options = new InteractiveBrowserCredentialOptions
+            {
+                Transport = new MockTransport(),
+                DisableInstanceDiscovery = true,
+                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>()
+            };
+
+            var pipeline = CredentialPipeline.GetInstance(options);
+            var client = new MockMsalPublicClient(pipeline, "tenant", Guid.NewGuid().ToString(), "https://redirect", options);
+
+            Assert.IsNull(client.GetAdditionalQueryParameters());
+            Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
+        }
+#pragma warning restore AZID5001
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions
         {

--- a/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
@@ -89,7 +89,7 @@ namespace Azure.Core.Tests.Identity
             Assert.AreEqual(expectedCalls, requestCount, $"Expected exactly {expectedCalls} requests (1 initial + {maxRetries} Azure SDK retries). If this is {expectedCalls + 1}, MSAL retry is not disabled.");
         }
 
-#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+#pragma warning disable AZID0001 // AdditionalQueryParameters is experimental
         [Test]
         public void AdditionalQueryParametersAreForwardedToBuilder()
         {
@@ -137,10 +137,10 @@ namespace Azure.Core.Tests.Identity
                 Retry = { MaxRetries = 0 },
                 DisableInstanceDiscovery = true,
             };
-#pragma warning disable AZID5001
+#pragma warning disable AZID0001
             options.AdditionalQueryParameters["feature"] = ("agenticSession", false);
             options.AdditionalQueryParameters["session_id"] = ("abc-123", true);
-#pragma warning restore AZID5001
+#pragma warning restore AZID0001
 
             var credential = new ClientSecretCredential("tenant", "client", "secret", options);
 
@@ -172,7 +172,7 @@ namespace Azure.Core.Tests.Identity
             Assert.IsNull(client.GetAdditionalQueryParameters());
             Assert.DoesNotThrowAsync(async () => await client.CallCreateClientAsync(false, true, default));
         }
-#pragma warning restore AZID5001
+#pragma warning restore AZID0001
 
         public class TestCredentialOptions : TokenCredentialOptions, ISupportsTokenCachePersistenceOptions
         {

--- a/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/MsalPublicClientTests.cs
@@ -122,10 +122,8 @@ namespace Azure.Core.Tests.Identity
         [Test]
         public async Task AdditionalQueryParametersAreIncludedInRequests()
         {
-            var capturedRequests = new List<MockRequest>();
             var mockTransport = new MockTransport(req =>
             {
-                capturedRequests.Add(req);
                 var response = new MockResponse(400);
                 response.SetContent("{\"error\":\"invalid_grant\",\"error_description\":\"bad request\"}");
                 return response;
@@ -147,9 +145,8 @@ namespace Azure.Core.Tests.Identity
             Assert.ThrowsAsync<AuthenticationFailedException>(
                 async () => await credential.GetTokenAsync(new TokenRequestContext(new[] { "https://vault.azure.net/.default" })));
 
-            Assert.IsNotEmpty(capturedRequests);
-            // Find the token request (POST to /oauth2/v2.0/token)
-            var tokenRequest = capturedRequests.Find(r => r.Uri.Path.Contains("/oauth2/v2.0/token"));
+            Assert.IsNotEmpty(mockTransport.Requests);
+            var tokenRequest = mockTransport.Requests.Find(r => r.Uri.Path.Contains("/oauth2/v2.0/token"));
             Assert.IsNotNull(tokenRequest, "Expected a token request to /oauth2/v2.0/token");
 
             var query = tokenRequest.Uri.Query;

--- a/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
@@ -253,7 +253,7 @@ namespace Azure.Core.Tests.Identity
                     AuthorityHost = AzureAuthorityHosts.AzureChina,
                     IsUnsafeSupportLoggingEnabled = true,
 #pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
-                    AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
+                    AdditionalQueryParameters =
                     {
                         ["feature"] = ("agenticSession", false),
                         ["session_id"] = (Guid.NewGuid().ToString(), true)
@@ -374,16 +374,15 @@ namespace Azure.Core.Tests.Identity
 #pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
             // AdditionalQueryParameters is on TokenCredentialOptions (base class), so it should always be cloned
             var sourceOptions = (TokenCredentialOptions)source;
-            var destOptions = (TokenCredentialOptions)destination;
-            sourceOptions.AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)> { ["test"] = ("value", true) };
+            sourceOptions.AdditionalQueryParameters["test"] = ("value", true);
 
-            // Re-clone after setting AdditionalQueryParameters to verify it's copied
+            // Re-clone after populating AdditionalQueryParameters to verify it's copied
             var reclonedDest = (TokenCredentialOptions)sourceType
                 .GetMethod("Clone", BindingFlags.Instance | BindingFlags.NonPublic)
                 .MakeGenericMethod(destinationType)
                 .Invoke(source, null);
 
-            Assert.IsNotNull(reclonedDest.AdditionalQueryParameters);
+            Assert.AreEqual(1, reclonedDest.AdditionalQueryParameters.Count);
             Assert.AreEqual(("value", true), reclonedDest.AdditionalQueryParameters["test"]);
             Assert.AreNotSame(sourceOptions.AdditionalQueryParameters, reclonedDest.AdditionalQueryParameters);
 #pragma warning restore AZID5001
@@ -391,23 +390,19 @@ namespace Azure.Core.Tests.Identity
 
 #pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
         [Test]
-        public void AdditionalQueryParametersDefaultsToNull()
+        public void AdditionalQueryParametersDefaultsToEmpty()
         {
             var options = new TokenCredentialOptions();
-            Assert.IsNull(options.AdditionalQueryParameters);
+            Assert.IsNotNull(options.AdditionalQueryParameters);
+            Assert.AreEqual(0, options.AdditionalQueryParameters.Count);
         }
 
         [Test]
-        public void AdditionalQueryParametersCanBeSet()
+        public void AdditionalQueryParametersCanBePopulated()
         {
-            var options = new TokenCredentialOptions
-            {
-                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
-                {
-                    ["feature"] = ("agenticSession", false),
-                    ["session_id"] = ("abc-123", true)
-                }
-            };
+            var options = new TokenCredentialOptions();
+            options.AdditionalQueryParameters["feature"] = ("agenticSession", false);
+            options.AdditionalQueryParameters["session_id"] = ("abc-123", true);
 
             Assert.AreEqual(2, options.AdditionalQueryParameters.Count);
             Assert.AreEqual(("agenticSession", false), options.AdditionalQueryParameters["feature"]);
@@ -415,49 +410,31 @@ namespace Azure.Core.Tests.Identity
         }
 
         [Test]
-        public void AdditionalQueryParametersCanBeSetToEmpty()
+        public void AdditionalQueryParametersCanBeCleared()
         {
-            var options = new TokenCredentialOptions
-            {
-                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>()
-            };
+            var options = new TokenCredentialOptions();
+            options.AdditionalQueryParameters["key"] = ("value", false);
 
-            Assert.IsNotNull(options.AdditionalQueryParameters);
+            options.AdditionalQueryParameters.Clear();
             Assert.AreEqual(0, options.AdditionalQueryParameters.Count);
         }
 
         [Test]
-        public void AdditionalQueryParametersCanBeCleared()
-        {
-            var options = new TokenCredentialOptions
-            {
-                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)> { ["key"] = ("value", false) }
-            };
-
-            options.AdditionalQueryParameters = null;
-            Assert.IsNull(options.AdditionalQueryParameters);
-        }
-
-        [Test]
-        public void CloneWithNullAdditionalQueryParametersReturnsNull()
+        public void CloneWithEmptyAdditionalQueryParametersReturnsEmpty()
         {
             var options = new TokenCredentialOptions();
             var clone = options.Clone<TokenCredentialOptions>();
 
-            Assert.IsNull(clone.AdditionalQueryParameters);
+            Assert.IsNotNull(clone.AdditionalQueryParameters);
+            Assert.AreEqual(0, clone.AdditionalQueryParameters.Count);
         }
 
         [Test]
         public void CloneDeepCopiesAdditionalQueryParameters()
         {
-            var options = new TokenCredentialOptions
-            {
-                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
-                {
-                    ["feature"] = ("agenticSession", false),
-                    ["session_id"] = ("abc-123", true)
-                }
-            };
+            var options = new TokenCredentialOptions();
+            options.AdditionalQueryParameters["feature"] = ("agenticSession", false);
+            options.AdditionalQueryParameters["session_id"] = ("abc-123", true);
 
             var clone = options.Clone<TokenCredentialOptions>();
 

--- a/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
@@ -160,6 +160,11 @@ namespace Azure.Core.Tests.Identity
 
         private void AssertOptionsCloned(CloneTestOptions original, CloneTestOptions clone)
         {
+#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+            CollectionAssert.AreEqual(original.AdditionalQueryParameters, clone.AdditionalQueryParameters);
+            Assert.AreNotSame(original.AdditionalQueryParameters, clone.AdditionalQueryParameters, "AdditionalQueryParameters should be deep-copied, not shared.");
+#pragma warning restore AZID5001
+
             if (original is ISupportsAdditionallyAllowedTenants && clone is ISupportsAdditionallyAllowedTenants)
             {
                 CollectionAssert.AreEqual(original.AdditionallyAllowedTenants, clone.AdditionallyAllowedTenants);
@@ -247,6 +252,13 @@ namespace Azure.Core.Tests.Identity
                     TokenCachePersistenceOptions = new TokenCachePersistenceOptions(),
                     AuthorityHost = AzureAuthorityHosts.AzureChina,
                     IsUnsafeSupportLoggingEnabled = true,
+#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+                    AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
+                    {
+                        ["feature"] = ("agenticSession", false),
+                        ["session_id"] = (Guid.NewGuid().ToString(), true)
+                    },
+#pragma warning restore AZID5001
                     Retry =
                     {
                         MaxRetries = 15,
@@ -358,6 +370,107 @@ namespace Azure.Core.Tests.Identity
             {
                 Assert.AreEqual(stiSource.TenantId, stiDestination.TenantId);
             }
+
+#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+            // AdditionalQueryParameters is on TokenCredentialOptions (base class), so it should always be cloned
+            var sourceOptions = (TokenCredentialOptions)source;
+            var destOptions = (TokenCredentialOptions)destination;
+            sourceOptions.AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)> { ["test"] = ("value", true) };
+
+            // Re-clone after setting AdditionalQueryParameters to verify it's copied
+            var reclonedDest = (TokenCredentialOptions)sourceType
+                .GetMethod("Clone", BindingFlags.Instance | BindingFlags.NonPublic)
+                .MakeGenericMethod(destinationType)
+                .Invoke(source, null);
+
+            Assert.IsNotNull(reclonedDest.AdditionalQueryParameters);
+            Assert.AreEqual(("value", true), reclonedDest.AdditionalQueryParameters["test"]);
+            Assert.AreNotSame(sourceOptions.AdditionalQueryParameters, reclonedDest.AdditionalQueryParameters);
+#pragma warning restore AZID5001
         }
+
+#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+        [Test]
+        public void AdditionalQueryParametersDefaultsToNull()
+        {
+            var options = new TokenCredentialOptions();
+            Assert.IsNull(options.AdditionalQueryParameters);
+        }
+
+        [Test]
+        public void AdditionalQueryParametersCanBeSet()
+        {
+            var options = new TokenCredentialOptions
+            {
+                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
+                {
+                    ["feature"] = ("agenticSession", false),
+                    ["session_id"] = ("abc-123", true)
+                }
+            };
+
+            Assert.AreEqual(2, options.AdditionalQueryParameters.Count);
+            Assert.AreEqual(("agenticSession", false), options.AdditionalQueryParameters["feature"]);
+            Assert.AreEqual(("abc-123", true), options.AdditionalQueryParameters["session_id"]);
+        }
+
+        [Test]
+        public void AdditionalQueryParametersCanBeSetToEmpty()
+        {
+            var options = new TokenCredentialOptions
+            {
+                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>()
+            };
+
+            Assert.IsNotNull(options.AdditionalQueryParameters);
+            Assert.AreEqual(0, options.AdditionalQueryParameters.Count);
+        }
+
+        [Test]
+        public void AdditionalQueryParametersCanBeCleared()
+        {
+            var options = new TokenCredentialOptions
+            {
+                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)> { ["key"] = ("value", false) }
+            };
+
+            options.AdditionalQueryParameters = null;
+            Assert.IsNull(options.AdditionalQueryParameters);
+        }
+
+        [Test]
+        public void CloneWithNullAdditionalQueryParametersReturnsNull()
+        {
+            var options = new TokenCredentialOptions();
+            var clone = options.Clone<TokenCredentialOptions>();
+
+            Assert.IsNull(clone.AdditionalQueryParameters);
+        }
+
+        [Test]
+        public void CloneDeepCopiesAdditionalQueryParameters()
+        {
+            var options = new TokenCredentialOptions
+            {
+                AdditionalQueryParameters = new Dictionary<string, (string Value, bool IncludeInCacheKey)>
+                {
+                    ["feature"] = ("agenticSession", false),
+                    ["session_id"] = ("abc-123", true)
+                }
+            };
+
+            var clone = options.Clone<TokenCredentialOptions>();
+
+            // Verify values are equal
+            CollectionAssert.AreEqual(options.AdditionalQueryParameters, clone.AdditionalQueryParameters);
+
+            // Verify it's a different instance (deep copy)
+            Assert.AreNotSame(options.AdditionalQueryParameters, clone.AdditionalQueryParameters);
+
+            // Verify mutation of clone doesn't affect original
+            clone.AdditionalQueryParameters["new_param"] = ("new_value", false);
+            Assert.IsFalse(options.AdditionalQueryParameters.ContainsKey("new_param"));
+        }
+#pragma warning restore AZID5001
     }
 }

--- a/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
+++ b/sdk/core/Azure.Core/tests/Identity/TokenCredentialOptionsTests.cs
@@ -160,10 +160,10 @@ namespace Azure.Core.Tests.Identity
 
         private void AssertOptionsCloned(CloneTestOptions original, CloneTestOptions clone)
         {
-#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+#pragma warning disable AZID0001 // AdditionalQueryParameters is experimental
             CollectionAssert.AreEqual(original.AdditionalQueryParameters, clone.AdditionalQueryParameters);
             Assert.AreNotSame(original.AdditionalQueryParameters, clone.AdditionalQueryParameters, "AdditionalQueryParameters should be deep-copied, not shared.");
-#pragma warning restore AZID5001
+#pragma warning restore AZID0001
 
             if (original is ISupportsAdditionallyAllowedTenants && clone is ISupportsAdditionallyAllowedTenants)
             {
@@ -252,13 +252,13 @@ namespace Azure.Core.Tests.Identity
                     TokenCachePersistenceOptions = new TokenCachePersistenceOptions(),
                     AuthorityHost = AzureAuthorityHosts.AzureChina,
                     IsUnsafeSupportLoggingEnabled = true,
-#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+#pragma warning disable AZID0001 // AdditionalQueryParameters is experimental
                     AdditionalQueryParameters =
                     {
                         ["feature"] = ("agenticSession", false),
                         ["session_id"] = (Guid.NewGuid().ToString(), true)
                     },
-#pragma warning restore AZID5001
+#pragma warning restore AZID0001
                     Retry =
                     {
                         MaxRetries = 15,
@@ -371,24 +371,24 @@ namespace Azure.Core.Tests.Identity
                 Assert.AreEqual(stiSource.TenantId, stiDestination.TenantId);
             }
 
-#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+#pragma warning disable AZID0001 // AdditionalQueryParameters is experimental
             // AdditionalQueryParameters is on TokenCredentialOptions (base class), so it should always be cloned
             var sourceOptions = (TokenCredentialOptions)source;
             sourceOptions.AdditionalQueryParameters["test"] = ("value", true);
 
-            // Re-clone after populating AdditionalQueryParameters to verify it's copied
-            var reclonedDest = (TokenCredentialOptions)sourceType
+            // Clone again after populating AdditionalQueryParameters to verify it's copied
+            var clonedDest = (TokenCredentialOptions)sourceType
                 .GetMethod("Clone", BindingFlags.Instance | BindingFlags.NonPublic)
                 .MakeGenericMethod(destinationType)
                 .Invoke(source, null);
 
-            Assert.AreEqual(1, reclonedDest.AdditionalQueryParameters.Count);
-            Assert.AreEqual(("value", true), reclonedDest.AdditionalQueryParameters["test"]);
-            Assert.AreNotSame(sourceOptions.AdditionalQueryParameters, reclonedDest.AdditionalQueryParameters);
-#pragma warning restore AZID5001
+            Assert.AreEqual(1, clonedDest.AdditionalQueryParameters.Count);
+            Assert.AreEqual(("value", true), clonedDest.AdditionalQueryParameters["test"]);
+            Assert.AreNotSame(sourceOptions.AdditionalQueryParameters, clonedDest.AdditionalQueryParameters);
+#pragma warning restore AZID0001
         }
 
-#pragma warning disable AZID5001 // AdditionalQueryParameters is experimental
+#pragma warning disable AZID0001 // AdditionalQueryParameters is experimental
         [Test]
         public void AdditionalQueryParametersDefaultsToEmpty()
         {
@@ -448,6 +448,6 @@ namespace Azure.Core.Tests.Identity
             clone.AdditionalQueryParameters["new_param"] = ("new_value", false);
             Assert.IsFalse(options.AdditionalQueryParameters.ContainsKey("new_param"));
         }
-#pragma warning restore AZID5001
+#pragma warning restore AZID0001
     }
 }

--- a/sdk/core/cspell.yaml
+++ b/sdk/core/cspell.yaml
@@ -1,0 +1,4 @@
+import:
+  - ../../.vscode/cspell.json
+words:
+  - AZID


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/58921

This is the first iteration of this issue and it's introduced as an **Experimental** feature. The design is subject to change on future implementations.

---
✨ AI Summary
This pull request adds support for passing additional query parameters to Microsoft Entra authentication requests via the `TokenCredentialOptions` class in the Azure Identity library. These parameters can be used to customize authentication requests and control whether each parameter is included in the token cache key. The feature is currently marked as experimental and is only honored by MSAL-backed credentials. The implementation includes deep copying to avoid shared mutable state and comprehensive tests to ensure correct behavior.

**Feature: Additional Query Parameters for Authentication Requests**
- Introduced the `AdditionalQueryParameters` property to `TokenCredentialOptions`, allowing users to specify extra query parameters (with an option to include each in the cache key) for authentication requests to Microsoft Entra. This property is marked as experimental and only applies to MSAL-backed credentials. (`TokenCredentialOptions` in `Azure.Core.net8.0.cs`, `Azure.Core.net10.0.cs`, `Azure.Core.net462.cs`, `Azure.Core.net472.cs`, `Azure.Core.netstandard2.0.cs`, and `TokenCredentialOptions.cs`) [[1]](diffhunk://#diff-9386e21c90bb6c6e306c56dc6f6cd93b8c5cd258533c40030e0810c2033ed66dR1674-R1675) [[2]](diffhunk://#diff-d59bbe8786fde11db4de05614cdacacfec2b025c3a298b04492a4f3c762e9627R1636) [[3]](diffhunk://#diff-01e988fdd0a61e75488f646d530012c8f843ff4925052d07c43218275d840a42R69-R76)

**Implementation: Propagation and Handling**
- Ensured that `AdditionalQueryParameters` is deep-copied during cloning of options to prevent shared mutable state. (`TokenCredentialOptions.cs`)
- Propagated `AdditionalQueryParameters` through MSAL client base classes and ensured they are passed to the MSAL builder methods. (`MsalClientBase.cs`, `MsalConfidentialClient.cs`, `MsalPublicClient.cs`) [[1]](diffhunk://#diff-7f7405ffeba34d97d573c56f028602c808ee05f01ae3b58130dd4937ed682eaeR27) [[2]](diffhunk://#diff-7f7405ffeba34d97d573c56f028602c808ee05f01ae3b58130dd4937ed682eaeR55-R59) [[3]](diffhunk://#diff-bb087844a7c3dccc429dff5f7c1cf6195a240fea3074ed33e5b4860c5a338423R146-R150) [[4]](diffhunk://#diff-bcd5e5eb5d1ea3f18c37f39dcf34e7635b62e86183775c65b46d5df6bebb8978R77-R81)

**Testing: Robustness and Correctness**
- Added unit tests to verify that `AdditionalQueryParameters` are correctly forwarded to MSAL builders, are snapshotted (not affected by later mutations), and that null or empty values are handled gracefully without throwing exceptions. (`MsalConfidentialClientTests.cs`, `MsalPublicClientTests.cs`) [[1]](diffhunk://#diff-8971af6ee3b67042b7d99ff5dc7793688caca0c2a9fa3ca91bf744274b1eaaf3R92-R161) [[2]](diffhunk://#diff-4ed4f40f0a2bf281df1a1545c7a43d19a98bb6d8aba61e8dd56f3c581e121a9fR92-R161)
- Updated mock clients to expose the stored `AdditionalQueryParameters` for test assertions. (`MockMsalConfidentialClient.cs`, `MockMsalPublicClient.cs`) [[1]](diffhunk://#diff-9a5878fd4ecc496324ae5c3136a72dd61dcde5b433de125f79ef0425b301dba7R128-R132) [[2]](diffhunk://#diff-6061d711c3b515765991d56a2ded9e85dcbdb2f428ea2f370021192e0c02f41dR159-R163)
- Enhanced clone tests to ensure `AdditionalQueryParameters` are deep-copied and not shared. (`TokenCredentialOptionsTests.cs`)