### PR TITLE
Set skipCodeownersVerification: true for Azure.Template

### DIFF
--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -45,6 +45,7 @@ extends:
     Artifacts:
     - name: Azure.Template
       safeName: AzureTemplate
+      skipCodeownersVerification: true
       triggeringPaths:
       - /.config
       - /.devcontainer


### PR DESCRIPTION
This can be set in main and changed in test branches if needed for CODEOWNERS scenario testing.