### PR TITLE
Fix mgmt PATCH union response return types

### DIFF
--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Providers/ResourceClientProvider.cs
@@ -484,13 +484,7 @@ namespace Azure.Generator.Management.Providers
 
         private static bool OperationReturnsContent(InputServiceMethod method)
         {
-            if (method is InputLongRunningServiceMethod lroMethod)
-            {
-                return lroMethod.LongRunningServiceMetadata.ReturnType is not null;
-            }
-
-            var response = method.Operation.Responses.FirstOrDefault(r => !r.IsErrorResponse);
-            return response?.BodyType is not null;
+            return method.GetResponseBodyType() is not null;
         }
 
         private List<MethodProvider> BuildGetChildResourceMethods()

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/InputServiceMethodExtensions.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/src/Utilities/InputServiceMethodExtensions.cs
@@ -31,17 +31,40 @@ namespace Azure.Generator.Management.Utilities
 
         public static CSharpType? GetResponseBodyType(this InputServiceMethod method)
         {
-            // For long-running operations, get the response body type from LongRunningServiceMetadata.ReturnType
+            InputType? responseBodyType;
             if (method is InputLongRunningServiceMethod lroMethod)
             {
-                var returnType = lroMethod.LongRunningServiceMetadata.ReturnType;
-                return returnType is null ? null : ManagementClientGenerator.Instance.TypeFactory.CreateCSharpType(returnType);
+                responseBodyType = GetLongRunningResponseBodyType(lroMethod);
+            }
+            else
+            {
+                responseBodyType = GetOperationResponseBodyType(method);
+            }
+            return responseBodyType is null ? null : ManagementClientGenerator.Instance.TypeFactory.CreateCSharpType(responseBodyType);
+        }
+
+        private static InputType? GetLongRunningResponseBodyType(InputLongRunningServiceMethod method)
+        {
+            if (method.Operation.HttpMethod == "PATCH" && method.Operation.Responses.Any(IsSuccessfulNoContentResponse))
+            {
+                return null;
             }
 
-            var operationResponses = method.Operation.Responses;
-            var response = operationResponses.FirstOrDefault(r => !r.IsErrorResponse);
-            var responseBodyType = response?.BodyType;
-            return responseBodyType is null ? null : ManagementClientGenerator.Instance.TypeFactory.CreateCSharpType(responseBodyType);
+            return method.LongRunningServiceMetadata.ReturnType;
+        }
+
+        private static InputType? GetOperationResponseBodyType(InputServiceMethod method)
+        {
+            var responses = method.Operation.Responses.Where(r => !r.IsErrorResponse);
+            return responses.FirstOrDefault(r => r.BodyType is not null)?.BodyType
+                ?? responses.FirstOrDefault()?.BodyType;
+        }
+
+        private static bool IsSuccessfulNoContentResponse(InputOperationResponse response)
+        {
+            return !response.IsErrorResponse
+                && response.BodyType is null
+                && response.StatusCodes.Any(statusCode => statusCode is 200 or 204);
         }
     }
 }

--- a/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Utilities/InputServiceMethodExtensionsTests.cs
+++ b/eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Utilities/InputServiceMethodExtensionsTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Generator.Management.Tests.Common;
+using Azure.Generator.Management.Tests.TestHelpers;
+using Azure.Generator.Management.Utilities;
+using NUnit.Framework;
+
+namespace Azure.Generator.Mgmt.Tests.Utilities
+{
+    public class InputServiceMethodExtensionsTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            ManagementMockHelpers.LoadMockPlugin();
+        }
+
+        [TestCase]
+        public void GetResponseBodyType_ReturnsTypedCreatedResponseForNonLroPatch()
+        {
+            var responseModel = InputFactory.Model("PartnerTopicData");
+            var method = InputFactory.BasicServiceMethod(
+                "update",
+                InputFactory.Operation(
+                    "update",
+                    responses:
+                    [
+                        InputFactory.OperationResponse([200]),
+                        InputFactory.OperationResponse([201], responseModel)
+                    ],
+                    httpMethod: "PATCH"));
+
+            var responseBodyType = method.GetResponseBodyType();
+
+            Assert.That(responseBodyType, Is.Not.Null);
+            Assert.That(responseBodyType!.Name, Is.EqualTo("PartnerTopicData"));
+        }
+
+        [TestCase]
+        public void GetResponseBodyType_ReturnsVoidForLroPatchWithNoContentOkResponse()
+        {
+            var responseModel = InputFactory.Model("TopicData");
+            var operation = InputFactory.Operation(
+                "update",
+                responses:
+                [
+                    InputFactory.OperationResponse([200]),
+                    InputFactory.OperationResponse([201], responseModel)
+                ],
+                httpMethod: "PATCH");
+            var method = InputFactory.LongRunningServiceMethod(
+                "update",
+                operation,
+                longRunningServiceMetadata: InputFactory.LongRunningServiceMetadata(
+                    1,
+                    InputFactory.OperationResponse([201], responseModel),
+                    null));
+
+            var responseBodyType = method.GetResponseBodyType();
+
+            Assert.That(responseBodyType, Is.Null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix management generator response-body selection for PATCH operations with union responses.
- Treat LRO PATCH operations with successful no-content responses as void final results.
- Add regression tests for non-LRO and LRO PATCH union response cases from #58136.

## Validation
- `dotnet test eng/packages/http-client-csharp-mgmt/generator/Azure.Generator.Management/test/Azure.Generator.Mgmt.Tests.csproj --no-restore --nologo --verbosity minimal`
- `cd eng/packages/http-client-csharp-mgmt && npm install --silent`
- `cd eng/packages/http-client-csharp-mgmt && pwsh ./eng/scripts/Generate.ps1`
- `cd eng/packages/http-client-csharp-mgmt && npm run lint --silent && npm run prettier --silent`

Fixes #58136
