### PR TITLE
Treat manual main mgmt generator runs as releases

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/ci.yml
+++ b/eng/packages/http-client-csharp-mgmt/ci.yml
@@ -69,7 +69,7 @@ extends:
           ShouldPublish: ${{ parameters.ShouldPublish }}
           ShouldRegenerate: ${{ parameters.ShouldRegenerate }}
           HasNugetPackages: ${{ parameters.PublishNugetPackages }}
-          ${{ if startswith(variables['Build.SourceBranch'], 'refs/pull/') }}:  # PR ref's can't be published to public, even in a manual run
+          ${{ if startswith(variables['Build.SourceBranch'], 'refs/pull/') }}:  # PR refs can't be published to public, even in a manual run
             PublishPublic: false
             PublishDependsOnTest: false
           ${{ else }}: # Any other manual run can go to public

--- a/eng/packages/http-client-csharp-mgmt/ci.yml
+++ b/eng/packages/http-client-csharp-mgmt/ci.yml
@@ -17,7 +17,7 @@ pr:
     include:
       - eng/packages/http-client-csharp-mgmt
       - eng/scripts/typespec
-      
+
 parameters:
   - name: UseTypeSpecNext
     displayName: "Use TypeSpec Next"
@@ -59,15 +59,22 @@ extends:
     UseTypeSpecNext: ${{ parameters.UseTypeSpecNext }}
     ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       ${{ if eq(variables['Build.Reason'], 'Manual') }}:
-        ShouldPublish: ${{ parameters.ShouldPublish }}
-        ShouldRegenerate: ${{ parameters.ShouldRegenerate }}
-        HasNugetPackages: ${{ parameters.PublishNugetPackages }}
-        ${{ if startswith(variables['Build.SourceBranch'], 'refs/pull/') }}:  # PR ref's can't be published to public, even in a manual run
-          PublishPublic: false
+        ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+          ShouldPublish: true
+          ShouldRegenerate: true
+          PublishPublic: true
           PublishDependsOnTest: false
-        ${{ else }}: # Any other manual run can go to public
-           PublishPublic: ${{ parameters.PublishPublic }}
-           PublishDependsOnTest: ${{ parameters.PublishPublic }}
+          HasNugetPackages: true
+        ${{ else }}:
+          ShouldPublish: ${{ parameters.ShouldPublish }}
+          ShouldRegenerate: ${{ parameters.ShouldRegenerate }}
+          HasNugetPackages: ${{ parameters.PublishNugetPackages }}
+          ${{ if startswith(variables['Build.SourceBranch'], 'refs/pull/') }}:  # PR ref's can't be published to public, even in a manual run
+            PublishPublic: false
+            PublishDependsOnTest: false
+          ${{ else }}: # Any other manual run can go to public
+            PublishPublic: ${{ parameters.PublishPublic }}
+            PublishDependsOnTest: ${{ parameters.PublishPublic }}
       ${{ else }}: # All automatic runs publish, but only CI of main goes public
         ShouldPublish: true
         ShouldRegenerate: true


### PR DESCRIPTION
## Description

Update the management TypeSpec emitter pipeline so manual internal runs targeting `refs/heads/main` use the same release behavior as automatic main-merge CI.

Manual main runs now set:
- `ShouldPublish: true`
- `ShouldRegenerate: true`
- `PublishPublic: true`
- `PublishDependsOnTest: false`
- `HasNugetPackages: true`

Manual runs for PR refs and non-main branches continue to use the existing parameter-driven behavior.
