### PR TITLE
[Storage] [DataMovement] Fix Live Copy Pause and Resume test credentials

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobPauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Blobs/tests/BlobPauseResumeTransferTests.cs
@@ -189,6 +189,57 @@ namespace Azure.Storage.DataMovement.Blobs.Tests
             return ClientBuilder.GetServiceClientFromAzureSasCredentialConfig(Tenants.TestConfigDefault, default);
         }
 
+        protected override async Task<(StorageResource Source, StorageResource Destination)> CreateCopyStorageResourcesWithAuthAsync(
+            long size,
+            BlobContainerClient sourceContainer,
+            BlobContainerClient destinationContainer,
+            StorageResourceProvider provider)
+        {
+            string itemName = GetNewItemName();
+
+            // Upload data using SharedKey client
+            BlockBlobClient blobClient = sourceContainer.GetBlockBlobClient(itemName);
+            using (Stream originalStream = await CreateLimitedMemoryStream(size))
+            {
+                originalStream.Position = 0;
+                await blobClient.UploadAsync(originalStream);
+            }
+
+            // Create resources through the SAS provider so copy-source URL is authenticated
+            BlobsStorageResourceProvider sasProvider = (BlobsStorageResourceProvider)provider;
+            StorageResource source = await sasProvider.FromBlobAsync(
+                blobClient.Uri,
+                new BlockBlobStorageResourceOptions());
+            BlockBlobClient destClient = destinationContainer.GetBlockBlobClient(itemName);
+            StorageResource destination = await sasProvider.FromBlobAsync(
+                destClient.Uri,
+                new BlockBlobStorageResourceOptions());
+            return (source, destination);
+        }
+
+        protected override async Task<(StorageResource Source, StorageResource Destination)> CreateCopyStorageResourceContainersWithAuthAsync(
+            long size,
+            int transferCount,
+            BlobContainerClient sourceContainer,
+            BlobContainerClient destinationContainer,
+            StorageResourceProvider provider)
+        {
+            string directoryPath = GetNewContainerName();
+
+            // Upload data using SharedKey client (discard the FromClient-based resource)
+            await CreateSourceStorageResourceContainerAsync(size, transferCount, directoryPath, sourceContainer);
+
+            // Create container resources through the SAS provider so copy-source URL is authenticated
+            BlobsStorageResourceProvider sasProvider = (BlobsStorageResourceProvider)provider;
+            BlobStorageResourceContainerOptions sourceOptions = new() { BlobPrefix = directoryPath };
+            StorageResource source = await sasProvider.FromContainerAsync(
+                sourceContainer.Uri,
+                sourceOptions);
+            StorageResource destination = await sasProvider.FromContainerAsync(
+                destinationContainer.Uri);
+            return (source, destination);
+        }
+
         #region Snapshot Tests
         [Test]
         [Ignore("Live tests only")]

--- a/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFilePauseResumeTransferTests.cs
+++ b/sdk/storage/Azure.Storage.DataMovement.Files.Shares/tests/ShareFilePauseResumeTransferTests.cs
@@ -161,6 +161,48 @@ namespace Azure.Storage.DataMovement.Files.Shares.Tests
         protected override ShareServiceClient GetAzureSasCredentialServiceClient()
             => ClientBuilder.GetServiceClientFromAzureSasCredentialConfig(Tenants.TestConfigDefault, default);
 
+        protected override async Task<(StorageResource Source, StorageResource Destination)> CreateCopyStorageResourcesWithAuthAsync(
+            long size,
+            ShareClient sourceContainer,
+            ShareClient destinationContainer,
+            StorageResourceProvider provider)
+        {
+            string itemName = GetNewItemName();
+
+            // Upload data using SharedKey client
+            ShareFileClient fileClient = sourceContainer.GetRootDirectoryClient().GetFileClient(itemName);
+            await fileClient.CreateAsync(size);
+            using (Stream originalStream = await CreateLimitedMemoryStream(size))
+            {
+                originalStream.Position = 0;
+                await fileClient.UploadAsync(originalStream);
+            }
+
+            // Create resources through the SAS provider so copy-source URL is authenticated
+            ShareFilesStorageResourceProvider sasProvider = (ShareFilesStorageResourceProvider)provider;
+            StorageResource source = await sasProvider.FromFileAsync(fileClient.Uri);
+            ShareFileClient destClient = destinationContainer.GetRootDirectoryClient().GetFileClient(itemName);
+            StorageResource destination = await sasProvider.FromFileAsync(destClient.Uri);
+            return (source, destination);
+        }
+
+        protected override async Task<(StorageResource Source, StorageResource Destination)> CreateCopyStorageResourceContainersWithAuthAsync(
+            long size,
+            int transferCount,
+            ShareClient sourceContainer,
+            ShareClient destinationContainer,
+            StorageResourceProvider provider)
+        {
+            // Upload data using SharedKey client (discard the FromClient-based resource)
+            await CreateSourceStorageResourceContainerAsync(size, transferCount, GetNewContainerName(), sourceContainer);
+
+            // Create container resources through the SAS provider so copy-source URL is authenticated
+            ShareFilesStorageResourceProvider sasProvider = (ShareFilesStorageResourceProvider)provider;
+            StorageResource source = await sasProvider.FromDirectoryAsync(sourceContainer.GetRootDirectoryClient().Uri);
+            StorageResource destination = await sasProvider.FromDirectoryAsync(destinationContainer.GetRootDirectoryClient().Uri);
+            return (source, destination);
+        }
+
         #region Snapshot Tests
         [Test]
         [Ignore("Live tests only")]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
@@ -87,8 +87,9 @@ namespace Azure.Storage.DataMovement.Tests
 
         /// <summary>
         /// Creates source and destination storage resources for Copy transfers that carry
-        /// proper copy-source authentication (e.g. SAS credentials). Override this method
-        /// to provide resources where the source URI is authenticated for service-to-service copy.
+        /// a SAS credential.
+        /// Override this method to provide resources where the source URI is authenticated
+        /// for service-to-service copy.
         /// </summary>
         /// <param name="size">Size of the source file to create and upload.</param>
         /// <param name="sourceContainer">The source container client.</param>
@@ -112,9 +113,10 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         /// <summary>
-        /// Creates source and destination container storage resources for Copy transfers that carry
-        /// proper copy-source authentication (e.g. SAS credentials). Override this method
-        /// to provide resources where the source URI is authenticated for service-to-service copy.
+        /// Creates source and destination storage resources for Copy transfers that carry
+        /// a SAS credential.
+        /// Override this method to provide resources where the source URI is authenticated
+        /// for service-to-service copy.
         /// </summary>
         protected virtual async Task<(StorageResource Source, StorageResource Destination)> CreateCopyStorageResourceContainersWithAuthAsync(
             long size,

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
@@ -86,15 +86,16 @@ namespace Azure.Storage.DataMovement.Tests
         protected abstract TServiceClient GetAzureSasCredentialServiceClient();
 
         /// <summary>
-        /// Creates source and destination storage resources for Copy transfers that carry
-        /// proper copy-source authentication (e.g. SAS credentials). Override this method
-        /// to provide resources where the source URI is authenticated for service-to-service copy.
+        /// Creates source and destination storage resources for Copy transfers.
+        /// Override this method to provide resources where the source URI includes
+        /// copy-source authentication (for example, SAS credentials) for service-to-service copy.
+        /// The default implementation does not add special copy-source authentication.
         /// </summary>
         /// <param name="size">Size of the source file to create and upload.</param>
         /// <param name="sourceContainer">The source container client.</param>
         /// <param name="destinationContainer">The destination container client.</param>
         /// <param name="provider">The SAS storage resource provider.</param>
-        /// <returns>Source and destination storage resources with copy-source auth.</returns>
+        /// <returns>Source and destination storage resources for a copy transfer; by default, these resources do not include special copy-source authentication.</returns>
         protected virtual async Task<(StorageResource Source, StorageResource Destination)> CreateCopyStorageResourcesWithAuthAsync(
             long size,
             TContainerClient sourceContainer,

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
@@ -84,6 +84,56 @@ namespace Azure.Storage.DataMovement.Tests
             TContainerClient container);
 
         protected abstract TServiceClient GetAzureSasCredentialServiceClient();
+
+        /// <summary>
+        /// Creates source and destination storage resources for Copy transfers that carry
+        /// proper copy-source authentication (e.g. SAS credentials). Override this method
+        /// to provide resources where the source URI is authenticated for service-to-service copy.
+        /// </summary>
+        /// <param name="size">Size of the source file to create and upload.</param>
+        /// <param name="sourceContainer">The source container client.</param>
+        /// <param name="destinationContainer">The destination container client.</param>
+        /// <param name="provider">The SAS storage resource provider.</param>
+        /// <returns>Source and destination storage resources with copy-source auth.</returns>
+        protected virtual async Task<(StorageResource Source, StorageResource Destination)> CreateCopyStorageResourcesWithAuthAsync(
+            long size,
+            TContainerClient sourceContainer,
+            TContainerClient destinationContainer,
+            StorageResourceProvider provider)
+        {
+            // Default implementation: create resources without special auth.
+            // Subclasses should override to provide SAS-authenticated resources.
+            return await CreateStorageResourcesAsync(
+                transferType: TransferDirection.Copy,
+                size: size,
+                localDirectory: default,
+                sourceContainer: sourceContainer,
+                destinationContainer: destinationContainer);
+        }
+
+        /// <summary>
+        /// Creates source and destination container storage resources for Copy transfers that carry
+        /// proper copy-source authentication (e.g. SAS credentials). Override this method
+        /// to provide resources where the source URI is authenticated for service-to-service copy.
+        /// </summary>
+        protected virtual async Task<(StorageResource Source, StorageResource Destination)> CreateCopyStorageResourceContainersWithAuthAsync(
+            long size,
+            int transferCount,
+            TContainerClient sourceContainer,
+            TContainerClient destinationContainer,
+            StorageResourceProvider provider)
+        {
+            // Default implementation: create resources without special auth.
+            // Subclasses should override to provide SAS-authenticated resources.
+            return await CreateStorageResourceContainersAsync(
+                transferType: TransferDirection.Copy,
+                size: size,
+                transferCount: transferCount,
+                sourceDirectoryPath: default,
+                destinationDirectoryPath: default,
+                sourceContainer: sourceContainer,
+                destinationContainer: destinationContainer);
+        }
         #endregion
 
         #region Helper Methods
@@ -627,7 +677,11 @@ namespace Azure.Storage.DataMovement.Tests
             await using IDisposingContainer<TContainerClient> sourceContainer = await GetDisposingContainerAsync();
             await using IDisposingContainer<TContainerClient> destinationContainer = await GetDisposingContainerAsync();
 
-            StorageResourceProvider provider = GetStorageResourceProvider();
+            // For Copy transfers, use a SAS provider so the copy-source URL is authenticated.
+            // SharedKey clients cannot provide copy-source authentication (no SAS on URI, no OAuth Bearer).
+            StorageResourceProvider provider = transferType == TransferDirection.Copy
+                ? GetContainerSasStorageResourceProvider(sourceContainer.Container, destinationContainer.Container)
+                : GetStorageResourceProvider();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
@@ -639,12 +693,25 @@ namespace Azure.Storage.DataMovement.Tests
             TransferManager transferManager = new TransferManager(options);
             long size = DataMovementTestConstants.KB * 100;
 
-            (StorageResource sResource, StorageResource dResource) = await CreateStorageResourcesAsync(
-                transferType: transferType,
-                size: size,
-                localDirectory: localDirectory.DirectoryPath,
-                sourceContainer: sourceContainer.Container,
-                destinationContainer: destinationContainer.Container);
+            StorageResource sResource;
+            StorageResource dResource;
+            if (transferType == TransferDirection.Copy)
+            {
+                (sResource, dResource) = await CreateCopyStorageResourcesWithAuthAsync(
+                    size: size,
+                    sourceContainer: sourceContainer.Container,
+                    destinationContainer: destinationContainer.Container,
+                    provider: provider);
+            }
+            else
+            {
+                (sResource, dResource) = await CreateStorageResourcesAsync(
+                    transferType: transferType,
+                    size: size,
+                    localDirectory: localDirectory.DirectoryPath,
+                    sourceContainer: sourceContainer.Container,
+                    destinationContainer: destinationContainer.Container);
+            }
 
             // Add long-running job to pause, if the job is not big enough
             // then the job might finish before we can pause it.
@@ -715,7 +782,10 @@ namespace Azure.Storage.DataMovement.Tests
             await using IDisposingContainer<TContainerClient> sourceContainer = await GetDisposingContainerAsync();
             await using IDisposingContainer<TContainerClient> destinationContainer = await GetDisposingContainerAsync();
 
-            StorageResourceProvider provider = GetStorageResourceProvider();
+            // For Copy transfers, use a SAS provider so the copy-source URL is authenticated.
+            StorageResourceProvider provider = transferType == TransferDirection.Copy
+                ? GetContainerSasStorageResourceProvider(sourceContainer.Container, destinationContainer.Container)
+                : GetStorageResourceProvider();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
@@ -727,12 +797,25 @@ namespace Azure.Storage.DataMovement.Tests
             TransferManager transferManager = new TransferManager(options);
             long size = DataMovementTestConstants.KB * 100;
 
-            (StorageResource sResource, StorageResource dResource) = await CreateStorageResourcesAsync(
-                transferType: transferType,
-                size: size,
-                localDirectory: localDirectory.DirectoryPath,
-                sourceContainer: sourceContainer.Container,
-                destinationContainer: destinationContainer.Container);
+            StorageResource sResource;
+            StorageResource dResource;
+            if (transferType == TransferDirection.Copy)
+            {
+                (sResource, dResource) = await CreateCopyStorageResourcesWithAuthAsync(
+                    size: size,
+                    sourceContainer: sourceContainer.Container,
+                    destinationContainer: destinationContainer.Container,
+                    provider: provider);
+            }
+            else
+            {
+                (sResource, dResource) = await CreateStorageResourcesAsync(
+                    transferType: transferType,
+                    size: size,
+                    localDirectory: localDirectory.DirectoryPath,
+                    sourceContainer: sourceContainer.Container,
+                    destinationContainer: destinationContainer.Container);
+            }
 
             // Add long-running job to pause, if the job is not big enough
             // then the job might finish before we can pause it.
@@ -1004,7 +1087,10 @@ namespace Azure.Storage.DataMovement.Tests
             await using IDisposingContainer<TContainerClient> sourceContainer = await GetDisposingContainerAsync();
             await using IDisposingContainer<TContainerClient> destinationContainer = await GetDisposingContainerAsync();
 
-            StorageResourceProvider provider = GetStorageResourceProvider();
+            // For Copy transfers, use a SAS provider so the copy-source URL is authenticated.
+            StorageResourceProvider provider = transferType == TransferDirection.Copy
+                ? GetContainerSasStorageResourceProvider(sourceContainer.Container, destinationContainer.Container)
+                : GetStorageResourceProvider();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
@@ -1021,14 +1107,28 @@ namespace Azure.Storage.DataMovement.Tests
             long size = DataMovementTestConstants.KB * 4;
             int partCount = 4;
 
-            (StorageResource sResource, StorageResource dResource) = await CreateStorageResourceContainersAsync(
-                transferType: transferType,
-                size: size,
-                transferCount: partCount,
-                sourceDirectoryPath: sourceDirectory.DirectoryPath,
-                destinationDirectoryPath: destinationDirectory.DirectoryPath,
-                sourceContainer: sourceContainer.Container,
-                destinationContainer: destinationContainer.Container);
+            StorageResource sResource;
+            StorageResource dResource;
+            if (transferType == TransferDirection.Copy)
+            {
+                (sResource, dResource) = await CreateCopyStorageResourceContainersWithAuthAsync(
+                    size: size,
+                    transferCount: partCount,
+                    sourceContainer: sourceContainer.Container,
+                    destinationContainer: destinationContainer.Container,
+                    provider: provider);
+            }
+            else
+            {
+                (sResource, dResource) = await CreateStorageResourceContainersAsync(
+                    transferType: transferType,
+                    size: size,
+                    transferCount: partCount,
+                    sourceDirectoryPath: sourceDirectory.DirectoryPath,
+                    destinationDirectoryPath: destinationDirectory.DirectoryPath,
+                    sourceContainer: sourceContainer.Container,
+                    destinationContainer: destinationContainer.Container);
+            }
 
             // Add long-running job to pause, if the job is not big enough
             // then the job might finish before we can pause it.
@@ -1088,7 +1188,10 @@ namespace Azure.Storage.DataMovement.Tests
             await using IDisposingContainer<TContainerClient> sourceContainer = await GetDisposingContainerAsync();
             await using IDisposingContainer<TContainerClient> destinationContainer = await GetDisposingContainerAsync();
 
-            StorageResourceProvider provider = GetStorageResourceProvider();
+            // For Copy transfers, use a SAS provider so the copy-source URL is authenticated.
+            StorageResourceProvider provider = transferType == TransferDirection.Copy
+                ? GetContainerSasStorageResourceProvider(sourceContainer.Container, destinationContainer.Container)
+                : GetStorageResourceProvider();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
@@ -1105,14 +1208,28 @@ namespace Azure.Storage.DataMovement.Tests
             long size = DataMovementTestConstants.KB * 4;
             int partCount = 4;
 
-            (StorageResource sResource, StorageResource dResource) = await CreateStorageResourceContainersAsync(
-                transferType: transferType,
-                size: size,
-                transferCount: partCount,
-                sourceDirectoryPath: sourceDirectory.DirectoryPath,
-                destinationDirectoryPath: destinationDirectory.DirectoryPath,
-                sourceContainer: sourceContainer.Container,
-                destinationContainer: destinationContainer.Container);
+            StorageResource sResource;
+            StorageResource dResource;
+            if (transferType == TransferDirection.Copy)
+            {
+                (sResource, dResource) = await CreateCopyStorageResourceContainersWithAuthAsync(
+                    size: size,
+                    transferCount: partCount,
+                    sourceContainer: sourceContainer.Container,
+                    destinationContainer: destinationContainer.Container,
+                    provider: provider);
+            }
+            else
+            {
+                (sResource, dResource) = await CreateStorageResourceContainersAsync(
+                    transferType: transferType,
+                    size: size,
+                    transferCount: partCount,
+                    sourceDirectoryPath: sourceDirectory.DirectoryPath,
+                    destinationDirectoryPath: destinationDirectory.DirectoryPath,
+                    sourceContainer: sourceContainer.Container,
+                    destinationContainer: destinationContainer.Container);
+            }
 
             // Add long-running job to pause, if the job is not big enough
             // then the job might finish before we can pause it.


### PR DESCRIPTION
Some technical debt I've been putting off getting these live tests fixed. Looks like the auth wasn't properly being set on the source, causing the CannotVerifyCopySource errors on these tests.