### PR TITLE
Sync-ReleaseArtifacts: drop unreleased prerelease superseded by GA

### DIFF
--- a/eng/scripts/Sync-ReleaseArtifacts.ps1
+++ b/eng/scripts/Sync-ReleaseArtifacts.ps1
@@ -57,6 +57,9 @@ function Merge-ChangeLogEntries {
     - If both have a dated entry for the same version, release wins (it has
       the latest content from prepare-release).
     - Otherwise keep main's entry.
+  After merging, any (Unreleased) prerelease entry in main whose
+  Major.Minor.Patch matches a dated stable (GA/Patch) release entry is
+  removed because it has been superseded by the GA/Patch release.
   Returns the merged entries (unordered — Set-ChangeLogContent handles sorting).
   #>
   param(
@@ -82,6 +85,41 @@ function Merge-ChangeLogEntries {
             $MainEntries[$version].ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS) {
       $MainEntries[$version] = $releaseEntry
       Write-Host "  Replaced changelog entry for $version with release content"
+    }
+  }
+
+  # Collect dated stable release versions (e.g. 1.11.0) coming from the
+  # release branch.  Any (Unreleased) prerelease in main with the same
+  # Major.Minor.Patch (e.g. 1.11.0-beta.1) is now superseded and should be
+  # removed so the changelog does not contain both the GA and a stale beta
+  # entry for the same version.
+  $datedStableReleases = @()
+  foreach ($version in $ReleaseEntries.Keys) {
+    if ($ReleaseEntries[$version].ReleaseStatus -eq $CHANGELOG_UNRELEASED_STATUS) { continue }
+    $semVer = [AzureEngSemanticVersion]::ParseVersionString($version)
+    if ($semVer -and -not $semVer.IsPrerelease) {
+      $datedStableReleases += $semVer
+    }
+  }
+
+  if ($datedStableReleases.Count -gt 0) {
+    $toRemove = @()
+    foreach ($version in @($MainEntries.Keys)) {
+      if ($MainEntries[$version].ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS) { continue }
+      $entrySemVer = [AzureEngSemanticVersion]::ParseVersionString($version)
+      if (-not $entrySemVer -or -not $entrySemVer.IsPrerelease) { continue }
+      foreach ($stable in $datedStableReleases) {
+        if ($entrySemVer.Major -eq $stable.Major -and
+            $entrySemVer.Minor -eq $stable.Minor -and
+            $entrySemVer.Patch -eq $stable.Patch) {
+          $toRemove += $version
+          break
+        }
+      }
+    }
+    foreach ($version in $toRemove) {
+      $MainEntries.Remove($version)
+      Write-Host "  Removed unreleased prerelease entry $version superseded by stable release"
     }
   }
 

--- a/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
+++ b/eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1
@@ -51,6 +51,36 @@ BeforeAll {
             }
         }
 
+        $datedStableReleases = @()
+        foreach ($version in $ReleaseEntries.Keys) {
+            if ($ReleaseEntries[$version].ReleaseStatus -eq $CHANGELOG_UNRELEASED_STATUS) { continue }
+            $semVer = [AzureEngSemanticVersion]::ParseVersionString($version)
+            if ($semVer -and -not $semVer.IsPrerelease) {
+                $datedStableReleases += $semVer
+            }
+        }
+
+        if ($datedStableReleases.Count -gt 0) {
+            $toRemove = @()
+            foreach ($version in @($MainEntries.Keys)) {
+                if ($MainEntries[$version].ReleaseStatus -ne $CHANGELOG_UNRELEASED_STATUS) { continue }
+                $entrySemVer = [AzureEngSemanticVersion]::ParseVersionString($version)
+                if (-not $entrySemVer -or -not $entrySemVer.IsPrerelease) { continue }
+                foreach ($stable in $datedStableReleases) {
+                    if ($entrySemVer.Major -eq $stable.Major -and
+                        $entrySemVer.Minor -eq $stable.Minor -and
+                        $entrySemVer.Patch -eq $stable.Patch) {
+                        $toRemove += $version
+                        break
+                    }
+                }
+            }
+            foreach ($version in $toRemove) {
+                $MainEntries.Remove($version)
+                Write-Host "  Removed unreleased prerelease entry $version superseded by stable release"
+            }
+        }
+
         return $MainEntries
     }
 
@@ -222,6 +252,71 @@ Describe "Merge-ChangeLogEntries" {
 
         # Both unreleased — main wins (no overwrite)
         $result["1.2.0"].ReleaseContent | Should -Contain "- main work in progress"
+    }
+
+    It "GA release supersedes unreleased beta of the same version" {
+        # Repro for https://github.com/Azure/azure-sdk-for-net/pull/58993
+        # Release branch shipped 1.11.0 GA; main has 1.11.0-beta.1 (Unreleased)
+        # plus a newer 1.12.0-beta.1 (Unreleased). The unreleased 1.11.0-beta.1
+        # should be removed because it is now superseded by the GA release.
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.12.0-beta.1"; Status = "(Unreleased)" },
+            @{ Version = "1.11.0-beta.1"; Status = "(Unreleased)" },
+            @{ Version = "1.10.0"; Status = "(2026-03-16)"; Content = @("", "### Features Added", "", "- prior") }
+        )
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.11.0"; Status = "(2026-05-05)"; Content = @("", "### Features Added", "", "- ga content") },
+            @{ Version = "1.10.0"; Status = "(2026-03-16)"; Content = @("", "### Features Added", "", "- prior") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        $result.Contains("1.11.0") | Should -BeTrue
+        $result["1.11.0"].ReleaseStatus | Should -Be "(2026-05-05)"
+        $result.Contains("1.11.0-beta.1") | Should -BeFalse
+        $result.Contains("1.12.0-beta.1") | Should -BeTrue
+        $result.Contains("1.10.0") | Should -BeTrue
+    }
+
+    It "GA release does not remove a dated (already shipped) prerelease of same MMP" {
+        # If main has a historical dated 1.11.0-beta.1 entry it must be preserved
+        # — only Unreleased prereleases are superseded.
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.11.0-beta.1"; Status = "(2026-04-01)"; Content = @("", "### Features Added", "", "- shipped beta") },
+            @{ Version = "1.10.0"; Status = "(2026-03-16)"; Content = @("", "### Features Added", "", "- prior") }
+        )
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.11.0"; Status = "(2026-05-05)"; Content = @("", "### Features Added", "", "- ga content") },
+            @{ Version = "1.10.0"; Status = "(2026-03-16)"; Content = @("", "### Features Added", "", "- prior") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        $result.Contains("1.11.0") | Should -BeTrue
+        $result.Contains("1.11.0-beta.1") | Should -BeTrue
+        $result["1.11.0-beta.1"].ReleaseStatus | Should -Be "(2026-04-01)"
+    }
+
+    It "GA release does not remove unreleased prereleases of different MMP" {
+        $mainChangelog = Build-Changelog @(
+            @{ Version = "1.12.0-beta.1"; Status = "(Unreleased)" },
+            @{ Version = "1.10.0"; Status = "(2026-03-16)"; Content = @("", "### Features Added", "", "- prior") }
+        )
+        $releaseChangelog = Build-Changelog @(
+            @{ Version = "1.11.0"; Status = "(2026-05-05)"; Content = @("", "### Features Added", "", "- ga content") },
+            @{ Version = "1.10.0"; Status = "(2026-03-16)"; Content = @("", "### Features Added", "", "- prior") }
+        )
+        $mainEntries = Get-ChangeLogEntriesFromContent $mainChangelog
+        $releaseEntries = Get-ChangeLogEntriesFromContent $releaseChangelog
+
+        $result = Merge-ChangeLogEntries -MainEntries $mainEntries -ReleaseEntries $releaseEntries
+
+        $result.Contains("1.12.0-beta.1") | Should -BeTrue
+        $result.Contains("1.11.0") | Should -BeTrue
     }
 
     It "Handles version ordering correctly after merge via Set-ChangeLogContent" {


### PR DESCRIPTION
Fixes a bug in the post-release version-bump PR script.

## Repro

[#58993](https://github.com/Azure/azure-sdk-for-net/pull/58993) ended up with both `## 1.11.0-beta.1 (Unreleased)` and `## 1.11.0 (2026-05-05)` in `System.ClientModel/CHANGELOG.md`.

The release branch had GA `1.11.0`; main had `1.11.0-beta.1` (Unreleased). `Merge-ChangeLogEntries` in `eng/scripts/Sync-ReleaseArtifacts.ps1` only matched entries by exact version string, so the two were treated as unrelated and both were kept.

## Fix

After merging, `Merge-ChangeLogEntries` now scans the merged set for any `(Unreleased)` prerelease entry whose `Major.Minor.Patch` matches a dated stable (GA/Patch) entry coming from the release branch and removes it.

The change is intentionally conservative:

- 🔴 Removed: `1.11.0-beta.1 (Unreleased)` when release ships `1.11.0` GA — superseded.
- 🟢 Preserved: `1.11.0-beta.1 (2026-04-01)` (dated, real history) — not touched.
- 🟢 Preserved: `1.12.0-beta.1 (Unreleased)` (different MMP) — not touched.

## Tests

Added 3 cases to `eng/scripts/tests/Sync-ReleaseArtifacts.tests.ps1`:

- `GA release supersedes unreleased beta of the same version` (the bug repro)
- `GA release does not remove a dated (already shipped) prerelease of same MMP`
- `GA release does not remove unreleased prereleases of different MMP`

All 19 tests pass (16 existing + 3 new). The bug-repro test fails on `main` and passes with the fix.