### PR TITLE
Fix mgmt ModelFactory parameter names

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/ModelFactoryVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.TypeSpec.Generator.ClientModel;
+using Microsoft.TypeSpec.Generator.Primitives;
 using Microsoft.TypeSpec.Generator.Providers;
 using Microsoft.TypeSpec.Generator.Statements;
 using System;
@@ -12,12 +13,6 @@ namespace Azure.Generator.Management.Visitors
 {
     internal class ModelFactoryVisitor : ScmLibraryVisitor
     {
-        // Dictionary mapping property names to their preferred parameter names
-        private static readonly Dictionary<string, string> PropertyToParameterNameMap = new()
-        {
-            { "ETag", "etag" }
-        };
-
         protected override TypeProvider? VisitType(TypeProvider type)
         {
             if (type is ModelFactoryProvider modelFactory)
@@ -58,26 +53,57 @@ namespace Azure.Generator.Management.Visitors
 
         private void UpdateParameterNames(MethodProvider method)
         {
-            bool updated = false;
-
-            // Check if any parameter needs to be renamed based on the property name mapping
-            foreach (var parameter in method.Signature.Parameters)
+            if (PreservePreviousParameterNames(method))
             {
-                // Check if the parameter is associated with a property and needs renaming
-                if (parameter.Property != null &&
-                    PropertyToParameterNameMap.TryGetValue(parameter.Property.Name, out var newName) &&
-                    parameter.Name != newName)
-                {
-                    parameter.Update(name: newName);
-                    updated = true;
-                }
-            }
-
-            if (updated)
-            {
-                // Update the method signature to refresh documentation
+                // Update the method signature to refresh documentation after parameter renames.
                 method.Update(signature: method.Signature);
             }
+        }
+
+        private static bool PreservePreviousParameterNames(MethodProvider method)
+        {
+            var previousMethods = method.EnclosingType.LastContractView?.Methods;
+            if (previousMethods is null || previousMethods.Count == 0)
+            {
+                return false;
+            }
+
+            var previousMethod = previousMethods.FirstOrDefault(previous => MethodSignature.MethodSignatureComparer.Equals(method.Signature, previous.Signature));
+            if (previousMethod is null)
+            {
+                return false;
+            }
+
+            var currentParameters = method.Signature.Parameters;
+            var previousParameters = previousMethod.Signature.Parameters;
+            if (currentParameters.Count != previousParameters.Count)
+            {
+                return false;
+            }
+
+            var updated = false;
+            var currentParameterNames = currentParameters.Select(parameter => parameter.Name).ToHashSet(StringComparer.Ordinal);
+            for (int i = 0; i < currentParameters.Count; i++)
+            {
+                var previousName = previousParameters[i].Name;
+                var currentParameter = currentParameters[i];
+                if (string.IsNullOrEmpty(previousName) || currentParameter.Name == previousName)
+                {
+                    continue;
+                }
+
+                if (currentParameterNames.Contains(previousName))
+                {
+                    continue;
+                }
+
+                currentParameterNames.Remove(currentParameter.Name);
+                currentParameter.Update(name: previousName);
+                currentParameterNames.Add(previousName);
+                updated = true;
+            }
+
+            return updated;
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/ModelFactoryVisitorTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Management.Tests.Common;
+using Azure.Generator.Management.Tests.TestHelpers;
+using Microsoft.TypeSpec.Generator;
+using Microsoft.TypeSpec.Generator.Input;
+using Microsoft.TypeSpec.Generator.Primitives;
+using Microsoft.TypeSpec.Generator.Providers;
+using Microsoft.TypeSpec.Generator.Statements;
+using NUnit.Framework;
+using System;
+using System.Reflection;
+
+namespace Azure.Generator.Mgmt.Tests
+{
+    internal class ModelFactoryVisitorTests
+    {
+        [Test]
+        public void ModelFactoryParametersPreserveLastContractNames()
+        {
+            var parentModel = InputFactory.Model(
+                "TestResource",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [parentModel]);
+            var model = plugin.Object.TypeFactory.CreateModel(parentModel)!;
+            var modelFactory = plugin.Object.OutputLibrary.TypeProviders.OfType<ModelFactoryProvider>().Single();
+
+            var eTagParameter = new ParameterProvider("eTag", $"ETag description", typeof(string));
+            eTagParameter.Update(wireInfo: new WireInformation(default, "etag"));
+            var ipv4Parameter = new ParameterProvider("ipv4Address", $"IPv4 description", typeof(string));
+            ipv4Parameter.Update(wireInfo: new WireInformation(default, "ipv4Address"));
+            var ipv6Parameter = new ParameterProvider("ipv6Address", $"IPv6 description", typeof(string));
+            ipv6Parameter.Update(wireInfo: new WireInformation(default, "ipv6Address"));
+
+            var signature = new MethodSignature(
+                "TestResource",
+                $"Creates a test resource.",
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                model.Type,
+                $"A test resource.",
+                [eTagParameter, ipv4Parameter, ipv6Parameter]);
+            var method = new MethodProvider(signature, MethodBodyStatement.Empty, modelFactory);
+
+            var lastContractView = new TestModelFactoryView(modelFactory.Name);
+            var previousSignature = new MethodSignature(
+                "TestResource",
+                $"Creates a test resource.",
+                MethodSignatureModifiers.Public | MethodSignatureModifiers.Static,
+                model.Type,
+                $"A test resource.",
+                [
+                    new ParameterProvider("etag", $"ETag description", typeof(string)),
+                    new ParameterProvider("iPv4Address", $"IPv4 description", typeof(string)),
+                    new ParameterProvider("iPv6Address", $"IPv6 description", typeof(string))
+                ]);
+            lastContractView.MethodsToBuild = [new MethodProvider(previousSignature, MethodBodyStatement.Empty, lastContractView)];
+
+            SetLastContractView(modelFactory, lastContractView);
+            modelFactory.Update(methods: [method]);
+
+            var updateParameterNames = typeof(Management.Visitors.ModelFactoryVisitor).GetMethod(
+                "UpdateParameterNames",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(updateParameterNames, Is.Not.Null);
+
+            updateParameterNames!.Invoke(new Management.Visitors.ModelFactoryVisitor(), [method]);
+
+            var updatedMethod = modelFactory.Methods.Single();
+            Assert.That(updatedMethod.Signature.Parameters.Select(p => p.Name), Is.EqualTo(new[] { "etag", "iPv4Address", "iPv6Address" }));
+
+            var rendered = new TypeProviderWriter(modelFactory).Write().Content;
+            Assert.That(rendered, Does.Contain("string etag"));
+            Assert.That(rendered, Does.Not.Contain("string eTag"));
+        }
+
+        private static void SetLastContractView(TypeProvider typeProvider, TypeProvider lastContractView)
+        {
+            typeof(TypeProvider).GetField(
+                    "_lastContractView",
+                    BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(typeProvider, new Lazy<TypeProvider?>(() => lastContractView));
+        }
+
+        private class TestModelFactoryView : TypeProvider
+        {
+            private readonly string _name;
+
+            public TestModelFactoryView(string name)
+            {
+                _name = name;
+            }
+
+            public MethodProvider[] MethodsToBuild { get; set; } = [];
+
+            protected override string BuildName() => _name;
+
+            protected override string BuildRelativeFilePath() => $"{Name}.cs";
+
+            protected override MethodProvider[] BuildMethods() => MethodsToBuild;
+        }
+    }
+}

--- a/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/TestProjects/Local/Mgmt-TypeSpec/src/Generated/MgmtTypeSpecTestsModelFactory.cs
@@ -130,7 +130,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <param name="doubleValue"> double value. </param>
         /// <param name="prop1"> Gets the Prop1. </param>
         /// <param name="prop2"> Gets the Prop2. </param>
-        /// <param name="etag"> ETag property for testing etag parameter name generation. </param>
+        /// <param name="eTag"> ETag property for testing etag parameter name generation. </param>
         /// <param name="writableSubResourceProp"> WritableSubResource property for testing WritableSubResource type replacement. </param>
         /// <param name="nestedPropertyProperties"> Gets or sets the Properties. </param>
         /// <param name="flattenedProperty"> Gets the FlattenedProperty. </param>
@@ -139,9 +139,8 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <param name="extendedLocation"></param>
         /// <param name="identity"> The managed service identities assigned to this resource. </param>
         /// <param name="plan"> Details of the resource plan. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="something"/>, <paramref name="prop1"/> or <paramref name="nestedPropertyProperties"/> is null. </exception>
         /// <returns> A new <see cref="Tests.FooData"/> instance for mocking. </returns>
-        public static FooData FooData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, AzureLocation location = default, Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, ETag? etag = default, WritableSubResource writableSubResourceProp = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default, ExtendedLocation extendedLocation = default, ManagedServiceIdentity identity = default, ArmPlan plan = default)
+        public static FooData FooData(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, IDictionary<string, string> tags = default, AzureLocation location = default, Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, ETag? eTag = default, WritableSubResource writableSubResourceProp = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default, ExtendedLocation extendedLocation = default, ManagedServiceIdentity identity = default, ArmPlan plan = default)
         {
             tags ??= new ChangeTrackingDictionary<string, string>();
 
@@ -164,7 +163,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                     new NestedFooModel(nestedPropertyProperties, null),
                     new SafeFlattenModel((flattenedProperty ?? new ChangeTrackingList<string>()).ToList(), null),
                     new VmProfile(new ApplicationProfile((vmGalleryApplications ?? new ChangeTrackingList<string>()).ToList(), null), null),
-                    etag,
+                    eTag,
                     writableSubResourceProp,
                     new ComputeFleetVmProfile(new CapacityReservationProfile(new TestSubResource(computeFleetVmCapacityReservationGroupId, null), null), null),
                     null),
@@ -183,12 +182,11 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <param name="nestedPropertyProperties"> Gets or sets the Properties. </param>
         /// <param name="flattenedProperty"> Gets the FlattenedProperty. </param>
         /// <param name="vmGalleryApplications"> Specifies the gallery applications that should be made available. </param>
-        /// <param name="etag"> ETag property for testing etag parameter name generation. </param>
+        /// <param name="eTag"> ETag property for testing etag parameter name generation. </param>
         /// <param name="writableSubResourceProp"> WritableSubResource property for testing WritableSubResource type replacement. </param>
         /// <param name="computeFleetVmCapacityReservationGroupId"> Gets or sets the Id. </param>
-        /// <exception cref="ArgumentNullException"> <paramref name="nestedPropertyProperties"/> is null. </exception>
         /// <returns> A new <see cref="Models.FooProperties"/> instance for mocking. </returns>
-        public static FooProperties FooProperties(Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ETag? etag = default, WritableSubResource writableSubResourceProp = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default)
+        public static FooProperties FooProperties(Uri serviceUri = default, ManagedServiceIdentity something = default, bool? boolValue = default, float? floatValue = default, double? doubleValue = default, IEnumerable<string> prop1 = default, IEnumerable<int> prop2 = default, FooProperties nestedPropertyProperties = default, IEnumerable<string> flattenedProperty = default, IEnumerable<string> vmGalleryApplications = default, ETag? eTag = default, WritableSubResource writableSubResourceProp = default, ResourceIdentifier computeFleetVmCapacityReservationGroupId = default)
         {
             prop1 ??= new ChangeTrackingList<string>();
             prop2 ??= new ChangeTrackingList<int>();
@@ -204,7 +202,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 new NestedFooModel(nestedPropertyProperties, null),
                 flattenedProperty is null ? default : new SafeFlattenModel((flattenedProperty ?? new ChangeTrackingList<string>()).ToList(), null),
                 vmGalleryApplications is null ? default : new VmProfile(new ApplicationProfile((vmGalleryApplications ?? new ChangeTrackingList<string>()).ToList(), null), null),
-                etag,
+                eTag,
                 writableSubResourceProp,
                 computeFleetVmCapacityReservationGroupId is null ? default : new ComputeFleetVmProfile(new CapacityReservationProfile(new TestSubResource(computeFleetVmCapacityReservationGroupId, null), null), null),
                 additionalBinaryDataProperties: null);
@@ -1451,10 +1449,10 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
         /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
-        /// <param name="etag"> Resource Etag. </param>
+        /// <param name="eTag"> Resource Etag. </param>
         /// <param name="containerItemLikeSomething"> A simple string property. </param>
         /// <returns> A new <see cref="Models.ContainerItemLike"/> instance for mocking. </returns>
-        public static ContainerItemLike ContainerItemLike(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, string etag = default, string containerItemLikeSomething = default)
+        public static ContainerItemLike ContainerItemLike(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, string eTag = default, string containerItemLikeSomething = default)
         {
             return new ContainerItemLike(
                 id,
@@ -1462,17 +1460,18 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 resourceType,
                 systemData,
                 additionalBinaryDataProperties: null,
-                etag,
+                eTag,
                 containerItemLikeSomething is null ? default : new ContainerItemLikeProperties(containerItemLikeSomething, null));
         }
 
+        /// <summary> Entity Resource Like. </summary>
         /// <param name="id"> Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}. </param>
         /// <param name="name"> The name of the resource. </param>
         /// <param name="resourceType"> The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts". </param>
         /// <param name="systemData"> Azure Resource Manager metadata containing createdBy and modifiedBy information. </param>
-        /// <param name="etag"> Resource Etag. </param>
+        /// <param name="eTag"> Resource Etag. </param>
         /// <returns> A new <see cref="Models.EntityResourceLike"/> instance for mocking. </returns>
-        public static EntityResourceLike EntityResourceLike(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, string etag = default)
+        public static EntityResourceLike EntityResourceLike(ResourceIdentifier id = default, string name = default, ResourceType resourceType = default, SystemData systemData = default, string eTag = default)
         {
             return new EntityResourceLike(
                 id,
@@ -1480,7 +1479,7 @@ namespace Azure.Generator.MgmtTypeSpec.Tests.Models
                 resourceType,
                 systemData,
                 additionalBinaryDataProperties: null,
-                etag);
+                eTag);
         }
 
         /// <summary> Paged collection of DerivedPatch items. </summary>


### PR DESCRIPTION
## Summary
- Preserve public `Arm*ModelFactory` parameter names from the previous API contract after management-plane visitors mutate ModelFactory signatures.
- Replace the earlier service-specific hard-coded name map with generic `LastContractView`-based parameter-name preservation.
- Add regression coverage for parameters whose current generated names changed (`eTag`, `ipv4Address`, `ipv6Address`) but whose previous public names must be kept (`etag`, `iPv4Address`, `iPv6Address`).
- Regenerate the local management generator test project output.

## Root cause
The shared C# generator added ModelFactory parameter-name preservation from `LastContractView`, which is the correct source of truth for source-compatible public parameter names. However, the management generator runs additional visitors after the shared ModelFactory methods are built. In particular, management flattening can replace ModelFactory parameters with newly-created flattened/synthetic parameters after the shared back-compat pass has already run.

That later mutation can reintroduce the current canonical generated names into public `Arm*ModelFactory` signatures, such as `eTag` or `ipv4Address`, even when the previous public contract exposed `etag` or `iPv4Address`. Updating XML docs to match the new names would only hide the doc/signature mismatch while accepting a source-breaking parameter rename for named-argument callers. This PR instead reapplies previous-contract parameter names after management ModelFactory mutations.

## Scope of the divergence
The XML doc/signature divergence only occurs in the back-compat path where `LastContractView` exists. In that path, the shared generator may build XML docs from the preserved previous parameter names, and then a later management visitor can replace the signature parameter with a current-name parameter if compatibility is not reapplied.

New API versions with no previous public contract are not affected by this specific issue. Without `LastContractView`, there is no previous name to preserve, so the generated XML docs and signatures should both use the current generated parameter names. If a no-last-contract API ever diverges, that would be a separate doc-refresh bug where a visitor changed final parameters without rebuilding XML docs.

## Fix
`ModelFactoryVisitor` now compares each updated ModelFactory method against `method.EnclosingType.LastContractView?.Methods` using the existing method-signature comparer, then restores parameter names by position when the method shape matches. This keeps the fix generic and driven by the prior public API contract instead of a manually-maintained list of special-case names.

## Issue
Fixes #59072

## Validation
- `dotnet test .\eng\packages\http-client-csharp-mgmt\generator\Azure.Generator.Management\test\Azure.Generator.Mgmt.Tests.csproj --filter FullyQualifiedName~ModelFactoryVisitorTests.ModelFactoryParametersPreserveLastContractNames --no-restore`
- `dotnet test .\eng\packages\http-client-csharp-mgmt\generator\Azure.Generator.Management\test\Azure.Generator.Mgmt.Tests.csproj --no-restore`
- `eng\packages\http-client-csharp-mgmt\eng\scripts\Generate.ps1`