### PR TITLE
EventHubBufferedProducerClient's FlushAsync and CloseAsync are stuck waiting for active publishing tasks to complete

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 ## 5.13.0-beta.1 (Unreleased)
 
+### Acknowledgments
+
+Thank you to our developer community members who helped to make the Event Hubs client libraries better with their contributions to this release:
+
+- Daniel Marbach _([GitHub](https://github.com/danielmarbach))_
+
 ### Features Added
 
 ### Breaking Changes
 
 ### Bugs Fixed
+
+- Fixed a bug where `EventHubBufferedProducerClient` could get stuck during `FlushAsync` or `CloseAsync` until `MaximumWaitTime` elapsed.
 
 ### Other Changes
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Producer/EventHubBufferedProducerClient.cs
@@ -1404,7 +1404,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         /// <param name="partitionState">The state of publishing for the partition.</param>
         /// <param name="releaseGuard"><c>true</c> if the <see cref="PartitionPublishingState.PartitionGuard" /> should be released after publishing; otherwise, <c>false</c>.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel publishing.</param>
+        /// <param name="publishCancellationToken">A <see cref="CancellationToken"/> instance to signal the request to cancel publishing.</param>
+        /// <param name="batchingWaitCancellationToken">A <see cref="CancellationToken"/> instance to signal that waiting for additional events to batch should stop without canceling publishing.</param>
         ///
         /// <remarks>
         ///   This method has responsibility for invoking the event handlers to communicate
@@ -1413,7 +1414,8 @@ namespace Azure.Messaging.EventHubs.Producer
         ///
         internal virtual async Task PublishBatchToPartition(PartitionPublishingState partitionState,
                                                             bool releaseGuard,
-                                                            CancellationToken cancellationToken)
+                                                            CancellationToken publishCancellationToken,
+                                                            CancellationToken batchingWaitCancellationToken)
         {
             var operationId = GenerateOperationId();
             var partitionId = partitionState.PartitionId;
@@ -1433,7 +1435,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 // The wait time constraint should not consider creating the batch; start tracking after the batch is available to build.
 
-                batch = await _producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partitionId }, cancellationToken).ConfigureAwait(false);
+                batch = await _producer.CreateBatchAsync(new CreateBatchOptions { PartitionId = partitionId }, publishCancellationToken).ConfigureAwait(false);
                 publishWatch = ValueStopwatch.StartNew();
 
                 // Build the batch, stopping either when it is full or when the allowable wait time
@@ -1467,7 +1469,7 @@ namespace Azure.Messaging.EventHubs.Producer
                                 // Handler invocation is performed with a guarantee not to throw; exceptions in the handler are logged
                                 // as part of the invocation.
 
-                                await SafeInvokeOnSendFailedAsync(new List<EventData>(1) { currentEvent }, exception, partitionId, cancellationToken).ConfigureAwait(false);
+                                await SafeInvokeOnSendFailedAsync(new List<EventData>(1) { currentEvent }, exception, partitionId, publishCancellationToken).ConfigureAwait(false);
                                 return;
                             }
 
@@ -1491,8 +1493,20 @@ namespace Azure.Messaging.EventHubs.Producer
 
                         if (ShouldWait(remainingWaitTime, MinimumPublishingWaitInterval))
                         {
-                            cancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
-                            await Task.Delay(delayInterval, cancellationToken).ConfigureAwait(false);
+                            publishCancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                            try
+                            {
+                                await Task.Delay(delayInterval, batchingWaitCancellationToken).ConfigureAwait(false);
+                            }
+                            catch (OperationCanceledException) when (batchingWaitCancellationToken.IsCancellationRequested)
+                            {
+                                publishCancellationToken.ThrowIfCancellationRequested<TaskCanceledException>();
+
+                                // The batching wait was interrupted by a graceful stop, such as FlushAsync or CloseAsync(true).
+                                // Stop waiting for a fuller batch and publish what has already been gathered.
+                                break;
+                            }
                         }
                     }
 
@@ -1509,8 +1523,8 @@ namespace Azure.Messaging.EventHubs.Producer
                     // Handler invocation is performed with a guarantee not to throw; exceptions in the handler are logged
                     // as part of the invocation.
 
-                    await SendBatchAsync(batch, partitionId, operationId, cancellationToken).ConfigureAwait(false);
-                    await SafeInvokeOnSendSucceededAsync(batchEvents, partitionId, cancellationToken).ConfigureAwait(false);
+                    await SendBatchAsync(batch, partitionId, operationId, publishCancellationToken).ConfigureAwait(false);
+                    await SafeInvokeOnSendSucceededAsync(batchEvents, partitionId, publishCancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
@@ -1522,7 +1536,7 @@ namespace Azure.Messaging.EventHubs.Producer
 
                 if (batch?.Count > 0)
                 {
-                    await SafeInvokeOnSendFailedAsync(batchEvents, ex, partitionId, cancellationToken).ConfigureAwait(false);
+                    await SafeInvokeOnSendFailedAsync(batchEvents, ex, partitionId, publishCancellationToken).ConfigureAwait(false);
                 }
             }
             finally
@@ -2257,7 +2271,7 @@ namespace Azure.Messaging.EventHubs.Producer
                             {
                                 // Responsibility for releasing the guard semaphore is passed to the task.
 
-                                activeTasks.Add(PublishBatchToPartition(partitionState, releaseGuard: true, activeOperationCancellationSource.Token));
+                                activeTasks.Add(PublishBatchToPartition(partitionState, releaseGuard: true, activeOperationCancellationSource.Token, cancellationToken));
                             }
 
                             // If there are no events in the buffer, avoid a tight loop by blocking to wait for events to be enqueued

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Producer/EventHubBufferedProducerClientTests.cs
@@ -1562,6 +1562,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -2154,6 +2155,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -2231,6 +2233,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -2300,6 +2303,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -2373,6 +2377,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -2675,6 +2680,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -2938,6 +2944,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -3016,6 +3023,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -3086,6 +3094,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -3160,6 +3169,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -3469,6 +3479,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
@@ -4073,7 +4084,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
             Assert.That(partitionState.BufferedEventCount, Is.EqualTo(1), "The buffered event count for the partition should have been decremented, but the extra event should remain.");
@@ -4129,7 +4140,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Start the publishing task; it should wait for a full batch before completing.
 
-            var publishingTask = mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            var publishingTask = mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
 
             // Enqueue the events that are expected to be returned with a small delay between them.
 
@@ -4212,7 +4223,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Start the publishing task; it should wait for a full batch before completing.
 
-            var publishingTask = mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            var publishingTask = mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
 
             // Wait for longer than the wait time before enqueuing the extra event.  The batch will accept it, but the
             // wait time will have elapsed before it was available and it should not be included in the batch.
@@ -4237,6 +4248,73 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 Assert.That(publishedEvents[index].IsEquivalentTo(expectedEvents[index]), Is.True, $"The event at index: [{index}] did not match the expected event.");
             }
+
+            mockProducer
+                .Verify(producer => producer.SendAsync(
+                    It.Is<EventDataBatch>(value => value.SendOptions.PartitionId == expectedPartition),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the background management task.
+        /// </summary>
+        ///
+        [Test]
+        public async Task PublishBatchToPartitionStopsWaitingWhenBatchingWaitIsCanceled()
+        {
+            using var cancellationSource = new CancellationTokenSource();
+            using var batchingWaitCancellationSource = new CancellationTokenSource();
+            cancellationSource.CancelAfter(EventHubsTestEnvironment.Instance.TestExecutionTimeLimit);
+
+            var publishedEventsCount = 0;
+            var expectedPartition = "4";
+            var expectedEvent = EventGenerator.CreateSmallEvents(1).Single();
+            var publishedEvents = new List<EventData>();
+            var sendCancellationToken = default(CancellationToken);
+            var options = new EventHubBufferedProducerClientOptions { MaximumWaitTime = EventHubsTestEnvironment.Instance.TestExecutionTimeLimit };
+            var partitionState = new EventHubBufferedProducerClient.PartitionPublishingState(expectedPartition, options);
+            var mockProducer = new Mock<EventHubProducerClient>("fakeNS", "fakeHub", Mock.Of<TokenCredential>(), new EventHubProducerClientOptions { Identifier = "abc123" });
+            var mockBufferedProducer = new Mock<EventHubBufferedProducerClient>(mockProducer.Object, options) { CallBase = true };
+
+            mockProducer
+                .Setup(producer => producer.GetPartitionIdsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new[] { expectedPartition, "6" });
+
+            mockProducer
+                .Setup(producer => producer.CreateBatchAsync(It.IsAny<CreateBatchOptions>(), It.IsAny<CancellationToken>()))
+                .Returns<CreateBatchOptions, CancellationToken>((options, token) => new ValueTask<EventDataBatch>(EventHubsModelFactory.EventDataBatch(1_048_576, publishedEvents, options, _ => true)));
+
+            mockProducer
+                .Setup(producer => producer.SendAsync(It.IsAny<EventDataBatch>(), It.IsAny<CancellationToken>()))
+                .Callback<EventDataBatch, CancellationToken>((batch, token) =>
+                {
+                    publishedEventsCount = batch.Count;
+                    sendCancellationToken = token;
+                })
+                .Returns(Task.CompletedTask);
+
+            // Enqueue the event that is expected to be published.
+
+            await partitionState.PendingEventsWriter.WriteAsync(expectedEvent, cancellationSource.Token);
+            partitionState.BufferedEventCount += 1;
+
+            // Start the publishing task; it should wait for a full batch before completing.
+
+            var publishingTask = mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, batchingWaitCancellationSource.Token);
+
+            // Request that batching stop waiting for more events; the partial batch should be published.
+
+            batchingWaitCancellationSource.Cancel();
+
+            await publishingTask.AwaitWithCancellation(cancellationSource.Token);
+
+            Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
+            Assert.That(sendCancellationToken.IsCancellationRequested, Is.False, "The send operation should not be canceled when only the batching wait is canceled.");
+            Assert.That(partitionState.BufferedEventCount, Is.EqualTo(0), "The buffered event count for the partition should have been decremented.");
+            Assert.That(publishedEventsCount, Is.EqualTo(1), "The partial batch should have been published when batching wait was canceled.");
+
+            Assert.That(publishedEvents.Single().IsEquivalentTo(expectedEvent), Is.True, "The published event should match the expected event.");
 
             mockProducer
                 .Verify(producer => producer.SendAsync(
@@ -4277,7 +4355,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
             Assert.That(partitionState.BufferedEventCount, Is.EqualTo(0), "No events should be buffered.");
@@ -4336,7 +4414,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
             Assert.That(partitionState.BufferedEventCount, Is.EqualTo(0), "No events should be buffered.");
@@ -4403,7 +4481,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -4484,7 +4562,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -4567,7 +4645,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, publishCancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, publishCancellationSource.Token, publishCancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -4653,7 +4731,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, publishCancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, publishCancellationSource.Token, publishCancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -4726,7 +4804,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, publishCancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, publishCancellationSource.Token, publishCancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -4797,7 +4875,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -4888,7 +4966,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -4953,7 +5031,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
             Assert.That(publishedEventsCount, Is.EqualTo(expectedEvents.Count), "The number of events published should match.");
@@ -5023,7 +5101,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
             Assert.That(publishedEventsCount, Is.EqualTo(0), "No events should have been published.");
@@ -5101,7 +5179,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -5164,7 +5242,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -5251,7 +5329,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             // Publish and verify.
 
-            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token);
+            await mockBufferedProducer.Object.PublishBatchToPartition(partitionState, false, cancellationSource.Token, cancellationSource.Token);
             await completionSource.Task.AwaitWithCancellation(cancellationSource.Token);
 
             Assert.That(cancellationSource.IsCancellationRequested, Is.False, "Cancellation should not have been requested.");
@@ -5290,8 +5368,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(new[] { expectedPartition });
 
             mockBufferedProducer
-                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken>((state, releaseFlag, token) =>
+                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<CancellationToken>()))
+                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken, CancellationToken>((state, releaseFlag, token, batchingWaitToken) =>
                 {
                     while (state.TryReadEvent(out _))
                     { }
@@ -5333,6 +5411,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.PublishBatchToPartition(
                     state,
                     true,
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()),
                 Times.Once);
         }
@@ -5359,8 +5438,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(validPartitions);
 
             mockBufferedProducer
-                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken>((state, releaseFlag, token) =>
+                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<CancellationToken>()))
+                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken, CancellationToken>((state, releaseFlag, token, batchingWaitToken) =>
                 {
                     while (state.TryReadEvent(out _))
                     { }
@@ -5418,6 +5497,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.PublishBatchToPartition(
                     It.Is<EventHubBufferedProducerClient.PartitionPublishingState>(value => validPartitions.Any(item => item == value.PartitionId)),
                     true,
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(validPartitions.Length));
         }
@@ -5446,8 +5526,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(validPartitions);
 
             mockBufferedProducer
-                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken>((state, releaseFlag, token) =>
+                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<CancellationToken>()))
+                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken, CancellationToken>((state, releaseFlag, token, batchingWaitToken) =>
                 {
                     state.TryReadEvent(out _);
                     --state.BufferedEventCount;
@@ -5507,6 +5587,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.PublishBatchToPartition(
                     It.Is<EventHubBufferedProducerClient.PartitionPublishingState>(value => validPartitions.Any(item => item == value.PartitionId)),
                     true,
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(expectedPublishCount));
         }
@@ -5536,8 +5617,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(validPartitions);
 
             mockBufferedProducer
-                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken>((state, releaseFlag, token) =>
+                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<CancellationToken>()))
+                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken, CancellationToken>((state, releaseFlag, token, batchingWaitToken) =>
                 {
                     state.TryReadEvent(out _);
                     --state.BufferedEventCount;
@@ -5597,6 +5678,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.PublishBatchToPartition(
                     It.Is<EventHubBufferedProducerClient.PartitionPublishingState>(value => validPartitions.Any(item => item == value.PartitionId)),
                     true,
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(expectedPublishCount));
         }
@@ -5627,8 +5709,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(validPartitions);
 
             mockBufferedProducer
-                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken>((state, releaseFlag, token) =>
+                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<CancellationToken>()))
+                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken, CancellationToken>((state, releaseFlag, token, batchingWaitToken) =>
                 {
                     state.TryReadEvent(out _);
                     Interlocked.Decrement(ref state.BufferedEventCount);
@@ -5688,6 +5770,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.PublishBatchToPartition(
                     It.Is<EventHubBufferedProducerClient.PartitionPublishingState>(value => validPartitions.Any(item => item == value.PartitionId)),
                     true,
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(expectedPublishCount));
         }
@@ -5729,8 +5812,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(validPartitions);
 
             mockBufferedProducer
-                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken>((state, releaseFlag, token) =>
+                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<CancellationToken>()))
+                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken, CancellationToken>((state, releaseFlag, token, batchingWaitToken) =>
                 {
                     state.TryReadEvent(out _);
                     Interlocked.Decrement(ref state.BufferedEventCount);
@@ -5799,6 +5882,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Verify(producer => producer.PublishBatchToPartition(
                     It.Is<EventHubBufferedProducerClient.PartitionPublishingState>(value => validPartitions.Any(item => item == value.PartitionId)),
                     true,
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()),
                 Times.Exactly(expectedPublishCount + 1));
 
@@ -5837,8 +5921,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 .ReturnsAsync(validPartitions);
 
             mockBufferedProducer
-                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken>(async (state, releaseFlag, token) =>
+                .Setup(producer => producer.PublishBatchToPartition(It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(), It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<CancellationToken>()))
+                .Callback<EventHubBufferedProducerClient.PartitionPublishingState, bool, CancellationToken, CancellationToken>(async (state, releaseFlag, token, batchingWaitToken) =>
                 {
                     if (Interlocked.Increment(ref startCount) >= validPartitions.Length)
                     {
@@ -5961,6 +6045,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Callback(() => completionSource.TrySetResult(true))
                 .Returns(Task.CompletedTask);
@@ -6029,6 +6114,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(producer => producer.PublishBatchToPartition(
                     It.IsAny<EventHubBufferedProducerClient.PartitionPublishingState>(),
                     It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>(),
                     It.IsAny<CancellationToken>()))
                 .Callback(() => startCompletionSource.TrySetResult(true))
                 .Throws(expectedException);


### PR DESCRIPTION
# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).

Potential fix for https://github.com/Azure/azure-sdk-for-net/issues/58969

Splits the single `CancellationToken` in `PublishBatchToPartition` into two:
- `publishCancellationToken`: cancels the actual send operation
- `batchingWaitCancellationToken`: signals that waiting for additional events
  to batch should stop without canceling publishing (e.g., FlushAsync/CloseAsync)

When `FlushAsync` or `CloseAsync(true)` is called, `StopPublishingAsync` cancels the background loop's cancellationToken, which now flows as the batchingWait token into active `PublishBatchToPartition` calls, breaking the `Task.Delay` wait and publishing what has already been gathered instead of blocking for the full MaximumWaitTime.

This approach uses the already-in-scope CancellationToken instead of allocating a TaskCompletionSource on the hot publishing path (which was recommended by the AI triage in #58969.

