### PR TITLE
Add IP address scalar coverage for management generator

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ManagementTypeFactoryTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ManagementTypeFactoryTests.cs
@@ -8,6 +8,7 @@ using Azure.ResourceManager.Resources.Models;
 using Microsoft.TypeSpec.Generator.Input;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Net;
 
 namespace Azure.Generator.Mgmt.Tests
 {
@@ -67,6 +68,20 @@ namespace Azure.Generator.Mgmt.Tests
             var plugin = ManagementMockHelpers.LoadMockPlugin(inputEnums: () => [enumType]);
             var result = plugin.Object.TypeFactory.CreateEnum(enumType, null);
             Assert.That(result, Is.Null);
+        }
+
+        [TestCase("Azure.Core.ipV4Address")]
+        [TestCase("Azure.Core.ipV6Address")]
+        public void AzureCoreIpAddressPrimitiveTypeIsReplacedWithIPAddress(string crossLanguageDefinitionId)
+        {
+            var primitiveType = InputFactory.Primitive.String("ipAddress", crossLanguageDefinitionId);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin();
+            var result = plugin.Object.TypeFactory.CreateCSharpType(primitiveType);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.IsFrameworkType, Is.True);
+            Assert.That(result.FrameworkType, Is.EqualTo(typeof(IPAddress)));
         }
 
         [TestCase]


### PR DESCRIPTION
Fixes #58989.

This adds management-generator regression coverage for the Azure Core IP address scalars:

- `Azure.Core.ipV4Address`
- `Azure.Core.ipV6Address`

Both are asserted to map to `System.Net.IPAddress` in the management generator type factory.

While investigating the NetApp package, `NetAppVolumeBreakFileLocksContent.ClientIP` and `NetAppVolumeMountTarget.IPAddress` are already generated as `System.Net.IPAddress`. The related `NicInfo.IPAddress` and `PeerClusterForVolumeMigrationContent.PeerIPAddresses` fields are still string-based, but changing those public members to `IPAddress`/`IList<IPAddress>` fails ApiCompat because they are part of the current GA contract.

Validation:

- `dotnet test .\eng\packages\http-client-csharp-mgmt\generator\Azure.Generator.Management\test\Azure.Generator.Mgmt.Tests.csproj --filter "FullyQualifiedName~ManagementTypeFactoryTests"`
- `dotnet build .\sdk\netapp\Azure.ResourceManager.NetApp\src\Azure.ResourceManager.NetApp.csproj`