### PR TITLE
Add CategoryName to custom events customDimensions

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/LogsHelper.cs
@@ -260,14 +260,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 
             logRecord.ForEachScope(s_processScope, properties);
 
-            if (eventName is null && availabilityInfo is null) // we will omit the following properties if we've detected a custom event or availability.
+            if (availabilityInfo is null)
             {
                 var categoryName = logRecord.CategoryName;
                 if (!properties.ContainsKey("CategoryName") && !string.IsNullOrEmpty(categoryName))
                 {
                     properties.Add("CategoryName", categoryName.Truncate(SchemaConstants.KVP_MaxValueLength)!);
                 }
+            }
 
+            if (eventName is null && availabilityInfo is null) // we will omit the following properties if we've detected a custom event or availability.
+            {
                 if (!properties.ContainsKey("EventId") && logRecord.EventId.Id != 0)
                 {
                     properties.Add("EventId", logRecord.EventId.Id.ToString(CultureInfo.InvariantCulture));

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/CustomEventsTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Azure.Monitor.OpenTelemetry.Exporter.Tests/E2ETelemetryItemValidation/CustomEventsTests.cs
@@ -123,7 +123,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             TelemetryItemValidationHelper.AssertCustomEventTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedName: "MyCustomEventName",
-                expectedProperties: new Dictionary<string, string>(),
+                expectedProperties: new Dictionary<string, string> { { "CategoryName", logCategoryName } },
                 expectedSpanId: null,
                 expectedTraceId: null);
         }
@@ -162,7 +162,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             TelemetryItemValidationHelper.AssertCustomEventTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedName: "MyCustomEventName",
-                expectedProperties: new Dictionary<string, string>(),
+                expectedProperties: new Dictionary<string, string> { { "CategoryName", logCategoryName } },
                 expectedSpanId: null,
                 expectedTraceId: null,
                 expectedClientIp: "1.2.3.4");
@@ -271,7 +271,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             TelemetryItemValidationHelper.AssertCustomEventTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedName: "MyCustomEventName",
-                expectedProperties: new Dictionary<string, string> (),
+                expectedProperties: new Dictionary<string, string> { { "CategoryName", logCategoryName } },
                 expectedSpanId: null,
                 expectedTraceId: null);
         }
@@ -312,7 +312,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             TelemetryItemValidationHelper.AssertCustomEventTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedName: "MyCustomEventName",
-                expectedProperties: new Dictionary<string, string>(),
+                expectedProperties: new Dictionary<string, string> { { "CategoryName", logCategoryName } },
                 expectedSpanId: null,
                 expectedTraceId: null,
                 expectedClientIp: "1.2.3.4");
@@ -420,7 +420,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             TelemetryItemValidationHelper.AssertCustomEventTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedName: "MyCustomEventName",
-                expectedProperties: new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" }, { "scopeKey1", "scopeValue1" }, { "scopeKey2", "scopeValue2" } },
+                expectedProperties: new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" }, { "scopeKey1", "scopeValue1" }, { "scopeKey2", "scopeValue2" }, { "CategoryName", logCategoryName } },
                 expectedSpanId: null,
                 expectedTraceId: null);
         }
@@ -473,7 +473,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Tests.E2ETelemetryItemValidation
             TelemetryItemValidationHelper.AssertCustomEventTelemetry(
                 telemetryItem: telemetryItem!,
                 expectedName: "Name1",
-                expectedProperties: new Dictionary<string, string>() { { "microsoft.custom_event.name", "Name2" } },
+                expectedProperties: new Dictionary<string, string>() { { "microsoft.custom_event.name", "Name2" }, { "CategoryName", logCategoryName } },
                 expectedSpanId: null,
                 expectedTraceId: null);
         }


### PR DESCRIPTION
Previously CategoryName was intentionally excluded from custom events. This change moves the CategoryName property addition outside the custom event/availability guard so it is now emitted for custom events (and continues to be emitted for traces and exceptions). Availability telemetry still does not include CategoryName.
