### PR TITLE
Add embedded ASP.NET project scenario for server codegen

### DIFF
--- a/eng/centralpackagemanagement/Directory.Generation.Packages.props
+++ b/eng/centralpackagemanagement/Directory.Generation.Packages.props
@@ -7,6 +7,7 @@
 
   <!-- Packages used by the TypeSpec generators -->
   <ItemGroup Condition="'$(IsGeneratorLibrary)' == 'true'">
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="Azure.Generator" Version="$(AzureGeneratorVersion)" />
     <PackageVersion Include="Azure.Generator.Management" Version="$(AzureManagementGeneratorVersion)" />
     <PackageVersion Include="Humanizer.Core" Version="3.0.1" />

--- a/eng/packages/http-server-csharp-aspnet/docs/plan.md
+++ b/eng/packages/http-server-csharp-aspnet/docs/plan.md
@@ -6,9 +6,10 @@ priority, but priorities will shift as we onboard pilot services.
 
 ## ✅ Implemented today
 
-- POCO models per TypeSpec model (`src/Generated/Models/`)
+- POCO models per TypeSpec model in the current API version folder
+  (`src/Generated/V<YYYYMMDD>/Models/`)
 - Abstract `<Name>ControllerBase` per TypeSpec interface, decorated with
-  `[ApiController]`, inheriting `ControllerBase`
+  `[ApiController]` / `[ApiVersion]`, inheriting `ControllerBase`
 - One abstract `Task<ActionResult<T>> <Name>Async(...)` method per operation
   with the correct `[Http*("route")]` attribute
 - Per-parameter binding attributes
@@ -22,13 +23,16 @@ priority, but priorities will shift as we onboard pilot services.
 - ASP.NET Core integration tests for the AzureSql scenario using
   `WebApplicationFactory<Program>` and real HTTP requests against generated
   routes
+- Current-version output layout: until incremental versioning exists, all
+  operations and generated POCO models are emitted under the latest
+  `InputNamespace.ApiVersions` value (for example `Generated/V20260201/`)
 
 ## 🔜 Planned
 
 ### 1. Versioning (largest gap)
 
-Today every operation lands in a single non-versioned `ControllerBase`. Real
-ARM services need:
+Today every operation lands in the latest version's `ControllerBase`. Real ARM
+services need:
 
 - **Version registry generation.** Walk `@versioned` enums and emit a
   per-service `ApiVersion` enum (or equivalent registry) with category

--- a/eng/packages/http-server-csharp-aspnet/docs/plan.md
+++ b/eng/packages/http-server-csharp-aspnet/docs/plan.md
@@ -16,6 +16,9 @@ priority, but priorities will shift as we onboard pilot services.
   TypeSpec `@path` / `@query` / `@header` / `@body`
 - Generated/hand-written separation: generated abstract bases live under
   `Generated/`, concrete controllers live in user-owned files
+- End-to-end test scenario that generates contracts into an existing ASP.NET
+  Core project (`generator/TestProjects/Local/AzureSql/src`) while preserving
+  user-owned concrete controllers outside `src/Generated/`
 
 ## 🔜 Planned
 
@@ -111,8 +114,9 @@ without changing the spec.
 
 ### 8. Documentation, samples, and onboarding
 
-- Service-author guide: how to lay out a project, where to put concrete
-  controllers, how to wire DI, how to register the generated routing helper.
+- Service-author guide: how to lay out an existing ASP.NET Core project, where
+  to put concrete controllers, how to wire DI, how to register the generated
+  routing helper.
 - Sample service: a small ARM RP end-to-end using only generated scaffolding.
 - Migration guide for existing hand-written ARM controllers.
 

--- a/eng/packages/http-server-csharp-aspnet/docs/plan.md
+++ b/eng/packages/http-server-csharp-aspnet/docs/plan.md
@@ -19,6 +19,9 @@ priority, but priorities will shift as we onboard pilot services.
 - End-to-end test scenario that generates contracts into an existing ASP.NET
   Core project (`generator/TestProjects/Local/AzureSql/src`) while preserving
   user-owned concrete controllers outside `src/Generated/`
+- ASP.NET Core integration tests for the AzureSql scenario using
+  `WebApplicationFactory<Program>` and real HTTP requests against generated
+  routes
 
 ## 🔜 Planned
 

--- a/eng/packages/http-server-csharp-aspnet/eng/scripts/Generate.ps1
+++ b/eng/packages/http-server-csharp-aspnet/eng/scripts/Generate.ps1
@@ -75,7 +75,7 @@ foreach ($project in $testProjects) {
     $testCsproj = Join-Path $projectDir 'tests' $project.TestCsproj
     if (Test-Path $testCsproj) {
         Write-Host "Testing $testCsproj..." -ForegroundColor Cyan
-        & dotnet test $testCsproj --no-restore
+        & dotnet test $testCsproj
         if ($LASTEXITCODE -ne 0) {
             throw "dotnet test failed for $($project.FilterName) (exit $LASTEXITCODE)."
         }

--- a/eng/packages/http-server-csharp-aspnet/eng/scripts/Generate.ps1
+++ b/eng/packages/http-server-csharp-aspnet/eng/scripts/Generate.ps1
@@ -27,6 +27,7 @@ $testProjects = @(
         Folder     = "AzureSql"
         EntryTsp   = "main.tsp"
         Csproj     = "Azure.TypeSpec.Generator.AspNetServer.AzureSql.csproj"
+        TestCsproj = "Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests.csproj"
     }
 )
 
@@ -68,6 +69,15 @@ foreach ($project in $testProjects) {
         & dotnet build $csproj
         if ($LASTEXITCODE -ne 0) {
             throw "dotnet build failed for $($project.FilterName) (exit $LASTEXITCODE)."
+        }
+    }
+
+    $testCsproj = Join-Path $projectDir 'tests' $project.TestCsproj
+    if (Test-Path $testCsproj) {
+        Write-Host "Testing $testCsproj..." -ForegroundColor Cyan
+        & dotnet test $testCsproj --no-restore
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet test failed for $($project.FilterName) (exit $LASTEXITCODE)."
         }
     }
 }

--- a/eng/packages/http-server-csharp-aspnet/eng/scripts/Generate.ps1
+++ b/eng/packages/http-server-csharp-aspnet/eng/scripts/Generate.ps1
@@ -38,8 +38,10 @@ foreach ($project in $testProjects) {
     $projectDir = Join-Path $testProjectsLocalDir $project.Folder
     $entryTsp = Join-Path $projectDir $project.EntryTsp
     $configFile = Join-Path $projectDir 'tspconfig.yaml'
+    $generatedDir = Join-Path $projectDir 'src' 'Generated'
 
     Write-Host "Generating $($project.FilterName)..." -ForegroundColor Cyan
+    Remove-Item -Recurse -Force $generatedDir -ErrorAction SilentlyContinue
 
     $command = "npx tsp compile `"$entryTsp`""
     $command += " --emit `"$emitterPackageDir`""

--- a/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/AspNetServerCodeModelGenerator.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/AspNetServerCodeModelGenerator.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.CodeAnalysis;
 using Microsoft.TypeSpec.Generator;
@@ -44,6 +47,21 @@ namespace Microsoft.TypeSpec.Generator.AspNetServer
         /// <inheritdoc/>
         public override AspNetServerOutputLibrary OutputLibrary { get; } = new();
 
+        internal string? CurrentApiVersion => InputLibrary.InputNamespace.ApiVersions.LastOrDefault();
+
+        internal string? CurrentApiVersionSegment =>
+            CurrentApiVersion is null ? null : $"V{CurrentApiVersion.Replace("-", string.Empty)}";
+
+        internal string GeneratedNamespace =>
+            CurrentApiVersionSegment is null
+                ? TypeFactory.PrimaryNamespace
+                : $"{TypeFactory.PrimaryNamespace}.Generated.{CurrentApiVersionSegment}";
+
+        internal string GeneratedDirectory =>
+            CurrentApiVersionSegment is null
+                ? Path.Combine("src", "Generated")
+                : Path.Combine("src", "Generated", CurrentApiVersionSegment);
+
         /// <inheritdoc/>
         protected override void Configure()
         {
@@ -63,9 +81,9 @@ namespace Microsoft.TypeSpec.Generator.AspNetServer
             // types from.
             AddMetadataReference(MetadataReference.CreateFromFile(typeof(ControllerBase).Assembly.Location));   // Microsoft.AspNetCore.Mvc.Core
             AddMetadataReference(MetadataReference.CreateFromFile(typeof(IActionResult).Assembly.Location));    // Microsoft.AspNetCore.Mvc.Abstractions
+            AddMetadataReference(MetadataReference.CreateFromFile(typeof(ApiVersionAttribute).Assembly.Location)); // Asp.Versioning.Mvc
         }
     }
 }
-
 
 

--- a/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/Microsoft.TypeSpec.Generator.AspNetServer.csproj
+++ b/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/Microsoft.TypeSpec.Generator.AspNetServer.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" />
     <PackageReference Include="Microsoft.TypeSpec.Generator.ClientModel" />
     <PackageReference Include="Microsoft.TypeSpec.Generator.Input" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/Providers/ControllerProvider.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/Providers/ControllerProvider.cs
@@ -146,11 +146,6 @@ namespace Microsoft.TypeSpec.Generator.AspNetServer.Providers
 
             foreach (var p in method.Operation.Parameters)
             {
-                if (p.IsApiVersion)
-                {
-                    continue;
-                }
-
                 var bindingAttr = BuildBindingAttribute(p);
                 if (bindingAttr is null)
                 {

--- a/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/Providers/ControllerProvider.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/Providers/ControllerProvider.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.TypeSpec.Generator.Input;
 using Microsoft.TypeSpec.Generator.Input.Extensions;
@@ -34,18 +35,30 @@ namespace Microsoft.TypeSpec.Generator.AspNetServer.Providers
         protected override string BuildName() => $"{_input.Name}ControllerBase";
 
         protected override string BuildNamespace() =>
-            $"{CodeModelGenerator.Instance.TypeFactory.PrimaryNamespace}.Controllers";
+            $"{AspNetServerCodeModelGenerator.Instance.GeneratedNamespace}.Controllers";
 
         protected override string BuildRelativeFilePath() =>
-            Path.Combine("src", "Generated", "Controllers", $"{Name}.cs");
+            Path.Combine(AspNetServerCodeModelGenerator.Instance.GeneratedDirectory, "Controllers", $"{Name}.cs");
 
         protected override TypeSignatureModifiers BuildDeclarationModifiers() =>
             TypeSignatureModifiers.Public | TypeSignatureModifiers.Partial | TypeSignatureModifiers.Abstract | TypeSignatureModifiers.Class;
 
         protected override CSharpType[] BuildImplements() => [typeof(ControllerBase)];
 
-        protected override IReadOnlyList<AttributeStatement> BuildAttributes() =>
-            [new AttributeStatement(typeof(ApiControllerAttribute))];
+        protected override IReadOnlyList<AttributeStatement> BuildAttributes()
+        {
+            var attributes = new List<AttributeStatement>
+            {
+                new AttributeStatement(typeof(ApiControllerAttribute))
+            };
+
+            if (AspNetServerCodeModelGenerator.Instance.CurrentApiVersion is string apiVersion)
+            {
+                attributes.Add(new AttributeStatement(typeof(ApiVersionAttribute), Literal(apiVersion)));
+            }
+
+            return attributes;
+        }
 
         protected override XmlDocProvider BuildXmlDocs()
         {
@@ -146,6 +159,11 @@ namespace Microsoft.TypeSpec.Generator.AspNetServer.Providers
 
             foreach (var p in method.Operation.Parameters)
             {
+                if (p.IsApiVersion)
+                {
+                    continue;
+                }
+
                 var bindingAttr = BuildBindingAttribute(p);
                 if (bindingAttr is null)
                 {

--- a/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/Providers/ServerModelProvider.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/Microsoft.TypeSpec.Generator.AspNetServer/src/Providers/ServerModelProvider.cs
@@ -31,10 +31,10 @@ namespace Microsoft.TypeSpec.Generator.AspNetServer.Providers
         protected override string BuildName() => _input.Name;
 
         protected override string BuildNamespace() =>
-            $"{CodeModelGenerator.Instance.TypeFactory.PrimaryNamespace}.Models";
+            $"{AspNetServerCodeModelGenerator.Instance.GeneratedNamespace}.Models";
 
         protected override string BuildRelativeFilePath() =>
-            Path.Combine("src", "Generated", "Models", $"{Name}.cs");
+            Path.Combine(AspNetServerCodeModelGenerator.Instance.GeneratedDirectory, "Models", $"{Name}.cs");
 
         protected override TypeSignatureModifiers BuildDeclarationModifiers() =>
             TypeSignatureModifiers.Public | TypeSignatureModifiers.Partial | TypeSignatureModifiers.Class;

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/Azure.TypeSpec.Generator.AspNetServer.AzureSql.slnx
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/Azure.TypeSpec.Generator.AspNetServer.AzureSql.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="src/Azure.TypeSpec.Generator.AspNetServer.AzureSql.csproj" />
+  <Project Path="tests/Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests.csproj" />
 </Solution>

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Azure.TypeSpec.Generator.AspNetServer.AzureSql.csproj
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Azure.TypeSpec.Generator.AspNetServer.AzureSql.csproj
@@ -6,7 +6,5 @@
     <PackageTags>Azure.TypeSpec.Generator.AspNetServer.AzureSql</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
-    <OutputType>Library</OutputType>
   </PropertyGroup>
 </Project>
-

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/DatabasesController.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/DatabasesController.cs
@@ -17,17 +17,19 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
     {
         /// <inheritdoc/>
         public override Task<ActionResult<Database>> GetAsync(
+            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             string databaseName,
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult<ActionResult<Database>>(Ok(CreateDatabase(subscriptionId, resourceGroupName, databaseName)));
+            return Task.FromResult<ActionResult<Database>>(Ok(CreateDatabase(apiVersion, subscriptionId, resourceGroupName, databaseName)));
         }
 
         /// <inheritdoc/>
         public override Task<ActionResult<Database>> CreateOrUpdateAsync(
+            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             string databaseName,
@@ -39,12 +41,15 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
             resource.Id = BuildDatabaseId(subscriptionId, resourceGroupName, databaseName);
             resource.Name = databaseName;
             resource.Type = "Microsoft.Sql/databases";
+            resource.Tags ??= new Dictionary<string, string>();
+            resource.Tags["api-version"] = apiVersion;
 
             return Task.FromResult<ActionResult<Database>>(Ok(resource));
         }
 
         /// <inheritdoc/>
         public override Task<IActionResult> DeleteAsync(
+            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             string databaseName,
@@ -56,6 +61,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
 
         /// <inheritdoc/>
         public override Task<ActionResult<Database>> UpdateAsync(
+            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             string databaseName,
@@ -64,8 +70,9 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var database = CreateDatabase(subscriptionId, resourceGroupName, databaseName);
+            var database = CreateDatabase(apiVersion, subscriptionId, resourceGroupName, databaseName);
             database.Tags = properties.Tags ?? database.Tags;
+            database.Tags["api-version"] = apiVersion;
             database.Properties.Collation = properties.Properties?.Collation ?? database.Properties.Collation;
             database.Properties.MaxSizeBytes = properties.Properties?.MaxSizeBytes ?? database.Properties.MaxSizeBytes;
             database.Properties.ElasticPoolId = properties.Properties?.ElasticPoolId ?? database.Properties.ElasticPoolId;
@@ -75,6 +82,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
 
         /// <inheritdoc/>
         public override Task<ActionResult<DatabaseListResult>> ListByResourceGroupAsync(
+            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             CancellationToken cancellationToken = default)
@@ -85,15 +93,15 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
             {
                 Value =
                 [
-                    CreateDatabase(subscriptionId, resourceGroupName, "database1"),
-                    CreateDatabase(subscriptionId, resourceGroupName, "database2")
+                    CreateDatabase(apiVersion, subscriptionId, resourceGroupName, "database1"),
+                    CreateDatabase(apiVersion, subscriptionId, resourceGroupName, "database2")
                 ]
             };
 
             return Task.FromResult<ActionResult<DatabaseListResult>>(Ok(result));
         }
 
-        private static Database CreateDatabase(string subscriptionId, string resourceGroupName, string databaseName)
+        private static Database CreateDatabase(string apiVersion, string subscriptionId, string resourceGroupName, string databaseName)
         {
             return new Database
             {
@@ -103,6 +111,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
                 Location = "westus",
                 Tags = new Dictionary<string, string>
                 {
+                    ["api-version"] = apiVersion,
                     ["scenario"] = "existing-project"
                 },
                 Properties = new DatabaseProperties

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/DatabasesController.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/DatabasesController.cs
@@ -4,7 +4,9 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models;
+using Asp.Versioning;
+using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Controllers;
+using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Sql;
 
@@ -13,23 +15,22 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
     /// <summary>
     /// Hand-written controller that consumes the generated server contract.
     /// </summary>
+    [ApiVersion("2026-02-01")]
     public sealed class DatabasesController : DatabasesControllerBase
     {
         /// <inheritdoc/>
         public override Task<ActionResult<Database>> GetAsync(
-            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             string databaseName,
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult<ActionResult<Database>>(Ok(CreateDatabase(apiVersion, subscriptionId, resourceGroupName, databaseName)));
+            return Task.FromResult<ActionResult<Database>>(Ok(CreateDatabase(subscriptionId, resourceGroupName, databaseName)));
         }
 
         /// <inheritdoc/>
         public override Task<ActionResult<Database>> CreateOrUpdateAsync(
-            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             string databaseName,
@@ -41,15 +42,12 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
             resource.Id = BuildDatabaseId(subscriptionId, resourceGroupName, databaseName);
             resource.Name = databaseName;
             resource.Type = "Microsoft.Sql/databases";
-            resource.Tags ??= new Dictionary<string, string>();
-            resource.Tags["api-version"] = apiVersion;
 
             return Task.FromResult<ActionResult<Database>>(Ok(resource));
         }
 
         /// <inheritdoc/>
         public override Task<IActionResult> DeleteAsync(
-            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             string databaseName,
@@ -61,7 +59,6 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
 
         /// <inheritdoc/>
         public override Task<ActionResult<Database>> UpdateAsync(
-            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             string databaseName,
@@ -70,9 +67,8 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var database = CreateDatabase(apiVersion, subscriptionId, resourceGroupName, databaseName);
+            var database = CreateDatabase(subscriptionId, resourceGroupName, databaseName);
             database.Tags = properties.Tags ?? database.Tags;
-            database.Tags["api-version"] = apiVersion;
             database.Properties.Collation = properties.Properties?.Collation ?? database.Properties.Collation;
             database.Properties.MaxSizeBytes = properties.Properties?.MaxSizeBytes ?? database.Properties.MaxSizeBytes;
             database.Properties.ElasticPoolId = properties.Properties?.ElasticPoolId ?? database.Properties.ElasticPoolId;
@@ -82,7 +78,6 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
 
         /// <inheritdoc/>
         public override Task<ActionResult<DatabaseListResult>> ListByResourceGroupAsync(
-            string apiVersion,
             string subscriptionId,
             string resourceGroupName,
             CancellationToken cancellationToken = default)
@@ -93,15 +88,15 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
             {
                 Value =
                 [
-                    CreateDatabase(apiVersion, subscriptionId, resourceGroupName, "database1"),
-                    CreateDatabase(apiVersion, subscriptionId, resourceGroupName, "database2")
+                    CreateDatabase(subscriptionId, resourceGroupName, "database1"),
+                    CreateDatabase(subscriptionId, resourceGroupName, "database2")
                 ]
             };
 
             return Task.FromResult<ActionResult<DatabaseListResult>>(Ok(result));
         }
 
-        private static Database CreateDatabase(string apiVersion, string subscriptionId, string resourceGroupName, string databaseName)
+        private static Database CreateDatabase(string subscriptionId, string resourceGroupName, string databaseName)
         {
             return new Database
             {
@@ -111,7 +106,6 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
                 Location = "westus",
                 Tags = new Dictionary<string, string>
                 {
-                    ["api-version"] = apiVersion,
                     ["scenario"] = "existing-project"
                 },
                 Properties = new DatabaseProperties

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/DatabasesController.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/DatabasesController.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Sql;
+
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
+{
+    /// <summary>
+    /// Hand-written controller that consumes the generated server contract.
+    /// </summary>
+    public sealed class DatabasesController : DatabasesControllerBase
+    {
+        /// <inheritdoc/>
+        public override Task<ActionResult<Database>> GetAsync(
+            string subscriptionId,
+            string resourceGroupName,
+            string databaseName,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<ActionResult<Database>>(Ok(CreateDatabase(subscriptionId, resourceGroupName, databaseName)));
+        }
+
+        /// <inheritdoc/>
+        public override Task<ActionResult<Database>> CreateOrUpdateAsync(
+            string subscriptionId,
+            string resourceGroupName,
+            string databaseName,
+            Database resource,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            resource.Id = BuildDatabaseId(subscriptionId, resourceGroupName, databaseName);
+            resource.Name = databaseName;
+            resource.Type = "Microsoft.Sql/databases";
+
+            return Task.FromResult<ActionResult<Database>>(Ok(resource));
+        }
+
+        /// <inheritdoc/>
+        public override Task<IActionResult> DeleteAsync(
+            string subscriptionId,
+            string resourceGroupName,
+            string databaseName,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<IActionResult>(NoContent());
+        }
+
+        /// <inheritdoc/>
+        public override Task<ActionResult<Database>> UpdateAsync(
+            string subscriptionId,
+            string resourceGroupName,
+            string databaseName,
+            DatabaseUpdate properties,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var database = CreateDatabase(subscriptionId, resourceGroupName, databaseName);
+            database.Tags = properties.Tags ?? database.Tags;
+            database.Properties.Collation = properties.Properties?.Collation ?? database.Properties.Collation;
+            database.Properties.MaxSizeBytes = properties.Properties?.MaxSizeBytes ?? database.Properties.MaxSizeBytes;
+            database.Properties.ElasticPoolId = properties.Properties?.ElasticPoolId ?? database.Properties.ElasticPoolId;
+
+            return Task.FromResult<ActionResult<Database>>(Ok(database));
+        }
+
+        /// <inheritdoc/>
+        public override Task<ActionResult<DatabaseListResult>> ListByResourceGroupAsync(
+            string subscriptionId,
+            string resourceGroupName,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var result = new DatabaseListResult
+            {
+                Value =
+                [
+                    CreateDatabase(subscriptionId, resourceGroupName, "database1"),
+                    CreateDatabase(subscriptionId, resourceGroupName, "database2")
+                ]
+            };
+
+            return Task.FromResult<ActionResult<DatabaseListResult>>(Ok(result));
+        }
+
+        private static Database CreateDatabase(string subscriptionId, string resourceGroupName, string databaseName)
+        {
+            return new Database
+            {
+                Id = BuildDatabaseId(subscriptionId, resourceGroupName, databaseName),
+                Name = databaseName,
+                Type = "Microsoft.Sql/databases",
+                Location = "westus",
+                Tags = new Dictionary<string, string>
+                {
+                    ["scenario"] = "existing-project"
+                },
+                Properties = new DatabaseProperties
+                {
+                    Collation = "SQL_Latin1_General_CP1_CI_AS",
+                    MaxSizeBytes = 268435456000,
+                    Status = "Online",
+                    ProvisioningState = ProvisioningState.Succeeded
+                }
+            };
+        }
+
+        private static string BuildDatabaseId(string subscriptionId, string resourceGroupName, string databaseName)
+        {
+            return $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases/{databaseName}";
+        }
+    }
+}

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/OperationsController.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/OperationsController.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.ResourceManager.CommonTypes;

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/OperationsController.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/OperationsController.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Asp.Versioning;
 using Azure.ResourceManager.CommonTypes;
-using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models;
+using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Controllers;
+using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
@@ -13,16 +14,16 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
     /// <summary>
     /// Hand-written controller that consumes the generated server contract.
     /// </summary>
+    [ApiVersion("2026-02-01")]
     public sealed class OperationsController : OperationsControllerBase
     {
         /// <inheritdoc/>
-        public override Task<ActionResult<OperationListResult>> ListAsync(string apiVersion, CancellationToken cancellationToken = default)
+        public override Task<ActionResult<OperationListResult>> ListAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var result = new OperationListResult
             {
-                NextLink = new Uri($"https://example.com/providers/Microsoft.Sql/operations?api-version={apiVersion}"),
                 Value =
                 [
                     new Operation

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/OperationsController.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/OperationsController.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.ResourceManager.CommonTypes;
+using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
+{
+    /// <summary>
+    /// Hand-written controller that consumes the generated server contract.
+    /// </summary>
+    public sealed class OperationsController : OperationsControllerBase
+    {
+        /// <inheritdoc/>
+        public override Task<ActionResult<OperationListResult>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var result = new OperationListResult
+            {
+                Value =
+                [
+                    new Operation
+                    {
+                        Name = "Microsoft.Sql/databases/read",
+                        IsDataAction = false,
+                        Origin = Origin.UserSystem,
+                        Display = new OperationDisplay
+                        {
+                            Provider = "Microsoft SQL",
+                            Resource = "Databases",
+                            Operation = "Get database",
+                            Description = "Gets an Azure SQL database."
+                        }
+                    },
+                    new Operation
+                    {
+                        Name = "Microsoft.Sql/databases/write",
+                        IsDataAction = false,
+                        Origin = Origin.UserSystem,
+                        ActionType = ActionType.Internal,
+                        Display = new OperationDisplay
+                        {
+                            Provider = "Microsoft SQL",
+                            Resource = "Databases",
+                            Operation = "Create or update database",
+                            Description = "Creates or updates an Azure SQL database."
+                        }
+                    }
+                ]
+            };
+
+            return Task.FromResult<ActionResult<OperationListResult>>(Ok(result));
+        }
+    }
+}

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/OperationsController.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Controllers/OperationsController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.ResourceManager.CommonTypes;
@@ -15,12 +16,13 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
     public sealed class OperationsController : OperationsControllerBase
     {
         /// <inheritdoc/>
-        public override Task<ActionResult<OperationListResult>> ListAsync(CancellationToken cancellationToken = default)
+        public override Task<ActionResult<OperationListResult>> ListAsync(string apiVersion, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var result = new OperationListResult
             {
+                NextLink = new Uri($"https://example.com/providers/Microsoft.Sql/operations?api-version={apiVersion}"),
                 Value =
                 [
                     new Operation

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/Controllers/DatabasesControllerBase.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/Controllers/DatabasesControllerBase.cs
@@ -15,14 +15,16 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
     {
         /// <summary> Gets a database. </summary>
         [HttpGet("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases/{databaseName}")]
-        public abstract Task<ActionResult<Database>> GetAsync([FromRoute(Name = "subscriptionId")]
+        public abstract Task<ActionResult<Database>> GetAsync([FromQuery(Name = "api-version")]
+        string apiVersion, [FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, [FromRoute(Name = "databaseName")]
         string databaseName, CancellationToken cancellationToken = default);
 
         /// <summary> Creates or updates a database (long-running operation). </summary>
         [HttpPut("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases/{databaseName}")]
-        public abstract Task<ActionResult<Database>> CreateOrUpdateAsync([FromRoute(Name = "subscriptionId")]
+        public abstract Task<ActionResult<Database>> CreateOrUpdateAsync([FromQuery(Name = "api-version")]
+        string apiVersion, [FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, [FromRoute(Name = "databaseName")]
         string databaseName, [FromBody]
@@ -30,14 +32,16 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
 
         /// <summary> Deletes a database (long-running operation). </summary>
         [HttpDelete("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases/{databaseName}")]
-        public abstract Task<IActionResult> DeleteAsync([FromRoute(Name = "subscriptionId")]
+        public abstract Task<IActionResult> DeleteAsync([FromQuery(Name = "api-version")]
+        string apiVersion, [FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, [FromRoute(Name = "databaseName")]
         string databaseName, CancellationToken cancellationToken = default);
 
         /// <summary> Updates a database. Added in 2025-12-01. </summary>
         [HttpPatch("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases/{databaseName}")]
-        public abstract Task<ActionResult<Database>> UpdateAsync([FromRoute(Name = "subscriptionId")]
+        public abstract Task<ActionResult<Database>> UpdateAsync([FromQuery(Name = "api-version")]
+        string apiVersion, [FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, [FromRoute(Name = "databaseName")]
         string databaseName, [FromBody]
@@ -45,7 +49,8 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
 
         /// <summary> Lists databases under a server. Added in 2025-12-01. </summary>
         [HttpGet("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases")]
-        public abstract Task<ActionResult<DatabaseListResult>> ListByResourceGroupAsync([FromRoute(Name = "subscriptionId")]
+        public abstract Task<ActionResult<DatabaseListResult>> ListByResourceGroupAsync([FromQuery(Name = "api-version")]
+        string apiVersion, [FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, CancellationToken cancellationToken = default);
     }

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/Controllers/OperationsControllerBase.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/Controllers/OperationsControllerBase.cs
@@ -15,6 +15,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
     {
         /// <summary> List the operations for the provider. </summary>
         [HttpGet("providers/Microsoft.Sql/operations")]
-        public abstract Task<ActionResult<OperationListResult>> ListAsync(CancellationToken cancellationToken = default);
+        public abstract Task<ActionResult<OperationListResult>> ListAsync([FromQuery(Name = "api-version")]
+        string apiVersion, CancellationToken cancellationToken = default);
     }
 }

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Controllers/DatabasesControllerBase.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Controllers/DatabasesControllerBase.cs
@@ -4,27 +4,27 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models;
+using Asp.Versioning;
+using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Controllers
 {
     /// <summary> Database resource operations. </summary>
     [ApiController]
+    [ApiVersion("2026-02-01")]
     public abstract partial class DatabasesControllerBase : ControllerBase
     {
         /// <summary> Gets a database. </summary>
         [HttpGet("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases/{databaseName}")]
-        public abstract Task<ActionResult<Database>> GetAsync([FromQuery(Name = "api-version")]
-        string apiVersion, [FromRoute(Name = "subscriptionId")]
+        public abstract Task<ActionResult<Database>> GetAsync([FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, [FromRoute(Name = "databaseName")]
         string databaseName, CancellationToken cancellationToken = default);
 
         /// <summary> Creates or updates a database (long-running operation). </summary>
         [HttpPut("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases/{databaseName}")]
-        public abstract Task<ActionResult<Database>> CreateOrUpdateAsync([FromQuery(Name = "api-version")]
-        string apiVersion, [FromRoute(Name = "subscriptionId")]
+        public abstract Task<ActionResult<Database>> CreateOrUpdateAsync([FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, [FromRoute(Name = "databaseName")]
         string databaseName, [FromBody]
@@ -32,16 +32,14 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
 
         /// <summary> Deletes a database (long-running operation). </summary>
         [HttpDelete("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases/{databaseName}")]
-        public abstract Task<IActionResult> DeleteAsync([FromQuery(Name = "api-version")]
-        string apiVersion, [FromRoute(Name = "subscriptionId")]
+        public abstract Task<IActionResult> DeleteAsync([FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, [FromRoute(Name = "databaseName")]
         string databaseName, CancellationToken cancellationToken = default);
 
         /// <summary> Updates a database. Added in 2025-12-01. </summary>
         [HttpPatch("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases/{databaseName}")]
-        public abstract Task<ActionResult<Database>> UpdateAsync([FromQuery(Name = "api-version")]
-        string apiVersion, [FromRoute(Name = "subscriptionId")]
+        public abstract Task<ActionResult<Database>> UpdateAsync([FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, [FromRoute(Name = "databaseName")]
         string databaseName, [FromBody]
@@ -49,8 +47,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
 
         /// <summary> Lists databases under a server. Added in 2025-12-01. </summary>
         [HttpGet("subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/databases")]
-        public abstract Task<ActionResult<DatabaseListResult>> ListByResourceGroupAsync([FromQuery(Name = "api-version")]
-        string apiVersion, [FromRoute(Name = "subscriptionId")]
+        public abstract Task<ActionResult<DatabaseListResult>> ListByResourceGroupAsync([FromRoute(Name = "subscriptionId")]
         string subscriptionId, [FromRoute(Name = "resourceGroupName")]
         string resourceGroupName, CancellationToken cancellationToken = default);
     }

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Controllers/OperationsControllerBase.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Controllers/OperationsControllerBase.cs
@@ -4,18 +4,19 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models;
+using Asp.Versioning;
+using Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Controllers
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Controllers
 {
     /// <summary> ARM operations endpoint. </summary>
     [ApiController]
+    [ApiVersion("2026-02-01")]
     public abstract partial class OperationsControllerBase : ControllerBase
     {
         /// <summary> List the operations for the provider. </summary>
         [HttpGet("providers/Microsoft.Sql/operations")]
-        public abstract Task<ActionResult<OperationListResult>> ListAsync([FromQuery(Name = "api-version")]
-        string apiVersion, CancellationToken cancellationToken = default);
+        public abstract Task<ActionResult<OperationListResult>> ListAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/ArmOperationStatusResourceProvisioningState.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/ArmOperationStatusResourceProvisioningState.cs
@@ -6,7 +6,7 @@ using System;
 using System.Text.Json.Serialization;
 using Azure.ResourceManager;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary>
     /// Standard Azure Resource Manager operation status response, used as the response

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/Database.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/Database.cs
@@ -4,7 +4,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> A SQL Database resource. </summary>
     public partial class Database : TrackedResource

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/DatabaseListResult.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/DatabaseListResult.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> The response of a Database list operation. </summary>
     public partial class DatabaseListResult

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/DatabaseProperties.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/DatabaseProperties.cs
@@ -6,7 +6,7 @@ using System;
 using System.Text.Json.Serialization;
 using Microsoft.Sql;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> Database resource properties. </summary>
     public partial class DatabaseProperties

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/DatabaseUpdate.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/DatabaseUpdate.cs
@@ -5,7 +5,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> The type used for update operations of the Database. </summary>
     public partial class DatabaseUpdate

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/DatabaseUpdateProperties.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/DatabaseUpdateProperties.cs
@@ -4,7 +4,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> The updatable properties of the Database. </summary>
     public partial class DatabaseUpdateProperties

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/ErrorAdditionalInfo.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/ErrorAdditionalInfo.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> The resource management error additional info. </summary>
     public partial class ErrorAdditionalInfo

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/ErrorDetail.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/ErrorDetail.cs
@@ -5,7 +5,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> The error detail. </summary>
     public partial class ErrorDetail

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/ErrorResponse.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/ErrorResponse.cs
@@ -4,7 +4,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> Error response. </summary>
     public partial class ErrorResponse

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/Operation.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/Operation.cs
@@ -5,7 +5,7 @@
 using System.Text.Json.Serialization;
 using Azure.ResourceManager.CommonTypes;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> REST API Operation. </summary>
     public partial class Operation

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/OperationDisplay.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/OperationDisplay.cs
@@ -4,7 +4,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> Localized display information for an operation. </summary>
     public partial class OperationDisplay

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/OperationListResult.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/OperationListResult.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get the next set of results. </summary>
     public partial class OperationListResult

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/Resource.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/Resource.cs
@@ -4,7 +4,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> Resource. </summary>
     public partial class Resource

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/SystemData.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/SystemData.cs
@@ -6,7 +6,7 @@ using System;
 using System.Text.Json.Serialization;
 using Azure.ResourceManager.CommonTypes;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> Metadata pertaining to creation and last modification of the resource. </summary>
     public partial class SystemData

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/TrackedResource.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Generated/V20260201/Models/TrackedResource.cs
@@ -5,7 +5,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Models
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Generated.V20260201.Models
 {
     /// <summary> Tracked Resource. </summary>
     public partial class TrackedResource : Resource

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Program.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Program.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();
+
+/// <summary>
+/// Entry point for the AzureSql ASP.NET Core scenario project.
+/// </summary>
+public partial class Program
+{
+}

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Program.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Asp.Versioning;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -16,6 +17,14 @@ public partial class Program
     public static void Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddApiVersioning(options =>
+        {
+            options.ApiVersionReader = new QueryStringApiVersionReader("api-version");
+            options.AssumeDefaultVersionWhenUnspecified = false;
+            options.ReportApiVersions = true;
+        })
+        .AddMvc();
 
         builder.Services.AddControllers();
 

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Program.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/src/Program.cs
@@ -4,19 +4,25 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddControllers();
-
-var app = builder.Build();
-
-app.MapControllers();
-
-app.Run();
-
 /// <summary>
 /// Entry point for the AzureSql ASP.NET Core scenario project.
 /// </summary>
 public partial class Program
 {
+    /// <summary>
+    /// Starts the AzureSql ASP.NET Core scenario project.
+    /// </summary>
+    /// <param name="args">Command-line arguments.</param>
+    public static void Main(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddControllers();
+
+        var app = builder.Build();
+
+        app.MapControllers();
+
+        app.Run();
+    }
 }

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/tests/Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests.csproj
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/tests/Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RequiredTargetFrameworks>$(LtsTargetFramework)</RequiredTargetFrameworks>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <RootNamespace>Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Azure.TypeSpec.Generator.AspNetServer.AzureSql.csproj" />
+  </ItemGroup>
+</Project>

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/tests/AzureSqlServerTests.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/tests/AzureSqlServerTests.cs
@@ -14,6 +14,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
 {
     public class AzureSqlServerTests
     {
+        private const string ApiVersion = "2026-02-01";
         private WebApplicationFactory<Program> _factory = null!;
         private HttpClient _client = null!;
 
@@ -34,7 +35,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
         [Test]
         public async Task GetDatabaseUsesGeneratedRouteAndReturnsResource()
         {
-            using var response = await _client.GetAsync("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db");
+            using var response = await _client.GetAsync(WithApiVersion("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db"));
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
@@ -42,13 +43,14 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
             var root = payload.RootElement;
             Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("db"));
             Assert.That(root.GetProperty("type").GetString(), Is.EqualTo("Microsoft.Sql/databases"));
+            Assert.That(root.GetProperty("tags").GetProperty("api-version").GetString(), Is.EqualTo(ApiVersion));
             Assert.That(root.GetProperty("properties").GetProperty("status").GetString(), Is.EqualTo("Online"));
         }
 
         [Test]
         public async Task ListDatabasesUsesGeneratedRouteAndReturnsPage()
         {
-            using var response = await _client.GetAsync("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases");
+            using var response = await _client.GetAsync(WithApiVersion("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases"));
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
@@ -56,6 +58,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
             var values = payload.RootElement.GetProperty("value");
             Assert.That(values.GetArrayLength(), Is.EqualTo(2));
             Assert.That(values[0].GetProperty("name").GetString(), Is.EqualTo("database1"));
+            Assert.That(values[0].GetProperty("tags").GetProperty("api-version").GetString(), Is.EqualTo(ApiVersion));
             Assert.That(values[1].GetProperty("name").GetString(), Is.EqualTo("database2"));
         }
 
@@ -77,7 +80,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
             };
 
             using var response = await _client.PutAsJsonAsync(
-                "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db",
+                WithApiVersion("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db"),
                 resource);
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
@@ -86,6 +89,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
             var root = payload.RootElement;
             Assert.That(root.GetProperty("id").GetString(), Is.EqualTo("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db"));
             Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("db"));
+            Assert.That(root.GetProperty("tags").GetProperty("api-version").GetString(), Is.EqualTo(ApiVersion));
             Assert.That(root.GetProperty("tags").GetProperty("environment").GetString(), Is.EqualTo("test"));
             Assert.That(root.GetProperty("properties").GetProperty("collation").GetString(), Is.EqualTo("Latin1_General_100_CI_AS"));
         }
@@ -93,7 +97,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
         [Test]
         public async Task DeleteDatabaseUsesGeneratedRouteAndReturnsNoContent()
         {
-            using var response = await _client.DeleteAsync("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db");
+            using var response = await _client.DeleteAsync(WithApiVersion("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db"));
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
         }
@@ -101,15 +105,18 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
         [Test]
         public async Task ListOperationsUsesGeneratedOperationsRoute()
         {
-            using var response = await _client.GetAsync("/providers/Microsoft.Sql/operations");
+            using var response = await _client.GetAsync(WithApiVersion("/providers/Microsoft.Sql/operations"));
 
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
             using var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
             var values = payload.RootElement.GetProperty("value");
             Assert.That(values.GetArrayLength(), Is.EqualTo(2));
+            Assert.That(payload.RootElement.GetProperty("nextLink").GetString(), Does.Contain($"api-version={ApiVersion}"));
             Assert.That(values[0].GetProperty("name").GetString(), Is.EqualTo("Microsoft.Sql/databases/read"));
             Assert.That(values[1].GetProperty("name").GetString(), Is.EqualTo("Microsoft.Sql/databases/write"));
         }
+
+        private static string WithApiVersion(string path) => $"{path}?api-version={ApiVersion}";
     }
 }

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/tests/AzureSqlServerTests.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/tests/AzureSqlServerTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using NUnit.Framework;
+
+namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
+{
+    public class AzureSqlServerTests
+    {
+        private WebApplicationFactory<Program> _factory = null!;
+        private HttpClient _client = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _factory = new WebApplicationFactory<Program>();
+            _client = _factory.CreateClient();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _client.Dispose();
+            _factory.Dispose();
+        }
+
+        [Test]
+        public async Task GetDatabaseUsesGeneratedRouteAndReturnsResource()
+        {
+            using var response = await _client.GetAsync("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db");
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+            using var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+            var root = payload.RootElement;
+            Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("db"));
+            Assert.That(root.GetProperty("type").GetString(), Is.EqualTo("Microsoft.Sql/databases"));
+            Assert.That(root.GetProperty("properties").GetProperty("status").GetString(), Is.EqualTo("Online"));
+        }
+
+        [Test]
+        public async Task ListDatabasesUsesGeneratedRouteAndReturnsPage()
+        {
+            using var response = await _client.GetAsync("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases");
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+            using var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+            var values = payload.RootElement.GetProperty("value");
+            Assert.That(values.GetArrayLength(), Is.EqualTo(2));
+            Assert.That(values[0].GetProperty("name").GetString(), Is.EqualTo("database1"));
+            Assert.That(values[1].GetProperty("name").GetString(), Is.EqualTo("database2"));
+        }
+
+        [Test]
+        public async Task CreateOrUpdateDatabaseBindsBodyAndRouteValues()
+        {
+            var resource = new
+            {
+                location = "eastus",
+                tags = new Dictionary<string, string>
+                {
+                    ["environment"] = "test"
+                },
+                properties = new
+                {
+                    collation = "Latin1_General_100_CI_AS",
+                    maxSizeBytes = 1024
+                }
+            };
+
+            using var response = await _client.PutAsJsonAsync(
+                "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db",
+                resource);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+            using var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+            var root = payload.RootElement;
+            Assert.That(root.GetProperty("id").GetString(), Is.EqualTo("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db"));
+            Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("db"));
+            Assert.That(root.GetProperty("tags").GetProperty("environment").GetString(), Is.EqualTo("test"));
+            Assert.That(root.GetProperty("properties").GetProperty("collation").GetString(), Is.EqualTo("Latin1_General_100_CI_AS"));
+        }
+
+        [Test]
+        public async Task DeleteDatabaseUsesGeneratedRouteAndReturnsNoContent()
+        {
+            using var response = await _client.DeleteAsync("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db");
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
+        }
+
+        [Test]
+        public async Task ListOperationsUsesGeneratedOperationsRoute()
+        {
+            using var response = await _client.GetAsync("/providers/Microsoft.Sql/operations");
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+            using var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+            var values = payload.RootElement.GetProperty("value");
+            Assert.That(values.GetArrayLength(), Is.EqualTo(2));
+            Assert.That(values[0].GetProperty("name").GetString(), Is.EqualTo("Microsoft.Sql/databases/read"));
+            Assert.That(values[1].GetProperty("name").GetString(), Is.EqualTo("Microsoft.Sql/databases/write"));
+        }
+    }
+}

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/tests/AzureSqlServerTests.cs
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/AzureSql/tests/AzureSqlServerTests.cs
@@ -43,7 +43,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
             var root = payload.RootElement;
             Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("db"));
             Assert.That(root.GetProperty("type").GetString(), Is.EqualTo("Microsoft.Sql/databases"));
-            Assert.That(root.GetProperty("tags").GetProperty("api-version").GetString(), Is.EqualTo(ApiVersion));
+            Assert.That(root.GetProperty("tags").GetProperty("scenario").GetString(), Is.EqualTo("existing-project"));
             Assert.That(root.GetProperty("properties").GetProperty("status").GetString(), Is.EqualTo("Online"));
         }
 
@@ -58,7 +58,7 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
             var values = payload.RootElement.GetProperty("value");
             Assert.That(values.GetArrayLength(), Is.EqualTo(2));
             Assert.That(values[0].GetProperty("name").GetString(), Is.EqualTo("database1"));
-            Assert.That(values[0].GetProperty("tags").GetProperty("api-version").GetString(), Is.EqualTo(ApiVersion));
+            Assert.That(values[0].GetProperty("tags").GetProperty("scenario").GetString(), Is.EqualTo("existing-project"));
             Assert.That(values[1].GetProperty("name").GetString(), Is.EqualTo("database2"));
         }
 
@@ -89,7 +89,6 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
             var root = payload.RootElement;
             Assert.That(root.GetProperty("id").GetString(), Is.EqualTo("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Sql/databases/db"));
             Assert.That(root.GetProperty("name").GetString(), Is.EqualTo("db"));
-            Assert.That(root.GetProperty("tags").GetProperty("api-version").GetString(), Is.EqualTo(ApiVersion));
             Assert.That(root.GetProperty("tags").GetProperty("environment").GetString(), Is.EqualTo("test"));
             Assert.That(root.GetProperty("properties").GetProperty("collation").GetString(), Is.EqualTo("Latin1_General_100_CI_AS"));
         }
@@ -112,9 +111,16 @@ namespace Azure.TypeSpec.Generator.AspNetServer.AzureSql.Tests
             using var payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
             var values = payload.RootElement.GetProperty("value");
             Assert.That(values.GetArrayLength(), Is.EqualTo(2));
-            Assert.That(payload.RootElement.GetProperty("nextLink").GetString(), Does.Contain($"api-version={ApiVersion}"));
             Assert.That(values[0].GetProperty("name").GetString(), Is.EqualTo("Microsoft.Sql/databases/read"));
             Assert.That(values[1].GetProperty("name").GetString(), Is.EqualTo("Microsoft.Sql/databases/write"));
+        }
+
+        [Test]
+        public async Task UnsupportedApiVersionIsRejected()
+        {
+            using var response = await _client.GetAsync("/providers/Microsoft.Sql/operations?api-version=2025-01-01");
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
         }
 
         private static string WithApiVersion(string path) => $"{path}?api-version={ApiVersion}";

--- a/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/Directory.Build.props
+++ b/eng/packages/http-server-csharp-aspnet/generator/TestProjects/Local/Directory.Build.props
@@ -18,4 +18,7 @@
     -->
     <PackageReference Include="System.Memory.Data" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This adds a local AzureSql scenario that better matches the intended server-side generator workflow: generated contracts land under src/Generated inside an existing ASP.NET Core project, while hand-written concrete controllers live outside the generated tree.

Changes:
- Add hand-written DatabasesController and OperationsController implementations that inherit from generated controller bases.
- Update Generate.ps1 to remove only src/Generated before regeneration, preserving user-owned project files.
- Update docs/plan.md to document the embedded-project scenario.

Validation:
- npm run build
- ./eng/scripts/Generate.ps1