### PR TITLE
[Storage] [DataMovement] Fixed bug where an exception thrown during the completion phase of a transfer was not properly caught on Upload

### DIFF
--- a/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
+++ b/sdk/storage/Azure.Storage.DataMovement/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed file handle leaks in local checkpointer that prevented checkpoint files from being accessed after transfer pause or completion by replacing MemoryMappedFiles with direct file access.
 - Fixed an issue where corrupted or truncated checkpoint files could cause unexpected errors during transfer resume.
 - Fixed known issue where passing a `AzureSasCredential` to authenticate the source resource will not properly pass the credential for service to service copy operations.
+- Fixed bug where an exception thrown during the completion phase of a transfer could go unhandled instead of being reported as a failed transfer item.
 
 ### Other Changes
 - Made TransferManager.DisposeAsync public

--- a/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/ServiceToServiceJobPart.cs
@@ -236,7 +236,6 @@ namespace Azure.Storage.DataMovement
 
                 await ReportBytesWrittenAsync(completeLength).ConfigureAwait(false);
                 await CompleteTransferAsync(sourceProperties).ConfigureAwait(false);
-                await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
             }
             catch (RequestFailedException exception)
                 when (_createMode == StorageResourceCreationMode.SkipIfExists

--- a/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/src/StreamToUriJobPart.cs
@@ -285,7 +285,6 @@ namespace Azure.Storage.DataMovement
                 // Report bytes written before completion
                 await ReportBytesWrittenAsync(blockSize).ConfigureAwait(false);
                 await CompleteTransferAsync(sourceProperties).ConfigureAwait(false);
-                await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
             }
             else
             {
@@ -386,19 +385,24 @@ namespace Azure.Storage.DataMovement
 
         internal async Task CompleteTransferAsync(StorageResourceItemProperties sourceProperties)
         {
-            CancellationHelper.ThrowIfCancellationRequested(_cancellationToken);
+            try
+            {
+                // Apply necessary transfer completions on the destination.
+                await _destinationResource.CompleteTransferAsync(
+                    overwrite: _createMode == StorageResourceCreationMode.OverwriteIfExists,
+                    completeTransferOptions: new() { SourceProperties = sourceProperties },
+                    cancellationToken: _cancellationToken).ConfigureAwait(false);
 
-            // Apply necessary transfer completions on the destination.
-            await _destinationResource.CompleteTransferAsync(
-                overwrite: _createMode == StorageResourceCreationMode.OverwriteIfExists,
-                completeTransferOptions: new() { SourceProperties = sourceProperties },
-                cancellationToken: _cancellationToken).ConfigureAwait(false);
+                // Dispose the handlers
+                await CleanUpHandlersAsync().ConfigureAwait(false);
 
-            // Dispose the handlers
-            await CleanUpHandlersAsync().ConfigureAwait(false);
-
-            // Set completion status to completed
-            await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
+                // Set completion status to completed
+                await OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                await InvokeFailedArgAsync(ex).ConfigureAwait(false);
+            }
         }
 
         private async Task QueueStageBlockRequests(

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
@@ -1478,6 +1478,98 @@ namespace Azure.Storage.DataMovement.Tests
         }
 
         [Test]
+        public async Task CompleteTransferAsync_Failure_ReportsFailedItem()
+        {
+            // Arrange - This test validates that when CompleteTransferAsync throws on the
+            // destination resource, the error is caught and reported as a failed item
+            // rather than being an unhandled exception.
+            using DisposingLocalDirectory checkpointerDirectory = DisposingLocalDirectory.GetTestDirectory();
+            TransferManagerOptions options = new TransferManagerOptions()
+            {
+                CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
+                ErrorMode = TransferErrorMode.ContinueOnFailure,
+            };
+            TransferManager transferManager = new TransferManager(options);
+
+            // Create mock checkpoint details for source and destination
+            Mock<StorageResourceCheckpointDetails> mockCheckpointDetails = new Mock<StorageResourceCheckpointDetails>();
+            mockCheckpointDetails.SetupGet(c => c.Length).Returns(0);
+
+            long resourceLength = DataMovementTestConstants.KB;
+
+            // Create a source resource that succeeds through GetPropertiesAsync
+            Mock<StorageResourceItem> source = new Mock<StorageResourceItem>(MockBehavior.Strict);
+            source.Setup(r => r.Uri).Returns(new Uri("https://example.com/source"));
+            source.SetupGet(r => r.ResourceId).Returns("Mock");
+            source.SetupGet(r => r.ProviderId).Returns("mock");
+            source.Setup(r => r.IsContainer).Returns(false);
+            source.Setup(r => r.ShouldItemTransferAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
+            source.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new StorageResourceItemProperties
+                {
+                    ResourceLength = resourceLength,
+                });
+            source.Setup(r => r.GetSourceCheckpointDetails())
+                .Returns(mockCheckpointDetails.Object);
+            source.Setup(r => r.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(default(HttpAuthorization));
+            source.Setup(r => r.GetSasWithUri()).Returns(new Uri("https://example.com/source"));
+
+            // Create a destination resource where CompleteTransferAsync throws
+            Mock<StorageResourceItem> destination = new Mock<StorageResourceItem>(MockBehavior.Strict);
+            destination.Setup(r => r.Uri).Returns(new Uri("https://example.com/dest"));
+            destination.SetupGet(r => r.ResourceId).Returns("Mock");
+            destination.SetupGet(r => r.ProviderId).Returns("mock");
+            destination.Setup(r => r.IsContainer).Returns(false);
+            destination.SetupGet(r => r.TransferType).Returns(default(TransferOrder));
+            destination.SetupGet(r => r.MaxSupportedSingleTransferSize).Returns(Constants.GB);
+            destination.SetupGet(r => r.MaxSupportedChunkSize).Returns(Constants.GB);
+            destination.SetupGet(r => r.MaxSupportedChunkCount).Returns(int.MaxValue);
+            destination.Setup(r => r.ValidateTransferAsync(It.IsAny<string>(), It.IsAny<StorageResource>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            destination.Setup(r => r.GetDestinationCheckpointDetails())
+                .Returns(mockCheckpointDetails.Object);
+            destination.Setup(r => r.SetPermissionsAsync(
+                It.IsAny<StorageResourceItem>(),
+                It.IsAny<StorageResourceItemProperties>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            destination.Setup(r => r.CopyFromUriAsync(
+                It.IsAny<StorageResourceItem>(),
+                It.IsAny<bool>(),
+                It.IsAny<long>(),
+                It.IsAny<StorageResourceCopyFromUriOptions>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            destination.Setup(r => r.CompleteTransferAsync(
+                It.IsAny<bool>(),
+                It.IsAny<StorageResourceCompleteTransferOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Simulated CompleteTransferAsync failure"));
+
+            TransferOptions transferOptions = new TransferOptions();
+            TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
+
+            // Act - Start transfer; CopyFromUriAsync succeeds but CompleteTransferAsync fails
+            TransferOperation transfer = await transferManager.StartTransferAsync(
+                source.Object,
+                destination.Object,
+                transferOptions);
+
+            // Wait for transfer to complete (with failure)
+            using CancellationTokenSource waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await transfer.WaitForCompletionAsync(waitCts.Token);
+
+            // Assert - Transfer should complete with a failed item, not crash
+            Assert.IsTrue(transfer.HasCompleted);
+            Assert.IsTrue(transfer.Status.HasFailedItems);
+            Assert.AreEqual(1, testEventsRaised.FailedEvents.Count);
+            Assert.That(
+                testEventsRaised.FailedEvents.First().Exception.Message,
+                Does.Contain("Simulated CompleteTransferAsync failure"));
+        }
+
+        [Test]
         [LiveOnly]
         [TestCase(TransferDirection.Upload)]
         [TestCase(TransferDirection.Download)]

--- a/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
+++ b/sdk/storage/Azure.Storage.DataMovement/tests/Shared/PauseResumeTransferTestBase.cs
@@ -1477,13 +1477,14 @@ namespace Azure.Storage.DataMovement.Tests
             AssertCheckpointerFilesAreAccessible(checkpointerDirectory.DirectoryPath, transfer.Id);
         }
 
-        [Test]
-        public async Task CompleteTransferAsync_Failure_ReportsFailedItem()
+        /// <summary>
+        /// Helper that sets up common mocks and infrastructure for CompleteTransferAsync failure tests.
+        /// Returns configured source/destination mocks and the resource length used.
+        /// </summary>
+        private (TransferManager TransferManager, Mock<StorageResourceItem> Source, Mock<StorageResourceItem> Destination, long ResourceLength, DisposingLocalDirectory CheckpointerDirectory)
+            SetupCompleteTransferAsyncFailureMocks()
         {
-            // Arrange - This test validates that when CompleteTransferAsync throws on the
-            // destination resource, the error is caught and reported as a failed item
-            // rather than being an unhandled exception.
-            using DisposingLocalDirectory checkpointerDirectory = DisposingLocalDirectory.GetTestDirectory();
+            DisposingLocalDirectory checkpointerDirectory = DisposingLocalDirectory.GetTestDirectory();
             TransferManagerOptions options = new TransferManagerOptions()
             {
                 CheckpointStoreOptions = TransferCheckpointStoreOptions.CreateLocalStore(checkpointerDirectory.DirectoryPath),
@@ -1491,33 +1492,20 @@ namespace Azure.Storage.DataMovement.Tests
             };
             TransferManager transferManager = new TransferManager(options);
 
-            // Create mock checkpoint details for source and destination
             Mock<StorageResourceCheckpointDetails> mockCheckpointDetails = new Mock<StorageResourceCheckpointDetails>();
             mockCheckpointDetails.SetupGet(c => c.Length).Returns(0);
 
             long resourceLength = DataMovementTestConstants.KB;
 
-            // Create a source resource that succeeds through GetPropertiesAsync
             Mock<StorageResourceItem> source = new Mock<StorageResourceItem>(MockBehavior.Strict);
-            source.Setup(r => r.Uri).Returns(new Uri("https://example.com/source"));
             source.SetupGet(r => r.ResourceId).Returns("Mock");
             source.SetupGet(r => r.ProviderId).Returns("mock");
             source.Setup(r => r.IsContainer).Returns(false);
             source.Setup(r => r.ShouldItemTransferAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
-            source.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new StorageResourceItemProperties
-                {
-                    ResourceLength = resourceLength,
-                });
             source.Setup(r => r.GetSourceCheckpointDetails())
                 .Returns(mockCheckpointDetails.Object);
-            source.Setup(r => r.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()))
-                .ReturnsAsync(default(HttpAuthorization));
-            source.Setup(r => r.GetSasWithUri()).Returns(new Uri("https://example.com/source"));
 
-            // Create a destination resource where CompleteTransferAsync throws
             Mock<StorageResourceItem> destination = new Mock<StorageResourceItem>(MockBehavior.Strict);
-            destination.Setup(r => r.Uri).Returns(new Uri("https://example.com/dest"));
             destination.SetupGet(r => r.ResourceId).Returns("Mock");
             destination.SetupGet(r => r.ProviderId).Returns("mock");
             destination.Setup(r => r.IsContainer).Returns(false);
@@ -1529,44 +1517,152 @@ namespace Azure.Storage.DataMovement.Tests
                 .Returns(Task.CompletedTask);
             destination.Setup(r => r.GetDestinationCheckpointDetails())
                 .Returns(mockCheckpointDetails.Object);
-            destination.Setup(r => r.SetPermissionsAsync(
-                It.IsAny<StorageResourceItem>(),
-                It.IsAny<StorageResourceItemProperties>(),
-                It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-            destination.Setup(r => r.CopyFromUriAsync(
-                It.IsAny<StorageResourceItem>(),
-                It.IsAny<bool>(),
-                It.IsAny<long>(),
-                It.IsAny<StorageResourceCopyFromUriOptions>(),
-                It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
             destination.Setup(r => r.CompleteTransferAsync(
                 It.IsAny<bool>(),
                 It.IsAny<StorageResourceCompleteTransferOptions>(),
                 It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception("Simulated CompleteTransferAsync failure"));
 
+            return (transferManager, source, destination, resourceLength, checkpointerDirectory);
+        }
+
+        /// <summary>
+        /// Helper that starts the transfer, waits for completion, and asserts failure behavior.
+        /// </summary>
+        private async Task AssertCompleteTransferAsyncFailureReportsFailedItem(
+            TransferManager transferManager,
+            Mock<StorageResourceItem> source,
+            Mock<StorageResourceItem> destination)
+        {
             TransferOptions transferOptions = new TransferOptions();
             TestEventsRaised testEventsRaised = new TestEventsRaised(transferOptions);
 
-            // Act - Start transfer; CopyFromUriAsync succeeds but CompleteTransferAsync fails
             TransferOperation transfer = await transferManager.StartTransferAsync(
                 source.Object,
                 destination.Object,
                 transferOptions);
 
-            // Wait for transfer to complete (with failure)
             using CancellationTokenSource waitCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             await transfer.WaitForCompletionAsync(waitCts.Token);
 
-            // Assert - Transfer should complete with a failed item, not crash
             Assert.IsTrue(transfer.HasCompleted);
             Assert.IsTrue(transfer.Status.HasFailedItems);
             Assert.AreEqual(1, testEventsRaised.FailedEvents.Count);
             Assert.That(
                 testEventsRaised.FailedEvents.First().Exception.Message,
                 Does.Contain("Simulated CompleteTransferAsync failure"));
+        }
+
+        [Test]
+        public async Task CompleteTransferAsync_Upload_Failure_ReportsFailedItem()
+        {
+            // Arrange
+            (TransferManager transferManager, Mock<StorageResourceItem> source, Mock<StorageResourceItem> destination, long resourceLength, DisposingLocalDirectory checkpointerDirectory) =
+                SetupCompleteTransferAsyncFailureMocks();
+            await using (transferManager)
+            using (checkpointerDirectory)
+            {
+                source.Setup(r => r.Uri).Returns(new Uri("file:///fake/source"));
+                source.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new StorageResourceItemProperties
+                    {
+                        ResourceLength = resourceLength,
+                    });
+                source.Setup(r => r.ReadStreamAsync(
+                    It.IsAny<long>(),
+                    It.IsAny<long?>(),
+                    It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new StorageResourceReadStreamResult(
+                        content: new MemoryStream(new byte[resourceLength]),
+                        range: new HttpRange(0, resourceLength),
+                        properties: new StorageResourceItemProperties { ResourceLength = resourceLength }));
+
+                destination.Setup(r => r.Uri).Returns(new Uri("https://example.com/dest"));
+                destination.Setup(r => r.CopyFromStreamAsync(
+                    It.IsAny<Stream>(),
+                    It.IsAny<long>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<long>(),
+                    It.IsAny<StorageResourceWriteToOffsetOptions>(),
+                    It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+
+                // Act & Assert
+                await AssertCompleteTransferAsyncFailureReportsFailedItem(transferManager, source, destination);
+            }
+        }
+
+        [Test]
+        public async Task CompleteTransferAsync_Download_Failure_ReportsFailedItem()
+        {
+            // Arrange
+            (TransferManager transferManager, Mock<StorageResourceItem> source, Mock<StorageResourceItem> destination, long resourceLength, DisposingLocalDirectory checkpointerDirectory) =
+                SetupCompleteTransferAsyncFailureMocks();
+            await using (transferManager)
+            using (checkpointerDirectory)
+            {
+                source.Setup(r => r.Uri).Returns(new Uri("https://example.com/source"));
+                source.SetupGet(r => r.Length).Returns(resourceLength);
+                source.Setup(r => r.ReadStreamAsync(
+                    It.IsAny<long>(),
+                    It.IsAny<long?>(),
+                    It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new StorageResourceReadStreamResult(
+                        content: new MemoryStream(new byte[resourceLength]),
+                        range: new HttpRange(0, resourceLength),
+                        properties: new StorageResourceItemProperties { ResourceLength = resourceLength }));
+
+                destination.Setup(r => r.Uri).Returns(new Uri("file:///fake/dest"));
+                destination.Setup(r => r.CopyFromStreamAsync(
+                    It.IsAny<Stream>(),
+                    It.IsAny<long>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<long>(),
+                    It.IsAny<StorageResourceWriteToOffsetOptions>(),
+                    It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+
+                // Act & Assert
+                await AssertCompleteTransferAsyncFailureReportsFailedItem(transferManager, source, destination);
+            }
+        }
+
+        [Test]
+        public async Task CompleteTransferAsync_Copy_Failure_ReportsFailedItem()
+        {
+            // Arrange
+            (TransferManager transferManager, Mock<StorageResourceItem> source, Mock<StorageResourceItem> destination, long resourceLength, DisposingLocalDirectory checkpointerDirectory) =
+                SetupCompleteTransferAsyncFailureMocks();
+            await using (transferManager)
+            using (checkpointerDirectory)
+            {
+                source.Setup(r => r.Uri).Returns(new Uri("https://example.com/source"));
+                source.Setup(r => r.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new StorageResourceItemProperties
+                    {
+                        ResourceLength = resourceLength,
+                    });
+                source.Setup(r => r.GetCopyAuthorizationHeaderAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(default(HttpAuthorization));
+                source.Setup(r => r.GetSasWithUri()).Returns(new Uri("https://example.com/source"));
+
+                destination.Setup(r => r.Uri).Returns(new Uri("https://example.com/dest"));
+                destination.Setup(r => r.SetPermissionsAsync(
+                    It.IsAny<StorageResourceItem>(),
+                    It.IsAny<StorageResourceItemProperties>(),
+                    It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+                destination.Setup(r => r.CopyFromUriAsync(
+                    It.IsAny<StorageResourceItem>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<long>(),
+                    It.IsAny<StorageResourceCopyFromUriOptions>(),
+                    It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
+
+                // Act & Assert
+                await AssertCompleteTransferAsyncFailureReportsFailedItem(transferManager, source, destination);
+            }
         }
 
         [Test]


### PR DESCRIPTION
Fixed bug where an exception thrown during `CompleteTransferAsync(bool, StorageResourceCompleteTransferOptions, CancellationToken)` on the destination resource could go unhandled. The error is now caught and reported as a failed transfer item.

Also removed redundant call to `OnTransferStateChangedAsync(TransferState.Completed).ConfigureAwait(false);`