### PR TITLE
[Monitor] Fix for issue #52787 `targetResourceType` property could be empty or null

### DIFF
--- a/sdk/monitor/Azure.ResourceManager.Monitor/CHANGELOG.md
+++ b/sdk/monitor/Azure.ResourceManager.Monitor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bugs Fixed
 
+- Fixed `ArgumentException` ("Value cannot be empty or contain only white-space characters. (Parameter resourceType)") thrown when deserializing a `MetricAlertData` whose `targetResourceType` property is returned as an empty or whitespace string by the service (for example, alerts created via Terraform's `azurerm_monitor_metric_alert` without `target_resource_type`). Empty/whitespace values are now treated the same as `null`. ([#52787](https://github.com/Azure/azure-sdk-for-net/issues/52787))
+
 ### Other Changes
 
 ## 1.4.0-beta.4 (2025-11-18)

--- a/sdk/monitor/Azure.ResourceManager.Monitor/src/Customized/MetricAlertData.Serialization.cs
+++ b/sdk/monitor/Azure.ResourceManager.Monitor/src/Customized/MetricAlertData.Serialization.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable disable
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Azure.Core;
+
+namespace Azure.ResourceManager.Monitor
+{
+    // Issue #52787:
+    // Some service responses contain targetResourceType as "" instead of null.
+    // The generated code would pass that value to new ResourceType(...), which throws.
+    // This hook keeps normal behavior for valid values and ignores null/empty/whitespace values.
+    [CodeGenSerialization(nameof(TargetResourceType), DeserializationValueHook = nameof(ReadTargetResourceType))]
+    public partial class MetricAlertData
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void ReadTargetResourceType(JsonProperty property, ref ResourceType? targetResourceType)
+        {
+            var value = property.Value.ValueKind == JsonValueKind.Null ? null : property.Value.GetString();
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                targetResourceType = new ResourceType(value);
+            }
+        }
+    }
+}

--- a/sdk/monitor/Azure.ResourceManager.Monitor/src/Generated/MetricAlertData.Serialization.cs
+++ b/sdk/monitor/Azure.ResourceManager.Monitor/src/Generated/MetricAlertData.Serialization.cs
@@ -291,11 +291,7 @@ namespace Azure.ResourceManager.Monitor
                         }
                         if (property0.NameEquals("targetResourceType"u8))
                         {
-                            if (property0.Value.ValueKind == JsonValueKind.Null)
-                            {
-                                continue;
-                            }
-                            targetResourceType = new ResourceType(property0.Value.GetString());
+                            ReadTargetResourceType(property0, ref targetResourceType);
                             continue;
                         }
                         if (property0.NameEquals("targetResourceRegion"u8))

--- a/sdk/monitor/Azure.ResourceManager.Monitor/tests/TestCase/MetricAlertDataDeserializationTests.cs
+++ b/sdk/monitor/Azure.ResourceManager.Monitor/tests/TestCase/MetricAlertDataDeserializationTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ClientModel.Primitives;
+using NUnit.Framework;
+
+namespace Azure.ResourceManager.Monitor.Tests
+{
+    public class MetricAlertDataDeserializationTests
+    {
+        // Regression test for https://github.com/Azure/azure-sdk-for-net/issues/52787:
+        // The service may return "targetResourceType": "" when no target resource type was set.
+        // Deserialization should not throw and TargetResourceType should be null.
+        [Test]
+        public void Deserialize_EmptyTargetResourceType_DoesNotThrow()
+        {
+            string json = """
+            {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/metricAlerts/alert1",
+                "name": "alert1",
+                "type": "Microsoft.Insights/metricAlerts",
+                "location": "global",
+                "properties": {
+                    "severity": 3,
+                    "enabled": true,
+                    "scopes": [
+                        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1"
+                    ],
+                    "evaluationFrequency": "PT1M",
+                    "windowSize": "PT5M",
+                    "targetResourceType": "",
+                    "criteria": {
+                        "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                        "allOf": []
+                    }
+                }
+            }
+            """;
+
+            MetricAlertData data = null;
+            Assert.DoesNotThrow(() => data = ModelReaderWriter.Read<MetricAlertData>(BinaryData.FromString(json)));
+            Assert.IsNotNull(data);
+            Assert.IsNull(data.TargetResourceType);
+        }
+
+        [Test]
+        public void Deserialize_WhitespaceTargetResourceType_DoesNotThrow()
+        {
+            string json = """
+            {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/metricAlerts/alert1",
+                "name": "alert1",
+                "type": "Microsoft.Insights/metricAlerts",
+                "location": "global",
+                "properties": {
+                    "severity": 3,
+                    "enabled": true,
+                    "scopes": [
+                        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1"
+                    ],
+                    "evaluationFrequency": "PT1M",
+                    "windowSize": "PT5M",
+                    "targetResourceType": "   ",
+                    "criteria": {
+                        "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                        "allOf": []
+                    }
+                }
+            }
+            """;
+
+            MetricAlertData data = null;
+            Assert.DoesNotThrow(() => data = ModelReaderWriter.Read<MetricAlertData>(BinaryData.FromString(json)));
+            Assert.IsNotNull(data);
+            Assert.IsNull(data.TargetResourceType);
+        }
+
+        [Test]
+        public void Deserialize_NonEmptyTargetResourceType_RoundTrips()
+        {
+            string json = """
+            {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Insights/metricAlerts/alert1",
+                "name": "alert1",
+                "type": "Microsoft.Insights/metricAlerts",
+                "location": "global",
+                "properties": {
+                    "severity": 3,
+                    "enabled": true,
+                    "scopes": [
+                        "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1"
+                    ],
+                    "evaluationFrequency": "PT1M",
+                    "windowSize": "PT5M",
+                    "targetResourceType": "Microsoft.Storage/storageAccounts",
+                    "criteria": {
+                        "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                        "allOf": []
+                    }
+                }
+            }
+            """;
+
+            MetricAlertData data = ModelReaderWriter.Read<MetricAlertData>(BinaryData.FromString(json));
+            Assert.IsNotNull(data);
+            Assert.IsNotNull(data.TargetResourceType);
+            Assert.AreEqual("Microsoft.Storage/storageAccounts", data.TargetResourceType.Value.ToString());
+        }
+    }
+}


### PR DESCRIPTION
- Fixed `ArgumentException` ("Value cannot be empty or contain only white-space characters. (Parameter resourceType)") thrown when deserializing a `MetricAlertData` whose `targetResourceType` property is returned as an empty or whitespace string by the service (for example, alerts created via Terraform's `azurerm_monitor_metric_alert` without `target_resource_type`). Empty/whitespace values are now treated the same as `null`. ([#52787](https://github.com/Azure/azure-sdk-for-net/issues/52787))

# Contributing to the Azure SDK

Please see our [CONTRIBUTING.md](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md) if you are not familiar with contributing to this repository or have questions.

For specific information about pull request etiquette and best practices, see [this section](https://github.com/Azure/azure-sdk-for-net/blob/main/CONTRIBUTING.md#pull-request-etiquette-and-best-practices).
