### PR TITLE
[mgmt-generator] Add disable-safe-flatten clientOption opt-out (fixes #58066)

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/docs/client-options.md
+++ b/eng/packages/http-client-csharp-mgmt/docs/client-options.md
@@ -79,7 +79,30 @@ public override ResourceNameRequirements GetResourceNameRequirements()
 
 The `pattern` string is parsed to determine which `ResourceNameCharacters` flags to include. Character classes (`[a-z]`, `[A-Z]`, `[0-9]`, `-`, `_`, `.`, `()`) are extracted from the regex and tested against representative characters.
 
+## `disable-safe-flatten`
+
+Opts a model out of the C# generator's *safe-flatten* transform. By default, when a parent model has a property whose type is another model that contains exactly one public, non-discriminator, non-obsolete property, the generator lifts that single inner property up onto the parent and removes the inner type. Setting `disable-safe-flatten` to `true` on the inner model preserves it as a public type and keeps the parent's property pointing at it.
+
+Use this when the inner model is part of the public API surface that consumers already depend on (for example, when migrating from AutoRest where `safe-flatten: false` was used in `readme.md` directives), or when future spec changes are likely to add more properties to the inner model and you do not want the public surface to change.
+
+**Target:** Any input model that would otherwise be safe-flattened (e.g. `AllInstancesDown`, `UserInitiatedRedeploy`).
+
+**Value:** Boolean `true`.
+
+**Example:**
+
+```typespec
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Preserve type for public API surface"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Preserve type for public API surface"
+@@clientOption(AllInstancesDown, "disable-safe-flatten", true, "csharp");
+```
+
+**Effect:** The C# generator skips the safe-flatten step for the targeted model wherever it appears as a single-property inner type. The model is emitted as a regular public type, and the parent property continues to expose it directly (i.e. `parent.AllInstancesDown.AutomaticallyApprove` rather than `parent.AutomaticallyApprove`).
+
+**Scope:** Inner-model. One decorator covers every parent that uses the model. There is no per-call-site granularity.
+
 ## Notes
 
 - All `@@clientOption` decorators require `#suppress` directives for the `client-option` and `client-option-requires-scope` diagnostics until the TCGC issue [Azure/typespec-azure#4104](https://github.com/Azure/typespec-azure/issues/4104) is resolved.
-- These options are read during resource detection in the emitter and serialized into the `armProviderSchema` decorator on the code model. The C# generator then deserializes them to drive code generation.
+- The `resource-rbac-roles` and `resource-name-constraint` keys are read during resource detection in the emitter and serialized into the `armProviderSchema` decorator on the code model. The C# generator then deserializes them to drive code generation.
+- The `disable-safe-flatten` key is propagated by TCGC onto the input model's `Decorators` collection. The C# generator reads it directly when deciding whether to apply safe-flatten.

--- a/eng/packages/http-client-csharp-mgmt/docs/client-options.md
+++ b/eng/packages/http-client-csharp-mgmt/docs/client-options.md
@@ -87,7 +87,7 @@ Use this when the inner model is part of the public API surface that consumers a
 
 **Target:** Any input model that would otherwise be safe-flattened (e.g. `AllInstancesDown`, `UserInitiatedRedeploy`).
 
-**Value:** Boolean `true`.
+**Value:** Boolean `true`. Any other value — including the string `"true"`, `1`, `false`, or omission — is ignored and the model will still be safe-flattened.
 
 **Example:**
 

--- a/eng/packages/http-client-csharp-mgmt/docs/client-options.md
+++ b/eng/packages/http-client-csharp-mgmt/docs/client-options.md
@@ -18,6 +18,7 @@ Defines RBAC (Role-Based Access Control) role definitions for a resource. Used b
 
 ```typespec
 #suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "RBAC roles for provisioning"
 @@clientOption(Vault,
   "resource-rbac-roles",
   #{
@@ -100,6 +101,8 @@ Use this when the inner model is part of the public API surface that consumers a
 **Effect:** The C# generator skips the safe-flatten step for the targeted model wherever it appears as a single-property inner type. The model is emitted as a regular public type, and the parent property continues to expose it directly (i.e. `parent.AllInstancesDown.AutomaticallyApprove` rather than `parent.AutomaticallyApprove`).
 
 **Scope:** Inner-model. One decorator covers every parent that uses the model. There is no per-call-site granularity.
+
+The C# generator only honors decorators scoped to `"csharp"` (or with no scope, which TCGC treats as "all languages"); decorators explicitly scoped to another language (e.g. `"java"`, `"python"`) are ignored.
 
 ## Notes
 

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
@@ -114,6 +114,11 @@ export const armProviderSchema =
 export const flattenPropertyDecorator =
   "Azure.ResourceManager.@flattenProperty";
 
+// https://azure.github.io/typespec-azure/docs/libraries/typespec-client-generator-core/reference/decorators#@Azure.ClientGenerator.Core.clientOption
+// Propagated to InputModelType.Decorators / InputModelProperty.Decorators so the
+// generator can read per-model / per-property opt-outs (e.g. "disable-safe-flatten").
+const clientOptionRegex = "Azure\\.ClientGenerator\\.Core\\.@clientOption";
+
 // TypeSpec validation decorators for resource name constraints
 const patternRegex = "TypeSpec\\.@pattern";
 const minLengthRegex = "TypeSpec\\.@minLength";
@@ -142,6 +147,7 @@ export const azureSDKContextOptions: CreateSdkContextOptions = {
     tenantResourceRegex,
     armResourceWithParameterRegex,
     customAzureResourceRegex,
+    clientOptionRegex,
     patternRegex,
     minLengthRegex,
     maxLengthRegex

--- a/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
+++ b/eng/packages/http-client-csharp-mgmt/emitter/src/sdk-context-options.ts
@@ -115,8 +115,9 @@ export const flattenPropertyDecorator =
   "Azure.ResourceManager.@flattenProperty";
 
 // https://azure.github.io/typespec-azure/docs/libraries/typespec-client-generator-core/reference/decorators#@Azure.ClientGenerator.Core.clientOption
-// Propagated to InputModelType.Decorators / InputModelProperty.Decorators so the
-// generator can read per-model / per-property opt-outs (e.g. "disable-safe-flatten").
+// Propagated onto InputModelType.Decorators so the management generator can read
+// per-model opt-outs (e.g. "disable-safe-flatten") that aren't consumed during
+// resource detection in the emitter.
 const clientOptionRegex = "Azure\\.ClientGenerator\\.Core\\.@clientOption";
 
 // TypeSpec validation decorators for resource name constraints

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
@@ -115,21 +115,23 @@ namespace Azure.Generator.Management
                 }
 
                 // @@clientOption(target, name, value, scope?) — TCGC propagates the named arguments as BinaryData JSON values.
-                if (!decorator.Arguments.TryGetValue("name", out var keyData) || keyData == null)
+                // Note: the second positional parameter is called "name" in the TCGC decorator definition,
+                // even though our docs and conceptual model refer to these as "keys".
+                if (!decorator.Arguments.TryGetValue("name", out var nameData) || nameData == null)
                 {
                     continue;
                 }
 
-                string? key;
+                string? optionName;
                 try
                 {
-                    key = keyData.ToObjectFromJson<string>();
+                    optionName = nameData.ToObjectFromJson<string>();
                 }
                 catch
                 {
                     continue;
                 }
-                if (key != DisableSafeFlattenKey)
+                if (optionName != DisableSafeFlattenKey)
                 {
                     continue;
                 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
@@ -136,34 +136,20 @@ namespace Azure.Generator.Management
                     continue;
                 }
 
-                if (!decorator.Arguments.TryGetValue("value", out var valueData) || valueData == null)
+                // Only accept a JSON boolean true. Any other value (string "true", 1, false, etc.) is ignored.
+                if (decorator.Arguments.TryGetValue("value", out var valueData) && valueData != null)
                 {
-                    continue;
-                }
-
-                // Accept JSON boolean true, or JSON string "true" (some pipelines stringify scalars).
-                try
-                {
-                    if (valueData.ToObjectFromJson<bool>())
+                    try
                     {
-                        return true;
+                        if (valueData.ToObjectFromJson<bool>())
+                        {
+                            return true;
+                        }
                     }
-                }
-                catch
-                {
-                    // not a boolean — try string
-                }
-                try
-                {
-                    var s = valueData.ToObjectFromJson<string>();
-                    if (string.Equals(s, "true", StringComparison.OrdinalIgnoreCase))
+                    catch
                     {
-                        return true;
+                        // not a boolean — ignore
                     }
-                }
-                catch
-                {
-                    // not a string either — skip
                 }
             }
             return false;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
@@ -15,10 +15,13 @@ namespace Azure.Generator.Management
     {
         private const string ArmProviderSchemaDecoratorName = "Azure.ClientGenerator.Core.@armProviderSchema";
         private const string FlattenPropertyDecoratorName = "Azure.ResourceManager.@flattenProperty";
+        private const string ClientOptionDecoratorName = "Azure.ClientGenerator.Core.@clientOption";
+        private const string DisableSafeFlattenKey = "disable-safe-flatten";
 
         private IReadOnlyDictionary<string, InputServiceMethod>? _inputServiceMethodsByCrossLanguageDefinitionId;
         private IReadOnlyDictionary<InputServiceMethod, InputClient>? _intMethodClientMap;
         private HashSet<InputModelType>? _resourceModels;
+        private HashSet<InputModelType>? _safeFlattenDisabledModels;
         private ArmProviderSchema? _providerSchema;
         private IReadOnlyDictionary<string, InputModelType>? _modelsByCrossLanguageDefinitionId;
 
@@ -81,6 +84,87 @@ namespace Azure.Generator.Management
                 }
             }
             return result;
+        }
+
+        /// <summary>
+        /// Set of input models for which safe-flatten should be disabled. Populated from
+        /// <c>@@clientOption(Model, "disable-safe-flatten", true, "csharp")</c> decorators.
+        /// </summary>
+        internal HashSet<InputModelType> SafeFlattenDisabledModels => _safeFlattenDisabledModels ??= BuildSafeFlattenDisabledModels();
+
+        private HashSet<InputModelType> BuildSafeFlattenDisabledModels()
+        {
+            var result = new HashSet<InputModelType>();
+            foreach (var model in InputNamespace.Models)
+            {
+                if (HasDisableSafeFlattenDecorator(model.Decorators))
+                {
+                    result.Add(model);
+                }
+            }
+            return result;
+        }
+
+        private static bool HasDisableSafeFlattenDecorator(IReadOnlyList<InputDecoratorInfo> decorators)
+        {
+            foreach (var decorator in decorators)
+            {
+                if (decorator.Name != ClientOptionDecoratorName || decorator.Arguments == null)
+                {
+                    continue;
+                }
+
+                // @@clientOption(target, name, value, scope?) — TCGC propagates the named arguments as BinaryData JSON values.
+                if (!decorator.Arguments.TryGetValue("name", out var keyData) || keyData == null)
+                {
+                    continue;
+                }
+
+                string? key;
+                try
+                {
+                    key = keyData.ToObjectFromJson<string>();
+                }
+                catch
+                {
+                    continue;
+                }
+                if (key != DisableSafeFlattenKey)
+                {
+                    continue;
+                }
+
+                if (!decorator.Arguments.TryGetValue("value", out var valueData) || valueData == null)
+                {
+                    continue;
+                }
+
+                // Accept JSON boolean true, or JSON string "true" (some pipelines stringify scalars).
+                try
+                {
+                    if (valueData.ToObjectFromJson<bool>())
+                    {
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // not a boolean — try string
+                }
+                try
+                {
+                    var s = valueData.ToObjectFromJson<string>();
+                    if (string.Equals(s, "true", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // not a string either — skip
+                }
+            }
+            return false;
         }
 
         /// <inheritdoc/>

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementInputLibrary.cs
@@ -17,6 +17,7 @@ namespace Azure.Generator.Management
         private const string FlattenPropertyDecoratorName = "Azure.ResourceManager.@flattenProperty";
         private const string ClientOptionDecoratorName = "Azure.ClientGenerator.Core.@clientOption";
         private const string DisableSafeFlattenKey = "disable-safe-flatten";
+        private const string CSharpScope = "csharp";
 
         private IReadOnlyDictionary<string, InputServiceMethod>? _inputServiceMethodsByCrossLanguageDefinitionId;
         private IReadOnlyDictionary<InputServiceMethod, InputClient>? _intMethodClientMap;
@@ -134,6 +135,28 @@ namespace Azure.Generator.Management
                 if (optionName != DisableSafeFlattenKey)
                 {
                     continue;
+                }
+
+                // Honor language scope. @@clientOption is language-scoped (the existing
+                // emitter readers use TCGC's getClientOptions which filters by scope), but
+                // because we read the raw decorator off the input model here we must filter
+                // explicitly. A missing scope is treated as "all languages" (TCGC default)
+                // and is still honored for the C# generator.
+                if (decorator.Arguments.TryGetValue("scope", out var scopeData) && scopeData != null)
+                {
+                    string? scope;
+                    try
+                    {
+                        scope = scopeData.ToObjectFromJson<string>();
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+                    if (scope != null && scope != CSharpScope)
+                    {
+                        continue;
+                    }
                 }
 
                 // Only accept a JSON boolean true. Any other value (string "true", 1, false, etc.) is ignored.

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/ManagementOutputLibrary.cs
@@ -67,6 +67,27 @@ namespace Azure.Generator.Management
                 kv => ManagementClientGenerator.Instance.TypeFactory.CreateModel(kv.Key)!,
                 kv => kv.Value.Select(p => ManagementClientGenerator.Instance.TypeFactory.CreateProperty(p, ManagementClientGenerator.Instance.TypeFactory.CreateModel(kv.Key)!)!).ToHashSet());
 
+        private HashSet<ModelProvider>? _safeFlattenDisabledModels;
+        /// <summary>
+        /// Set of model providers for which safe-flatten should be disabled, derived from the
+        /// <c>@@clientOption(Model, "disable-safe-flatten", true, "csharp")</c> decorator on the input model.
+        /// </summary>
+        internal HashSet<ModelProvider> SafeFlattenDisabledModels => _safeFlattenDisabledModels ??= BuildSafeFlattenDisabledModels();
+
+        private HashSet<ModelProvider> BuildSafeFlattenDisabledModels()
+        {
+            var result = new HashSet<ModelProvider>();
+            foreach (var inputModel in ManagementClientGenerator.Instance.InputLibrary.SafeFlattenDisabledModels)
+            {
+                var model = ManagementClientGenerator.Instance.TypeFactory.CreateModel(inputModel);
+                if (model != null)
+                {
+                    result.Add(model);
+                }
+            }
+            return result;
+        }
+
         private T GetValue<T>(ref T? field) where T : class
         {
             InitializeResourceClients(

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -696,6 +696,13 @@ namespace Azure.Generator.Management.Visitors
                         continue;
                     }
 
+                    // skip if the inner model opts out of safe-flatten via
+                    // @@clientOption(InnerModel, "disable-safe-flatten", true, "csharp")
+                    if (ManagementClientGenerator.Instance.OutputLibrary.SafeFlattenDisabledModels.Contains(modelProvider))
+                    {
+                        continue;
+                    }
+
                     isSafeFlatten = SafeFlatten(model, innerProperties, propertyMap, internalProperty, modelProvider);
                 }
             }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -826,6 +826,218 @@ namespace Azure.Generator.Mgmt.Tests
                 "Chained safe-flatten setter should delegate assignment through the inner flattened property");
         }
 
+        /// <summary>
+        /// Baseline for the disable-safe-flatten opt-out tests: when a wrapper inner model has
+        /// exactly one public property, the parent's wrapper property is normally safe-flattened
+        /// (the wrapper property becomes internal and a new public property mirroring the inner
+        /// one is added to the parent). This test pins that baseline behavior so the opt-out
+        /// tests below can clearly demonstrate the difference.
+        /// </summary>
+        [Test]
+        public void TestSafeFlattenAppliedByDefaultForSinglePropertyWrapper()
+        {
+            var (parentModelProvider, _) = SetupSafeFlattenScenario(
+                wrapperDecorators: null,
+                runVisitors: true);
+
+            AssertSafeFlattenApplied(parentModelProvider, "baseline (no decorator)");
+        }
+
+        /// <summary>
+        /// Verifies the new opt-out: when the wrapper inner model carries
+        /// <c>@@clientOption(WrapperModel, "disable-safe-flatten", true, "csharp")</c>,
+        /// safe-flatten is skipped for that wrapper. The parent's wrapper property remains
+        /// public and no flattened mirror property is promoted onto the parent.
+        /// </summary>
+        [Test]
+        public void TestSafeFlattenSkippedWhenDisableSafeFlattenDecoratorIsTrue()
+        {
+            var (parentModelProvider, _) = SetupSafeFlattenScenario(
+                wrapperDecorators: [BuildClientOptionDecorator("disable-safe-flatten", BinaryData.FromObjectAsJson(true))],
+                runVisitors: true);
+
+            AssertSafeFlattenSkipped(parentModelProvider, "disable-safe-flatten=true");
+        }
+
+        /// <summary>
+        /// Only a JSON boolean <c>true</c> is honored. A boolean <c>false</c> must be ignored and
+        /// the wrapper must still be safe-flattened normally.
+        /// </summary>
+        [Test]
+        public void TestSafeFlattenStillAppliedWhenDisableSafeFlattenDecoratorIsFalse()
+        {
+            var (parentModelProvider, _) = SetupSafeFlattenScenario(
+                wrapperDecorators: [BuildClientOptionDecorator("disable-safe-flatten", BinaryData.FromObjectAsJson(false))],
+                runVisitors: true);
+
+            AssertSafeFlattenApplied(parentModelProvider, "disable-safe-flatten=false (must be ignored)");
+        }
+
+        /// <summary>
+        /// Only a JSON boolean <c>true</c> is honored. A non-boolean value (e.g. the string
+        /// <c>"true"</c>) must be ignored and safe-flatten must still apply. This pins the
+        /// "strictly boolean true" contract from the PR description.
+        /// </summary>
+        [Test]
+        public void TestSafeFlattenStillAppliedWhenDisableSafeFlattenValueIsStringTrue()
+        {
+            var (parentModelProvider, _) = SetupSafeFlattenScenario(
+                wrapperDecorators: [BuildClientOptionDecorator("disable-safe-flatten", BinaryData.FromObjectAsJson("true"))],
+                runVisitors: true);
+
+            AssertSafeFlattenApplied(parentModelProvider, "disable-safe-flatten=\"true\" (string, must be ignored)");
+        }
+
+        /// <summary>
+        /// A different clientOption key (e.g. <c>resource-rbac-roles</c>) must not be misinterpreted
+        /// as the disable-safe-flatten opt-out. Safe-flatten should still apply when only an
+        /// unrelated clientOption decorator is present on the wrapper model.
+        /// </summary>
+        [Test]
+        public void TestSafeFlattenStillAppliedForUnrelatedClientOptionDecorator()
+        {
+            var (parentModelProvider, _) = SetupSafeFlattenScenario(
+                wrapperDecorators: [BuildClientOptionDecorator("some-other-option", BinaryData.FromObjectAsJson(true))],
+                runVisitors: true);
+
+            AssertSafeFlattenApplied(parentModelProvider, "unrelated clientOption key");
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="ManagementInputLibrary.SafeFlattenDisabledModels"/> exposes
+        /// the wrapper input model when the decorator is present with a JSON boolean true.
+        /// </summary>
+        [Test]
+        public void TestInputLibraryExposesSafeFlattenDisabledModels()
+        {
+            var (_, wrapperInputModel) = SetupSafeFlattenScenario(
+                wrapperDecorators: [BuildClientOptionDecorator("disable-safe-flatten", BinaryData.FromObjectAsJson(true))],
+                runVisitors: false);
+
+            Assert.That(
+                ManagementClientGenerator.Instance.InputLibrary.SafeFlattenDisabledModels,
+                Has.Member(wrapperInputModel),
+                "InputLibrary.SafeFlattenDisabledModels should contain the wrapper model when the decorator opts it out");
+
+            var wrapperOutput = ManagementClientGenerator.Instance.TypeFactory.CreateModel(wrapperInputModel);
+            Assert.That(wrapperOutput, Is.Not.Null);
+            Assert.That(
+                ManagementClientGenerator.Instance.OutputLibrary.SafeFlattenDisabledModels,
+                Has.Member(wrapperOutput!),
+                "OutputLibrary.SafeFlattenDisabledModels should mirror the input library's set");
+        }
+
+        // After safe-flatten on a wrapper-shape parent (`Wrapper -> WrapperModel { value }`):
+        //  - The original "Wrapper" property is internalized.
+        //  - A new public flattened property is promoted onto the parent.
+        // The exact promoted name is computed by PropertyHelpers.GetCombinedPropertyName and is
+        // not part of the disable-safe-flatten contract, so we assert structural signals (the
+        // wrapper's modifier change + the gain of an extra public property) rather than a
+        // hard-coded name.
+        private static void AssertSafeFlattenApplied(ModelProvider parent, string scenario)
+        {
+            var wrapperProp = parent.Properties.SingleOrDefault(p => p.Name == "Wrapper");
+            Assert.That(wrapperProp, Is.Not.Null, $"[{scenario}] Wrapper property should still exist on the parent");
+            Assert.That(
+                wrapperProp!.Modifiers.HasFlag(MethodSignatureModifiers.Internal),
+                Is.True,
+                $"[{scenario}] Wrapper property should be internalized when safe-flatten is applied");
+            Assert.That(
+                wrapperProp.Modifiers.HasFlag(MethodSignatureModifiers.Public),
+                Is.False,
+                $"[{scenario}] Wrapper property should not be public after safe-flatten");
+
+            var promotedPublic = parent.Properties
+                .Where(p => p.Name != "Wrapper" && p.Modifiers.HasFlag(MethodSignatureModifiers.Public))
+                .ToList();
+            Assert.That(
+                promotedPublic,
+                Has.Count.EqualTo(1),
+                $"[{scenario}] Exactly one new public property should be promoted onto the parent by safe-flatten");
+        }
+
+        private static void AssertSafeFlattenSkipped(ModelProvider parent, string scenario)
+        {
+            var wrapperProp = parent.Properties.SingleOrDefault(p => p.Name == "Wrapper");
+            Assert.That(wrapperProp, Is.Not.Null, $"[{scenario}] Wrapper property must still exist on the parent");
+            Assert.That(
+                wrapperProp!.Modifiers.HasFlag(MethodSignatureModifiers.Public),
+                Is.True,
+                $"[{scenario}] Wrapper property should remain public when safe-flatten is disabled");
+            Assert.That(
+                wrapperProp.Modifiers.HasFlag(MethodSignatureModifiers.Internal),
+                Is.False,
+                $"[{scenario}] Wrapper property should not be internalized when safe-flatten is disabled");
+
+            var promotedPublic = parent.Properties
+                .Where(p => p.Name != "Wrapper" && p.Modifiers.HasFlag(MethodSignatureModifiers.Public))
+                .ToList();
+            Assert.That(
+                promotedPublic,
+                Is.Empty,
+                $"[{scenario}] No flattened mirror property should be promoted when safe-flatten is disabled");
+        }
+
+        private static InputDecoratorInfo BuildClientOptionDecorator(string optionName, BinaryData value)
+        {
+            // Mirrors the shape that TCGC propagates for @@clientOption: positional-named
+            // parameters surface as a Dictionary<string, BinaryData>. The second positional
+            // parameter is named "name" in TCGC's decorator definition (even though our docs
+            // refer to it as a "key").
+            var arguments = new Dictionary<string, BinaryData>
+            {
+                ["name"] = BinaryData.FromObjectAsJson(optionName),
+                ["value"] = value,
+                ["scope"] = BinaryData.FromObjectAsJson("csharp"),
+            };
+            return new InputDecoratorInfo("Azure.ClientGenerator.Core.@clientOption", arguments);
+        }
+
+        /// <summary>
+        /// Builds a wrapper-style scenario: a parent model with a single property whose type is
+        /// a wrapper model that itself has a single public property — the canonical safe-flatten
+        /// trigger. Optionally attaches decorators to the wrapper model and runs all visitors so
+        /// callers can inspect the post-visit state of the parent.
+        /// </summary>
+        private static (ModelProvider Parent, InputModelType WrapperInput) SetupSafeFlattenScenario(
+            IReadOnlyList<InputDecoratorInfo>? wrapperDecorators,
+            bool runVisitors)
+        {
+            var valueProp = InputFactory.Property("value", InputPrimitiveType.String, isRequired: true, serializedName: "value");
+            var wrapperModel = InputFactory.Model(
+                "WrapperModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [valueProp],
+                decorators: wrapperDecorators);
+
+            var wrapperProperty = InputFactory.Property("wrapper", wrapperModel, isRequired: true, serializedName: "wrapper");
+            var parentInputModel = InputFactory.Model(
+                "ParentModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [wrapperProperty]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [parentInputModel, wrapperModel]);
+
+            var parentProvider = plugin.Object.TypeFactory.CreateModel(parentInputModel)!;
+            Assert.That(parentProvider, Is.Not.Null);
+
+            if (runVisitors)
+            {
+                var visitTypeCore = typeof(LibraryVisitor).GetMethod(
+                    "VisitTypeCore",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.That(visitTypeCore, Is.Not.Null);
+
+                foreach (var visitor in ManagementClientGenerator.Instance.Visitors)
+                {
+                    visitTypeCore!.Invoke(visitor, [parentProvider]);
+                }
+            }
+
+            return (parentProvider, wrapperModel);
+        }
+
         private class ObsoletePropertyCustomCodeView : TypeProvider
         {
             private readonly TypeProvider _enclosingType;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -978,7 +978,35 @@ namespace Azure.Generator.Mgmt.Tests
                 $"[{scenario}] No flattened mirror property should be promoted when safe-flatten is disabled");
         }
 
-        private static InputDecoratorInfo BuildClientOptionDecorator(string optionName, BinaryData value)
+        /// <summary>
+        /// A decorator scoped to a different language (e.g. <c>"java"</c>) must be ignored
+        /// by the C# generator, even when the key and value match.
+        /// </summary>
+        [Test]
+        public void TestSafeFlattenStillAppliedWhenDisableSafeFlattenScopeIsNotCSharp()
+        {
+            var (parentModelProvider, _) = SetupSafeFlattenScenario(
+                wrapperDecorators: [BuildClientOptionDecorator("disable-safe-flatten", BinaryData.FromObjectAsJson(true), scope: "java")],
+                runVisitors: true);
+
+            AssertSafeFlattenApplied(parentModelProvider, "disable-safe-flatten=true scoped to \"java\"");
+        }
+
+        /// <summary>
+        /// A decorator with no scope argument is treated by TCGC as "all languages" and must
+        /// be honored by the C# generator.
+        /// </summary>
+        [Test]
+        public void TestSafeFlattenSkippedWhenDisableSafeFlattenHasNoScope()
+        {
+            var (parentModelProvider, _) = SetupSafeFlattenScenario(
+                wrapperDecorators: [BuildClientOptionDecorator("disable-safe-flatten", BinaryData.FromObjectAsJson(true), scope: null)],
+                runVisitors: true);
+
+            AssertSafeFlattenSkipped(parentModelProvider, "disable-safe-flatten=true with no scope (all languages)");
+        }
+
+        private static InputDecoratorInfo BuildClientOptionDecorator(string optionName, BinaryData value, string? scope = "csharp")
         {
             // Mirrors the shape that TCGC propagates for @@clientOption: positional-named
             // parameters surface as a Dictionary<string, BinaryData>. The second positional
@@ -988,8 +1016,11 @@ namespace Azure.Generator.Mgmt.Tests
             {
                 ["name"] = BinaryData.FromObjectAsJson(optionName),
                 ["value"] = value,
-                ["scope"] = BinaryData.FromObjectAsJson("csharp"),
             };
+            if (scope is not null)
+            {
+                arguments["scope"] = BinaryData.FromObjectAsJson(scope);
+            }
             return new InputDecoratorInfo("Azure.ClientGenerator.Core.@clientOption", arguments);
         }
 


### PR DESCRIPTION
Fixes #58066

## Summary

Adds a generator-side opt-out for the management C# emitter's *safe-flatten* transform via TCGC's `@@clientOption` decorator. Spec authors can now preserve a wrapper model as a public type even when it currently has only one public property:

```typespec
#suppress "@azure-tools/typespec-client-generator-core/client-option" "Preserve type for public API surface"
#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Preserve type for public API surface"
@@clientOption(AllInstancesDown, "disable-safe-flatten", true, "csharp");
```

This is the `client.tsp` equivalent of the legacy AutoRest `directive: safe-flatten: false` and is intended for migration scenarios where the wrapper type is already part of the shipped public API.

## Why a new clientOption?

Existing `@@clientOption` keys (`resource-rbac-roles`, `resource-name-constraint`) are consumed entirely inside the emitter during resource detection. The safe-flatten decision happens later — inside the C# generator's `FlattenPropertyVisitor`. To make the decorator visible there, this PR:

1. Adds `Azure\.ClientGenerator\.Core\.@clientOption` to the emitter's `additionalDecorators` list so TCGC propagates it onto `InputModelType.Decorators` in `tspCodeModel.json`.
2. Mirrors the existing `FlattenPropertyMap` pattern in `ManagementInputLibrary` / `ManagementOutputLibrary` to expose a `SafeFlattenDisabledModels` set of `ModelProvider`s.
3. Adds a 4th skip condition in `FlattenPropertyVisitor` right before `SafeFlatten(...)`.

## Changes

- `emitter/src/sdk-context-options.ts` — register `@clientOption` in `additionalDecorators`.
- `generator/.../ManagementInputLibrary.cs` — build `SafeFlattenDisabledModels` from `InputModelType.Decorators`. Only a JSON boolean `true` value is honored; any other value (string `"true"`, `1`, `false`, …) is ignored.
- `generator/.../ManagementOutputLibrary.cs` — translate to `HashSet<ModelProvider>` via `TypeFactory.CreateModel`.
- `generator/.../Visitors/FlattenPropertyVisitor.cs` — new skip condition.
- `docs/client-options.md` — document the new `disable-safe-flatten` key.

## Verification

- Generator builds clean (0 warnings / 0 errors).
- End-to-end validated on Compute (`AllInstancesDown`, `UserInitiatedRedeploy`): both wrapper types are now generated as `public partial class` and the parent `ScheduledEventsPolicy` exposes them as public properties. ApiCompat `TypesMustExist` errors for these two types went from 2 → 0.

## Notes

- TCGC names the second positional parameter of `@@clientOption` `name` (not `key`), even though TCGC's helper API uses `key`. The C# parsing code looks up `"name"` and includes a comment explaining the inconsistency.
- The Compute regen that exercises this opt-out lives on a separate migration branch and will land via the Compute migration PR.
