### PR TITLE
[provisioning-generator] RegenSdkLocal.ps1: require exact library name for -Services

### DIFF
--- a/eng/packages/http-client-csharp-provisioning/eng/scripts/RegenSdkLocal.ps1
+++ b/eng/packages/http-client-csharp-provisioning/eng/scripts/RegenSdkLocal.ps1
@@ -7,15 +7,18 @@
 .DESCRIPTION
     Builds the provisioning generator locally and regenerates SDK folders using TypeSpec.
     Does NOT modify package.json files or create versioned packages.
-    By default, regenerates ALL provisioning SDKs. Use -Services to limit scope.
-
-    Pattern matching: The -Services parameter uses substring matching.
-    For example, "Key" matches both "KeyVault" and "MyKeyService".
-    Use wildcards for more precise matching (e.g., "KeyVault*").
+    By default (when -Services is omitted), regenerates ALL provisioning SDKs.
+    Use -Services to regenerate one or more specific libraries by exact
+    library folder name (e.g., "Azure.Provisioning.KeyVault").
 
 .PARAMETER Services
-    One or more service name patterns to regenerate (e.g., "KeyVault", "Compute").
-    Supports wildcards. Case-insensitive. Uses substring matching.
+    One or more library folder names to regenerate (e.g.,
+    "Azure.Provisioning.KeyVault"). Each value must match an SDK folder
+    name exactly (case-insensitive). Omit -Services to regenerate ALL
+    provisioning SDKs.
+
+    Exact matching avoids the common pitfall where a substring like
+    "Container" also picks up ContainerInstance, ContainerService, etc.
 
 .PARAMETER Parallel
     Number of parallel jobs (default: 4, min: 1). Set to 1 for sequential execution.
@@ -36,16 +39,18 @@
     The powershell-yaml module will be auto-installed if not present.
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "KeyVault"
+    .\RegenSdkLocal.ps1
+    # Regenerates ALL provisioning SDKs.
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "KeyVault","Compute","Network"
+    .\RegenSdkLocal.ps1 -Services "Azure.Provisioning.KeyVault"
+    # Exact match against the SDK folder name.
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "Key*" -Parallel 8
+    .\RegenSdkLocal.ps1 -Services "Azure.Provisioning.KeyVault","Azure.Provisioning.Batch" -Parallel 8
 
 .EXAMPLE
-    .\RegenSdkLocal.ps1 -Services "KeyVault" -LocalSpecRepoPath "C:\src\azure-rest-api-specs"
+    .\RegenSdkLocal.ps1 -Services "Azure.Provisioning.KeyVault" -LocalSpecRepoPath "C:\src\azure-rest-api-specs"
 #>
 
 param(
@@ -144,11 +149,19 @@ foreach ($tspFile in $tspFiles) {
 
 Write-Host "Found $($provisioningSdkFolders.Count) provisioning SDK folders"
 
-# Apply services filter
+# Apply services filter: each value must match an SDK folder name exactly
+# (case-insensitive). Throws if any value matches no folder.
 if ($Services -and $Services.Count -gt 0) {
+    $unmatched = @($Services | Where-Object {
+        $name = $_
+        -not ($provisioningSdkFolders | Where-Object { $_.Library -ieq $name })
+    })
+    if ($unmatched.Count -gt 0) {
+        throw "No provisioning SDK folder matched: $($unmatched -join ', '). Pass the exact library folder name, e.g., 'Azure.Provisioning.KeyVault'."
+    }
     $provisioningSdkFolders = @($provisioningSdkFolders | Where-Object {
         $folder = $_
-        $Services | Where-Object { $folder.Library -like "*$_*" -or $folder.Service -like "*$_*" }
+        $null -ne ($Services | Where-Object { $folder.Library -ieq $_ })
     })
     Write-Host "Filtered to $($provisioningSdkFolders.Count) matching: $($Services -join ', ')"
 }


### PR DESCRIPTION
## Why
Following up on #58945 which fixed the same issue in the mgmt generator's `RegenSdkLocal.ps1`.

The provisioning generator's `RegenSdkLocal.ps1` had the same problem: `-Services` padded every value with `*…*` wildcards and matched on substrings of both the library and service folder names. That made a value like `Container` accidentally regenerate every sibling library (`Azure.Provisioning.ContainerInstance`, `Azure.Provisioning.ContainerService`, …), tripling iteration time and producing noisy failures.

## What
Mirror the contract from #58945:

* Each `-Services` value must match an SDK folder name **exactly** (case-insensitive).
* Pass the full library folder name (e.g., `Azure.Provisioning.KeyVault`) — no auto-prefixing, no wildcards.
* If any value matches nothing, the script throws a clear error instead of silently regenerating nothing.
* Omit `-Services` to regenerate all provisioning SDKs (unchanged).

| Pattern | Before | After |
|---|---|---|
| `Azure.Provisioning.ContainerInstance` | substring → 1 match | exact → 1 match |
| `Container` | substring → 2 matches (ContainerInstance, ContainerService) | no match → throws |
| _(omitted)_ | all provisioning SDKs | all provisioning SDKs (unchanged) |

Doc block + examples updated accordingly.

---
🤖 arcturus-copilot