### PR TITLE
[mgmt-generator] RegenSdkLocal.ps1: avoid sibling matches for full library names

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1
+++ b/eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1
@@ -15,7 +15,20 @@
 
 .PARAMETER Services
     One or more service name patterns to regenerate (e.g., "KeyVault", "Compute").
-    Supports wildcards. Case-insensitive. Uses substring matching.
+    Case-insensitive. Matching rules:
+      * If the pattern contains a wildcard ('*' or '?'), it is matched verbatim
+        with -like (no implicit padding).
+      * Otherwise the pattern is treated as a literal substring and matched
+        against both Library and Service names (the legacy behavior).
+      * As a special case, a pattern that starts with "Azure.ResourceManager."
+        and contains no wildcards is matched as an exact Library name. This
+        avoids the common pitfall where "Azure.ResourceManager.Compute" also
+        selects ComputeFleet, ComputeLimit, ComputeSchedule, etc.
+      * Use -Exact to force exact Library-name matching for any pattern.
+
+.PARAMETER Exact
+    When specified, every pattern in -Services must match a Library name
+    exactly (case-insensitive). Disables substring/wildcard matching.
 
 .PARAMETER Parallel
     Number of parallel jobs (default: 4, min: 1). Set to 1 for sequential execution.
@@ -46,10 +59,20 @@
 
 .EXAMPLE
     .\RegenSdkLocal.ps1 -Services "KeyVault" -LocalSpecRepoPath "C:\src\azure-rest-api-specs"
+
+.EXAMPLE
+    .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.Compute"
+    # Auto-treated as exact Library match because it starts with "Azure.ResourceManager."
+    # Will NOT also pick up ComputeFleet, ComputeLimit, ComputeSchedule.
+
+.EXAMPLE
+    .\RegenSdkLocal.ps1 -Services "Compute" -Exact
+    # Forces exact match against Library name only (no service-arm, no substring).
 #>
 
 param(
     [string[]]$Services,
+    [switch]$Exact,
     [ValidateRange(1, [int]::MaxValue)]
     [int]$Parallel = 4,
     [string]$LocalSpecRepoPath,
@@ -146,9 +169,31 @@ Write-Host "Found $($mgmtSdkFolders.Count) mgmt SDK folders"
 
 # Apply services filter
 if ($Services -and $Services.Count -gt 0) {
-    $mgmtSdkFolders = @($mgmtSdkFolders | Where-Object { 
+    $mgmtSdkFolders = @($mgmtSdkFolders | Where-Object {
         $folder = $_
-        $Services | Where-Object { $folder.Library -like "*$_*" -or $folder.Service -like "*$_*" }
+        $matched = $false
+        foreach ($pattern in $Services) {
+            $hasWildcard = $pattern -match '[\*\?]'
+            $isFullLibName = -not $hasWildcard -and $pattern -like 'Azure.ResourceManager.*'
+
+            if ($Exact -or $isFullLibName) {
+                # Exact Library-name match (case-insensitive)
+                if ($folder.Library -ieq $pattern) { $matched = $true; break }
+            }
+            elseif ($hasWildcard) {
+                # User-supplied wildcard pattern, used verbatim
+                if ($folder.Library -like $pattern -or $folder.Service -like $pattern) {
+                    $matched = $true; break
+                }
+            }
+            else {
+                # Legacy substring match against Library or Service
+                if ($folder.Library -like "*$pattern*" -or $folder.Service -like "*$pattern*") {
+                    $matched = $true; break
+                }
+            }
+        }
+        $matched
     })
     Write-Host "Filtered to $($mgmtSdkFolders.Count) matching: $($Services -join ', ')"
 }

--- a/eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1
+++ b/eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1
@@ -8,24 +8,18 @@
     Builds the mgmt generator locally and regenerates SDK folders using TypeSpec.
     Does NOT modify package.json files or create versioned packages.
     By default (when -Services is omitted), regenerates ALL mgmt SDKs.
-    Use -Services to regenerate one or more specific libraries by exact name.
+    Use -Services to regenerate one or more specific libraries by exact
+    library folder name (e.g., "Azure.ResourceManager.Compute").
 
 .PARAMETER Services
-    One or more library names to regenerate, matched against the SDK folder
-    name (case-insensitive). Omit -Services to regenerate ALL mgmt SDKs.
+    One or more library folder names to regenerate (e.g.,
+    "Azure.ResourceManager.Compute"). Each value must match an SDK folder
+    name exactly (case-insensitive). Omit -Services to regenerate ALL
+    mgmt SDKs.
 
-    Each value is normalized before matching: if it does not already start
-    with "Azure.ResourceManager." (case-insensitive), the prefix is added
-    automatically. So "Compute" is treated as "Azure.ResourceManager.Compute".
-
-    Wildcards ('*' and '?') are supported and matched verbatim with -like
-    against the library name. Patterns without wildcards must match exactly.
-
-    This avoids the common pitfall where a substring like "Compute" also
-    picks up ComputeFleet, ComputeLimit, ComputeSchedule, etc.: bare
-    "Compute" now means exactly Azure.ResourceManager.Compute, while users
-    who explicitly want the family can pass "Compute*" (or
-    "Azure.ResourceManager.Compute*").
+    Exact matching avoids the common pitfall where a substring like
+    "Compute" also picks up ComputeFleet, ComputeLimit, ComputeSchedule,
+    etc.
 
 .PARAMETER Parallel
     Number of parallel jobs (default: 4, min: 1). Set to 1 for sequential execution.
@@ -50,16 +44,11 @@
     # Regenerates ALL mgmt SDKs.
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "KeyVault"
-    # Treated as "Azure.ResourceManager.KeyVault" (exact match).
+    .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.KeyVault"
+    # Exact match against the SDK folder name.
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "KeyVault","Compute"
-
-.EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "Compute*"
-    # Wildcard: matches Azure.ResourceManager.Compute and all sibling
-    # libraries (ComputeFleet, ComputeSchedule, etc.).
+    .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.KeyVault","Azure.ResourceManager.Compute"
 
 .EXAMPLE
     .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.KeyVault" -LocalSpecRepoPath "C:\src\azure-rest-api-specs"
@@ -161,45 +150,21 @@ foreach ($tspFile in $tspFiles) {
 
 Write-Host "Found $($mgmtSdkFolders.Count) mgmt SDK folders"
 
-# Apply services filter
-#   * Each pattern is normalized: if it doesn't already start with
-#     "Azure.ResourceManager." (case-insensitive), the prefix is added.
-#   * Wildcards ('*' / '?') are matched verbatim with -like.
-#   * Patterns without wildcards must match the library name exactly.
+# Apply services filter: each value must match an SDK folder name exactly
+# (case-insensitive). Throws if any value matches no folder.
 if ($Services -and $Services.Count -gt 0) {
-    $normalizedPatterns = @($Services | ForEach-Object {
-        $p = $_
-        if ($p -like 'Azure.ResourceManager.*') { $p } else { "Azure.ResourceManager.$p" }
+    $unmatched = @($Services | Where-Object {
+        $name = $_
+        -not ($mgmtSdkFolders | Where-Object { $_.Library -ieq $name })
     })
-
-    $unmatched = @()
+    if ($unmatched.Count -gt 0) {
+        throw "No mgmt SDK folder matched: $($unmatched -join ', '). Pass the exact library folder name, e.g., 'Azure.ResourceManager.Compute'."
+    }
     $mgmtSdkFolders = @($mgmtSdkFolders | Where-Object {
         $folder = $_
-        foreach ($pattern in $normalizedPatterns) {
-            if ($pattern -match '[\*\?]') {
-                if ($folder.Library -like $pattern) { return $true }
-            }
-            elseif ($folder.Library -ieq $pattern) {
-                return $true
-            }
-        }
-        return $false
+        $null -ne ($Services | Where-Object { $folder.Library -ieq $_ })
     })
-
-    foreach ($pattern in $normalizedPatterns) {
-        $hit = $false
-        foreach ($folder in $mgmtSdkFolders) {
-            if ($pattern -match '[\*\?]') {
-                if ($folder.Library -like $pattern) { $hit = $true; break }
-            }
-            elseif ($folder.Library -ieq $pattern) { $hit = $true; break }
-        }
-        if (-not $hit) { $unmatched += $pattern }
-    }
-    if ($unmatched.Count -gt 0) {
-        throw "No mgmt SDK folder matched: $($unmatched -join ', '). Pass an exact library name (with or without the 'Azure.ResourceManager.' prefix) or a wildcard such as 'Compute*'."
-    }
-    Write-Host "Filtered to $($mgmtSdkFolders.Count) matching: $($normalizedPatterns -join ', ')"
+    Write-Host "Filtered to $($mgmtSdkFolders.Count) matching: $($Services -join ', ')"
 }
 
 if ($mgmtSdkFolders.Count -eq 0) {

--- a/eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1
+++ b/eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1
@@ -7,28 +7,17 @@
 .DESCRIPTION
     Builds the mgmt generator locally and regenerates SDK folders using TypeSpec.
     Does NOT modify package.json files or create versioned packages.
-    By default, regenerates ALL mgmt SDKs. Use -Services to limit scope.
-    
-    Pattern matching: The -Services parameter uses substring matching.
-    For example, "Key" matches both "KeyVault" and "MyKeyService".
-    Use wildcards for more precise matching (e.g., "KeyVault*").
+    By default (when -Services is omitted), regenerates ALL mgmt SDKs.
+    Use -Services to regenerate one or more specific libraries by exact name.
 
 .PARAMETER Services
-    One or more service name patterns to regenerate (e.g., "KeyVault", "Compute").
-    Case-insensitive. Matching rules:
-      * If the pattern contains a wildcard ('*' or '?'), it is matched verbatim
-        with -like (no implicit padding).
-      * Otherwise the pattern is treated as a literal substring and matched
-        against both Library and Service names (the legacy behavior).
-      * As a special case, a pattern that starts with "Azure.ResourceManager."
-        and contains no wildcards is matched as an exact Library name. This
-        avoids the common pitfall where "Azure.ResourceManager.Compute" also
-        selects ComputeFleet, ComputeLimit, ComputeSchedule, etc.
-      * Use -Exact to force exact Library-name matching for any pattern.
-
-.PARAMETER Exact
-    When specified, every pattern in -Services must match a Library name
-    exactly (case-insensitive). Disables substring/wildcard matching.
+    One or more library names to regenerate, matched exactly against the SDK
+    folder name (case-insensitive). Each value must be the full library name,
+    e.g. "Azure.ResourceManager.Compute". Substring and wildcard matching are
+    intentionally not supported: in practice we either regenerate exactly one
+    library or regenerate everything, so requiring an exact match avoids the
+    common pitfall where "Compute" also picks up ComputeFleet, ComputeLimit,
+    ComputeSchedule, etc. Omit -Services to regenerate ALL mgmt SDKs.
 
 .PARAMETER Parallel
     Number of parallel jobs (default: 4, min: 1). Set to 1 for sequential execution.
@@ -49,30 +38,21 @@
     The powershell-yaml module will be auto-installed if not present.
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "KeyVault"
+    .\RegenSdkLocal.ps1
+    # Regenerates ALL mgmt SDKs.
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "KeyVault","Compute","Network"
+    .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.KeyVault"
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "Key*" -Parallel 8
+    .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.KeyVault","Azure.ResourceManager.Compute"
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "KeyVault" -LocalSpecRepoPath "C:\src\azure-rest-api-specs"
-
-.EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.Compute"
-    # Auto-treated as exact Library match because it starts with "Azure.ResourceManager."
-    # Will NOT also pick up ComputeFleet, ComputeLimit, ComputeSchedule.
-
-.EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "Compute" -Exact
-    # Forces exact match against Library name only (no service-arm, no substring).
+    .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.KeyVault" -LocalSpecRepoPath "C:\src\azure-rest-api-specs"
 #>
 
 param(
     [string[]]$Services,
-    [switch]$Exact,
     [ValidateRange(1, [int]::MaxValue)]
     [int]$Parallel = 4,
     [string]$LocalSpecRepoPath,
@@ -167,34 +147,21 @@ foreach ($tspFile in $tspFiles) {
 
 Write-Host "Found $($mgmtSdkFolders.Count) mgmt SDK folders"
 
-# Apply services filter
+# Apply services filter (exact Library-name match, case-insensitive)
 if ($Services -and $Services.Count -gt 0) {
-    $mgmtSdkFolders = @($mgmtSdkFolders | Where-Object {
-        $folder = $_
-        $matched = $false
-        foreach ($pattern in $Services) {
-            $hasWildcard = $pattern -match '[\*\?]'
-            $isFullLibName = -not $hasWildcard -and $pattern -like 'Azure.ResourceManager.*'
+    $serviceSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in $Services) { [void]$serviceSet.Add($name) }
 
-            if ($Exact -or $isFullLibName) {
-                # Exact Library-name match (case-insensitive)
-                if ($folder.Library -ieq $pattern) { $matched = $true; break }
-            }
-            elseif ($hasWildcard) {
-                # User-supplied wildcard pattern, used verbatim
-                if ($folder.Library -like $pattern -or $folder.Service -like $pattern) {
-                    $matched = $true; break
-                }
-            }
-            else {
-                # Legacy substring match against Library or Service
-                if ($folder.Library -like "*$pattern*" -or $folder.Service -like "*$pattern*") {
-                    $matched = $true; break
-                }
-            }
-        }
-        $matched
+    $mgmtSdkFolders = @($mgmtSdkFolders | Where-Object { $serviceSet.Contains($_.Library) })
+
+    $matchedNames = $mgmtSdkFolders | ForEach-Object { $_.Library }
+    $missing = @($Services | Where-Object {
+        $name = $_
+        -not ($matchedNames | Where-Object { $_ -ieq $name })
     })
+    if ($missing.Count -gt 0) {
+        throw "No mgmt SDK folder found for: $($missing -join ', '). -Services requires the exact library name (e.g. 'Azure.ResourceManager.Compute')."
+    }
     Write-Host "Filtered to $($mgmtSdkFolders.Count) matching: $($Services -join ', ')"
 }
 

--- a/eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1
+++ b/eng/packages/http-client-csharp-mgmt/eng/scripts/RegenSdkLocal.ps1
@@ -11,13 +11,21 @@
     Use -Services to regenerate one or more specific libraries by exact name.
 
 .PARAMETER Services
-    One or more library names to regenerate, matched exactly against the SDK
-    folder name (case-insensitive). Each value must be the full library name,
-    e.g. "Azure.ResourceManager.Compute". Substring and wildcard matching are
-    intentionally not supported: in practice we either regenerate exactly one
-    library or regenerate everything, so requiring an exact match avoids the
-    common pitfall where "Compute" also picks up ComputeFleet, ComputeLimit,
-    ComputeSchedule, etc. Omit -Services to regenerate ALL mgmt SDKs.
+    One or more library names to regenerate, matched against the SDK folder
+    name (case-insensitive). Omit -Services to regenerate ALL mgmt SDKs.
+
+    Each value is normalized before matching: if it does not already start
+    with "Azure.ResourceManager." (case-insensitive), the prefix is added
+    automatically. So "Compute" is treated as "Azure.ResourceManager.Compute".
+
+    Wildcards ('*' and '?') are supported and matched verbatim with -like
+    against the library name. Patterns without wildcards must match exactly.
+
+    This avoids the common pitfall where a substring like "Compute" also
+    picks up ComputeFleet, ComputeLimit, ComputeSchedule, etc.: bare
+    "Compute" now means exactly Azure.ResourceManager.Compute, while users
+    who explicitly want the family can pass "Compute*" (or
+    "Azure.ResourceManager.Compute*").
 
 .PARAMETER Parallel
     Number of parallel jobs (default: 4, min: 1). Set to 1 for sequential execution.
@@ -42,10 +50,16 @@
     # Regenerates ALL mgmt SDKs.
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.KeyVault"
+    .\RegenSdkLocal.ps1 -Services "KeyVault"
+    # Treated as "Azure.ResourceManager.KeyVault" (exact match).
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.KeyVault","Azure.ResourceManager.Compute"
+    .\RegenSdkLocal.ps1 -Services "KeyVault","Compute"
+
+.EXAMPLE
+    .\RegenSdkLocal.ps1 -Services "Compute*"
+    # Wildcard: matches Azure.ResourceManager.Compute and all sibling
+    # libraries (ComputeFleet, ComputeSchedule, etc.).
 
 .EXAMPLE
     .\RegenSdkLocal.ps1 -Services "Azure.ResourceManager.KeyVault" -LocalSpecRepoPath "C:\src\azure-rest-api-specs"
@@ -147,22 +161,45 @@ foreach ($tspFile in $tspFiles) {
 
 Write-Host "Found $($mgmtSdkFolders.Count) mgmt SDK folders"
 
-# Apply services filter (exact Library-name match, case-insensitive)
+# Apply services filter
+#   * Each pattern is normalized: if it doesn't already start with
+#     "Azure.ResourceManager." (case-insensitive), the prefix is added.
+#   * Wildcards ('*' / '?') are matched verbatim with -like.
+#   * Patterns without wildcards must match the library name exactly.
 if ($Services -and $Services.Count -gt 0) {
-    $serviceSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-    foreach ($name in $Services) { [void]$serviceSet.Add($name) }
-
-    $mgmtSdkFolders = @($mgmtSdkFolders | Where-Object { $serviceSet.Contains($_.Library) })
-
-    $matchedNames = $mgmtSdkFolders | ForEach-Object { $_.Library }
-    $missing = @($Services | Where-Object {
-        $name = $_
-        -not ($matchedNames | Where-Object { $_ -ieq $name })
+    $normalizedPatterns = @($Services | ForEach-Object {
+        $p = $_
+        if ($p -like 'Azure.ResourceManager.*') { $p } else { "Azure.ResourceManager.$p" }
     })
-    if ($missing.Count -gt 0) {
-        throw "No mgmt SDK folder found for: $($missing -join ', '). -Services requires the exact library name (e.g. 'Azure.ResourceManager.Compute')."
+
+    $unmatched = @()
+    $mgmtSdkFolders = @($mgmtSdkFolders | Where-Object {
+        $folder = $_
+        foreach ($pattern in $normalizedPatterns) {
+            if ($pattern -match '[\*\?]') {
+                if ($folder.Library -like $pattern) { return $true }
+            }
+            elseif ($folder.Library -ieq $pattern) {
+                return $true
+            }
+        }
+        return $false
+    })
+
+    foreach ($pattern in $normalizedPatterns) {
+        $hit = $false
+        foreach ($folder in $mgmtSdkFolders) {
+            if ($pattern -match '[\*\?]') {
+                if ($folder.Library -like $pattern) { $hit = $true; break }
+            }
+            elseif ($folder.Library -ieq $pattern) { $hit = $true; break }
+        }
+        if (-not $hit) { $unmatched += $pattern }
     }
-    Write-Host "Filtered to $($mgmtSdkFolders.Count) matching: $($Services -join ', ')"
+    if ($unmatched.Count -gt 0) {
+        throw "No mgmt SDK folder matched: $($unmatched -join ', '). Pass an exact library name (with or without the 'Azure.ResourceManager.' prefix) or a wildcard such as 'Compute*'."
+    }
+    Write-Host "Filtered to $($mgmtSdkFolders.Count) matching: $($normalizedPatterns -join ', ')"
 }
 
 if ($mgmtSdkFolders.Count -eq 0) {


### PR DESCRIPTION
## Why
`RegenSdkLocal.ps1`'s `-Services` filter padded every pattern with `*…*` wildcards. That made a full library name like `Azure.ResourceManager.Compute` also match its siblings:

- `Azure.ResourceManager.ComputeFleet`
- `Azure.ResourceManager.ComputeLimit`
- `Azure.ResourceManager.ComputeSchedule`
- `Azure.ResourceManager.Compute.Recommender`

Those unrelated regenerations triple iteration time and produce noisy failures (e.g., a Recommender path that doesn't exist on a feature branch).

## What
Tighten `-Services` to a simple, predictable contract:

* Each value must match an SDK folder name **exactly** (case-insensitive).
* Pass the full library folder name (e.g., `Azure.ResourceManager.Compute`) — no auto-prefixing, no wildcards.
* If any value matches nothing, the script throws a clear error instead of silently regenerating nothing.
* Omit `-Services` to regenerate all mgmt SDKs (unchanged).

| Pattern | Before | After |
|---|---|---|
| `Azure.ResourceManager.Compute` | substring → 5 matches | exact → 1 match |
| `Compute` | substring → 5 matches | no match → throws |
| `Azure.ResourceManager.KeyVault` | substring → 1 match | exact → 1 match |
| _(omitted)_ | all mgmt SDKs | all mgmt SDKs (unchanged) |

Doc block + examples updated accordingly.

---
🤖 arcturus-copilot