### PR TITLE
Add yml for VL Live Tests

### DIFF
--- a/sdk/voicelive/tests.yml
+++ b/sdk/voicelive/tests.yml
@@ -1,0 +1,7 @@
+trigger: none
+
+extends:
+  template: /eng/pipelines/templates/stages/archetype-sdk-tests.yml
+  parameters:
+    ServiceDirectory: voicelive
+    SupportedClouds: 'Public'


### PR DESCRIPTION
Add sdk/voicelive/tests.yml which tells the Azure SDK pipeline generator that voicelive has a live test pipeline