### PR TITLE
Normalize line endings to LF in Update-Snippets.ps1

### DIFF
--- a/eng/scripts/Update-Snippets.ps1
+++ b/eng/scripts/Update-Snippets.ps1
@@ -22,50 +22,73 @@ if ($StrictMode) {
 }
 
 dotnet tool restore
-Resolve-Path $root | ForEach-Object {
-    $resolvedRoot = $_.Path
-    dotnet tool run snippet-generator -b "$resolvedRoot" $additionalArgs
 
-    # The snippet-generator tool builds inserted snippet blocks using
-    # Environment.NewLine, which produces CRLF on Windows. The original .md/.cs
-    # files in this repo use LF endings, so the rewritten files end up with mixed
-    # CRLF/LF endings, producing whitespace-only diffs. Normalize touched files to
-    # LF here. Only the files the tool actually modified (per git) are normalized
-    # to avoid touching unrelated files.
-    Push-Location $resolvedRoot
+# Helper: capture the set of currently-dirty .md/.cs files (relative to repo
+# root) under a given working directory, along with each file's content hash.
+# Used to distinguish files modified by snippet-generator from files the
+# developer already had dirty before the script ran, so we don't rewrite
+# unrelated local edits.
+function Get-DirtyMdCsHashes {
+    param([string] $WorkingDir)
+
+    $result = @{}
+    Push-Location $WorkingDir
     try {
-        # `git diff --name-only` doesn't surface CRLF↔LF-only changes when
-        # core.autocrlf is enabled, but `git status --porcelain` does (it tracks
-        # working-tree changes regardless of normalization). The format is
-        # "XY <path>" where XY is the two-letter status code.
         $statusOutput = git status --porcelain -- . 2>$null
-        if ($LASTEXITCODE -eq 0 -and $statusOutput) {
-            $repoRoot = (git rev-parse --show-toplevel).Trim()
-            foreach ($statusLine in $statusOutput) {
-                if ($statusLine.Length -lt 4) { continue }
-                $relPath = $statusLine.Substring(3).Trim('"')
-                # Handle renames: "old -> new"
-                $arrowIdx = $relPath.IndexOf(' -> ')
-                if ($arrowIdx -ge 0) {
-                    $relPath = $relPath.Substring($arrowIdx + 4).Trim('"')
-                }
-                if (-not ($relPath -match '\.(md|cs)$')) { continue }
-                $fullPath = Join-Path $repoRoot $relPath
-                if (-not (Test-Path -LiteralPath $fullPath)) { continue }
-                $content = [System.IO.File]::ReadAllText($fullPath)
-                if ($null -eq $content) { continue }
-                if ($content.Contains("`r")) {
-                    $normalized = $content -replace "`r`n", "`n"
-                    $normalized = $normalized -replace "`r", "`n"
-                    if ($normalized -ne $content) {
-                        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-                        [System.IO.File]::WriteAllText($fullPath, $normalized, $utf8NoBom)
-                    }
-                }
+        if ($LASTEXITCODE -ne 0 -or -not $statusOutput) { return $result }
+        $repoRoot = (git rev-parse --show-toplevel).Trim()
+        foreach ($statusLine in $statusOutput) {
+            if ($statusLine.Length -lt 4) { continue }
+            $relPath = $statusLine.Substring(3).Trim('"')
+            $arrowIdx = $relPath.IndexOf(' -> ')
+            if ($arrowIdx -ge 0) {
+                $relPath = $relPath.Substring($arrowIdx + 4).Trim('"')
             }
+            if (-not ($relPath -match '\.(md|cs)$')) { continue }
+            $fullPath = Join-Path $repoRoot $relPath
+            if (-not (Test-Path -LiteralPath $fullPath)) { continue }
+            $hash = (Get-FileHash -LiteralPath $fullPath -Algorithm SHA256).Hash
+            $result[$fullPath] = $hash
         }
     }
     finally {
         Pop-Location
+    }
+    return $result
+}
+
+Resolve-Path $root | ForEach-Object {
+    $resolvedRoot = $_.Path
+
+    # Snapshot dirty .md/.cs files BEFORE running snippet-generator so we can
+    # tell which files the tool actually touched.
+    $beforeHashes = Get-DirtyMdCsHashes -WorkingDir $resolvedRoot
+
+    dotnet tool run snippet-generator -b "$resolvedRoot" $additionalArgs
+
+    # The snippet-generator tool builds inserted snippet blocks using
+    # Environment.NewLine, which produces CRLF on Windows. The repo's .md/.cs
+    # files use LF endings, so the rewritten files end up with mixed CRLF/LF
+    # endings, producing whitespace-only diffs. Normalize only files that the
+    # tool actually changed (newly dirty, or dirty before with a different
+    # content hash) to avoid rewriting unrelated local edits.
+    $afterHashes = Get-DirtyMdCsHashes -WorkingDir $resolvedRoot
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    foreach ($fullPath in $afterHashes.Keys) {
+        $afterHash = $afterHashes[$fullPath]
+        if ($beforeHashes.ContainsKey($fullPath) -and $beforeHashes[$fullPath] -eq $afterHash) {
+            # File was already dirty before the run with identical content — the
+            # tool didn't touch it, so leave it alone.
+            continue
+        }
+        if (-not (Test-Path -LiteralPath $fullPath)) { continue }
+        $content = [System.IO.File]::ReadAllText($fullPath)
+        if ($null -eq $content) { continue }
+        if (-not $content.Contains("`r")) { continue }
+        $normalized = $content -replace "`r`n", "`n"
+        $normalized = $normalized -replace "`r", "`n"
+        if ($normalized -ne $content) {
+            [System.IO.File]::WriteAllText($fullPath, $normalized, $utf8NoBom)
+        }
     }
 }

--- a/eng/scripts/Update-Snippets.ps1
+++ b/eng/scripts/Update-Snippets.ps1
@@ -23,5 +23,49 @@ if ($StrictMode) {
 
 dotnet tool restore
 Resolve-Path $root | ForEach-Object {
-    dotnet tool run snippet-generator -b "$_" $additionalArgs
+    $resolvedRoot = $_.Path
+    dotnet tool run snippet-generator -b "$resolvedRoot" $additionalArgs
+
+    # The snippet-generator tool builds inserted snippet blocks using
+    # Environment.NewLine, which produces CRLF on Windows. The original .md/.cs
+    # files in this repo use LF endings, so the rewritten files end up with mixed
+    # CRLF/LF endings, producing whitespace-only diffs. Normalize touched files to
+    # LF here. Only the files the tool actually modified (per git) are normalized
+    # to avoid touching unrelated files.
+    Push-Location $resolvedRoot
+    try {
+        # `git diff --name-only` doesn't surface CRLF↔LF-only changes when
+        # core.autocrlf is enabled, but `git status --porcelain` does (it tracks
+        # working-tree changes regardless of normalization). The format is
+        # "XY <path>" where XY is the two-letter status code.
+        $statusOutput = git status --porcelain -- . 2>$null
+        if ($LASTEXITCODE -eq 0 -and $statusOutput) {
+            $repoRoot = (git rev-parse --show-toplevel).Trim()
+            foreach ($statusLine in $statusOutput) {
+                if ($statusLine.Length -lt 4) { continue }
+                $relPath = $statusLine.Substring(3).Trim('"')
+                # Handle renames: "old -> new"
+                $arrowIdx = $relPath.IndexOf(' -> ')
+                if ($arrowIdx -ge 0) {
+                    $relPath = $relPath.Substring($arrowIdx + 4).Trim('"')
+                }
+                if (-not ($relPath -match '\.(md|cs)$')) { continue }
+                $fullPath = Join-Path $repoRoot $relPath
+                if (-not (Test-Path -LiteralPath $fullPath)) { continue }
+                $content = [System.IO.File]::ReadAllText($fullPath)
+                if ($null -eq $content) { continue }
+                if ($content.Contains("`r")) {
+                    $normalized = $content -replace "`r`n", "`n"
+                    $normalized = $normalized -replace "`r", "`n"
+                    if ($normalized -ne $content) {
+                        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+                        [System.IO.File]::WriteAllText($fullPath, $normalized, $utf8NoBom)
+                    }
+                }
+            }
+        }
+    }
+    finally {
+        Pop-Location
+    }
 }


### PR DESCRIPTION
## What

The snippet-generator tool (from `Azure/azure-sdk-tools`) builds inserted snippet blocks using `Environment.NewLine`, which produces CRLF on Windows. The repo's `.md`/`.cs` files use LF endings, so running `Update-Snippets.ps1` on Windows ends up writing files with mixed CRLF/LF endings — producing whitespace-only diffs that are easy to commit by accident.

## Repro before the fix

Running `./eng/scripts/Update-Snippets.ps1 core` on Windows modified 38 files under `sdk/core/`. Example: `sdk/core/Azure.Core/README.md` went from 276 LF / 0 CRLF (HEAD) to 175 LF / **101 CRLF** — `git diff` only printed `warning: CRLF will be replaced by LF the next time Git touches it`.

## Fix

After each `snippet-generator` invocation, post-process the files that were actually modified (via `git status --porcelain`) and replace `\r\n` and stray `\r` with `\n`, writing back as UTF-8 without BOM. Only `.md` and `.cs` files are touched, and only when content actually changes.

`git status --porcelain` is used (rather than `git diff --name-only`) because `core.autocrlf=true` causes `git diff` to hide CRLF<->LF-only changes — exactly the case we need to fix.

This mirrors the existing CRLF->LF normalization step in `eng/scripts/Export-API.ps1`.

## Verification

After the change, `./eng/scripts/Update-Snippets.ps1 core` produces **0** modified files under `sdk/`, and `sdk/core/Azure.Core/README.md` is back to 276 LF / 0 CRLF (matches HEAD).

## Future work

The underlying behavior lives in `Azure/azure-sdk-tools` `tools/snippet-generator/` — `DirectoryProcessor.cs`, `MarkdownProcessor.cs`, and `CSharpProcessor.cs` all build snippet output using `Environment.NewLine` / `StringBuilder.AppendLine`. A source-side fix there would benefit all consumers; this PR is the consumer-side mitigation.