### PR TITLE
[Mgmt Generator] Resolve flatten-visitor base via BaseType instead of BaseModelProvider

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Visitors/FlattenPropertyVisitor.cs
@@ -638,7 +638,7 @@ namespace Azure.Generator.Management.Visitors
             // Ensure base model types are flattened first so that inherited properties
             // are in their final state (e.g., safe-flattened single-property models become internal)
             // before this model processes them via GetAllProperties.
-            if (model.BaseModelProvider is ModelProvider baseModel && !_flattenedModelTypes.ContainsKey(baseModel.Type))
+            if (TryGetBaseModelProvider(model, out var baseModel) && !_flattenedModelTypes.ContainsKey(baseModel.Type))
             {
                 FlattenModel(baseModel);
             }
@@ -716,7 +716,7 @@ namespace Azure.Generator.Management.Visitors
                 _flattenedModelTypes.Add(model.Type, propertyNameMap);
                 UpdatePublicConstructor(model, propertyNameMap);
             }
-            else if (model.BaseModelProvider is ModelProvider flattenedBase && _flattenedModelTypes.TryGetValue(flattenedBase.Type, out var basePropertyNameMap))
+            else if (TryGetBaseModelProvider(model, out var flattenedBase) && _flattenedModelTypes.TryGetValue(flattenedBase.Type, out var basePropertyNameMap))
             {
                 // This model has no flattenable properties of its own, but its base model was
                 // safe-flattened. The base's public constructor signature changed (e.g. an
@@ -1127,6 +1127,25 @@ namespace Azure.Generator.Management.Visitors
             return false;
         }
 
+        /// <summary>
+        /// Resolves the base <see cref="ModelProvider"/> of a model by looking up its <see cref="TypeProvider.BaseType"/>
+        /// in the type factory. This is preferred over <see cref="ModelProvider.BaseModelProvider"/> because
+        /// <see cref="TypeProvider.BaseType"/> reflects the actual base type that will be emitted, including any
+        /// overrides applied by visitors. <see cref="ModelProvider.BaseModelProvider"/> is computed independently
+        /// and may be stale relative to <see cref="TypeProvider.BaseType"/>, which can cause this visitor to
+        /// flatten inherited properties twice (once via the stale base, once via the actual base).
+        /// </summary>
+        private static bool TryGetBaseModelProvider(ModelProvider model, [NotNullWhen(true)] out ModelProvider? baseModel)
+        {
+            var baseType = model.BaseType;
+            if (baseType is not null && TryGetModelProvider(baseType, out baseModel))
+            {
+                return true;
+            }
+            baseModel = null;
+            return false;
+        }
+
         private class CSharpTypeNameComparer : IEqualityComparer<CSharpType>
         {
             public bool Equals(CSharpType? x, CSharpType? y)
@@ -1181,14 +1200,14 @@ namespace Azure.Generator.Management.Visitors
             // Check base types for inherited flattened properties
             if (TryGetModelProvider(type, out var model))
             {
-                var baseModel = model.BaseModelProvider;
-                while (baseModel is not null)
+                var current = model;
+                while (TryGetBaseModelProvider(current, out var baseModel))
                 {
                     if (_flattenedModelTypes.TryGetValue(baseModel.Type, out propertyNameMap))
                     {
                         return true;
                     }
-                    baseModel = baseModel.BaseModelProvider;
+                    current = baseModel;
                 }
             }
             return false;

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/FlattenPropertyVisitorTests.cs
@@ -1143,5 +1143,95 @@ namespace Azure.Generator.Mgmt.Tests
             Assert.That(flattened!.Type.IsNullable, Is.True,
                 "Required value-type property flattened from an optional parent should be exposed as Nullable<T>");
         }
+
+        /// <summary>
+        /// Regression test for https://github.com/microsoft/typespec/issues/10485.
+        ///
+        /// <see cref="ModelProvider.BaseModelProvider"/> is computed independently from
+        /// <see cref="TypeProvider.BaseType"/>: the former reads <see cref="InputModelType.BaseModel"/>
+        /// directly while <see cref="TypeProvider.BuildBaseType"/> is virtual and may be overridden by
+        /// downstream emitters (or by the management generator itself when it replaces the spec
+        /// inheritance with a hand-picked base). When the two disagree, walking
+        /// <see cref="ModelProvider.BaseModelProvider"/> can pull in inherited properties from a parent
+        /// that is NOT in the actual C# inheritance chain, which causes the flatten visitor to flatten
+        /// the same properties twice (once via the spec base, once via the overridden base).
+        ///
+        /// This test constructs a child model whose spec base ("SpecBaseModel") differs from the base
+        /// returned by an overridden <see cref="ModelProvider.BuildBaseType"/> ("OverrideBaseModel"),
+        /// and asserts that <see cref="FlattenPropertyVisitor"/>'s internal base-resolution helper
+        /// (<c>TryGetBaseModelProvider</c>) returns the OverrideBaseModel's provider — i.e. the model
+        /// matching <see cref="TypeProvider.BaseType"/>, not <see cref="ModelProvider.BaseModelProvider"/>.
+        /// </summary>
+        [Test]
+        public void TestTryGetBaseModelProviderHonorsOverriddenBaseType()
+        {
+            // SpecBaseModel: the base recorded in the input spec. Has its own property to make it
+            // distinguishable from OverrideBaseModel.
+            var specBaseProp = InputFactory.Property("specBaseProp", InputPrimitiveType.String, isRequired: true, serializedName: "specBaseProp");
+            var specBaseInput = InputFactory.Model(
+                "SpecBaseModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [specBaseProp]);
+
+            // OverrideBaseModel: an unrelated model that the subclass will redirect BaseType to.
+            var overrideBaseProp = InputFactory.Property("overrideBaseProp", InputPrimitiveType.String, isRequired: true, serializedName: "overrideBaseProp");
+            var overrideBaseInput = InputFactory.Model(
+                "OverrideBaseModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                properties: [overrideBaseProp]);
+
+            // ChildModel: spec base = SpecBaseModel.
+            var childProp = InputFactory.Property("childProp", InputPrimitiveType.String, isRequired: true, serializedName: "childProp");
+            var childInput = InputFactory.Model(
+                "ChildModel",
+                usage: InputModelTypeUsage.Output | InputModelTypeUsage.Input | InputModelTypeUsage.Json,
+                baseModel: specBaseInput,
+                properties: [childProp]);
+
+            var plugin = ManagementMockHelpers.LoadMockPlugin(
+                inputModels: () => [specBaseInput, overrideBaseInput, childInput]);
+
+            var specBaseProvider = plugin.Object.TypeFactory.CreateModel(specBaseInput)!;
+            var overrideBaseProvider = plugin.Object.TypeFactory.CreateModel(overrideBaseInput)!;
+            Assert.That(specBaseProvider, Is.Not.Null);
+            Assert.That(overrideBaseProvider, Is.Not.Null);
+
+            var childWithOverride = new ChildModelProviderWithOverriddenBase(childInput, overrideBaseProvider.Type);
+
+            // Sanity check: BaseType is the override, but BaseModelProvider still points at the spec
+            // base (this is exactly the inconsistency we want the visitor to be resilient to).
+            Assert.That(childWithOverride.BaseType, Is.EqualTo(overrideBaseProvider.Type),
+                "Subclass override should make BaseType point at OverrideBaseModel");
+            Assert.That(childWithOverride.BaseModelProvider, Is.SameAs(specBaseProvider),
+                "Precondition: with the upstream typespec dependency unchanged, BaseModelProvider " +
+                "still resolves via InputModelType.BaseModel — the inconsistency this test guards against");
+
+            // Invoke the private static helper via reflection.
+            var helper = typeof(FlattenPropertyVisitor).GetMethod(
+                "TryGetBaseModelProvider",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(helper, Is.Not.Null, "Could not find FlattenPropertyVisitor.TryGetBaseModelProvider");
+
+            var args = new object?[] { childWithOverride, null };
+            var resolved = (bool)helper!.Invoke(null, args)!;
+            var resolvedProvider = (ModelProvider?)args[1];
+
+            Assert.That(resolved, Is.True, "Helper should resolve a base provider when BaseType is in the type cache");
+            Assert.That(resolvedProvider, Is.SameAs(overrideBaseProvider),
+                "Helper must return the provider matching BaseType (OverrideBaseModel), not BaseModelProvider (SpecBaseModel)");
+        }
+
+        private class ChildModelProviderWithOverriddenBase : ModelProvider
+        {
+            private readonly CSharpType _overriddenBase;
+
+            public ChildModelProviderWithOverriddenBase(InputModelType inputModel, CSharpType overriddenBase)
+                : base(inputModel)
+            {
+                _overriddenBase = overriddenBase;
+            }
+
+            protected override CSharpType? BuildBaseType() => _overriddenBase;
+        }
     }
 }


### PR DESCRIPTION
## Why

`ModelProvider` exposes two parallel APIs for the parent type:

- `BaseType` (virtual on `TypeProvider`) — the single source of truth for the base that will be emitted into the generated C#.
- `BaseModelProvider` (computed independently from `InputModelType.BaseModel`).

Their resolution paths can diverge when a downstream emitter overrides `BuildBaseType` or otherwise replaces the spec inheritance with a hand-picked base. When that happens, walking `BaseModelProvider` in `FlattenPropertyVisitor` pulls in inherited properties from a parent that is **not** in the actual C# inheritance chain, which causes the same property to be flattened twice (once via the spec base, once via the overridden base).

This was the symptom we hit while regenerating `Azure.Provisioning.CostManagement` on top of the TypeSpec-emitted `Azure.ResourceManager.CostManagement`.

Related upstream root-cause issue: microsoft/typespec#10485

## What

- Add a `TryGetBaseModelProvider` helper in `FlattenPropertyVisitor` that resolves the base `ModelProvider` by looking up `BaseType` in `TypeFactory.CSharpTypeMap`.
- Replace all direct `model.BaseModelProvider` walks inside `FlattenPropertyVisitor` with the new helper. The visitor now stays consistent with the actual emitted base regardless of any subclass overrides upstream.
- Add a regression test that constructs a `ModelProvider` whose overridden `BuildBaseType` points at a different model than `InputModelType.BaseModel` and asserts the helper returns the override-matching provider.

Scope is intentionally limited to `FlattenPropertyVisitor`. Other sites in the mgmt generator (`InheritableSystemObjectModelVisitor`, `PropertyHelpers`, `ManagementOutputLibrary`) still use `BaseModelProvider` directly and can be migrated in follow-up PRs if/when they exhibit similar symptoms.

## Validation

- `dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test` — **182 / 182 passing** (181 prior + 1 new).
- `./eng/packages/http-client-csharp-mgmt/eng/scripts/Generate.ps1` — no test-project regen diff (the change is behavior-equivalent on all current generator scenarios).