### PR TITLE
 Fix DataProtection dependency target mismatch

### DIFF
--- a/eng/centralpackagemanagement/Directory.Extensions.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Extensions.Packages.props
@@ -23,7 +23,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsExtensionClientLibrary)' == 'true'">
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
+    <!--
+      The AspNetCore.DataProtection 10.x package does not include a net8.0 target.  Though the package can be used
+      in net8.0 projects, via the netstandard2.0 path, it conflicts with the explicit net8.0 target of the Azure SDK
+      package, causing warnings.  To avoid these warnings, we use the last 8.0 version of the package for net8.0
+      builds and the latest 10.x version for all other target frameworks.
+    -->
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" Condition="'$(TargetFramework)' != 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.26" Condition="'$(TargetFramework)' == 'net8.0'" />
+
     <PackageVersion Include="Microsoft.AspNetCore.Http.Connections" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions" Version="1.3.0" />
     <PackageVersion Update="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsVersion)" />

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.6.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.5.3 (2026-05-08)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed a misalignment between the explicit `net8.0` target of this package and its `Microsoft.AspNetCore.DataProtection` dependency, which does not offer a `net8.0` asset in the 10.x version. The dependency now resolves to version 8.0.26 when targeting `net8.0`, ensuring consumers receive a framework-compatible asset and eliminating the associated dependency warnings.
 
 ## 1.5.2 (2026-04-28)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/src/Azure.Extensions.AspNetCore.DataProtection.Blobs.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Microsoft Azure Blob storage support as key store (https://docs.microsoft.com/aspnet/core/security/data-protection/implementation/key-storage-providers).</Description>
     <PackageTags>aspnetcore;dataprotection;azure;blob;key store</PackageTags>
-    <Version>1.6.0-beta.1</Version>
+    <Version>1.5.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.5.2</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/CHANGELOG.md
@@ -1,14 +1,10 @@
 # Release History
 
-## 1.7.0-beta.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.6.3 (2026-05-08)
 
 ### Bugs Fixed
 
-### Other Changes
+- Fixed a misalignment between the explicit `net8.0` target of this package and its `Microsoft.AspNetCore.DataProtection` dependency, which does not offer a `net8.0` asset in the 10.x version. The dependency now resolves to version 8.0.26 when targeting `net8.0`, ensuring consumers receive a framework-compatible asset and eliminating the associated dependency warnings.
 
 ## 1.6.2 (2026-04-28)
 

--- a/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
+++ b/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Keys/src/Azure.Extensions.AspNetCore.DataProtection.Keys.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <Description>Microsoft Azure Key Vault key encryption support.</Description>
     <PackageTags>aspnetcore;dataprotection;azure;keyvault</PackageTags>
-    <Version>1.7.0-beta.1</Version>
+    <Version>1.6.3</Version>
     <!--The ApiCompatVersion is managed automatically and should not generally be modified manually.-->
     <ApiCompatVersion>1.6.2</ApiCompatVersion>
     <IsExtensionClientLibrary>true</IsExtensionClientLibrary>


### PR DESCRIPTION
# Summary

The `Microsoft.AspNetCore.DataProtection` 10.x package does not include  a `net8.0` target, causing consumers of the DataProtection extension  packages targeting `net8.0` to fall back to the `netstandard2.0` asset  and emit dependency warnings.  This adds a conditional package version override in central package  management so that `Microsoft.AspNetCore.DataProtection` resolves to  8.0.26 when the target framework is `net8.0`, while continuing to use 10.0.7 for all other targets.

## References and resources

- [[BUG] Azure.Extensions.AspNetCore.DataProtection Blobs/Keys incorrectly reference Microsoft.AspNetCore.DataProtection 10.0.7 for net8.0 (#58901)](https://github.com/Azure/azure-sdk-for-net/issues/58901#top)
