### PR TITLE
Remove duplicate 1.11.0-beta.1 entry from System.ClientModel changelog

### DIFF
--- a/sdk/core/System.ClientModel/CHANGELOG.md
+++ b/sdk/core/System.ClientModel/CHANGELOG.md
@@ -10,25 +10,6 @@
 
 ### Other Changes
 
-## 1.11.0-beta.1 (Unreleased)
-
-### Features Added
-
-- Added `CredentialResolver` abstract class — an extensibility hook that lets credential providers participate in the configuration-driven credential resolution pipeline. Resolvers are invoked in registration order until one produces an `AuthenticationTokenProvider` for a given configuration section.
-- Added `IConfiguration.GetCredential(...)` extension overloads on `ConfigurationExtensions` that walk a chain of `CredentialResolver` instances against a named credential section, with optional `configureOverrides` to mutate the section in-flight.
-- Added `IConfiguration.GetClientSettings<T>(...)` extension overloads that bind a `ClientSettings`-derived type and resolve its `Credential` via the resolver chain.
-- Added `AddCredentialResolver<T>` extension methods on `IServiceCollection` and `IHostApplicationBuilder` that register a `CredentialResolver` once per implementation type (idempotent).
-- The DI `AddClient<TClient, TSettings>` / `AddKeyedClient<TClient, TSettings>` paths now auto-resolve credentials from the registered resolver chain, so callers no longer need to wire up provider-specific helpers like `WithAzureCredential` explicitly when a resolver is registered.
-- Resolving the same credential section more than once returns the same `AuthenticationTokenProvider` instance.
-
-### Breaking Changes
-
-- `IClientBuilder` no longer inherits from `IHostApplicationBuilder`. The internal `ClientBuilder` implementation now uses composition instead of inheritance. `PostConfigure` return type changed from `IHostApplicationBuilder` to `IClientBuilder`. `AddClient` and `AddKeyedClient` continue to return `IClientBuilder`.
-
-### Bugs Fixed
-
-### Other Changes
-
 ## 1.11.0 (2026-05-05)
 
 ### Features Added


### PR DESCRIPTION
The System.ClientModel CHANGELOG had a duplicate `1.11.0-beta.1 (Unreleased)` section containing the same content as the released `1.11.0 (2026-05-05)` entry directly below it. Removed the beta entry.